### PR TITLE
add protocol constants to latex ledger spec

### DIFF
--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -138,8 +138,8 @@ this document.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \var{vk} & \SKey & \text{signing key}\\
-      \var{vk} & \VKey & \text{verifying key}\\
+      \var{vk} & \SKey & \text{private signing key}\\
+      \var{vk} & \VKey & \text{public verifying key}\\
       \var{hk} & \Hash & \text{hash of a key}\\
       \sigma & \Sig  & \text{signature}\\
       \var{d} & \Data  & \text{data}\\


### PR DESCRIPTION
Adding the protocol constants to the latex ledger spec requires exactly the same changes that were made to the ledger [spec](https://github.com/input-output-hk/cardano-chain/tree/master/specs/ledger/latex) in the cardano-chain repo.