### PR TITLE
operational certificates in shelley ledger spec

### DIFF
--- a/latex/chain.tex
+++ b/latex/chain.tex
@@ -21,6 +21,7 @@
 \newcommand{\bHeaderSize}[1]{\fun{bHeaderSize}~ \var{#1}}
 \newcommand{\bSize}[1]{\fun{bSize}~ \var{#1}}
 \newcommand{\bBodySize}[1]{\fun{bBodySize}~ \var{#1}}
+\newcommand{\OCert}{\type{OCert}}
 \newcommand{\BHeader}{\type{BHeader}}
 \newcommand{\BHBody}{\type{BHBody}}
 
@@ -34,6 +35,7 @@
 \newcommand{\bprfn}[1]{\fun{bprf}_{n}~\var{#1}}
 \newcommand{\bseedn}[1]{\fun{bseed}_{n}~\var{#1}}
 \newcommand{\bprfl}[1]{\fun{bprf}_{\ell}~\var{#1}}
+\newcommand{\bocert}[1]{\fun{bocert}~\var{#1}}
 
 \newcommand{\PraosEnv}{\type{PraosEnv}}
 \newcommand{\PraosState}{\type{PraosState}}
@@ -127,6 +129,20 @@
     \end{array}
   \end{equation*}
   %
+  \emph{Operational Certificate}
+  %
+  \begin{equation*}
+    \OCert =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{vk_{hot}} & \VKeyEv & \text{operational (hot) key}\\
+        \var{n} & \N & \text{counter}\\
+        c_0 & \Cycle & \text{start cycle}\\
+        \sigma & \Sig & \text{cold key signature}\\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
   \emph{Block Header Body}
   %
   \begin{equation*}
@@ -141,6 +157,7 @@
         \ell & \unitInterval & \text{leader election value}\\
         \var{prf_{\ell}} & \Proof & \text{leader election proof}\\
         \var{sig} & \Sig & \text{block body signature}\\
+        \var{oc} & \OCert & \text{operational certificate}\\
       \end{array}
     \right)
   \end{equation*}
@@ -188,6 +205,7 @@
       \fun{bleader} & \BHBody \to \unitInterval\\
       \fun{bprf}_\ell & \BHBody \to \Proof\\
       \fun{bsig} & \BHBody \to \Sig \\
+      \fun{bocert} & \BHBody \to \OCert \\
     \end{array}
   \end{equation*}
   %
@@ -410,6 +428,61 @@
 \label{sec:block-header-trans}
 
 \begin{figure}
+  \emph{Operational Certificate Transitions}
+  \begin{equation*}
+    \vdash \var{\_} \trans{ocert}{\_} \var{\_} \subseteq
+    \powerset (\PState \times \BHBody \times \PState)
+  \end{equation*}
+  \caption{OCert transition-system types}
+  \label{fig:ts-types:ocert}
+\end{figure}
+
+\begin{figure}[ht]
+  \begin{equation}\label{eq:ocert}
+    \inference[OCert]
+    {
+      (\var{vk_{hot}},~n,~d_{0},~\sigma) \leteq \bocert{bhb}
+      &
+      \var{vk_{cold}} \leteq \bissuer{bhb}
+      &
+      \var{hk} \leteq \hashKey{vk_{cold}}
+      \\~\\
+      c_0 \leq \cycle{\bslot{bhb}} < c_0 + 90
+      \\
+      \var{hk}\mapsto m\in\var{cs}
+      &
+      m \leq n
+      &
+      \mathcal{V}_{\var{vk_{cold}}}{\serialised{(\var{vk_{hot}},~n,~c_0)}}_{\sigma}
+    }
+    {
+      \vdash
+      \left(
+      \begin{array}{r}
+        \var{stpools} \\
+        \var{poolParams} \\
+        \var{retiring} \\
+        \var{avgs} \\
+        \var{cs} \\
+      \end{array}
+      \right)
+      \trans{ocert}{\var{bhb}}
+      \left(
+      \begin{array}{rcl}
+        \var{stpools} \\
+        \var{poolParams} \\
+        \var{retiring} \\
+        \var{avgs} \\
+        \varUpdate{\var{cs}\unionoverrideRight\{\var{hk}\mapsto n\}} \\
+      \end{array}
+      \right)
+    }
+  \end{equation}
+  \caption{OCert rules}
+  \label{fig:rules:ocert}
+\end{figure}
+
+\begin{figure}
   \emph{Block Header environments}
   \begin{equation*}
     \BHeaderEnv =
@@ -417,6 +490,7 @@
       \begin{array}{r@{~\in~}lr}
         \var{s_{now}} & \Slot & \text{current slot (wall-clock)} \\
         \var{pp} & \PParams & \text{protocol parameters} \\
+        \var{stpools} & \StakePools & \text{stake pools} \\
       \end{array}
     \right)
   \end{equation*}
@@ -453,15 +527,19 @@
       (\var{bhb},~\sigma) \leteq \var{bh}
       &
       \var{slot} \leteq \bslot{bh}
-      &
-      \var{vk} \leteq \bissuer{block}
       \\
+      (\var{vk_{hot}},~\wcard,~\wcard,~\wcard) \leteq \bocert{block}
+      \\~\\
+      \var{vk_{hot}}\mapsto s_0\in\var{stpools}
+      &
+      t \leteq \cycle{slot} - \cycle{s_0}
+      \\~\\
       \var{s_{last}} < \var{slot} \leq \var{s_{now}}
       &
       \var{h} = \bprev{bh}
-      &
-      \mathcal{V}_{\var{vk}}{\serialised{txs}}_{\sigma}
       \\
+      \mathcal{V}_{\var{vk_{hot}}}{\serialised{txs}}_{\sigma}^{t}
+      &
       \bHeaderSize{bh} < \fun{maxBHSize}~\var{pp}
     }
     {
@@ -469,6 +547,7 @@
         {\begin{array}{c}
             \var{s_{now}} \\
             \var{pp} \\
+            \var{stpools} \\
         \end{array}}
       \right)
       \vdash
@@ -497,6 +576,7 @@
         \var{pp} & \PParams & \text{protocol parameters} \\
         \eta_0 & \Seed & \text{epoch nonce} \\
         \var{pd} & \PoolDistr & \text{pool stake distribution} \\
+        \var{stpools} & \StakePools & \text{stake pools} \\
       \end{array}
     \right)
   \end{equation*}
@@ -546,6 +626,7 @@
           {\begin{array}{c}
              \var{s_{now}} \\
              \var{pp} \\
+             \var{stpools} \\
            \end{array}}
         \right)
         \vdash
@@ -832,6 +913,14 @@
       }
       \\~\\
       (\var{acnt}',~\var{pp}',~\var{ss}',~\var{ls}') \leteq \var{es}'
+      &
+      (\var{us}',~(\var{ds}',~\var{ps'})) \leteq \var{ls}'
+      \\
+      \vdash\var{ps}'\trans{ocert}{bhb}\var{ps}''
+      &
+      \var{ls}'' \leteq (\var{us}',~(\var{ds}',~\var{ps}''))
+      &
+      (\var{stpools},~\wcard,~\wcard,~\wcard,~\wcard) \leteq \var{ps}''
       \\
       {
         \left(
@@ -840,6 +929,7 @@
               \var{pp}' \\
               \eta_0' \\
               \var{pd}' \\
+              \var{stpools} \\
           \end{array}}
         \right)
         \vdash
@@ -867,17 +957,17 @@
       {
         \var{pp}\vdash
         {\left(\begin{array}{c}
-              \var{ls'} \\
+              \var{ls}'' \\
               \var{b'} \\
         \end{array}\right)}
         \trans{bbody}{\var{block}}
         {\left(\begin{array}{c}
-              \var{ls}'' \\
+              \var{ls}''' \\
               b'' \\
         \end{array}\right)}
       }
       &
-      \var{es}'' \leteq (\var{acnt}',~\var{pp}'~\var{ss}'~\var{ls}'')
+      \var{es}'' \leteq (\var{acnt}',~\var{pp}'~\var{ss}'~\var{ls}''')
     }
     {
       \left(

--- a/latex/crypto-primitives.tex
+++ b/latex/crypto-primitives.tex
@@ -81,5 +81,54 @@ organization chosen for an implementation.
   \label{fig:crypto-defs-shelley}
 \end{figure}
 
+When we get to the blockchain layer validation, we will use
+key evolving signatures according to the MMM scheme \citep{cryptoeprint:2001:034}.
+Figure~\ref{fig:crypto-defs-shelley} introduces the additional cryptographic abstractions
+needed for KES.
+
+
+\begin{figure}[htb]
+  \emph{Abstract types}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \var{sk} & \N \to \SKeyEv & \text{private signing keys}\\
+      \var{vk} & \VKeyEv & \text{public verifying key}\\
+    \end{array}
+  \end{equation*}
+  \emph{Notation for evolved signing key}
+  \begin{align*}
+    & \var{sk_n} = \var{sk}~n & n\text{-th evolution of }sk
+  \end{align*}
+  \emph{Derived types}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      (sk_n, vk) & \KeyPairEv & \text{signing-verifying key pairs}
+    \end{array}
+  \end{equation*}
+  \emph{Abstract functions}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \fun{verify_{ev}} & \powerset{\left(\VKey \times \N \times \Data \times \Sig\right)}
+                        & \text{verification relation}\\
+                        %
+      \fun{sign_{ev}} & \SKey \to \N \to \Data \to \Sig
+                      & \text{signing function}\\
+    \end{array}
+  \end{equation*}
+  \emph{Constraints}
+  \begin{align*}
+    & \forall m,n\in\N, (sk_n, vk) \in \KeyPairEv, ~ d \in \Data,~ \sigma \in \Sig \cdot \\
+    & ~~~~~~~~m\leq n \land \signEv{sk}{n}{d} = \sigma \implies \verifyEv{vk}{m}{d}{\sigma}
+  \end{align*}
+  \emph{Notation for verified KES data}
+  \begin{align*}
+    & \mathcal{V}_{\var{vk}}{\serialised{d}}_{\sigma}^n = \verifyEv{vk}{n}{d}{\sigma}
+    & \text{shorthand notation for } \fun{verify_{ev}}
+  \end{align*}
+  \caption{KES Cryptographic definitions}
+  \label{fig:kes-defs-shelley}
+\end{figure}
 \clearpage
 

--- a/latex/delegation.tex
+++ b/latex/delegation.tex
@@ -195,6 +195,8 @@ state transition types. We define two separate parts of the ledger state.
         the epoch in which it will retire.
       \item $\var{avgs}$ stores the latest value of the pool's performance moving average.  This
         value quantifies the desirability of delegating to a given pool, based on past performance.
+      \item $\var{cs}$ stores the latest operational certificate counter used for each pool.
+        The counters are used the operation certificate transition in Figure~\ref{fig:rules:ocert}.
     \end{itemize}
 \end{itemize}
 
@@ -227,6 +229,7 @@ and the protocol parameters.
         & \text{registered pools to pool parameters}\\
       \var{retiring} & \HashKey_{pool} \mapsto \Epoch & \text{retiring stake pools}\\
       \var{avgs} & \HashKey_{pool} \mapsto \Rnn & \text{performance moving average}\\
+      \var{cs} & \HashKey_{pool} \mapsto \N & \text{operational certificate counters}\\
     \end{array}\right)
     \end{array}
   \end{equation*}
@@ -439,6 +442,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
     \begin{itemize}
       \item The key is added to the set of registered stake pools.
       \item The pool's parameters are stored.
+      \item The pool's operational certificate counter is set to zero.
     \end{itemize}
   \item Stake pool parameter updates are handled by \cref{eq:pool-rereg}.
     This rule, which also matches on the certificate type $\type{DCertRegPool}$,
@@ -496,7 +500,8 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
         \var{stpools} \\
         \var{poolParams} \\
         \var{retiring} \\
-        \var{avgs}
+        \var{avgs} \\
+        \var{cs} \\
       \end{array}
       \right)
       \trans{pool}{c}
@@ -507,7 +512,9 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
         \varUpdate{\var{poolParams}} & \varUpdate{\union}
                                     & \varUpdate{\{\var{hk} \mapsto \poolParam{c}\}} \\
        \var{retiring} \\
-       \var{avgs}
+       \var{avgs} \\
+       \varUpdate{\var{cs}} & \varUpdate{\union}
+                            & \varUpdate{\{\var{hk} \mapsto 0\}} \\
       \end{array}
       \right)
     }
@@ -531,7 +538,8 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
         \var{stpools} \\
         \var{poolParams} \\
         \var{retiring} \\
-        \var{avgs}
+        \var{avgs} \\
+        \var{cs} \\
       \end{array}
       \right)
       \trans{pool}{c}
@@ -541,7 +549,8 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
         \varUpdate{\var{poolParams}} & \varUpdate{\unionoverrideRight}
                                   & \varUpdate{\{\var{hk} \mapsto \poolParam{c}\}}\\
         \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
-        \var{avgs}
+        \var{avgs} \\
+        \var{cs} \\
       \end{array}
       \right)
     }
@@ -568,7 +577,8 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
         \var{stpools} \\
         \var{poolParams} \\
         \var{retiring} \\
-        \var{avgs}
+        \var{avgs} \\
+        \var{cs} \\
       \end{array}
     \right)
     \trans{pool}{c}
@@ -578,7 +588,8 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
         \var{poolParams} \\
         \varUpdate{\var{retiring}} & \varUpdate{\unionoverrideRight}
                                    & \varUpdate{\{\var{hk} \mapsto \var{e}\}} \\
-        \var{avgs}
+        \var{avgs} \\
+        \var{cs} \\
       \end{array}
     \right)
   }
@@ -802,7 +813,8 @@ will be invalid.
         \var{stpools} \\
         \var{poolParams} \\
         \var{retiring} \\
-        \var{avgs}
+        \var{avgs} \\
+        \var{cs} \\
       \end{array}
       \right)
       \trans{delegs}{\epsilon}
@@ -815,7 +827,8 @@ will be invalid.
         \var{stpools} \\
         \var{poolParams} \\
         \var{retiring} \\
-        \var{avgs}
+        \var{avgs} \\
+        \var{cs} \\
       \end{array}
       \right)
     }

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -304,7 +304,7 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
       (\dom{\var{activeDelegs}})\restrictdom\left(\fun{aggregate_{+}}~\var{stakeRelation}\right)\\
       & \where \\
       & ~~~~ (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs}) = \var{dstate} \\
-      & ~~~~ (\var{stpools},~\wcard,~\wcard,~\wcard) = \var{pstate} \\
+      & ~~~~ (\var{stpools},~\wcard,~\wcard,~\wcard,~\wcard) = \var{pstate} \\
       & ~~~~ \var{stakeRelation} = \left(
         \left(\fun{stakeHK_b}^{-1}\cup\left(\fun{addrPtr}\circ\var{ptr}\right)^{-1}\right)
         \circ\left(\range{\var{utxo}}\right)
@@ -420,7 +420,7 @@ This transition has no preconditions and results in the following state change:
       \begin{array}{r@{~\leteq~}l}
         (\var{utxo},~\var{deposits},~\var{fees}) & \var{utxoSt}\\
         (\var{stkeys},~\wcard,~\var{delegations},~\wcard) & \var{dstate}\\
-        (\var{stpools},~\var{poolParams},~\wcard,~\wcard) & \var{pstate}\\
+        (\var{stpools},~\var{poolParams},~\wcard,~\wcard,~\wcard) & \var{pstate}\\
         \var{stake} & \stakeDistr{utxo}{dstate}{pstate} \\
         \var{slot} & \firstSlot{e} \\
         \var{oblg} & \obligation{pp}{stkeys}{stpools}{slot} \\
@@ -567,6 +567,7 @@ This transition has no preconditions and results in the following state change:
           \var{poolParams} \\
           \var{retiring} \\
           \var{avgs} \\
+          \var{cs} \\
         \end{array}
       \right)
       \trans{poolreap}{e}
@@ -585,6 +586,7 @@ This transition has no preconditions and results in the following state change:
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{poolParams}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{avgs}} \\
+          \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{cs}} \\
         \end{array}
       \right)
     }
@@ -1407,6 +1409,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
           \var{poolParams} \\
           \var{retiring} \\
           \var{avgs} \\
+          \var{cs} \\
           ~ \\
           \var{utxo} \\
           \var{deposits} \\
@@ -1429,6 +1432,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
           \var{poolParams} \\
           \var{retiring} \\
           \var{avgs} \\
+          \var{cs} \\
           ~ \\
           \var{utxo} \\
           \var{deposits} \\

--- a/latex/ledger-spec.tex
+++ b/latex/ledger-spec.tex
@@ -51,6 +51,7 @@
 \newcommand{\PParams}{\type{PParams}}
 \newcommand{\Slot}{\type{Slot}}
 \newcommand{\SlotsPerEpoch}{\mathsf{SlotsPerEpoch}}
+\newcommand{\SlotsPerCycle}{\mathsf{SlotsPerCycle}}
 \newcommand{\Duration}{\type{Duration}}
 \newcommand{\StakePools}{\type{StakePools}}
 \newcommand{\StakeKeys}{\type{StakeKeys}}
@@ -86,13 +87,17 @@
 \newcommand{\TxIn}{\type{TxIn}}
 \newcommand{\TxOut}{\type{TxOut}}
 \newcommand{\VKey}{\type{VKey}}
+\newcommand{\VKeyEv}{\type{VKey_{ev}}}
 \newcommand{\SKey}{\type{SKey}}
+\newcommand{\SKeyEv}{\type{SKey_{ev}}}
 \newcommand{\HashKey}{\type{HashKey}}
 \newcommand{\KeyPair}{\type{KeyPair}}
+\newcommand{\KeyPairEv}{\type{KeyPair_{ev}}}
 \newcommand{\Sig}{\type{Sig}}
 \newcommand{\Data}{\type{Data}}
 %% Adding delegation
 \newcommand{\Epoch}{\type{Epoch}}
+\newcommand{\Cycle}{\type{Cycle}}
 \newcommand{\VKeyGen}{\type{VKeyGen}}
 %% Blockchain
 \newcommand{\Gkeys}{\var{G_{keys}}}
@@ -139,6 +144,7 @@
 \newcommand{\retire}[1]{\fun{retire}~ \var{#1}}
 \newcommand{\addrRw}[1]{\fun{addr_{rwd}}~ \var{#1}}
 \newcommand{\epoch}[1]{\fun{epoch}~ \var{#1}}
+\newcommand{\cycle}[1]{\fun{cycle}~ \var{#1}}
 \newcommand{\dcerts}[1]{\fun{dcerts}~ \var{#1}}
 
 %% UTxO witnesses
@@ -146,6 +152,8 @@
 \newcommand{\txwits}[1]{\fun{txwits}~ \var{#1}}
 \newcommand{\verify}[3]{\fun{verify} ~ #1 ~ #2 ~ #3}
 \newcommand{\sign}[2]{\fun{sign} ~ #1 ~ #2}
+\newcommand{\verifyEv}[4]{\fun{verify_{ev}} ~ #1 ~ #2 ~ #3 ~ #4}
+\newcommand{\signEv}[3]{\fun{sign_{ev}} ~ #1 ~ #2 ~ #3}
 \newcommand{\serialised}[1]{\llbracket \var{#1} \rrbracket}
 \newcommand{\hashKey}[1]{\fun{hashKey}~ \var{#1}}
 \newcommand{\txbody}[1]{\fun{txbody}~ \var{#1}}

--- a/latex/ledger.tex
+++ b/latex/ledger.tex
@@ -62,7 +62,7 @@ and then calls the $\mathsf{DELEGS}$ transition.
     {
       (\var{dstate}, \var{pstate}) \leteq \var{dpstate} \\
     (\var{stkeys}, \_, \_, \_) \leteq \var{dstate} \\
-    (\_, \_, \var{stpools}, \_) \leteq \var{pstate} \\~\\
+    (\var{stpools}, \_, \_, \_, \_) \leteq \var{pstate} \\~\\
       \left({
         \begin{array}{r}
         \var{slot} \\

--- a/latex/non-integral.tex
+++ b/latex/non-integral.tex
@@ -36,7 +36,7 @@ rules that use non-integral calculations and which type.
     \fun{updateAvgs}
          & \pageref{fig:funcs:epoch-helper} & \checkmark & \checkmark &&\\
     \fun{REWARD}
-         &\pageref{fig:rules:reward} & \checkmark &&& \\
+         &\pageref{fig:rules:reward-update} & \checkmark &&& \\
     \bottomrule
   \end{tabular}
   \caption{Functions with Non-Integral Calculation}

--- a/latex/protocol-parameters.tex
+++ b/latex/protocol-parameters.tex
@@ -14,11 +14,13 @@ This value depends on the protocol parameters and the size of the transaction.
 Two time related types are introduced, $\Epoch$ and $\type{Duration}$.
 A $\type{Duration}$ is the difference between two slots, as given by $\slotminus{}{}$.
 
-One global constant is defined, $\SlotsPerEpoch$, representing the number of slots
-in an epoch. As a global constant, this value can only be changed by updating the software.
+Two global constants are defined,
+$\SlotsPerEpoch$ and $\SlotsPerCycle$, representing the number of slots in an epoch/cycle.
+Cycles will be used in the key evolving signatures.
+As global constants, these values can only be changed by updating the software.
 
 Lastly, there are two functions, $\fun{epoch}$ and $\fun{firstSlot}$ for converting
-between epochs and slots.
+between epochs and slots, and one function $\fun{cycle}$ for getting the cycle of a slot.
 
 \begin{figure*}[htb]
   \emph{Abstract types}
@@ -28,6 +30,7 @@ between epochs and slots.
       \var{fparams} & \type{FeeParams} & \text{min fee parameters}\\
       \var{dur} & \Duration & \text{difference between slots}\\
       \var{epoch} & \Epoch & \text{epoch} \\
+      \var{cycle} & \Cycle & \text{cycle} \\
     \end{array}
   \end{equation*}
   %
@@ -107,6 +110,7 @@ between epochs and slots.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \SlotsPerEpoch & \N & \text{slots per epoch} \\
+      \SlotsPerCycle & \N & \text{slots per cycle} \\
     \end{array}
   \end{equation*}
   %
@@ -122,6 +126,11 @@ between epochs and slots.
                & \text{first slot of an epoch}
     \\
     \fun{firstSlot} & ~\var{e} = \var{e}~\cdot~\SlotsPerEpoch
+    \\
+    \\
+    \fun{cycle} & \in ~ \Slot \to \Cycle & \text{cycle of a slot}
+    \\
+    \fun{cycle} & ~\var{slot} = \var{slot}~\mathsf{div}~\SlotsPerCycle
   \end{align*}
   %
   \caption{Definitions used in Protocol Parameters}

--- a/latex/references.bib
+++ b/latex/references.bib
@@ -59,3 +59,11 @@ Cardano},
   year = {2017},
   url   = {https://eprint.iacr.org/2017/573.pdf}
 }
+
+@misc{cryptoeprint:2001:034,
+    author = {Tal Malkin and Daniele Micciancio and Sara Miner},
+    title = {Composition and Efficiency Tradeoffs for Forward-Secure Digital Signatures},
+    howpublished = {Cryptology ePrint Archive, Report 2001/034},
+    year = {2001},
+    note = {\url{https://eprint.iacr.org/2001/034}},
+}


### PR DESCRIPTION
This PR introduces operational certificates to the Shelley ledger spec, as described in section `4.4.7` of the delegation design document. #338 

The block header now includes an additional item, the `OCert`, defined as:

![ocert](https://user-images.githubusercontent.com/943479/54553720-33357780-4989-11e9-9e4e-a73231172b6e.png)

The hot keys used in the operational certs use key evolving signatures, and require an additional table in the cryptography section.  Essentially, pubkeys are fixed as before, but private keys can be evolved, with the new constraint that when you verify a signature, the verifier verifies against a minimal number of evolutions that must have occurred:

![kes](https://user-images.githubusercontent.com/943479/54553881-8f000080-4989-11e9-9b3d-60f3f8c33dca.png)

The previous rule `BHEAD` has been modified so that instead of checking that the pool operator key (ie cold key) signed the header, we now check that the (hot) operational key signed the header, given the proper number of evolutions.  The delegation design document specifies that these keys must be evolved once a day, so we have introduced a new constant for the number of slots in a day, namely `SlotsPerDay`.  We can therefore enforce that the key is properly evolved by counting the days since the pool registration cert was accepted.

`BHead` now does these checks:

![bhead](https://user-images.githubusercontent.com/943479/54554868-e4d5a800-498b-11e9-98c8-91e8946c20cc.png)

There is now a new transition system `OCert` which checks the validity of an operational certificate.

We need to keep track of the the counters for each stake pool's operational certificates. This is now done in `PState`, in the new variable `cs`.  Here is the new transition `OCert`:

![ocertTrs](https://user-images.githubusercontent.com/943479/54554566-1ac65c80-498b-11e9-8056-c35521b06dcb.png)

It checks that the cert is within 90 days of its start day (as specified in the deleg design doc), that the counter does not decrease, and that the cold key signed the relevant information.