### PR TITLE
Use `lib.nix` instead of `nix/fetch-nixpkgs.nix`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,6 @@ TAGS
 auto/
 
 # Nix artifacts
-specs/**/result
-result
+specs/**/result*
+result*
 specs/**/.ghc.environment.x86_64-linux-*

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ from [the Shelley ledger spec](./latex)).
 2. Modify the `DOCNAME` in the `Makefile`.
 3. Update `default.nix` to:
    1. Make sure that the relative path in the first line is pointing to
-      (fetch-nixpkgs.nix)[./nix/fetch-nixpkgs.nix]. This is used to pin the
+      (lib.nix)[./lib.nix]. This is used to pin the
       `nixpkgs` version used to build the LaTeX specifications.
    2. Update the `buildInputs` to add in any LaTeX packages you need in your
       document, and remove any unneeded ones.

--- a/dependencies/non-integer/doc/default.nix
+++ b/dependencies/non-integer/doc/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (import ../../../nix/fetch-nixpkgs.nix) {}
+{ pkgs ? (import ../../../lib.nix).pkgs
 }:
 
 with pkgs;

--- a/docs/delegation_design_spec/default.nix
+++ b/docs/delegation_design_spec/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (import ../../nix/fetch-nixpkgs.nix) {}
+{ pkgs ? (import ../../lib.nix).pkgs
 }:
 
 with pkgs;

--- a/latex/default.nix
+++ b/latex/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (import ../nix/fetch-nixpkgs.nix) {}
+{ pkgs ? (import ../lib.nix).pkgs
 }:
 
 with pkgs;

--- a/nix/fetch-nixpkgs.nix
+++ b/nix/fetch-nixpkgs.nix
@@ -1,6 +1,0 @@
-let
-  spec = builtins.fromJSON (builtins.readFile ./nixpkgs-src.json);
-in builtins.fetchTarball {
-  url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.rev}.tar.gz";
-  inherit (spec) sha256;
-}

--- a/nix/nixpkgs-src.json
+++ b/nix/nixpkgs-src.json
@@ -1,6 +1,0 @@
-{
-  "owner": "NixOS",
-  "repo": "nixpkgs",
-  "rev": "6054276a8e6e877f8846c79b0779e3310c495a6b",
-  "sha256": "11mv8an4zikh2hybn11znqcbxazqq32byvvvaymy2xkpww2jnkxp"
-}

--- a/specs/chain/latex/default.nix
+++ b/specs/chain/latex/default.nix
@@ -1,5 +1,6 @@
-{ pkgs ? import (import ../../../nix/fetch-nixpkgs.nix) {}
+{ pkgs ? (import ../../../lib.nix).pkgs
 }:
+
 
 with pkgs;
 

--- a/specs/ledger/latex/default.nix
+++ b/specs/ledger/latex/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (import ../../../nix/fetch-nixpkgs.nix) {}
+{ pkgs ? (import ../../../lib.nix).pkgs
 }:
 
 with pkgs;

--- a/specs/semantics/latex/default.nix
+++ b/specs/semantics/latex/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (import ../../../nix/fetch-nixpkgs.nix) {}
+{ pkgs ? (import ../../../lib.nix).pkgs
 }:
 
 with pkgs;


### PR DESCRIPTION
This seems to be the right way of pinning the version of the `nix` packages
used by IOHK.

`nix/fetch-nixpkgs.nix` and `nix/nixpkgs-src.json` were also removed since they
don't seem to be necessary anymore.