### PR TITLE
Update the links to the PDF documents compiled in our hydra server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 
 # Editors
 TAGS
+*.temp
 
 # Emacs auto-generated Emacs-lisp code
 auto/

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ Formal and executable specifications for the new features to be introduced by Sh
 The documents are built in our CI and can be readily accessed using the
 following links:
 
-- [Delegation Design Specification](https://hydra.iohk.io/job/Cardano/fm-ledger-rules/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec)
-- [Shelley specification](https://hydra.iohk.io/job/Cardano/fm-ledger-rules/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec)
-- [Non-integer Calculations Specification](https://hydra.iohk.io/job/Cardano/fm-ledger-rules/nonIntegerCalculations/latest/download-by-type/doc-pdf/non-integer-calculations)
-- [Byron Chain Specification](https://hydra.iohk.io/job/Cardano/fm-ledger-rules/byronChainSpec/latest/download-by-type/doc-pdf/blockchain-spec)
-- [Byron Ledger Specification](https://hydra.iohk.io/job/Cardano/fm-ledger-rules/byronLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec)
-- [Explanation of the Small-step-semantics Framework](https://hydra.iohk.io/job/Cardano/fm-ledger-rules/semanticsSpec/latest/download-by-type/doc-pdf/semantics-spec)
+- [Delegation Design Specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/delegationDesignSpec/latest/download-by-type/doc-pdf/delegation_design_spec)
+- [Shelley specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec)
+- [Non-integer Calculations Specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/nonIntegerCalculations/latest/download-by-type/doc-pdf/non-integer-calculations)
+- [Byron Chain Specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/byronChainSpec/latest/download-by-type/doc-pdf/blockchain-spec)
+- [Byron Ledger Specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/byronLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec)
+- [Explanation of the Small-step-semantics Framework](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/semanticsSpec/latest/download-by-type/doc-pdf/semantics-spec)
 
 ## Build tools
 

--- a/dependencies/non-integer/doc/references.bib
+++ b/dependencies/non-integer/doc/references.bib
@@ -11,7 +11,7 @@
   title  = {Design Specification for Delegation and Incentives in
 Cardano},
   year   = {2018},
-  url   = {https://github.com/input-output-hk/fm-ledger-rules/tree/master/docs/delegation_design_spec},
+  url   = {https://github.com/input-output-hk/cardano-ledger-specs/tree/master/docs/delegation_design_spec},
 }
 
 @article{chimeric,

--- a/dependencies/non-integer/non-integer.cabal
+++ b/dependencies/non-integer/non-integer.cabal
@@ -12,7 +12,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/input-output-hk/fm-ledger-rules.git
+  location: https://github.com/input-output-hk/cardano-ledger-specs.git
   subdir:   dependencies/non-integer
 
 library

--- a/hs/delegation.cabal
+++ b/hs/delegation.cabal
@@ -8,7 +8,7 @@ cabal-version:       >=1.8
 
 source-repository head
   type: git
-  location: https://github.com/input-output-hk/fm-ledger-rules.git
+  location: https://github.com/input-output-hk/cardano-ledger-specs.git
   subdir:   hs
 
 library


### PR DESCRIPTION
Also change `fm-ledger-rules` to `cardano-ledger-specs` in:

- dependencies/non-integer/doc/references.bib
- dependencies/non-integer/non-integer.cabal
- hs/delegation.cabal