### PR TITLE
Small edits to the chain-level validation

### DIFF
--- a/latex/CHANGELOG.md
+++ b/latex/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2019-03-22
+- The blockchain layer for the spec has been completed and polished.
+- There are now operational certificates and key evolving signatures.
+
 ## 2019-03-01
 - Added the blockchain layer to the spec for Praos, including a new top-level transition CHAIN.
 

--- a/latex/chain.tex
+++ b/latex/chain.tex
@@ -8,7 +8,7 @@
 \newcommand{\Seede}{\mathsf{Seed}_\eta}
 \newcommand{\SlotsPrior}{\ensuremath{\mathsf{SlotsPrior}}}
 \newcommand{\StartRewards}{\ensuremath{\mathsf{StartRewards}}}
-\newcommand{\ActiveSlotCoeff}{\mathsf{ActiveSlotCoeff}}
+\newcommand{\activeSlotCoeff}[1]{\fun{activeSlotCoeff}~ \var{#1}}
 \newcommand{\slotToSeed}[1]{\fun{slotToSeed}~ \var{#1}}
 
 \newcommand{\Bool}{\type{Bool}}
@@ -113,22 +113,11 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
     & \Seede \in \Seed & \text{nonce seed constant}\\
     & \SlotsPrior \in \Duration & \tau\text{ in \cite{ouroboros_praos}}\\
     & \StartRewards \in \Duration & \text{duration to start reward calculations}\\
-    & \ActiveSlotCoeff \in \unitInterval & f\text{ in \cite{ouroboros_praos}}\\
   \end{align*}
 
   \caption{VRF definitions}
   \label{fig:defs-vrf}
 \end{figure}
-
-\begin{question}
-  Are there any constraints on $\seedOp$?
-\end{question}
-
-\begin{question}
-  What are good values for $\SlotsPrior$, $\StartRewards$, and $\ActiveSlotCoeff$?
-  Which are better as a constant or a protocol parameter?
-  % $2\cdot\fun{stableAfter}$?
-\end{question}
 
 \clearpage
 
@@ -413,20 +402,14 @@ in the pool distribution.
   \label{fig:rules:not-new-epoch}
 \end{figure}
 
-\begin{question}
-  Is $\var{pstake_{set}}$ definitely the correct snapshot to be
-  used for leader election in the new epoch?
-  See Equation~\ref{eq:new-epoch}
-\end{question}
-
 \subsection{Update Nonces Transition}
 \label{sec:update-nonces-trans}
 
 The update nonce transition updates the nonces until the randomness gets
 fixed. The environment is shown in Figure~\ref{fig:ts-types:updnonce} and
-consists of the epoch nonce \var{\eta}. The update nonce state is shown in
+consists of the epoch nonce $\eta$. The update nonce state is shown in
 Figure~\ref{fig:rules:update-nonce} and consists of the candidate nonce
-\var{\eta_c} and the evolving nonce \var{\eta_v}.
+$\eta_c$ and the evolving nonce $\eta_v$.
 
 \begin{figure}
   \emph{Update Nonce Transitions}
@@ -671,11 +654,6 @@ This transition makes sure that the block can be applied at the current time,
 that the block header is in the right sequence and that the block header has
 been signed with the correct signing key according to the KES.
 
-\begin{question}
-  Is it okay to use wall-clock in the evironment in $\BHeaderEnv$?
-  See Figure~\ref{fig:ts-types:bheader}.
-\end{question}
-
 \begin{figure}[ht]
   \begin{equation}\label{eq:bheader}
     \inference[BHead]
@@ -813,7 +791,7 @@ returned by the application of the $\mathsf{BHEAD}$ transition rule.
     {
       \var{bhb} \leteq \fun{bhbody}~{\var{bh}}
       &
-      f \leteq \ActiveSlotCoeff
+      f \leteq \activeSlotCoeff{pp}
       \\
       \var{vk} \leteq \bissuer bhb
       &

--- a/latex/crypto-primitives.tex
+++ b/latex/crypto-primitives.tex
@@ -119,8 +119,8 @@ needed for KES.
   \end{equation*}
   \emph{Constraints}
   \begin{align*}
-    & \forall m,n\in\N, (sk_n, vk) \in \KeyPairEv, ~ d \in \Data,~ \sigma \in \Sig \cdot \\
-    & ~~~~~~~~m\leq n \land \signEv{sk}{n}{d} = \sigma \implies \verifyEv{vk}{m}{d}{\sigma}
+    & \forall n\in\N, (sk_n, vk) \in \KeyPairEv, ~ d \in \Data,~ \sigma \in \Sig \cdot \\
+    & ~~~~~~~~\signEv{sk}{n}{d} = \sigma \implies \verifyEv{vk}{m}{d}{\sigma}
   \end{align*}
   \emph{Notation for verified KES data}
   \begin{align*}

--- a/latex/epoch.tex
+++ b/latex/epoch.tex
@@ -107,6 +107,14 @@ The two main transition systems in this section are:
     covering the reward calculation which happens between (E) and (F).
 \end{itemize}
 
+
+\begin{note}
+  Between time D and E we are concerned with chain growth and stability.
+  Therefore this duration can be stated as 2k blocks (to state it in slots requires details about
+  particular version of ouroboros). The duration between F and G is the same, 2k blocks.
+  Between E and F a single honest block is enough to ensure a random nonce.
+\end{note}
+
 \subsection{Helper Functions and Accounting Fields}
 \label{sec:stake-dist-helpers}
 

--- a/latex/protocol-parameters.tex
+++ b/latex/protocol-parameters.tex
@@ -68,6 +68,7 @@ between epochs and slots, and one function $\fun{kesPeriod}$ for getting the cyc
         \rho & \unitInterval & \text{monetary expansion}\\
         \var{maxBHSize} & \N & \text{max block header size}\\
         \var{maxBBSize} & \N & \text{max block body size}\\
+        \var{activeSlotCoeff} & \unitInterval & f\text{ in \cite{ouroboros_praos}}\\
       \end{array}
     \right)
   \end{equation*}
@@ -91,6 +92,7 @@ between epochs and slots, and one function $\fun{kesPeriod}$ for getting the cyc
     \fun{rho},
     \fun{maxBHSize},
     \fun{maxBBSize},
+    \fun{activeSlotCoeff},
   \end{center}
   %
   \emph{Abstract Functions}


### PR DESCRIPTION
- `activeCoeffSlot` is now a protocol parameter
- the KES evolution number is now the same for signer and verifier
- added context for the divisions of the epoch
- updated the changelog
- closed all the questions except for the one about wall-clock

closes #351 #355 #356 