### PR TITLE
Discard pending update proposals on protocol parameters change

### DIFF
--- a/specs/ledger/latex/blockchain-interface.tex
+++ b/specs/ledger/latex/blockchain-interface.tex
@@ -292,8 +292,16 @@ information in the confirmed proposal. Note that, unlike protocol updates,
 software updates take effect as soon as a proposal is confirmed. In this rule,
 we also delete the confirmed proposal id's from the set of registered
 application update proposals ($\var{raus}$), since this information is no
-longer needed once the application-name to software-version map ($\var{avs}$) is
-updated.
+longer needed once the application-name to software-version map ($\var{avs}$)
+is updated.
+
+Also note that, unlike the rules of \cref{fig:rules:upi-ec}, we need not remove
+other update proposals that refer to the software names whose versions were
+changed in $\var{avs_{new}}$. The reason for this is that the map $\var{raus}$
+can contain only one pair of the form $(\var{an}, \wcard)$ for any given
+application name $\var{an}$: in Rule~\ref{eq:rule:up-av-validity} function
+$\fun{svCanFollow}$ ensures that there is only one allowed version for any
+given application name $\var{an}$.
 
 \begin{figure}[htb]
   \begin{equation}

--- a/specs/ledger/latex/blockchain-interface.tex
+++ b/specs/ledger/latex/blockchain-interface.tex
@@ -441,12 +441,11 @@ are removed from the parts of the state that hold:
 In Rule~\ref{eq:rule:upi-pend}, the set of proposal id's $\var{pid_{keep}}$
 contains only those proposals that haven't expired yet or that are confirmed.
 Once a proposal $\var{up}$ is confirmed, it is removed from the set of
-confirmed proposals ($\var{cps}$) either when it is adopted or when a protocol
-version higher than that of $\var{up}$ gets adopted (see
-Rule~\ref{eq:rule:upi-ec}).
+confirmed proposals ($\var{cps}$) when a new a protocol version gets adopted
+(see Rule~\ref{eq:rule:upi-ec-pv-change}).
 %
 The set of endorsement-key pairs is cleaned here as well as in the epoch change
-rule (Rule~\ref{eq:rule:upi-ec}). The reason for this is that this set grows at
+rule (Rule~\ref{eq:rule:upi-ec-pv-change}). The reason for this is that this set grows at
 each block, and it can get considerably large if no proposal gets adopted at
 the end on an epoch.
 
@@ -543,7 +542,7 @@ the end on an epoch.
 
 \clearpage
 
-Rule~\ref{eq:rule:upi-ec} models how the epoch, protocol-version and its
+Rule~\ref{eq:rule:upi-ec-pv-change} models how the epoch, protocol-version and its
 parameters are changed depending on the epoch in the signal ($e_n$ in this
 case). A change in the epoch only occurs if the new epoch is greater than the
 previously seen epoch ($e_p$).
@@ -563,18 +562,25 @@ Note that, in the final state, we use union override to define the updated
 parameters ($\var{pps} \unionoverrideRight \var{pps'}$). This is because candidate
 proposal might only update some parameters of the protocol.
 
-Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
-\begin{itemize}
-\item We keep only the information of proposals whose proposed
-  protocol-versions are greater than the newly adopted protocol version
-  ($\var{pv'}$). This means that active proposals will be discarded even if the
-  voting period is not over (it makes no sense to vote on a proposal that
-  proposes to upgrade to an older version of the protocol).
-\item The registered software-update proposals need not be cleaned here, since
-  this is done either when a proposal gets confirmed or when it expires.
-\item Rule~\ref{eq:rule:pvbump-change} keeps only those candidates that can be
-  adopted in future epochs.
-\end{itemize}
+In Rule~\ref{eq:rule:upi-ec-pv-change}, when a new proposal gets adopted, all
+the state components that refer to protocol update proposals get emptied. The
+reason for this is that at the moment of registering a proposal, we evaluated
+it in a state where the protocol parameters that we used for this are no longer
+up to date (see for instance \cref{eq:func:can-update}). For instance, assume
+we register a proposal $\var{up}$ which only changes the maximum transaction
+size to $x$, and the current block size is set to $x + 1$. Then,
+$\fun{canUpdate}$ holds, since the maximum transaction size is less than the
+maximum block size. If now a new proposal gets adopted that changes the maximum
+block size to $x - 1$, then this invalidates $\var{up}$ since $\fun{canUpdate}$
+no longer holds.
+%
+
+If there are no candidates for adoption, then the state variables remain
+unaltered (Rule~\ref{eq:rule:upi-ec-pv-unchanged}).
+
+Also note that the registered software-update proposals need not be cleaned
+here, since this is done either when a proposal gets confirmed or when it
+expires.
 
 \begin{figure}[htb]
   \begin{equation}
@@ -586,15 +592,15 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
     {
       {\begin{array}{l}
          k\\
-         s_n
+         s_n\\
+         \var{fads}
        \end{array}}
       \vdash
       {
         \left(
           \begin{array}{l}
             \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}\\
-            \var{fads}
+            \var{(\var{pv}, \var{pps})}
           \end{array}
         \right)
       }
@@ -603,8 +609,7 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
         \left(
           \begin{array}{l}
             \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}\\
-            \var{fads}
+            \var{(\var{pv}, \var{pps})}
           \end{array}
         \right)
       }
@@ -620,7 +625,8 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
     {
       {\begin{array}{l}
          k\\
-         s_n
+         s_n\\
+         \var{fads}
        \end{array}}
       \vdash
       {
@@ -628,7 +634,6 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
           \begin{array}{l}
             \var{e_p}\\
             \var{(\var{pv}, \var{pps})}\\
-            \var{fads}
           \end{array}
         \right)
       }
@@ -638,7 +643,6 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
           \begin{array}{l}
             \var{e_n}\\
             \var{(\var{pv}, \var{pps})}\\
-            \var{fads}
           \end{array}
         \right)
       }
@@ -655,7 +659,8 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
     {
       {\begin{array}{l}
          k\\
-         s_n
+         s_n\\
+         \var{fads}
        \end{array}}
       \vdash
       {
@@ -663,7 +668,6 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
           \begin{array}{l}
             \var{e_p}\\
             \var{(\var{pv}, \var{pps})}\\
-            \var{fads}
           \end{array}
         \right)
       }
@@ -673,29 +677,32 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
           \begin{array}{l}
             \var{e_n}\\
             \var{(\var{pv_c}, \var{pps_c})}\\
-            {[s_n - 2 \cdot k + 1, ..]} \restrictdom fads
           \end{array}
         \right)
       }
     }
   \end{equation}
-  \nextdef
+  \caption{Protocol version bump rules}
+  \label{fig:rules:fads}
+\end{figure}
+
+\begin{figure}[htb]
   \begin{equation}
-    \label{eq:rule:upi-ec}
+    \label{eq:rule:upi-ec-pv-unchanged}
     \inference
     {
       \var{stableAfter} \mapsto k \in  \var{pps} &
       {\begin{array}{l}
          k\\
-         s_n
+         s_n\\
+         \var{fads}
        \end{array}}
       \vdash
       {
         \left(
           \begin{array}{l}
             \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}\\
-            \var{fads}
+            \var{(\var{pv}, \var{pps})}
           \end{array}
         \right)
       }
@@ -705,20 +712,16 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
           \begin{array}{l}
             \var{e'}\\
             \var{(\var{pv'}, \var{pps'})}\\
-            \var{fads'}
           \end{array}
         \right)
-      }\\ ~ \\
-      \var{pids_{keep}} = \{ \var{pid} \mid
-      \var{pid} \mapsto (\var{pv_i}, \wcard) \in \var{rpus}
-      ,~ \var{pv'} < \var{pv_i}\}
+      }\\ ~ \\ \var{pv} = \var{pv'}
     }
     {
       {
         \begin{array}{l}
           e_c\\
           s_n\\
-          \var{dms}\\
+          \var{dms}
         \end{array}
       }
       \vdash
@@ -743,15 +746,89 @@ Rule~\ref{eq:rule:upi-ec} performs cleanup of several state variables:
         \left(
           \begin{array}{l}
             \var{e'}\\
-            \var{(\var{pv'}, \var{pps} \unionoverrideRight \var{pps'})}\\
-            \var{fads'}\\
+            \var{(\var{pv}, \var{pps})}\\
+            \var{fads}\\
             \var{avs}\\
-            \var{pids_{keep}} \restrictdom \var{rpus}\\
+            \var{rpus}\\
             \var{raus}\\
-            \var{pids_{keep}} \restrictdom \var{cps}\\
-            \var{pids_{keep}} \restrictdom \var{vts}\\
-            {[\var{pv'}, ..]} \restrictdom \var{bvs}\\
-            \var{pids_{keep}} \restrictdom \var{pws}
+            \var{cps}\\
+            \var{vts}\\
+            \var{bvs}\\
+            \var{pws}
+          \end{array}
+        \right)
+      }
+    }
+  \end{equation}
+  \nextdef
+  \begin{equation}
+    \label{eq:rule:upi-ec-pv-change}
+    \inference
+    {
+      \var{stableAfter} \mapsto k \in  \var{pps} &
+      {\begin{array}{l}
+         k\\
+         s_n\\
+         \var{fads}
+       \end{array}}
+      \vdash
+      {
+        \left(
+          \begin{array}{l}
+            \var{e_p}\\
+            \var{(\var{pv}, \var{pps})}
+          \end{array}
+        \right)
+      }
+      \trans{pvbump}{\var{e_n}}
+      {
+        \left(
+          \begin{array}{l}
+            \var{e'}\\
+            \var{(\var{pv'}, \var{pps'})}\\
+          \end{array}
+        \right)
+      }\\ ~ \\ \var{pv} \neq \var{pv'}
+    }
+    {
+      {
+        \begin{array}{l}
+          e_c\\
+          s_n\\
+          \var{dms}
+        \end{array}
+      }
+      \vdash
+      {
+        \left(
+          \begin{array}{l}
+            \var{e_p}\\
+            \var{(\var{pv}, \var{pps})}\\
+            \var{fads}\\
+            \var{avs}\\
+            \var{rpus}\\
+            \var{raus}\\
+            \var{cps}\\
+            \var{vts}\\
+            \var{bvs}\\
+            \var{pws}
+          \end{array}
+        \right)
+      }
+      \trans{upiec}{\var{e_n}}
+      {
+        \left(
+          \begin{array}{l}
+            \var{e'}\\
+            \var{(\var{pv'}, \var{pps'})}\\
+            \epsilon\\
+            \var{avs}\\
+            \emptyset\\
+            \var{raus}\\
+            \emptyset\\
+            \emptyset\\
+            \emptyset\\
+            \emptyset\\
           \end{array}
         \right)
       }

--- a/specs/ledger/latex/update-mechanism.tex
+++ b/specs/ledger/latex/update-mechanism.tex
@@ -226,8 +226,11 @@ The rules in Figure~\ref{fig:rules:up-validity} model the validity of a proposal
     then the proposed minor version must be zero.
   \item must be consistent with the current protocol parameters:
     \begin{itemize}
-    \item the proposal size must not exceed the maximum size specified by
-      the current protocol parameters,
+    \item the proposal size must not exceed the maximum size specified by the
+      current protocol parameters, (note that here we use function application
+      to extract the value of the different protocol parameters, and a rule
+      that uses a value of the map can be applied only if the function -e.g.
+      $\var{pps}$- is defined for that value)
     \item the proposed new maximum block size should be not greater than twice
       current maximum block size,
     \item the maximum transaction size must be smaller than the maximum block
@@ -259,7 +262,7 @@ cause a soft-fork we might use the alt version for that purpose.
   \begin{equation}
     \label{eq:func:pv-can-follow}
     \begin{array}{r c l}
-      \fun{pvCanFollow}~(\var{mj_n}, \var{mi_n}, \var{a_n})~(\var{mj_p}, \var{mi_p}, \var{a_p})
+      \fun{pvCanFollow}~(\var{mj_p}, \var{mi_p}, \var{a_p})~(\var{mj_n}, \var{mi_n}, \var{a_n})
       & = & (\var{mj_p}, \var{mi_p}, \var{a_p}) < (\var{mj_n}, \var{mi_n}, \var{a_n})\\
       & \wedge & 0 \leq \var{mj_n} - \var{mj_p} \leq 1\\
       & \wedge & (\var{mj_p} = \var{mj_n} \Rightarrow \var{mi_p} + 1 = \var{mi_n}))\\
@@ -270,19 +273,14 @@ cause a soft-fork we might use the alt version for that purpose.
   \begin{equation}
     \label{eq:func:can-update}
     \begin{array}{l}
-      \fun{canUpdate}~\var{pps}~\var{up}\\
+      \fun{canUpdate}~\var{pps}~\var{pps'}\\
       {\begin{array}{r c l}
-         & = & \var{maxProposalSize} \mapsto \var{mus} \in \var{pps}\\
-         & \wedge & \upSize{up} \leq \var{mus}\\
-         & \wedge & (\var{maxBlockSize} \mapsto \var{bszm_{up}} \in (\upParams{up})\\
-         & & \Rightarrow \var{maxBlockSize} \mapsto \var{bszm} \in \var{pps}
-             \wedge  \var{bszm_{up}} \leq 2*\var{bszm})\\
-         & \wedge & (\var{maxBlockSize} \mapsto \var{bszm_{up}} \in (\upParams{up})
-         \wedge \var{maxTxSize} \mapsto \var{txzm_{up}} \in (\upParams{up})\\
-         & & \Rightarrow \var{txzm_{up}} < \var{bszm_{up}})\\
-         & \wedge & (\var{scriptVersion} \mapsto \var{sv_{up}} \in (\upParams{up}) \\
-         & & \Rightarrow \var{scriptVersion} \mapsto \var{sv} \in \var{pps}
-             \wedge  0 \leq \var{sv_{up}} - \var{sv} \leq 1)
+         & = & \var{pps'}~\var{maxBlockSize} \leq 2\cdot\var{pps}~\var{maxBlockSize}\\
+         & \wedge & \var{pps'}~\var{maxBlockSize} <  \var{pps'}~\var{maxTxSize}\\
+         & \wedge
+             & 0 \leq
+               \var{pps'}~\var{scriptVersion} - \var{pps}~\var{scriptVersion}
+               \leq 1
        \end{array}}
     \end{array}
   \end{equation}
@@ -337,11 +335,11 @@ cause a soft-fork we might use the alt version for that purpose.
     \label{eq:rule:up-pv-validity}
     \inference
     {
-      \var{pid} = \upId{up}
+      \var{pps'} = \var{pps} \unionoverrideRight \upParams{up}
+      & \fun{canUpdate}~\var{pps}~\var{pps'}\\
       & \var{nv} = \upPV{up}
-      & \var{pps_n} = \upParams{up}\\
-      & \fun{pvCanFollow}~\var{nv}~\var{pv}
-      & \fun{canUpdate}~\var{pps}~\var{up}
+      & \fun{pvCanFollow}~\var{nv}~\var{pv}\\
+      & \upSize{up} \leq \var{pps}~\var{maxProposalSize}
       & \var{nv} \notin \dom~(\range~\var{rpus})
     }
     {
@@ -363,7 +361,8 @@ cause a soft-fork we might use the alt version for that purpose.
       {
         \left(
           \begin{array}{l}
-            \var{rpus} \unionoverrideRight \{ \var{pid} \mapsto (\var{nv}, \var{pps_n}) \}
+            \var{rpus} \unionoverrideRight
+            \{ \upId{up} \mapsto (\var{nv}, \var{pps'}) \}
           \end{array}
         \right)
       }


### PR DESCRIPTION
On epoch change, now we discard the the pending protocol update proposals:

![image](https://user-images.githubusercontent.com/175315/54885448-6d68b280-4e7c-11e9-9021-8a9b0166414b.png)

The `PVBUMP` transition system is now in its own Figure:

![image](https://user-images.githubusercontent.com/175315/54885468-a0ab4180-4e7c-11e9-913a-230d421a8486.png)

We need not clean up the `fads` set anymore, since it will get cleaned up on protocol parameters change.

The `UPPVV` (update protocol version validation) rule registers the update as the current protocol parameters overwritten by the values in the update proposal. This allows for a simpler implementation (since we do not have to consider `Maybe` values):

![image](https://user-images.githubusercontent.com/175315/54885506-14e5e500-4e7d-11e9-8a49-146b42dbfaa5.png)


The `canUpdate` function is simplified now by using the protocols parameters map as a function:

![image](https://user-images.githubusercontent.com/175315/54885494-ea942780-4e7c-11e9-9a50-066722be064d.png)

Closes #357 