### PR TITLE
Adapt the meaning of `upAdpThd` to coincide with the actual implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,28 @@
 ## Ignore LaTeX build products
-**/latex/*.aux
-**/latex/*.lof
-**/latex/*.log
-**/latex/*.lot
-**/latex/*.fls
-**/latex/*.out
-**/latex/*.toc
-**/latex/*.fmt
-**/latex/*.fot
-**/latex/*.cb
-**/latex/*.cb2
-**/latex/*.lb
-**/latex/*.pdf
-**/latex/*.fdb_latexmk
-**/latex/auto
-**/latex/*.synctex.gz
+**/*.aux
+**/*.lof
+**/*.log
+**/*.lot
+**/*.fls
+**/*.out
+**/*.toc
+**/*.fmt
+**/*.fot
+**/*.cb
+**/*.cb2
+**/*.lb
+**/*.pdf
+**/*.fdb_latexmk
+**/auto
+**/*.synctex.gz
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
-**/latex/*.bbl
-**/latex/*.bcf
-**/latex/*.blg
-**/latex/*-blx.aux
-**/latex/*-blx.bib
-**/latex/*.run.xml
+**/*.bbl
+**/*.bcf
+**/*.blg
+**/*-blx.aux
+**/*-blx.bib
+**/*.run.xml
 
 # Cabal & Stack
 .stack-work/

--- a/byron/ledger/formal-spec/Makefile
+++ b/byron/ledger/formal-spec/Makefile
@@ -32,10 +32,10 @@ all: $(DOCNAME).pdf
 # missing file reference and interactively asking you for an alternative.
 
 $(DOCNAME).pdf: $(DOCNAME).tex
-	latexmk -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make $(DOCNAME).tex
+	latexmk -pdf -pdflatex="pdflatex -interaction=nonstopmode -synctex=1" -use-make $(DOCNAME).tex
 
 watch: $(DOCNAME).tex
-	latexmk -pvc -pdf -pdflatex="pdflatex -interaction=nonstopmode" -use-make $(DOCNAME).tex
+	latexmk -pvc -pdf -pdflatex="pdflatex -interaction=nonstopmode -synctex=1" -use-make $(DOCNAME).tex
 
 clean:
 	latexmk -CA

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -232,7 +232,7 @@ labels have the following meaning:
         \right)
       }
       &
-      pws' = pws \unionoverrideRight \{ \upId{up} \mapsto s_n\}
+      pws' \leteq pws \unionoverrideRight \{ \upId{up} \mapsto s_n\}
     }
     {
       {
@@ -334,7 +334,7 @@ given application name $\var{an}$.
           \end{array}
         \right)
       }\\
-      \var{avs_{new}} = \{ \var{an} \mapsto (\var{av}, \var{s_n})
+      \var{avs_{new}} \leteq \{ \var{an} \mapsto (\var{av}, \var{s_n})
       \mid \var{pid} \mapsto (\var{an}, \var{av}) \in \var{raus}
       ,~ \var{pid} \in \dom~\var{cps'}
       \}
@@ -343,7 +343,7 @@ given application name $\var{an}$.
       {
         \begin{array}{l}
           s_n\\
-          \var{nkg}\\
+          \var{ngk}\\
           \var{dms}
         \end{array}
       }
@@ -437,7 +437,7 @@ Figure~\ref{fig:st-diagram-pt-up}.
 
 The interface rule for protocol-version endorsement makes use of the
 $\trans{upend}{}$ transition, where we set the threshold for proposal adoption
-to: the number of genesis keys ($\var{nkg}$) times the minimum proportion of
+to: the number of genesis keys ($\var{ngk}$) times the minimum proportion of
 genesis keys that need to endorse an update proposal for it to become a
 candidate for adoption (given by the protocol parameter $\var{upAdptThd}$). In
 addition, the unconfirmed proposals that are older than $u$ blocks are removed
@@ -469,7 +469,7 @@ the end on an epoch.
         \begin{array}{l}
           k\\
           s_n\\
-          q \cdot \var{nkg}\\
+          q \cdot \var{ngk}\\
           \var{dms}\\
           \var{cps}\\
           \var{rpus}
@@ -497,7 +497,7 @@ the end on an epoch.
       & \var{upropTTL} \mapsto u \in \var{pps}
       & \var{upAdptThd} \mapsto q \in \var{pps} \\
       {
-        \begin{array}{r@{~=~}l}
+        \begin{array}{r@{~\leteq~}l}
           \var{pids_{keep}} & \dom~(pws \restrictrange [s_n - u, ..]) \cup \dom~\var{cps}\\
           \var{vs_{keep}} & \dom~(\range~\var{rpus'})\\
           \var{rpus'} & \var{pids_{keep}} \restrictdom \var{rpus}
@@ -508,7 +508,7 @@ the end on an epoch.
       {
         \begin{array}{l}
           s_n\\
-          \var{nkg}\\
+          \var{ngk}\\
           \var{dms}
         \end{array}
       }

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -152,8 +152,8 @@ labels have the following meaning:
     & \UPIEnv
       = \left(
       \begin{array}{r@{~\in~}lr}
-        \var{e_c} & \Epoch & \text{current epoch}\\
         \var{s_n} & \Slot & \text{current slot number}\\
+        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
       \end{array}\right)
   \end{align*}
@@ -237,8 +237,8 @@ labels have the following meaning:
     {
       {
         \begin{array}{l}
-          e_c\\
           s_n\\
+          \var{ngk}\\
           \var{dms}
         \end{array}
       }
@@ -342,8 +342,8 @@ given application name $\var{an}$.
     {
       {
         \begin{array}{l}
-          e_c\\
           s_n\\
+          \var{nkg}\\
           \var{dms}
         \end{array}
       }
@@ -436,9 +436,12 @@ Figure~\ref{fig:st-diagram-pt-up}.
 \clearpage
 
 The interface rule for protocol-version endorsement makes use of the
-$\trans{upend}{}$ transition, passing only the portion of the state relevant
-to it. In addition, the unconfirmed proposals that are older than $u$ blocks
-are removed from the parts of the state that hold:
+$\trans{upend}{}$ transition, where we set the threshold for proposal adoption
+to: the number of genesis keys ($\var{nkg}$) times the minimum proportion of
+genesis keys that need to endorse an update proposal for it to become a
+candidate for adoption (given by the protocol parameter $\var{upAdptThd}$). In
+addition, the unconfirmed proposals that are older than $u$ blocks are removed
+from the parts of the state that hold:
 \begin{itemize}
 \item the registered protocol and software update proposals,
 \item the votes associated with the proposals,
@@ -466,8 +469,8 @@ the end on an epoch.
         \begin{array}{l}
           k\\
           s_n\\
+          q \cdot \var{nkg}\\
           \var{dms}\\
-          (\var{pv}, \var{pps})\\
           \var{cps}\\
           \var{rpus}
         \end{array}
@@ -490,8 +493,9 @@ the end on an epoch.
           \end{array}
         \right)
       }\\
-      \var{stableAfter} \mapsto k \in  \var{pps} &
-      \var{upropTTL} \mapsto u \in \var{pps} \\
+      \var{stableAfter} \mapsto k \in  \var{pps}
+      & \var{upropTTL} \mapsto u \in \var{pps}
+      & \var{upAdptThd} \mapsto q \in \var{pps} \\
       {
         \begin{array}{r@{~=~}l}
           \var{pids_{keep}} & \dom~(pws \restrictrange [s_n - u, ..]) \cup \dom~\var{cps}\\
@@ -503,8 +507,8 @@ the end on an epoch.
     {
       {
         \begin{array}{l}
-          e_c\\
           s_n\\
+          \var{nkg}\\
           \var{dms}
         \end{array}
       }
@@ -727,8 +731,8 @@ expires.
     {
       {
         \begin{array}{l}
-          e_c\\
           s_n\\
+          \var{ngk}\\
           \var{dms}
         \end{array}
       }
@@ -801,8 +805,8 @@ expires.
     {
       {
         \begin{array}{l}
-          e_c\\
           s_n\\
+          \var{ngk}\\
           \var{dms}
         \end{array}
       }

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -133,9 +133,9 @@ $\trans{sdeleg}{\wcard}$ are presented in
     \label{eq:rule:delegation-scheduling}
     \inference
     {
-      (\var{vk_s},~ \sigma) = \dwit{c}
+      (\var{vk_s},~ \sigma) \leteq \dwit{c}
       & \verify{vk_s}{\serialised{\dbody{c}}}{\sigma} & vk_s \in \mathcal{K}\\ ~ \\
-      (\var{vk_s},~ \var{vk_d}) = \dwho{c} & e_d = \depoch{c}
+      (\var{vk_s},~ \var{vk_d}) \leteq \dwho{c} & e_d \leteq \depoch{c}
       & (e_d,~ \var{vk_s}) \notin \var{eks} & 0 \leq e_d - e \leq 1 \\ ~ \\
       d \leteq 2 \cdot k & (s + d,~ (\var{vk_s},~ \wcard)) \notin \var{sds}\\
     }
@@ -252,8 +252,8 @@ delegation certificate (Rule~\ref{eq:rule:delegation-nop}).
   \begin{equation}
     \inference
     {
-      \var{dms_0} = \Set{k \mapsto k}{k \in \mathcal{K}} &
-      \var{dws_0} = \Set{k \mapsto 0}{k \in \mathcal{K}}
+      \var{dms_0} \leteq \Set{k \mapsto k}{k \in \mathcal{K}} &
+      \var{dws_0} \leteq \Set{k \mapsto 0}{k \in \mathcal{K}}
     }
     {
       \mathcal{K}
@@ -469,8 +469,8 @@ delegations have on the ledger.
   \begin{equation}
     \inference[Initial-ADELEGS]
     {
-      \var{dms_0} = \Set{k \mapsto k}{k \in \mathcal{K}} &
-      \var{dws_0} = \Set{k \mapsto 0}{k \in \mathcal{K}}
+      \var{dms_0} \leteq \Set{k \mapsto k}{k \in \mathcal{K}} &
+      \var{dws_0} \leteq \Set{k \mapsto 0}{k \in \mathcal{K}}
     }
     {
       \mathcal{K}

--- a/byron/ledger/formal-spec/notation.tex
+++ b/byron/ledger/formal-spec/notation.tex
@@ -2,7 +2,8 @@
 
 \begin{description}
 \item[Natural Numbers] The set $\mathbb{N}$ refers to the set of all natural
-  numbers $\{0, 1, 2, \ldots\}$.
+  numbers $\{0, 1, 2, \ldots\}$. The set $\mathbb{Q}$ refers to the set of
+  rational numbers.
 \item[Powerset] Given a set $\type{X}$, $\powerset{\type{X}}$ is the set of all
   the subsets of $X$.
 \item[Sequences] Given a set $\type{X}$, $\seqof{\type{X}}$ is the set of

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -137,8 +137,9 @@ this specification can be extended to incorporate the research results.
 \end{figure}
 
 The set of protocol parameters ($\ProtPm$) is assumed to contain the following
-keys, some of which correspond with fields of the current `BlockVersionData`
-structure:
+keys, some of which correspond with fields of the
+\href{https://github.com/input-output-hk/cardano-sl/}{\texttt{cardano-sl}}
+`BlockVersionData` structure:
 \begin{itemize}
 \item Slot duration: $\var{slotDuration}$
 \item Maximum block size: $\var{maxBlockSize}$
@@ -148,9 +149,10 @@ structure:
 \item Maximum proposal size: $\var{maxProposalSize}$
 \item Transaction fee policy: $\var{txFeePolicy}$
 \item Script version: $\var{scriptVersion}$
-\item Update adoption threshold: $\var{upAdptThd}$. This would correspond with
-  `srInitThd` in `SoftForkRule`, if we set `srMinThd` to `srInitThd` and
-  `srThdDecrement` to $0$.
+\item Update adoption threshold : $\var{upAdptThd}$. This represents the
+  minimum percentage of the total number of genesis keys that have to endorse a
+  protocol version to be able to become adopted. This parameter would
+  correspond with `srMinThd` in `bvdSoftforkRule`.
 \item Chain stability parameter: $\var{stableAfter}$.
 \item Update proposal time-to-live: $\var{upropTTL}$. This would correspond to
   the number of slots specified by `bvdUpdateImplicit`. In `cardano-sl` the
@@ -988,11 +990,10 @@ blocks. Some clarifications are in order:
     & \BVREnv
       = \left(
       \begin{array}{r@{~\in~}lr}
-        \var{k} & \mathbb{N} & \text{chain stability parameter}\\
-        \var{s_n} & \Slot & \text{current block number}\\
+        k & \mathbb{N} & \text{chain stability parameter}\\
+        \var{s_n} & \Slot & \text{current slot number}\\
+        t & \mathbb{Q} & \text{adoption threshold percentage}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
-        (\var{pv}, \var{pps}) & \ProtVer \times \PPMMap
-                             & \text{current protocol parameters map}\\
         \var{cps} & \UPropId \mapsto \Slot & \text{confirmed proposals}\\
         \var{rpus} & \UPropId \mapsto (\ProtVer \times \PPMMap)
                              & \text{registered update proposals}\\
@@ -1039,7 +1040,7 @@ rule by $\var{bv}$:
   incorporate the results of ongoing research on a decentralized update
   mechanism.
 \item If there are a significant number of genesis keys that endorse $\var{bv}$
-  (condition formalized in \cref{eq:predicate:canadopt}), there is a registered
+  (the $t$ environment variable is used for this), there is a registered
   proposal (which are contained in $\var{rpus}$) which proposes to upgrade the
   protocol to version $\var{bv}$, and this update proposal was confirmed at
   least $2 \cdot k$ slots ago (to ensure stability of the confirmation), then
@@ -1061,19 +1062,6 @@ rule by $\var{bv}$:
 \item If a block version does not correspond to a registered or confirmed
   proposal, we just ignore the endorsement.
 \end{itemize}
-
-\begin{figure}[htb]
-  \begin{equation}
-    \label{eq:predicate:canadopt}
-    \begin{array}{r c l}
-      \fun{canAdopt}~\var{pps}~\var{bvs}~\var{bv}
-      & =
-      & \var{upAdptThd} \mapsto t \in pps \wedge
-        t \leq \size{\{\var{bv}\} \restrictdom \var{bvs}}\\
-    \end{array}
-  \end{equation}
-  \caption{Update-proposal endorsement functions}
-\end{figure}
 
 \begin{figure}[htb]
   \begin{equation}
@@ -1140,8 +1128,8 @@ rule by $\var{bv}$:
         \begin{array}{l}
           k\\
           s_n\\
+          t\\
           \var{dms}\\
-          (\var{pv}, \var{pps})\\
           \var{cps}\\
           \var{rpus}
         \end{array}
@@ -1174,7 +1162,7 @@ rule by $\var{bv}$:
     {
       \var{bvs'} = \var{bvs} \cup
       \{ (\var{bv}, \var{vk_s}) \mid \var{vk_s} \mapsto \var{vk} \in \var{dms} \}
-      & \neg (\fun{canAdopt}~\var{pps}~\var{bvs'}~\var{bv}) \\
+      & \size{\{\var{bv}\} \restrictdom \var{bvs}} < t\\
       \var{pid} \mapsto (\var{bv}, \wcard) \in \var{rpus}
       & \var{pid} \in \dom~(\var{cps} \restrictrange [.., s_n - 2 \cdot k])
     }
@@ -1183,8 +1171,8 @@ rule by $\var{bv}$:
         \begin{array}{l}
           k\\
           s_n\\
+          t\\
           \var{dms}\\
-          (\var{pv}, \var{pps})\\
           \var{cps}\\
           \var{rpus}
         \end{array}
@@ -1218,7 +1206,7 @@ rule by $\var{bv}$:
     {
       \var{bvs'} = \var{bvs} \cup
       \{ (\var{bv}, \var{vk_s}) \mid \var{vk_s} \mapsto \var{vk} \in \var{dms} \}
-      & \fun{canAdopt}~\var{pps}~\var{bvs'}~\var{bv} \\
+      & t \leq \size{\{\var{bv}\} \restrictdom \var{bvs}}\\
       \var{pid} \mapsto (\var{bv}, \var{pps_c}) \in \var{rpus}
       & \var{pid} \in \dom~(\var{cps} \restrictrange [.., s_n - 2 \cdot k])\\
       (\var{fads}) \trans{fads}{(s_n, (\var{bv}, \var{pps_c}))} (\var{fads'})
@@ -1228,8 +1216,8 @@ rule by $\var{bv}$:
         \begin{array}{l}
           k\\
           s_n\\
+          t\\
           \var{dms}\\
-          (\var{pv}, \var{pps})\\
           \var{cps}\\
           \var{rpus}
         \end{array}

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -304,7 +304,7 @@ cause a soft-fork we might use the alt version for that purpose.
     \label{eq:rule:up-av-validity}
     \inference
     {
-      (\var{an}, \var{av}) = \upSwVer{up}
+      (\var{an}, \var{av}) \leteq \upSwVer{up}
       & \fun{svCanFollow}~\var{avs}~(\var{an}, \var{av})
       & (\var{an}, \var{av}) \notin \range~\var{raus}
     }
@@ -337,9 +337,9 @@ cause a soft-fork we might use the alt version for that purpose.
     \label{eq:rule:up-pv-validity}
     \inference
     {
-      \var{pps'} = \var{pps} \unionoverrideRight \upParams{up}
+      \var{pps'} \leteq \var{pps} \unionoverrideRight \upParams{up}
       & \fun{canUpdate}~\var{pps}~\var{pps'}\\
-      & \var{nv} = \upPV{up}
+      & \var{nv} \leteq \upPV{up}
       & \fun{pvCanFollow}~\var{nv}~\var{pv}\\
       & \upSize{up} \leq \var{pps}~\var{maxProposalSize}
       & \var{nv} \notin \dom~(\range~\var{rpus})
@@ -398,7 +398,7 @@ cause a soft-fork we might use the alt version for that purpose.
         \right)
       }
       &
-      (\var{an}, \var{av}) = \upSwVer{up} & \var{an} \mapsto (\var{av}, \_) \in \var{avs}
+      (\var{an}, \var{av}) \leteq \upSwVer{up} & \var{an} \mapsto (\var{av}, \_) \in \var{avs}
     }
     {
       {
@@ -433,7 +433,7 @@ cause a soft-fork we might use the alt version for that purpose.
     \label{eq:rule:up-validity-nopu-no}
     \inference
     {
-      \var{pv} = \upPV{up} & \upParams{up} = \emptyset &
+      \var{pv} \leteq \upPV{up} & \upParams{up} \leteq \emptyset &
       {
         \begin{array}{l}
           \var{avs}
@@ -650,7 +650,7 @@ an update proposal:
       }
       &
       \var{dms} \restrictrange \{\var{vk}\} \neq \emptyset\\
-      \var{vk} = \upIssuer{up} &
+      \var{vk} \leteq \upIssuer{up} &
       \mathcal{V}_{\var{vk}}\serialised{\upSigData{up}}_{(\upSig{up})}
     }
     {
@@ -758,8 +758,8 @@ In Rule~\ref{eq:rule:voting}:
     \label{eq:rule:voting}
     \inference
     {
-      \var{pid} = \vPropId{v} & \var{vk} = \vCaster{v} & \var{pid} \in \var{rups}\\
-      \var{vts}_{\var{pid}} =
+      \var{pid} \leteq \vPropId{v} & \var{vk} \leteq \vCaster{v} & \var{pid} \in \var{rups}\\
+      \var{vts}_{\var{pid}} \leteq
       \{ (\var{pid}, \var{vk_s}) \mid \var{vk_s} \mapsto \var{vk} \in \var{dms} \} &
       \var{vts}_{\var{pid}} \neq \emptyset &
       \mathcal{V}_{\var{vk}}\serialised{\var{pid}}_{(\vSig{v})}\\
@@ -867,7 +867,7 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
           \end{array}
         \right)
       }\\
-      \var{pid} = \vPropId{v}
+      \var{pid} \leteq \vPropId{v}
       & \var{cfmThd} \mapsto t \in \var{pps}
       & (\size{\{\var{pid}\} \restrictdom \var{vts'}} < t
       \vee \var{pid} \in \dom~\var{cps}
@@ -929,7 +929,7 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
           \end{array}
         \right)
       }\\
-      \var{pid} = \vPropId{v}
+      \var{pid} \leteq \vPropId{v}
       & \var{cfmThd} \mapsto t \in \var{pps}
       & t \leq \size{\{\var{pid}\} \restrictdom \var{vts'}}
       & \var{pid} \notin \dom~\var{cps}
@@ -1160,7 +1160,7 @@ rule by $\var{bv}$:
     \label{eq:rule:up-cant-adopt}
     \inference
     {
-      \var{bvs'} = \var{bvs} \cup
+      \var{bvs'} \leteq \var{bvs} \cup
       \{ (\var{bv}, \var{vk_s}) \mid \var{vk_s} \mapsto \var{vk} \in \var{dms} \}
       & \size{\{\var{bv}\} \restrictdom \var{bvs}} < t\\
       \var{pid} \mapsto (\var{bv}, \wcard) \in \var{rpus}
@@ -1204,7 +1204,7 @@ rule by $\var{bv}$:
     \label{eq:rule:up-canadopt}
     \inference
     {
-      \var{bvs'} = \var{bvs} \cup
+      \var{bvs'} \leteq \var{bvs} \cup
       \{ (\var{bv}, \var{vk_s}) \mid \var{vk_s} \mapsto \var{vk} \in \var{dms} \}
       & t \leq \size{\{\var{bv}\} \restrictdom \var{bvs}}\\
       \var{pid} \mapsto (\var{bv}, \var{pps_c}) \in \var{rpus}

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -992,7 +992,7 @@ blocks. Some clarifications are in order:
       \begin{array}{r@{~\in~}lr}
         k & \mathbb{N} & \text{chain stability parameter}\\
         \var{s_n} & \Slot & \text{current slot number}\\
-        t & \mathbb{Q} & \text{adoption threshold percentage}\\
+        t & \mathbb{Q} & \text{adoption threshold}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
         \var{cps} & \UPropId \mapsto \Slot & \text{confirmed proposals}\\
         \var{rpus} & \UPropId \mapsto (\ProtVer \times \PPMMap)


### PR DESCRIPTION
- Adapt the update rules so that the meaning of `upAdptThd` coincides with `srMinThd . ppSoftforkRule` in the implementation.
- Remove unused current epoch from the environment of the update interface rules.
- Use synctex in the ledger specs.

Closes #377 
Closes #296 