### PR TITLE
[#326] Replace Map with Bimap in the delegation state

### DIFF
--- a/byron/chain/executable-spec/cs-blockchain.cabal
+++ b/byron/chain/executable-spec/cs-blockchain.cabal
@@ -34,6 +34,7 @@ library
   hs-source-dirs:      src
   default-language:    Haskell2010
   build-depends:       base >=4.11 && <5
+                     , bimap
                      , bytestring
                      , containers
                      , cryptonite

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
@@ -5,7 +5,7 @@
 module Cardano.Spec.Chain.STS.Rule.BHead where
 
 import Control.Lens ((^.))
-import Data.Map.Strict (Map)
+import Data.Bimap (Bimap)
 import Data.Sequence (Seq)
 
 import Control.State.Transition
@@ -21,7 +21,7 @@ data BHEAD
 instance STS BHEAD where
   type Environment BHEAD
     = ( Slot
-      , Map VKeyGenesis VKey
+      , Bimap VKeyGenesis VKey
       )
   type State BHEAD
     = ( Epoch

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -9,8 +9,8 @@ module Cardano.Spec.Chain.STS.Rule.Chain where
 
 import Control.Lens ((^.), _1, _3, _5, Lens')
 import qualified Crypto.Hash
+import qualified Data.Bimap as Bimap
 import Data.ByteString (ByteString)
-import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Data.Sequence (Seq)
 import qualified Hedgehog.Gen as Gen
@@ -191,7 +191,7 @@ instance HasTrace CHAIN where
     -- size numbers.
     slotInc <- Gen.integral (Range.exponential 0 10)
     -- Get some random issuer from the delegates of the delegation map.
-    vkI <- Gen.element $ Map.elems (ds ^. dms)
+    vkI <- Gen.element $ Bimap.elems (ds ^. dms)
     let dsEnv
           = DSEnv
           { _dSEnvAllowedDelegators = gks

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -29,6 +29,7 @@ library
                      , Ledger.Update
                      , Ledger.UTxO
   build-depends:       base >=4.11 && <5
+                     , bimap
                      , bytestring
                      , containers
                      , cryptonite
@@ -85,6 +86,7 @@ test-suite ledger-delegation-test
   type: exitcode-stdio-1.0
   default-language:    Haskell2010
   build-depends: base
+               , bimap
                , containers
                , lens
                , hedgehog

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
@@ -6,6 +6,7 @@ module Ledger.Delegation.Examples
   )
 where
 
+import qualified Data.Bimap as Bimap (fromList)
 import Data.Set (fromList, Set)
 import Data.Word (Word64)
 import Numeric.Natural (Natural)
@@ -38,18 +39,18 @@ deleg =
   [ testGroup "Activation"
     [ testCase "Example 0" $ checkTrace @ADELEG genKeys $
 
-      pure (DState [] [])
+      pure (DState (Bimap.fromList []) [])
 
-      .- (s 0, (gk 0, k 10)) .-> DState [(gk 0, k 10)]
+      .- (s 0, (gk 0, k 10)) .-> DState (Bimap.fromList [(gk 0, k 10)])
                                         [(gk 0, s 0)]
 
-      .- (s 1, (gk 1, k 11)) .-> DState [(gk 0, k 10), (gk 1, k 11)]
+      .- (s 1, (gk 1, k 11)) .-> DState (Bimap.fromList [(gk 0, k 10), (gk 1, k 11)])
                                         [(gk 0, s 0), (gk 1, s 1)]
 
-      .- (s 2, (gk 0, k 11)) .-> DState [(gk 0, k 11), (gk 1, k 11)]
+      .- (s 2, (gk 0, k 11)) .-> DState (Bimap.fromList [(gk 0, k 11), (gk 1, k 11)])
                                         [(gk 0, s 2), (gk 1, s 1)]
 
-      .- (s 3, (gk 2, k 12)) .-> DState [(gk 0, k 11), (gk 1, k 11), (gk 2, k 12)]
+      .- (s 3, (gk 2, k 12)) .-> DState (Bimap.fromList [(gk 0, k 11), (gk 1, k 11), (gk 2, k 12)])
                                         [(gk 0, s 2), (gk 1, s 1), (gk 2, s 3)]
     ]
 

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -12,8 +12,9 @@ where
 
 import Control.Arrow ((&&&), first)
 import Control.Lens ((^.), makeLenses, (&), (.~), view, to)
+import Data.Bimap (Bimap)
+import qualified Data.Bimap as Bimap
 import Data.List (last)
-import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Hedgehog
@@ -114,7 +115,7 @@ import Ledger.Core.Generator (vkGen)
 -- | Initial state for the ADELEG and ADELEGS systems
 initADelegsState :: DState
 initADelegsState = DState
-  { _dStateDelegationMap  = Map.empty
+  { _dStateDelegationMap  = Bimap.empty
   , _dStateLastDelegation = Map.empty
   }
 
@@ -224,8 +225,8 @@ expectedDms
   -> [(Int, DBlock)]
   -- ^ Delegation certificates to apply, and the slot at which these
   -- certificates where scheduled.
-  -> Map VKeyGenesis VKey
-expectedDms s d sbs = Map.fromList (fmap (delegator &&& delegate) activeCerts)
+  -> Bimap VKeyGenesis VKey
+expectedDms s d sbs = Bimap.fromList (fmap (delegator &&& delegate) activeCerts)
   where
     -- | We keep all the blocks whose certificates should be active given the
     -- current slot.

--- a/nix/.stack.nix/cs-blockchain.nix
+++ b/nix/.stack.nix/cs-blockchain.nix
@@ -18,6 +18,7 @@
       "library" = {
         depends = [
           (hsPkgs.base)
+          (hsPkgs.bimap)
           (hsPkgs.bytestring)
           (hsPkgs.containers)
           (hsPkgs.cryptonite)

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -18,6 +18,7 @@
       "library" = {
         depends = [
           (hsPkgs.base)
+          (hsPkgs.bimap)
           (hsPkgs.bytestring)
           (hsPkgs.containers)
           (hsPkgs.cryptonite)
@@ -47,6 +48,7 @@
         "ledger-delegation-test" = {
           depends = [
             (hsPkgs.base)
+            (hsPkgs.bimap)
             (hsPkgs.containers)
             (hsPkgs.lens)
             (hsPkgs.hedgehog)


### PR DESCRIPTION
_Closes issue #326_

> The delegation map is now injective #292. We could be more explicit about this fact in our code by changing the type of the delegation map from Map VKeyGenesis VKey to Bimap VKeyGenesis VKey, where Bimap can be found here.
>
>Another reason for wanting this is that the operation for finding which genesis key delegated to a given key becomes O (log n) instead of O (n).