### PR TITLE
Split protocol parameters into updatable and non-updateable

### DIFF
--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -384,15 +384,32 @@ block header, since the block body is entirely concerned with the ledger.
 \newcommand{\BSCEnv}{\type{BSCEnv}}
 \newcommand{\BSCState}{\type{BSCState}}
 
-To guard against the compromise of a minority of the genesis keys,
-we require that in the rolling window of the last $k$ blocks, the number of
-blocks signed by keys that $sk_s$ delegated to is no more than a threshold $k
-\cdot t$, where $t$ is a constant that will be picked in the range
-$1/5 \leq t \leq 1/4$. Initial research suggests setting $t=0.22$ as a good
-value. Specifically, given $k=2160$, we would allow a single genesis key to
-issue (via delegates) $475$ blocks (since $2160 \cdot 0.22 = 475.2$), but a
-$476^{\text{th}}$ block would be rejected. See Appendix
-\ref{apdx:calculating-t} for the background on this value.
+To guard against the compromise of a minority of the genesis keys, we require
+that in the rolling window of the last $k$ blocks, where $k$ is the chain
+stability parameter, the number of blocks signed by keys that $sk_s$ delegated
+to is no more than a threshold $k \cdot t$, where $t$ is a constant that will
+be picked in the range $1/5 \leq t \leq 1/4$. Initial research suggests setting
+$t=0.22$ as a good value. Specifically, given $k=2160$, we would allow a single
+genesis key to issue (via delegates) $475$ blocks (since
+$2160 \cdot 0.22 = 475.2$), but a $476^{\text{th}}$ block would be rejected.
+See Appendix \ref{apdx:calculating-t} for the background on this value. The
+abstract constant (functions) related to the protocol are defined in
+\cref{fig:defs:proto-abstract-funcs}.
+
+\begin{figure}[ht]
+  \emph{Abstract functions}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      k & \mathbb{N} & \text{chain stability parameter}\\
+      t & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{block signature count threshold}\\
+    \end{array}
+  \end{equation*}
+
+  \caption{Protocol abstract functions}
+  \label{fig:defs:proto-abstract-funcs}
+\end{figure}
+
 
 Figure \ref{fig:rules:sigcnt} gives the rules for signature counting. We verify
 that the key that delegates to the signer of this block has not already signed
@@ -408,8 +425,6 @@ outside the size of the moving window ($k$).
     \BSCEnv =
     \left(
       \begin{array}{r@{~\in~}lr}
-        k & \mathbb{N} & \text{chain stability parameter} \\
-        t & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{block signature count threshold}\\
         \var{ds} & \DelegState & \text{delegation state} \\
       \end{array}
     \right)
@@ -433,18 +448,12 @@ outside the size of the moving window ($k$).
       \size{\fun{filter}~(=\var{vk_g})~\var{sgs'}} \leq k \cdot t \\
     }
     {
-      \left(
-        {\begin{array}{l}
-           k\\
-           t\\
-           \var{ds}
-         \end{array}}
-     \right)
-     \vdash
-     {\var{sgs}}
-     \trans{sigcnt}{\var{vk_d}}
-     {\var{sgs'}}
-   }
+      \var{ds}
+      \vdash
+      {\var{sgs}}
+      \trans{sigcnt}{\var{vk_d}}
+      {\var{sgs'}}
+    }
    \label{eq:rule:sigcnt}
  \end{equation*}
  \caption{Block signature count rules}
@@ -514,8 +523,6 @@ During PBFT processing of the block header, we do the following:
     \PBFTEnv =
     \left(
       \begin{array}{r@{~\in~}lr}
-        k & \mathbb{N} & \text{chain stability parameter} \\
-        t & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{block signature count threshold}\\
         \var{ds} & \DelegState & \text{delegation state} \\
         \var{s_{last}} & \Slot & \text{slot for which the last known block was issued} \\
         \var{s_{now}} & \Slot & \text{current slot} \\
@@ -550,13 +557,7 @@ During PBFT processing of the block header, we do the following:
       \\ \var{s} > \var{s_{last}} & \var{s} \leq \var{s_{now}}
       \\ \bhprevhash{bh} = \var{h} & \verify{vk_d}{\serialised{\bhtosign{bh}}}{(\bhsig{bh})}
       \\
-      {\left(
-          \begin{array}{l}
-            k\\
-            t\\
-            ds
-          \end{array}
-        \right)}
+      ds
       \vdash
       \var{sgs} \trans{sigcnt}{\var{vk_d}} \var{sgs'}
       \\
@@ -564,8 +565,6 @@ During PBFT processing of the block header, we do the following:
     {
       \left(
         {\begin{array}{c}
-           k\\
-           t\\
            \var{ds} \\
            \var{s_{last}} \\
            \var{s_{now}} \\
@@ -648,7 +647,6 @@ updates the update state to the correct version.
     & \ETEnv
       = \left(
       \begin{array}{r@{~\in~}lr}
-        k & \mathbb{N} & \text{chain stability parameter}\\
         \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
         \var{e_c} & \Epoch & \text{Current epoch}
@@ -668,7 +666,7 @@ updates the update state to the correct version.
   \emph{Epoch transition transitions}
   \begin{equation*}
     \_ \vdash \var{\_} \trans{epoch}{\_} \var{\_} \subseteq
-    \powerset ((\VKey \mapsto \VKeyGen) \times \ETState \times \Slot \times \ETState)
+    \powerset (\ETEnv \times \ETState \times \Slot \times \ETState)
   \end{equation*}
   \caption{Epoch transition transition-system types}
   \label{fig:ts-types:epoch}
@@ -683,7 +681,6 @@ updates the update state to the correct version.
     {
       {\left(
         \begin{array}{l}
-          k\\
           \var{ngk}\\
           \var{dms}\\
           \var{e_c}
@@ -717,7 +714,6 @@ updates the update state to the correct version.
     &
     {\left(
         \begin{array}{l}
-          k\\
           s\\
           \var{ngk}\\
           \var{dms}
@@ -729,7 +725,6 @@ updates the update state to the correct version.
   {
     {
       \begin{array}{l}
-        k\\
         \var{ngk}\\
         \var{dms}\\
         \var{e_c}
@@ -878,7 +873,6 @@ header processing we verify the following things:
     & \BHEnv
       = \left(
       \begin{array}{r@{~\in~}lr}
-        k & \mathbb{N} & \text{chain stability parameter}\\
         \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
         \var{s_{last}} & \Slot & \text{slot of the last seen block}
@@ -909,7 +903,6 @@ header processing we verify the following things:
     {
       {\left(
         \begin{array}{l}
-          k\\
           \var{ngk}\\
           \var{dms}\\
           \sepoch{s_{last}}\\
@@ -933,7 +926,6 @@ header processing we verify the following things:
     {
       {\left(
         \begin{array}{l}
-          k\\
           \var{ngk}\\
           \var{dms}\\
           \var{s_{last}}
@@ -1021,7 +1013,6 @@ payload; UTxO, delegation and update.
     \BBEnv =
     \left(
       \begin{array}{r@{~\in~}lr}
-        k & \mathbb{N} & \text{chain stability parameter}\\
         \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{pps} & \ProtParams & \text{protocol parameters} \\
         \var{e_n} & \Epoch & \text{epoch we are currently processing blocks for}
@@ -1060,7 +1051,6 @@ payload; UTxO, delegation and update.
       \verify{\var{vk_d}}{\serialised{\bupdpayload{b}}}{(\fun{bhUpdSig}~\var{bh})} \\
       {\left(
           \begin{array}{l}
-            k \\
             \bslot{b} \\
             \var{ngk}\\
             \fun{dms}~ ds
@@ -1079,7 +1069,6 @@ payload; UTxO, delegation and update.
       {\left(
           \begin{array}{l}
             \dom{(\fun{dms}~ ds)} \\
-            k\\
             \var{e_n}\\
             \bslot{b}
           \end{array}
@@ -1090,7 +1079,6 @@ payload; UTxO, delegation and update.
     {
       \left(
         {\begin{array}{l}
-           k\\
            \var{ngk}\\
            \var{pps} \\
            \var{e_n}
@@ -1161,8 +1149,6 @@ body according to the rules in figures \ref{fig:rules:bhead} and
     \CEEnv
     = \left(
       \begin{array}{r@{~\in~}lr}
-        k & \mathbb{N} & \text{chain stability parameter}\\
-        t & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{block signature count threshold}\\
         \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{s_{now}} & \Slot & \text{current slot}
       \end{array}\right)
@@ -1187,7 +1173,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
   \emph{Chain extension transitions}
   \begin{equation*}
     \_ \vdash \var{\_} \trans{chain}{\_} \var{\_} \subseteq
-    \powerset (\Slot \times \CEState \times \Block \times \CEState)
+    \powerset (\CEEnv \times \CEState \times \Block \times \CEState)
   \end{equation*}
 
   \caption{Blockchain extension transition-system types}
@@ -1239,7 +1225,6 @@ body according to the rules in figures \ref{fig:rules:bhead} and
       \begin{array}{r@{~\vdash~}l}
         {\left(
         \begin{array}{l}
-          k\\
           \var{ngk}\\
           \fun{dms}~\var{ds}\\
           \var{s_{last}}
@@ -1259,8 +1244,6 @@ body according to the rules in figures \ref{fig:rules:bhead} and
         \right)\\
         \left(
         {\begin{array}{l}
-           k\\
-           t\\
            \var{ds} \\
            \var{s_{last}} \\
            \var{s_{now}} \\
@@ -1282,7 +1265,6 @@ body according to the rules in figures \ref{fig:rules:bhead} and
         \right)\\
         {\left(
         \begin{array}{l}
-          k\\
           \var{ngk}\\
           \fun{pps} ~  us' \\
           \sepoch{(\bslot{b})} \\
@@ -1310,8 +1292,6 @@ body according to the rules in figures \ref{fig:rules:bhead} and
   {
     \left(
       {\begin{array}{l}
-         k\\
-         t\\
          \var{ngk}\\
          \var{s_{now}}
        \end{array}}

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -273,9 +273,9 @@ cases where there is or is not an update proposal contained within the block.
     \Bupisig =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{mprop} & \UProp^{?} & \text{Possible update proposal}\\
-        \var{votes} & \seqof{\Vote} & \text{Votes for update proposals}\\
-        \var{end} & (\VKey \times \ProtVer) & \text{Protocol version endorsment}
+        \var{mprop} & \UProp^{?} & \text{possible update proposal}\\
+        \var{votes} & \seqof{\Vote} & \text{votes for update proposals}\\
+        \var{end} & (\VKey \times \ProtVer) & \text{protocol version endorsment}
       \end{array}
     \right)
   \end{equation*}
@@ -354,18 +354,21 @@ cases where there is or is not an update proposal contained within the block.
 \newcommand{\ETEnv}{\type{ETEnv}}
 
 \newcommand{\sepochname}{sEpoch}
-\newcommand{\sepoch}[2]{\fun{\sepochname}\ #1\ #2}
+\newcommand{\sepoch}[1]{\fun{\sepochname}\ #1}
 
 During each block transition, we must determine whether that block sits on an
 epoch boundary and, if so, carry out various actions which are done on that
 boundary. In the BFT era, the only computation carried out at the epoch boundary
 is the update of protocol versions.
 
-In figure~\ref{fig:defs:epoch} we give the definition of the $\sepoch$
-function to determine the epoch corresponding to a given slot. This relies on
-keeping a map of the length of each epoch. Such a map is also required by the
-database layer to find the requisite epoch file to look up a given block, and is
-hence maintained by the ledger layer for this purpose. We envision that an
+We rely on a function $\fun{\sepochname}$, whose type is given in
+\cref{fig:defs:epoch}, to determine the epoch corresponding to a given slot.
+%
+We do not provide an implementation for such function in this specification,
+but in practice a possible way of implementing such function is to rely on map
+from the epochs to their corresponding length (given in number of slots they
+contain). Such a map would also be required by the database layer to find the
+requisite epoch file to look up a given block. We envision that an
 implementation may of course choose a more compact representation for this
 partial function that only records the changes in epoch length, rather than
 storing a length for each epoch.
@@ -377,21 +380,13 @@ Figure \ref{fig:rules:epoch} determines when an epoch change has occurred and
 updates the update state to the correct version.
 
 \begin{figure}[ht]
-  \emph{Derived functions}
+  \emph{Abstract functions}
   %
   \begin{equation*}
     \begin{array}{rlr}
-      \fun{\sepochname} & \in \Slot \totalf (\Epoch \partialf \SlotCount) \totalf \Epoch & \text{Epoch containing this slot} \\
-    \end{array}
-  \end{equation*}
-  \begin{equation*}
-      \fun{\sepochname}~\var{slot}~\fun{elens} = \min  \left\{ e \middle| slot < \sum_{i \leq e} \fun{elens}~i \right\}
-  \end{equation*}
-
-  \emph{Protocol parameters}
-  \begin{equation*}
-    \begin{array}{r@{~\partialf~}l!{~\in~\ProtParams~}r}
-      \pp{slotsPerEpoch} & \SlotCount & \text{Number of slots in the current epoch} \\
+      \fun{\sepochname}
+      & \in \Slot \totalf \Epoch
+      & \text{epoch containing this slot} \\
     \end{array}
   \end{equation*}
 
@@ -400,13 +395,22 @@ updates the update state to the correct version.
 \end{figure}
 
 \begin{figure}[ht]
+  \emph{Epoch transition environments}
+  \begin{align*}
+    & \ETEnv
+      = \left(
+      \begin{array}{r@{~\in~}lr}
+        k & \mathbb{N} & \text{chain stability parameter}\\
+        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
+        \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
+      \end{array}\right)
+  \end{align*}
 
   \emph{Epoch transition states}
   \begin{equation*}
     \ETState =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{elens} & \Epoch \partialf \SlotCount & \text{Historical epoch lengths} \\
         \var{e_c} & \Epoch & \text{Current epoch} \\
         \var{us} & \UPIState & \text{Update interface state}
       \end{array}
@@ -426,13 +430,20 @@ updates the update state to the correct version.
   \begin{equation*}
     \inference
     {
-      \var{e_c} \geq \sepoch{s}{elens}
+      \var{e_c} \geq \sepoch{s}
     }
-    {\var{dms} \vdash
+    {
+      {\left(
+        \begin{array}{l}
+          k\\
+          \var{ngk}\\
+          \var{dms}
+        \end{array}
+      \right)}
+      \vdash
       {
         \left(
           {\begin{array}{c}
-             \var{elens} \\
              \var{e_c} \\
              \var{us}
            \end{array}
@@ -443,7 +454,6 @@ updates the update state to the correct version.
      {
        \left(
          {\begin{array}{c}
-            \var{elens} \\
             \var{e_c} \\
             \var{us}
           \end{array}
@@ -456,36 +466,42 @@ updates the update state to the correct version.
 \begin{equation*}
   \inference
   {
-    \pp{slotsPerEpoch} \mapsto \var{es} \in \fun{pps}~\var{us} & \var{e_n} \leteq \sepoch{s}{elens} \\
-    \var{e_c} < \var{e_n}
-    \\
+    \var{e_n} \leteq \sepoch{s}
+    & \var{e_c} < \var{e_n}
+    &
     {\left(
         \begin{array}{l}
-          \var{\var{e_c}} \\
-          \var{s} \\
+          k\\
+          s\\
+          \var{ngk}\\
           \var{dms}
         \end{array}
       \right)
     }
-    \vdash \var{us} \trans{upiec}{\var{e_n}} \var{us'}
+    \vdash \var{us} \trans{upiec}{} \var{us'}
   }
   {
-    \var{dms} \vdash
+    {
+      \begin{array}{l}
+        k\\
+        \var{ngk}\\
+        \var{dms}
+      \end{array}
+    }
+    \vdash
     {
       \left(
         {\begin{array}{c}
-           \var{elens} \\
            \var{e_c} \\
            \var{us}
          \end{array}
        }
      \right)
    }
-   \trans{epoch}{\var{s}}
+   \trans{epoch}{s}
    {
      \left(
        {\begin{array}{c}
-          \var{elens} \unionoverride \{\var{e_n} \mapsto \var{es}\}\\
           \var{e_n} \\
           \var{us'}
         \end{array}
@@ -548,18 +564,6 @@ issue (via delegates) $475$ blocks (since $2160 \cdot 0.22 = 475.2$), but a
 $476^{\text{th}}$ block would be rejected. See Appendix
 \ref{apdx:calculating-t} for the background on this value.
 
-\begin{figure}[ht]
-  \emph{Protocol parameters}
-  \begin{equation*}
-    \begin{array}{r@{~\partialf~}l!{~\in~\ProtParams~}r}
-      \pp{stableAfter} & \mathbb{N} & \text{Chain stability parameter} \\
-      \pp{blockSignatureCountThreshold} & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{Block signature count threshold} \\
-    \end{array}
-  \end{equation*}
-  \caption{Blockchain signature count protocol parameters}
-  \label{fig:defs:sigcnt}
-\end{figure}
-
 Figure \ref{fig:rules:sigcnt} gives the rules for signature counting. We verify
 that the key that delegates to the signer of this block has not already signed
 more than its allowed threshold of blocks. If there are no delegators for the
@@ -574,7 +578,8 @@ outside the size of the moving window ($k$).
     \BSCEnv =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{pps} & \ProtParams & \text{Protocol parameters} \\
+        k & \mathbb{N} & \text{chain stability parameter} \\
+        t & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{block signature count threshold}\\
         \var{ds} & \DelegState & \text{Delegation state} \\
       \end{array}
     \right)
@@ -593,15 +598,15 @@ outside the size of the moving window ($k$).
   \begin{equation*}
     \inference
     {
-      \pp{stableAfter} \partialf \var{k} \in pps & \pp{blockSignatureCountThreshold} \partialf \var{t} \in pps \\
       \{\var{vk_g}\} \leteq (\fun{dms} ~ \var{ds}) \restrictrange \{\var{vk_d}\}
       & \var{sgs'} \leteq \var{sgs};_k {vk_g} &
       \size{\fun{filter}~(=\var{vk_g})~\var{sgs'}} \leq k \cdot t \\
     }
     {
       \left(
-        {\begin{array}{c}
-           \var{pps} \\
+        {\begin{array}{l}
+           k\\
+           t\\
            \var{ds}
          \end{array}}
      \right)
@@ -662,11 +667,11 @@ During PBFT processing of the block header, we do the following:
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{\bhprevhashname} & \Bhead \totalf \Hash & \text{Previous header hash} \\
-      \fun{\bhhashname} & \Bhead \totalf \Hash & \text{Header hash} \\
-      \fun{\bhsigname} & \Bhead \totalf \Sig & \text{Block signature} \\
-      \fun{\bhissuername} & \Bhead \totalf \VKey & \text{Block issuer} \\
-      \fun{\bhslotname} & \Bhead \totalf \Slot & \text{Slot for which this block is issued}
+      \fun{\bhprevhashname} & \Bhead \totalf \Hash & \text{previous header hash} \\
+      \fun{\bhhashname} & \Bhead \totalf \Hash & \text{header hash} \\
+      \fun{\bhsigname} & \Bhead \totalf \Sig & \text{block signature} \\
+      \fun{\bhissuername} & \Bhead \totalf \VKey & \text{block issuer} \\
+      \fun{\bhslotname} & \Bhead \totalf \Slot & \text{slot for which this block is issued}
     \end{array}
   \end{equation*}
   \caption{Permissive BFT types and functions}
@@ -679,10 +684,11 @@ During PBFT processing of the block header, we do the following:
     \PBFTEnv =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{pps} & \ProtParams & \text{Protocol parameters} \\
-        \var{ds} & \DelegState & \text{Delegation state} \\
-        \var{s_{last}} & \Slot & \text{Slot for which the last known block was issued} \\
-        \var{s_{now}} & \Slot & \text{Current slot} \\
+        k & \mathbb{N} & \text{chain stability parameter} \\
+        t & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{block signature count threshold}\\
+        \var{ds} & \DelegState & \text{delegation state} \\
+        \var{s_{last}} & \Slot & \text{slot for which the last known block was issued} \\
+        \var{s_{now}} & \Slot & \text{current slot} \\
       \end{array}
     \right)
   \end{equation*}
@@ -716,7 +722,8 @@ During PBFT processing of the block header, we do the following:
       \\
       {\left(
           \begin{array}{l}
-            \var{pps} \\
+            k\\
+            t\\
             ds
           \end{array}
         \right)}
@@ -727,7 +734,8 @@ During PBFT processing of the block header, we do the following:
     {
       \left(
         {\begin{array}{c}
-          \var{pps} \\
+           k\\
+           t\\
            \var{ds} \\
            \var{s_{last}} \\
            \var{s_{now}} \\
@@ -843,8 +851,8 @@ header processing we verify the following things:
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      bh & \Bhead & \text{Block header} \\
-      bts & \Bhtosign & \text{Part of the block header which must be signed}
+      bh & \Bhead & \text{block header} \\
+      bts & \Bhtosign & \text{part of the block header which must be signed}
     \end{array}
   \end{equation*}
   %
@@ -852,8 +860,8 @@ header processing we verify the following things:
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{\bheadname} & \Block \totalf \Bhead & \text{Block header} \\
-      \fun{\bhdrsizename} & \Bhead \totalf \mathbb{N} & \text{Block header size in bytes}\\
+      \fun{\bheadname} & \Block \totalf \Bhead & \text{block header} \\
+      \fun{\bhdrsizename} & \Bhead \totalf \mathbb{N} & \text{block header size in bytes}\\
     \end{array}
   \end{equation*}
   \emph{Protocol parameters}
@@ -873,8 +881,7 @@ header processing we verify the following things:
     \BHState =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{us} & \UPIState & \text{Update state} \\
-        \var{elens} & \Epoch \partialf \SlotCount & \text{Historical epoch lengths} \\
+        \var{us} & \UPIState & \text{update state}
       \end{array}
     \right)
   \end{equation*}
@@ -890,18 +897,24 @@ header processing we verify the following things:
 \begin{figure}[ht]
   \begin{equation*}
     \inference
-    { \fun{pps} ~ us \vdash
+    {
+      {\left(
+        \begin{array}{l}
+          k\\
+          \var{ngk}\\
+          \var{dms}
+        \end{array}
+      \right)}
+      \vdash
       {\left(
           \begin{array}{l}
-            \var{elens} \\
-            \sepoch{s_{last}}{elens} \\
+            \sepoch{s}\\
             us
           \end{array}
         \right)}
       \trans{epoch}{\bslot{b}}
       {\left(
           \begin{array}{l}
-            \var{elens'} \\
             \var{e_n} \\
             us'
           \end{array}
@@ -910,18 +923,23 @@ header processing we verify the following things:
       \\ \maxheadersize \mapsto \var{s_{max}} \in \fun{pps}~\var{us'} & \bhdrsize{bh} \leq \var{s_{max}}
     }
     {
-      \var{s_{last}} \vdash
+      {\left(
+        \begin{array}{l}
+          k\\
+          \var{ngk}\\
+          \var{dms}
+        \end{array}
+        \right)}
+      \vdash
       \left(
         {\begin{array}{c}
-           \var{us} \\
-           \var{elens}
+           \var{us}
          \end{array}}
      \right)
      \trans{bhead}{\var{bh}}
      \left(
        {\begin{array}{c}
-          \var{us'} \\
-          \var{elens'}
+          \var{us'}
         \end{array}}
     \right)
   }
@@ -953,7 +971,7 @@ payload; UTxO, delegation and update.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      bb & \Bbody & \text{Block body} \\
+      bb & \Bbody & \text{block body} \\
 
     \end{array}
   \end{equation*}
@@ -962,15 +980,15 @@ payload; UTxO, delegation and update.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{bUtxo} & \Block \totalf \UTxO & \text{Block UTxO payload} \\
+      \fun{bUtxo} & \Block \totalf \UTxO & \text{block UTxO payload} \\
       \fun{\bcertsname} & \Block \totalf \seqof{\DCert}
                                          & \text{block certificates} \\
-      \fun{bUpdProp} & \Block \totalf \UProp^{?} & \text{Block update proposal payload} \\
-      \fun{bUpdVotes} & \Block \totalf \seqof{\Vote} & \text{Block update votes payload} \\
-      \fun{bProtVer} & \Block \totalf \ProtVer & \text{Block protocol version} \\
+      \fun{bUpdProp} & \Block \totalf \UProp^{?} & \text{block update proposal payload} \\
+      \fun{bUpdVotes} & \Block \totalf \seqof{\Vote} & \text{block update votes payload} \\
+      \fun{bProtVer} & \Block \totalf \ProtVer & \text{block protocol version} \\
       \fun{bhUtxoSig} & \Bhead \totalf \Sig & \text{UTxO payload signature} \\
-      \fun{bhDlgSig} & \Bhead \totalf \Sig & \text{Delegation payload signature} \\
-      \fun{bhUpdSig} & \Bhead \totalf \Sig & \text{Update payload signature} \\
+      \fun{bhDlgSig} & \Bhead \totalf \Sig & \text{delegation payload signature} \\
+      \fun{bhUpdSig} & \Bhead \totalf \Sig & \text{update payload signature} \\
     \end{array}
   \end{equation*}
   \emph{Derived functions}
@@ -994,8 +1012,10 @@ payload; UTxO, delegation and update.
     \BBEnv =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{pps} & \ProtParams & \text{Protocol parameters} \\
-        \var{e_n} & \Epoch & \text{Epoch we are currently processing blocks for}
+        k & \mathbb{N} & \text{chain stability parameter}\\
+        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
+        \var{pps} & \ProtParams & \text{protocol parameters} \\
+        \var{e_n} & \Epoch & \text{epoch we are currently processing blocks for}
       \end{array}
     \right)
   \end{equation*}
@@ -1006,8 +1026,8 @@ payload; UTxO, delegation and update.
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{utxo} & \UTxO & \text{UTxO} \\
-        \var{us} & \UPIState & \text{Update interface state} \\
-        \var{ds} & \DIState & \text{Delegation state}
+        \var{ds} & \DIState & \text{delegation state} \\
+        \var{us} & \UPIState & \text{update interface state}
       \end{array}
     \right)
   \end{equation*}
@@ -1031,9 +1051,10 @@ payload; UTxO, delegation and update.
       \verify{\var{vk_d}}{\serialised{\bupdpayload{b}}}{(\fun{bhUpdSig}~\var{bh})} \\
       {\left(
           \begin{array}{l}
+            k \\
             \bslot{b} \\
-            \var{e_n} \\
-            \fun{dms} ~ \var{ds}
+            \var{ngk}\\
+            \fun{dms}~ ds
           \end{array}
         \right)}
       \vdash \var{us} \trans{bupi}{
@@ -1049,6 +1070,7 @@ payload; UTxO, delegation and update.
       {\left(
           \begin{array}{l}
             \dom{(\fun{dms}~ ds)} \\
+            k\\
             \var{e_n} \\
             \bslot{b} \\
             \fun{pps} ~  us \\
@@ -1059,7 +1081,9 @@ payload; UTxO, delegation and update.
     }
     {
       \left(
-        {\begin{array}{c}
+        {\begin{array}{l}
+           k\\
+           \var{ngk}\\
            \var{pps} \\
            \var{e_n}
          \end{array}}
@@ -1124,18 +1148,30 @@ body according to the rules in figures \ref{fig:rules:bhead} and
 \end{figure}
 
 \begin{figure}[ht]
+  \emph{Chain extension environments}
+  \begin{equation*}
+    \CEEnv
+    = \left(
+      \begin{array}{r@{~\in~}lr}
+        k & \mathbb{N} & \text{chain stability parameter}\\
+        t & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{block signature count threshold}\\
+        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
+        \var{s_{now}} & \Slot & \text{current slot}
+      \end{array}\right)
+  \end{equation*}
+
+
   \emph{Chain extension states}
   \begin{equation*}
     \CEState =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{s_{last}} & \Slot & \text{Slot of the last seen block} \\
-        \var{elens} & \Epoch \partialf \SlotCount & \text{Historical epoch lengths} \\
-        \var{sgs} & \seqof{\VKeyGen} & \text{Last signers}\\
-        \var{h} & \Hash & \text{Current block hash} \\
+        \var{s_{last}} & \Slot & \text{slot of the last seen block} \\
+        \var{sgs} & \seqof{\VKeyGen} & \text{last signers}\\
+        \var{h} & \Hash & \text{current block hash} \\
         \var{utxo} & \UTxO & \text{UTxO} \\
-        \var{us} & \UPIState & \text{Update interface state} \\
-        \var{ds} & \DIState & \text{Delegation state}
+        \var{ds} & \DIState & \text{delegation state}\\
+        \var{us} & \UPIState & \text{update interface state} \\
       \end{array}
     \right)
   \end{equation*}
@@ -1169,8 +1205,8 @@ body according to the rules in figures \ref{fig:rules:bhead} and
           \var{sgs} \\
           \var{h} \\
           \var{utxo} \\
-          \var{us} \\
-          \var{ds}
+          \var{ds} \\
+          \var{us}
         \end{array}}
     \right)
     \trans{chain}{b}
@@ -1180,8 +1216,8 @@ body according to the rules in figures \ref{fig:rules:bhead} and
          \var{sgs} \\
          \var{h'} \\
          \var{utxo} \\
-         \var{us} \\
-         \var{ds}
+         \var{ds} \\
+         \var{us}
        \end{array}}
    \right)
  }
@@ -1190,104 +1226,110 @@ body according to the rules in figures \ref{fig:rules:bhead} and
 \begin{equation*}
   \inference
   {
-    \neg\isebb{b} &
-    \var{s_{last}}
-    \vdash
-    \left(
-      {\begin{array}{c}
-         \var{us} \\
-         \var{elens} \\
-       \end{array}}
-   \right)
-   \trans{bhead}{\bhead{b}}
-   \left(
-     {\begin{array}{c}
-        \var{us'} \\
-        \var{elens'} \\
-      \end{array}}
-  \right)
-  \\
-  \left(
-    {\begin{array}{c}
-       \fun{pps} ~ us' \\
-       \var{ds} \\
-       \var{s_{last}} \\
-       \var{s_{now}} \\
-     \end{array}}
- \right)
- \vdash
- \left(
-   {\begin{array}{c}
-      \var{h} \\
-      \var{sgs}
-    \end{array}}
-\right)
-\trans{pbft}{\var{bh}}
-\left(
-  {\begin{array}{c}
-     \var{h'} \\
-     \var{sgs}'
-   \end{array}}
-\right)
-  \\
-  {\left(
-      \begin{array}{l}
-        \fun{pps} ~  us' \\
-        \sepoch{(\bslot{b})}{elens} \\
+    \neg\isebb{b} \\~\\
+    {
+      \begin{array}{r@{~\vdash~}l}
+        {\left(
+        \begin{array}{l}
+          k\\
+          \var{ngk}\\
+          \fun{dms}~\var{ds}
+        \end{array}
+        \right)}
+        &
+        \left(
+          {\begin{array}{c}
+             \var{us}
+           \end{array}
+        }\right)
+        \trans{bhead}{\bhead{b}}
+        \left(
+        {\begin{array}{c}
+           \var{us'}
+         \end{array}}
+        \right)\\
+        \left(
+        {\begin{array}{l}
+           k\\
+           t\\
+           \var{ds} \\
+           \var{s_{last}} \\
+           \var{s_{now}} \\
+         \end{array}}
+        \right)
+        &
+        \left(
+          {\begin{array}{c}
+             \var{h} \\
+             \var{sgs}
+           \end{array}}
+        \right)
+        \trans{pbft}{\var{bh}}
+        \left(
+        {\begin{array}{c}
+           \var{h'} \\
+           \var{sgs}'
+         \end{array}}
+        \right)\\
+        {\left(
+        \begin{array}{l}
+          k\\
+          \var{ngk}\\
+          \fun{pps} ~  us' \\
+          \sepoch{(\bslot{b})} \\
+        \end{array}
+        \right)}
+        &
+        {\left(
+          {\begin{array}{c}
+             \var{utxo} \\
+             \var{ds} \\
+             \var{us'}
+           \end{array}}
+        \right)}
+        \trans{bbody}{b}
+        {\left(
+          {\begin{array}{c}
+             \var{utxo'} \\
+             \var{ds'} \\
+             \var{us''}
+           \end{array}}
+        \right)}
       \end{array}
-    \right)}
-  \vdash
+    }
+  }
   {
     \left(
-      {\begin{array}{c}
-         \var{utxo} \\
-         \var{ds} \\
-         \var{us'}
+      {\begin{array}{l}
+         k\\
+         t\\
+         \var{ngk}\\
+         \var{s_{now}}
        \end{array}}
-   \right)
- }
- \trans{bbody}{b}
- {
-   \left(
-     {\begin{array}{c}
-        \var{utxo'} \\
-        \var{ds'} \\
-        \var{us''}
-      \end{array}}
-  \right)
-}
-}
-{
-  \left(
-    {\begin{array}{c}
-       \var{s_{now}}
-     \end{array}}
- \right)
- \vdash
- \left(
-   {\begin{array}{c}
-      \var{s_{last}} \\
-      \var{elens} \\
-      \var{sgs} \\
-      \var{h} \\
-      \var{utxo} \\
-      \var{us} \\
-      \var{ds}
-    \end{array}}
-\right)
-\trans{chain}{b}
-\left(
-  {\begin{array}{c}
-     \var{\bslot{b}} \\
-     \var{elens'} \\
-     \var{sgs'} \\
-     \var{h'} \\
-     \var{utxo'} \\
-     \var{us''} \\
-     \var{ds'}
-   \end{array}}
-\right)
-}
+     \right)
+     \vdash
+     \left(
+       {\begin{array}{c}
+          \var{s_{last}} \\
+          \var{sgs} \\
+          \var{h} \\
+          \var{utxo} \\
+          \var{ds} \\
+          \var{us}
+        \end{array}}
+    \right)
+    \trans{chain}{b}
+    \left(
+      {\begin{array}{c}
+         \var{\bslot{b}} \\
+         \var{sgs'} \\
+         \var{h'} \\
+         \var{utxo'} \\
+         \var{ds'} \\
+         \var{us''}
+       \end{array}}
+    \right)
+  }
 \end{equation*}
 \caption{Blockchain extension rules}
 \label{fig:rules:chain-extension}

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -1244,7 +1244,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
              \var{sgs}
            \end{array}}
         \right)
-        \trans{pbft}{\var{bh}}
+        \trans{pbft}{\bhead{b}}
         \left(
         {\begin{array}{c}
            \var{h'} \\

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -619,6 +619,9 @@ requisite epoch file to look up a given block. We envision that an
 implementation may of course choose a more compact representation for this
 partial function that only records the changes in epoch length, rather than
 storing a length for each epoch.
+%
+In addition, we rely on abstract constant (function) $\var{ngk}$, which
+determines the number of genesis keys.
 
 It is also worth noticing that in the Byron era, the number of slots per-epoch
 is fixed to $10 \cdot k$, where $k$ is the chain stability parameter.
@@ -630,10 +633,11 @@ updates the update state to the correct version.
   \emph{Abstract functions}
   %
   \begin{equation*}
-    \begin{array}{rlr}
+    \begin{array}{r@{~\in~}lr}
       \fun{\sepochname}
-      & \in \Slot \totalf \Epoch
+      & \Slot \totalf \Epoch
       & \text{epoch containing this slot} \\
+      \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
     \end{array}
   \end{equation*}
 
@@ -647,7 +651,6 @@ updates the update state to the correct version.
     & \ETEnv
       = \left(
       \begin{array}{r@{~\in~}lr}
-        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
         \var{e_c} & \Epoch & \text{Current epoch}
       \end{array}\right)
@@ -681,7 +684,6 @@ updates the update state to the correct version.
     {
       {\left(
         \begin{array}{l}
-          \var{ngk}\\
           \var{dms}\\
           \var{e_c}
         \end{array}
@@ -715,7 +717,6 @@ updates the update state to the correct version.
     {\left(
         \begin{array}{l}
           s\\
-          \var{ngk}\\
           \var{dms}
         \end{array}
       \right)
@@ -723,13 +724,12 @@ updates the update state to the correct version.
     \vdash \var{us} \trans{upiec}{} \var{us'}
   }
   {
-    {
+    {\left(
       \begin{array}{l}
-        \var{ngk}\\
         \var{dms}\\
         \var{e_c}
       \end{array}
-    }
+    \right)}
     \vdash
     {
       \left(
@@ -873,7 +873,6 @@ header processing we verify the following things:
     & \BHEnv
       = \left(
       \begin{array}{r@{~\in~}lr}
-        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
         \var{s_{last}} & \Slot & \text{slot of the last seen block}
       \end{array}\right)
@@ -891,7 +890,7 @@ header processing we verify the following things:
   \emph{Block header processing transitions}
   \begin{equation*}
     \var{\_} \vdash \var{\_} \trans{bhead}{\_} \var{\_} \subseteq
-    \powerset (\Slot \times \BHState \times \Bhead \times \BHState)
+    \powerset (\BHEnv \times \BHState \times \Bhead \times \BHState)
   \end{equation*}
   \caption{Block header processing transition-system types}
   \label{fig:ts-types:bhead}
@@ -903,7 +902,6 @@ header processing we verify the following things:
     {
       {\left(
         \begin{array}{l}
-          \var{ngk}\\
           \var{dms}\\
           \sepoch{s_{last}}\\
         \end{array}
@@ -926,7 +924,6 @@ header processing we verify the following things:
     {
       {\left(
         \begin{array}{l}
-          \var{ngk}\\
           \var{dms}\\
           \var{s_{last}}
         \end{array}
@@ -1013,7 +1010,6 @@ payload; UTxO, delegation and update.
     \BBEnv =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{pps} & \ProtParams & \text{protocol parameters} \\
         \var{e_n} & \Epoch & \text{epoch we are currently processing blocks for}
       \end{array}
@@ -1052,7 +1048,6 @@ payload; UTxO, delegation and update.
       {\left(
           \begin{array}{l}
             \bslot{b} \\
-            \var{ngk}\\
             \fun{dms}~ ds
           \end{array}
         \right)}
@@ -1079,7 +1074,6 @@ payload; UTxO, delegation and update.
     {
       \left(
         {\begin{array}{l}
-           \var{ngk}\\
            \var{pps} \\
            \var{e_n}
          \end{array}}
@@ -1149,7 +1143,6 @@ body according to the rules in figures \ref{fig:rules:bhead} and
     \CEEnv
     = \left(
       \begin{array}{r@{~\in~}lr}
-        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{s_{now}} & \Slot & \text{current slot}
       \end{array}\right)
   \end{equation*}
@@ -1187,11 +1180,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
        \var{h'} \leteq \bhhash{(\bhead b)}
     }
     {
-      \left(
-        {\begin{array}{c}
-           \var{s_{now}}
-         \end{array}}
-     \right)
+     \var{s_{now}}
      \vdash
      \left(
        {\begin{array}{c}
@@ -1225,7 +1214,6 @@ body according to the rules in figures \ref{fig:rules:bhead} and
       \begin{array}{r@{~\vdash~}l}
         {\left(
         \begin{array}{l}
-          \var{ngk}\\
           \fun{dms}~\var{ds}\\
           \var{s_{last}}
         \end{array}
@@ -1265,7 +1253,6 @@ body according to the rules in figures \ref{fig:rules:bhead} and
         \right)\\
         {\left(
         \begin{array}{l}
-          \var{ngk}\\
           \fun{pps} ~  us' \\
           \sepoch{(\bslot{b})} \\
         \end{array}
@@ -1290,12 +1277,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
     }
   }
   {
-    \left(
-      {\begin{array}{l}
-         \var{ngk}\\
-         \var{s_{now}}
-       \end{array}}
-     \right)
+     \var{s_{now}}
      \vdash
      \left(
        {\begin{array}{c}

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -1080,9 +1080,8 @@ payload; UTxO, delegation and update.
           \begin{array}{l}
             \dom{(\fun{dms}~ ds)} \\
             k\\
-            \var{e_n} \\
-            \bslot{b} \\
-            \fun{pps} ~  us \\
+            \var{e_n}\\
+            \bslot{b}
           \end{array}
         \right)}
       \vdash \var{ds} \trans{deleg}{\bcerts{b}} \var{ds'} &

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -345,176 +345,6 @@ cases where there is or is not an update proposal contained within the block.
 \end{figure}
 
 \clearpage
-
-\section{Epoch transitions}
-
-\newcommand{\Epoch}{\type{Epoch}}
-
-\newcommand{\ETState}{\type{ETState}}
-\newcommand{\ETEnv}{\type{ETEnv}}
-
-\newcommand{\sepochname}{sEpoch}
-\newcommand{\sepoch}[1]{\fun{\sepochname}\ #1}
-
-During each block transition, we must determine whether that block sits on an
-epoch boundary and, if so, carry out various actions which are done on that
-boundary. In the BFT era, the only computation carried out at the epoch boundary
-is the update of protocol versions.
-
-We rely on a function $\fun{\sepochname}$, whose type is given in
-\cref{fig:defs:epoch}, to determine the epoch corresponding to a given slot.
-%
-We do not provide an implementation for such function in this specification,
-but in practice a possible way of implementing such function is to rely on map
-from the epochs to their corresponding length (given in number of slots they
-contain). Such a map would also be required by the database layer to find the
-requisite epoch file to look up a given block. We envision that an
-implementation may of course choose a more compact representation for this
-partial function that only records the changes in epoch length, rather than
-storing a length for each epoch.
-
-It is also worth noticing that in the Byron era, the number of slots per-epoch
-is fixed to $10 \cdot k$, where $k$ is the chain stability parameter.
-
-Figure \ref{fig:rules:epoch} determines when an epoch change has occurred and
-updates the update state to the correct version.
-
-\begin{figure}[ht]
-  \emph{Abstract functions}
-  %
-  \begin{equation*}
-    \begin{array}{rlr}
-      \fun{\sepochname}
-      & \in \Slot \totalf \Epoch
-      & \text{epoch containing this slot} \\
-    \end{array}
-  \end{equation*}
-
-  \caption{Epoch transition types and functions}
-  \label{fig:defs:epoch}
-\end{figure}
-
-\begin{figure}[ht]
-  \emph{Epoch transition environments}
-  \begin{align*}
-    & \ETEnv
-      = \left(
-      \begin{array}{r@{~\in~}lr}
-        k & \mathbb{N} & \text{chain stability parameter}\\
-        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
-        \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
-      \end{array}\right)
-  \end{align*}
-
-  \emph{Epoch transition states}
-  \begin{equation*}
-    \ETState =
-    \left(
-      \begin{array}{r@{~\in~}lr}
-        \var{e_c} & \Epoch & \text{Current epoch} \\
-        \var{us} & \UPIState & \text{Update interface state}
-      \end{array}
-    \right)
-  \end{equation*}
-
-  \emph{Epoch transition transitions}
-  \begin{equation*}
-    \_ \vdash \var{\_} \trans{epoch}{\_} \var{\_} \subseteq
-    \powerset ((\VKey \mapsto \VKeyGen) \times \ETState \times \Slot \times \ETState)
-  \end{equation*}
-  \caption{Epoch transition transition-system types}
-  \label{fig:ts-types:epoch}
-\end{figure}
-
-\begin{figure}[ht]
-  \begin{equation*}
-    \inference
-    {
-      \var{e_c} \geq \sepoch{s}
-    }
-    {
-      {\left(
-        \begin{array}{l}
-          k\\
-          \var{ngk}\\
-          \var{dms}
-        \end{array}
-      \right)}
-      \vdash
-      {
-        \left(
-          {\begin{array}{c}
-             \var{e_c} \\
-             \var{us}
-           \end{array}
-         }
-       \right)
-     }
-     \trans{epoch}{s}
-     {
-       \left(
-         {\begin{array}{c}
-            \var{e_c} \\
-            \var{us}
-          \end{array}
-        }
-      \right)
-    }
-  }
-\end{equation*}
-\vspace{20pt}
-\begin{equation*}
-  \inference
-  {
-    \var{e_n} \leteq \sepoch{s}
-    & \var{e_c} < \var{e_n}
-    &
-    {\left(
-        \begin{array}{l}
-          k\\
-          s\\
-          \var{ngk}\\
-          \var{dms}
-        \end{array}
-      \right)
-    }
-    \vdash \var{us} \trans{upiec}{} \var{us'}
-  }
-  {
-    {
-      \begin{array}{l}
-        k\\
-        \var{ngk}\\
-        \var{dms}
-      \end{array}
-    }
-    \vdash
-    {
-      \left(
-        {\begin{array}{c}
-           \var{e_c} \\
-           \var{us}
-         \end{array}
-       }
-     \right)
-   }
-   \trans{epoch}{s}
-   {
-     \left(
-       {\begin{array}{c}
-          \var{e_n} \\
-          \var{us'}
-        \end{array}
-      }
-    \right)
-  }
-}
-\end{equation*}
-\caption{Epoch transition rules}
-\label{fig:rules:epoch}
-\end{figure}
-
-\clearpage
 \section{Permissive BFT}
 
 The majority of this specification is concerned with the processing of the
@@ -764,6 +594,173 @@ During PBFT processing of the block header, we do the following:
 
 \clearpage
 
+\section{Epoch transitions}
+
+\newcommand{\Epoch}{\type{Epoch}}
+
+\newcommand{\ETState}{\type{ETState}}
+\newcommand{\ETEnv}{\type{ETEnv}}
+
+\newcommand{\sepochname}{sEpoch}
+\newcommand{\sepoch}[1]{\fun{\sepochname}\ #1}
+
+During each block transition, we must determine whether that block sits on an
+epoch boundary and, if so, carry out various actions which are done on that
+boundary. In the BFT era, the only computation carried out at the epoch boundary
+is the update of protocol versions.
+
+We rely on a function $\fun{\sepochname}$, whose type is given in
+\cref{fig:defs:epoch}, to determine the epoch corresponding to a given slot.
+%
+We do not provide an implementation for such function in this specification,
+but in practice a possible way of implementing such function is to rely on map
+from the epochs to their corresponding length (given in number of slots they
+contain). Such a map would also be required by the database layer to find the
+requisite epoch file to look up a given block. We envision that an
+implementation may of course choose a more compact representation for this
+partial function that only records the changes in epoch length, rather than
+storing a length for each epoch.
+
+It is also worth noticing that in the Byron era, the number of slots per-epoch
+is fixed to $10 \cdot k$, where $k$ is the chain stability parameter.
+
+Figure \ref{fig:rules:epoch} determines when an epoch change has occurred and
+updates the update state to the correct version.
+
+\begin{figure}[ht]
+  \emph{Abstract functions}
+  %
+  \begin{equation*}
+    \begin{array}{rlr}
+      \fun{\sepochname}
+      & \in \Slot \totalf \Epoch
+      & \text{epoch containing this slot} \\
+    \end{array}
+  \end{equation*}
+
+  \caption{Epoch transition types and functions}
+  \label{fig:defs:epoch}
+\end{figure}
+
+\begin{figure}[ht]
+  \emph{Epoch transition environments}
+  \begin{align*}
+    & \ETEnv
+      = \left(
+      \begin{array}{r@{~\in~}lr}
+        k & \mathbb{N} & \text{chain stability parameter}\\
+        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
+        \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
+        \var{e_c} & \Epoch & \text{Current epoch}
+      \end{array}\right)
+  \end{align*}
+
+  \emph{Epoch transition states}
+  \begin{equation*}
+    \ETState =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{us} & \UPIState & \text{update interface state}
+      \end{array}
+    \right)
+  \end{equation*}
+
+  \emph{Epoch transition transitions}
+  \begin{equation*}
+    \_ \vdash \var{\_} \trans{epoch}{\_} \var{\_} \subseteq
+    \powerset ((\VKey \mapsto \VKeyGen) \times \ETState \times \Slot \times \ETState)
+  \end{equation*}
+  \caption{Epoch transition transition-system types}
+  \label{fig:ts-types:epoch}
+\end{figure}
+
+\begin{figure}[ht]
+  \begin{equation*}
+    \inference
+    {
+      \var{e_c} \geq \sepoch{s}
+    }
+    {
+      {\left(
+        \begin{array}{l}
+          k\\
+          \var{ngk}\\
+          \var{dms}\\
+          \var{e_c}
+        \end{array}
+      \right)}
+      \vdash
+      {
+        \left(
+          {\begin{array}{c}
+             \var{us}
+           \end{array}
+         }
+       \right)
+     }
+     \trans{epoch}{s}
+     {
+       \left(
+         {\begin{array}{c}
+            \var{us}
+          \end{array}
+        }
+      \right)
+    }
+  }
+\end{equation*}
+\vspace{20pt}
+\begin{equation*}
+  \inference
+  {
+    \var{e_c} < \sepoch{s}
+    &
+    {\left(
+        \begin{array}{l}
+          k\\
+          s\\
+          \var{ngk}\\
+          \var{dms}
+        \end{array}
+      \right)
+    }
+    \vdash \var{us} \trans{upiec}{} \var{us'}
+  }
+  {
+    {
+      \begin{array}{l}
+        k\\
+        \var{ngk}\\
+        \var{dms}\\
+        \var{e_c}
+      \end{array}
+    }
+    \vdash
+    {
+      \left(
+        {\begin{array}{c}
+           \var{us}
+         \end{array}
+       }
+     \right)
+   }
+   \trans{epoch}{s}
+   {
+     \left(
+       {\begin{array}{c}
+          \var{us'}
+        \end{array}
+      }
+    \right)
+  }
+}
+\end{equation*}
+\caption{Epoch transition rules}
+\label{fig:rules:epoch}
+\end{figure}
+
+\clearpage
+
 \section{Block processing}
 \label{sec:block-processing}
 
@@ -884,6 +881,7 @@ header processing we verify the following things:
         k & \mathbb{N} & \text{chain stability parameter}\\
         \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
+        \var{s_{last}} & \Slot & \text{slot of the last seen block}
       \end{array}\right)
   \end{align*}
 
@@ -913,20 +911,19 @@ header processing we verify the following things:
         \begin{array}{l}
           k\\
           \var{ngk}\\
-          \var{dms}
+          \var{dms}\\
+          \sepoch{s_{last}}\\
         \end{array}
       \right)}
       \vdash
       {\left(
           \begin{array}{l}
-            \sepoch{s}\\
             us
           \end{array}
         \right)}
       \trans{epoch}{\bslot{b}}
       {\left(
           \begin{array}{l}
-            \var{e_n} \\
             us'
           \end{array}
         \right)}
@@ -938,7 +935,8 @@ header processing we verify the following things:
         \begin{array}{l}
           k\\
           \var{ngk}\\
-          \var{dms}
+          \var{dms}\\
+          \var{s_{last}}
         \end{array}
         \right)}
       \vdash
@@ -1233,7 +1231,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
    \right)
  }
 \end{equation*}
-\vspace{20pt}
+\vspace{30pt}
 \begin{equation*}
   \inference
   {
@@ -1244,7 +1242,8 @@ body according to the rules in figures \ref{fig:rules:bhead} and
         \begin{array}{l}
           k\\
           \var{ngk}\\
-          \fun{dms}~\var{ds}
+          \fun{dms}~\var{ds}\\
+          \var{s_{last}}
         \end{array}
         \right)}
         &

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -393,7 +393,7 @@ $t=0.22$ as a good value. Specifically, given $k=2160$, we would allow a single
 genesis key to issue (via delegates) $475$ blocks (since
 $2160 \cdot 0.22 = 475.2$), but a $476^{\text{th}}$ block would be rejected.
 See Appendix \ref{apdx:calculating-t} for the background on this value. The
-abstract constant (functions) related to the protocol are defined in
+abstract constant (nullary functions) related to the protocol are defined in
 \cref{fig:defs:proto-abstract-funcs}.
 
 \begin{figure}[ht]
@@ -620,7 +620,7 @@ implementation may of course choose a more compact representation for this
 partial function that only records the changes in epoch length, rather than
 storing a length for each epoch.
 %
-In addition, we rely on abstract constant (function) $\var{ngk}$, which
+In addition, we rely on abstract constant (nullary function) $\var{ngk}$, which
 determines the number of genesis keys.
 
 It is also worth noticing that in the Byron era, the number of slots per-epoch

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -580,7 +580,7 @@ outside the size of the moving window ($k$).
       \begin{array}{r@{~\in~}lr}
         k & \mathbb{N} & \text{chain stability parameter} \\
         t & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{block signature count threshold}\\
-        \var{ds} & \DelegState & \text{Delegation state} \\
+        \var{ds} & \DelegState & \text{delegation state} \\
       \end{array}
     \right)
   \end{equation*}
@@ -767,6 +767,7 @@ During PBFT processing of the block header, we do the following:
 \section{Block processing}
 \label{sec:block-processing}
 
+\newcommand{\BHEnv}{\type{BHEnv}}
 \newcommand{\BHState}{\type{BHState}}
 
 \newcommand{\BBEnv}{\type{BBEnv}}
@@ -875,6 +876,16 @@ header processing we verify the following things:
 \end{figure}
 
 \begin{figure}[ht]
+  \emph{Block header processing environments}
+  \begin{align*}
+    & \BHEnv
+      = \left(
+      \begin{array}{r@{~\in~}lr}
+        k & \mathbb{N} & \text{chain stability parameter}\\
+        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
+        \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
+      \end{array}\right)
+  \end{align*}
 
   \emph{Block header processing states}
   \begin{equation*}

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -308,10 +308,11 @@ given application name $\var{an}$.
     \label{eq:rule:upi-vote}
     \inference
     {
+      \var{cfmThd} \mapsto q \in \var{pps}\\
       {
         \begin{array}{l}
           s_n\\
-          \var{pps}\\
+          q \cdot \var{ngk}\\
           \var{\dom~pws}\\
           \var{dms}
         \end{array}

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -17,7 +17,6 @@
     \left(
       \begin{array}{r@{~\in~}lr}
         \mathcal{K} & \powerset{\VKeyGen} & \text{allowed delegators}\\
-        k & \mathbb{N} & \text{chain stability parameter}\\
         \var{e} & \Epoch & \text{current epoch}\\
         \var{s} & \Slot & \text{current slot}
       \end{array}
@@ -55,12 +54,11 @@
     \inference
     {
       d \leteq 2 \cdot k \\
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
          \mathcal{K} \\
          e\\
-         s\\
-         k
-       \end{array}}
+         s
+       \end{array}\right)}
       \vdash
       {
         \left(
@@ -80,6 +78,10 @@
         \right)
       }
       &
+      {\begin{array}{l}
+       \mathcal{K}
+       \end{array}}
+      \vdash
       {
         \left(
           \begin{array}{l}
@@ -99,12 +101,11 @@
       }
     }
     {
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
          \mathcal{K} \\
-         k\\
          e\\
          s
-      \end{array}}
+      \end{array}\right)}
       \vdash
       {
         \left(
@@ -146,15 +147,30 @@ labels have the following meaning:
 \item[UPIEC] Update-proposal-interface epoch-change.
 \end{description}
 
+In these rules we make use of the abstract constant $\var{ngk}$, defined in
+\cref{fig:defs:upi}, which determines the number of genesis keys:
+
+\begin{figure}[ht]
+  \emph{Abstract functions}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
+    \end{array}
+  \end{equation*}
+
+  \caption{Update interface types and functions}
+  \label{fig:defs:upi}
+\end{figure}
+
+
 \begin{figure}[htb]
   \emph{Update-proposals interface environments}
   \begin{align*}
     & \UPIEnv
       = \left(
       \begin{array}{r@{~\in~}lr}
-        k & \mathbb{N} & \text{chain stability parameter}\\
         \var{s_n} & \Slot & \text{current slot number}\\
-        \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
       \end{array}\right)
   \end{align*}
@@ -235,13 +251,12 @@ labels have the following meaning:
       pws' \leteq pws \unionoverrideRight \{ \upId{up} \mapsto s_n\}
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           s_n\\
-          \var{ngk}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -339,13 +354,12 @@ given application name $\var{an}$.
       \}
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           s_n\\
-          \var{ngk}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -464,7 +478,6 @@ the end on an epoch.
     {
       {
         \begin{array}{l}
-          k\\
           s_n\\
           q \cdot \var{ngk}\\
           \var{dms}\\
@@ -501,14 +514,12 @@ the end on an epoch.
       }
     }
     {
-      {
+      {\left(
         \begin{array}{l}
-          k\\
           s_n\\
-          \var{ngk}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -595,11 +606,10 @@ expires.
       [.., s_n - 2 \cdot k] \restrictdom \var{fads} = \epsilon
     }
     {
-      {\begin{array}{l}
-         k\\
+      {\left(\begin{array}{l}
          s_n\\
          \var{fads}
-       \end{array}}
+       \end{array}\right)}
       \vdash
       {
         \left(
@@ -626,11 +636,10 @@ expires.
       \wcard ; (\wcard , (\var{pv_c}, \var{pps_c})) \leteq [.., s_n - 2 \cdot k] \restrictdom \var{fads}
     }
     {
-      {\begin{array}{l}
-         k\\
+      {\left(\begin{array}{l}
          s_n\\
          \var{fads}
-       \end{array}}
+       \end{array}\right)}
       \vdash
       {
         \left(
@@ -658,11 +667,10 @@ expires.
     \label{eq:rule:upi-ec-pv-unchanged}
     \inference
     {
-      {\begin{array}{l}
-         k\\
+      {\left(\begin{array}{l}
          s_n\\
          \var{fads}
-       \end{array}}
+       \end{array}\right)}
       \vdash
       {
         \left(
@@ -681,14 +689,12 @@ expires.
       } &\var{pv} = \var{pv'}
     }
     {
-      {
+      {\left(
         \begin{array}{l}
-          k\\
           s_n\\
-          \var{ngk}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -728,11 +734,10 @@ expires.
     \label{eq:rule:upi-ec-pv-change}
     \inference
     {
-      {\begin{array}{l}
-         k\\
+      {\left(\begin{array}{l}
          s_n\\
          \var{fads}
-       \end{array}}
+       \end{array}\right)}
       \vdash
       {
         \left(
@@ -752,14 +757,12 @@ expires.
       & \var{pv} \neq \var{pv'}
     }
     {
-      {
+      {\left(
         \begin{array}{l}
-          k \\
           s_n\\
-          \var{ngk}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -17,9 +17,10 @@
     \left(
       \begin{array}{r@{~\in~}lr}
         \mathcal{K} & \powerset{\VKeyGen} & \text{allowed delegators}\\
-        \var{e} & \Epoch & \text{epoch}\\
-        \var{s} & \Slot & \text{slot}\\
-        \var{pps} & \PPMMap & \text{Protocol parameters}
+        k & \mathbb{N} & \text{chain stability parameter}\\
+        \var{e} & \Epoch & \text{current epoch}\\
+        \var{s} & \Slot & \text{current slot}\\
+        \var{pps} & \PPMMap & \text{protocol parameters}
       \end{array}
     \right)
   \end{equation*}
@@ -194,7 +195,7 @@ labels have the following meaning:
       \powerset (\UPIEnv \times \UPIState
       \times (\ProtVer \times \VKey) \times \UPIState)\\
       \_ \vdash \_ \trans{upiec}{\_} \_ &
-      \powerset (\UPIEnv \times \UPIState \times \Epoch \times \UPIState)
+      \powerset (\UPIEnv \times \UPIState \times \UPIState)
     \end{array}
   \end{equation*}
   \caption{Update-proposals interface transition-system types}

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -19,8 +19,7 @@
         \mathcal{K} & \powerset{\VKeyGen} & \text{allowed delegators}\\
         k & \mathbb{N} & \text{chain stability parameter}\\
         \var{e} & \Epoch & \text{current epoch}\\
-        \var{s} & \Slot & \text{current slot}\\
-        \var{pps} & \PPMMap & \text{protocol parameters}
+        \var{s} & \Slot & \text{current slot}
       \end{array}
     \right)
   \end{equation*}
@@ -104,8 +103,7 @@
          \mathcal{K} \\
          k\\
          e\\
-         s\\
-         pps
+         s
       \end{array}}
       \vdash
       {

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -54,7 +54,7 @@
     \label{eq:rule:delegation-interface}
     \inference
     {
-      \var{stableAfter} \mapsto k \in \var{pps} & d \leteq 2 \cdot k \\
+      d \leteq 2 \cdot k \\
       {\begin{array}{l}
          \mathcal{K} \\
          e\\
@@ -101,6 +101,7 @@
     {
       {\begin{array}{l}
          \mathcal{K} \\
+         k\\
          e\\
          s\\
          pps
@@ -152,6 +153,7 @@ labels have the following meaning:
     & \UPIEnv
       = \left(
       \begin{array}{r@{~\in~}lr}
+        k & \mathbb{N} & \text{chain stability parameter}\\
         \var{s_n} & \Slot & \text{current slot number}\\
         \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
@@ -163,7 +165,6 @@ labels have the following meaning:
     & \UPIState = \\
     & \left(
       \begin{array}{r@{~\in~}lr}
-        \var{e_p} & \Epoch & \text{previously seen epoch}\\
         (\var{pv}, \var{pps}) & \ProtVer \times \PPMMap
         & \text{current protocol information}\\
         \var{fads} & \seqof{(\Slot \times (\ProtVer \times \PPMMap))}
@@ -246,7 +247,6 @@ labels have the following meaning:
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
             (\var{pv}, \var{pps})\\
             \var{fads}\\
             \var{avs}\\
@@ -263,7 +263,6 @@ labels have the following meaning:
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
             (\var{pv}, \var{pps})\\
             \var{fads}\\
             \var{avs}\\
@@ -352,7 +351,6 @@ given application name $\var{an}$.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
             (\var{pv}, \var{pps})\\
             \var{fads}\\
             \var{avs}\\
@@ -369,7 +367,6 @@ given application name $\var{an}$.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
             (\var{pv}, \var{pps})\\
             \var{fads}\\
             \var{avs} \unionoverrideRight \var{avs_{new}}\\
@@ -494,8 +491,7 @@ the end on an epoch.
           \end{array}
         \right)
       }\\
-      \var{stableAfter} \mapsto k \in  \var{pps}
-      & \var{upropTTL} \mapsto u \in \var{pps}
+      \var{upropTTL} \mapsto u \in \var{pps}
       & \var{upAdptThd} \mapsto q \in \var{pps} \\
       {
         \begin{array}{r@{~\leteq~}l}
@@ -508,6 +504,7 @@ the end on an epoch.
     {
       {
         \begin{array}{l}
+          k\\
           s_n\\
           \var{ngk}\\
           \var{dms}
@@ -517,7 +514,6 @@ the end on an epoch.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
             (\var{pv}, \var{pps})\\
             \var{fads}\\
             \var{avs}\\
@@ -534,7 +530,6 @@ the end on an epoch.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
             (\var{pv}, \var{pps})\\
             \var{fads'}\\
             \var{avs}\\
@@ -555,10 +550,8 @@ the end on an epoch.
 
 \clearpage
 
-Rule~\ref{eq:rule:upi-ec-pv-change} models how the epoch, protocol-version and its
-parameters are changed depending on the epoch in the signal ($e_n$ in this
-case). A change in the epoch only occurs if the new epoch is greater than the
-previously seen epoch ($e_p$).
+Rule~\ref{eq:rule:upi-ec-pv-change} models how the protocol-version and its
+parameters are changed depending on an epoch change signal.
 %
 On an epoch change, this rule will pick a candidate that gathered enough
 endorsements at least $2 \cdot k$ slots ago. If a protocol-version candidate
@@ -597,43 +590,10 @@ expires.
 
 \begin{figure}[htb]
   \begin{equation}
-    \label{eq:rule:pvbump-change-noop}
-    \inference
-    {
-      e_n \leq e_p
-    }
-    {
-      {\begin{array}{l}
-         k\\
-         s_n\\
-         \var{fads}
-       \end{array}}
-      \vdash
-      {
-        \left(
-          \begin{array}{l}
-            \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}
-          \end{array}
-        \right)
-      }
-      \trans{pvbump}{\var{e_n}}
-      {
-        \left(
-          \begin{array}{l}
-            \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}
-          \end{array}
-        \right)
-      }
-    }
-  \end{equation}
-  \nextdef
-  \begin{equation}
     \label{eq:rule:pvbump-change-epoch-only}
     \inference
     {
-      [.., s_n - 2 \cdot k] \restrictdom \var{fads} = \epsilon &  e_p < e_n
+      [.., s_n - 2 \cdot k] \restrictdom \var{fads} = \epsilon
     }
     {
       {\begin{array}{l}
@@ -645,17 +605,15 @@ expires.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}\\
+            \var{pv}, \var{pps}\\
           \end{array}
         \right)
       }
-      \trans{pvbump}{\var{e_n}}
+      \trans{pvbump}{}
       {
         \left(
           \begin{array}{l}
-            \var{e_n}\\
-            \var{(\var{pv}, \var{pps})}\\
+            \var{pv}, \var{pps}\\
           \end{array}
         \right)
       }
@@ -667,7 +625,6 @@ expires.
     \inference
     {
       \wcard ; (\wcard , (\var{pv_c}, \var{pps_c})) \leteq [.., s_n - 2 \cdot k] \restrictdom \var{fads}
-      & e_p < e_n
     }
     {
       {\begin{array}{l}
@@ -679,17 +636,15 @@ expires.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}\\
+            \var{pv}, \var{pps}\\
           \end{array}
         \right)
       }
-      \trans{pvbump}{\var{e_n}}
+      \trans{pvbump}{}
       {
         \left(
           \begin{array}{l}
-            \var{e_n}\\
-            \var{(\var{pv_c}, \var{pps_c})}\\
+            \var{pv_c}, \var{pps_c}\\
           \end{array}
         \right)
       }
@@ -704,7 +659,6 @@ expires.
     \label{eq:rule:upi-ec-pv-unchanged}
     \inference
     {
-      \var{stableAfter} \mapsto k \in  \var{pps} &
       {\begin{array}{l}
          k\\
          s_n\\
@@ -714,24 +668,23 @@ expires.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}
+            \var{pv}, \var{pps}
           \end{array}
         \right)
       }
-      \trans{pvbump}{\var{e_n}}
+      \trans{pvbump}{}
       {
         \left(
           \begin{array}{l}
-            \var{e'}\\
-            \var{(\var{pv'}, \var{pps'})}\\
+            \var{pv'}, \var{pps'}\\
           \end{array}
         \right)
-      }\\ ~ \\ \var{pv} = \var{pv'}
+      } &\var{pv} = \var{pv'}
     }
     {
       {
         \begin{array}{l}
+          k\\
           s_n\\
           \var{ngk}\\
           \var{dms}
@@ -741,8 +694,7 @@ expires.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}\\
+            (\var{pv}, \var{pps})\\
             \var{fads}\\
             \var{avs}\\
             \var{rpus}\\
@@ -754,12 +706,11 @@ expires.
           \end{array}
         \right)
       }
-      \trans{upiec}{\var{e_n}}
+      \trans{upiec}{}
       {
         \left(
           \begin{array}{l}
-            \var{e'}\\
-            \var{(\var{pv}, \var{pps})}\\
+            (\var{pv}, \var{pps})\\
             \var{fads}\\
             \var{avs}\\
             \var{rpus}\\
@@ -778,7 +729,6 @@ expires.
     \label{eq:rule:upi-ec-pv-change}
     \inference
     {
-      \var{stableAfter} \mapsto k \in  \var{pps} &
       {\begin{array}{l}
          k\\
          s_n\\
@@ -788,24 +738,24 @@ expires.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
-            \var{(\var{pv}, \var{pps})}
+            \var{pv}, \var{pps}\\
           \end{array}
         \right)
       }
-      \trans{pvbump}{\var{e_n}}
+      \trans{pvbump}{}
       {
         \left(
           \begin{array}{l}
-            \var{e'}\\
-            \var{(\var{pv'}, \var{pps'})}\\
+            \var{pv'}, \var{pps'}\\
           \end{array}
         \right)
-      }\\ ~ \\ \var{pv} \neq \var{pv'}
+      }
+      & \var{pv} \neq \var{pv'}
     }
     {
       {
         \begin{array}{l}
+          k \\
           s_n\\
           \var{ngk}\\
           \var{dms}
@@ -815,7 +765,6 @@ expires.
       {
         \left(
           \begin{array}{l}
-            \var{e_p}\\
             \var{(\var{pv}, \var{pps})}\\
             \var{fads}\\
             \var{avs}\\
@@ -828,12 +777,11 @@ expires.
           \end{array}
         \right)
       }
-      \trans{upiec}{\var{e_n}}
+      \trans{upiec}{}
       {
         \left(
           \begin{array}{l}
-            \var{e'}\\
-            \var{(\var{pv'}, \var{pps'})}\\
+            (\var{pv'}, \var{pps'})\\
             \epsilon\\
             \var{avs}\\
             \emptyset\\

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -81,7 +81,7 @@ $\trans{sdeleg}{\wcard}$ are presented in
         \mathcal{K} & \powerset{\VKeyGen} & \text{allowed delegators}\\
         \var{e} & \Epoch & \text{epoch}\\
         \var{s} & \Slot & \text{slot}\\
-        \var{k} & \SlotCount & \text{chain stability parameter}
+        \var{k} & \mathbb{N} & \text{chain stability parameter}
       \end{array}
     \right)
   \end{equation*}

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -30,7 +30,9 @@ Rule~\ref{eq:rule:delegation-scheduling} determines when a certificate can
 become ``scheduled''. The definitions used in this rules are presented in
 \cref{fig:defs:delegation-scheduling}, and the types of the system induced by
 $\trans{sdeleg}{\wcard}$ are presented in
-\cref{fig:ts-types:delegation-scheduling}.
+\cref{fig:ts-types:delegation-scheduling}. Here and in the remaining rules we
+will be using $k$ as an abstract constant that give us the chain stability
+parameter.
 
 \begin{figure}[htb]
   \emph{Abstract types}
@@ -65,7 +67,8 @@ $\trans{sdeleg}{\wcard}$ are presented in
       \fun{dwho} & \DCert \mapsto (\VKeyGen \times \VKey)
       & \text{who delegates to whom in the certificate}\\
       \fun{depoch} & \DCert \mapsto \Epoch
-      & \text{certificate epoch}
+      & \text{certificate epoch}\\
+      \var{k} & \mathbb{N} & \text{chain stability parameter}
     \end{array}
   \end{equation*}
   \caption{Delegation scheduling definitions}
@@ -81,7 +84,6 @@ $\trans{sdeleg}{\wcard}$ are presented in
         \mathcal{K} & \powerset{\VKeyGen} & \text{allowed delegators}\\
         \var{e} & \Epoch & \text{epoch}\\
         \var{s} & \Slot & \text{slot}\\
-        \var{k} & \mathbb{N} & \text{chain stability parameter}
       \end{array}
     \right)
   \end{equation*}
@@ -113,12 +115,11 @@ $\trans{sdeleg}{\wcard}$ are presented in
     {
     }
     {
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
        \mathcal{K}\\
         e\\
-        s\\
-        d
-      \end{array}}
+        s
+      \end{array}\right)}
       \vdash
       \left(
         \begin{array}{l}
@@ -140,12 +141,11 @@ $\trans{sdeleg}{\wcard}$ are presented in
       d \leteq 2 \cdot k & (s + d,~ (\var{vk_s},~ \wcard)) \notin \var{sds}\\
     }
     {
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
        \mathcal{K}\\
         e\\
-        s\\
-        k
-      \end{array}}
+        s
+      \end{array}\right)}
       \vdash
       {
         \left(
@@ -331,12 +331,11 @@ delegations have on the ledger.
     {
     }
     {
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
        \mathcal{K}\\
         e\\
-        s\\
-        d
-      \end{array}}
+        s
+      \end{array}\right)}
       \vdash
       \left(
         \begin{array}{l}
@@ -353,12 +352,11 @@ delegations have on the ledger.
     {
     }
     {
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
          \mathcal{K} \\
          e\\
          s\\
-         k
-       \end{array}}
+       \end{array}\right)}
       \vdash
       {
         \left(
@@ -384,12 +382,11 @@ delegations have on the ledger.
     \label{eq:rule:delegation-scheduling-seq-ind}
     \inference
     {
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
          \mathcal{K} \\
          e\\
-         s\\
-         k
-       \end{array}}
+         s
+       \end{array}\right)}
       \vdash
       {
         \left(
@@ -409,12 +406,11 @@ delegations have on the ledger.
         \right)
       }
       &
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
          \mathcal{K} \\
          e\\
-         s\\
-         k
-       \end{array}}
+         s
+       \end{array}\right)}
       \vdash
       {
         \left(
@@ -435,12 +431,11 @@ delegations have on the ledger.
       }
     }
     {
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
          \mathcal{K} \\
          e\\
-         s\\
-         k
-       \end{array}}
+         s
+       \end{array}\right)}
       \vdash
       {
         \left(
@@ -516,6 +511,8 @@ delegations have on the ledger.
     \label{eq:rule:delegation-seq-ind}
     \inference
     {
+      \mathcal{K}
+      \vdash
       {
         \left(
           \begin{array}{l}
@@ -534,6 +531,8 @@ delegations have on the ledger.
         \right)
       }
       &
+      \mathcal{K}
+      \vdash
       {
         \left(
           \begin{array}{l}

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -357,7 +357,7 @@ delegations have on the ledger.
          \mathcal{K} \\
          e\\
          s\\
-         d
+         k
        \end{array}}
       \vdash
       {
@@ -388,7 +388,7 @@ delegations have on the ledger.
          \mathcal{K} \\
          e\\
          s\\
-         d
+         k
        \end{array}}
       \vdash
       {
@@ -413,7 +413,7 @@ delegations have on the ledger.
          \mathcal{K} \\
          e\\
          s\\
-         d
+         k
        \end{array}}
       \vdash
       {
@@ -439,7 +439,7 @@ delegations have on the ledger.
          \mathcal{K} \\
          e\\
          s\\
-         d
+         k
        \end{array}}
       \vdash
       {

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -327,7 +327,7 @@ delegations have on the ledger.
 
 \begin{figure}[htb]
   \begin{equation}
-    \inference[Initial-SDELEGS]
+    \inference
     {
     }
     {
@@ -467,10 +467,10 @@ delegations have on the ledger.
 
 \begin{figure}
   \begin{equation}
-    \inference[Initial-ADELEGS]
+    \inference
     {
-      \var{dms_0} \leteq \Set{k \mapsto k}{k \in \mathcal{K}} &
-      \var{dws_0} \leteq \Set{k \mapsto 0}{k \in \mathcal{K}}
+      \var{dms_0} \leteq \Set{\var{vk} \mapsto \var{vk}}{\var{vk} \in \mathcal{K}} &
+      \var{dws_0} \leteq \Set{\var{vk} \mapsto 0}{\var{vk} \in \mathcal{K}}
     }
     {
       \mathcal{K}

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -991,7 +991,6 @@ blocks. Some clarifications are in order:
     & \BVREnv
       = \left(
       \begin{array}{r@{~\in~}lr}
-        k & \mathbb{N} & \text{chain stability parameter}\\
         \var{s_n} & \Slot & \text{current slot number}\\
         t & \mathbb{Q} & \text{adoption threshold}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
@@ -1127,7 +1126,6 @@ rule by $\var{bv}$:
     {
       {
         \begin{array}{l}
-          k\\
           s_n\\
           t\\
           \var{dms}\\
@@ -1170,7 +1168,6 @@ rule by $\var{bv}$:
     {
       {
         \begin{array}{l}
-          k\\
           s_n\\
           t\\
           \var{dms}\\
@@ -1215,7 +1212,6 @@ rule by $\var{bv}$:
     {
       {
         \begin{array}{l}
-          k\\
           s_n\\
           t\\
           \var{dms}\\

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -165,7 +165,6 @@ keys, some of which correspond with fields of the
   corresponding protocol parameter in the `cardano-sl` protocol parameters, so
   in the implementation we will be using `srMinThd` as well to get the portion
   of keys that need to vote on a proposal to be confirmed.
-\item Chain stability parameter: $\var{stableAfter}$.
 \item Update proposal time-to-live: $\var{upropTTL}$. This would correspond to
   the number of slots specified by `bvdUpdateImplicit`. In `cardano-sl` the
   rule was that after `bvdUpdateImplicit` slots, if a proposal did not reach a

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -149,10 +149,22 @@ keys, some of which correspond with fields of the
 \item Maximum proposal size: $\var{maxProposalSize}$
 \item Transaction fee policy: $\var{txFeePolicy}$
 \item Script version: $\var{scriptVersion}$
-\item Update adoption threshold : $\var{upAdptThd}$. This represents the
-  minimum percentage of the total number of genesis keys that have to endorse a
-  protocol version to be able to become adopted. This parameter would
-  correspond with `srMinThd` in `bvdSoftforkRule`.
+\item Update adoption threshold: $\var{upAdptThd}$. This represents the minimum
+  percentage of the total number of genesis keys that have to endorse a
+  protocol version to be able to become adopted. There is no corresponding
+  parameter in the `cardano-sl` protocol parameters, however we do have a
+  soft-fork minimum threshold parameter (`srMinThd` in `bvdSoftforkRule`). When
+  divided by, $1\times 10^{15}$, it determines the minimum portion of the total
+  stake that is needed for the adoption of a new protocol version. On mainnet,
+  this number is set to $6 \times 10^{14}$, so the minimum portion becomes
+  $0.6$. This number can be multiplied by the total number of genesis keys to
+  obtain how many keys are needed to reach a majority.
+\item Confirmation threshold $\var{cfmThd}$: This represents the minimum
+  percentage of the total number of genesis keys that have to vote on a
+  proposal for it to become confirmed. As with $\var{upAdptThd}$ there is no
+  corresponding protocol parameter in the `cardano-sl` protocol parameters, so
+  in the implementation we will be using `srMinThd` as well to get the portion
+  of keys that need to vote on a proposal to be confirmed.
 \item Chain stability parameter: $\var{stableAfter}$.
 \item Update proposal time-to-live: $\var{upropTTL}$. This would correspond to
   the number of slots specified by `bvdUpdateImplicit`. In `cardano-sl` the
@@ -162,16 +174,10 @@ keys, some of which correspond with fields of the
   specification, we re-interpret the meaning of this parameter as the proposal
   time-to-live: if after the number of slots specified by `bvdUpdateImplicit`
   the proposal does not reach a majority of approvals, the proposal is simply
-  discarded. In the mainnet configuration (`mainnet-genesis.json` this value is
+  discarded. In the mainnet configuration (`mainnet-genesis.json`) this value is
   set to $10000$, which corresponds with almost half of the total number of
-  slots in an epoch).
+  slots in an epoch.
 \end{itemize}
-In addition we make use of the $\var{cfmThd}$ key, which determines the portion
-of the stakeholders that have to vote for a proposal to consider it confirmed.
-This key does not seem to have a corresponding field in `BlockVersionData`, so
-to be consistent with the existing chain the value corresponding to
-$\var{cfmThd}$ can be set to $4$, which represents the majority of the $7$
-genesis keys.
 
 \subsection{Update proposals registration}
 \label{sec:update-proposals-registration}
@@ -237,9 +243,7 @@ The rules in Figure~\ref{fig:rules:up-validity} model the validity of a proposal
       current maximum block size,
     \item the maximum transaction size must be smaller than the maximum block
       size (this requirement is \textbf{crucial} for having every transaction
-      fitting in a block \footnote{TODO: we should discuss if this is enough,
-        since a block might contain other data that contributes to its total
-        size}), and
+      fitting in a block, and
     \item the proposed new script version can be incremented by at most 1.
     \end{itemize}
   \item must have a unique version among the current active proposals. This
@@ -802,7 +806,7 @@ In Rule~\ref{eq:rule:voting}:
       = \left(
       \begin{array}{r@{~\in~}lr}
         \var{s_n} & \Slot & \text{current slot number}\\
-        \var{pps} & \PPMMap & \text{current protocol parameters map}\\
+        \var{t} & \mathbb{Q} & \text{confirmation threshold}\\
         \var{rups} & \powerset{\UPropId}
         & \text{registered update proposals}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}
@@ -868,7 +872,6 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
         \right)
       }\\
       \var{pid} \leteq \vPropId{v}
-      & \var{cfmThd} \mapsto t \in \var{pps}
       & (\size{\{\var{pid}\} \restrictdom \var{vts'}} < t
       \vee \var{pid} \in \dom~\var{cps}
       )
@@ -877,7 +880,7 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
       {
         \begin{array}{l}
           s_n\\
-          \var{pps}\\
+          \var{t}\\
           \var{rups}\\
           \var{dms}
         \end{array}
@@ -930,7 +933,6 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
         \right)
       }\\
       \var{pid} \leteq \vPropId{v}
-      & \var{cfmThd} \mapsto t \in \var{pps}
       & t \leq \size{\{\var{pid}\} \restrictdom \var{vts'}}
       & \var{pid} \notin \dom~\var{cps}
     }
@@ -938,7 +940,7 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
       {
         \begin{array}{l}
           \var{s_n}\\
-          \var{pps}\\
+          \var{t}\\
           \var{rups}\\
           \var{dms}
         \end{array}
@@ -1386,14 +1388,3 @@ complex update mechanism depends on research that is in progress at the time of
 writing this specification. We decided to keep the update mechanism as simple
 as possible in the centralized era and incorporate the research results for the
 decentralized era at a later stage.
-
-\subsection{Questions}
-\label{sec:up-questions}
-
-This temporary section contains unanswered questions about the formalization of
-update mechanism:
-
-\begin{itemize}
-\item Do we need to model the $\var{scriptVersion}$?
-\item Do we allow an update proposal that proposes no update?
-\end{itemize}


### PR DESCRIPTION
- Remove epoch change logic from update interface, as this is now handled by the chain spec.
- Reorganize the chain spec so that the related transition system definitions are closer to each other.
- Make the Byron chain and ledger spec match.
- Remove reference to `elens` and make `sEpoch` be an abstract function, to match what we want in the implementation: have the mapping from epoch to epoch lengths be a constant parameter to our validation functions.
- Remove labels from initial rules.
- Add explanations on how to map `upAdptThd` and `cfmThd` to `cardano-sl` protocol paramters.
- Update the voting rule to that the confirmation threshold is passed as an environment variable, and the `UPIVOTE` rule now multiplies `cfmThd` by the number of genesis keys.
- Remove questions as they are no longer relevant.
- Remove TODO as we seem to be OK with the constraint that on an update proposal the proposed maximum transaction size must be lower than the maximum block size.

Closes #343 
Closes #264 