### PR TITLE
adding bootstrap addresses

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/address.tex
+++ b/shelley/chain-and-ledger/formal-spec/address.tex
@@ -3,7 +3,7 @@
 
 Addresses are described in section 4.2 of the delegation design document \cite{delegation_design}.
 The types needed for the addresses are defined in Figure~\ref{fig:defs:addresses}.
-There are three types of UTxO addresses:
+There are four types of UTxO addresses:
 \begin{itemize}
   \item Base addresses, $\AddrB$,
         containing the hash of a payment key and the hash of a staking key,
@@ -11,6 +11,8 @@ There are three types of UTxO addresses:
         containing the hash of a payment key and a pointer to a stake key registration certificate,
   \item Enterprise addresses, $\AddrE$,
         containing only the hash of a payment key (and which have no staking rights).
+  \item Bootstrap addresses, $\AddrBS$,
+        corresponding to the addresses in Byron, behaving exactly like enterprise addresses.
 \end{itemize}
 Together, these three address types make up the $\Addr$ type, which will be used
 in transaction outputs in Section~\ref{sec:utxo}.
@@ -62,8 +64,17 @@ Section~\ref{sec:utxo} and follows \cite{chimeric}.
       & \text{enterprise address}
       \\
       \var{addr}
+      & \AddrBS
+      & \HashKey_{pay}
+      & \text{bootstrap address}
+      \\
+      \var{addr}
       & \Addr
-      & \AddrB \uniondistinct \AddrP \uniondistinct \AddrE
+      & \begin{array}{l@{~\uniondistinct}l}
+          \AddrB & \AddrP \uniondistinct \AddrE
+          \\
+                 & \AddrBS
+        \end{array}
       & \text{output address}
       \\
       \var{acct}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -70,6 +70,7 @@
 \newcommand{\AddrB}{\type{Addr_{base}}}
 \newcommand{\AddrP}{\type{Addr_{ptr}}}
 \newcommand{\AddrE}{\type{Addr_{enterprise}}}
+\newcommand{\AddrBS}{\type{Addr_{bootstrap}}}
 \newcommand{\Ptr}{\type{Ptr}}
 \newcommand{\DState}{\type{DState}}
 \newcommand{\DWEnv}{\type{DWEnv}}


### PR DESCRIPTION
Adding bootstrap (ie Byron) address to the Shelley ledger spec. closes #391 