### PR TITLE
[#262] Derive a Semigroup instance for PairSet

### DIFF
--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -141,7 +141,7 @@ newtype Value = Value Natural
 ---------------------------------------------------------------------------------
 
 newtype PairSet a b = PairSet {unPairSet :: Set (a,b)}
-  deriving (Eq, Show)
+  deriving (Eq, Semigroup, Show)
 
 psSize :: PairSet a b -> Int
 psSize = Set.size . unPairSet

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -385,11 +385,11 @@ instance STS ADDVOTE where
             ) <- judgmentContext
         let pid = vote ^. vPropId
             vk = vote ^. vCaster
-            vtsPid = Set.fromList
+            vtsPid = Core.PairSet $ Set.fromList
               [(pid, vks) | vks <- Set.toList . Map.findWithDefault Set.empty vk $ invertMap dms ]
         Set.member pid rups ?! NoUpdateProposal pid
         Core.verify vk pid (vote ^. vSig) ?! AVSigDoesNotVerify
-        return $! Core.PairSet $ Set.union (Core.unPairSet vts) vtsPid
+        return $! vts <> vtsPid
     ]
 
 data UPVOTE


### PR DESCRIPTION
_Closes issue #262_

Derive a `Semigroup` instance for `PairSet` such that:

> we can define unions of set of pairs in a more convenient way