### PR TITLE
Use dom function rather than Map.keysSet

### DIFF
--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -216,7 +216,7 @@ instance Relation (Map k v) where
   r ▹ s = Map.filter (flip Set.member s) r
 
   d0 ∪ d1 = Map.union d0 d1
-  d0 ⨃ d1 = d1 ∪ (Map.keysSet d1 ⋪ d0)
+  d0 ⨃ d1 = d1 ∪ (dom d1 ⋪ d0)
 
 -- TODO: Remove `PairSet` and just use `Set (a, b)`?
 instance Relation (PairSet a b) where

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -114,7 +114,7 @@ utxoInductive = do
     ?! IncreasedTotalBalance
   pcMinFee pc tx <= txfee tx ?! FeeTooLow
   let
-    unspentInputs (UTxO aUtxo) = Map.keysSet aUtxo
+    unspentInputs (UTxO aUtxo) = dom aUtxo
     txinsSet = Set.fromList $ txins tx
   Set.size txinsSet == length (txins tx)
     && txinsSet `Set.isSubsetOf` unspentInputs utxo


### PR DESCRIPTION
Since
```
instance Relation (Map k v) where
  ...
  dom = Map.keysSet
  ...
```
I figure it makes sense to stick with using `dom` throughout the package where applicable.