### PR TITLE
using Byron update mechanisms in Shelley ledeger

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -43,6 +43,8 @@
 \newcommand{\BHeaderState}{\type{BHeaderState}}
 \newcommand{\VRFEnv}{\type{VRFEnv}}
 \newcommand{\DSliderEnv}{\type{DSliderEnv}}
+\newcommand{\VRFState}{\type{VRFState}}
+\newcommand{\OCertState}{\type{OCertState}}
 \newcommand{\NewEpochEnv}{\type{NewEpochEnv}}
 \newcommand{\NewEpochState}{\type{NewEpochState}}
 \newcommand{\PoolDistr}{\type{PoolDistr}}
@@ -222,8 +224,7 @@ given in Figure~\ref{fig:ts-types:newepoch}, it consists of
 
 \begin{itemize}
 \item The epoch nonce.
-\item The new protocol parameters.
-\item An optional rewards update.
+\item The current slot.
 \end{itemize}
 The new epoch state is given in Figure~\ref{fig:ts-types:newepoch}, it consists
 of
@@ -240,7 +241,7 @@ of
 
 Figure~\ref{fig:ts-types:newepoch} also defines an abstract pseudorandom function
 $\fun{obftSchedule}$ for creating the OBFT leader schedule for each new epoch,
-as explained in section 3.9.2 of \cite{delegation_design}.
+as explained in section 3.9.2 of~\cite{delegation_design}.
 The function takes a seed, the decentralization parameter $d$, and the active slot coeffient $f$.
 It must create $(d\cdot\SlotsPerEpoch)$-many OBFT slots, $(f\cdot d\cdot \SlotsPerEpoch)$
 of which are active.
@@ -252,7 +253,7 @@ of which are active.
     \left(
       \begin{array}{r@{~\in~}lr}
         \eta_1 & \Seed & \text{epoch nonce} \\
-        \var{pp_n} & \PParams & \text{new protocol parameters}
+        \var{s} & \Slot & \text{current slot}
       \end{array}
     \right)
   \end{equation*}
@@ -329,9 +330,15 @@ in the pool distribution.
     {
       e = e_\ell + 1
       &
-      \var{es}' \leteq \fun{applyRUpd}~\var{ru}~\var{es}
+      (\wcard,~\wcard,~(\wcard,~\wcard,~\var{us}))\leteq\var{es}
       \\
       {
+        \var{s}\vdash\var{us} \trans{upiec}{} \var{us'}
+      }
+      &
+      \var{pp_n}\leteq\pps{us'}
+     \\
+     {
         \left(
           {\begin{array}{c}
               \var{pp}_n \\
@@ -339,7 +346,7 @@ in the pool distribution.
            \end{array}}
        \right)
        \vdash
-       \var{es'}\trans{epoch}{\var{e}}\var{es''}
+       (\fun{applyRUpd}~\var{ru}~\var{es})\trans{epoch}{\var{e}}\var{es'}
      }
      \\~\\~\\
      {\begin{array}{r@{~\leteq~}l}
@@ -353,14 +360,15 @@ in the pool distribution.
                     (\var{hk}, \frac{\var{c}}{\var{total}}) \vert (\var{hk},
                     \var{c}) \in \var{stake}
                     \right\} \\
-         \var{dsched} & \fun{obftSchedule}~\eta_1~(\activeSlotCoeff{pp})~(\fun{d}~{pp})\\
+         \var{dsched'} & \fun{obftSchedule}~\eta_1~(\activeSlotCoeff{pp})~(\fun{d}~{pp})\\
+        \var{es''} & \var{es'}\unionoverrideRight\{us'\}
       \end{array}}
     }
     {
       \left(
         {\begin{array}{c}
             \eta_1 \\
-            \var{pp_n} \\
+            \var{s} \\
         \end{array}}
       \right)
       \vdash
@@ -371,6 +379,7 @@ in the pool distribution.
             \var{es} \\
             \var{ru} \\
             \var{pd} \\
+            \var{dsched} \\
       \end{array}\right)}
       \trans{newepoch}{\var{e}}
       {\left(\begin{array}{c}
@@ -380,6 +389,7 @@ in the pool distribution.
             \varUpdate{\var{es}''} \\
             \varUpdate{\Nothing} \\
             \varUpdate{\var{pd}'} \\
+            \varUpdate{\var{dsched}'} \\
       \end{array}\right)}
     }
   \end{equation}
@@ -395,7 +405,7 @@ in the pool distribution.
       \left(
         {\begin{array}{c}
             \eta_1 \\
-            \var{pp_n} \\
+            \var{s} \\
         \end{array}}
       \right)
       \vdash
@@ -503,22 +513,36 @@ There are two different cases for $\mathsf{UPDN}$, one where \var{s} is not yet
 \subsection{Operational Certificate Transition}
 \label{sec:oper-cert-trans}
 
-The Operational Certificate Transition does not use any environment, its signal
-is a block header body, its state is shown in
-Figure~\ref{fig:ts-types:ocert}. The state consists of
+The Operational Certificate Transition contains the genesis keys as its environment.
+Its signal is a block header body, its state is shown in
+Figure~\ref{fig:ts-types:ocert}. The state consists of the pool state and the genesis
+key delegations:
 
 \begin{itemize}
 \item The stake pools map \var{stpools}.
 \item The pool parameters \var{poolParams}.
 \item The map of retiring stake pools to epochs \var{retiring}.
 \item The mapping \var{cs} of operational certificate counters.
+\item The mapping of genesis keys to operational keys.
 \end{itemize}
 
 \begin{figure}
+  %
+  \emph{Operational Certificate states}
+  \begin{equation*}
+    \OCertState =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{ps} & \PState & \text{pool state} \\
+        \var{dms} & \VKeyGen\mapsto\VKey & \text{genesis key delegations} \\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
   \emph{Operational Certificate Transitions}
   \begin{equation*}
-    \vdash \var{\_} \trans{ocert}{\_} \var{\_} \subseteq
-    \powerset (\PState \times \BHBody \times \PState)
+    \_ \vdash \var{\_} \trans{ocert}{\_} \var{\_} \subseteq
+    \powerset (\powerset{\VKeyGen} \times \OCertState \times \BHBody \times \OCertState)
   \end{equation*}
   \caption{OCert transition-system types}
   \label{fig:ts-types:ocert}
@@ -550,6 +574,8 @@ transition which are the following:
 After this, the transition system updates the operational certificate state by
 updating the mapping of operational certificates where it overwrites the entry
 of the key \var{hk} with the KES period \var{n}.
+If the cold key was a genesis key, then the \var{dms} map is updated with the new
+operational hot key.
 
 \begin{figure}[ht]
   \begin{equation}\label{eq:ocert}
@@ -568,8 +594,11 @@ of the key \var{hk} with the KES period \var{n}.
       m \leq n
       &
       \mathcal{V}_{\var{vk_{cold}}}{\serialised{(\var{vk_{hot}},~n,~c_0)}}_{\sigma}
+      \\
+      d = \var{gkeys} \restrictdom \{\var{vk_{cold}}\mapsto \var{vk_{hot}}\}
     }
     {
+      \var{gkeys}
       \vdash
       \left(
       \begin{array}{r}
@@ -577,6 +606,8 @@ of the key \var{hk} with the KES period \var{n}.
         \var{poolParams} \\
         \var{retiring} \\
         \var{cs} \\
+        \\
+        \var{dms} \\
       \end{array}
       \right)
       \trans{ocert}{\var{bhb}}
@@ -586,6 +617,8 @@ of the key \var{hk} with the KES period \var{n}.
         \var{poolParams} \\
         \var{retiring} \\
         \varUpdate{\var{cs}\unionoverrideRight\{\var{hk}\mapsto n\}} \\
+        \\
+        \varUpdate{\var{dms}\unionoverrideRight d} \\
       \end{array}
       \right)
     }
@@ -865,7 +898,7 @@ returned by the application of the $\mathsf{BHEAD}$ transition rule.
 \label{sec:decentralization-slider}
 
 The transition from the boostrap era to a fully decentralized network is explained in
-section 3.9.2 of \cite{delegation_design}.
+section 3.9.2 of~\cite{delegation_design}.
 Key to this transition is a protocol parameter $d$ which controls how many slots are governed by
 the genesis nodes via OBFT, and which slots are open to any registered stake pool.
 The transition system introduced in this section, $\type{DSLIDE}$, covers this mechanism.
@@ -1007,14 +1040,14 @@ The environments for this transition is:
 
 The Block Body Transition updates the block body state which comprises the
 ledger state and the map describing the produced blocks. The environment of the
-$\mathsf{BBODY}$ transition are the protocol parameters.
+$\mathsf{BBODY}$ transition are the genesis key delegations.
 
 \begin{figure}
   \emph{BBody Transitions}
 
   \begin{equation*}
     \_ \vdash \var{\_} \trans{bbody}{\_} \var{\_} \subseteq
-    \powerset (\PParams \times (\LState\times\BlocksMade)
+    \powerset ((\VKeyGen\mapsto\VKey) \times (\LState\times\BlocksMade)
     \times \Block \times (\LState\times\BlocksMade))
   \end{equation*}
   \caption{BBody transition-system types}
@@ -1061,6 +1094,10 @@ keys to the incremented value of produced blocks (\var{n} + 1).
       \var{bh} \leteq \bheader{block}
       &
       \var{bhb} \leteq \bhbody{bh}
+      \\
+      (\wcard,~\wcard,~\var{us})\leteq ls
+      &
+      \var{pp}\leteq\pps{us}
       \\~\\
       \bBodySize{txs} < \fun{maxBBSize}~\var{pp}
       &
@@ -1072,7 +1109,7 @@ keys to the incremented value of produced blocks (\var{n} + 1).
         \left(
           {\begin{array}{c}
              \bslot{bhb} \\
-             \var{pp} \\
+             \var{dms} \\
            \end{array}}
         \right)
         \vdash
@@ -1082,7 +1119,7 @@ keys to the incremented value of produced blocks (\var{n} + 1).
       }
     }
     {
-      \var{pp} \\
+      \var{dms} \\
       \vdash
       {\left(\begin{array}{c}
             \var{ls} \\
@@ -1221,8 +1258,7 @@ part of the STS. It calls $\mathsf{BBODY}$, $\mathsf{VRF}$, $\mathsf{RUPD}$,
 $\mathsf{UPDN}$, $\mathsf{OCERT}$ and $\mathsf{NEWEPOCH}$ as sub-rules.
 
 The environment for the chain rule is shown in Figure~\ref{fig:ts-types:chain},
-it is comprised of the current slot number \var{s_{now}} and the new protocol
-parameters \var{pp_n}.
+it is comprised of the current slot number \var{s_{now}} and the set of genesis keys.
 
 The chain state is shown in Figure~\ref{fig:ts-types:chain}, it consists of the
 following:
@@ -1235,6 +1271,7 @@ following:
 \item The epoch state \var{es}.
 \item The reward update \var{ru}.
 \item The stake pool distribution \var{pd}.
+\item The genesis key delegations.
 \end{itemize}
 
 \begin{figure}
@@ -1244,7 +1281,7 @@ following:
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{s_{now}} & \Slot & \text{current slot} \\
-        \var{pp_n} & \PParams & \text{new protocol parameters} \\
+        \var{gkeys} & \VKeyGen & \text{genesis keys} \\
       \end{array}
     \right)
   \end{equation*}
@@ -1263,6 +1300,7 @@ following:
         \var{ru} & \RewardUpdate^? & \text{potential reward update} \\
         \var{pd} & \PoolDistr & \text{pool stake distribution} \\
         \var{dsched} & \Slot\mapsto\VKeyGen^? & \text{OBFT schedule} \\
+        \var{dms} & \VKeyGen\mapsto\VKey & \text{genesis key delegations} \\
       \end{array}
     \right)
   \end{equation*}
@@ -1281,6 +1319,7 @@ Figure~\ref{fig:rules:chain}. Its signal is a \var{block} from the \var{block}
 we extract the block header body \var{bhb}. From \var{bhb} we extract the block
 nonce $\eta$ and the block slot \var{s}. The transition rule itself has no
 preconditions, instead it calls all its subrules.
+Note that $\mathsf{UPIEC}$ is defined in \cite{byron_ledger_spec}.
 
 \begin{figure}[ht]
   \begin{equation}\label{eq:chain}
@@ -1298,7 +1337,7 @@ preconditions, instead it calls all its subrules.
         \left(
           {\begin{array}{c}
               \eta_c \\
-              \var{pp_n} \\
+              \var{s} \\
           \end{array}}
         \right)
         \vdash
@@ -1336,13 +1375,19 @@ preconditions, instead it calls all its subrules.
         \end{array}\right)}
       }
       \\~\\
-      (\var{acnt}',~\var{pp}',~\var{ss}',~\var{ls}') \leteq \var{es}'
-      &
-      (\var{us}',~(\var{ds}',~\var{ps'})) \leteq \var{ls}'
+      (\var{acnt}',~\var{ss}',~(\var{utxoSt}',~(\var{ds}',~\var{ps'}),~\var{us}'))\leteq\var{es}'
       \\
-      \vdash\var{ps}'\trans{ocert}{bhb}\var{ps}''
-      &
-      \var{ls}'' \leteq (\var{us}',~(\var{ds}',~\var{ps}''))
+      \var{gkeys}
+      \vdash
+      {\left(\begin{array}{c}
+      \var{ps}' \\
+      \var{dms} \\
+      \end{array}\right)}
+      \trans{ocert}{bhb}
+      {\left(\begin{array}{c}
+      \var{ps}'' \\
+      \var{dms}' \\
+      \end{array}\right)}
       &
       (\var{stpools},~\wcard,~\wcard,~\wcard,~\wcard) \leteq \var{ps}''
       \\
@@ -1355,7 +1400,7 @@ preconditions, instead it calls all its subrules.
               \var{pd}' \\
               \var{stpools} \\
               \\
-              \var{dsched} \\
+              \var{dsched'} \\
           \end{array}}
         \right)
         \vdash
@@ -1380,26 +1425,28 @@ preconditions, instead it calls all its subrules.
         \vdash \var{ru}' \trans{rupd}{\var{s}} \var{ru}''
       }
       \\
+      \var{ls} \leteq (\var{utxoSt}',~(\var{ds}',~\var{ps}''),~\var{us}')
+      \\
       {
-        \var{pp'}\vdash
+        \var{dms}'\vdash
         {\left(\begin{array}{c}
-              \var{ls}'' \\
+              \var{ls} \\
               \var{b'} \\
         \end{array}\right)}
         \trans{bbody}{\var{block}}
         {\left(\begin{array}{c}
-              \var{ls}''' \\
+              \var{ls}' \\
               b'' \\
         \end{array}\right)}
       }
       &
-      \var{es}'' \leteq (\var{acnt}',~\var{pp}'~\var{ss}',~\var{ls}''')
+      \var{es}'' \leteq (\var{acnt}',~\var{ss}',~\var{ls}')
     }
     {
       \left(
         {\begin{array}{c}
             \var{s_{now}} \\
-            \var{pp_n} \\
+            \var{gkeys} \\
         \end{array}}
       \right)
       \vdash
@@ -1413,6 +1460,7 @@ preconditions, instead it calls all its subrules.
             \var{ru} \\
             \var{pd} \\
             \var{dsched} \\
+            \var{dms} \\
       \end{array}\right)}
       \trans{chain}{\var{block}}
       {\left(\begin{array}{c}
@@ -1425,6 +1473,7 @@ preconditions, instead it calls all its subrules.
             \varUpdate{\var{ru}''} \\
             \varUpdate{\var{pd}'} \\
             \varUpdate{\var{dsched}'} \\
+            \varUpdate{\var{dms}'} \\
       \end{array}\right)}
     }
   \end{equation}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -764,7 +764,7 @@ Finally, it is possible to define the complete epoch boundary transition type,
 which is defined in Figure~\ref{fig:ts-types:epoch}.
 In the environment of this transition, we have the potentially new
 protocol parameters and the blocks made during this epoch.  The state is made up of the
-the accounting state, the current protocol parameters, the snapshots and the ledger state.
+the accounting state, the snapshots and the ledger state.
 
 %%
 %% Figure - Epoch Defs
@@ -787,7 +787,6 @@ the accounting state, the current protocol parameters, the snapshots and the led
     \left(
       \begin{array}{r@{~\in~}ll}
         \var{acnt} & \Acnt & \text{accounting}\\
-        \var{pp} & \PParams & \text{current protocol parameters}\\
         \var{ss} & \Snapshots & \text{snapshots}\\
         \var{ls} & \LState & \text{ledger state}\\
       \end{array}
@@ -816,7 +815,9 @@ in sequence.
   \begin{equation}\label{eq:epoch}
     \inference[Epoch]
     {
-      (\var{utxoSt},~(\var{dstate}~\var{pstate}))\leteq\var{ls}
+      (\var{utxoSt},~(\var{dstate}~\var{pstate}),~\var{us})\leteq\var{ls}
+      &
+      \var{pp}\leteq\pps{us}
       \\
       {
         \begin{array}{l}
@@ -898,8 +899,9 @@ in sequence.
         \end{array}
       }
       \right)
-      \\~\\
-      \var{ls}' \leteq (\var{utxoSt}'',~(\var{dstate}',~\var{pstate}'))
+      \\~\\~\\
+      \var{us}' \leteq \var{us}\unionoverrideRight\{pp'\} \\
+      \var{ls}' \leteq (\var{utxoSt}'',~(\var{dstate}',~\var{pstate}'),~\var{us'})
     }
     {
       \begin{array}{l}
@@ -910,7 +912,6 @@ in sequence.
       \left(
       \begin{array}{r}
         \var{acnt} \\
-        \var{pp} \\
         \var{ss} \\
         \var{ls} \\
       \end{array}
@@ -919,7 +920,6 @@ in sequence.
       \left(
       \begin{array}{rcl}
         \varUpdate{\var{acnt''}} \\
-        \varUpdate{\var{pp'}} \\
         \varUpdate{\var{ss'}} \\
         \varUpdate{\var{ls'}} \\
       \end{array}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -83,6 +83,8 @@
 \newcommand{\DCertBody}{\type{DCertBody}}
 \newcommand{\TData}{\type{TData}}
 \newcommand{\DPoolReap}{\ensuremath{\type{poolreap}}}
+\newcommand{\UPIState}{\type{UPIState}}
+\newcommand{\UpdatePayload}{\type{UpdatePayload}}
 
 %% Adding witnesses
 \newcommand{\TxIn}{\type{TxIn}}

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -9,12 +9,13 @@ The environment for this rule consists of:
 \begin{itemize}
   \item The current slot.
   \item The transaction index within the current block.
-  \item The protocol parameters.
+  \item The genesis key delegation map. The type $\VKeyGen$ is defined in \cite{byron_ledger_spec}.
 \end{itemize}
 The ledger state consists of:
 \begin{itemize}
   \item The UTxO state.
   \item The delegation and pool states.
+  \item The update state, as defined in \cite{byron_ledger_spec}.
 \end{itemize}
 
 \begin{figure}[htb]
@@ -25,7 +26,7 @@ The ledger state consists of:
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
         \var{txIx} & \Ix & \text{transaction index}\\
-        \var{pp} & \PParams & \text{protocol parameters}\\
+        \var{dms} & \VKeyGen \mapsto \VKey & \text{genesis delegations}\\
       \end{array}
     \right)
   \end{equation*}
@@ -37,6 +38,7 @@ The ledger state consists of:
       \begin{array}{r@{~\in~}lr}
         \var{utxoSt} & \UTxOState & \text{UTxO state}\\
         \var{dpstate} & \DPState & \text{delegation and pool state}\\
+        \var{us} & \UPIState & \text{update state}\\
       \end{array}
     \right)
   \end{equation*}
@@ -53,7 +55,8 @@ The ledger state consists of:
 
 Figure~\ref{fig:ts-types:ledger} defines the ledger state transition.
 It has a single rule, which first calls the $\mathsf{UTXOW}$ transition,
-and then calls the $\mathsf{DELEGS}$ transition.
+then calls the $\mathsf{DELEGS}$ transition, and finally calls
+the $\mathsf{BUPI}$ transition (from \cite{byron_chain_spec}).
 
 \begin{figure}
   \begin{equation}
@@ -62,7 +65,8 @@ and then calls the $\mathsf{DELEGS}$ transition.
     {
       (\var{dstate}, \var{pstate}) \leteq \var{dpstate} \\
     (\var{stkeys}, \_, \_, \_) \leteq \var{dstate} \\
-    (\var{stpools}, \_, \_, \_, \_) \leteq \var{pstate} \\~\\
+    (\var{stpools}, \_, \_, \_, \_) \leteq \var{pstate} \\
+    \var{pp} \leteq \pps{us}\\~\\
       \left({
         \begin{array}{r}
         \var{slot} \\
@@ -84,13 +88,24 @@ and then calls the $\mathsf{DELEGS}$ transition.
       }
       \vdash
       dpstate \trans{delegs}{\var{tx}} dpstate'
+      \\~\\~\\
+      {
+        \left(
+        \begin{array}{l}
+          \var{slot} \\
+          \var{dms} \\
+        \end{array}
+      \right)
+      }
+      \vdash
+      us \trans{bupi}{\fun{txup}~\var{tx}} us'
     }
     {
       \left(
         \begin{array}{l}
           \var{slot} \\
           \var{txIx} \\
-          \var{pp} \\
+          \var{dms} \\
         \end{array}
       \right)
       \vdash
@@ -98,6 +113,7 @@ and then calls the $\mathsf{DELEGS}$ transition.
         \begin{array}{ll}
           utxoSt \\
           dpstate \\
+          us \\
         \end{array}
       \right)
       \trans{ledger}{tx}
@@ -105,6 +121,7 @@ and then calls the $\mathsf{DELEGS}$ transition.
         \begin{array}{ll}
           \varUpdate{utxoSt'} \\
           \varUpdate{dpstate'} \\
+          \varUpdate{us'} \\
         \end{array}
       \right)
     }
@@ -123,7 +140,8 @@ in $\mathsf{LEDGERS}$ in order to process a list of transitions.
   \begin{equation*}
     \_ \vdash
     \var{\_} \trans{ledgers}{\_} \var{\_}
-    \subseteq \powerset ((\Slot\times\PParams) \times \LState \times \seqof{\Tx} \times \LState)
+    \subseteq \powerset \Big((\Slot\times(\VKeyGen\mapsto\VKey)\Big) \times \LState \times
+      \seqof{\Tx} \times \LState)
   \end{equation*}
   \caption{Ledger transition-system types}
   \label{fig:ts-types:ledgers}
@@ -138,7 +156,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transitions.
      \left(
       \begin{array}{r}
         \var{slot} \\
-        \var{pp} \\
+        \var{dms} \\
       \end{array}
     \right)
     \vdash \var{ls} \trans{ledgers}{\epsilon} \var{ls}
@@ -155,7 +173,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transitions.
         \left(
           \begin{array}{r}
             \var{slot}\\
-            \var{pp}\\
+            \var{dms}\\
           \end{array}
         \right)
       }
@@ -169,7 +187,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transitions.
           \begin{array}{r}
             \var{slot}\\
             \mathsf{len}~\Gamma - 1\\
-            \var{pp}\\
+            \var{dms}\\
           \end{array}
         \right)
       }
@@ -183,7 +201,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transitions.
       \left(
       \begin{array}{r}
         \var{slot}\\
-        \var{pp}\\
+        \var{dms}\\
       \end{array}
     \right)
     }

--- a/shelley/chain-and-ledger/formal-spec/references.bib
+++ b/shelley/chain-and-ledger/formal-spec/references.bib
@@ -14,6 +14,22 @@ Cardano},
   url   = {https://github.com/input-output-hk/cardano-ledger-specs/tree/master/docs/delegation_design_spec},
 }
 
+@misc{byron_ledger_spec,
+  author = {Damian Nadales, IOHK},
+  title = {A Formal Specification of the Cardano Ledger},
+  titleaddon = {(for the Byron release)},
+  year = {2019},
+  url   = {https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/byronLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec}
+}
+
+@misc{byron_chain_spec,
+  author = {Marko Dimja\v{s}evi\'c, Nicholas Clarke, IOHK},
+  title = {Specification of the Blockchain Layer},
+  titleaddon = {(for the Byron release)},
+  year = {2019},
+  url   = {https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/byronChainSpec/latest/download-by-type/doc-pdf/blockchain-spec}
+}
+
 @article{chimeric,
   author  = {Joachim Zahnentferner},
   title   = {Chimeric Ledgers: Translating and Unifying UTXO-based and Account-based Cryptocurrencies},

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -25,6 +25,8 @@ A transaction, $\Tx$, is a transaction body together with:
 \begin{itemize}
   \item A collection of witnesses, represented as a finite map from payment verification keys
     to signatures.
+  \item Update payloads from genesis keys.
+    The payload type ($\UpdatePayload$) is defined in \cite{byron_chain_spec}.
 \end{itemize}
 
 Additionally, the $\UTxO$ type will be used by the ledger state to store all the
@@ -79,7 +81,7 @@ This function must produce a unique id for each unique transaction.
       \\
       \var{tx}
       & \Tx
-      & \TxBody \times (\VKey \mapsto \Sig)
+      & \TxBody \times (\VKey \mapsto \Sig) \times \UpdatePayload
       \\
     \end{array}
   \end{equation*}
@@ -95,6 +97,7 @@ This function must produce a unique id for each unique transaction.
       \fun{txwdrls} & \Tx \to \Wdrl & \text{withdrawals} \\
       \fun{txbody} & \Tx \to \TxBody & \text{transaction body}\\
       \fun{txwits} & \Tx \to (\VKey \mapsto \Sig) & \text{witnesses} \\
+      \fun{txup} & \Tx \to \UpdatePayload & \text{update payload} \\
     \end{array}
   \end{equation*}
   %


### PR DESCRIPTION
This PR adds the update mechanisms from the Byron formal specs to the Shelley spec.

The main changes are:
1) The `CHAIN` rule now calls the `UPIEC` rule from the Byron ledger spec to get the new protocol parameters.
2) the protocol parameters have been replaced in serveral spots by `UPIState` (from the Byron ledger spec), which contains the protocol parameters.
3) The transactions now have a new component, the `UpdatePayload`, currently called the `BUPISig` in the Byron Chain spec (but will be changed to match soon).
4) The `LEDGER` rule now processes update payloads in the transactions by using `BUPI` (from the Byron Chain spec) to update the `UPIState`.

Some relevant details about the changes above:

* As a result of the `LEDGER` rule mutating the `UPIState`, the `LState` now contains the `UPIState`. This then also affects `LEDGERS` and `EPOCH`.
* The `CHAIN` rule now has the genesis keys in the environment instead of the new protocol parameters.
* The `OCERT` rule now maintains the mapping of genesis keys to the operational keys.

One thing to note is how these changes interact with the `NEWPP` rule.  If an update is successfully voted in which would incur a debt on the system that can not be covered by the reserves, then `NEWPP` still prevents the new protocol parameters inside the new UPIState from being changed.

closes #390 