### PR TITLE
Small changes from chain implementation + Jared's feedback

### DIFF
--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -854,8 +854,7 @@ header processing we verify the following things:
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \fun{\bheadname} & \Block \totalf \Bhead & \text{block header} \\
-      \fun{\bhdrsizename} & \Bhead \totalf \mathbb{N} & \text{block header size in bytes}\\
-      \fun{pps} & \UPIState \totalf \ProtParams & \text{update-state protocol-parameters}
+      \fun{\bhdrsizename} & \Bhead \totalf \mathbb{N} & \text{block header size in bytes}
     \end{array}
   \end{equation*}
 
@@ -1071,7 +1070,7 @@ payload; UTxO, delegation and update.
           \end{array}
         \right)}
       \vdash \var{ds} \trans{deleg}{\bcerts{b}} \var{ds'} &
-      \fun{pps} ~  \var{us'} \vdash \var{utxo} \trans{utxow}{\butxo{b}} \var{utxo'} \\
+      \var{pps} \vdash \var{utxo} \trans{utxow}{\butxo{b}} \var{utxo'} \\
     }
     {
       \left(
@@ -1133,6 +1132,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \fun{\isebbname} & \Block \totalf \mathbb{B} & \text{epoch boundary block check} \\
+      \fun{pps} & \UPIState \totalf \ProtParams & \text{update-state protocol-parameters}
     \end{array}
   \end{equation*}
   \caption{Blockchain Extension Types and Functions}

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -1029,7 +1029,7 @@ payload; UTxO, delegation and update.
   \begin{equation*}
     \begin{array}{rlr}
       \fun{bEndorsment} & \in \Block \to \ProtVer \times \VKey & \text{Protocol version endorsment} \\
-      \bendorsment{b} & = (\bprotver{b}, \bhissuer{b}) \\
+      \bendorsment{b} & = (\bprotver{b}, (\bhissuer{} \cdot \bhead{}) ~ b)\\
       \fun{\bslotname} & \in \Block \to \Slot & \text{Slot for which this block is being issued} \\
       \bslot{b} & = (\bhslotname \cdot \bheadname)~b \\
       \fun{\bupdpayloadname} & \in \Block \to (\UProp^{?}\times\seqof{\Vote}) & \text{Block update payload} \\

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -86,6 +86,10 @@
 \newcommand{\DelegState}{\type{DIState}}
 
 \newcommand{\ProtParams}{\type{PParams}} % protocol parameters
+\newcommand{\ProtPm}{\ensuremath{\type{Ppm}}}
+\newcommand{\maxblocksize}{\pp{maxBlockSize}}
+\newcommand{\maxheadersize}{\pp{maxHeaderSize}}
+
 \newcommand{\Nothing}{\Diamond}
 
 %%
@@ -98,7 +102,7 @@
 \newcommand{\isebbname}{bIsEBB}
 \newcommand{\bcertsname}{bCerts}
 \newcommand{\bhsigname}{bhSig}
-\newcommand{\bhissuername}{bhissuer}
+\newcommand{\bhissuername}{bhIssuer}
 
 %%
 %% Functions and relations
@@ -237,6 +241,10 @@ underlying systems and types defined will rely on definitions in that document.
   be able to deconstruct a sequence $\Lambda$ in its last element, and prefix.
   If an expression does not match the given pattern, then the premise does not
   hold, and the rule cannot trigger.
+\item[Maps and partial functions] $A \mapsto B$ denotes a \textbf{partial
+    function} from $A$ to $B$, which can be seen as a map (dictionary) with
+  keys in $A$ and values in $B$. Given a map $m \in A \mapsto B$, notation
+  $a \mapsto b \in m$ is equivalent to $m~ a = b$.
 \end{description}
 
 \subsection{Sets}
@@ -498,7 +506,7 @@ During PBFT processing of the block header, we do the following:
     corresponds to the known hash of the previous block.
   \item We check that the header signature correctly verifies the ``signed''
     content of the header.
-  \item Finally, we verify and update the signature count rules.
+  \item Finally, we verify and update the state according to the signature count rules.
   \end{enumerate}
   \begin{figure}[ht]
   \emph{Abstract types}
@@ -763,6 +771,51 @@ updates the update state to the correct version.
 
 \clearpage
 
+\section{Protocol parameters}
+
+The rules presented henceforth make use of a protocol parameters map, which map
+different protocol parameters to their current values. The types associated to
+protocol parameters are defined in \cref{fig:prot-params-defs}.
+
+\begin{figure}[ht]
+  \emph{Abstract types}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \var{p} & \ProtPm & \text{protocol parameter}\\
+      \var{v} & \type{Value} & \text{disjoint union of all value types}\\
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Derived types}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l@{~=~}r@{~\in~}lr}
+      \var{pps} & \ProtParams & \var{pps} & \ProtPm \mapsto \type{Value}
+      & \text{protocol parameters map}\\
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Protocol parameters}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \maxblocksize{} & \ProtPm & \text{maximum block size}\\
+      \maxheadersize{} & \ProtPm & \text{maximum block header size} \\
+    \end{array}
+  \end{equation*}
+  %
+  \emph{Protocol-parameter types} Given $\var{pps} \in \ProtParams$
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l}
+      \var{pps}~\maxblocksize{} & \mathbb{N}\\
+      \var{pps}~\maxheadersize{} & \mathbb{N} \\
+    \end{array}
+  \end{equation*}
+  \caption{Protocol-parameters definitions}
+  \label{fig:prot-params-defs}
+\end{figure}
+
+
+\clearpage
+
 \section{Block processing}
 \label{sec:block-processing}
 
@@ -781,9 +834,6 @@ updates the update state to the correct version.
 \newcommand{\bslot}[1]{\fun{\bslotname}\ #1}
 
 \newcommand{\butxo}[1]{\fun{bUtxo}\ #1}
-
-\newcommand{\maxblocksize}{\pp{maxBlockSize}}
-\newcommand{\maxheadersize}{\pp{maxHeaderSize}}
 
 % Imported definitions
 \newcommand{\UTxO}{\type{UTxO}}
@@ -814,12 +864,6 @@ of block bodies.
     \begin{array}{r@{~\in~}lr}
       \fun{\bsizename} & \Block \totalf \mathbb{N} & \text{block size in bytes} \\
       \fun{\verifyname} & \VKey \times \Data \times \Sig & \text{verification relation} \\
-    \end{array}
-  \end{equation*}
-  \emph{Protocol parameters}
-  \begin{equation*}
-    \begin{array}{r@{~\partialf~}l!{~\in~\ProtParams~}r}
-      \maxblocksize & \mathbb{N} & \text{maximum block size} \\
     \end{array}
   \end{equation*}
   \caption{Basic Block-related Types and Functions}
@@ -860,13 +904,6 @@ header processing we verify the following things:
     \begin{array}{r@{~\in~}lr}
       \fun{\bheadname} & \Block \totalf \Bhead & \text{block header} \\
       \fun{\bhdrsizename} & \Bhead \totalf \mathbb{N} & \text{block header size in bytes}
-    \end{array}
-  \end{equation*}
-
-  \emph{Protocol parameters}
-  \begin{equation*}
-    \begin{array}{r@{~\partialf~}l!{~\in~\ProtParams~}r}
-      \maxheadersize & \mathbb{N} & \text{maximum block header size} \\
     \end{array}
   \end{equation*}
   \caption{Block header processing types and functions}
@@ -956,10 +993,12 @@ header processing we verify the following things:
 
 \subsection{Block body processing}
 
-During processing of the block body, we perform two main functions: verification
-of the body integrity using the proofs contained in the block header, and update
-of the various state components. These rules are given in figure
-\ref{fig:rules:bbody}.
+During processing of the block body, we perform two main functions:
+verification of the body integrity using the proofs contained in the block
+header, and update of the various state components. These rules are given in
+figure \ref{fig:rules:bbody}, and the types and functions used there are
+defined in \cref{fig:ts-types:bbody}, where the UTxO, delegation, and update
+state are defined in \cite{byron_ledger_spec}.
 
 Verification is done independently for the three components of the body payload:
 UTxO, delegation and update. Each of these three have a signature in the block

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -1069,7 +1069,7 @@ payload; UTxO, delegation and update.
           \end{array}
         \right)}
       \vdash \var{ds} \trans{deleg}{\bcerts{b}} \var{ds'} &
-      \fun{pps} ~  us \vdash \var{utxo} \trans{utxow}{\butxo{b}} \var{utxo'} \\
+      \fun{pps} ~  \var{us'} \vdash \var{utxo} \trans{utxow}{\butxo{b}} \var{utxo'} \\
     }
     {
       \left(

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -252,7 +252,7 @@ There are several standard sets used in the document:
 \newcommand{\bprotver}[1]{\fun{bProtVer}\ #1}
 \newcommand{\bendorsment}[1]{\fun{bEndorsment}\ #1}
 
-\newcommand{\Bupisig}{\type{BUPISig}}
+\newcommand{\UpdatePayload}{\type{UpdatePayload}}
 % Imported definitions
 
 \newcommand{\UPIEnv}{\type{UPIEnv}}
@@ -270,7 +270,7 @@ cases where there is or is not an update proposal contained within the block.
 \begin{figure}[ht]
   \emph{Update interface signals}
   \begin{equation*}
-    \Bupisig =
+    \UpdatePayload =
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{mprop} & \UProp^{?} & \text{possible update proposal}\\
@@ -288,7 +288,7 @@ cases where there is or is not an update proposal contained within the block.
   \emph{Update interface processing transitions}
   \begin{equation*}
     \_ \vdash \var{\_} \trans{bupi}{\_} \var{\_} \subseteq
-    \powerset (\UPIEnv \times \UPIState \times \Bupisig \times \UPIState)
+    \powerset (\UPIEnv \times \UPIState \times \UpdatePayload \times \UPIState)
   \end{equation*}
   \caption{Update interface processing transition-system types}
   \label{fig:ts-types:bupi}

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -855,8 +855,10 @@ header processing we verify the following things:
     \begin{array}{r@{~\in~}lr}
       \fun{\bheadname} & \Block \totalf \Bhead & \text{block header} \\
       \fun{\bhdrsizename} & \Bhead \totalf \mathbb{N} & \text{block header size in bytes}\\
+      \fun{pps} & \UPIState \totalf \ProtParams & \text{update-state protocol-parameters}
     \end{array}
   \end{equation*}
+
   \emph{Protocol parameters}
   \begin{equation*}
     \begin{array}{r@{~\partialf~}l!{~\in~\ProtParams~}r}

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -1020,9 +1020,9 @@ payload; UTxO, delegation and update.
       \fun{bUpdProp} & \Block \totalf \UProp^{?} & \text{block update proposal payload} \\
       \fun{bUpdVotes} & \Block \totalf \seqof{\Vote} & \text{block update votes payload} \\
       \fun{bProtVer} & \Block \totalf \ProtVer & \text{block protocol version} \\
-      \fun{bhUtxoSig} & \Bhead \totalf \Sig & \text{UTxO payload signature} \\
-      \fun{bhDlgSig} & \Bhead \totalf \Sig & \text{delegation payload signature} \\
-      \fun{bhUpdSig} & \Bhead \totalf \Sig & \text{update payload signature} \\
+      \fun{bhUtxoProof} & \Bhead \totalf \Hash & \text{UTxO payload hash} \\
+      \fun{bhDlgProof} & \Bhead \totalf \Hash & \text{delegation payload hash} \\
+      \fun{bhUpdProof} & \Bhead \totalf \Hash & \text{update payload hash} \\
     \end{array}
   \end{equation*}
   \emph{Derived functions}
@@ -1078,9 +1078,9 @@ payload; UTxO, delegation and update.
     \inference
     { \maxblocksize \mapsto \var{b_{max}} \in \var{pps} && \bsize{b} \leq \var{b_{max}} \\
       \var{bh} \leteq \bhead{b} & \var{vk_d} \leteq \bhissuer{\var{bh}} \\
-      \verify{\var{vk_d}}{\serialised{\butxo{b}}}{(\fun{bhUtxoSig}~\var{bh})} &
-      \verify{\var{vk_d}}{\serialised{\bcerts{b}}}{(\fun{bhDlgSig}~\var{bh})} \\
-      \verify{\var{vk_d}}{\serialised{\bupdpayload{b}}}{(\fun{bhUpdSig}~\var{bh})} \\
+      \fun{hash}~(\butxo{b}) = \fun{bhUtxoProof}~\var{bh} &
+      \fun{hash}~(\bcerts{b}) = \fun{bhDlgProof}~\var{bh} \\
+      \fun{hash}~(\bupdpayload{b}) = \fun{bhUpdProof}~\var{bh}\\~\\
       {\left(
           \begin{array}{l}
             \bslot{b} \\

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -231,6 +231,12 @@ underlying systems and types defined will rely on definitions in that document.
     \caption{Definition of the Union Override Operation}
     \label{fig:unionoverride}
   \end{figure}
+\item[Pattern matching in premises] In the inference-rules premises use
+  $\var{patt} = \var{exp}$ to pattern-match an expression $\var{exp} $ with a
+  certain pattern $\var{patt}$. For instance, we use $\Lambda'; x = \Lambda$ to
+  be able to deconstruct a sequence $\Lambda$ in its last element, and prefix.
+  If an expression does not match the given pattern, then the premise does not
+  hold, and the rule cannot trigger.
 \end{description}
 
 \subsection{Sets}

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -771,50 +771,6 @@ updates the update state to the correct version.
 
 \clearpage
 
-\section{Protocol parameters}
-
-The rules presented henceforth make use of a protocol parameters map, which maps
-different protocol parameters to their current values. The types associated to
-protocol parameters are defined in \cref{fig:prot-params-defs}.
-
-\begin{figure}[ht]
-  \emph{Abstract types}
-  \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
-      \var{p} & \ProtPm & \text{protocol parameter}
-    \end{array}
-  \end{equation*}
-  %
-  \emph{Derived types}
-  \begin{equation*}
-    \begin{array}{r@{~\in~}l@{~=~}r@{~\in~}lr}
-      \var{pps} & \ProtParams & \var{pps} & \ProtPm \mapsto \type{Data}
-      & \text{protocol parameters map}\\
-    \end{array}
-  \end{equation*}
-  %
-  \emph{Protocol parameters}
-  \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
-      \maxblocksize{} & \ProtPm & \text{maximum block size}\\
-      \maxheadersize{} & \ProtPm & \text{maximum block header size}\\
-    \end{array}
-  \end{equation*}
-  %
-  \emph{Protocol-parameter types} given $\var{pps} \in \ProtParams$
-  \begin{equation*}
-    \begin{array}{r@{~\in~}l}
-      \var{pps}~\maxblocksize{} & \mathbb{N}\\
-      \var{pps}~\maxheadersize{} & \mathbb{N}\\
-    \end{array}
-  \end{equation*}
-  \caption{Protocol-parameters definitions}
-  \label{fig:prot-params-defs}
-\end{figure}
-
-
-\clearpage
-
 \section{Block processing}
 \label{sec:block-processing}
 
@@ -872,10 +828,11 @@ of block bodies.
 \subsection{Block header processing}
 
 Figure \ref{fig:ts-types:bhead} gives the transition system types for block
-header processing. The header state contains the current update state and
-historical epoch length map, which must be updated along the epoch boundary.
-Figure \ref{fig:rules:bhead} gives the corresponding transition rules. During
-header processing we verify the following things:
+header processing. The $\maxheadersize{}$ protocol parameter is defined in
+\cite{byron_ledger_spec}. The header state contains the current update state
+and historical epoch length map, which must be updated along the epoch
+boundary. Figure \ref{fig:rules:bhead} gives the corresponding transition
+rules. During header processing we verify the following things:
 
 \begin{enumerate}
   \item We compute whether this block is the first block in a new epoch.
@@ -995,9 +952,10 @@ header processing we verify the following things:
 During processing of the block body, we perform two main functions:
 verification of the body integrity using the proofs contained in the block
 header, and update of the various state components. These rules are given in
-figure \ref{fig:rules:bbody}, and the types and functions used there are
-defined in \cref{fig:ts-types:bbody}, where the UTxO, delegation, and update
-state are defined in \cite{byron_ledger_spec}.
+\cref{fig:rules:bbody}, where the types and the functions used there are
+defined in \cref{fig:ts-types:bbody}. The UTxO, delegation, and update state as
+well as the $\maxblocksize{}$ protocol parameter are defined in
+\cite{byron_ledger_spec}.
 
 Verification is done independently for the three components of the body payload:
 UTxO, delegation and update. Each of these three have a signature in the block

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -765,8 +765,6 @@ updates the update state to the correct version.
 \newcommand{\BBEnv}{\type{BBEnv}}
 \newcommand{\BBState}{\type{BBState}}
 
-\newcommand{\Bbody}{\type{BlockBody}}
-
 \newcommand{\bheadname}{bHead}
 \newcommand{\bhead}[1]{\fun{\bheadname}\ #1}
 \newcommand{\bupdpayloadname}{bUpdPayload}
@@ -966,15 +964,6 @@ In addition to block verification, we also process the three components of the
 payload; UTxO, delegation and update.
 
 \begin{figure}[ht]
-  \emph{Abstract types}
-  %
-  \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
-      bb & \Bbody & \text{block body} \\
-
-    \end{array}
-  \end{equation*}
-  %
   \emph{Abstract functions}
   %
   \begin{equation*}

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -1066,7 +1066,7 @@ payload; UTxO, delegation and update.
           \end{array}
         \right)}
       \vdash \var{ds} \trans{deleg}{\bcerts{b}} \var{ds'} &
-      \var{pps} \vdash \var{utxo} \trans{utxow}{\butxo{b}} \var{utxo'} \\
+      \var{pps} \vdash \var{utxo} \trans{utxows}{\butxo{b}} \var{utxo'} \\
     }
     {
       \left(

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -403,6 +403,7 @@ abstract constant (nullary functions) related to the protocol are defined in
     \begin{array}{r@{~\in~}lr}
       k & \mathbb{N} & \text{chain stability parameter}\\
       t & \left[\frac{1}{5}, \frac{1}{4}\right] & \text{block signature count threshold}\\
+      \fun{dms} & \DelegState \totalf (\VKeyGen \mapsto \VKey) & \text{delegation-state delegation-map}
     \end{array}
   \end{equation*}
 
@@ -443,7 +444,7 @@ outside the size of the moving window ($k$).
   \begin{equation*}
     \inference
     {
-      \{\var{vk_g}\} \leteq (\fun{dms} ~ \var{ds}) \restrictrange \{\var{vk_d}\}
+      \{\var{vk_g}\} \leteq \dom{((\fun{dms} ~ \var{ds}) \restrictrange \{\var{vk_d}\})}
       & \var{sgs'} \leteq \var{sgs};_k {vk_g} &
       \size{\fun{filter}~(=\var{vk_g})~\var{sgs'}} \leq k \cdot t \\
     }

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -773,7 +773,7 @@ updates the update state to the correct version.
 
 \section{Protocol parameters}
 
-The rules presented henceforth make use of a protocol parameters map, which map
+The rules presented henceforth make use of a protocol parameters map, which maps
 different protocol parameters to their current values. The types associated to
 protocol parameters are defined in \cref{fig:prot-params-defs}.
 
@@ -781,15 +781,14 @@ protocol parameters are defined in \cref{fig:prot-params-defs}.
   \emph{Abstract types}
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \var{p} & \ProtPm & \text{protocol parameter}\\
-      \var{v} & \type{Value} & \text{disjoint union of all value types}\\
+      \var{p} & \ProtPm & \text{protocol parameter}
     \end{array}
   \end{equation*}
   %
   \emph{Derived types}
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{~=~}r@{~\in~}lr}
-      \var{pps} & \ProtParams & \var{pps} & \ProtPm \mapsto \type{Value}
+      \var{pps} & \ProtParams & \var{pps} & \ProtPm \mapsto \type{Data}
       & \text{protocol parameters map}\\
     \end{array}
   \end{equation*}
@@ -798,15 +797,15 @@ protocol parameters are defined in \cref{fig:prot-params-defs}.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \maxblocksize{} & \ProtPm & \text{maximum block size}\\
-      \maxheadersize{} & \ProtPm & \text{maximum block header size} \\
+      \maxheadersize{} & \ProtPm & \text{maximum block header size}\\
     \end{array}
   \end{equation*}
   %
-  \emph{Protocol-parameter types} Given $\var{pps} \in \ProtParams$
+  \emph{Protocol-parameter types} given $\var{pps} \in \ProtParams$
   \begin{equation*}
     \begin{array}{r@{~\in~}l}
       \var{pps}~\maxblocksize{} & \mathbb{N}\\
-      \var{pps}~\maxheadersize{} & \mathbb{N} \\
+      \var{pps}~\maxheadersize{} & \mathbb{N}\\
     \end{array}
   \end{equation*}
   \caption{Protocol-parameters definitions}
@@ -1020,9 +1019,10 @@ payload; UTxO, delegation and update.
       \fun{bUpdProp} & \Block \totalf \UProp^{?} & \text{block update proposal payload} \\
       \fun{bUpdVotes} & \Block \totalf \seqof{\Vote} & \text{block update votes payload} \\
       \fun{bProtVer} & \Block \totalf \ProtVer & \text{block protocol version} \\
-      \fun{bhUtxoProof} & \Bhead \totalf \Hash & \text{UTxO payload hash} \\
-      \fun{bhDlgProof} & \Bhead \totalf \Hash & \text{delegation payload hash} \\
-      \fun{bhUpdProof} & \Bhead \totalf \Hash & \text{update payload hash} \\
+      \fun{bhUtxoHash} & \Bhead \totalf \Hash & \text{UTxO payload hash} \\
+      \fun{bhDlgHash} & \Bhead \totalf \Hash & \text{delegation payload hash} \\
+      \fun{bhUpdHash} & \Bhead \totalf \Hash & \text{update payload hash} \\
+      \fun{hash} & \type{Data} \totalf \Hash & \text{hash function} \\
     \end{array}
   \end{equation*}
   \emph{Derived functions}
@@ -1078,9 +1078,9 @@ payload; UTxO, delegation and update.
     \inference
     { \maxblocksize \mapsto \var{b_{max}} \in \var{pps} && \bsize{b} \leq \var{b_{max}} \\
       \var{bh} \leteq \bhead{b} & \var{vk_d} \leteq \bhissuer{\var{bh}} \\
-      \fun{hash}~(\butxo{b}) = \fun{bhUtxoProof}~\var{bh} &
-      \fun{hash}~(\bcerts{b}) = \fun{bhDlgProof}~\var{bh} \\
-      \fun{hash}~(\bupdpayload{b}) = \fun{bhUpdProof}~\var{bh}\\~\\
+      \fun{hash}~(\butxo{b}) = \fun{bhUtxoHash}~\var{bh} &
+      \fun{hash}~(\bcerts{b}) = \fun{bhDlgHash}~\var{bh} \\
+      \fun{hash}~(\bupdpayload{b}) = \fun{bhUpdHash}~\var{bh}\\~\\
       {\left(
           \begin{array}{l}
             \bslot{b} \\

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -208,7 +208,7 @@ In these rules we make use of the abstract constant $\var{ngk}$, defined in
       \_ \vdash \_ \trans{upiend}{\_} \_ &
       \powerset (\UPIEnv \times \UPIState
       \times (\ProtVer \times \VKey) \times \UPIState)\\
-      \_ \vdash \_ \trans{upiec}{\_} \_ &
+      \_ \vdash \_ \trans{upiec}{} \_ &
       \powerset (\UPIEnv \times \UPIState \times \UPIState)
     \end{array}
   \end{equation*}

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -446,6 +446,73 @@ Figure~\ref{fig:st-diagram-pt-up}.
 
 \clearpage
 
+A sequence of votes can be applied using $\trans{upivotes}{}$ transitions. The
+inference rules for them are presented in \cref{fig:rules:upi-votes}.
+
+\begin{figure}[htb]
+  \begin{equation}
+    \label{eq:rule:upi-votes-base}
+    \inference
+    {
+    }
+    {
+      {\left(
+        \begin{array}{l}
+          s_n\\
+          \var{dms}
+        \end{array}
+      \right)}
+      \vdash
+      \var{us}
+      \trans{upivotes}{\epsilon}
+      \var{us}
+    }
+  \end{equation}
+  %
+  \begin{equation}
+    \label{eq:rule:upi-votes-ind}
+    \inference
+    {
+      {\left(
+        \begin{array}{l}
+          s_n\\
+          \var{dms}
+        \end{array}
+      \right)}
+      \vdash
+      \var{us}
+      \trans{upivotes}{\Gamma}
+      \var{us'}
+      &
+      {\left(
+        \begin{array}{l}
+          s_n\\
+          \var{dms}
+        \end{array}
+      \right)}
+      \vdash
+      \var{us'}
+      \trans{upivote}{v}
+      \var{us''}
+    }
+    {
+      {\left(
+        \begin{array}{l}
+          s_n\\
+          \var{dms}
+        \end{array}
+      \right)}
+      \vdash
+      \var{us}
+      \trans{upivotes}{\Gamma;v}
+      \var{us''}
+    }
+  \end{equation}
+  \caption{Applying multiple votes on update-proposals rules}
+  \label{fig:rules:upi-votes}
+\end{figure}
+\clearpage
+
 The interface rule for protocol-version endorsement makes use of the
 $\trans{upend}{}$ transition, where we set the threshold for proposal adoption
 to: the number of genesis keys ($\var{ngk}$) times the minimum proportion of

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -573,6 +573,6 @@ delegations have on the ledger.
       }
     }
   \end{equation}
-  \caption{Delegations sequence rules }
+  \caption{Delegations sequence rules}
   \label{fig:rules:delegation-seq}
 \end{figure}

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -141,11 +141,9 @@ keys, some of which correspond with fields of the
 \href{https://github.com/input-output-hk/cardano-sl/}{\texttt{cardano-sl}}
 `BlockVersionData` structure:
 \begin{itemize}
-\item Slot duration: $\var{slotDuration}$
 \item Maximum block size: $\var{maxBlockSize}$
 \item Maximum transaction size: $\var{maxTxSize}$
 \item Maximum header size: $\var{maxHeaderSize}$
-\item Maximum transaction size: $\var{maxTxSize}$
 \item Maximum proposal size: $\var{maxProposalSize}$
 \item Transaction fee policy: $\var{txFeePolicy}$
 \item Script version: $\var{scriptVersion}$
@@ -177,6 +175,24 @@ keys, some of which correspond with fields of the
   set to $10000$, which corresponds with almost half of the total number of
   slots in an epoch.
 \end{itemize}
+
+The protocol parameters are formally defined in \cref{fig:prot-params-defs}.
+
+\begin{figure}[ht]
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \var{maxBlockSize} \mapsto \mathbb{N} & \PPMMap & \text{maximum block size}\\
+      \var{maxTxSize} \mapsto \mathbb{N} & \PPMMap & \text{maximum transaction size}\\
+      \var{maxHeaderSize} \mapsto \mathbb{N} & \PPMMap & \text{maximum header size}\\
+      \var{scriptVersion} \mapsto \mathbb{N} & \PPMMap & \text{script version}\\
+      \var{upAdptThd} \mapsto \mathbb{R} & \PPMMap & \text{update proposal adoption threshold}\\
+      \var{cfmThd} \mapsto \mathbb{N} & \PPMMap & \text{update proposal confirmation threshold}\\
+      \var{upropTTL} \mapsto \mathbb{\Slot} & \PPMMap & \text{update proposal time-to-live}\\
+    \end{array}
+  \end{equation*}
+  \caption{Protocol-parameters definitions}
+  \label{fig:prot-params-defs}
+\end{figure}
 
 \subsection{Update proposals registration}
 \label{sec:update-proposals-registration}

--- a/byron/ledger/formal-spec/utxo.tex
+++ b/byron/ledger/formal-spec/utxo.tex
@@ -257,3 +257,35 @@ different order). The choice here is arbitrary.
   \caption{UTxO with witnesses inference rules}
   \label{fig:rules:utxow}
 \end{figure}
+
+\clearpage
+
+\subsection{Transaction sequences}
+\label{sec:transaction-seqs}
+
+\cref{fig:rules:utxow-seq} models the application of a sequence of
+transactions.
+
+\begin{figure}[htb]
+  \begin{equation}
+    \label{eq:rule:utxow-seq-base}
+    \inference
+    {}
+    {\var{pps} \vdash \var{utxo} \trans{utxows}{\epsilon} \var{utxo}}
+  \end{equation}
+  %
+  \nextdef
+  %
+  \begin{equation}
+    \label{eq:rule:utxow-seq-ind}
+    \inference
+    {
+      \var{pps} \vdash \var{utxo} \trans{utxows}{\Gamma} \var{utxo'}
+      &
+      \var{pps} \vdash \var{utxo'} \trans{utxow}{\var{tx}} \var{utxo''}
+    }
+    {\var{pps} \vdash \var{utxo} \trans{utxows}{\Gamma;\var{tx}} \var{utxo''}}
+  \end{equation}
+  \caption{UTxO sequence rules}
+  \label{fig:rules:utxow-seq}
+\end{figure}


### PR DESCRIPTION
- Use the protocol parameters from the environment in the block body processing rule

![image](https://user-images.githubusercontent.com/175315/56724975-4b4ca380-674c-11e9-80f1-a66bd50e8b8c.png)

- Use the hash of the UTxO, delegation, and update payload instead of their signature, to align spec with implementation.

- Put the protocol parameters in a single section

![image](https://user-images.githubusercontent.com/175315/56725163-9f578800-674c-11e9-86fa-0d5ee786996a.png)

Later we can decide whether we move this to the ledger spec. See https://github.com/input-output-hk/cardano-ledger-specs/issues/344

- Add notation for maps and pattern matching in inference rules.

- Add a `UPIVOTES` rules

![image](https://user-images.githubusercontent.com/175315/56724460-57843100-674b-11e9-82b7-dccd81e00c8e.png)

- Add `UTXOWS` rules

![image](https://user-images.githubusercontent.com/175315/56724519-75ea2c80-674b-11e9-8cb0-59873357563d.png)

Closes #409 
Close #344 