### PR TITLE
Added a rule for transitioning to decentralization

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -42,7 +42,7 @@
 \newcommand{\BHeaderEnv}{\type{BHeaderEnv}}
 \newcommand{\BHeaderState}{\type{BHeaderState}}
 \newcommand{\VRFEnv}{\type{VRFEnv}}
-\newcommand{\VRFState}{\type{VRFState}}
+\newcommand{\DSliderEnv}{\type{DSliderEnv}}
 \newcommand{\NewEpochEnv}{\type{NewEpochEnv}}
 \newcommand{\NewEpochState}{\type{NewEpochState}}
 \newcommand{\PoolDistr}{\type{PoolDistr}}
@@ -235,7 +235,15 @@ of
 \item The old epoch state.
 \item An optional rewards update.
 \item The stake pool distribution of the epoch.
+\item The OBFT leader schedule.
 \end{itemize}
+
+Figure~\ref{fig:ts-types:newepoch} also defines an abstract pseudorandom function
+$\fun{obftSchedule}$ for creating the OBFT leader schedule for each new epoch,
+as explained in section 3.9.2 of \cite{delegation_design}.
+The function takes a seed, the decentralization parameter $d$, and the active slot coeffient $f$.
+It must create $(d\cdot\SlotsPerEpoch)$-many OBFT slots, $(f\cdot d\cdot \SlotsPerEpoch)$
+of which are active.
 
 \begin{figure}
   \emph{New Epoch environments}
@@ -260,9 +268,23 @@ of
         \var{es} & \EpochState & \text{epoch state} \\
         \var{ru} & \RewardUpdate^? & \text{reward update} \\
         \var{pd} & \PoolDistr & \text{pool stake distribution} \\
+        \var{dsched} & \Slot\mapsto\VKeyGen^? & \text{OBFT schedule} \\
       \end{array}
     \right)
   \end{equation*}
+  %
+  \emph{Abstract pseudorandom schedule function}
+  \begin{align*}
+    & \fun{obftSchedule} \in \Seed \to \unitInterval \to \unitInterval \to
+      (\Slot\mapsto\VKeyGen^?) \\
+  \end{align*}
+  %
+  \emph{Constraints}
+  \begin{align*}
+    \text{ given: }~\var{dsched}\leteq\fun{obftSchedule}~\eta~\var{d}~\var{f} \\
+    |\var{dsched}| = \floor{d\cdot\SlotsPerEpoch} \\
+    |\{s\mapsto k\in\var{dsched}~\mid~k\neq\Nothing\}| = \floor{f\cdot d\cdot\SlotsPerEpoch} \\
+  \end{align*}
   %
   \emph{New Epoch Transitions}
   \begin{equation*}
@@ -290,8 +312,8 @@ In the second case, the new epoch state is updated as follows:
 \item The epoch state is updated first with the rewards update \var{ru} and then
   via the call to $\mathsf{EPOCH}$.
 \item The rewards update is set to \Nothing.
-\item The pool distribution is updated according to the changes in the stake
-  pools.
+\item The pool distribution is updated according to the changes in the stake pools.
+\item A new OBFT schedule is created.
 \end{itemize}
 
 The new pool distribution \var{pd}' is calculated from the delegation map and
@@ -321,7 +343,8 @@ in the pool distribution.
      }
      \\~\\~\\
      {\begin{array}{r@{~\leteq~}l}
-        (\wcard,~\wcard,~\var{ss},~\wcard) & \var{es} \\
+        (\wcard,~\wcard,~\var{ss},~(\wcard,~\wcard,~\var{us})) & \var{es} \\
+        \var{pp} & \pps{us} \\
         (\wcard,~\var{pstake_{set}},~\wcard,~\wcard,~\wcard,~\wcard) & \var{ss} \\
         (\var{stake}, \var{delegs}) & \var{pstake_{set}} \\
         total & \sum_{\_ \mapsto c\in\var{stake}} c \\
@@ -329,7 +352,8 @@ in the pool distribution.
                     \left\{
                     (\var{hk}, \frac{\var{c}}{\var{total}}) \vert (\var{hk},
                     \var{c}) \in \var{stake}
-                    \right\}
+                    \right\} \\
+         \var{dsched} & \fun{obftSchedule}~\eta_1~(\activeSlotCoeff{pp})~(\fun{d}~{pp})\\
       \end{array}}
     }
     {
@@ -666,7 +690,7 @@ been signed with the correct signing key according to the KES.
       &
       \var{h} = \bprev{bhb}
       \\
-      \mathcal{V}_{\var{hk}}{\serialised{bhb}}_{\sigma}^{t}
+      \mathcal{V}_{vk_{hot}}{\serialised{bhb}}_{\sigma}^{t}
       &
       \bHeaderSize{bh} \leq \fun{maxBHSize}~\var{pp}
     }
@@ -712,12 +736,7 @@ Figure~\ref{fig:ts-types:vrf} which consists of
 \item The stake pool mapping \var{stpools}.
 \end{itemize}
 
-The VRF state is shown in Figure~\ref{fig:ts-types:vrf} and consists of
-
-\begin{itemize}
-\item The hash \var{h} of the previous block header hash.
-\item The slot \var{s_\ell} number of the last slot.
-\end{itemize}
+The VRF state is $\BHeaderState$.
 
 \begin{figure}
   \emph{VRF environments}
@@ -734,21 +753,10 @@ The VRF state is shown in Figure~\ref{fig:ts-types:vrf} and consists of
     \right)
   \end{equation*}
   %
-  \emph{VRF states}
-  \begin{equation*}
-    \VRFState =
-    \left(
-      \begin{array}{r@{~\in~}lr}
-        \var{h} & \HashHeader & \text{latest header hash} \\
-        \var{s_\ell} & \Slot & \text{last slot} \\
-      \end{array}
-    \right)
-  \end{equation*}
-  %
   \emph{VRF Transitions}
   \begin{equation*}
     \_ \vdash \var{\_} \trans{vrf}{\_} \var{\_} \subseteq
-    \powerset (\VRFEnv \times \VRFState \times \BHeader \times \VRFState)
+    \powerset (\VRFEnv \times \BHeaderState \times \BHeader \times \BHeaderState)
   \end{equation*}
   \caption{VRF transition-system types}
   \label{fig:ts-types:vrf}
@@ -832,6 +840,7 @@ returned by the application of the $\mathsf{BHEAD}$ transition rule.
             \var{pp} \\
             \eta_0 \\
             \var{pd} \\
+            \var{stpools} \\
         \end{array}}
       \right)
       \vdash
@@ -848,6 +857,149 @@ returned by the application of the $\mathsf{BHEAD}$ transition rule.
   \end{equation}
   \caption{VRF rules}
   \label{fig:rules:vrf}
+\end{figure}
+
+\clearpage
+
+\subsection{Decentralization Slider}
+\label{sec:decentralization-slider}
+
+The transition from the boostrap era to a fully decentralized network is explained in
+section 3.9.2 of \cite{delegation_design}.
+Key to this transition is a protocol parameter $d$ which controls how many slots are governed by
+the genesis nodes via OBFT, and which slots are open to any registered stake pool.
+The transition system introduced in this section, $\type{DSLIDE}$, covers this mechanism.
+
+The environments for this transition is:
+\begin{itemize}
+  \item The environment for the $\type{VRF}$ transition $\var{ve}$.
+  \item A mapping $\var{dsched}$ of slots to an optional genesis key.
+    In the terminology of \cite{delegation_design},
+    the slots in $\var{dsched}$ are the ``OBFT slots''.
+    A slot in this map with a value of $\Nothing$ is a non-active slots,
+    otherwise it is an active slot and its value designates the genesis key
+    responsible for producing the block.
+\end{itemize}
+
+\begin{figure}
+  \emph{DSlider environments}
+  \begin{equation*}
+    \DSliderEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{ve} & \VRFEnv & \text{VRF environment} \\
+        \var{dsched} & \Slot\mapsto\VKeyGen^? & \text{OBFT schedule} \\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
+  \emph{DSlider Transitions}
+  \begin{equation*}
+    \_ \vdash \var{\_} \trans{dslider}{\_} \var{\_} \subseteq
+    \powerset (\DSliderEnv \times \BHeaderState \times \BHeader \times \BHeaderState)
+  \end{equation*}
+  \caption{DSlider transition-system types}
+  \label{fig:ts-types:decent-slider}
+\end{figure}
+
+\begin{figure}[ht]
+  \begin{equation}\label{eq:active-pbft}
+    \inference[Active-OBFT]
+    {
+      \{\bslot \bhbody bh \mapsto \var{gkey}\} \in \var{dsched}
+      \\
+      (\var{s_{now}},~\var{pp},~\wcard,~\wcard,~\var{stpools})\leteq ve
+      \\~\\
+      {
+        \left(
+          {\begin{array}{c}
+             \var{s_{now}} \\
+             \var{pp} \\
+             \var{stpools} \\
+           \end{array}}
+        \right)
+        \vdash
+        \left(
+          {\begin{array}{c}
+             \var{h} \\
+             \var{s_{\ell}} \\
+           \end{array}}
+        \right)
+        \trans{bhead}{\var{bh}}
+        \left(
+          {\begin{array}{c}
+             \var{h}' \\
+             \var{s_{\ell}}' \\
+           \end{array}}
+        \right)
+      }
+    }
+    {
+      \left(
+        {\begin{array}{c}
+            \var{ve} \\
+            \var{dsched} \\
+        \end{array}}
+      \right)
+      \vdash
+      {\left(\begin{array}{c}
+            \var{h} \\
+            \var{s_\ell} \\
+      \end{array}\right)}
+      \trans{dslider}{\var{bh}}
+      {\left(\begin{array}{c}
+            \varUpdate{\var{h}'} \\
+            \varUpdate{\var{s_\ell}'} \\
+      \end{array}\right)}
+    }
+  \end{equation}
+
+  \nextdef
+
+  \begin{equation}\label{eq:decentralized}
+    \inference[Decentralized]
+    {
+      \bslot \bhbody bh \notin \dom{\var{dsched}}
+      \\~\\
+      {
+        \var{ve}\vdash
+        \left(
+          {\begin{array}{c}
+             \var{h} \\
+             \var{s_{\ell}} \\
+           \end{array}}
+        \right)
+        \trans{vrf}{\var{bh}}
+        \left(
+          {\begin{array}{c}
+             \var{h}' \\
+             \var{s_{\ell}}' \\
+           \end{array}}
+        \right)
+      }
+    }
+    {
+      \left(
+        {\begin{array}{c}
+            \var{ve} \\
+            \var{dsched} \\
+        \end{array}}
+      \right)
+      \vdash
+      {\left(\begin{array}{c}
+            \var{h} \\
+            \var{s_\ell} \\
+      \end{array}\right)}
+      \trans{dslider}{\var{bh}}
+      {\left(\begin{array}{c}
+            \varUpdate{\var{h}'} \\
+            \varUpdate{\var{s_\ell}'} \\
+      \end{array}\right)}
+    }
+  \end{equation}
+
+  \caption{DSlider rules}
+  \label{fig:rules:decent-slider}
 \end{figure}
 
 \subsection{Block Body Transition}
@@ -1104,11 +1256,13 @@ following:
       \begin{array}{r@{~\in~}lr}
         (\eta_0,~\eta_c,~\eta_v) & \Seed\times\Seed\times\Seed & \text{nonces} \\
         \var{b} & \BlocksMade & \text{blocks made} \\
+        \var{h} & \HashHeader & \text{latest header hash} \\
         \var{s_\ell} & \Slot & \text{last slot} \\
         \var{e_\ell} & \Epoch & \text{lats epoch} \\
         \var{es} & \EpochState & \text{epoch state} \\
         \var{ru} & \RewardUpdate^? & \text{potential reward update} \\
         \var{pd} & \PoolDistr & \text{pool stake distribution} \\
+        \var{dsched} & \Slot\mapsto\VKeyGen^? & \text{OBFT schedule} \\
       \end{array}
     \right)
   \end{equation*}
@@ -1137,8 +1291,6 @@ preconditions, instead it calls all its subrules.
       \var{bhb} \leteq \bhbody{bh}
       &
       \eta \leteq \fun{bnonce}~\var{bhb}
-      \\
-      \var{h} \leteq \fun{bprev}~\var{bhb}
       &
       \var{s} \leteq \bslot{bhb}
       \\~\\
@@ -1157,6 +1309,7 @@ preconditions, instead it calls all its subrules.
               \var{es} \\
               \var{ru} \\
               \var{pd} \\
+              \var{dsched} \\
         \end{array}\right)}
         \trans{newepoch}{\var{e}}
         {\left(\begin{array}{c}
@@ -1166,6 +1319,7 @@ preconditions, instead it calls all its subrules.
               \var{es}' \\
               \var{ru}' \\
               \var{pd}' \\
+              \var{dsched}' \\
         \end{array}\right)}
       }
       &
@@ -1200,6 +1354,8 @@ preconditions, instead it calls all its subrules.
               \eta_0' \\
               \var{pd}' \\
               \var{stpools} \\
+              \\
+              \var{dsched} \\
           \end{array}}
         \right)
         \vdash
@@ -1207,7 +1363,7 @@ preconditions, instead it calls all its subrules.
               \var{h} \\
               \var{s_\ell} \\
         \end{array}\right)}
-        \trans{vrf}{\var{bh}}
+        \trans{dslider}{\var{bh}}
         {\left(\begin{array}{c}
               \var{h}' \\
               \var{s_\ell}' \\
@@ -1250,21 +1406,25 @@ preconditions, instead it calls all its subrules.
       {\left(\begin{array}{c}
             (\eta_0,~\eta_c,~\eta_v) \\
             \var{b} \\
+            \var{h} \\
             \var{s_\ell} \\
             \var{e_\ell} \\
             \var{es} \\
             \var{ru} \\
             \var{pd} \\
+            \var{dsched} \\
       \end{array}\right)}
       \trans{chain}{\var{block}}
       {\left(\begin{array}{c}
             \varUpdate{(\eta_0',~\eta_c',~\eta_v')} \\
             \varUpdate{\var{b}''} \\
+            \varUpdate{\var{h}'} \\
             \varUpdate{\var{s_\ell}'} \\
             \varUpdate{\var{e_\ell}'} \\
             \varUpdate{\var{es}''} \\
             \varUpdate{\var{ru}''} \\
             \varUpdate{\var{pd}'} \\
+            \varUpdate{\var{dsched}'} \\
       \end{array}\right)}
     }
   \end{equation}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -89,6 +89,7 @@
 \newcommand{\TxOut}{\type{TxOut}}
 \newcommand{\VKey}{\type{VKey}}
 \newcommand{\VKeyEv}{\type{VKey_{ev}}}
+\newcommand{\VKeyGen}{\type{VKey_G}}
 \newcommand{\SKey}{\type{SKey}}
 \newcommand{\SKeyEv}{\type{SKey_{ev}}}
 \newcommand{\HashKey}{\type{HashKey}}
@@ -99,7 +100,6 @@
 %% Adding delegation
 \newcommand{\Epoch}{\type{Epoch}}
 \newcommand{\KESPeriod}{\type{KESPeriod}}
-\newcommand{\VKeyGen}{\type{VKeyGen}}
 %% Blockchain
 \newcommand{\Gkeys}{\var{G_{keys}}}
 \newcommand{\Block}{\type{Block}}
@@ -147,6 +147,7 @@
 \newcommand{\epoch}[1]{\fun{epoch}~\var{#1}}
 \newcommand{\kesPeriod}[1]{\fun{kesPeriod}~\var{#1}}
 \newcommand{\dcerts}[1]{\fun{dcerts}~ \var{#1}}
+\newcommand{\pps}[1]{\fun{pps}~ \var{#1}}
 
 %% UTxO witnesses
 \newcommand{\inputs}[1]{\fun{inputs}~ \var{#1}}

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -67,6 +67,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
         \var{maxBHSize} & \N & \text{max block header size}\\
         \var{maxBBSize} & \N & \text{max block body size}\\
         \var{activeSlotCoeff} & \unitInterval & f\text{ in \cite{ouroboros_praos}}\\
+        \var{d} & \{0,~0.1,~0.2,~\ldots,~1\} & \text{decentralization parameter}\\
       \end{array}
     \right)
   \end{equation*}
@@ -89,6 +90,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
     \fun{maxBHSize},
     \fun{maxBBSize},
     \fun{activeSlotCoeff},
+    \fun{d},
   \end{center}
   %
   \emph{Abstract Functions}


### PR DESCRIPTION
This PR adds a rule for transitioning from the bootstrap/byron era to a fully decentralized network, as governed by the `d` parameter in the delegation design document.

The `d` value is now a protocol parameter.

The `NEWEPOCH` rule now creates the OBFT schedule using a new pseudorandom function `obftSchedule`, which takes the epoch nonce, `d`, and the active slot coefficient. The schedule is a map of slots to optional genesis keys, where a value of Nothing indicates a non-active OBFT slot.

(Sorry, I am having trouble adding images, I will add them as soon as I figure out what is going on...)

I added a layer of indirection to the `VRF` transition, which in turn calls `BHEAD`. Now there is a new transition `DSLIDE` which calls `VRF` in the case that the slot is _not_ an OBFT slot, and calls `BHEAD` directly if the slot is an _active_ OBFT slot. The `CHAIN` transition now calls `DSLIDE` instead of `VRF`.

small things:

* I fixed a typo in the `BHEAD` rule. It was using the hash of a key to check a signature.
* The `BHEAD` and `VRF` rules have the same state, so I removed `VRFState` and re-used `BHEADState` for `VRF`.
* `BHEAD` was missing `stpools` in one spot in the transition.
* The main `CHAIN` rule was not saving the block header hash, as needed by `BHEAD`. So I added it to the `CHAIN` environment.

closes #397 