### PR TITLE
remove the delegation map from the UPIEC env

### DIFF
--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -729,14 +729,7 @@ updates the update state to the correct version.
   {
     \var{e_c} < \sepoch{s}
     &
-    {\left(
-        \begin{array}{l}
-          s\\
-          \var{dms}
-        \end{array}
-      \right)
-    }
-    \vdash \var{us} \trans{upiec}{} \var{us'}
+    s\vdash \var{us} \trans{upiec}{} \var{us'}
   }
   {
     {\left(

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -209,7 +209,7 @@ In these rules we make use of the abstract constant $\var{ngk}$, defined in
       \powerset (\UPIEnv \times \UPIState
       \times (\ProtVer \times \VKey) \times \UPIState)\\
       \_ \vdash \_ \trans{upiec}{} \_ &
-      \powerset (\UPIEnv \times \UPIState \times \UPIState)
+      \powerset (\Slot \times \UPIState \times \UPIState)
     \end{array}
   \end{equation*}
   \caption{Update-proposals interface transition-system types}
@@ -756,12 +756,7 @@ expires.
       } &\var{pv} = \var{pv'}
     }
     {
-      {\left(
-        \begin{array}{l}
-          s_n\\
-          \var{dms}
-        \end{array}
-      \right)}
+      s_n
       \vdash
       {
         \left(
@@ -824,12 +819,7 @@ expires.
       & \var{pv} \neq \var{pv'}
     }
     {
-      {\left(
-        \begin{array}{l}
-          s_n\\
-          \var{dms}
-        \end{array}
-      \right)}
+      s_n
       \vdash
       {
         \left(


### PR DESCRIPTION
The `UPIEC` transition in the Byron ledger spec uses the same interface as all the `UPI...` transitions. In particular, the environment for `UPIEC` includes the genesis key delegation mapping, though it is not used by this transition.  Having a common interface is nice, but `UPIEC` is the only transition not called by the Bryon chain rule `BUPI`, and is thus a bit of a special case.

This PR changes the ledger spec and the chain spec so that `UPIEC` only takes a slot in the environment.

closes #285 