### PR TITLE
Model software metadata in update mechanism

### DIFF
--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -184,11 +184,11 @@ In these rules we make use of the abstract constant $\var{ngk}$, defined in
         & \text{current protocol information}\\
         \var{fads} & \seqof{(\Slot \times (\ProtVer \times \PPMMap))}
         & \text{future protocol version adoptions}\\
-        \var{avs} & \ApName \mapsto (\ApVer \times \Slot)
+        \var{avs} & \ApName \mapsto (\ApVer \times \Slot \times \Metadata)
         & \text{application versions}\\
         \var{rpus} & \UPropId \mapsto (\ProtVer \times \PPMMap)
         & \text{registered protocol update proposals}\\
-        \var{raus} & \UPropId \mapsto (\ApName \times \mathbb{N})
+        \var{raus} & \UPropId \mapsto (\ApName \times \ApVer \times \Metadata)
         & \text{registered software update proposals}\\
         \var{cps} & \UPropId \mapsto \Slot & \text{confirmed proposals}\\
         \var{vts} & \powerset{(\UPropId \times \VKeyGen)} & \text{proposals votes}\\
@@ -348,8 +348,8 @@ given application name $\var{an}$.
           \end{array}
         \right)
       }\\
-      \var{avs_{new}} \leteq \{ \var{an} \mapsto (\var{av}, \var{s_n})
-      \mid \var{pid} \mapsto (\var{an}, \var{av}) \in \var{raus}
+      \var{avs_{new}} \leteq \{ \var{an} \mapsto (\var{av}, \var{s_n}, m)
+      \mid \var{pid} \mapsto (\var{an}, \var{av}, m) \in \var{raus}
       ,~ \var{pid} \in \dom~\var{cps'}
       \}
     }

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -279,9 +279,7 @@ The rules in Figure~\ref{fig:rules:up-validity} model the validity of a proposal
       fitting in a block, and
     \item the proposed new script version can be incremented by at most 1.
     \end{itemize}
-  \item must have a unique version among the current active proposals. This
-    implies that a proposal is uniquely determined by the protocol version it
-    proposes.
+  \item must have a unique version among the current active proposals.
   \end{itemize}
 \item if an update proposal proposes to increase the application version
   version ($\var{av}$) for a given application ($\var{an}$), then there should
@@ -1348,6 +1346,11 @@ update proposals we can simplify the version checking logic considerably.
 We do not model the implicit agreement rule. If a proposal does not get enough
 votes before the end of the voting period, then we simply discard it. At the
 moment it is not clear whether the implicit agreement rule is needed.
+Furthermore, in a non-federated setting, one could imagine an attack based on
+exploiting an implicit agreement rule, where the attacker would attempt to
+carry out a DoS attack on the parts of network that are likely to affect a
+proposal in a way that is undesirable for the attacker. Thus the explicit
+agreement seems to be a safer option.
 
 \subsubsection{Adoption threshold}
 \label{sec:adoption-threshold}
@@ -1380,12 +1383,6 @@ The rule of Figure~\ref{eq:rule:up-pv-validity} does not check the
 meaning in the handover phase: its use will be reserved for unlocking the
 Ouroboros-BFT logic in the software.
 
-\subsubsection{No grouping of proposals per-application name}
-\label{sec:no-app-up-grouping}
-
-It is unclear at this moment whether we need to model the applications names
-and versions, so this aspect is not modeled in the present rules.
-
 \subsubsection{Ignored attributes of proposals}
 
 In Figure~\ref{fig:defs:update-proposals} the types
@@ -1414,13 +1411,6 @@ proposal must be submitted with a different key, which adds extra complexity
 for devops. In light of the preceding discussion, unless there is a benefit for
 restricting the number of times a genesis key can submit an update proposal, we
 opted for removing such constraint in the current specification.
-
-\subsubsection{Protocol only or software only updates allowed}
-\label{sec:ptonly-or-swonly-allowed}
-
-We allow for updates in the protocol version without requiring a software
-version update, and conversely, we allow for a software update without
-requiring an update in the protocol.
 
 \subsubsection{Acceptance of blocks endorsing unconfirmed proposal updates}
 \label{sec:acceptance-of-uncofirmed-up-endorsements}

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -20,6 +20,7 @@
 \newcommand{\ApName}{\ensuremath{\type{ApName}}}
 \newcommand{\SWVer}{\ensuremath{\type{SWVer}}}
 \newcommand{\ApVer}{\ensuremath{\type{ApVer}}}
+\newcommand{\Metadata}{\ensuremath{\type{Mdt}}}
 
 \newcommand{\upSize}[1]{\ensuremath{\fun{upSize}~\var{#1}}}
 \newcommand{\upPV}[1]{\ensuremath{\fun{upPV}~\var{#1}}}
@@ -29,6 +30,7 @@
 \newcommand{\upIssuer}[1]{\ensuremath{\fun{upIssuer}~\var{#1}}}
 \newcommand{\upParams}[1]{\ensuremath{\fun{upParams}~\var{#1}}}
 \newcommand{\upSwVer}[1]{\ensuremath{\fun{upSwVer}~\var{#1}}}
+\newcommand{\upMetadata}[1]{\ensuremath{\fun{upMdt}~\var{#1}}}
 \newcommand{\vCaster}[1]{\ensuremath{\fun{vCaster}~\var{#1}}}
 \newcommand{\vPropId}[1]{\ensuremath{\fun{vPropId}~\var{#1}}}
 \newcommand{\vSig}[1]{\ensuremath{\fun{vSig}~\var{#1}}}
@@ -68,6 +70,8 @@ this specification can be extended to incorporate the research results.
 
 \subsection{Update proposals}
 \label{sec:update-proposals}
+
+% TODO: add prose explaining what metadata is.
 
 \begin{figure}[htb]
   \emph{Abstract types}
@@ -129,7 +133,8 @@ this specification can be extended to incorporate the research results.
                                            & \text{proposed parameters update}\\
       \fun{upSwVer} & \UProp \to \SWVer & \text{software-version update proposal}\\
       \fun{upSig} & \UProp \to \Sig & \text{update proposal signature}\\
-      \fun{upSigdata} & \UProp \to \UPropSD & \text{update proposal signed data}\\
+      \fun{upSigData} & \UProp \to \UPropSD & \text{update proposal signed data}\\
+      \fun{upMdt} & \UProp \to \Metadata & \text{software update metadata}
     \end{array}
   \end{equation*}
   \caption{Update proposals definitions}
@@ -205,24 +210,24 @@ The protocol parameters are formally defined in \cref{fig:prot-params-defs}.
       \begin{array}{r@{~\in~}lr}
         \var{pv} & \ProtVer & \text{adopted (current) protocol version}\\
         \var{pps} & \PPMMap & \text{adopted protocol parameters map}\\
-        \var{avs} & \ApName \mapsto (\ApVer \times \Slot)
+        \var{avs} & \ApName \mapsto (\ApVer \times \Slot \times \Metadata)
         & \text{application versions}\\
       \end{array}
     \right)
   \end{equation*}
   %
   \emph{Update proposals validity states}
-  \begin{equation*}
-    \UPVState
-    = \left(
+  \begin{align*}
+    & \UPVState \\
+    & = \left(
       \begin{array}{r@{~\in~}lr}
         \var{rpus} & \UPropId \mapsto (\ProtVer \times \PPMMap)
         & \text{registered protocol update proposals}\\
-        \var{raus} & \UPropId \mapsto (\ApName \times \ApVer)
+        \var{raus} & \UPropId \mapsto (\ApName \times \ApVer \times \Metadata)
         & \text{registered software update proposals}\\
       \end{array}
     \right)
-  \end{equation*}
+  \end{align*}
   %
   \emph{Update proposals validity transitions}
     \begin{equation*}
@@ -310,7 +315,7 @@ cause a soft-fork we might use the alt version for that purpose.
     \label{eq:func:av-can-follow}
     \begin{array}{r c l}
       \fun{svCanFollow}~\var{avs}~(\var{an}, \var{av}) & =
-      & (\var{an} \mapsto (\var{av_c}, \wcard) \in \var{avs}
+      & (\var{an} \mapsto (\var{av_c}, \wcard, \wcard) \in \var{avs}
         \Rightarrow \var{av} = \var{av_c} + 1)\\
       & \wedge & (\var{an} \notin \dom~\var{avs} \Rightarrow \var{av} = 0)
     \end{array}
@@ -325,7 +330,7 @@ cause a soft-fork we might use the alt version for that purpose.
     {
       (\var{an}, \var{av}) \leteq \upSwVer{up}
       & \fun{svCanFollow}~\var{avs}~(\var{an}, \var{av})
-      & (\var{an}, \var{av}) \notin \range~\var{raus}
+      & (\var{an}, \var{av}, \wcard) \notin \range~\var{raus}
     }
     {
       {
@@ -345,7 +350,7 @@ cause a soft-fork we might use the alt version for that purpose.
       {
         \left(
           \begin{array}{l}
-            \var{raus} \unionoverrideRight \{ \upId{up} \mapsto (\var{an}, \var{av})\}
+            \var{raus} \unionoverrideRight \{ \upId{up} \mapsto (\var{an}, \var{av}, \upMetadata{up})\}
           \end{array}
         \right)
       }
@@ -417,7 +422,7 @@ cause a soft-fork we might use the alt version for that purpose.
         \right)
       }
       &
-      (\var{an}, \var{av}) \leteq \upSwVer{up} & \var{an} \mapsto (\var{av}, \_) \in \var{avs}
+      (\var{an}, \var{av}) \leteq \upSwVer{up} & \var{an} \mapsto (\var{av}, \_, \_) \in \var{avs}
     }
     {
       {
@@ -607,7 +612,7 @@ an update proposal:
       \begin{array}{r@{~\in~}lr}
         \var{pv} & \ProtVer & \text{adopted (current) protocol version}\\
         \var{pps} & \PPMMap & \text{adopted protocol parameters map}\\
-        \var{avs} & \ApName \mapsto (\ApVer \times \Slot)
+        \var{avs} & \ApName \mapsto (\ApVer \times \Slot \times \Metadata)
         & \text{application versions}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
       \end{array}
@@ -621,7 +626,7 @@ an update proposal:
       \begin{array}{r@{~\in~}lr}
         \var{rpus} & \UPropId \mapsto (\ProtVer \times \PPMMap)
         & \text{registered update proposals}\\
-        \var{raus} & \UPropId \mapsto (\ApName \times \ApVer)
+        \var{raus} & \UPropId \mapsto (\ApName \times \ApVer \times \Metadata)
         & \text{registered software update proposals}
       \end{array}
     \right)


### PR DESCRIPTION
Model the software update metadata.

The `avs` and `raus` component of the state include (abstract) metadata:

![image](https://user-images.githubusercontent.com/175315/57295436-c8700500-70ca-11e9-829d-097ab9c8718d.png)

The rules where modified accordingly:

![image](https://user-images.githubusercontent.com/175315/57295471-e2114c80-70ca-11e9-9325-67d76495d08a.png)

![image](https://user-images.githubusercontent.com/175315/57295490-f1909580-70ca-11e9-8ad2-ec62d325fdae.png)

![image](https://user-images.githubusercontent.com/175315/57295509-fbb29400-70ca-11e9-9cce-e8f095e8623a.png)

![image](https://user-images.githubusercontent.com/175315/57295543-108f2780-70cb-11e9-8610-77342d3e1a36.png)

Closes #271 