### PR TITLE
hyperlinks in shelley sub-transitions

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -302,7 +302,7 @@ of which are active.
   \label{fig:ts-types:newepoch}
 \end{figure}
 
-Figure~\ref{fig:rules:not-new-epoch} defines the new epoch state transition. It
+Figure~\ref{fig:rules:new-epoch} defines the new epoch state transition. It
 has two rules: the first one deals with the case when the epoch signal $e$ is before the
 current epoch \var{e_\ell}. This rule does not change the state. The second rule
 describes the change in the case of $e$ being equal to the next epoch
@@ -339,7 +339,7 @@ in the pool distribution.
       (\wcard,~\wcard,~(\wcard,~\wcard,~\var{us}))\leteq\var{es}
       \\
       {
-        \var{s}\vdash\var{us} \trans{upiec}{} \var{us'}
+        \var{s}\vdash\var{us} \trans{\hyperlink{byron_ledger_spec_link}{upiec}}{} \var{us'}
       }
       &
       \var{pp_n}\leteq\pps{us'}
@@ -352,7 +352,8 @@ in the pool distribution.
            \end{array}}
        \right)
        \vdash
-       (\fun{applyRUpd}~\var{ru}~\var{es})\trans{epoch}{\var{e}}\var{es'}
+       (\fun{applyRUpd}~\var{ru}~\var{es})
+         \trans{\hyperref[fig:rules:epoch]{epoch}}{\var{e}}\var{es'}
      }
      \\~\\~\\
      {\begin{array}{r@{~\leteq~}l}
@@ -435,7 +436,7 @@ in the pool distribution.
     }
   \end{equation}
   \caption{New Epoch rules}
-  \label{fig:rules:not-new-epoch}
+  \label{fig:rules:new-epoch}
 \end{figure}
 
 \subsection{Update Nonce Transition}
@@ -870,7 +871,7 @@ returned by the application of the $\mathsf{BHEAD}$ transition rule.
              \var{s_{\ell}} \\
            \end{array}}
         \right)
-        \trans{bhead}{\var{bh}}
+        \trans{\hyperref[fig:rules:bheader]{bhead}}{\var{bh}}
         \left(
           {\begin{array}{c}
              \var{h}' \\
@@ -971,7 +972,7 @@ The environments for this transition is:
              \var{s_{\ell}} \\
            \end{array}}
         \right)
-        \trans{bhead}{\var{bh}}
+        \trans{\hyperref[fig:rules:bheader]{bhead}}{\var{bh}}
         \left(
           {\begin{array}{c}
              \var{h}' \\
@@ -1015,7 +1016,7 @@ The environments for this transition is:
              \var{s_{\ell}} \\
            \end{array}}
         \right)
-        \trans{vrf}{\var{bh}}
+        \trans{\hyperref[fig:rules:vrf]{vrf}}{\var{bh}}
         \left(
           {\begin{array}{c}
              \var{h}' \\
@@ -1152,7 +1153,7 @@ current slot is not an overlay slot.
         \right)
         \vdash
              \var{ls} \\
-        \trans{ledgers}{\var{txs}}
+        \trans{\hyperref[fig:rules:ledger-sequence]{ledgers}}{\var{txs}}
              \var{ls}' \\
       }
     }
@@ -1383,7 +1384,7 @@ Note that $\mathsf{UPIEC}$ is defined in \cite{byron_ledger_spec}.
               \var{pd} \\
               \var{osched} \\
         \end{array}\right)}
-        \trans{newepoch}{\epoch{s}}
+        \trans{\hyperref[fig:rules:new-epoch]{newepoch}}{\epoch{s}}
         {\left(\begin{array}{c}
               \var{e_\ell}' \\
               \eta_0' \\
@@ -1401,7 +1402,7 @@ Note that $\mathsf{UPIEC}$ is defined in \cite{byron_ledger_spec}.
               \eta_v \\
               \eta_c \\
         \end{array}\right)}
-        \trans{updn}{\var{s}}
+        \trans{\hyperref[fig:rules:update-nonce]{updn}}{\var{s}}
         {\left(\begin{array}{c}
               \eta_v' \\
               \eta_c' \\
@@ -1416,7 +1417,7 @@ Note that $\mathsf{UPIEC}$ is defined in \cite{byron_ledger_spec}.
       \var{ps}' \\
       \var{dms} \\
       \end{array}\right)}
-      \trans{ocert}{bhb}
+      \trans{\hyperref[fig:rules:ocert]{ocert}}{bhb}
       {\left(\begin{array}{c}
       \var{ps}'' \\
       \var{dms}' \\
@@ -1445,7 +1446,7 @@ Note that $\mathsf{UPIEC}$ is defined in \cite{byron_ledger_spec}.
               \var{h} \\
               \var{s_\ell} \\
         \end{array}\right)}
-        \trans{overlay}{\var{bh}}
+        \trans{\hyperref[fig:rules:overlay]{overlay}}{\var{bh}}
         {\left(\begin{array}{c}
               \var{h}' \\
               \var{s_\ell}' \\
@@ -1459,7 +1460,7 @@ Note that $\mathsf{UPIEC}$ is defined in \cite{byron_ledger_spec}.
               \var{es}' \\
           \end{array}}
         \right)
-        \vdash \var{ru}' \trans{rupd}{\var{s}} \var{ru}''
+        \vdash \var{ru}' \trans{\hyperref[fig:rules:reward-update]{rupd}}{\var{s}} \var{ru}''
       }
       \\
       \var{ls} \leteq (\var{utxoSt}',~(\var{ds}',~\var{ps}''),~\var{us}')
@@ -1474,7 +1475,7 @@ Note that $\mathsf{UPIEC}$ is defined in \cite{byron_ledger_spec}.
               \var{ls} \\
               \var{b'} \\
         \end{array}\right)}
-        \trans{bbody}{\var{block}}
+        \trans{\hyperref[fig:rules:bbody]{bbody}}{\var{block}}
         {\left(\begin{array}{c}
               \var{ls}' \\
               b'' \\

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -654,7 +654,7 @@ will be successful, since the pool certificates are disjoint from the delegation
           \var{ptr} \\
         \end{array}
       }
-      \vdash \var{dstate} \trans{deleg}{c} \var{dstate'}
+      \vdash \var{dstate} \trans{\hyperref[fig:delegation-rules]{deleg}}{c} \var{dstate'}
     }
     { \left(
         \begin{array}{r}
@@ -690,7 +690,7 @@ will be successful, since the pool certificates are disjoint from the delegation
         \var{pp} \\
       \end{array}
     }
-    \vdash \var{pstate} \trans{pool}{c} \var{pstate'}
+    \vdash \var{pstate} \trans{\hyperref[fig:pool-rules]{pool}}{c} \var{pstate'}
     }
     { \left(
         \begin{array}{r}
@@ -856,7 +856,7 @@ will be invalid.
     }
     \vdash
       \var{dpstate'}
-      \trans{delpl}{c}
+      \trans{\hyperref[fig:rules:delpl]{delpl}}{c}
       \var{dpstate''}
     }
     {

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -838,7 +838,7 @@ in sequence.
           }
         \right)
       }
-      \trans{snap}{e}
+      \trans{\hyperref[fig:rules:snapshot]{snap}}{e}
       {
         \left(
           {
@@ -861,7 +861,7 @@ in sequence.
           \end{array}
         }
       \right)
-      \trans{poolreap}{e}
+      \trans{\hyperref[fig:rules:pool-reap]{poolreap}}{e}
       \left(
       {
         \begin{array}{rcl}
@@ -889,7 +889,7 @@ in sequence.
           \end{array}
         }
       \right)
-      \trans{newpp}{e}
+      \trans{\hyperref[fig:rules:new-proto-param]{newpp}}{e}
       \left(
       {
         \begin{array}{rcl}

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -75,7 +75,7 @@ the $\mathsf{BUPI}$ transition (from \cite{byron_chain_spec}).
         \var{stpools}
         \end{array}
     }\right)
-      \vdash \var{utxoSt} \trans{utxow}{tx} \var{utxoSt'}\\~\\~\\
+      \vdash \var{utxoSt} \trans{\hyperref[fig:rules:utxow-shelley]{utxow}}{tx} \var{utxoSt'}\\~\\~\\
       %
       {
         \left(
@@ -87,7 +87,7 @@ the $\mathsf{BUPI}$ transition (from \cite{byron_chain_spec}).
       \right)
       }
       \vdash
-      dpstate \trans{delegs}{\var{tx}} dpstate'
+      dpstate \trans{\hyperref[fig:rules:delegation-sequence]{delegs}}{\var{tx}} dpstate'
       \\~\\~\\
       {
         \left(
@@ -98,7 +98,7 @@ the $\mathsf{BUPI}$ transition (from \cite{byron_chain_spec}).
       \right)
       }
       \vdash
-      us \trans{bupi}{\fun{txup}~\var{tx}} us'
+      us \trans{\hyperlink{byron_chain_spec_link}{bupi}}{\fun{txup}~\var{tx}} us'
     }
     {
       \left(
@@ -193,7 +193,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transitions.
       }
       \vdash
         \var{ls'}
-        \trans{ledger}{c}
+        \trans{\hyperref[fig:rules:ledger]{ledger}}{c}
         \var{ls''}
     }
     {

--- a/shelley/chain-and-ledger/formal-spec/references.bib
+++ b/shelley/chain-and-ledger/formal-spec/references.bib
@@ -15,7 +15,7 @@ Cardano},
 }
 
 @misc{byron_ledger_spec,
-  author = {Damian Nadales, IOHK},
+  author = {Damian Nadales, IOHK \hypertarget{byron_ledger_spec_link}{}},
   title = {A Formal Specification of the Cardano Ledger},
   titleaddon = {(for the Byron release)},
   year = {2019},
@@ -23,7 +23,7 @@ Cardano},
 }
 
 @misc{byron_chain_spec,
-  author = {Marko Dimja\v{s}evi\'c, Nicholas Clarke, IOHK},
+  author = {Marko Dimja\v{s}evi\'c, Nicholas Clarke, IOHK \hypertarget{byron_chain_spec_link}{}},
   title = {Specification of the Blockchain Layer},
   titleaddon = {(for the Byron release)},
   year = {2019},

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -567,7 +567,7 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
         \var{utxoEnv}
         \end{array}
       }
-      \vdash \var{utxoSt} \trans{utxo}{tx} \var{utxoSt'}\\
+      \vdash \var{utxoSt} \trans{\hyperref[fig:rules:utxo-shelley]{utxo}}{tx} \var{utxoSt'}\\
     }
     {
       \begin{array}{l}


### PR DESCRIPTION
This PR adds some new hyper links.

Whenever a transition is used inside another transition,the inner transition name now links to the table that defines it. closes #454 