### PR TITLE
max tx size check in Shelley ledger rules

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -4,7 +4,7 @@
 The rules for the ledger depend on several parameters contained in the $\PParams$ type,
 defined in \cite{byron_ledger_spec}.
 The parameters are listed in Figure~\ref{fig:defs:protocol-parameters},
-the first nine of which below are common to the Byron era.
+the first ten of which below are common to the Byron era.
 
 The type $\Coin$ is defined as an alias for the integers.
 Negative values will not be allowed in UTxO outputs or reward accounts,
@@ -55,6 +55,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
         \var{a} \mapsto \Z & \PParams & \text{min fee factor}\\
         \var{b} \mapsto \Z & \PParams & \text{min fee constant}\\
         \var{maxBlockSize} \mapsto \N & \PParams & \text{max block body size}\\
+        \var{maxTxSize} \mapsto \N & \PParams & \text{max transaction size}\\
         \var{maxHeaderSize} \mapsto \N & \PParams & \text{max block header size}\\
         \var{scriptVersion} \mapsto \N & \PParams & \text{script version}\\
         \var{upAdptThd} \mapsto \R & \PParams & \text{update proposal adoption threshold}\\
@@ -82,6 +83,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
     \fun{a},
     \fun{b},
     \fun{maxBlockSize},
+    \fun{maxTxSize},
     \fun{maxHeaderSize},
     \fun{scriptVersion},
     \fun{upAdptThd},

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -210,6 +210,13 @@ The transition contains the following predicates:
     the amount consumed.
   \item
     The coin value of each new output must be non-negative.
+  \item
+    The transaction size must be below the allowed maximum.
+    Note that there is an implicit max transaction size given by the max block size,
+    and that if we wished to allow a transaction to be as large as will fit in a block, this
+    check would not be needed.
+    Being able to limit the size below that of the block, however, gives us some
+    control over how transactions will be packed into the blocks.
 \end{itemize}
 If all the predicates are satisfied, the state is updated as follows:
 

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -284,6 +284,8 @@ requests).
       \\
       \forall (\_\mapsto (\_, c)) \in \txouts{tx}, c \geq 0
       \\
+      \fun{txsize}~{tx}\leq\fun{maxTxSize}~\var{pp}
+      \\
       ~
       \\
       \var{refunded} \leteq \keyRefunds{pp}{stkeys}~{tx}


### PR DESCRIPTION
This (small!) PR adds a max transaction size to the Shelley ledger rules.  The Byron rules add the check to the `UTXOW` transition, but I thought that putting it in `UTXO` would be more natural for the Shelley rules.

closes #442 