### PR TITLE
Correct operational certificate start time

### DIFF
--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -311,11 +311,14 @@ cases where there is or is not an update proposal contained within the block.
 \begin{figure}[ht]
   \begin{equation*}
     \inference
-    { \Gamma \vdash \var{us} \trans{upireg}{\var{prop}} \var{us'}
+    { \Gamma \vdash \var{us}
+      \trans{\hyperlink{byron_ledger_spec_link}{upireg}}{\var{prop}} \var{us'}
       \\
-      \Gamma \vdash \var{us'} \trans{upivotes}{\var{votes}} \var{us''}
+      \Gamma \vdash \var{us'}
+      \trans{\hyperlink{byron_ledger_spec_link}{upivotes}}{\var{votes}} \var{us''}
       &
-      \Gamma \vdash \var{us''} \trans{upiend}{\var{end}} \var{us'''}
+      \Gamma \vdash \var{us''}
+      \trans{\hyperlink{byron_ledger_spec_link}{upiend}}{\var{end}} \var{us'''}
     }
     {
       \Gamma \vdash
@@ -336,9 +339,11 @@ cases where there is or is not an update proposal contained within the block.
   \vspace{20pt}
   \begin{equation*}
     \inference
-    { \Gamma \vdash \var{us} \trans{upivotes}{\var{votes}} \var{us'}
+    { \Gamma \vdash \var{us}
+      \trans{\hyperlink{byron_ledger_spec_link}{upivotes}}{\var{votes}} \var{us'}
       &
-      \Gamma \vdash \var{us'} \trans{upiend}{\var{end}} \var{us''}
+      \Gamma \vdash \var{us'}
+      \trans{\hyperlink{byron_ledger_spec_link}{upiend}}{\var{end}} \var{us''}
     }
     {
       \Gamma \vdash \var{us}
@@ -574,7 +579,7 @@ During PBFT processing of the block header, we do the following:
       \\
       ds
       \vdash
-      \var{sgs} \trans{sigcnt}{\var{vk_d}} \var{sgs'}
+      \var{sgs} \trans{\hyperref[fig:rules:sigcnt]{sigcnt}}{\var{vk_d}} \var{sgs'}
       \\
     }
     {
@@ -729,7 +734,7 @@ updates the update state to the correct version.
   {
     \var{e_c} < \sepoch{s}
     &
-    s\vdash \var{us} \trans{upiec}{} \var{us'}
+    s\vdash \var{us} \trans{\hyperlink{byron_ledger_spec_link}{upiec}}{} \var{us'}
   }
   {
     {\left(
@@ -904,7 +909,7 @@ rules. During header processing we verify the following things:
             us
           \end{array}
         \right)}
-      \trans{epoch}{\bslot{b}}
+      \trans{\hyperref[fig:rules:epoch]{epoch}}{\bslot{b}}
       {\left(
           \begin{array}{l}
             us'
@@ -1038,7 +1043,7 @@ payload; UTxO, delegation and update.
             \fun{dms}~ ds
           \end{array}
         \right)}
-      \vdash \var{us} \trans{bupi}{
+      \vdash \var{us} \trans{\hyperref[fig:rules:bupi]{bupi}}{
         {\left(
             \begin{array}{l}
               \bupdprop{b} \\
@@ -1055,8 +1060,9 @@ payload; UTxO, delegation and update.
             \bslot{b}
           \end{array}
         \right)}
-      \vdash \var{ds} \trans{deleg}{\bcerts{b}} \var{ds'} &
-      \var{pps} \vdash \var{utxo} \trans{utxows}{\butxo{b}} \var{utxo'} \\
+      \vdash \var{ds} \trans{\hyperlink{byron_ledger_spec_link}{deleg}}{\bcerts{b}} \var{ds'} &
+      \var{pps} \vdash \var{utxo}
+        \trans{\hyperlink{byron_ledger_spec_link}{utxows}}{\butxo{b}} \var{utxo'} \\
     }
     {
       \left(
@@ -1212,7 +1218,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
              \var{us}
            \end{array}
         }\right)
-        \trans{bhead}{\bhead{b}}
+        \trans{\hyperref[fig:rules:bhead]{bhead}}{\bhead{b}}
         \left(
         {\begin{array}{c}
            \var{us'}
@@ -1232,7 +1238,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
              \var{sgs}
            \end{array}}
         \right)
-        \trans{pbft}{\bhead{b}}
+        \trans{\hyperref[fig:rules:pbft]{pbft}}{\bhead{b}}
         \left(
         {\begin{array}{c}
            \var{h'} \\
@@ -1253,7 +1259,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
              \var{us'}
            \end{array}}
         \right)}
-        \trans{bbody}{b}
+        \trans{\hyperref[fig:rules:bbody]{bbody}}{b}
         {\left(
           {\begin{array}{c}
              \var{utxo'} \\

--- a/byron/chain/formal-spec/references.bib
+++ b/byron/chain/formal-spec/references.bib
@@ -6,7 +6,7 @@
 }
 
 @misc{byron_ledger_spec,
-  author = {Damian Nadales, IOHK},
+  author = {Damian Nadales, IOHK \hypertarget{byron_ledger_spec_link}{}},
   title = {A Formal Specification of the Cardano Ledger},
   titleaddon = {(for the Byron release)},
   year = {2019},

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -732,7 +732,7 @@ The state update finally sets \var{slot} as new block header slot and hash of
       &
       \var{h} = \bprev{bhb}
       &
-      \mathcal{V}_{vk_{hot}}{\serialised{bhb}}_{\sigma}^{t}
+      \mathcal{V}^{\mathsf{KES}}_{vk_{hot}}{\serialised{bhb}}_{\sigma}^{t}
       \\
       \bHeaderSize{bh} \leq \fun{maxHeaderSize}~\var{pp}
       &

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -946,9 +946,13 @@ The environments for this transition is:
   \begin{equation}\label{eq:active-pbft}
     \inference[Active-OBFT]
     {
-      \{\bslot \bhbody bh \mapsto \var{gkey}\} \in \var{osched}
-      \\
+      \var{bhb}\leteq\bhbody{bh}
+      &
       (\var{s_{now}},~\var{pp},~\wcard,~\wcard)\leteq ve
+      \\
+      \{\bslot bhb \mapsto \var{gkey}\} \in \var{osched}
+      &
+      \var{gkey} = \bvkcold{bhb}
       \\~\\
       {
         \left(

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -657,7 +657,6 @@ the last slot.
       \begin{array}{r@{~\in~}lr}
         \var{s_{now}} & \Slot & \text{current slot (wall-clock)} \\
         \var{pp} & \PParams & \text{protocol parameters} \\
-        \var{stpools} & \StakePools & \text{stake pools} \\
       \end{array}
     \right)
   \end{equation*}
@@ -724,12 +723,10 @@ The state update finally sets \var{slot} as new block header slot and hash of
       &
       \var{slot} \leteq \bslot{bhb}
       \\
-      (\var{vk_{hot}},~\wcard,~\wcard,~\wcard) \leteq \bocert{bhb}
+      (\var{vk_{hot}},~\wcard,~\wcard,\var{c_0},~\wcard) \leteq \bocert{bhb}
       & \var{hk} \leteq \hashKey{vk_{hot}}
-      \\~\\
-      \var{hk}\mapsto s_0\in\var{stpools}
-      &
-      t \leteq \kesPeriod{slot} - \kesPeriod{s_0}
+      \\
+      t \leteq \kesPeriod{slot} - c_0
       \\~\\
       \var{s_\ell} < \var{slot} \leq \var{s_{now}}
       &
@@ -746,7 +743,6 @@ The state update finally sets \var{slot} as new block header slot and hash of
         {\begin{array}{c}
             \var{s_{now}} \\
             \var{pp} \\
-            \var{stpools} \\
         \end{array}}
       \right)
       \vdash
@@ -795,7 +791,6 @@ The VRF state is $\BHeaderState$.
         \var{pp} & \PParams & \text{protocol parameters} \\
         \eta_0 & \Seed & \text{epoch nonce} \\
         \var{pd} & \PoolDistr & \text{pool stake distribution} \\
-        \var{stpools} & \StakePools & \text{stake pools} \\
       \end{array}
     \right)
   \end{equation*}
@@ -861,7 +856,6 @@ returned by the application of the $\mathsf{BHEAD}$ transition rule.
           {\begin{array}{c}
              \var{s_{now}} \\
              \var{pp} \\
-             \var{stpools} \\
            \end{array}}
         \right)
         \vdash
@@ -887,7 +881,6 @@ returned by the application of the $\mathsf{BHEAD}$ transition rule.
             \var{pp} \\
             \eta_0 \\
             \var{pd} \\
-            \var{stpools} \\
         \end{array}}
       \right)
       \vdash
@@ -955,14 +948,13 @@ The environments for this transition is:
     {
       \{\bslot \bhbody bh \mapsto \var{gkey}\} \in \var{osched}
       \\
-      (\var{s_{now}},~\var{pp},~\wcard,~\wcard,~\var{stpools})\leteq ve
+      (\var{s_{now}},~\var{pp},~\wcard,~\wcard)\leteq ve
       \\~\\
       {
         \left(
           {\begin{array}{c}
              \var{s_{now}} \\
              \var{pp} \\
-             \var{stpools} \\
            \end{array}}
         \right)
         \vdash
@@ -1422,8 +1414,6 @@ Note that $\mathsf{UPIEC}$ is defined in \cite{byron_ledger_spec}.
       \var{ps}'' \\
       \var{dms}' \\
       \end{array}\right)}
-      &
-      (\var{stpools},~\wcard,~\wcard,~\wcard,~\wcard) \leteq \var{ps}''
       \\
       {
         \left(
@@ -1434,7 +1424,6 @@ Note that $\mathsf{UPIEC}$ is defined in \cite{byron_ledger_spec}.
                 \var{pp}' \\
                 \eta_0' \\
                 \var{pd}' \\
-                \var{stpools} \\
                 \end{array}}
               \right)
               \\

--- a/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
+++ b/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
@@ -124,7 +124,8 @@ needed for KES.
   \end{align*}
   \emph{Notation for verified KES data}
   \begin{align*}
-    & \mathcal{V}_{\var{vk}}{\serialised{d}}_{\sigma}^n = \verifyEv{vk}{n}{d}{\sigma}
+    & \mathcal{V}^{\mathsf{KES}}_{\var{vk}}{\serialised{d}}_{\sigma}^n
+        = \verifyEv{vk}{n}{d}{\sigma}
     & \text{shorthand notation for } \fun{verify_{ev}}
   \end{align*}
   \caption{KES Cryptographic definitions}


### PR DESCRIPTION
Previous to this PR, the rules we using two different and conflicting ways to get the start time of an operational certificate: 1) the `KESPeriod` in the cert, and 2) the time associated with the registration of the pool. The second way is completely wrong.

We no longer need `stpools` passed to the header transitions (`BHEAD`, `OVERLAY`, and `VRF`). The `BHEAD` rule now correctly checks the time range of the certificate:

![bhead](https://user-images.githubusercontent.com/943479/57322765-5ac7d700-70d2-11e9-878b-11abeb4dacb8.png)

Note also that we added the "superscript KES" notation for verifying KES signatures.

Finally, since it was a small change, this PR also adds the missing check in the `OVERLAY` transition which asserts that the cold key for the given block matches the schedule in the active OBFT rule:

![active-overlay](https://user-images.githubusercontent.com/943479/57322928-b4c89c80-70d2-11e9-8e87-c3bbb824d50b.png)


close #450 #446