### PR TITLE
hyperlinks in byron ledger sub-transitions

### DIFF
--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -68,7 +68,7 @@
           \end{array}
         \right)
       }
-      \trans{sdelegs}{\Gamma}
+      \trans{\hyperref[fig:rules:delegation-scheduling-seq]{sdelegs}}{\Gamma}
       {
         \left(
           \begin{array}{l}
@@ -90,7 +90,7 @@
           \end{array}
         \right)
       }
-      \trans{adelegs}{[.., s] \restrictdom \var{sds'}}
+      \trans{\hyperref[fig:rules:delegation-seq]{adelegs}}{[.., s] \restrictdom \var{sds'}}
       {
         \left(
           \begin{array}{l}
@@ -238,7 +238,7 @@ In these rules we make use of the abstract constant $\var{ngk}$, defined in
           \end{array}
         \right)
       }
-      \trans{upreg}{\var{up}}
+      \trans{\hyperref[fig:rules:up-registration]{upreg}}{\var{up}}
       {
         \left(
           \begin{array}{l}
@@ -339,7 +339,7 @@ given application name $\var{an}$.
           \end{array}
         \right)
       }
-      \trans{upvote}{\var{v}}
+      \trans{\hyperref[fig:rules:up-vote-reg]{upvote}}{\var{v}}
       {
         \left(
           \begin{array}{l}
@@ -492,7 +492,7 @@ inference rules for them are presented in \cref{fig:rules:upi-votes}.
       \right)}
       \vdash
       \var{us'}
-      \trans{upivote}{v}
+      \trans{\hyperref[fig:rules:upi-vote]{upivote}}{v}
       \var{us''}
     }
     {
@@ -561,7 +561,7 @@ the end on an epoch.
           \end{array}
         \right)
       }
-      \trans{upend}{(\var{bv}, \var{vk})}
+      \trans{\hyperref[fig:rules:up-end]{upend}}{(\var{bv}, \var{vk})}
       {
         \left(
           \begin{array}{l}
@@ -746,7 +746,7 @@ expires.
           \end{array}
         \right)
       }
-      \trans{pvbump}{}
+      \trans{\hyperref[fig:rules:fads]{pvbump}}{}
       {
         \left(
           \begin{array}{l}
@@ -808,7 +808,7 @@ expires.
           \end{array}
         \right)
       }
-      \trans{pvbump}{}
+      \trans{\hyperref[fig:rules:fads]{pvbump}}{}
       {
         \left(
           \begin{array}{l}

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -420,7 +420,7 @@ delegations have on the ledger.
           \end{array}
         \right)
       }
-      \trans{sdeleg}{c}
+      \trans{\hyperref[fig:rules:delegation-scheduling]{sdeleg}}{c}
       {
         \left(
           \begin{array}{l}
@@ -541,7 +541,7 @@ delegations have on the ledger.
           \end{array}
         \right)
       }
-      \trans{adeleg}{c}
+      \trans{\hyperref[fig:rules:delegation]{adeleg}}{c}
       {
         \left(
           \begin{array}{l}

--- a/byron/ledger/formal-spec/properties.tex
+++ b/byron/ledger/formal-spec/properties.tex
@@ -118,7 +118,7 @@ UTxO does not contain any future outputs, which is a reasonable constraint.
 \begin{property}[No double spending]\label{prop:no-double-spending}
   For all
 
-  $$\var{utxo_0} \transtar{UTXO}{\txs} \var{utxo}$$
+  $$\var{utxo_0} \transtar{\hyperref[fig:rules:utxo]{utxo}}{\txs} \var{utxo}$$
 
   such that
 
@@ -141,7 +141,7 @@ spent outputs.
 \begin{property}[UTxO is outputs minus inputs]\label{prop:utxo-out-min-in}
   For all
 
-  $$\var{utxo_0} \transtar{UTXO}{\txs} \var{utxo}$$
+  $$\var{utxo_0} \transtar{\hyperref[fig:rules:utxo]{utxo}}{\txs} \var{utxo}$$
 
   such that
 

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -688,7 +688,7 @@ an update proposal:
           \end{array}
         \right)
       }
-      \trans{upv}{\var{up}}
+      \trans{\hyperref[fig:rules:up-validity]{upv}}{\var{up}}
       {
         \left(
           \begin{array}{l}
@@ -908,7 +908,7 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
           \end{array}
         \right)
       }
-      \trans{addvote}{\var{v}}
+      \trans{\hyperref[fig:rules:voting]{addvote}}{\var{v}}
       {
         \left(
           \begin{array}{l}
@@ -969,7 +969,7 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
           \end{array}
         \right)
       }
-      \trans{addvote}{\var{v}}
+      \trans{\hyperref[fig:rules:voting]{addvote}}{\var{v}}
       {
         \left(
           \begin{array}{l}

--- a/byron/ledger/formal-spec/utxo.tex
+++ b/byron/ledger/formal-spec/utxo.tex
@@ -245,7 +245,7 @@ different order). The choice here is arbitrary.
   \begin{equation}
     \label{eq:utxo-witness-inductive}
     \inference
-    { \var{pps} \vdash \var{utxo} \trans{utxo}{tx} \var{utxo'}
+    { \var{pps} \vdash \var{utxo} \trans{\hyperref[fig:rules:utxo]{utxo}}{tx} \var{utxo'}
       & \var{maxTxSize} \mapsto \var{t} \in \var{pps} & \fun{txSize}~\var{tx} \leq t \\ ~ \\
       & \forall i \in \txins{tx} \cdot \exists (\var{vk}, \sigma) \in \wits{\var{tx}}
       \cdot
@@ -282,7 +282,7 @@ transactions.
     {
       \var{pps} \vdash \var{utxo} \trans{utxows}{\Gamma} \var{utxo'}
       &
-      \var{pps} \vdash \var{utxo'} \trans{utxow}{\var{tx}} \var{utxo''}
+      \var{pps} \vdash \var{utxo'} \trans{\hyperref[fig:rules:utxow]{utxow}}{\var{tx}} \var{utxo''}
     }
     {\var{pps} \vdash \var{utxo} \trans{utxows}{\Gamma;\var{tx}} \var{utxo''}}
   \end{equation}


### PR DESCRIPTION
For the Byron ledger rules, adding hyperlinks to transition tables when one transition is called inside another transition.