### PR TITLE
Update app versions when confirmation is stable

### DIFF
--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -26,6 +26,7 @@ library
   exposed-modules:     Ledger.Core
                      , Ledger.Core.Generator
                      , Ledger.Delegation
+                     , Ledger.GlobalParams
                      , Ledger.Update
                      , Ledger.UTxO
   build-depends:       base >=4.11 && <5

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -107,7 +107,7 @@ newtype Slot = Slot { unSlot :: Word64 }
 --  We use this newtype to distinguish between a cardinal slot and a relative
 --  period of slots, and also to distinguish between number of slots and number
 --  of blocks.
-newtype SlotCount = SlotCount { unSlotCount :: Word64}
+newtype SlotCount = SlotCount { unSlotCount :: Word64 }
   deriving (Eq, Ord, Num, Show)
 
 -- | Add a slot count to a slot.

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -1,0 +1,14 @@
+-- | Ledger global parameters.
+
+module Ledger.GlobalParams
+  (k)
+where
+
+import Ledger.Core (BlockCount (BlockCount))
+
+-- | Chain stability parameter, measured in terms of number of blocks.
+--
+-- We're fixing this for now. In the future we might want to make this
+-- configurable.
+k :: BlockCount
+k = BlockCount 2160

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -302,11 +302,12 @@ after a vote, a proposal might get confirmed, which means that it will be added
 to the set $\var{cps'}$. In such case, the mapping of application names to
 their latest version known to the ledger will be updated to include the
 information in the confirmed proposal. Note that, unlike protocol updates,
-software updates take effect as soon as a proposal is confirmed. In this rule,
-we also delete the confirmed proposal id's from the set of registered
-application update proposals ($\var{raus}$), since this information is no
-longer needed once the application-name to software-version map ($\var{avs}$)
-is updated.
+software updates take effect as soon as a proposal is confirmed and stable
+(i.e. its confirmation occurred at least $2\cdot k$ slots ago). In this rule,
+we also delete the confirmed and stable proposals id's from the set of
+registered application update proposals ($\var{raus}$), since this information
+is no longer needed once the application-name to software-version map
+($\var{avs}$) is updated.
 
 Also note that, unlike the rules of \cref{fig:rules:upi-ec}, we need not remove
 other update proposals that refer to the software names whose versions were
@@ -348,9 +349,11 @@ given application name $\var{an}$.
           \end{array}
         \right)
       }\\
+      \var{stbl_{cps}} \leteq \dom~(cps' \restrictrange [.., s_n - 2 \cdot k])
+      \\
       \var{avs_{new}} \leteq \{ \var{an} \mapsto (\var{av}, \var{s_n}, m)
       \mid \var{pid} \mapsto (\var{an}, \var{av}, m) \in \var{raus}
-      ,~ \var{pid} \in \dom~\var{cps'}
+      ,~ \var{pid} \in \var{stbl_{cps}}
       \}
     }
     {
@@ -384,7 +387,7 @@ given application name $\var{an}$.
             \var{fads}\\
             \var{avs} \unionoverrideRight \var{avs_{new}}\\
             \var{rpus}\\
-            \dom~ \var{cps} \subtractdom \var{raus}\\
+            \var{stbl_{cps}} \subtractdom \var{raus}\\
             \var{cps'}\\
             \var{vts'}\\
             \var{bvs}\\
@@ -401,10 +404,10 @@ given application name $\var{an}$.
 Figure~\ref{fig:st-diagram-sw-up} shows the different states in which a
 software proposal update might be: if valid, a software update proposal becomes
 active whenever it is included in a block. If the update proposal gets enough
-votes, then the corresponding software update proposal becomes confirmed, and
-the ledger state reflects this. If the voting period ends without an update
-proposal being confirmed, then the corresponding software update proposal gets
-rejected.
+votes, then the corresponding software update proposal becomes confirmed. After
+this confirmation becomes stable, the new software version gets adopted. If the
+voting period ends without an update proposal being confirmed, then the
+corresponding software update proposal gets rejected.
 %
 Protocol updates on the other hand, involve a slightly different logic, and the
 state transition diagram for these kind of updates is shown in
@@ -427,6 +430,7 @@ Figure~\ref{fig:st-diagram-pt-up}.
   \node (active) [fill = blue!10] {Active};
   \node (rejected) [below = of active, fill = red!10] {Rejected};
   \node (confirmed) [right = of active, fill = green!30] {Confirmed};
+  \node (adopted) [below = of confirmed, fill = green!30] {Adopted};
 
   \tikzset{every node/.style={align=center, text width=10em, text=brown}}
 
@@ -437,6 +441,12 @@ Figure~\ref{fig:st-diagram-pt-up}.
   \draw[->] (active)
   edge node [left] {Voting period \\ends}
   (rejected);
+
+  \draw[->] (confirmed)
+  edge node [right, text width=8em]
+  {Proposal was confirmed at least $2 \cdot k$ slots ago}
+  (adopted);
+
 
   \end{tikzpicture}
 

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -490,7 +490,7 @@ functions:
     \label{eq:rule:up-validity-nopu-no}
     \inference
     {
-      \var{pv} \leteq \upPV{up} & \upParams{up} \leteq \emptyset &
+      \var{pv} = \upPV{up} & \upParams{up} = \emptyset &
       {
         \begin{array}{l}
           \var{avs}


### PR DESCRIPTION
This PR changes the `UPIVOTE` rule, so that the application name to version map is updated with confirmed proposals (before/after):

![image](https://user-images.githubusercontent.com/175315/57513705-2a20b100-730f-11e9-9bc6-ec74a4f450ac.png)


Closes #463 