### PR TITLE
Import Byron data types into Shelley for `UPIEC` and `BUPI` rules

### DIFF
--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -29,7 +29,7 @@ import Data.AbstractSize
 -- | An encoded hash of part of the system.
 type Hash = Crypto.Digest Crypto.SHA256
 
--- | Hash part of the ledger paylod
+-- | Hash part of the ledger payload
 class HasHash a where
   hash :: a -> Hash
 

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -648,7 +648,19 @@ type UPIState =
 
 emptyUPIState :: UPIState
 emptyUPIState =
-  ((ProtVer 0 0 0, PParams 0 0 0 0 0.0 0 0 0 0 0 0)
+  (( ProtVer 0 0 0
+   , PParams                    -- TODO: choose more sensible default values
+     (2^(20::Natural))          -- max sizes chosen as non-zero to allow progress
+     (2^(20::Natural))
+     (2^(20::Natural))
+     (2^(20::Natural))
+     0.2
+     0
+     0
+     0
+     0
+     0
+     0)
   , []
   , Map.empty
   , Map.empty

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -10,7 +10,9 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Ledger.Update where
+module Ledger.Update
+  (module Ledger.Update)
+where
 
 import Control.Lens
 import qualified Crypto.Hash as Crypto
@@ -643,6 +645,18 @@ type UPIState =
   , Core.PairSet ProtVer Core.VKeyGenesis
   , Map UpId Core.Slot
   )
+
+emptyUPIState :: UPIState
+emptyUPIState =
+  ((ProtVer 0 0 0, PParams 0 0 0 0 0.0 0 0 0 0 0 0)
+  , []
+  , Map.empty
+  , Map.empty
+  , Map.empty
+  , Map.empty
+  , Core.PairSet Set.empty
+  , Core.PairSet Set.empty
+  , Map.empty)
 
 data UPIREG
 

--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -26,6 +26,7 @@
           (hsPkgs.microlens)
           (hsPkgs.microlens-th)
           (hsPkgs.non-integer)
+          (hsPkgs.cs-ledger)
           ];
         };
       tests = {

--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -43,6 +43,7 @@
             (hsPkgs.multiset)
             (hsPkgs.text)
             (hsPkgs.microlens)
+            (hsPkgs.cs-ledger)
             ];
           };
         };

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -91,4 +91,5 @@ test-suite delegation-test
       containers,
       multiset,
       text,
-      microlens
+      microlens,
+      cs-ledger

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -60,7 +60,8 @@ library
     small-steps,
     microlens,
     microlens-th,
-    non-integer
+    non-integer,
+    cs-ledger
 
 test-suite delegation-test
     type:                exitcode-stdio-1.0

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -2,6 +2,9 @@ module Keys
   ( Owner(..)
   , SKey(..)
   , VKey(..)
+  , VKeyGenesis(..)
+  , GKeys(..)
+  , Dms(..)
   , KeyPair(..)
   , keyPair
   , HashKey(..)
@@ -11,7 +14,13 @@ module Keys
   , verify
   , KESig
   , signKES
-  , verifyKES)
+  , verifyKES
+  -- | conversion between Byron / Shelley
+  , keyByronToShelley
+  , keyShelleyToByron
+  , genesisKeyByronToShelley
+  , genesisKeyShelleyToByron
+  )
 where
 
 import           Crypto.Hash           (Digest, SHA256, hash)
@@ -19,7 +28,16 @@ import qualified Data.ByteArray        as BA
 import qualified Data.ByteString.Char8 as BS
 import           Numeric.Natural       (Natural)
 
-import qualified Ledger.Core           as Byron (VKey, VKeyGenesis)
+import qualified Ledger.Core           as Byron (VKey(..)
+                                                , VKeyGenesis(..)
+                                                , Owner(..))
+
+import qualified Data.Map.Strict       as Map
+import qualified Data.Set              as Set
+
+-- | A genesis key is a specialisation of a generic VKey.
+newtype VKeyGenesis = VKeyGenesis VKey
+  deriving (Eq, Ord, Show)
 
 -- |Representation of the owner of keypair.
 newtype Owner = Owner Natural deriving (Show, Eq, Ord)
@@ -68,3 +86,27 @@ verifyKES (VKey vk) vd (KESig (Sig sd sk) m) n = vk == sk && vd == sd && m == n
 instance BA.ByteArrayAccess VKey where
   length        = BA.length . BS.pack . show
   withByteArray = BA.withByteArray . BS.pack . show
+
+instance BA.ByteArrayAccess VKeyGenesis where
+  length (VKeyGenesis vk)        = (BA.length . BS.pack . show) vk
+  withByteArray (VKeyGenesis vk) = (BA.withByteArray . BS.pack . show) vk
+
+newtype Dms = Dms (Map.Map VKeyGenesis VKey)
+  deriving (Show, Eq)
+
+newtype GKeys = GKeys (Set.Set VKeyGenesis)
+  deriving (Show, Eq)
+
+keyByronToShelley :: Byron.VKey -> VKey
+keyByronToShelley (Byron.VKey (Byron.Owner owner)) =
+  VKey (Owner $ fromIntegral owner)
+
+keyShelleyToByron :: VKey -> Byron.VKey
+keyShelleyToByron (VKey (Owner owner)) =
+  Byron.VKey $ (Byron.Owner $ fromIntegral owner)
+
+genesisKeyByronToShelley :: Byron.VKeyGenesis -> VKeyGenesis
+genesisKeyByronToShelley (Byron.VKeyGenesis vk) = VKeyGenesis (keyByronToShelley vk)
+
+genesisKeyShelleyToByron :: VKeyGenesis -> Byron.VKeyGenesis
+genesisKeyShelleyToByron (VKeyGenesis vk) = Byron.VKeyGenesis (keyShelleyToByron vk)

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -15,51 +15,28 @@ module Keys
   , KESig
   , signKES
   , verifyKES
-  -- | conversion between Byron / Shelley
-  , keyByronToShelley
-  , keyShelleyToByron
-  , genesisKeyByronToShelley
-  , genesisKeyShelleyToByron
   )
 where
 
-import           Crypto.Hash           (Digest, SHA256, hash)
 import qualified Data.ByteArray        as BA
 import qualified Data.ByteString.Char8 as BS
 import           Numeric.Natural       (Natural)
 
-import qualified Ledger.Core           as Byron (VKey(..)
-                                                , VKeyGenesis(..)
-                                                , Owner(..))
+import           Ledger.Core           (VKey(..)
+                                       , VKeyGenesis(..)
+                                       , Owner(..)
+                                       , SKey(..)
+                                       , Sig(..)
+                                       , Hash
+                                       , hash
+                                       , KeyPair(..)
+                                       , keyPair)
 
 import qualified Data.Map.Strict       as Map
 import qualified Data.Set              as Set
 
--- | A genesis key is a specialisation of a generic VKey.
-newtype VKeyGenesis = VKeyGenesis VKey
-  deriving (Eq, Ord, Show)
-
--- |Representation of the owner of keypair.
-newtype Owner = Owner Natural deriving (Show, Eq, Ord)
-
--- |Private/Secret Key
-newtype SKey = SKey Owner deriving (Show, Eq, Ord)
-
--- |Public Key
-newtype VKey = VKey Owner deriving (Show, Eq, Ord)
-
--- |Key Pair
-data KeyPair = KeyPair
-  {sKey :: SKey, vKey :: VKey} deriving (Show, Eq, Ord)
-
-keyPair :: Owner -> KeyPair
-keyPair owner = KeyPair (SKey owner) (VKey owner)
-
 -- |The hash of public Key
-newtype HashKey = HashKey (Digest SHA256) deriving (Show, Eq, Ord)
-
--- |A digital signature
-data Sig a = Sig a Owner deriving (Show, Eq, Ord)
+newtype HashKey = HashKey Hash deriving (Show, Eq, Ord)
 
 data KESig a = KESig (Sig a) Natural deriving (Show, Eq, Ord)
 
@@ -83,30 +60,8 @@ verify (VKey vk) vd (Sig sd sk) = vk == sk && vd == sd
 verifyKES :: Eq a => VKey -> a -> KESig a -> Natural -> Bool
 verifyKES (VKey vk) vd (KESig (Sig sd sk) m) n = vk == sk && vd == sd && m == n
 
-instance BA.ByteArrayAccess VKey where
-  length        = BA.length . BS.pack . show
-  withByteArray = BA.withByteArray . BS.pack . show
-
-instance BA.ByteArrayAccess VKeyGenesis where
-  length (VKeyGenesis vk)        = (BA.length . BS.pack . show) vk
-  withByteArray (VKeyGenesis vk) = (BA.withByteArray . BS.pack . show) vk
-
 newtype Dms = Dms (Map.Map VKeyGenesis VKey)
   deriving (Show, Eq)
 
 newtype GKeys = GKeys (Set.Set VKeyGenesis)
   deriving (Show, Eq)
-
-keyByronToShelley :: Byron.VKey -> VKey
-keyByronToShelley (Byron.VKey (Byron.Owner owner)) =
-  VKey (Owner $ fromIntegral owner)
-
-keyShelleyToByron :: VKey -> Byron.VKey
-keyShelleyToByron (VKey (Owner owner)) =
-  Byron.VKey $ (Byron.Owner $ fromIntegral owner)
-
-genesisKeyByronToShelley :: Byron.VKeyGenesis -> VKeyGenesis
-genesisKeyByronToShelley (Byron.VKeyGenesis vk) = VKeyGenesis (keyByronToShelley vk)
-
-genesisKeyShelleyToByron :: VKeyGenesis -> Byron.VKeyGenesis
-genesisKeyShelleyToByron (VKeyGenesis vk) = Byron.VKeyGenesis (keyShelleyToByron vk)

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -19,6 +19,8 @@ import qualified Data.ByteArray        as BA
 import qualified Data.ByteString.Char8 as BS
 import           Numeric.Natural       (Natural)
 
+import qualified Ledger.Core           as Byron (VKey, VKeyGenesis)
+
 -- |Representation of the owner of keypair.
 newtype Owner = Owner Natural deriving (Show, Eq, Ord)
 

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -40,6 +40,7 @@ module LedgerState
   , emptyAccount
   , emptyPState
   , emptyDState
+  , emptyUPIState
   , poolRAcnt
   , treasury
   , reserves
@@ -259,7 +260,7 @@ emptyLedgerState :: LedgerState
 emptyLedgerState = LedgerState
                    (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0))
                    emptyDelegation
-                   Byron.Update.emptyUPIState
+                   emptyUPIState
                    emptyPParams
                    0
                    (Slot 0)
@@ -286,6 +287,14 @@ data UTxOState =
     , _fees      :: Coin
     } deriving (Show, Eq)
 
+-- | For now this contains the Byron `UPIState` and the Shelley PParams
+-- separately.
+data UPIState = UPIState Byron.Update.UPIState PParams
+  deriving (Show, Eq)
+
+emptyUPIState :: UPIState
+emptyUPIState = UPIState Byron.Update.emptyUPIState emptyPParams
+
 -- |The state associated with a 'Ledger'.
 data LedgerState =
   LedgerState
@@ -294,7 +303,7 @@ data LedgerState =
     -- |The current delegation state
   , _delegationState   :: !DWState
     -- | UPIState
-  , _upiState          :: !Byron.Update.UPIState
+  , _upiState          :: !UPIState
     -- |The current protocol constants.
   , _pcs               :: !PParams
     -- | The current transaction index in the current slot.
@@ -323,7 +332,7 @@ genesisState pc outs = LedgerState
     (Coin 0)
     (Coin 0))
   emptyDelegation
-  Byron.Update.emptyUPIState
+  emptyUPIState
   pc
   0
   (Slot 0)

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -133,6 +133,8 @@ import           Delegation.PoolParams   (Delegation (..), PoolParams (..),
 
 import           BaseTypes
 
+import qualified Ledger.Update as Byron.Update (UPIState, emptyUPIState)
+
 -- | Representation of a list of pairs of key pairs, e.g., pay and stake keys
 type KeyPairs = [(KeyPair, KeyPair)]
 
@@ -257,6 +259,7 @@ emptyLedgerState :: LedgerState
 emptyLedgerState = LedgerState
                    (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0))
                    emptyDelegation
+                   Byron.Update.emptyUPIState
                    emptyPParams
                    0
                    (Slot 0)
@@ -290,6 +293,8 @@ data LedgerState =
     _utxoState         :: !UTxOState
     -- |The current delegation state
   , _delegationState   :: !DWState
+    -- | UPIState
+  , _upiState          :: !Byron.Update.UPIState
     -- |The current protocol constants.
   , _pcs               :: !PParams
     -- | The current transaction index in the current slot.
@@ -318,6 +323,7 @@ genesisState pc outs = LedgerState
     (Coin 0)
     (Coin 0))
   emptyDelegation
+  Byron.Update.emptyUPIState
   pc
   0
   (Slot 0)
@@ -594,7 +600,7 @@ asStateTransition' slot (LedgerValidation valErrors ls) tx =
 
 -- |Retire the appropriate stake pools when the epoch changes.
 retirePools :: LedgerState -> Epoch -> LedgerState
-retirePools ls@(LedgerState _ ds _ _ _) epoch =
+retirePools ls@(LedgerState _ ds _ _ _ _) epoch =
     ls & delegationState .~
            (ds & pstate . stPools .~
                  (StakePools $ Map.filterWithKey
@@ -671,7 +677,7 @@ applyDCert _ (RetirePool key epoch) ds =
 
 -- |Compute how much stake each active stake pool controls.
 delegatedStake :: LedgerState -> Map.Map HashKey Coin
-delegatedStake ls@(LedgerState _ ds _ _ _) = Map.fromListWith (+) delegatedOutputs
+delegatedStake ls@(LedgerState _ ds _ _ _ _) = Map.fromListWith (+) delegatedOutputs
   where
     getOutputs (UTxO utxo') = Map.elems utxo'
     addStake delegs (TxOut (AddrTxin _ hsk) c) = do

--- a/shelley/chain-and-ledger/executable-spec/src/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/PParams.hs
@@ -34,6 +34,8 @@ import           Slot            (Epoch(..))
 
 import           Lens.Micro.TH   (makeLenses)
 
+import qualified Ledger.Update as Byron.Update (PParams(..))
+
 data PParams = PParams
   { -- |The linear factor for the minimum fee calculation
     _minfeeA         :: Integer

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
@@ -40,7 +40,8 @@ ledgersTransition = do
          trans @LEDGER $ TRC ((pp, slot, ix), (u', dw'), tx))
       (u, dw) $
     zip [0 ..] txwits
-  pure $ LedgerState u'' dw'' (_pcs ls) (_txSlotIx ls) (_currentSlot ls)
+  pure $
+    LedgerState u'' dw'' (_upiState ls) (_pcs ls) (_txSlotIx ls) (_currentSlot ls)
 
 instance Embed LEDGER LEDGERS where
   wrapFailed = LedgerFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Slot.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Slot.hs
@@ -11,10 +11,15 @@ module Slot
   , epochFromSlot
   , slotsPerEpoch
   , firstSlot
+  -- conversion between Byron / Shelley
+  , slotByronToShelley
+  , slotShelleyToByron
   ) where
 
 import           Data.Monoid             (Sum(..))
 import           Numeric.Natural         (Natural)
+
+import qualified Ledger.Core           as Byron (Slot(..))
 
 -- |A Slot
 newtype Slot = Slot Natural
@@ -48,3 +53,11 @@ firstSlot = slotFromEpoch
 -- | Hard coded global constant for number of slots per epoch
 slotsPerEpoch :: Natural
 slotsPerEpoch = 100
+
+-- | Convert `Slot` data from Byron to Shelley, there should be a check that
+-- Shelley slots fit into `Word64` used in Byron.
+slotByronToShelley :: Byron.Slot -> Slot
+slotByronToShelley (Byron.Slot s) = Slot $ fromIntegral s
+
+slotShelleyToByron :: Slot -> Byron.Slot
+slotShelleyToByron (Slot s) = Byron.Slot $ fromIntegral s

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -25,8 +25,6 @@ import           PParams
 import           Slot
 import           UTxO
 
-import qualified Ledger.Update as Byron.Update (emptyUPIState)
-
 alicePay :: KeyPair
 alicePay = keyPair (Owner 1)
 
@@ -82,7 +80,7 @@ testLedgerValidTransactions ls utxoState' =
     ls @?= Right (LedgerState
                      utxoState'
                      LedgerState.emptyDelegation
-                     Byron.Update.emptyUPIState
+                     emptyUPIState
                      testPCs
                      1
                      (Slot 0))
@@ -95,7 +93,7 @@ testValidStakeKeyRegistration tx utxoState' stakeKeyRegistration =
   in ls2 @?= Right (LedgerState
                      utxoState'
                      stakeKeyRegistration
-                     Byron.Update.emptyUPIState
+                     emptyUPIState
                      testPCs
                      1
                      (Slot 0))
@@ -113,7 +111,7 @@ testValidDelegation txs utxoState' stakeKeyRegistration pool =
            & dstate . delegations .~ Map.fromList [(hashKey $ vKey aliceStake, poolhk)]
            & pstate . stPools .~ (StakePools $ Map.fromList [(poolhk, Slot 0)])
            & pstate . pParams .~ Map.fromList [(poolhk, pool)])
-          Byron.Update.emptyUPIState
+          emptyUPIState
           testPCs
           (fromIntegral $ length txs)
           (Slot 0))
@@ -132,7 +130,7 @@ testValidRetirement txs utxoState' stakeKeyRegistration e pool =
            & pstate . stPools .~  (StakePools $ Map.fromList [(poolhk, Slot 0)])
            & pstate . pParams .~ Map.fromList [(poolhk, pool)]
            & pstate . retiring .~ Map.fromList [(poolhk, e)])
-          Byron.Update.emptyUPIState
+          emptyUPIState
           testPCs
           3
           (Slot 0))
@@ -165,7 +163,7 @@ testValidWithdrawal =
   in ls @?= Right (LedgerState
                      (UTxOState (UTxO utxo') (Coin 0) (Coin 1000))
                      expectedDS
-                     Byron.Update.emptyUPIState
+                     emptyUPIState
                      testPCs
                      1
                      (Slot 0))

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -25,6 +25,8 @@ import           PParams
 import           Slot
 import           UTxO
 
+import qualified Ledger.Update as Byron.Update (emptyUPIState)
+
 alicePay :: KeyPair
 alicePay = keyPair (Owner 1)
 
@@ -80,6 +82,7 @@ testLedgerValidTransactions ls utxoState' =
     ls @?= Right (LedgerState
                      utxoState'
                      LedgerState.emptyDelegation
+                     Byron.Update.emptyUPIState
                      testPCs
                      1
                      (Slot 0))
@@ -92,6 +95,7 @@ testValidStakeKeyRegistration tx utxoState' stakeKeyRegistration =
   in ls2 @?= Right (LedgerState
                      utxoState'
                      stakeKeyRegistration
+                     Byron.Update.emptyUPIState
                      testPCs
                      1
                      (Slot 0))
@@ -109,6 +113,7 @@ testValidDelegation txs utxoState' stakeKeyRegistration pool =
            & dstate . delegations .~ Map.fromList [(hashKey $ vKey aliceStake, poolhk)]
            & pstate . stPools .~ (StakePools $ Map.fromList [(poolhk, Slot 0)])
            & pstate . pParams .~ Map.fromList [(poolhk, pool)])
+          Byron.Update.emptyUPIState
           testPCs
           (fromIntegral $ length txs)
           (Slot 0))
@@ -127,6 +132,7 @@ testValidRetirement txs utxoState' stakeKeyRegistration e pool =
            & pstate . stPools .~  (StakePools $ Map.fromList [(poolhk, Slot 0)])
            & pstate . pParams .~ Map.fromList [(poolhk, pool)]
            & pstate . retiring .~ Map.fromList [(poolhk, e)])
+          Byron.Update.emptyUPIState
           testPCs
           3
           (Slot 0))
@@ -159,6 +165,7 @@ testValidWithdrawal =
   in ls @?= Right (LedgerState
                      (UTxOState (UTxO utxo') (Coin 0) (Coin 1000))
                      expectedDS
+                     Byron.Update.emptyUPIState
                      testPCs
                      1
                      (Slot 0))

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -336,7 +336,7 @@ in the pool distribution.
     {
       e = e_\ell + 1
       &
-      (\wcard,~\wcard,~(\wcard,~\wcard,~\var{us}))\leteq\var{es}
+      (\wcard,~\wcard,~\var{ss}, (\wcard,~\wcard,~\var{us}))\leteq\var{es}
       \\
       {
         \var{s}\vdash\var{us} \trans{\hyperlink{byron_ledger_spec_link}{upiec}}{} \var{us'}
@@ -357,7 +357,6 @@ in the pool distribution.
      }
      \\~\\~\\
      {\begin{array}{r@{~\leteq~}l}
-        (\wcard,~\wcard,~\var{ss},~(\wcard,~\wcard,~\var{us})) & \var{es} \\
         \var{pp} & \pps{us} \\
         (\wcard,~\var{pstake_{set}},~\wcard,~\wcard,~\wcard,~\wcard) & \var{ss} \\
         (\var{stake}, \var{delegs}) & \var{pstake_{set}} \\
@@ -423,6 +422,7 @@ in the pool distribution.
             \var{es} \\
             \var{ru} \\
             \var{pd} \\
+            \var{osched}
       \end{array}\right)}
       \trans{newepoch}{\var{e}}
       {\left(\begin{array}{c}
@@ -432,6 +432,7 @@ in the pool distribution.
             \var{es} \\
             \var{ru} \\
             \var{pd} \\
+            \var{osched}
       \end{array}\right)}
     }
   \end{equation}


### PR DESCRIPTION
`VKey` and `Slot` with conversion functions
`UPIState`
make `cs-ledger` a dependency