### PR TITLE
Define property: money is constant in the system

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
@@ -37,7 +37,7 @@ import Ledger.Delegation
   , _dSEnvSlot
   )
 import Ledger.Update (PParams, maxBkSz, UPIState)
-import Ledger.UTxO (UTxO, TxId, UTXOWS, UTxOEnv(UTxOEnv, pps, utxo0))
+import Ledger.UTxO (UTxO, TxId, UTXOWS, UTxOEnv(UTxOEnv, pps, utxo0), UTxOState)
 
 import Cardano.Spec.Chain.STS.Block
 
@@ -51,7 +51,7 @@ instance STS BBODY where
     )
 
   type State BBODY =
-    ( UTxO TxId
+    ( UTxOState TxId
     , DIState
     , UPIState
     )
@@ -72,7 +72,7 @@ instance STS BBODY where
 
   transitionRules =
     [ do
-        TRC ((ppsVal, e_n, utxoGenesis), (utxo, ds, us), b) <- judgmentContext
+        TRC ((ppsVal, e_n, utxoGenesis), (utxoSt, ds, us), b) <- judgmentContext
         let bMax = ppsVal ^. maxBkSz
         bSize b <= bMax ?! InvalidBlockSize
         let bh = b ^. bHeader
@@ -95,10 +95,10 @@ instance STS BBODY where
           , ds
           , b ^. bBody ^. bDCerts
           )
-        utxo' <- trans @(UTXOWS TxId) $ TRC
-          ( UTxOEnv {utxo0 = utxoGenesis, pps = ppsVal}, utxo, b ^. bBody ^. bUtxo )
+        utxoSt' <- trans @(UTXOWS TxId) $ TRC
+          ( UTxOEnv {utxo0 = utxoGenesis, pps = ppsVal}, utxoSt, b ^. bBody ^. bUtxo )
 
-        return $! (utxo', ds', us')
+        return $! (utxoSt', ds', us')
     ]
 
 instance Embed BUPI BBODY where

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -791,6 +791,7 @@ updates the update state to the correct version.
 
 % Imported definitions
 \newcommand{\UTxO}{\type{UTxO}}
+\newcommand{\UTxOState}{\type{UTxOState}}
 \newcommand{\DIEnv}{\type{DIEnv}}
 \newcommand{\DIState}{\type{DIState}}
 
@@ -1015,7 +1016,7 @@ payload; UTxO, delegation and update.
     \BBState =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{utxo} & \UTxO & \text{UTxO} \\
+        \var{utxoSt} & \UTxOState & \text{UTxO state} \\
         \var{ds} & \DIState & \text{delegation state} \\
         \var{us} & \UPIState & \text{update interface state}
       \end{array}
@@ -1069,8 +1070,8 @@ payload; UTxO, delegation and update.
             \var{pps}
           \end{array}
         \right)}
-      \vdash \var{utxo}
-        \trans{\hyperlink{byron_ledger_spec_link}{utxows}}{\butxo{b}} \var{utxo'} \\
+      \vdash \var{utxoSt}
+        \trans{\hyperlink{byron_ledger_spec_link}{utxows}}{\butxo{b}} \var{utxoSt'} \\
     }
     {
       \left(
@@ -1084,7 +1085,7 @@ payload; UTxO, delegation and update.
      {
        \left(
          {\begin{array}{c}
-            \var{utxo} \\
+            \var{utxoSt} \\
             \var{ds} \\
             \var{us}
           \end{array}}
@@ -1094,7 +1095,7 @@ payload; UTxO, delegation and update.
     {
       \left(
         {\begin{array}{c}
-           \var{utxo'} \\
+           \var{utxoSt'} \\
            \var{ds'} \\
            \var{us'}
          \end{array}}
@@ -1160,7 +1161,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
         \var{s_{last}} & \Slot & \text{slot of the last seen block} \\
         \var{sgs} & \seqof{\VKeyGen} & \text{last signers}\\
         \var{h} & \Hash & \text{current block hash} \\
-        \var{utxo} & \UTxO & \text{UTxO} \\
+        \var{utxoSt} & \UTxO & \text{UTxOState} \\
         \var{ds} & \DIState & \text{delegation state}\\
         \var{us} & \UPIState & \text{update interface state} \\
       \end{array}
@@ -1196,7 +1197,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
           \var{s_{last}} \\
           \var{sgs} \\
           \var{h} \\
-          \var{utxo} \\
+          \var{utxoSt} \\
           \var{ds} \\
           \var{us}
         \end{array}}
@@ -1207,7 +1208,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
          \var{s_{last}} \\
          \var{sgs} \\
          \var{h'} \\
-         \var{utxo} \\
+         \var{utxoSt} \\
          \var{ds} \\
          \var{us}
        \end{array}}
@@ -1270,7 +1271,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
         &
         {\left(
           {\begin{array}{c}
-             \var{utxo} \\
+             \var{utxoSt} \\
              \var{ds} \\
              \var{us'}
            \end{array}}
@@ -1278,7 +1279,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
         \trans{\hyperref[fig:rules:bbody]{bbody}}{b}
         {\left(
           {\begin{array}{c}
-             \var{utxo'} \\
+             \var{utxoSt'} \\
              \var{ds'} \\
              \var{us''}
            \end{array}}
@@ -1299,7 +1300,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
           \var{s_{last}} \\
           \var{sgs} \\
           \var{h} \\
-          \var{utxo} \\
+          \var{utxoSt} \\
           \var{ds} \\
           \var{us}
         \end{array}}
@@ -1310,7 +1311,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
          \var{\bslot{b}} \\
          \var{sgs'} \\
          \var{h'} \\
-         \var{utxo'} \\
+         \var{utxoSt'} \\
          \var{ds'} \\
          \var{us''}
        \end{array}}

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -1,10 +1,15 @@
 -- | Ledger global parameters.
 
 module Ledger.GlobalParams
-  (k)
+  ( k
+  , lovelaceCap
+  )
 where
 
-import Ledger.Core (BlockCount (BlockCount))
+import Data.Int (Int64)
+
+import Ledger.Core (BlockCount (BlockCount), Lovelace (Lovelace))
+
 
 -- | Chain stability parameter, measured in terms of number of blocks.
 --
@@ -12,3 +17,7 @@ import Ledger.Core (BlockCount (BlockCount))
 -- configurable.
 k :: BlockCount
 k = BlockCount 2160
+
+-- | Constant amount of Lovelace in the system.
+lovelaceCap :: Lovelace
+lovelaceCap = Lovelace $ 45 * fromIntegral ((10 :: Int64) ^ (15 :: Int64))

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -67,6 +67,8 @@ data PParams = PParams -- TODO: this should be a module of @cs-ledger@.
   -- ^ Update adoption threshold (number of block issuers)
   , _stableAfter :: Core.BlockCount
   -- ^ Chain stability parameter
+  , _factorA :: Int
+  , _factorB :: Int
   } deriving (Eq, Generic, Ord, Show)
 
 makeLenses ''PParams
@@ -660,7 +662,10 @@ emptyUPIState =
      0
      0
      0
-     0)
+     0
+     0
+     0
+   )
   , []
   , Map.empty
   , Map.empty

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -576,3 +576,18 @@ delegations have on the ledger.
   \caption{Delegations sequence rules}
   \label{fig:rules:delegation-seq}
 \end{figure}
+
+\subsection{Deviation from the \texttt{cardano-sl} implementation}
+\label{sec:delegation:deviation-cardano-sl-imp}
+
+In the \texttt{cardano-sl} implementation, the block issuer needs to include a
+delegation certificate in the block, which witness the fact that a genesis key
+gave the issuer the rights of issuing blocks on behalf of this genesis key. The
+reasons why this was implemented in this way in \texttt{cardano-sl} are not
+clear, since the delegation certificates are posted on the chain, so the ledger
+state contains the information about who delegates to whom. Hence in the
+current specification we use a heavyweight delegation scheme, i.e. where the
+certificates are posted on the chain, but an implementation of this rules that
+aims at being compatible with the implementation in \texttt{cardano-sl} has to
+take the fact that delegation certificates are also present in a block into
+account.

--- a/byron/ledger/formal-spec/ledger-spec.tex
+++ b/byron/ledger/formal-spec/ledger-spec.tex
@@ -42,6 +42,7 @@
 \newcommand{\Value}{\type{Value}}
 \newcommand{\Lovelace}{\type{Lovelace}}
 \newcommand{\UTxOEnv}{\type{UTxOEnv}}
+\newcommand{\UTxOState}{\type{UTxOState}}
 %% Adding witnesses
 \newcommand{\TxIn}{\type{TxIn}}
 \newcommand{\TxOut}{\type{TxOut}}

--- a/byron/ledger/formal-spec/properties.tex
+++ b/byron/ledger/formal-spec/properties.tex
@@ -118,7 +118,21 @@ UTxO does not contain any future outputs, which is a reasonable constraint.
 \begin{property}[No double spending]\label{prop:no-double-spending}
   For all
 
-  $$\var{utxo_0} \transtar{\hyperref[fig:rules:utxo]{utxo}}{\txs} \var{utxo}$$
+  $$
+  \left(
+    \begin{array}{l}
+      \var{utxo_0}\\
+      \var{reserves_0}
+    \end{array}
+  \right)
+  \transtar{\hyperref[fig:rules:utxo]{utxo}}{\txs}
+  \left(
+    \begin{array}{l}
+      \var{utxo}\\
+      \var{reserves}
+    \end{array}
+  \right)
+  $$
 
   such that
 
@@ -141,7 +155,21 @@ spent outputs.
 \begin{property}[UTxO is outputs minus inputs]\label{prop:utxo-out-min-in}
   For all
 
-  $$\var{utxo_0} \transtar{\hyperref[fig:rules:utxo]{utxo}}{\txs} \var{utxo}$$
+  $$
+  \left(
+    \begin{array}{l}
+      \var{utxo_0}\\
+      \var{reserves_0}
+    \end{array}
+  \right)
+  \transtar{\hyperref[fig:rules:utxo]{utxo}}{\txs}
+  \left(
+    \begin{array}{l}
+      \var{utxo}\\
+      \var{reserves}
+    \end{array}
+  \right)
+  $$
 
   such that
 
@@ -154,5 +182,33 @@ spent outputs.
   $$
   \bigcup_{\txins{}} \txs \subtractdom (\var{utxo_0} \cup \bigcup_{\txouts{}} \txs) = \var{utxo}
   $$
+
+\end{property}
+
+Property~\ref{prop:utxo-money-supply-cnst} models the fact that the amount of
+money in the system (counted as Lovelaces) remains constant.
+
+\begin{property}[Money supply is constant in the system]\label{prop:utxo-money-supply-cnst}
+  For all
+
+  $$
+  \left(
+    \begin{array}{l}
+      \var{utxo_0}\\
+      \var{reserves_0}
+    \end{array}
+  \right)
+  \transtar{\hyperref[fig:rules:utxo]{utxo}}{\txs}
+  \left(
+    \begin{array}{l}
+      \var{utxo}\\
+      \var{reserves}
+    \end{array}
+  \right)
+  $$
+
+  we have:
+
+  $$ \var{reserves} + \balance{utxo} =  \var{reserves_0} + \balance{utxo_0} $$
 
 \end{property}

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -1296,8 +1296,8 @@ rule by $\var{bv}$:
 
 \clearpage
 
-\subsection{Deviations from the actual implementation}
-\label{sec:deviation-actual-impl}
+\subsection{Deviations from the \texttt{cardano-sl} implementation}
+\label{sec:update:deviation-actual-impl}
 
 The current specification of the voting mechanism deviates from the actual
 implementation, although it should be backwards compatible with the latter.

--- a/byron/ledger/formal-spec/utxo.tex
+++ b/byron/ledger/formal-spec/utxo.tex
@@ -3,15 +3,31 @@
 \section{UTxO}
 \label{sec:state-trans-utxo-1}
 
-The transition rules for unspent outputs are presented in
+The transition rules for unspent transaction outputs are presented in
 Figure~\ref{fig:rules:utxo}. The states of the UTxO transition system, along
-with their types are defined in Figure~\ref{fig:defs:utxo}, here we define the
-protocol parameters as an abstract type, this type is made concrete in
-Section~\ref{sec:update}, where the update mechanism is discussed. Functions on
-these types are defined in Figure~\ref{fig:derived-defs:utxo}. In particular,
-note that in function $\fun{minfee}$ we make use of the fact that the
-$\Lovelace$ type is an alias for the set of the integers numbers
-($\mathbb{Z}$).
+with their types are defined in Figure~\ref{fig:defs:utxo}:
+\begin{itemize}
+\item we define the protocol parameters as an abstract type, this type is made
+  concrete in Section~\ref{sec:update}, where the update mechanism is
+  discussed.
+\item The lovelace supply cap ($\fun{lovelaceCap}$) is treated as an abstract
+  function in this specification. In the actual system this value equals
+  $$
+  45 \times 10^{15}
+  $$
+\end{itemize}
+
+
+Functions on the types introduced in \cref{fig:rules:utxo} are defined in
+\cref{fig:derived-defs:utxo}. In particular, note that in function
+$\fun{minfee}$ we make use of the fact that the $\Lovelace$ type is an alias
+for the set of the integers numbers ($\mathbb{Z}$).
+
+Rule~\ref{eq:utxo-bootstrap}, models the fact that the \textbf{reserves} of
+the system are set to:
+$$ \fun{lovelaceCap} - \balance{utxo_0} $$
+The Lovelace amount $45 \times 10^{15}$ is the initial money supply in the
+system.
 
 \begin{figure*}[htb]
   \emph{Abstract types}
@@ -70,7 +86,9 @@ $\Lovelace$ type is an alias for the set of the integers numbers
       %
       \fun{b} & \PPMMap \to \mathbb{Z} & \text{minumum fee constant}\\
       %
-      \fun{txSize} & \Tx \to \mathbb{Z} & \text{abstract size of a transaction}
+      \fun{txSize} & \Tx \to \mathbb{Z} & \text{abstract size of a transaction}\\
+      %
+      \fun{lovelaceCap} & \Lovelace & \text{lovelace supply cap}
     \end{array}
   \end{equation*}
   %
@@ -120,7 +138,18 @@ $\Lovelace$ type is an alias for the set of the integers numbers
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{utxo_0} & \UTxO & \text{genesis UTxO}\\
-        \var{pps} & \PPMMap & \text{protocol parameters map}\\
+        \var{pps} & \PPMMap & \text{protocol parameters map}
+      \end{array}
+    \right)
+  \end{equation*}
+
+  \emph{UTxO states}
+  \begin{equation*}
+    \UTxOState =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \var{utxo} & \UTxO & \text{unspent transaction outputs}\\
+        \var{reserves} & \Lovelace & \text{system's reserves}
       \end{array}
     \right)
   \end{equation*}
@@ -129,7 +158,7 @@ $\Lovelace$ type is an alias for the set of the integers numbers
   \begin{equation*}
     \_ \vdash
     \var{\_} \trans{utxo}{\_} \var{\_}
-    \subseteq \powerset (\UTxOEnv \times \UTxO \times \Tx \times \UTxO)
+    \subseteq \powerset (\UTxOEnv \times \UTxOState \times \Tx \times \UTxOState)
   \end{equation*}
   \caption{UTxO transition-system types}
   \label{fig:ts-types:utxo}
@@ -146,15 +175,22 @@ $\Lovelace$ type is an alias for the set of the integers numbers
         pps
       \end{array}}
       \vdash
-      \var{utxo_0}
+      \trans{utxo}{}
+      \left(
+        \begin{array}{l}
+          \var{utxo_0}\\
+          \fun{lovelaceCap} - \balance{utxo_0}
+        \end{array}
+      \right)
     }
   \end{equation}
   \nextdef
   \begin{equation}\label{eq:utxo-inductive}
     \inference
-    { \txins{tx} \subseteq \dom \var{utxo}
-      & \minfee{pps}{tx} \leq \balance{(\txouts{tx})} - \balance{(\txins{tx} \restrictdom \var{utxo})}\\
-      \txins{tx} \neq \emptyset
+    { \txins{tx} \subseteq \dom \var{utxo}\\
+      \var{fee} \leteq \balance{(\txins{tx} \restrictdom \var{utxo})} - \balance{(\txouts{tx})}
+      & \minfee{pps}{tx} \leq \var{fee}\\
+      \txins{tx} \neq \emptyset & \forall \wcard \mapsto (\wcard, c) \in \txouts{tx} \cdot 0 < c
     }
     {
       {\begin{array}{l}
@@ -162,9 +198,19 @@ $\Lovelace$ type is an alias for the set of the integers numbers
         pps
       \end{array}}
       \vdash
-      \var{utxo}
+      \left(
+          \begin{array}{l}
+            \var{utxo}\\
+            \var{reserves}
+          \end{array}
+      \right)
       \trans{utxo}{tx}
-      (\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx}
+      \left(
+        \begin{array}{l}
+          (\txins{tx} \subtractdom \var{utxo}) \cup \txouts{tx}\\
+          \var{reserves + \var{fee}}
+        \end{array}
+      \right)
     }
   \end{equation}
   \caption{UTxO inference rules}
@@ -182,6 +228,8 @@ changes with a transaction:
   the unspent outputs in a transaction (i.e. the total amount paid in a
   transaction) and the amount of spent inputs.
 \item The set of inputs must not be empty.
+\item All the transaction outputs must be positive. We do not allow $0$ value
+  outputs to be consistent with the current implementation.
 \item If the above conditions hold, then the new state will not have the inputs
   spent in transaction $\var{tx}$ and it will have the new outputs in
   $\var{tx}$.
@@ -192,15 +240,17 @@ changes with a transaction:
 \subsection{Witnesses}
 \label{sec:witnesses}
 
-The rules for witnesses are presented in Figure~\ref{fig:rules:utxow}.
-The definitions used in Rule~\ref{eq:utxo-witness-inductive} are given in
-Figure~\ref{fig:defs:utxow}. Note that
-Rule~\ref{eq:utxo-witness-inductive} uses the transition relation defined in
-Figure~\ref{fig:rules:utxo}. The main reason for doing this is to define
-the rules incrementally, modeling different aspects in isolation to keep the
-rules as simple as possible. Also note that the $\trans{utxo}{}$ relation could
-have been defined in terms of $\trans{utxow}{}$ (thus composing the rules in a
-different order). The choice here is arbitrary.
+The rules for witnesses are presented in Figure~\ref{fig:rules:utxow}. In the
+initial rules note that $\var{utxoEnv}$ and $\var{utxoSt}$ are tuples, where
+$\var{utxoEnv} \in \UTxOEnv$ and $\var{utxoSt} \in \UTxOState$. The definitions
+used in Rule~\ref{eq:utxo-witness-inductive} are given in
+Figure~\ref{fig:defs:utxow}. Note that Rule~\ref{eq:utxo-witness-inductive}
+uses the transition relation defined in Figure~\ref{fig:rules:utxo}. The main
+reason for doing this is to define the rules incrementally, modeling different
+aspects in isolation to keep the rules as simple as possible. Also note that
+the $\trans{utxo}{}$ relation could have been defined in terms of
+$\trans{utxow}{}$ (thus composing the rules in a different order). The choice
+here is arbitrary.
 
 \begin{figure}[htb]
   \emph{Abstract functions}
@@ -235,24 +285,77 @@ different order). The choice here is arbitrary.
   \begin{equation*}
     \var{\_} \vdash
     \var{\_} \trans{utxow}{\_} \var{\_}
-    \subseteq \powerset (\PPMMap \times \UTxO \times (\Tx \times \powerset{(\VKey \times \Sig)}) \times \UTxO)
+    \subseteq \powerset
+    (\UTxOEnv \times \UTxOState \times (\Tx \times \powerset{(\VKey \times \Sig)}) \times \UTxOState)
   \end{equation*}
   \caption{UTxO with witness transition-system types}
   \label{fig:ts-types:utxow}
 \end{figure}
 
 \begin{figure}
+  \begin{equation}\label{eq:utxow-bootstrap}
+    \inference
+    {
+      {\begin{array}{l}
+         utxoEnv
+      \end{array}}
+      \vdash
+      \trans{\hyperref[fig:rules:utxo]{utxo}}{}
+      \left(
+        \var{utxoSt}
+      \right)
+    }
+    {
+      {\begin{array}{l}
+         utxoEnv
+      \end{array}}
+      \vdash
+      \trans{utxow}{}
+      \left(
+        \var{utxoSt}
+      \right)
+    }
+  \end{equation}
+  \nextdef
   \begin{equation}
     \label{eq:utxo-witness-inductive}
     \inference
-    { \var{pps} \vdash \var{utxo} \trans{\hyperref[fig:rules:utxo]{utxo}}{tx} \var{utxo'}
+    { \var{utxoEnv}
+      \vdash
+      {\left(
+        \begin{array}{l}
+          \var{utxo}\\
+          \var{reserves}
+        \end{array}
+      \right)}
+      \trans{\hyperref[fig:rules:utxo]{utxo}}{tx}
+      {\left(
+        \begin{array}{l}
+          \var{utxo'}\\
+          \var{reserves'}
+        \end{array}
+      \right)}
       & \var{maxTxSize} \mapsto \var{t} \in \var{pps} & \fun{txSize}~\var{tx} \leq t \\ ~ \\
       & \forall i \in \txins{tx} \cdot \exists (\var{vk}, \sigma) \in \wits{\var{tx}}
       \cdot
       \mathcal{V}^\sigma_{\var{vk}}~{\serialised{\txbody{tx}}}
       \wedge  \fun{addr_h}~{utxo}~i = \hash{vk}\\
     }
-    {\var{pps} \vdash \var{utxo} \trans{utxow}{tx} \var{utxo'}}
+    {\var{utxoEnv} \vdash
+      \left(
+        \begin{array}{l}
+          \var{utxo}\\
+          \var{reserves}
+        \end{array}
+      \right)
+      \trans{utxow}{tx}
+      \left(
+        \begin{array}{l}
+          \var{utxo'}\\
+          \var{reserves'}
+        \end{array}
+      \right)
+    }
   \end{equation}
   \caption{UTxO with witnesses inference rules}
   \label{fig:rules:utxow}
@@ -264,14 +367,39 @@ different order). The choice here is arbitrary.
 \label{sec:transaction-seqs}
 
 \cref{fig:rules:utxow-seq} models the application of a sequence of
-transactions.
+transactions. For the sake of concison we omit the types of this transition
+system, since they are the same as the ones of $\trans{utxow}{}$.
 
 \begin{figure}[htb]
+  \begin{equation}\label{eq:utxows-bootstrap}
+    \inference
+    {
+      {\begin{array}{l}
+         utxoEnv
+      \end{array}}
+      \vdash
+      \trans{\hyperref[fig:rules:utxo]{utxow}}{}
+      \left(
+        \var{utxoSt}
+      \right)
+    }
+    {
+      {\begin{array}{l}
+         utxoEnv
+      \end{array}}
+      \vdash
+      \trans{utxows}{}
+      \left(
+        \var{utxoSt}
+      \right)
+    }
+  \end{equation}
+  \nextdef
   \begin{equation}
     \label{eq:rule:utxow-seq-base}
     \inference
     {}
-    {\var{pps} \vdash \var{utxo} \trans{utxows}{\epsilon} \var{utxo}}
+    {\var{utxoEnv} \vdash \var{utxoSt} \trans{utxows}{\epsilon} \var{utxoSt}}
   \end{equation}
   %
   \nextdef
@@ -280,11 +408,11 @@ transactions.
     \label{eq:rule:utxow-seq-ind}
     \inference
     {
-      \var{pps} \vdash \var{utxo} \trans{utxows}{\Gamma} \var{utxo'}
+      \var{utxoEnv} \vdash \var{utxoSt} \trans{utxows}{\Gamma} \var{utxoSt'}
       &
-      \var{pps} \vdash \var{utxo'} \trans{\hyperref[fig:rules:utxow]{utxow}}{\var{tx}} \var{utxo''}
+      \var{utxoEnv} \vdash \var{utxoSt'} \trans{\hyperref[fig:rules:utxow]{utxow}}{\var{tx}} \var{utxoSt''}
     }
-    {\var{pps} \vdash \var{utxo} \trans{utxows}{\Gamma;\var{tx}} \var{utxo''}}
+    {\var{utxoEnv} \vdash \var{utxoSt} \trans{utxows}{\Gamma;\var{tx}} \var{utxoSt''}}
   \end{equation}
   \caption{UTxO sequence rules}
   \label{fig:rules:utxow-seq}

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1538,7 +1538,7 @@ which takes the Byron ledger state and creates the Shelley ledger state.
           \var{s_{last}} \\
           \wcard \\
           \var{h} \\
-          \var{utxo} \\
+          (\var{utxo},~\var{reserves}) \\
           \var{ds} \\
           \var{us}
         \end{array}
@@ -1557,7 +1557,7 @@ which takes the Byron ledger state and creates the Shelley ledger state.
               \left(
                 \begin{array}{c}
                   0 \\
-                  45\times 10^{15} - \fun{balance}~{utxo}
+                  \var{reserves}
                 \end{array}
               \right) \\
               \left(


### PR DESCRIPTION
This PR adds the following property:

![image](https://user-images.githubusercontent.com/175315/57879993-f9181300-781d-11e9-895c-4fe3c7df383e.png)

This requires the introduction of the reserves in the UTxO state:

![image](https://user-images.githubusercontent.com/175315/57880054-1baa2c00-781e-11e9-991c-14ffca0dc8e5.png)

The executable specification for UTxO was also brought up in sync with the formal spec. The changes in the spec introduced in this PR were also applied to the executable spec.

Closes #244 
Closes #299 