### PR TITLE
Update Shelley exec spec tests to using `hedgehog` 1.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,6 +3,3 @@ packages: shelley/chain-and-ledger/executable-spec
           byron/ledger/executable-spec
           byron/chain/executable-spec
           shelley/chain-and-ledger/dependencies/non-integer
-
-constraints:
-  tasty-hedgehog-coverage == 0.1.0.0

--- a/iohk-nix.json
+++ b/iohk-nix.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "8a5bc149b4d4cfa8704be62cf1b8755c33e8ec4d",
-  "date": "2019-04-10T19:37:38+08:00",
-  "sha256": "0v1x8zwyiwxhjhfrws2mvick7j1qvfj111chb4c4ixjinlgby0nl",
+  "rev": "c01bbd4e0c55a4101e2078d24046e0b2a731f871",
+  "date": "2019-05-21T16:09:13+00:00",
+  "sha256": "0xygkrfwc6g6bf6y9cvzbn23sxc55iy5sfnnpp6dbz5i0xpq51lr",
   "fetchSubmodules": false
 }

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -43,7 +43,9 @@
             (hsPkgs.small-steps)
             (hsPkgs.cs-ledger)
             ];
-          build-tools = [ ((hsPkgs.buildPackages).doctest-discover) ];
+          build-tools = [
+            (hsPkgs.buildPackages.doctest-discover or (pkgs.buildPackages.doctest-discover))
+            ];
           };
         "ledger-delegation-test" = {
           depends = [

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -3,10 +3,9 @@
     {
       packages = {
         "sequence" = (((hackage.sequence)."0.9.8").revisions).default;
-        "tasty-hedgehog" = (((hackage.tasty-hedgehog)."0.2.0.0").revisions).default;
-        "tasty-hedgehog-coverage" = (((hackage.tasty-hedgehog-coverage)."0.1.0.0").revisions).default;
+        "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.0").revisions).default;
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
-        "half" = (((hackage.half)."0.2.2.3").revisions).default;
+        "hedgehog" = (((hackage.hedgehog)."1.0").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;
         "streaming-binary" = (((hackage.streaming-binary)."0.3.0.1").revisions).default;
         "transformers" = (((hackage.transformers)."0.5.6.2").revisions).default;
@@ -19,7 +18,6 @@
         non-integer = ./non-integer.nix;
         cborg = ./cborg.nix;
         cardano-crypto = ./cardano-crypto.nix;
-        hedgehog = ./hedgehog.nix;
         canonical-json = ./canonical-json.nix;
         };
       compiler.version = "8.6.4";

--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -36,7 +36,6 @@
             (hsPkgs.tasty)
             (hsPkgs.tasty-hunit)
             (hsPkgs.tasty-hedgehog)
-            (hsPkgs.tasty-hedgehog-coverage)
             (hsPkgs.hedgehog)
             (hsPkgs.delegation)
             (hsPkgs.containers)

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -44,7 +44,9 @@
             (hsPkgs.doctest)
             (hsPkgs.small-steps)
             ];
-          build-tools = [ ((hsPkgs.buildPackages).doctest-discover) ];
+          build-tools = [
+            (hsPkgs.buildPackages.doctest-discover or (pkgs.buildPackages.doctest-discover))
+            ];
           };
         };
       };

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -85,7 +85,6 @@ test-suite delegation-test
       tasty,
       tasty-hunit,
       tasty-hedgehog,
-      tasty-hedgehog-coverage,
       hedgehog,
       delegation,
       containers,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/b25eed0ab3b6da51bc10970759d491331e56c822/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/a136c4242b9c9f6124b811329bc8ccdfd86c514e/snapshot.yaml
 
 packages:
 - shelley/chain-and-ledger/executable-spec
@@ -9,5 +9,4 @@ packages:
 
 extra-deps:
 - sequence-0.9.8
-- tasty-hedgehog-0.2.0.0
-- tasty-hedgehog-coverage-0.1.0.0
+- tasty-hedgehog-1.0.0.0


### PR DESCRIPTION
Remove dependency on `tasty-hedgehog-coverage`, coverage and labelling is now supported by `hedgehog` directly.