### PR TITLE
[skip ci] org-mode milestone 2019-05-31

### DIFF
--- a/weekly-reports/2019-05-31/milestone.org
+++ b/weekly-reports/2019-05-31/milestone.org
@@ -1,0 +1,9 @@
+* Shelley Ledger Team Milestone 2019-05-31
+** TODO Update the formal spec with a new transaction component for adding extra entropy to the epoch nonce.
+   - [ ] Issue #394
+** TODO Update the formal spec with a mapping from the genesis keys to the other stake pool cold keys.
+   - [ ] Issue #447
+** TODO Plan out the work required to finish importing the Byron update system into Shelley.
+   - [ ] Issue #448 (We may need to break this issue up into more parts.)
+** Update the executable spec with <details needed>
+** Update the multi-sig spec with <details needed>


### PR DESCRIPTION
Here is a minimal first pass at an org-mode file that can track our biweekly progress.

At the beginning of each period, we make an new directory and file, which we update along with PRs as work is completed.