### PR TITLE
Rewrite the trace generator

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Block.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Block.hs
@@ -13,7 +13,7 @@ import Data.Typeable (typeOf)
 import Numeric.Natural (Natural)
 import GHC.Generics (Generic)
 import Control.State.Transition.Generator
-import Ledger.Core hiding ((<|))
+import Ledger.Core (Hash, VKey, Slot, Sig)
 import Ledger.Delegation
 import Ledger.Update (ProtVer, UProp, Vote)
 import Ledger.UTxO (TxWits, TxId)

--- a/byron/chain/executable-spec/src/Cardano/Spec/Consensus/Block.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Consensus/Block.hs
@@ -2,6 +2,10 @@
 {-# LANGUAGE TypeFamilies     #-}
 
 -- | Type classes for interfacing with the consensus layer
+--
+-- NOTE: at the moment there are no plans of interfacing the executable spec
+-- with the consensus layer, and this module is not used anywhere in
+-- `cardano-ledger-specs`.
 module Cardano.Spec.Consensus.Block where
 
 import           Control.Lens ((^.))

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -10,12 +10,13 @@ import Control.State.Transition
 import Control.State.Transition.Generator
 import Control.State.Transition.Trace
 
-import Cardano.Spec.Chain.STS.Block
-import Cardano.Spec.Chain.STS.Rule.Chain
 import Ledger.Delegation
 
--- slotsIncrease :: Property
--- slotsIncrease = property $ forAll trace >>= slotsIncreaseInTrace
+import Cardano.Spec.Chain.STS.Block
+import Cardano.Spec.Chain.STS.Rule.Chain
+
+slotsIncrease :: Property
+slotsIncrease = property $ forAll (trace 1000) >>= slotsIncreaseInTrace
 
 slotsIncreaseInTrace :: MonadTest m => Trace CHAIN -> m ()
 slotsIncreaseInTrace tr = assert $ slots == sortedSlots && nub slots == slots
@@ -23,19 +24,19 @@ slotsIncreaseInTrace tr = assert $ slots == sortedSlots && nub slots == slots
         slots = blocks ^.. traverse . bHeader . bhSlot
         sortedSlots = sort slots
 
--- blockIssuersAreDelegates :: Property
--- blockIssuersAreDelegates =
---   withTests 1000 $ property $ forAll trace >>= checkBlockIssuersAreDelegates
---   where
---     checkBlockIssuersAreDelegates :: MonadTest m => Trace CHAIN -> m ()
---     checkBlockIssuersAreDelegates tr =
---        traverse_ checkIssuer $ preStatesAndSignals OldestFirst tr
---        where
---          checkIssuer :: MonadTest m => (State CHAIN, Signal CHAIN) -> m ()
---          checkIssuer (st, bk) =
---            case delegatorOf dm issuer of
---              Just _ -> pure $! ()
---              Nothing -> failure
---            where
---              issuer = bk ^. bHeader . bhIssuer
---              dm = st ^. disL . delegationMap
+blockIssuersAreDelegates :: Property
+blockIssuersAreDelegates =
+  withTests 1000 $ property $ forAll (trace 1000) >>= checkBlockIssuersAreDelegates
+  where
+    checkBlockIssuersAreDelegates :: MonadTest m => Trace CHAIN -> m ()
+    checkBlockIssuersAreDelegates tr =
+       traverse_ checkIssuer $ preStatesAndSignals OldestFirst tr
+       where
+         checkIssuer :: MonadTest m => (State CHAIN, Signal CHAIN) -> m ()
+         checkIssuer (st, bk) =
+           case delegatorOf dm issuer of
+             Just _ -> pure $! ()
+             Nothing -> failure
+           where
+             issuer = bk ^. bHeader . bhIssuer
+             dm = st ^. disL . delegationMap

--- a/byron/chain/executable-spec/test/Main.hs
+++ b/byron/chain/executable-spec/test/Main.hs
@@ -14,7 +14,7 @@ main = defaultMain tests
   tests =
     testGroup "Chain"
     [ testGroup "Properties"
-      [ -- testProperty "Increasing slots" slotsIncrease
-      -- , testProperty "Block issuers are delegates" blockIssuersAreDelegates
+      [ testProperty "Increasing slots" slotsIncrease
+      , testProperty "Block issuers are delegates" blockIssuersAreDelegates
       ]
     ]

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -117,6 +117,7 @@ data UTXO id
 data UTxOState id = UTxOState { utxo :: UTxO id
                               , reserves :: Lovelace
                               }
+  deriving (Show)
 
 instance (Ord id, HasTypeReps id) => STS (UTXO id) where
 

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -267,7 +267,7 @@ dcertsAreTriggered :: Property
 dcertsAreTriggered = withTests 300 $ property $
   -- The number of tests was determined ad-hoc, since the default failed to
   -- uncover the presence of errors.
-  forAll nonTrivialTrace >>= dcertsAreTriggeredInTrace
+  forAll (nonTrivialTrace 1000) >>= dcertsAreTriggeredInTrace
 
 --------------------------------------------------------------------------------
 -- Properties related to the transition rules
@@ -283,7 +283,7 @@ dcertsAreTriggered = withTests 300 $ property $
 rejectDupSchedDelegs :: Property
 rejectDupSchedDelegs = property $ do
   (tr, dcert) <- forAll $ do
-    tr <- trace @DELEG
+    tr <- trace @DELEG 1000
           `suchThatLastState` (not . null . view scheduledDelegations)
     let vkS =
           case lastState tr ^. scheduledDelegations of

--- a/byron/semantics/executable-spec/small-steps.cabal
+++ b/byron/semantics/executable-spec/small-steps.cabal
@@ -76,3 +76,21 @@ test-suite doctests
 
   if (!flag(development))
     ghc-options:      -Werror
+
+
+test-suite examples
+  hs-source-dirs:      test
+  main-is:             examples/Main.hs
+  other-modules:       Control.State.Transition.Examples.Sum
+  type:                exitcode-stdio-1.0
+  default-language:    Haskell2010
+  build-depends:       base
+                     , containers
+                     , hedgehog
+                     , tasty
+                     , tasty-hedgehog
+                     , tasty-expected-failure
+                     --
+                     , small-steps
+  if (!flag(development))
+    ghc-options:      -Werror

--- a/byron/semantics/executable-spec/test/Control/State/Transition/Examples/Sum.hs
+++ b/byron/semantics/executable-spec/test/Control/State/Transition/Examples/Sum.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeApplications #-}
+
+ -- | Simple example of a transition system whose states contain the sum of the
+-- integers seen in the signals.
+--
+module Control.State.Transition.Examples.Sum where
+
+import Hedgehog (Property, forAll, property, withTests, assert, classify)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Control.State.Transition
+import Control.State.Transition.Generator
+import Control.State.Transition.Trace
+
+
+data SUM
+
+instance STS SUM where
+
+  type Environment SUM = ()
+
+  type State SUM = Int
+
+  type Signal SUM = [Int]
+
+  data PredicateFailure SUM = NoFailure deriving (Eq, Show)
+
+  initialRules = [pure 0]
+
+  transitionRules =
+    [ do
+        TRC ((), st, xs) <- judgmentContext
+        return $! st + sum xs
+    ]
+
+instance HasTrace SUM where
+  initEnvGen = pure ()
+
+  sigGen _ _ =
+    Gen.list (Range.constant 1 100) (Gen.integral (Range.constant (-3) 3))
+
+-- | This property is intended to be used to manually inspect the
+-- counterexamples that we get.
+prop_Bounded :: Property
+prop_Bounded = property $ do
+  tr <- forAll (trace @SUM 300)
+  classify "empty" $ traceLength tr == 0
+  classify "[1, 150)" $ 1 < traceLength tr && traceLength tr < 150
+  classify "[150, 300]" $ 150 < traceLength tr
+  assert (lastState tr < 10)
+
+-- | Property that simply classifies the trace length distribution.
+prop_Classified :: Property
+prop_Classified = withTests 300 $ property $ do
+  tr <- forAll (trace @SUM 1000)
+  classify "empty"       $ traceLength tr == 0
+  classify "singleton"   $ traceLength tr == 1
+  classify "[2, 100)"    $ 2 < traceLength tr && traceLength tr < 100
+  classify "[100, 500)"  $ 100 < traceLength tr && traceLength tr < 500
+  classify "[500, 1000)" $ 500 < traceLength tr && traceLength tr < 1000
+  classify "1000"        $ traceLength tr == 1000
+  assert True

--- a/byron/semantics/executable-spec/test/examples/Main.hs
+++ b/byron/semantics/executable-spec/test/examples/Main.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import Hedgehog (checkParallel, Group (Group))
+import Test.Tasty (TestTree, defaultMain, testGroup, localOption)
+import Test.Tasty.ExpectedFailure (expectFailBecause)
+import Test.Tasty.Hedgehog (testProperty)
+
+import qualified Control.State.Transition.Examples.Sum as Sum
+
+main :: IO ()
+main = do
+  checkParallel
+    $ Group "Sum" [ ("Classified", Sum.prop_Classified)
+                  ]
+
+  defaultMain tests
+  where
+    tests =
+      testGroup
+        "Sum"
+        [ expectFailBecause "it allows to inspect generated trace counterexamples"
+          $ testProperty "False" Sum.prop_Bounded
+        ]

--- a/nix/.stack.nix/small-steps.nix
+++ b/nix/.stack.nix/small-steps.nix
@@ -48,6 +48,17 @@
             (hsPkgs.buildPackages.doctest-discover or (pkgs.buildPackages.doctest-discover))
             ];
           };
+        "examples" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.containers)
+            (hsPkgs.hedgehog)
+            (hsPkgs.tasty)
+            (hsPkgs.tasty-hedgehog)
+            (hsPkgs.tasty-expected-failure)
+            (hsPkgs.small-steps)
+            ];
+          };
         };
       };
     } // rec {


### PR DESCRIPTION
- Rewrite the traces generator so that it shrinks properly
- Add an example of a transition system that can be used to: 
  - Document how to use our STS framework
  - Test the shrinks that we get with our integrated traces-generator
- Re-enable the tests that were disabled in https://github.com/input-output-hk/cardano-ledger-specs/pull/424

Part of #476 