### PR TITLE
New transaction component for adding extra entropy

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1,8 +1,6 @@
 \section{Blockchain layer}
 \label{sec:chain}
 
-\newcommand{\Seed}{\type{Seed}}
-\newcommand{\seedOp}{\star}
 \newcommand{\Proof}{\type{Proof}}
 \newcommand{\Seedl}{\mathsf{Seed}_\ell}
 \newcommand{\Seede}{\mathsf{Seed}_\eta}
@@ -105,6 +103,7 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
   %
   \emph{Constants}
   \begin{align*}
+    & 0_{seed} \in \Seed & \text{neutral seed element} \\
     & \Seedl \in \Seed & \text{leader seed constant} \\
     & \Seede \in \Seed & \text{nonce seed constant}\\
     & \SlotsPrior \in \Duration & \tau\text{ in \cite{ouroboros_praos}}\\
@@ -316,25 +315,75 @@ In the second case, the new epoch state is updated as follows:
 
 \begin{itemize}
 \item The epoch is set to the new epoch $e$.
-\item The epoch nonce is replaced with the new one from the new epoch
-  environment.
+\item The epoch nonce is replaced with the compbination of the new one from the
+  environment and any extra entropy present in the UTxO state.
 \item The mapping for the blocks produced by each stake pool for the previous epoch
   is set to the current such mapping.
 \item The mapping for the blocks produced by each stake pool for the current epoch
   is set to the empty map.
-\item The epoch state is updated first with the rewards update \var{ru} and then
-  via the call to $\mathsf{EPOCH}$.
+\item The epoch state is updated with: first applying the rewards update \var{ru},
+  then calling the $\mathsf{EPOCH}$ transition, updating the update state, and finally
+  resetting the extra entropy mapping.
 \item The rewards update is set to \Nothing.
-\item The pool distribution is updated according to the changes in the stake pools.
+\item The new pool distribution \var{pd}' is calculated from the delegation map and
+  stake allocation of the previous epoch.
 \item A new OBFT overlay schedule is created.
 \end{itemize}
 
-The new pool distribution \var{pd}' is calculated from the delegation map and
-stake allocation of the previous epoch. It associates every stake pool key
-($\HashKey_{pool}$) to which a staking key ($\HashKey_{stake}$) delegates with
-the stake that $\HashKey_{stake}$ has. The sum of stake for all staking keys
-delegating to $\HashKey_{pool}$ then becomes the new entry of $\HashKey_{pool}$
-in the pool distribution.
+Figure~\ref{fig:funcs:new-epoch-helper} gives some helper functions for the
+$\mathsf{NEWEPOCH}$ transition.
+Three of the four functions help with the nested data structures.
+The other function, $\fun{extraEntropy}$, will return a seed value to be used as extra
+entropy for the next epoch nonce if at least five genesis keys are in agreement of the value,
+and zero otherwise.
+
+%%
+%% Figure - Helper Functions for New Epoch Rules
+%%
+\begin{figure}[htb]
+  \begin{align*}
+      & \fun{getEEnt} \in \EpochState \to \VKeyGen\mapsto\Seed \\
+      & \fun{getEEnt}~
+          (\wcard, ~\wcard,
+          ~((\wcard,~\wcard,~\wcard,~\var{H}),~\wcard,~\wcard))
+    = H
+  \end{align*}
+
+  \begin{align*}
+      & \fun{resetEEnt} \in \EpochState \to \EpochState \\
+      & \fun{resetEEnt}~
+          (\var{acnt},
+          ~\var{ss},
+          ~((\var{utxo},~\var{deposits},~\var{fees},~\wcard),~\var{dpstate},~\var{us}))
+    = \\
+      &~~
+          (\var{acnt},
+          ~\var{ss},
+          ~((\var{utxo},~\var{deposits},~\var{fees},~\emptyset),~\var{dpstate},~\var{us}))
+  \end{align*}
+
+  \begin{align*}
+      & \fun{extraEntropy} \in \EpochState \to \PParams \to \powerset{\VKeyGen} \to \Seed \\
+      & \fun{extraEntropy}~\var{es}~\var{pp}~\var{gkeys} =
+        \begin{cases}
+          \eta & \text{if}~\exists\eta(~|H\restrictrange \{\eta\}|/|gkeys|\geq t~)\\
+          0_{seed} & \text{otherwise} \\
+        \end{cases} \\
+      &
+        \where \\
+      & ~~~~ H = \fun{getEEnt}~\var{es} \\
+      & ~~~~ t = \fun{upAdptThd}~\var{pp}
+  \end{align*}
+
+  \begin{align*}
+      & \fun{setUPIState} \in \EpochState \to \UPIState \to \EpochState \\
+      & \fun{setUPIState}~(\var{acnt},~\var{ss},~(\var{utxoSt},~\var{dpstate},~\wcard))~\var{us} =
+      (\var{acnt},~\var{ss},~(\var{utxoSt},~\var{dpstate},~\var{us}))
+  \end{align*}
+
+  \caption{New Epoch Helper Functions}
+  \label{fig:funcs:new-epoch-helper}
+\end{figure}
 
 \begin{figure}[ht]
   \begin{equation}\label{eq:new-epoch}
@@ -374,7 +423,9 @@ in the pool distribution.
                     \var{c}) \in \var{stake}
                 \right\}\right) \\
          \var{osched'} & \overlaySchedule{gkeys}{\eta_1}{pp} \\
-        \var{es''} & \var{es'}\unionoverrideRight\{us'\}
+         \eta_e & \fun{extraEntropy}~\var{es'}~\var{pp}~\var{gkeys} \\
+         \var{es''} & \fun{setUPIState}~\var{es'}~\var{us'} \\
+         \var{es'''} & \fun{resetEEnt}~\var{es''} \\
       \end{array}}
     }
     {
@@ -382,6 +433,7 @@ in the pool distribution.
         {\begin{array}{c}
             \eta_1 \\
             \var{s} \\
+            \var{gkeys} \\
         \end{array}}
       \right)
       \vdash
@@ -398,10 +450,10 @@ in the pool distribution.
       \trans{newepoch}{\var{e}}
       {\left(\begin{array}{c}
             \varUpdate{\var{e}} \\
-            \varUpdate{\eta_1} \\
+            \varUpdate{\eta_1\seedOp\eta_e} \\
             \varUpdate{\var{b_{cur}}} \\
             \varUpdate{\emptyset} \\
-            \varUpdate{\var{es}''} \\
+            \varUpdate{\var{es}'''} \\
             \varUpdate{\Nothing} \\
             \varUpdate{\var{pd}'} \\
             \varUpdate{\var{osched}'} \\
@@ -421,6 +473,7 @@ in the pool distribution.
         {\begin{array}{c}
             \eta_1 \\
             \var{s} \\
+            \var{gkeys} \\
         \end{array}}
       \right)
       \vdash
@@ -654,14 +707,14 @@ execution of the transition role is as follows:
 \label{sec:block-header-trans}
 
 The Block Header Transition checks a couple sizes and performs some chain level upkeep.
-The environment consists of a set of genesis keys, and the state is the
+The environment consists of a candidate nonce and a set of genesis keys, and the state is the
 epoch specific state necessary for the $\mathsf{NEWEPOCH}$ transition.
 
 \begin{figure}
   \emph{Block Header Transitions}
   \begin{equation*}
     \_ \vdash \var{\_} \trans{bhead}{\_} \var{\_} \subseteq
-    \powerset (\powerset{\VKeyGen} \times \NewEpochState \times \BHeader \times \NewEpochState)
+    \powerset ((\Seed\times\powerset{\VKeyGen}) \times \NewEpochState \times \BHeader \times \NewEpochState)
   \end{equation*}
   \caption{BHeader transition-system types}
   \label{fig:ts-types:bheader}
@@ -738,7 +791,12 @@ If the size checks pass, then three transitions are done:
       \var{nes}''\leteq\var{nes'}\unionoverrideRight\{\var{ru'}\}
     }
     {
-      \var{gkeys}
+      \left(
+        {\begin{array}{c}
+            \eta_c \\
+            \var{gkeys} \\
+        \end{array}}
+      \right)
       \vdash\var{nes}\trans{bhead}{\var{bh}}\varUpdate{\var{nes''}}
     }
   \end{equation}
@@ -1292,7 +1350,13 @@ The transition rule itself has no preconditions, instead it calls all its subrul
       \var{bh} \leteq \bheader{block} \\
       \\~\\
       {
-        \dom{dms}\vdash\var{nes}\trans{\hyperref[fig:rules:bhead]{bhead}}{\var{bh}}\var{nes'}
+        \left(
+          {\begin{array}{c}
+              \eta_c \\
+              \var{gkeys} \\
+          \end{array}}
+        \right)
+        \vdash\var{nes}\trans{\hyperref[fig:rules:bhead]{bhead}}{\var{bh}}\var{nes'}
       } \\~\\
       (\wcard,~\eta_0,~\wcard,~\var{b_{cur}},~\var{es},~\wcard,~\var{pd},\var{osched})
         \leteq\var{nes'} \\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -397,7 +397,7 @@ This transition has no preconditions and results in the following state change:
     {
       {
       \begin{array}{r@{~\leteq~}l}
-        (\var{utxo},~\var{deposits},~\var{fees}) & \var{utxoSt}\\
+        (\var{utxo},~\var{deposits},~\var{fees},~\wcard) & \var{utxoSt}\\
         (\var{stkeys},~\wcard,~\var{delegations},~\wcard) & \var{dstate}\\
         (\var{stpools},~\var{poolParams},~\wcard,~\wcard,~\wcard) & \var{pstate}\\
         \var{stake} & \stakeDistr{utxo}{dstate}{pstate} \\
@@ -673,6 +673,7 @@ for ease of reading.
             \var{utxo} \\
             \varUpdate{oblg_{new}} \\
             \var{fees} \\
+            \var{H} \\
           \end{array}
         }
       \right)

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -55,6 +55,9 @@
 \newcommand{\Duration}{\type{Duration}}
 \newcommand{\StakePools}{\type{StakePools}}
 \newcommand{\StakeKeys}{\type{StakeKeys}}
+\newcommand{\Seed}{\type{Seed}}
+\newcommand{\seedOp}{\star}
+\newcommand{\EEnt}{\type{EEnt}}
 
 \newcommand{\DCert}{\type{DCert}}
 \newcommand{\DCertRegKey}{\type{DCert_{regkey}}}

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -72,7 +72,8 @@ the $\mathsf{BUPI}$ transition (from \cite{byron_chain_spec}).
         \var{slot} \\
         \var{pp} \\
         \var{stkeys} \\
-        \var{stpools}
+        \var{stpools} \\
+        \var{dms} \\
         \end{array}
     }\right)
       \vdash \var{utxoSt} \trans{\hyperref[fig:rules:utxow-shelley]{utxow}}{tx} \var{utxoSt'}\\~\\~\\

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -2,7 +2,7 @@
 \label{sec:transactions}
 
 Transactions are defined in Figure~\ref{fig:defs:utxo-shelley}.
-A transaction body, $\TxBody$, is made up of six pieces:
+A transaction body, $\TxBody$, is made up of seven pieces:
 
 \begin{itemize}
   \item A set of transaction inputs.
@@ -19,6 +19,11 @@ A transaction body, $\TxBody$, is made up of six pieces:
     a reward address to the coin value to be withdrawn. The coin value must be equal
     to the full value contained in the account. Explicitly stating these values ensures
     that error messages can be precise about why a transaction is invalid.
+  \item A mapping of genesis keys to an extra seed value. If there is a consensus on this value
+    among the genesis keys, this value will be used in the next epoch as extra entropy for
+    the nonce. The extra entropy is needed for the transition from the Byron era to the Shelley
+    era. It will be used as evidence that the initial nonces were not manipulated by the genesis
+    key holders before full decentralization has occured.
 \end{itemize}
 A transaction, $\Tx$, is a transaction body together with:
 
@@ -67,6 +72,11 @@ This function must produce a unique id for each unique transaction.
       & \Wdrl
       & \AddrRWD \mapsto \Coin
       & \text{reward withdrawal}
+      \\
+      \var{H}
+      & \EEnt
+      & \VKeyGen \mapsto \Seed
+      & \text{extra entropy}
     \end{array}
   \end{equation*}
   %
@@ -77,7 +87,7 @@ This function must produce a unique id for each unique transaction.
       \var{txbody}
       & \TxBody
       & \powerset{\TxIn} \times (\Ix \mapsto \TxOut) \times \seqof{\DCert}
-        \times \Coin \times \Slot \times \Wdrl
+        \times \Coin \times \Slot \times \Wdrl \times \EEnt
       \\
       \var{tx}
       & \Tx
@@ -98,6 +108,7 @@ This function must produce a unique id for each unique transaction.
       \fun{txbody} & \Tx \to \TxBody & \text{transaction body}\\
       \fun{txwits} & \Tx \to (\VKey \mapsto \Sig) & \text{witnesses} \\
       \fun{txup} & \Tx \to \UpdatePayload & \text{update payload} \\
+      \fun{txeent} & \Tx \to \EEnt & \text{extra entropy} \\
     \end{array}
   \end{equation*}
   %

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -154,6 +154,7 @@ The signal for the UTxO transition is a transaction.
         \var{pp} & \PParams & \text{protocol parameters}\\
         \var{stkeys} & \StakeKeys & \text{stake key}\\
         \var{stpools} & \StakePools & \text{stake pool}\\
+        \var{dms} & \VKeyGen\mapsto\VKey & \text{genesis key delegations} \\
       \end{array}
     \right)
   \end{equation*}
@@ -166,6 +167,7 @@ The signal for the UTxO transition is a transaction.
         \var{utxo} & \UTxO & \text{UTxO}\\
         \var{deposits} & \Coin & \text{deposits pot}\\
         \var{fees} & \Coin & \text{fee pot}\\
+        \var{H} & \VKey\mapsto\Seed & \text{extra entropy}\\
       \end{array}
     \right)
   \end{equation*}
@@ -209,6 +211,8 @@ The transition contains the following predicates:
     In other words, the amount of value produced by the transaction must be the same as
     the amount consumed.
   \item
+    The extra entropy values can only come from the genesis keys.
+  \item
     The coin value of each new output must be non-negative.
   \item
     The transaction size must be below the allowed maximum.
@@ -234,6 +238,8 @@ If all the predicates are satisfied, the state is updated as follows:
     which has decayed to the fee pot.
     The amount decayed will depend on the time to live of the transaction
     and will be explained further in Section~\ref{sec:deps-refunds}.
+  \item Update the extra entropy mapping, overriding any old values so that
+    each genesis key can vote for at most one value each epoch.
 \end{itemize}
 
 The accounting for the reward withdrawals is not done in this transition system.
@@ -289,6 +295,12 @@ requests).
       \\
       ~
       \\
+      H'\leteq\fun{txeent}~\var{tx}
+      &
+      \dom{H'}\subseteq\dom{dms}
+      \\
+      ~
+      \\
       \forall (\_\mapsto (\_, c)) \in \txouts{tx}, c \geq 0
       \\
       \fun{txsize}~{tx}\leq\fun{maxTxSize}~\var{pp}
@@ -308,6 +320,7 @@ requests).
         \var{pp}\\
         \var{stkeys}\\
         \var{stpools}\\
+        \var{dms}\\
       \end{array}
       \vdash
       \left(
@@ -315,6 +328,7 @@ requests).
         \var{utxo} \\
         \var{deposits} \\
         \var{fees} \\
+        \var{H}\\
       \end{array}
       \right)
       \trans{utxo}{tx}
@@ -323,6 +337,7 @@ requests).
         \varUpdate{(\txins{tx} \subtractdom \var{utxo}) \cup \outs{tx}}  \\
         \varUpdate{\var{deposits} + \var{depositChange}} \\
         \varUpdate{\var{fees} + \txfee{tx} + \var{decayed}} \\
+        \varUpdate{H\unionoverrideRight H'}\\
       \end{array}
       \right)
     }
@@ -522,17 +537,20 @@ This consists of:
   \item payment keys for outputs being spent
   \item stake keys for reward withdrawals
   \item stake keys for delegation certificates (all five types)
+  \item delegates of the genesis keys for any extra entropy values
   \item stake keys for the pool owners in a pool registration certificate
 \end{itemize}
 
 \begin{figure}[htb]
   \begin{align*}
-    & \fun{witsNeeded} \in \UTxO \to \Tx \to \powerset{\HashKey}
+    & \fun{witsNeeded} \in \UTxO \to \Tx \to (\VKeyGen\mapsto\VKey) \to \powerset{\HashKey}
     & \text{hashkeys for needed witnesses} \\
-    & \fun{witsNeeded}~{utxo}~{tx} = \\
+    & \fun{witsNeeded}~\var{utxo}~\var{tx}~\var{dms} = \\
     & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\txins{tx} \}~\cup \\
     & ~~\{\fun{stakeHK_r}~a \mid a\mapsto \wcard \in \txwdrls{tx}\}~\cup \\
     & ~~\{\cwitness{c} \mid c \in \txcerts{tx}\}~\cup \\
+    & ~~\{\hashKey{vkey} \mid
+    \var{gkey}\mapsto\var{vkey}\in(\dom{(\fun{txeent}~\var{tx})}\restrictdom\var{dms})\}~\cup \\
     & ~~\bigcup_{\substack{c \in \txcerts{tx} \\ ~c \in\DCertRegPool}} \fun{poolOwners}~{c} \\
   \end{align*}
   \caption{Functions used in witness rule}
@@ -570,7 +588,8 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
       (utxo, \wcard, \wcard) \leteq \var{utxoSt} \\~\\
       \forall \var{vk} \mapsto \sigma \in \txwits{tx},
         \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma} \\
-      \fun{witsNeeded}~{utxo}~{tx} = \{ \hashKey \var{vk} \mid \var{vk}\in\dom{(\txwits{tx})} \}\\
+      \fun{witsNeeded}~\var{utxo}~\var{tx}~\var{dms} =
+        \{ \hashKey \var{vk} \mid \var{vk}\in\dom{(\txwits{tx})} \}\\
       {
         \begin{array}{l}
         \var{utxoEnv}

--- a/weekly-reports/2019-05-31/milestone.org
+++ b/weekly-reports/2019-05-31/milestone.org
@@ -1,6 +1,6 @@
 * Shelley Ledger Team Milestone 2019-05-31
 ** TODO Update the formal spec with a new transaction component for adding extra entropy to the epoch nonce.
-   - [ ] Issue #394
+   - [X] Issue #394
 ** TODO Update the formal spec with a mapping from the genesis keys to the other stake pool cold keys.
    - [ ] Issue #447
 ** TODO Plan out the work required to finish importing the Byron update system into Shelley.


### PR DESCRIPTION
This PR adds a new component to the transaction for adding extra entropy to the epoch nonce. The new component can only be used by the genesis key holders. The component is a mapping of genesis keys to seeds.

![tx](https://user-images.githubusercontent.com/943479/58112067-b1e4a600-7bc0-11e9-99c9-ad14ae96528e.png)

In the UTxO transition, we check that _only_ genesis keys use the component:

![check-gen](https://user-images.githubusercontent.com/943479/58112156-eb1d1600-7bc0-11e9-95c0-ff78d8d7d5c8.png)

In the UTxOW transition we check that all these genesis keys have provided a signature:


![wits](https://user-images.githubusercontent.com/943479/58112223-13a51000-7bc1-11e9-9644-96005195421b.png)

The UTxOState maintains the cumulative mapping. Each genesis key is allowed to be linked to one seed per epoch, and if there are at least five such keys in agreement at the end of an epoch, this common value will be used for generating the next epoch nonce.  In order to help with this, there is a new figure with helper functions, three of which are just for dealing with the nested data. The other function, `extraEntropy`, manages collecting an agreed upon seed if such a seed exists:

![ee](https://user-images.githubusercontent.com/943479/58112811-3d126b80-7bc2-11e9-8890-675192409af2.png)


The relevant part of the `NEWEPOCH` transition now looks like:

![newepoch](https://user-images.githubusercontent.com/943479/58112986-9e3a3f00-7bc2-11e9-975d-fd42b635a953.png)

This PR did uncover one mistake, namely that the `BHEAD` environment was missing the nonce candidate.

Note that we are still using the hash of the hash of the last Byron block as the first Shelley nonce. The difference is that now the genesis key holders now add extra entropy at any time during an epoch for the next epoch.

closes #394 