### PR TITLE
Makes a HedgeHog version constraint to at least 1.0

### DIFF
--- a/byron/chain/executable-spec/cs-blockchain.cabal
+++ b/byron/chain/executable-spec/cs-blockchain.cabal
@@ -41,7 +41,7 @@ library
                      , containers
                      , cryptonite
                      , cs-ledger
-                     , hedgehog
+                     , hedgehog >= 1.0
                      , lens
                      , small-steps
   ghc-options:         -Wall
@@ -60,7 +60,7 @@ test-suite chain-spec-test
   default-language:    Haskell2010
   build-depends:       base
                      , data-ordlist
-                     , hedgehog
+                     , hedgehog >= 1.0
                      , lens
                      , tasty
                      , tasty-hedgehog

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -35,7 +35,7 @@ library
                      , bytestring
                      , containers
                      , cryptonite
-                     , hedgehog
+                     , hedgehog >= 1.0
                      , lens
                      , memory
                      -- Local deps
@@ -61,7 +61,7 @@ test-suite doctests
                      , bytestring
                      , containers
                      , cryptonite
-                     , hedgehog
+                     , hedgehog >= 1.0
                      , lens
                      , memory
                      , text
@@ -91,7 +91,7 @@ test-suite ledger-delegation-test
                , bimap
                , containers
                , lens
-               , hedgehog
+               , hedgehog >= 1.0
                , tasty
                , tasty-hunit
                , tasty-hedgehog

--- a/byron/semantics/executable-spec/small-steps.cabal
+++ b/byron/semantics/executable-spec/small-steps.cabal
@@ -32,7 +32,7 @@ library
                      , containers
                      , cryptonite
                      , free
-                     , hedgehog
+                     , hedgehog >= 1.0
                      , tasty-hunit
                      , lens
                      , mtl
@@ -56,7 +56,7 @@ test-suite doctests
                      , containers
                      , data-default
                      , free
-                     , hedgehog
+                     , hedgehog >= 1.0
                      , tasty-hunit
                      , lens
                      , mtl
@@ -86,7 +86,7 @@ test-suite examples
   default-language:    Haskell2010
   build-depends:       base
                      , containers
-                     , hedgehog
+                     , hedgehog >= 1.0
                      , tasty
                      , tasty-hedgehog
                      , tasty-expected-failure


### PR DESCRIPTION
For the Byron-Shelley era Haskell code makes a HedgeHog version constraint to at least 1.0.

Closes #505.