### PR TITLE
Extend witness type of transaction, move script witness out of transaction body

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/multi-sig.tex
+++ b/shelley/chain-and-ledger/formal-spec/multi-sig.tex
@@ -37,10 +37,12 @@
 \newcommand{\N}{\ensuremath{\mathbb{N}}}
 \newcommand{\Bool}{\ensuremath{\mathbb{B}}}
 \newcommand{\Tx}{\type{Tx}}
+\newcommand{\TxWitness}{\type{TxWitness}}
 \newcommand{\TxBody}{\type{TxBody}}
 \newcommand{\Ix}{\type{Ix}}
 \newcommand{\TxId}{\type{TxId}}
 \newcommand{\Addr}{\type{Addr}}
+\newcommand{\AddrVKey}{\type{Addr^{vkey}}}
 \newcommand{\UTxO}{\type{UTxO}}
 \newcommand{\Wdrl}{\type{Wdrl}}
 \newcommand{\Coin}{\type{Coin}}
@@ -64,11 +66,11 @@
 \newcommand{\ledgerState}{\ensuremath{\type{ledgerState}}}
 
 \newcommand{\AddrRWD}{\type{Addr_{rwd}}}
-\newcommand{\AddrB}{\type{Addr_{base}}}
-\newcommand{\AddrP}{\type{Addr_{ptr}}}
-\newcommand{\AddrE}{\type{Addr_{enterprise}}}
-\newcommand{\AddrBS}{\type{Addr_{bootstrap}}}
-\newcommand{\AddrScr}{\type{Addr_{script}}}
+\newcommand{\AddrVKeyB}{\type{Addr^{vkey}_{base}}}
+\newcommand{\AddrVKeyP}{\type{Addr^{vkey}_{ptr}}}
+\newcommand{\AddrVKeyE}{\type{Addr^{vkey}_{enterprise}}}
+\newcommand{\AddrVKeyBS}{\type{Addr^{vkey}_{bootstrap}}}
+\newcommand{\AddrScr}{\type{Addr^{script}}}
 \newcommand{\AddrScrBase}{\type{Addr_{base}^{script}}}
 \newcommand{\AddrScrEnterprise}{\type{Addr_{enterprise}^{script}}}
 \newcommand{\AddrScrPtr}{\type{Addr_{ptr}^{script}}}
@@ -299,13 +301,14 @@ required signatures for a specific unspent transaction output.
 
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
-      \var{addr} & \AddrScr & \AddrScrBase \uniondistinct \AddrScrEnterprise
+      \var{addr_{s}} & \AddrScr & \AddrScrBase \uniondistinct \AddrScrEnterprise
                               \uniondistinct \AddrScrPtr & \text{Script address} \\
-      \var{addr} & \Addr & \begin{array}{l@{~\uniondistinct}l}
-                             \AddrB & \AddrP \uniondistinct \AddrE \\
-                                    & \AddrBS \uniondistinct \AddrScr
+      \var{addr_{vk}} & \AddrVKey & \begin{array}{l@{~\uniondistinct}l}
+                             \AddrVKeyB & \AddrVKeyP \uniondistinct \AddrVKeyE \\
+                                    & \AddrVKeyBS
                            \end{array}
-                            & \text{output address}
+                                & \text{VKey address}\\
+      \var{addr} & \Addr & \AddrScr \uniondistinct \AddrVKey
     \end{array}
   \end{equation*}
 
@@ -313,14 +316,14 @@ required signatures for a specific unspent transaction output.
 
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{paymentHK} & \Addr \to \HashKey_{pay}^{?}
+      \fun{paymentHK} & \AddrVKey \to \HashKey_{pay}
       & \text{hash of payment key from addr}\\
-      \fun{validatorHash} & \Addr \to \HashScr^{?} & \text{hash of validator
+      \fun{validatorHash} & \AddrScr \to \HashScr & \text{hash of validator
                                                      script} \\
-      \fun{stakeHK_{b}} & (\AddrB \uniondistinct \AddrScrBase) \to
+      \fun{stakeHK_{b}} & (\AddrVKeyB \uniondistinct \AddrScrBase) \to
                           \HashKey_{stake} & \text{hash of stake key for base
                                              addresses}\\
-      \fun{addrPtr} & (\AddrP \uniondistinct \AddrScrPtr) \to \Ptr &
+      \fun{addrPtr} & (\AddrVKeyP \uniondistinct \AddrScrPtr) \to \Ptr &
                                                                      \text{pointer
                                                                      from
                                                                      pointer addresses}
@@ -350,11 +353,11 @@ validator script. The output can only be spent if the matching script is
 presented and validates its input. The $\AddrScr$
 (Figure~\ref{fig:types-scripts}) sub-type of $\Addr$ carries the necessary
 information and can therefore be part of a transaction output that consists of a
-pair of $\Addr\times\Coin$. Analogously to $\Addr$, $\AddrScr$ also has an
+pair of $\Addr\times\Coin$. Analogously to $\AddrVKey$, $\AddrScr$ also has an
 \emph{enterprise} script address sub-type which does not allow for using the
 locked funds in staking, as well as \emph{base} and \emph{pointer} script
-address sub-types which allow for staking in the same way as $\AddrB$ and
-$\AddrP$.
+address sub-types which allow for staking in the same way as $\AddrVKeyB$ and
+$\AddrVKeyP$.
 
 The $\fun{hashScript}$ function calculates the hash of a script. The accessor
 function $\fun{validatorHash}$ returns the hash of a script of a script address,
@@ -377,10 +380,11 @@ respective script address variants.
 
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}l}
-      \var{txbody}
-      & \TxBody
-      & \powerset{(\TxIn \times \Script^{?})} \times (\Ix \mapsto \TxOut) \times \seqof{\DCert}
-        \times \Coin \times \Slot \times \Wdrl
+      \var{wit} & \TxWitness & (\VKey \mapsto \Sig, \powerset \Script)
+      \\
+      \var{tx}
+      & \Tx
+      & \TxBody \times \TxWitness \times \UpdatePayload
       \\
     \end{array}
   \end{equation*}
@@ -389,16 +393,7 @@ respective script address variants.
 
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{txinsVKey} & \Tx \to \powerset{\TxIn} &\text{VKey locked transaction inputs} \\
-      \fun{txinsScript} & \Tx \to \powerset{(\TxIn \times \Script)} &\text{Script locked transaction inputs} \\
       \fun{txwitsVKey} & \Tx \to (\VKey \mapsto \Sig) & \text{VKey witnesses} \\
-    \end{array}
-  \end{equation*}
-
-  \emph{Functions}
-
-  \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
       \fun{txwitsScripts} & \Tx \to \powerset{\Script} & \text{script witnesses}
     \end{array}
   \end{equation*}
@@ -408,7 +403,8 @@ respective script address variants.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \fun{txPending} & \Tx \to \PendingTx & \text{Get necessary information from Tx} \\
-      \fun{validate} & () \to () \to \PendingTx \to () & \text{validate multi-sig}
+      \fun{validate} & () \to () \to \PendingTx \to () & \text{validator script}\\
+      \fun{validateScript} & \Script \to \PendingTx \to \Bool & \text{script interpreter}
     \end{array}
   \end{equation*}
   \caption{Types for Transaction Inputs with Scripts}
@@ -469,6 +465,41 @@ for the multi-signature are present. Else the script ends in the Plutus
 script with the correct type according as in Figure~\ref{fig:types_defs_multi}
 when $hkeys$ is a value of type $\type{MultiSig}$.
 
+\begin{figure*}[htb]
+  \emph{Helper Functions}
+  %
+  \begin{align*}
+    \fun{txinsVKey} & \in \powerset \TxIn \to \UTxO \to \TxIn & \text{VKey Tx inputs}\\
+    \fun{txinsVKey} & ~\var{txins}~\var{utxo} =
+    \var{txins} \cap \dom (\var{utxo} \restrictrange (\AddrVKey \times Coin))
+    \\
+    \\
+    \fun{txinsScript} & \in \powerset \TxIn \to \UTxO \to \TxIn & \text{Script Tx inputs}\\
+    \fun{txinsScript} & ~\var{txins}~\var{utxo} =
+                        \var{txins} \cap \dom (\var{utxo} \restrictrange (\AddrScr \times Coin))
+    \\
+    \\
+    \fun{validators} & \in \powerset\TxIn \to \UTxO \to \powerset \Script \to
+                       (\TxIn \mapsto \Script) \\
+    \fun{validators} &~\var{txins}~\var{utxo}~\var{scripts} = \\
+                       & \{
+                         i\mapsto s \vert
+                         i\mapsto (a,\wcard) \in \var{txins}\restrictdom(utxo
+                         \restrictrange (\AddrScr\times\Coin)) \\
+                    &
+                      \wedge s \in scripts
+                      \wedge a = \fun{hashScript}~s
+                      \}
+  \end{align*}
+  %
+  \caption{Helper Functions for Transaction Inputs}
+  \label{fig:defs:functions-txins}
+\end{figure*}
+
+Figure~\ref{fig:defs:functions-txins} shows the functions $\fun{txinsVKey}$ and
+$\fun{txinsScript}$ which split the transaction inputs of the transaction into
+those that are locked with a private key and those that are locked via a script.
+
 \section{Ledger Transition for Multi-Signature}
 \label{sec:ledg-trans-multi}
 
@@ -495,16 +526,11 @@ The set of all validator scripts of $\fun{txinsScript~tx}$ is checked for:
   \begin{equation*}
     \inference[UTxO-wit]
     {
-      (utxo, \wcard, \wcard) \leteq \var{utxoSt} \\
-      validators \leteq \left\{
-        \var{s}\mapsto\var{a}\vert
-        (\var{inp}, \var{s})\in\fun{txinsScript}~tx,
-        \var{inp}\mapsto(\var{a},\wcard) \in \var{utxo}
-      \right\}
+      (utxo, \wcard, \wcard) \leteq \var{utxoSt}
       \\~\\
-      \forall \var{validate}\mapsto\var{a} \in validators, \fun{validatorHash}~\var{a} = \fun{hashScript}~validate \\
-      \forall \var{validate} \in \dom~validators, \fun{validate}~()~()~{(\fun{pendingTx}~tx)}\\~\\
-      \range(\fun{txinsVKey}~tx \restrictdom \var{utxo}) \cap (\AddrScr\times\Coin) = \emptyset
+      \forall \var{inp}\mapsto\var{validator} \in
+      \fun{validators}~(\fun{txinsScript}~(\fun{txins}~tx))~utxo~(\fun{txwitsScript}~tx),
+      \\ \fun{interpreteScript}~validator~(\fun{pendingTx}~tx)
       \\~\\
       \forall \var{vk} \mapsto \sigma \in \txwitsVKey{tx},
       \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma} \\
@@ -525,86 +551,6 @@ The set of all validator scripts of $\fun{txinsScript~tx}$ is checked for:
   \end{equation*}
   \caption{UTxO with Witnesses and Multi-Sig}
   \label{fig:rules:utxow-multi-sig}
-\end{figure}
-
-In the UTXO transition rule, the transaction inputs are used to restrict the
-domain of the $\var{utxo}$. We define the local variable $\var{txInps}$ as the
-union of $\fun{txinsVKey}~tx$ and the domain of $\fun{txinsScript}~tx$. This
-variable consists of all inputs that the transaction wants to consume. It has to
-be a subset of the domain of $utxo$ and cannot be empty.
-
-\begin{figure}[htb]
-  \begin{equation}\label{eq:utxo-inductive-shelley}
-    \inference[UTxO-inductive]
-    { \var{txInps} \leteq \fun{txinsVKey}~tx \cup \dom (\fun{txinsScript}~tx)\\~\\
-      \txttl tx \geq \var{slot}
-      & txInps \neq \emptyset
-      & \minfee{pp}{tx} \leq \txfee{tx}
-      & \var{txInps}\subseteq \dom \var{utxo}
-      \\
-      \consumed{pp}{utxo}{stkeys}{rewards}~{tx} = \produced{pp}{stpools}~{tx}
-      \\
-      ~
-      \\
-      \forall (\_\mapsto (\_, c)) \in \txouts{tx}, c \geq 0
-      \\
-      ~
-      \\
-      \var{refunded} \leteq \keyRefunds{pp}{stkeys}~{tx}
-      \\
-      \var{decayed} \leteq \decayedTx{pp}{stkeys}~{tx}
-      \\
-      \var{depositChange} \leteq
-        (\deposits{pp}~{stpools}~{\fun{dcerts}~tx}) - (\var{refunded} + \var{decayed})
-    }
-    {
-      \begin{array}{l}
-        \var{slot}\\
-        \var{pp}\\
-        \var{stkeys}\\
-        \var{stpools}\\
-      \end{array}
-      \vdash
-      \left(
-      \begin{array}{r}
-        \var{utxo} \\
-        \var{deposits} \\
-        \var{fees} \\
-      \end{array}
-      \right)
-      \trans{utxo}{tx}
-      \left(
-      \begin{array}{r}
-        \varUpdate{(\var{txInps}\subtractdom \var{utxo}) \cup \outs{tx}}  \\
-        \varUpdate{\var{deposits} + \var{depositChange}} \\
-        \varUpdate{\var{fees} + \txfee{tx} + \var{decayed}} \\
-      \end{array}
-      \right)
-    }
-  \end{equation}
-  \caption{UTxO inference rules}
-  \label{fig:rules:utxo-multi-sig}
-\end{figure}
-
-In order to work with the new types, some function definitions
-of~\cite{shelley_formal_spec} have to be adapted. In particular,
-$\fun{witsNeeded}$ will use $\fun{txinsVKey}$ instead of the original
-$\fun{txins}$ function. The function $\fun{consumed}$ is adapted as shown in
-Figure~\ref{fig:functions:multi-sig-utxo}, restricting the domain of the $utxo$
-to the union of the inputs of $\fun{txinsVKey}~tx$ and $\fun{txinsScript}~tx$.
-
-\begin{figure}[htb]
-  \begin{align*}
-    & \fun{consumed} \in \PParams \to \UTxO \to \StakeKeys \to \Wdrl \to \Tx \to \Coin
-    & \text{value consumed} \\
-    & \consumed{pp}{utxo}{stkeys}{rewards}~{tx} = \\
-    & ~~\ubalance{(\fun{txinsVKey}~{tx} \cup \dom (\fun{txinsScript}~{tx})\restrictdom \var{utxo})} +
-      \fun{wbalance}~(\fun{txwdrls}~{tx}) \\
-    & ~~~~ + \keyRefunds{pp}{stkeys}{tx} \\
-  \end{align*}
-
-  \caption{Functions used in UTxO rules}
-  \label{fig:functions:multi-sig-utxo}
 \end{figure}
 
 \section{Alternative Implementation}

--- a/shelley/chain-and-ledger/formal-spec/multi-sig.tex
+++ b/shelley/chain-and-ledger/formal-spec/multi-sig.tex
@@ -498,11 +498,12 @@ when $hkeys$ is a value of type $\type{MultiSig}$.
 \end{figure*}
 
 Figure~\ref{fig:defs:functions-txins} shows the helper functions
-$\fun{txinsVKey}$ and $\fun{txinsScript}$ which split the transaction inputs of
-the transaction into those that are locked with a private key and those that are
-locked via a script. The helper function $\fun{validators}$ constructs a map
-from transaction inputs to scripts where for each input, the corresponding
-output of the UTxO can only be spent if the script validates the transaction.
+$\fun{txinsVKey}$ and $\fun{txinsScript}$ which partition the set of transaction
+inputs of the transaction into those that are locked with a private key and
+those that are locked via a script. The helper function $\fun{validators}$
+constructs a map from transaction inputs to scripts where for each input, the
+corresponding output of the UTxO can only be spent if the script validates the
+transaction.
 
 \section{Ledger Transition for Multi-Signature}
 \label{sec:ledg-trans-multi}
@@ -614,6 +615,13 @@ verifyCases script cases =
 The appendix~\ref{sec:native-multi-sign} provides some example of how this
 scheme can be used. The intention is to have an alternative in the case for
 whenever the simple Plutus script integration would not be viable.
+
+The integration would follow the same approach as outlined for Plutus scripts in
+Sections~\ref{sec:types} and \ref{sec:ledg-trans-multi}. First, a new type of
+address is introduced which holds the hash of the necessary information about
+how an output can be unlocked. Then, a new witness type is defined and added to
+the transaction type definition. After that, the STS rule UTXOW is extended with
+the validation of the new witnesses.
 
 \section{Summary}
 \label{sec:summary}

--- a/shelley/chain-and-ledger/formal-spec/multi-sig.tex
+++ b/shelley/chain-and-ledger/formal-spec/multi-sig.tex
@@ -267,8 +267,7 @@ ledger. The main changes are the following:
 
 \begin{itemize}
 \item Add a new address type that for outputs locked by scripts.
-\item Pair transaction inputs in a transaction with an optional validator
-  script for outputs locked by a script.
+\item Add a new witness type to the transaction.
 \item Adapt the transaction validation in such a way that funds locked by a
   multi-signature script can be spent.
 \item Adapt the functions used in the validation for the extended types of
@@ -343,10 +342,11 @@ required signatures for a specific unspent transaction output.
 \end{figure*}
 
 In Figure~\ref{fig:types-scripts} the $\Addr$ type of~\cite{shelley_formal_spec}
-is extended to also include script addresses. This new script address contains
-the hash of the validator script. In accordance with the extended UTxO
-specification of Plutus~\cite{plutus_eutxo}, the producer signs the script when
-creating and the consumer provides it later when spending the output.
+is changed to include both public key and script addresses, split into the
+sub-types $\AddrVKey$ and $\AddrScr$. The new script addresses contain the hash
+of the validator script. In accordance with the extended UTxO specification of
+Plutus~\cite{plutus_eutxo}, the producer signs the script when creating and the
+consumer provides it later when spending the output.
 
 A transaction output that is locked by a script carries the hash of the
 validator script. The output can only be spent if the matching script is
@@ -359,13 +359,13 @@ locked funds in staking, as well as \emph{base} and \emph{pointer} script
 address sub-types which allow for staking in the same way as $\AddrVKeyB$ and
 $\AddrVKeyP$.
 
-The $\fun{hashScript}$ function calculates the hash of a script. The accessor
-function $\fun{validatorHash}$ returns the hash of a script of a script address,
-or $\Nothing$ in case of a non-script address. The accessor function
-$\fun{paymentHK}$ is changed to return an optional hash key now, as script
-addresses do not carry hash keys. The domains of the accessor functions
-$\fun{stakeHK_b}$ and $\fun{addrPtr}$ are extended to also include the
-respective script address variants.
+The $\fun{hashScript}$ function calculates the hash of a script by serializing
+and then hashing it. The accessor function $\fun{validatorHash}$ returns the
+hash of a script of a script address, or $\Nothing$ in case of a non-script
+address. The domain of the accessor function $\fun{paymentHK}$ is changed to
+pubkey addresses. The domains of the accessor functions $\fun{stakeHK_b}$ and
+$\fun{addrPtr}$ are extended to also include the respective script address
+variants.
 
 \begin{figure*}[hbt]
   \emph{Abstract Type}
@@ -411,13 +411,11 @@ respective script address variants.
   \label{fig:types_defs_multi}
 \end{figure*}
 
-In Figure~\ref{fig:types_defs_multi} the type for the transaction body
-from~\cite{shelley_formal_spec} is extended to optionally carry a validator
-script for an unspent output that is locked by a script and should be spent in
-the transaction.
-
-The new script addresses also require a new type of witness. The former
-$\fun{txwits}$ is renamed to $\fun{txwitsVKey}$. The new function
+In Figure~\ref{fig:types_defs_multi} the type of a transaction
+from~\cite{shelley_formal_spec} is extended to carry an additional witness
+type. This is achieved by explicitly defining $\TxWitness$ as a type of the form
+of a pair of pubkey witnesses and a set of scripts. The former accessor function
+$\fun{txwits}$ is renamed to $\fun{txwitsVKey}$. The new accessor function
 $\fun{txwitsScript}$ returns the set of all validator scripts of a
 transaction. All scripts in this set need to validate the transaction in order
 for it to be accepted.
@@ -427,8 +425,8 @@ information contains the set of keys that signed the transaction. The function
 $\fun{txPending}$ constructs the necessary information about a transaction
 which can be passed as value of type $\PendingTx$ to the validator script.
 
-In order to spend funds locked by a multi-signature script, the validator script
-need to validate the transaction. The abstract function $\fun{validate}$
+In order to spend funds locked by a multi-signature script, the validator
+scripts need to validate the transaction. The abstract function $\fun{validate}$
 corresponds to such a validator script. Its type consists of two parameters of
 unit type and one parameter of type $\PendingTx$; its return type is also
 unit. The first two input parameters correspond to the redeemer and the data
@@ -436,9 +434,12 @@ scripts which are used in the full extended UTxO model for
 Plutus~\cite{plutus_eutxo}. As those values are not required for simple
 multi-signature, we the unit type for them. The unit return type signifies that
 there is no data to return. Plutus uses an ``error'' state to represent a failed
-validation. Despite that, we will use the validate function as a predicate where
-\emph{False} corresponds to the Plutus error state and \emph{True} to the unit
-return result.
+validation.
+
+The function $\fun{interpreteScript}$ takes a script and a $\PendingTx$ value,
+evaluates the script and returns a Boolean result. We will use this function as
+a predicate where \emph{False} corresponds to the Plutus error state and
+\emph{True} to the unit return result.
 
 The following is a possible Plutus implementation of a simple $n$ out of $m$
 multi-signature validation script. The type $\type{MultiSig}$ is a list of keys
@@ -496,31 +497,37 @@ when $hkeys$ is a value of type $\type{MultiSig}$.
   \label{fig:defs:functions-txins}
 \end{figure*}
 
-Figure~\ref{fig:defs:functions-txins} shows the functions $\fun{txinsVKey}$ and
-$\fun{txinsScript}$ which split the transaction inputs of the transaction into
-those that are locked with a private key and those that are locked via a script.
+Figure~\ref{fig:defs:functions-txins} shows the helper functions
+$\fun{txinsVKey}$ and $\fun{txinsScript}$ which split the transaction inputs of
+the transaction into those that are locked with a private key and those that are
+locked via a script. The helper function $\fun{validators}$ constructs a map
+from transaction inputs to scripts where for each input, the corresponding
+output of the UTxO can only be spent if the script validates the transaction.
 
 \section{Ledger Transition for Multi-Signature}
 \label{sec:ledg-trans-multi}
 
 The main change for the ledger transitions when using script based
-multi-signature is the validation of the UTXOW and UTXO transitions
-of~\cite{shelley_formal_spec}.
-
-The extended transition system for UTxOW is shown in
+multi-signature is the validation of the UTXOW transition
+of~\cite{shelley_formal_spec}. Its extended transition system is shown in
 Figure~\ref{fig:rules:utxow-multi-sig}, in the format described
 in~\cite{small_step_semantics}. The constraint on the set of required witnesses
 is relaxed in such a way that ``redundant'' signatures can be supplied in the
 transaction. The complete set of verification keys is then passed to
 $\fun{validate}$ as part of $pendingTx$ when validating all supplied scripts.
-We also check that no input from $\fun{txinsVKey}~tx$ tries to spend an output
-locked by a script.
 
-The set of all validator scripts of $\fun{txinsScript~tx}$ is checked for:
+The set of all validator scripts of $\fun{txinsScript~(\fun{txins}~tx})$ is
+checked for:
 \begin{itemize}
-\item the script hash being equal to the hash stored in the output to spent and
+\item the script hash being equal to the hash stored in the output to spent
+  (done in the function $\fun{validators}$) and
 \item the validator script validating the transaction.
 \end{itemize}
+
+We also check that the size of the set of spent outputs locked by a script is
+equal to the elements of the inputs for which we have a validator
+script. Overall that means that for each spent output we have one signature or
+one validation script.
 
 \begin{figure}[htb]
   \begin{equation*}
@@ -531,6 +538,10 @@ The set of all validator scripts of $\fun{txinsScript~tx}$ is checked for:
       \forall \var{inp}\mapsto\var{validator} \in
       \fun{validators}~(\fun{txinsScript}~(\fun{txins}~tx))~utxo~(\fun{txwitsScript}~tx),
       \\ \fun{interpreteScript}~validator~(\fun{pendingTx}~tx)
+      \\~\\
+      \vert
+      \fun{validators}~(\fun{txinsScript}~(\fun{txins}~tx))~utxo~(\fun{txwitsScript}~tx)
+      \vert = \vert \fun{txinsScript}~(\fun{txins}~tx)~utxo\vert
       \\~\\
       \forall \var{vk} \mapsto \sigma \in \txwitsVKey{tx},
       \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma} \\


### PR DESCRIPTION
simplify definitions as now a partition of `txins` is used 