### PR TITLE
Restructure multi-sig example

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/multi-sig.tex
+++ b/shelley/chain-and-ledger/formal-spec/multi-sig.tex
@@ -602,10 +602,6 @@ evalMultiSigScript (SingleSig vkh) vkhs =
 evalMultiSigScript (MultiSig m ts) vkhs =
     sum [ if evalMultiSigScript t vkhs then 1 else 0 | t <- ts ] >= m
 
-
-mkVKeyHashSet :: [Int] -> Set VKeyHash
-mkVKeyHashSet = Set.fromList . map VKeyHash
-
 verifyCases :: MultiSigScript -> [(Set VKeyHash, Bool)] -> Bool
 verifyCases script cases =
     and [ evalMultiSigScript script keyset == expected
@@ -658,6 +654,9 @@ library, it can be pursued instead.
 \label{sec:native-multi-sign}
 
 \begin{verbatim}
+mkVKeyHashSet :: [Int] -> Set VKeyHash
+mkVKeyHashSet = Set.fromList . map VKeyHash
+
 example1Of2 =
   MultiSig 1 [SingleSig (VKeyHash 1), SingleSig (VKeyHash 2)]
 

--- a/weekly-reports/2019-05-31/milestone.org
+++ b/weekly-reports/2019-05-31/milestone.org
@@ -22,4 +22,4 @@
     CLOSED: [2019-05-23 Thu 10:22]
  - [X] Issue #485
 *** Add Duncan's example as script-like DSL alternative
- - [ ] Issue #498
+ - [X] Issue #498


### PR DESCRIPTION
moves `mkVKeyHashSet` helper function to appendix