### PR TITLE
[477] Add Initial State rules for delegation to the Byron spec

### DIFF
--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -50,7 +50,7 @@
 
 \begin{figure}[htb]
   \begin{equation}
-    \label{eq:rule:delegation-interface}
+    \label{eq:rule:delegation-interface-init}
     \inference
     {
       {\left(\begin{array}{l}
@@ -59,18 +59,18 @@
         s
       \end{array}\right)}
       \vdash
-      \trans{sdeleg}{}
+      \trans{\hyperref[eq:sdeleg-bootstrap]{sdeleg}}{}
       {\left(
         \begin{array}{l}
-          \epsilon\\
-          \emptyset
+          \var{sds_0}\\
+          \var{eks_0}
         \end{array}
       \right)}
       &
       {
         \mathcal{K}
         \vdash
-        \trans{adeleg}{}
+        \trans{\hyperref[eq:adeleg-bootstrap]{adeleg}}{}
         \left(
           \begin{array}{l}
             \var{dms_0}\\
@@ -92,8 +92,8 @@
           \begin{array}{l}
             \var{dms_0}\\
             \var{dws_0}\\
-            \epsilon\\
-            \emptyset
+            \var{sds_0}\\
+            \var{eks_0}
           \end{array}
         \right)
       }

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -53,6 +53,57 @@
     \label{eq:rule:delegation-interface}
     \inference
     {
+      {\left(\begin{array}{l}
+       \mathcal{K}\\
+        e\\
+        s
+      \end{array}\right)}
+      \vdash
+      \trans{sdeleg}{}
+      {\left(
+        \begin{array}{l}
+          \epsilon\\
+          \emptyset
+        \end{array}
+      \right)}
+      &
+      {
+        \mathcal{K}
+        \vdash
+        \trans{adeleg}{}
+        \left(
+          \begin{array}{l}
+            \var{dms_0}\\
+            \var{dws_0}
+          \end{array}
+        \right)
+      }
+    }
+    {
+      {\left(\begin{array}{l}
+         \mathcal{K} \\
+         e\\
+         s
+      \end{array}\right)}
+      \vdash
+      \trans{deleg}{}
+      {
+        \left(
+          \begin{array}{l}
+            \var{dms_0}\\
+            \var{dws_0}\\
+            \epsilon\\
+            \emptyset
+          \end{array}
+        \right)
+      }
+    }
+  \end{equation}
+  \nextdef
+  \begin{equation}
+    \label{eq:rule:delegation-interface}
+    \inference
+    {
       d \leteq 2 \cdot k \\
       {\left(\begin{array}{l}
          \mathcal{K} \\

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -27,7 +27,7 @@ There are several restrictions on a certificate posted on the blockchain:
 \end{enumerate}
 These conditions are formalized in \cref{fig:rules:delegation-scheduling}.
 Rule~\ref{eq:rule:delegation-scheduling} determines when a certificate can
-become ``scheduled''. The definitions used in this rules are presented in
+become ``scheduled''. The definitions used in these rules are presented in
 \cref{fig:defs:delegation-scheduling}, and the types of the system induced by
 $\trans{sdeleg}{\wcard}$ are presented in
 \cref{fig:ts-types:delegation-scheduling}. Here and in the remaining rules we

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -114,6 +114,9 @@ parameter.
     \label{eq:sdeleg-bootstrap}
     \inference
     {
+      \var{sds_0} \leteq \epsilon
+      &
+      \var{eks_0} \leteq \emptyset
     }
     {
       {\left(\begin{array}{l}
@@ -125,8 +128,8 @@ parameter.
       \trans{sdeleg}{}
       \left(
         \begin{array}{l}
-          \epsilon\\
-          \emptyset
+          \var{sds_0}\\
+          \var{eks_0}
         \end{array}
       \right)
     }
@@ -334,7 +337,7 @@ delegations have on the ledger.
     \inference
     {
       {\begin{array}{l}
-         delegEnv
+         \var{delegEnv}
       \end{array}}
       \vdash
       \trans{\hyperref[eq:sdeleg-bootstrap]{sdeleg}}{}
@@ -344,7 +347,7 @@ delegations have on the ledger.
     }
     {
       {\begin{array}{l}
-         delegEnv
+         \var{delegEnv}
       \end{array}}
       \vdash
       \trans{sdelegs}{}
@@ -377,7 +380,7 @@ delegations have on the ledger.
       \trans{sdelegs}{\Gamma}
       \var{delegSt'}
       &
-      delegEnv
+      \var{delegEnv}
       \vdash
       \var{delegSt'}
       \trans{\hyperref[fig:rules:delegation-scheduling]{sdeleg}}{c}
@@ -400,7 +403,7 @@ delegations have on the ledger.
     \inference
     {
       {\begin{array}{l}
-         delegEnv
+         \var{delegEnv}
       \end{array}}
       \vdash
       \trans{\hyperref[eq:adeleg-bootstrap]{adeleg}}{}
@@ -410,7 +413,7 @@ delegations have on the ledger.
     }
     {
       {\begin{array}{l}
-         delegEnv
+         \var{delegEnv}
       \end{array}}
       \vdash
       \trans{adelegs}{}

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -111,6 +111,7 @@ parameter.
 
 \begin{figure}[htb]
   \begin{equation}
+    \label{eq:sdeleg-bootstrap}
     \inference
     {
     }
@@ -121,6 +122,7 @@ parameter.
         s
       \end{array}\right)}
       \vdash
+      \trans{sdeleg}{}
       \left(
         \begin{array}{l}
           \epsilon\\
@@ -250,6 +252,7 @@ delegation certificate (Rule~\ref{eq:rule:delegation-nop}).
 
 \begin{figure}[htb]
   \begin{equation}
+    \label{eq:adeleg-bootstrap}
     \inference
     {
       \var{dms_0} \leteq \Set{k \mapsto k}{k \in \mathcal{K}} &
@@ -258,6 +261,7 @@ delegation certificate (Rule~\ref{eq:rule:delegation-nop}).
     {
       \mathcal{K}
       \vdash
+      \trans{adeleg}{}
       \left(
         \begin{array}{l}
           \var{dms_0}\\
@@ -329,19 +333,23 @@ delegations have on the ledger.
   \begin{equation}
     \inference
     {
+      {\begin{array}{l}
+         delegEnv
+      \end{array}}
+      \vdash
+      \trans{\hyperref[eq:sdeleg-bootstrap]{sdeleg}}{}
+      \left(
+        \var{delegSt}
+      \right)
     }
     {
-      {\left(\begin{array}{l}
-       \mathcal{K}\\
-        e\\
-        s
-      \end{array}\right)}
+      {\begin{array}{l}
+         delegEnv
+      \end{array}}
       \vdash
+      \trans{sdelegs}{}
       \left(
-        \begin{array}{l}
-          \epsilon\\
-          \emptyset
-        \end{array}
+        \var{delegSt}
       \right)
     }
   \end{equation}
@@ -349,32 +357,13 @@ delegations have on the ledger.
   \begin{equation}
     \label{eq:rule:delegation-scheduling-seq-base}
     \inference
+    {}
     {
-    }
-    {
-      {\left(\begin{array}{l}
-         \mathcal{K} \\
-         e\\
-         s\\
-       \end{array}\right)}
+      \var{delegEnv}
       \vdash
-      {
-        \left(
-          \begin{array}{l}
-            \var{sds}\\
-            \var{eks}
-          \end{array}
-        \right)
-      }
+      \var{delegSt}
       \trans{sdelegs}{\epsilon}
-      {
-        \left(
-          \begin{array}{l}
-            \var{sds}\\
-            \var{eks}
-          \end{array}
-        \right)
-      }
+      \var{delegSt}
     }
   \end{equation}
   \nextdef
@@ -382,78 +371,24 @@ delegations have on the ledger.
     \label{eq:rule:delegation-scheduling-seq-ind}
     \inference
     {
-      {\left(\begin{array}{l}
-         \mathcal{K} \\
-         e\\
-         s
-       \end{array}\right)}
+      \var{delegEnv}
       \vdash
-      {
-        \left(
-          \begin{array}{l}
-            \var{sds}\\
-            \var{eks}
-          \end{array}
-        \right)
-      }
+      \var{delegSt}
       \trans{sdelegs}{\Gamma}
-      {
-        \left(
-          \begin{array}{l}
-            \var{sds'}\\
-            \var{eks'}
-          \end{array}
-        \right)
-      }
+      \var{delegSt'}
       &
-      {\left(\begin{array}{l}
-         \mathcal{K} \\
-         e\\
-         s
-       \end{array}\right)}
+      delegEnv
       \vdash
-      {
-        \left(
-          \begin{array}{l}
-            \var{sds'}\\
-            \var{eks'}
-          \end{array}
-        \right)
-      }
+      \var{delegSt'}
       \trans{\hyperref[fig:rules:delegation-scheduling]{sdeleg}}{c}
-      {
-        \left(
-          \begin{array}{l}
-            \var{sds''}\\
-            \var{eks''}
-          \end{array}
-        \right)
-      }
+      \var{delegSt''}
     }
     {
-      {\left(\begin{array}{l}
-         \mathcal{K} \\
-         e\\
-         s
-       \end{array}\right)}
+      \var{delegEnv}
       \vdash
-      {
-        \left(
-          \begin{array}{l}
-            \var{sds}\\
-            \var{eks}
-          \end{array}
-        \right)
-      }
+      \var{delegSt}
       \trans{sdelegs}{\Gamma; c}
-      {
-        \left(
-          \begin{array}{l}
-            \var{sds''}\\
-            \var{eks''}
-          \end{array}
-        \right)
-      }
+      \var{delegSt''}
     }
   \end{equation}
   \caption{Delegation scheduling sequence rules}
@@ -464,17 +399,23 @@ delegations have on the ledger.
   \begin{equation}
     \inference
     {
-      \var{dms_0} \leteq \Set{\var{vk} \mapsto \var{vk}}{\var{vk} \in \mathcal{K}} &
-      \var{dws_0} \leteq \Set{\var{vk} \mapsto 0}{\var{vk} \in \mathcal{K}}
+      {\begin{array}{l}
+         delegEnv
+      \end{array}}
+      \vdash
+      \trans{\hyperref[eq:adeleg-bootstrap]{adeleg}}{}
+      \left(
+        \var{delegSt}
+      \right)
     }
     {
-      \mathcal{K}
+      {\begin{array}{l}
+         delegEnv
+      \end{array}}
       \vdash
+      \trans{adelegs}{}
       \left(
-        \begin{array}{l}
-          \var{dms_0}\\
-          \var{dws_0}
-        \end{array}
+        \var{delegSt}
       \right)
     }
   \end{equation}
@@ -482,28 +423,13 @@ delegations have on the ledger.
   \begin{equation}
     \label{eq:rule:delegation-seq-base}
     \inference
+    {}
     {
-    }
-    {
-      \mathcal{K}
+      \var{delegEnv}
       \vdash
-      {
-        \left(
-          \begin{array}{l}
-            \var{dms}\\
-            \var{dws}
-          \end{array}
-        \right)
-      }
+      \var{delegSt}
       \trans{adelegs}{\epsilon}
-      {
-        \left(
-          \begin{array}{l}
-            \var{dms}\\
-            \var{dws}
-          \end{array}
-        \right)
-      }
+      \var{delegSt}
     }
   \end{equation}
   \nextdef
@@ -511,66 +437,24 @@ delegations have on the ledger.
     \label{eq:rule:delegation-seq-ind}
     \inference
     {
-      \mathcal{K}
+      \var{delegEnv}
       \vdash
-      {
-        \left(
-          \begin{array}{l}
-            \var{dms}\\
-            \var{dws}
-          \end{array}
-        \right)
-      }
+      \var{delegSt}
       \trans{adelegs}{\Gamma}
-      {
-        \left(
-          \begin{array}{l}
-            \var{dms'}\\
-            \var{dws'}
-          \end{array}
-        \right)
-      }
+      \var{delegSt'}
       &
-      \mathcal{K}
+      \var{delegEnv}
       \vdash
-      {
-        \left(
-          \begin{array}{l}
-            \var{dms'}\\
-            \var{dws'}
-          \end{array}
-        \right)
-      }
+      \var{delegSt'}
       \trans{\hyperref[fig:rules:delegation]{adeleg}}{c}
-      {
-        \left(
-          \begin{array}{l}
-            \var{dms''}\\
-            \var{dws''}
-          \end{array}
-        \right)
-      }
+      \var{delegSt''}
     }
     {
-      \mathcal{K}
+      \var{delegEnv}
       \vdash
-      {
-        \left(
-          \begin{array}{l}
-            \var{dms}\\
-            \var{dws}
-          \end{array}
-        \right)
-      }
+      \var{delegSt}
       \trans{adelegs}{\Gamma; c}
-      {
-        \left(
-          \begin{array}{l}
-            \var{dms''}\\
-            \var{dws''}
-          \end{array}
-        \right)
-      }
+      \var{delegSt''}
     }
   \end{equation}
   \caption{Delegations sequence rules}

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -341,9 +341,7 @@ delegations have on the ledger.
       \end{array}}
       \vdash
       \trans{\hyperref[eq:sdeleg-bootstrap]{sdeleg}}{}
-      \left(
-        \var{delegSt}
-      \right)
+      \var{delegSt}
     }
     {
       {\begin{array}{l}
@@ -351,9 +349,7 @@ delegations have on the ledger.
       \end{array}}
       \vdash
       \trans{sdelegs}{}
-      \left(
-        \var{delegSt}
-      \right)
+      \var{delegSt}
     }
   \end{equation}
   \nextdef
@@ -407,9 +403,7 @@ delegations have on the ledger.
       \end{array}}
       \vdash
       \trans{\hyperref[eq:adeleg-bootstrap]{adeleg}}{}
-      \left(
-        \var{delegSt}
-      \right)
+      \var{delegSt}
     }
     {
       {\begin{array}{l}
@@ -417,9 +411,7 @@ delegations have on the ledger.
       \end{array}}
       \vdash
       \trans{adelegs}{}
-      \left(
-        \var{delegSt}
-      \right)
+      \var{delegSt}
     }
   \end{equation}
   \nextdef

--- a/byron/ledger/formal-spec/frontmatter.tex
+++ b/byron/ledger/formal-spec/frontmatter.tex
@@ -25,7 +25,7 @@
 \maketitle
 
 \begin{abstract}
-  This documents defines the rules for extending a ledger with transactions, as
+  This document defines the rules for extending a ledger with transactions, as
   implemented in the Byron release of the Cardano Ledger. It is intended to
   serve as the specification for random generators of transactions which adhere
   to the rules presented here.

--- a/byron/ledger/formal-spec/properties.tex
+++ b/byron/ledger/formal-spec/properties.tex
@@ -26,7 +26,7 @@ described in \cite{small_step_semantics}.
   \item For all $e \in \Gamma$, $s \in S$, $(e, s, \epsilon, s)$ is a valid
     trace of $L$.
 
-  \item If $(e, s, \txs s')$ is a valid trace, and
+  \item If $(e, s, \txs, s')$ is a valid trace, and
     $e \vdash s' \trans{}{\var{t}} s''$ is a valid transition according to the
     rules of $L$, then $(e, s, \txs; t, s'')$ is also a valid trace.
   \end{itemize}

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -287,7 +287,7 @@ The rules in Figure~\ref{fig:rules:up-validity} model the validity of a proposal
 \end{itemize}
 Note that the rules in Figure~\ref{fig:rules:up-validity} allow for an update
 that does not propose changes in the protocol version, or does not propose
-changes the software version. However the update proposal must contain a change
+changes to the software version. However the update proposal must contain a change
 proposal in any of these two aspects.
 %
 Also note that we do not allow for updating the protocol parameters without
@@ -1031,7 +1031,7 @@ Figure~\ref{fig:ts-types:up-end} shows the types of the transition system
 associated with the registration of candidate protocol versions present in
 blocks. Some clarifications are in order:
 \begin{itemize}
-\item The $k$ parameter is used to determined when a confirmed proposal is
+\item The $k$ parameter is used to determine when a confirmed proposal is
   stable. Given we are in a current slot $s_n$, all update proposals confirmed
   at or before slot $s_n - 2 \cdot k$ are deemed stable.
 \item For the sake of conciseness, we omit the types associated to the
@@ -1089,7 +1089,7 @@ rule by $\var{bv}$:
   %
   Note that before the decentralized era we do not count the total number nodes
   that are ready to upgrade to a new protocol version, but we count only nodes
-  that are delegated by a genesis key. This allow us to implement a simple
+  that are delegated by a genesis key. This allows us to implement a simple
   update mechanism while we transition to the decentralized era, where we will
   incorporate the results of ongoing research on a decentralized update
   mechanism.
@@ -1396,8 +1396,7 @@ constraint:
 \begin{itemize}
 \item Genesis keys are controlled by the Cardano foundation.
 \item Even if a genesis key falls in the hands of the adversary, only one
-  update proposal can be submitted per-block, and proposals have an time to
-  live of $u$ blocks. So in the worst case scenario we are looking at an
+  update proposal can be submitted per-block, and proposals have a time to live of $u$ blocks. So in the worst case scenario we are looking at an
   increase in the state size of the ledger proportional to $u$.
 \end{itemize}
 On the other hand, having that constraint in place brings some extra complexity
@@ -1407,7 +1406,7 @@ then if an amendment must be made within the current epoch, then a new update
 proposal must be submitted with a different key, which adds extra complexity
 for devops. In light of the preceding discussion, unless there is a benefit for
 restricting the number of times a genesis key can submit an update proposal, we
-opted for removing such constraint in the current specification.
+opted for removing such a constraint in the current specification.
 
 \subsubsection{Acceptance of blocks endorsing unconfirmed proposal updates}
 \label{sec:acceptance-of-uncofirmed-up-endorsements}
@@ -1415,7 +1414,7 @@ opted for removing such constraint in the current specification.
 A consequence of enforcing the update rules in \cref{fig:rules:up-end} is that
 a block that is endorsing an unconfirmed proposal gets accepted, although it
 will not have any effect on the update mechanism. It is not clear at this stage
-whether such block should be rejected, therefore we have chosen to be lenient.
+whether such a block should be rejected, therefore we have chosen to be lenient.
 
 \subsubsection{Only genesis keys are counted for endorsement}
 \label{sec:only-genesis-keys-count-for-endorsement}

--- a/byron/ledger/formal-spec/utxo.tex
+++ b/byron/ledger/formal-spec/utxo.tex
@@ -366,7 +366,7 @@ here is arbitrary.
 \label{sec:transaction-seqs}
 
 \cref{fig:rules:utxow-seq} models the application of a sequence of
-transactions. For the sake of concison we omit the types of this transition
+transactions. For the sake of concision we omit the types of this transition
 system, since they are the same as the ones of $\trans{utxow}{}$.
 
 \begin{figure}[htb]


### PR DESCRIPTION
Edits the Byron Ledger spec - adds initial rules for delegation (initial rules already exist for other parts of the spec) - where possible, refer to existing init rules

Issue: https://github.com/input-output-hk/cardano-ledger-specs/issues/477

<img width="861" alt="FIG 14 b" src="https://user-images.githubusercontent.com/8812/58472807-5fb6fe00-8147-11e9-9cc4-cd2580f8481e.png">
<img width="675" alt="FIG 17" src="https://user-images.githubusercontent.com/8812/58465543-39d62d00-8138-11e9-92ea-d48e8b51aed3.png">
<img width="676" alt="FIG 18" src="https://user-images.githubusercontent.com/8812/58465664-773aba80-8138-11e9-93fd-31dc546f7593.png">
<img width="676" alt="FIG 19" src="https://user-images.githubusercontent.com/8812/58465768-a7825900-8138-11e9-9ba1-9582536d1d30.png">
<img width="887" alt="FIG 36 b" src="https://user-images.githubusercontent.com/8812/58472818-680f3900-8147-11e9-9e1e-9395fb49e110.png">
