### PR TITLE
Fix adoption threshold rules

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -89,8 +89,8 @@ instance STS CHAIN where
                         , Map.empty
                         , Map.empty
                         , Map.empty
-                        , PairSet (Set.empty)
-                        , PairSet (Set.empty)
+                        , Set.empty
+                        , Set.empty
                         , Map.empty
                         )
         utxoSt0 <- trans @(UTXOWS TxId) $ IRC UTxOEnv {utxo0 = utxo0', pps = pps' }

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
@@ -12,7 +12,7 @@ import Control.State.Transition
 
 import Ledger.Core hiding ((|>))
 import Ledger.GlobalParams (k)
-import Ledger.Update
+import Ledger.Update hiding (NotADelegate)
 
 data SIGCNT
 

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -20,7 +20,7 @@ import Data.Monoid (Sum(..))
 import Data.Set (Set, isSubsetOf)
 import qualified Data.Set as Set
 import Data.Word (Word64)
-import Data.Foldable (toList)
+import Data.Foldable (toList, elem)
 import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
 
@@ -127,6 +127,19 @@ minusSlot (Slot m) (SlotCount n)
   | m <= n    = Slot 0
   | otherwise = Slot $ m - n
 
+-- | An alias for 'minusSlot'
+(-.) :: Slot -> SlotCount -> Slot
+(-.) = minusSlot
+
+infixl 6 -.
+
+-- | Multiply the block count by the given constant. This function does not
+-- check for overflow.
+(*.) :: Word64 -> BlockCount -> SlotCount
+n *. (BlockCount c) = SlotCount $ n * c
+
+infixl 7 *.
+
 -- | Subtract a slot count from a slot.
 --
 -- In case the slot count is greater than the slot's index, it returns
@@ -175,9 +188,6 @@ newtype Lovelace = Lovelace
 newtype PairSet a b = PairSet {unPairSet :: Set (a,b)}
   deriving (Eq, Semigroup, Show)
 
-psSize :: PairSet a b -> Int
-psSize = Set.size . unPairSet
-
 class Relation m where
   type Domain m :: *
   type Range m :: *
@@ -191,25 +201,51 @@ class Relation m where
 
   -- | Domain restriction
   --
-  (◁), (◃), (<|) :: (Ord (Domain m), Foldable f) => f (Domain m) -> m -> m
-  s ◃ r = s ◁ r
+  -- Unicode: 25c1
+  (◁), (<|) :: (Ord (Domain m), Foldable f) => f (Domain m) -> m -> m
   s <| r = s ◁ r
 
   -- | Domain exclusion
   --
+  -- Unicode: 22ea
   (⋪), (</|) :: (Ord (Domain m), Foldable f) => f (Domain m) -> m -> m
   s </| r = s ⋪ r
 
   -- | Range restriction
   --
-  (▹), (|>) :: Ord (Range m) => m -> Set (Range m) -> m
-  s |> r = s ▹ r
+  -- Unicode: 25b7
+  (▷), (|>) :: Ord (Range m) => m -> Set (Range m) -> m
+  s |> r = s ▷ r
 
   -- | Union
   (∪) :: (Ord (Domain m), Ord (Range m)) => m -> m -> m
 
   -- | Union Override
-  (⨃) :: (Ord (Domain m), Ord (Range m)) => m -> m -> m
+  (⨃) :: (Ord (Domain m), Ord (Range m), Foldable f) => m -> f (Domain m, Range m) -> m
+
+  -- | Restrict range to values less or equal than the given value
+  --
+  -- Unicode: 25b7
+  (▷<=) :: (Ord (Range m)) => m -> Range m -> m
+
+  infixl 5 ▷<=
+
+  -- | Size of the relation
+  size :: Integral n => m -> n
+
+-- | Alias for 'elem'.
+--
+-- Unicode: 2208
+(∈) :: (Eq a, Foldable f) => a -> f a -> Bool
+a ∈ f = elem a f
+
+-- | Alias for not 'elem'.
+--
+-- Unicode: 2209
+(∉) :: (Eq a, Foldable f) => a -> f a -> Bool
+a ∉ f = not $ elem a f
+
+infixl 4 ∉
 
 instance (Ord k, Ord v) => Relation (Bimap k v) where
   type Domain (Bimap k v) = k
@@ -221,14 +257,17 @@ instance (Ord k, Ord v) => Relation (Bimap k v) where
   range = Set.fromList . Bimap.elems
 
   s ◁ r = Bimap.filter (\k _ -> k `Set.member` toSet s) r
-  s ◃ r = s ◁ r
 
   s ⋪ r = Bimap.filter (\k _ -> k `Set.notMember` toSet s) r
 
-  r ▹ s = Bimap.filter (\_ v -> Set.member v s) r
+  r ▷ s = Bimap.filter (\_ v -> Set.member v s) r
 
   d0 ∪ d1 = Bimap.fold Bimap.insert d0 d1
-  d0 ⨃ d1 = d1 ∪ (dom d1 ⋪ d0)
+  d0 ⨃ d1 = foldr (uncurry Bimap.insert) d0 (toList d1)
+
+  r ▷<= vmax = Bimap.filter (\_ v -> v <= vmax) r
+
+  size = fromIntegral . Bimap.size
 
 instance Relation (Map k v) where
   type Domain (Map k v) = k
@@ -243,10 +282,16 @@ instance Relation (Map k v) where
 
   s ⋪ r = Map.filterWithKey (\k _ -> k `Set.notMember` toSet s) r
 
-  r ▹ s = Map.filter (flip Set.member s) r
+  r ▷ s = Map.filter (flip Set.member s) r
 
   d0 ∪ d1 = Map.union d0 d1
-  d0 ⨃ d1 = d1 ∪ (dom d1 ⋪ d0)
+  -- For union override we pass @d1@ as first argument, since 'Map.union' is
+  -- left biased.
+  d0 ⨃ d1 = Map.union (Map.fromList . toList $ d1) d0
+
+  r ▷<= vmax = Map.filter (<= vmax) r
+
+  size = fromIntegral . Map.size
 
 -- TODO: Remove `PairSet` and just use `Set (a, b)`?
 instance Relation (PairSet a b) where
@@ -262,12 +307,17 @@ instance Relation (PairSet a b) where
 
   s ⋪ r = PairSet . Set.filter (\(k,_) -> k `Set.notMember` toSet s) $ unPairSet r
 
-  r ▹ s = PairSet . Set.filter (\(_,v) -> Set.member v s) $ unPairSet r
+  r ▷ s = PairSet . Set.filter (\(_,v) -> Set.member v s) $ unPairSet r
 
   (PairSet d0) ∪ (PairSet d1) = PairSet $ Set.union d0 d1
 
-  d0 ⨃ d1 = d1 ∪ ((dom d1) ⋪ d0)
+  d0 ⨃ d1 = d1' ∪ ((dom d1') ⋪ d0)
+    where
+      d1' = PairSet $ toSet d1
 
+  r ▷<= vmax = PairSet . Set.filter ((<= vmax) . snd) $ unPairSet r
+
+  size = fromIntegral . Set.size . unPairSet
 
 ---------------------------------------------------------------------------------
 -- Aliases
@@ -275,7 +325,7 @@ instance Relation (PairSet a b) where
 
 -- | Inclusion among foldables.
 --
--- Unicode: 2286.
+-- Unicode: 2286
 --
 (⊆) :: (Foldable f, Foldable g, Ord a) => f a -> g a -> Bool
 x ⊆ y = toSet x `isSubsetOf` toSet y

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -357,8 +357,8 @@ instance STS ADELEG where
           Nothing -> True ?! BeforeExistingDelegation
           Just sp -> sp < slt ?! BeforeExistingDelegation
         return $ st
-          & delegationMap %~ (\sdm -> sdm ⨃ Bimap.singleton vks vkd)
-          & lastDelegation %~ (\ldm -> ldm ⨃ Map.singleton vks slt)
+          & delegationMap %~ (\sdm -> sdm ⨃ [(vks, vkd)])
+          & lastDelegation %~ (\ldm -> ldm ⨃ [(vks, slt)])
     , do
         (TRC (_env, st, (slt, (vks, _vkd)))) <- judgmentContext
         case Map.lookup vks (st ^. lastDelegation) of

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -3,10 +3,12 @@
 module Ledger.GlobalParams
   ( k
   , lovelaceCap
+  , ngk
   )
 where
 
 import Data.Int (Int64)
+import Data.Word (Word64)
 
 import Ledger.Core (BlockCount (BlockCount), Lovelace (Lovelace))
 
@@ -21,3 +23,7 @@ k = BlockCount 2160
 -- | Constant amount of Lovelace in the system.
 lovelaceCap :: Lovelace
 lovelaceCap = Lovelace $ 45 * fromIntegral ((10 :: Int64) ^ (15 :: Int64))
+
+-- | Number of genesis keys
+ngk :: Word64
+ngk = 7

--- a/byron/ledger/executable-spec/src/Ledger/UTxO/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO/Generators.hs
@@ -46,10 +46,10 @@ genTraverseSubsequence genA as =
 
 -- | Generate a list using 'genTraverseSubsequence'
 genList :: Range Int -> Gen a -> Gen [a]
-genList range gen = Gen.sized $ \size ->
-  ensure (atLeast $ Range.lowerBound size range) $ genTraverseSubsequence
+genList range gen = Gen.sized $ \gSize ->
+  ensure (atLeast $ Range.lowerBound gSize range) $ genTraverseSubsequence
     (const gen)
-    (replicate (Range.upperBound size range) ())
+    (replicate (Range.upperBound gSize range) ())
 
 -- | Temporarily defined here until hedgehog exposes this function
 interleaveTreeT :: Monad m => [TreeT m a] -> m (NodeT m [a])

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -33,7 +33,23 @@ import Numeric.Natural
 
 import Control.State.Transition
 
-import Ledger.Core (Relation(..), (⋪), (▹), (◃), (⨃), unSlot, HasHash, hash, PairSet(..), VKeyGenesis, VKey, BlockCount(..), Slot(..), minusSlotMaybe, SlotCount(..))
+import Ledger.Core
+  ( BlockCount(..)
+  , HasHash
+  , PairSet(..)
+  , Relation(..)
+  , Slot(..)
+  , SlotCount(..)
+  , VKey
+  , VKeyGenesis
+  , (⋪)
+  , (▹)
+  , (◃)
+  , (⨃)
+  , hash
+  , minusSlotMaybe
+  , unSlot
+  )
 import qualified Ledger.Core as Core
 import Ledger.Delegation (liveAfter)
 import qualified Ledger.GlobalParams as GP
@@ -566,8 +582,8 @@ instance STS UPEND where
             , (fads, bvs)
             , (bv, _vk)
             ) <- judgmentContext
-        case (Map.lookup bv (invertBijection $ fst <$> rpus)) of
-          Just pid -> do
+        case Map.lookup bv (invertBijection $ fst <$> rpus) of
+          Just pid ->
             pid `Map.notMember` (Map.filter (<= sn `Core.minusSlot` liveAfter GP.k) cps) ?! NotAFailure
           Nothing -> True ?! NotAFailure
         return $! (fads, bvs)
@@ -579,12 +595,10 @@ instance STS UPEND where
             ) <- judgmentContext
         case lookupR vk dms of
           Nothing  -> do
-            False ?! CannotAdopt -- md 2019-05-03: not sure what to
-                                 -- return/error on here
-            return $! (fads, bvs) -- a silly thing needed to get types line up
+            False ?! NotAFailure
+            return $! (fads, bvs)
           Just vks -> do
             let bvs' = bvs ∪ singleton bv vks
-            -- (not $ canAdopt pps bvs' bv) ?! CanAdopt
             Core.psSize (Set.singleton bv ◃ bvs) < (fromIntegral . unBlockCount) t ?! CanAdopt
             case (Map.lookup bv (invertBijection $ fst <$> rpus)) of
               Just pid -> do

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -83,7 +83,8 @@ data PParams = PParams -- TODO: this should be a module of @cs-ledger@.
   , _cfmThd :: Int -- TODO: this should be a double
   -- ^ Update proposal confirmation threshold (number of votes)
   , _upAdptThd :: Double
-  -- ^ Update adoption threshold (number of block issuers)
+  -- ^ Update adoption threshold: a proportion of block issuers that have to
+  -- endorse a given version to become candidate for adoption
   , _stableAfter :: Core.BlockCount
   -- ^ Chain stability parameter
   , _factorA :: Int
@@ -554,7 +555,7 @@ instance STS FADS where
 data UPEND
 
 -- | Find the key that corresponds to the value satisfying the given predicate.
--- In case more than one key is found this function returns Nothing.
+-- In case zero or more than one key is found this function returns Nothing.
 findKey :: (v -> Bool) -> Map k v -> Maybe (k, v)
 findKey p m =
   case Map.toList (Map.filter p m) of

--- a/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
@@ -69,7 +69,7 @@ pparamsGen =
     <*> slotBlockGen
     <*> Gen.integral (Range.linear (0 :: Natural) 1000) -- scriptVersion
     <*> Gen.integral (Range.linear 0 1000)              -- cfmThd
-    <*> Gen.double (Range.constant 0 1)               -- upAdptThd
+    <*> Gen.double (Range.constant 0 1)                 -- upAdptThd
     <*> pure 0                                          -- factor @a@
     <*> pure 0                                          -- factor @b@
  where

--- a/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
@@ -46,7 +46,7 @@ pparamsGen =
     ((bkSlotsPerEpoch, upTtl, stableAfter) :: (SlotCount, SlotCount, BlockCount))
     (scriptVersion :: Natural)
     (cfmThd :: Int)
-    (upAdptThd :: Int)
+    (upAdptThd :: Double)
     (factorA :: Int)
     (factorB :: Int)
     -> PParams
@@ -69,7 +69,7 @@ pparamsGen =
     <*> slotBlockGen
     <*> Gen.integral (Range.linear (0 :: Natural) 1000) -- scriptVersion
     <*> Gen.integral (Range.linear 0 1000)              -- cfmThd
-    <*> Gen.integral (Range.linear 1 100)               -- upAdptThd
+    <*> Gen.double (Range.constant 0 1)               -- upAdptThd
     <*> pure 0                                          -- factor @a@
     <*> pure 0                                          -- factor @b@
  where

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
@@ -46,10 +46,10 @@ deleg =
       .- (s 1, (gk 1, k 11)) .-> DState (Bimap.fromList [(gk 0, k 10), (gk 1, k 11)])
                                         [(gk 0, s 0), (gk 1, s 1)]
 
-      .- (s 2, (gk 0, k 11)) .-> DState (Bimap.fromList [(gk 0, k 11), (gk 1, k 11)])
+      .- (s 2, (gk 0, k 11)) .-> DState (Bimap.fromList [(gk 0, k 11)])
                                         [(gk 0, s 2), (gk 1, s 1)]
 
-      .- (s 3, (gk 2, k 12)) .-> DState (Bimap.fromList [(gk 0, k 11), (gk 1, k 11), (gk 2, k 12)])
+      .- (s 3, (gk 2, k 12)) .-> DState (Bimap.fromList [(gk 0, k 11), (gk 2, k 12)])
                                         [(gk 0, s 2), (gk 1, s 1), (gk 2, s 3)]
     ]
 

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -272,14 +272,14 @@ In these rules we make use of the abstract constant $\var{ngk}$, defined in
     \label{eq:rule:upi-reg-interface}
     \inference
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{pv}\\
           \var{pps}\\
           \var{avs}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -374,14 +374,14 @@ given application name $\var{an}$.
     \inference
     {
       \var{cfmThd} \mapsto q \in \var{pps}\\
-      {
+      {\left(
         \begin{array}{l}
           s_n\\
           q \cdot \var{ngk}\\
           \var{\dom~pws}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -817,7 +817,7 @@ expires.
       } &\var{pv} = \var{pv'}
     }
     {
-      s_n
+      (s_n)
       \vdash
       {
         \left(
@@ -880,7 +880,7 @@ expires.
       & \var{pv} \neq \var{pv'}
     }
     {
-      s_n
+      (s_n)
       \vdash
       {
         \left(

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -377,7 +377,7 @@ given application name $\var{an}$.
       {\left(
         \begin{array}{l}
           s_n\\
-          \ceil{q \cdot \var{ngk}}\\
+          \floor{q \cdot \var{ngk}}\\
           \var{\dom~pws}\\
           \var{dms}
         \end{array}
@@ -608,7 +608,7 @@ the end of an epoch.
       \left({
         \begin{array}{l}
           s_n\\
-          \ceil{q \cdot \var{ngk}}\\
+          \floor{q \cdot \var{ngk}}\\
           \var{dms}\\
           \var{cps}\\
           \var{rpus}

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -377,7 +377,7 @@ given application name $\var{an}$.
       {\left(
         \begin{array}{l}
           s_n\\
-          q \cdot \var{ngk}\\
+          \ceil{q \cdot \var{ngk}}\\
           \var{\dom~pws}\\
           \var{dms}
         \end{array}
@@ -608,7 +608,7 @@ the end of an epoch.
       \left({
         \begin{array}{l}
           s_n\\
-          q \cdot \var{ngk}\\
+          \ceil{q \cdot \var{ngk}}\\
           \var{dms}\\
           \var{cps}\\
           \var{rpus}

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -604,9 +604,11 @@ the end of an epoch.
     \label{eq:rule:upi-pend}
     \inference
     {
+      \var{upAdptThd} \mapsto q \in \var{pps} \\
       \left({
         \begin{array}{l}
           s_n\\
+          q \cdot \var{ngk}\\
           \var{dms}\\
           \var{cps}\\
           \var{rpus}
@@ -630,8 +632,7 @@ the end of an epoch.
           \end{array}
         \right)
       }\\
-      \var{upropTTL} \mapsto u \in \var{pps}
-      & \var{upAdptThd} \mapsto q \in \var{pps} \\
+      \var{upropTTL} \mapsto u \in \var{pps}\\
       {
         \begin{array}{r@{~\leteq~}l}
           \var{pids_{keep}} & \dom~(pws \restrictrange [s_n - u, ..]) \cup \dom~\var{cps}\\

--- a/byron/ledger/formal-spec/delegation.tex
+++ b/byron/ledger/formal-spec/delegation.tex
@@ -262,7 +262,9 @@ delegation certificate (Rule~\ref{eq:rule:delegation-nop}).
       \var{dws_0} \leteq \Set{k \mapsto 0}{k \in \mathcal{K}}
     }
     {
-      \mathcal{K}
+      \left(
+        \mathcal{K}
+      \right)
       \vdash
       \trans{adeleg}{}
       \left(
@@ -280,7 +282,7 @@ delegation certificate (Rule~\ref{eq:rule:delegation-nop}).
       \var{vk_d} \notin \range~\var{dms} & (\var{vk_s} \mapsto s_p \in \var{dws} \Rightarrow s_p < s)
     }
     {
-      \mathcal{K}
+      \left(\mathcal{K}\right)
       \vdash
       \left(
       \begin{array}{r}
@@ -303,7 +305,7 @@ delegation certificate (Rule~\ref{eq:rule:delegation-nop}).
     {\var{vk_d} \in \range~\var{dms} \vee (\var{vk_s} \mapsto s_p  \in \var{dws}  \wedge s \leq s_p)
     }
     {
-      \mathcal{K}
+      \left(\mathcal{K}\right)
       \vdash
       \left(
       \begin{array}{r}

--- a/byron/ledger/formal-spec/frontmatter.tex
+++ b/byron/ledger/formal-spec/frontmatter.tex
@@ -35,4 +35,4 @@
 \label{acknowledgements}
 
 Jared Corduan, Nicholas Clarke, Marko Dimjašević, Duncan Coutts, Ru Horlick,
-Michael Hueschen.
+Michael Hueschen, Ryan Lemmer.

--- a/byron/ledger/formal-spec/iohk.sty
+++ b/byron/ledger/formal-spec/iohk.sty
@@ -28,6 +28,11 @@
 \newcommand{\nextdef}{\\[1em]}
 \newcommand{\where}{~ ~ \mathbf{where}~ ~ }
 
+% Ceiling
+\usepackage{mathtools}
+\DeclarePairedDelimiter{\ceil}{\lceil}{\rceil}
+
+
 \newenvironment{question}
   {\begin{bclogo}[logo=\bcquestion, couleur=orange!10, arrondi=0.2]{ QUESTION}}
   {\end{bclogo}}

--- a/byron/ledger/formal-spec/iohk.sty
+++ b/byron/ledger/formal-spec/iohk.sty
@@ -31,6 +31,8 @@
 % Ceiling
 \usepackage{mathtools}
 \DeclarePairedDelimiter{\ceil}{\lceil}{\rceil}
+% Floor
+\DeclarePairedDelimiter{\floor}{\lfloor}{\rfloor}
 
 
 \newenvironment{question}

--- a/byron/ledger/formal-spec/notation.tex
+++ b/byron/ledger/formal-spec/notation.tex
@@ -61,6 +61,9 @@
   $\Lambda'; x \leteq \Lambda$ to be able to deconstruct a sequence $\Lambda$
   in its last element, and prefix. If an expression does not match the given
   pattern, then the premise does not hold, and the rule cannot trigger.
+
+\item[Ceiling] Given a number $n \in \mathbb{R}$, $\ceil{n}$ represents the
+  ceiling of $n$.
 \end{description}
 
 \begin{figure}[htb]

--- a/byron/ledger/formal-spec/notation.tex
+++ b/byron/ledger/formal-spec/notation.tex
@@ -63,7 +63,7 @@
   pattern, then the premise does not hold, and the rule cannot trigger.
 
 \item[Ceiling] Given a number $n \in \mathbb{R}$, $\ceil{n}$ represents the
-  ceiling of $n$.
+  ceiling of $n$, and $\floor{n}$ represents its floor.
 \end{description}
 
 \begin{figure}[htb]

--- a/byron/ledger/formal-spec/properties.tex
+++ b/byron/ledger/formal-spec/properties.tex
@@ -140,7 +140,7 @@ UTxO does not contain any future outputs, which is a reasonable constraint.
     \forall \txs_i \cdot \dom~(\txouts{\txs_i}) \cap \dom~(\var{utxo_0}) = \emptyset
   $$
 
-  we have
+  we have:
 
   $$
   \forall \txs_i,~\txs_j \cdot i < j \Rightarrow \txins{\txs_i} \cap \txins{\txs_j} = \emptyset
@@ -222,8 +222,12 @@ Property~\ref{PVBUMP-empty-future-adopt} states that when no proposals are
 available, the system remains in the same state it started with.
 
 \begin{property}[PVBUMP no change on empty future adoptions]\label{PVBUMP-empty-future-adopt}
-  \textrm{For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such
-    that $fads = \epsilon$:}
+  For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such
+  that:
+
+  $$fads = \epsilon$$
+
+  we have:
 
   $$
   \left(
@@ -251,8 +255,11 @@ Property~\ref{prop:pvbump-early-on} states that early on in the lifetime
 of the blockchain the PVBUMP system remains in the same state it started with.
 
 \begin{property}[PVBUMP early on]\label{prop:pvbump-early-on}
-  \textrm{For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such
-    that $s_n \leq 2 \cdot k$:}
+  For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such that:
+
+  $$s_n \leq 2 \cdot k$$
+
+  we have:
 
   $$
   \left(
@@ -284,14 +291,18 @@ protocol version and protocol parameters that is after a slot with an index
 $2 \cdot k$.
 
 \begin{property}[PVBUMP last proposal]\label{prop:pvbump-last-proposal}
-  \textrm{For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such
-    that $s_n > 2 \cdot k$ and}
+  For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such that:
+
+  $$s_n > 2 \cdot k$$
+
+  and
 
   $$
   \wcard ; (\wcard , (\var{pv_c}, \var{pps_c})) \leteq [.., s_n - 2 \cdot k]
   \restrictdom \var{fads}
   $$
-  \textrm{ we have: }
+
+  we have:
 
   $$
   \left(

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -203,8 +203,8 @@ The protocol parameters are formally defined in \cref{fig:prot-params-defs}.
       \var{maxTxSize} \mapsto \mathbb{N} & \PPMMap & \text{maximum transaction size}\\
       \var{maxHeaderSize} \mapsto \mathbb{N} & \PPMMap & \text{maximum header size}\\
       \var{scriptVersion} \mapsto \mathbb{N} & \PPMMap & \text{script version}\\
-      \var{upAdptThd} \mapsto \mathbb{R} & \PPMMap & \text{update proposal adoption threshold}\\
-      \var{cfmThd} \mapsto \mathbb{N} & \PPMMap & \text{update proposal confirmation threshold}\\
+      \var{upAdptThd} \mapsto \mathbb{Q} & \PPMMap & \text{update proposal adoption threshold}\\
+      \var{cfmThd} \mapsto \mathbb{Q} & \PPMMap & \text{update proposal confirmation threshold}\\
       \var{upropTTL} \mapsto \mathbb{\Slot} & \PPMMap & \text{update proposal time-to-live}\\
     \end{array}
   \end{equation*}
@@ -859,7 +859,7 @@ In Rule~\ref{eq:rule:voting}:
       = \left(
       \begin{array}{r@{~\in~}lr}
         \var{s_n} & \Slot & \text{current slot number}\\
-        \var{t} & \mathbb{Q} & \text{confirmation threshold}\\
+        \var{t} & \mathbb{N} & \text{confirmation threshold}\\
         \var{rups} & \powerset{\UPropId}
         & \text{registered update proposals}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}
@@ -1046,7 +1046,7 @@ blocks. Some clarifications are in order:
       = \left(
       \begin{array}{r@{~\in~}lr}
         \var{s_n} & \Slot & \text{current slot number}\\
-        t & \mathbb{Q} & \text{adoption threshold}\\
+        t & \mathbb{N} & \text{adoption threshold}\\
         \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
         \var{cps} & \UPropId \mapsto \Slot & \text{confirmed proposals}\\
         \var{rpus} & \UPropId \mapsto (\ProtVer \times \PPMMap)

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -365,11 +365,11 @@ functions:
       & (\var{an}, \var{av}, \wcard) \notin \range~\var{raus}
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{avs}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -402,12 +402,12 @@ functions:
       \forall \var{t} \in \fun{upSTags}~\var{up} \cdot \fun{sTagValid}~t
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{pv}\\
           \var{pps}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -432,12 +432,12 @@ functions:
     \label{eq:rule:up-validity-pu-nosu}
     \inference
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{pv}\\
           \var{pps}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -458,13 +458,13 @@ functions:
       (\var{an}, \var{av}) \leteq \upSwVer{up} & \var{an} \mapsto (\var{av}, \_, \_) \in \var{avs}
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{pv}\\
           \var{pps}\\
           \var{avs}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -491,11 +491,11 @@ functions:
     \inference
     {
       \var{pv} = \upPV{up} & \upParams{up} = \emptyset &
-      {
+      {\left(
         \begin{array}{l}
           \var{avs}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -514,13 +514,13 @@ functions:
       }
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{pv}\\
           \var{pps}\\
           \var{avs}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -546,12 +546,12 @@ functions:
     \label{eq:rule:up-validity-pu-su}
     \inference
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{pv}\\
           \var{pps}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -592,13 +592,13 @@ functions:
       }
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{pv}\\
           \var{pps}\\
           \var{avs}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -680,13 +680,13 @@ an update proposal:
     \label{eq:rule:up-registration}
     \inference
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{pv}\\
           \var{pps}\\
           \var{avs}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -711,14 +711,14 @@ an update proposal:
       \mathcal{V}_{\var{vk}}\serialised{\upSigData{up}}_{(\upSig{up})}
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{pv}\\
           \var{pps}\\
           \var{avs}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -822,12 +822,12 @@ In Rule~\ref{eq:rule:voting}:
       \mathcal{V}_{\var{vk}}\serialised{\var{pid}}_{(\vSig{v})}\\
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{rups}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -902,12 +902,12 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
     \label{eq:rule:up-no-confirmation}
     \inference
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{rups}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -930,14 +930,14 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
       )
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           s_n\\
           \var{t}\\
           \var{rups}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -963,12 +963,12 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
     \label{eq:rule:up-vote-reg}
     \inference
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{rups}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -990,14 +990,14 @@ The rules in Figure~\ref{fig:rules:up-vote-reg} model the registration of a vote
       & \var{pid} \notin \dom~\var{cps}
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           \var{s_n}\\
           \var{t}\\
           \var{rups}\\
           \var{dms}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -1178,7 +1178,7 @@ rule by $\var{bv}$:
       \vee \var{pid} \notin \dom~(\var{cps} \restrictrange [.., s_n - 2 \cdot k])
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           s_n\\
           t\\
@@ -1186,7 +1186,7 @@ rule by $\var{bv}$:
           \var{cps}\\
           \var{rpus}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -1220,7 +1220,7 @@ rule by $\var{bv}$:
       & \var{pid} \in \dom~(\var{cps} \restrictrange [.., s_n - 2 \cdot k])
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           s_n\\
           t\\
@@ -1228,7 +1228,7 @@ rule by $\var{bv}$:
           \var{cps}\\
           \var{rpus}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(
@@ -1264,7 +1264,7 @@ rule by $\var{bv}$:
       (\var{fads}) \trans{fads}{(s_n, (\var{bv}, \var{pps_c}))} (\var{fads'})
     }
     {
-      {
+      {\left(
         \begin{array}{l}
           s_n\\
           t\\
@@ -1272,7 +1272,7 @@ rule by $\var{bv}$:
           \var{cps}\\
           \var{rpus}
         \end{array}
-      }
+      \right)}
       \vdash
       {
         \left(

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -333,7 +333,7 @@ functions:
       \fun{canUpdate}~\var{pps}~\var{pps'}\\
       {\begin{array}{r c l}
          & = & \var{pps'}~\var{maxBlockSize} \leq 2\cdot\var{pps}~\var{maxBlockSize}\\
-         & \wedge & \var{pps'}~\var{maxBlockSize} <  \var{pps'}~\var{maxTxSize}\\
+         & \wedge & \var{pps'}~\var{maxTxSize} < \var{pps'}~\var{maxBlockSize} \\
          & \wedge
              & 0 \leq
                \var{pps'}~\var{scriptVersion} - \var{pps}~\var{scriptVersion}

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -1181,6 +1181,7 @@ rule by $\var{bv}$:
       {
         \begin{array}{l}
           s_n\\
+          t\\
           \var{dms}\\
           \var{cps}\\
           \var{rpus}
@@ -1222,6 +1223,7 @@ rule by $\var{bv}$:
       {
         \begin{array}{l}
           s_n\\
+          t\\
           \var{dms}\\
           \var{cps}\\
           \var{rpus}
@@ -1265,6 +1267,7 @@ rule by $\var{bv}$:
       {
         \begin{array}{l}
           s_n\\
+          t\\
           \var{dms}\\
           \var{cps}\\
           \var{rpus}

--- a/byron/ledger/formal-spec/utxo.tex
+++ b/byron/ledger/formal-spec/utxo.tex
@@ -170,10 +170,10 @@ system.
     {
     }
     {
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
         utxo_0\\
         pps
-      \end{array}}
+      \end{array}\right)}
       \vdash
       \trans{utxo}{}
       \left(
@@ -193,10 +193,10 @@ system.
       \txins{tx} \neq \emptyset & \forall \wcard \mapsto (\wcard, c) \in \txouts{tx} \cdot 0 < c
     }
     {
-      {\begin{array}{l}
+      {\left(\begin{array}{l}
         utxo_0\\
         pps
-      \end{array}}
+       \end{array}\right)}
       \vdash
       \left(
           \begin{array}{l}


### PR DESCRIPTION
The `UPEND` rule incorporates a `t` parameter of type `N` (before/after):

![image](https://user-images.githubusercontent.com/175315/58561923-8a2cb800-8228-11e9-83e4-75b09ed5b805.png)

And the `UPIEND` rule makes use of this parameter using the floor function and the `upAdptThd` protocol parameter:

![image](https://user-images.githubusercontent.com/175315/58562042-bea07400-8228-11e9-830a-3b0644e06b52.png)

Regarding the executable spec these are the changes:

- Remove `PairSet` in favor of a a `Relation` Instance for `Set (a, b)`.

- Add infix operators to give the executable spec a more similar
look to the formal spec.

- Add `nkg` abstract function.

- Change the type of `upAdptThd` from `Int` to `Double`.

Closes #465 