### PR TITLE
[466] Remove dms map from EPOCH STS/latex spec

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
@@ -40,7 +40,7 @@ instance STS BHEAD where
 
   transitionRules =
     [ do
-        TRC ((epochEnv, sLast), us, bh) <- judgmentContext
+        TRC ((_, sLast), us, bh) <- judgmentContext
         us' <- trans @EPOCH $ TRC (sEpoch sLast, us, bh ^. bhSlot)
         let sMax = snd (us' ^. _1) ^. maxHdrSz
         bHeaderSize bh <= sMax ?! HeaderSizeTooBig

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
@@ -41,7 +41,7 @@ instance STS BHEAD where
   transitionRules =
     [ do
         TRC ((epochEnv, sLast), us, bh) <- judgmentContext
-        us' <- trans @EPOCH $ TRC ((epochEnv, sEpoch sLast), us, bh ^. bhSlot)
+        us' <- trans @EPOCH $ TRC (sEpoch sLast, us, bh ^. bhSlot)
         let sMax = snd (us' ^. _1) ^. maxHdrSz
         bHeaderSize bh <= sMax ?! HeaderSizeTooBig
         return $! us'

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
@@ -19,10 +19,7 @@ sEpoch (Slot s) = Epoch $ s `div` 21600
 data EPOCH
 
 instance STS EPOCH where
-  type Environment EPOCH =
-    ( Bimap VKeyGenesis VKey
-    , Epoch
-    )
+  type Environment EPOCH = Epoch
   type State EPOCH = UPIState
 
   type Signal EPOCH = Slot
@@ -34,7 +31,7 @@ instance STS EPOCH where
 
   transitionRules =
     [ do
-        TRC ((_, e_c), _, s) <- judgmentContext
+        TRC (e_c, _, s) <- judgmentContext
         case e_c >= sEpoch s of
           True  -> onOrAfterCurrentEpoch
           False -> beforeCurrentEpoch
@@ -42,7 +39,7 @@ instance STS EPOCH where
    where
     beforeCurrentEpoch :: TransitionRule EPOCH
     beforeCurrentEpoch = do
-      TRC ((_dms, _), us, s) <- judgmentContext
+      TRC (_, us, s) <- judgmentContext
       us' <- trans @UPIEC $ TRC (s, us, ())
       return $! us'
 

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
@@ -6,7 +6,6 @@ module Cardano.Spec.Chain.STS.Rule.Epoch where
 
 -- import Control.Lens ((^.), _2)
 import Control.State.Transition
-import Data.Bimap (Bimap)
 import Ledger.Core
 import Ledger.Update
 

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -671,10 +671,9 @@ updates the update state to the correct version.
   \begin{align*}
     & \ETEnv
       = \left(
-      \begin{array}{r@{~\in~}lr}
-        \var{dms} & \VKeyGen \mapsto \VKey & \text{delegation map}\\
-        \var{e_c} & \Epoch & \text{Current epoch}
-      \end{array}\right)
+          \begin{array}{r@{~\in~}lr}
+            \var{e_c} & \Epoch & \text{current epoch}
+          \end{array}\right)
   \end{align*}
 
   \emph{Epoch transition states}
@@ -702,30 +701,20 @@ updates the update state to the correct version.
     {
       \var{e_c} \geq \sepoch{s}
     }
-    {
-      {\left(
-        \begin{array}{l}
-          \var{dms}\\
-          \var{e_c}
-        \end{array}
-      \right)}
+    {\var{e_c}
       \vdash
       {
-        \left(
           {\begin{array}{c}
              \var{us}
            \end{array}
          }
-       \right)
      }
      \trans{epoch}{s}
      {
-       \left(
          {\begin{array}{c}
             \var{us}
           \end{array}
         }
-      \right)
     }
   }
 \end{equation*}
@@ -738,29 +727,20 @@ updates the update state to the correct version.
     s\vdash \var{us} \trans{\hyperlink{byron_ledger_spec_link}{upiec}}{} \var{us'}
   }
   {
-    {\left(
-      \begin{array}{l}
-        \var{dms}\\
-        \var{e_c}
-      \end{array}
-    \right)}
+    \var{e_c}
     \vdash
     {
-      \left(
         {\begin{array}{c}
            \var{us}
          \end{array}
        }
-     \right)
    }
    \trans{epoch}{s}
    {
-     \left(
        {\begin{array}{c}
           \var{us'}
         \end{array}
       }
-    \right)
   }
 }
 \end{equation*}


### PR DESCRIPTION
Issue https://github.com/input-output-hk/cardano-ledger-specs/issues/466

* remove the delegation map `dms` from the EPOCH STS environment
* update the latex spec figures that refer to the Epoch Env (Epoch Transition Types and Rules)

<img width="1069" alt="FIG 12 - 13" src="https://user-images.githubusercontent.com/8812/58651511-c9830380-8311-11e9-893c-5323895622f6.png">
