### PR TITLE
Formulates and implements properties for UPIEC STS in Byron-Shelley

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -169,7 +169,7 @@ instance HasTrace CHAIN where
             <$> gCurrentSlot
             <*> pure initialUTxO
             <*> initEnvGen @DELEG
-            <*> UpdateGen.pparamsGen
+            <*> UpdateGen.pparams
     where
       -- If we want to generate large traces, we need to set up the value of the
       -- current slot to a sufficiently large value.

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -91,6 +91,7 @@ test-suite ledger-rules-test
   other-modules: Ledger.Delegation.Examples
                , Ledger.Delegation.Properties
                , Ledger.Pvbump.Properties
+               , Ledger.Upiec.Properties
                , Ledger.UTxO.Properties
   type: exitcode-stdio-1.0
   default-language:    Haskell2010

--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
@@ -117,7 +117,7 @@ traceAddrs = mkAddr <$> [0 .. 10]
 
 instance HasTrace (UTXOW TxId) where
   initEnvGen
-    = UTxOEnv <$> genUTxO <*> UpdateGen.pparamsGen
+    = UTxOEnv <$> genUTxO <*> UpdateGen.pparams
     where
       genUTxO = do
         txOuts <- UTxOGen.genInitialTxOuts traceAddrs

--- a/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
@@ -1,9 +1,9 @@
 -- | Generators for the 'Ledger.Core' values.
 module Ledger.Core.Generators
-  ( vkGen
-  , vkgenesisGen
-  , addrGen
-  , slotGen
+  ( vk
+  , vkgenesis
+  , addr
+  , slot
   )
 where
 
@@ -20,16 +20,16 @@ import Ledger.Core
   , Slot(Slot)
   )
 
-vkGen :: Gen VKey
-vkGen = VKey . Owner <$> Gen.integral (Range.linear 0 10000)
+vk :: Gen VKey
+vk = VKey . Owner <$> Gen.integral (Range.linear 0 10000)
 
-vkgenesisGen :: Gen VKeyGenesis
-vkgenesisGen = VKeyGenesis <$> vkGen
+vkgenesis :: Gen VKeyGenesis
+vkgenesis = VKeyGenesis <$> vk
 
-addrGen :: Gen Addr
-addrGen = Addr <$> vkGen
+addr :: Gen Addr
+addr = Addr <$> vk
 
 -- | Generates a slot within the given bound
-slotGen :: Word64 -> Word64 -> Gen Slot
-slotGen lower upper =
+slot :: Word64 -> Word64 -> Gen Slot
+slot lower upper =
   Slot <$> Gen.word64 (Range.linear lower upper)

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -135,7 +135,7 @@ import Ledger.Core
   , HasHash
   , hash
   )
-import Ledger.Core.Generators (vkGen, vkgenesisGen)
+import qualified Ledger.Core.Generators as CG
 import Ledger.GlobalParams (k)
 
 
@@ -487,7 +487,7 @@ dcertGen env = do
   -- The generated delegator must be one of the genesis keys in the
   -- environment.
   vkS <- Gen.element $ Set.toList (env ^. allowedDelegators)
-  vkD <- vkGen
+  vkD <- CG.vk
   let Epoch n = env ^. epoch
   m   <- Gen.integral (linear 0 100)
   let epo = Epoch (n + m)
@@ -526,7 +526,7 @@ instance HasTrace DELEG where
     --
     -- A similar remark applies to the ranges chosen for slot and slot count
     -- generators.
-    <$> Gen.set (linear 1 7) vkgenesisGen
+    <$> Gen.set (linear 1 7) CG.vkgenesis
     <*> (Epoch <$> Gen.integral (linear 0 100))
     <*> (Slot <$> Gen.integral (linear 0 10000))
 

--- a/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
@@ -5,6 +5,11 @@
 module Ledger.Update.Generators
   ( pparams
   , protVer
+  -- PVBUMP judgement contexts
+  , emptyPVUpdateJC
+  , beginningsNoUpdateJC
+  , lastProposalJC
+  -- UPIEC state generators
   , apName
   , apVer
   , metadata
@@ -26,7 +31,7 @@ module Ledger.Update.Generators
   )
 where
 
-import           Control.State.Transition (Environment, State)
+import           Control.State.Transition (Environment, State, Signal)
 import           Data.Map.Strict (Map)
 import           Data.Word (Word64)
 import           Hedgehog
@@ -154,6 +159,27 @@ pvbumpAfter2kEnv =
 -- | Generates a state value for the PVBUMP STS
 pvbumpState :: Gen (State PVBUMP)
 pvbumpState = (,) <$> protVer <*> pparams
+
+-- | Generates a judgement context for the PVBUMP STS for its property #1
+emptyPVUpdateJC :: Gen (Environment PVBUMP, State PVBUMP, Signal PVBUMP)
+emptyPVUpdateJC = (,,)
+  <$> pvbumpEmptyListEnv
+  <*> pvbumpState
+  <*> pure ()
+
+-- | Generates a judgement context for the PVBUMP STS for its property #2
+beginningsNoUpdateJC :: Gen (Environment PVBUMP, State PVBUMP, Signal PVBUMP)
+beginningsNoUpdateJC = (,,)
+  <$> pvbumpBeginningsEnv
+  <*> pvbumpState
+  <*> pure ()
+
+-- | Generates a judgement context for the PVBUMP STS for its property #3
+lastProposalJC :: Gen (Environment PVBUMP, State PVBUMP, Signal PVBUMP)
+lastProposalJC = (,,)
+  <$> pvbumpAfter2kEnv
+  <*> pvbumpState
+  <*> pure ()
 
 -- | Generates an @ApName@
 apName :: Gen ApName

--- a/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
@@ -39,11 +39,10 @@ type JC sts = (Environment sts, State sts, Signal sts)
 
 -- | Generates a 'ProtVer'
 protVer :: Gen ProtVer
-protVer =
-  (\a b alt -> ProtVer a b alt)
-    <$> Gen.integral (Range.linear (0 :: Natural) 100)
-    <*> Gen.integral (Range.linear (0 :: Natural) 100)
-    <*> Gen.integral (Range.linear (0 :: Natural) 100)
+protVer = ProtVer
+  <$> Gen.integral (Range.linear (0 :: Natural) 100)
+  <*> Gen.integral (Range.linear (0 :: Natural) 100)
+  <*> Gen.integral (Range.linear (0 :: Natural) 100)
 
 -- | Generates valid protocol parameters
 --
@@ -176,7 +175,8 @@ lastProposalJC = (,,)
 
 -- | Generates an @ApName@
 apName :: Gen ApName
-apName = ApName <$> Gen.element ["byron", "shelley", "praos"]
+apName = ApName <$> Gen.element
+  ["the", "quick", "brown", "fox", "jumps", "over", "lazy", "dog"]
 
 -- | Generates an @ApVer@
 apVer :: Gen ApVer

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -111,7 +111,7 @@ import Ledger.Delegation
   )
 
 import Ledger.GlobalParams (k)
-import Ledger.Core.Generators (vkGen)
+import qualified Ledger.Core.Generators as CG
 
 --------------------------------------------------------------------------------
 -- Delegation certification triggering tests
@@ -296,7 +296,7 @@ rejectDupSchedDelegs = property $ do
             (_, (res, _)):_ -> res
             _ -> error $  "This should not happen: "
                        ++ "tr is guaranteed to contain a non-empty sequence of scheduled delegations"
-    vkD <- vkGen
+    vkD <- CG.vk
     epo <- Epoch <$> integral (linear 0 100)
     let dcert
           = DCert

--- a/byron/ledger/executable-spec/test/Ledger/Pvbump/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Pvbump/Properties.hs
@@ -4,7 +4,7 @@ module Ledger.Pvbump.Properties where
 
 import           Control.State.Transition (applySTS, TRC(..))
 import           Data.Maybe (fromMaybe)
-import           Ledger.Update.Generators
+import qualified Ledger.Update.Generators as G
 import           Hedgehog
 import           Ledger.Core (BlockCount(..), SlotCount(..), minusSlotMaybe)
 import           Ledger.GlobalParams (k)
@@ -21,8 +21,8 @@ emptyPVUpdate :: Property
 emptyPVUpdate = property $ do
   judgementContext <-
     forAll $ fmap TRC $ (,,)
-      <$> pvbumpEmptyListEnvGen
-      <*> pvbumpStateGen
+      <$> G.pvbumpEmptyListEnv
+      <*> G.pvbumpState
       <*> pure ()
   let TRC (_, st, _) = judgementContext
   case applySTS @PVBUMP judgementContext of
@@ -37,8 +37,8 @@ beginningsNoUpdate :: Property
 beginningsNoUpdate = property $ do
   judgementContext <-
     forAll $ fmap TRC $ (,,)
-      <$> pvbumpBeginningsEnvGen
-      <*> pvbumpStateGen
+      <$> G.pvbumpBeginningsEnv
+      <*> G.pvbumpState
       <*> pure ()
   let TRC (_, st, _) = judgementContext
   case applySTS @PVBUMP $ judgementContext of
@@ -55,8 +55,8 @@ lastProposal :: Property
 lastProposal = property $ do
   judgementContext <-
     forAll $ fmap TRC $ (,,)
-      <$> pvbumpAfter2kEnvGen
-      <*> pvbumpStateGen
+      <$> G.pvbumpAfter2kEnv
+      <*> G.pvbumpState
       <*> pure ()
   let
     TRC ((s_n, fads), _, _) = judgementContext

--- a/byron/ledger/executable-spec/test/Ledger/Upiec/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Upiec/Properties.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Ledger.Upiec.Properties
+  ( noProtVerChange
+  , protVerChangeAdopt
+  , protVerChangeSameComponents
+  , protVerChangeEmptyComponents
+  ) where
+
+import           Control.Lens (_1, _2, _3, _4, _5, _6, _7, _8, _9, (^.))
+import           Control.State.Transition (applySTS, TRC(..))
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import           Ledger.Core (Slot)
+import           Ledger.Update (UpId)
+import qualified Ledger.Update.Generators as G
+import           Hedgehog
+import           Ledger.Update (PVBUMP, UPIEC, ProtVer, PParams)
+
+
+-- Property #1 for the UPIEC STS
+--
+-- If PVBUMP transitions into a state with the same protocol version,
+-- the UPIEC STS results in the same state it started in.
+noProtVerChange :: Property
+noProtVerChange = property $ do
+  jc <- forAll G.noProtVerChangeJC
+  let (_, st, _) = jc
+  case applySTS @UPIEC (TRC jc) of
+    Right st' -> st === st'
+    Left _    -> failure
+
+-- Property #2 for the UPIEC STS
+--
+-- If PVBUMP transitions into a state with a new different protocol
+-- version, the UPIEC STS results in a state that adopts the new
+-- protocol version (pv) and new protocol parameters (pps).
+protVerChangeAdopt :: Property
+protVerChangeAdopt = property $ do
+  jc <- forAll G.protVerChangeJC
+  let
+    (s_n, st, _) = jc
+    (pv, pps)    = st ^. _1 :: (ProtVer, PParams)
+    fads         = st ^. _2 :: [(Slot, (ProtVer, PParams))]
+  case applySTS @PVBUMP (TRC ((s_n, fads), (pv, pps), ())) of
+    Left _            -> failure
+    Right (pv', pps') -> do
+      case applySTS @UPIEC (TRC jc) of
+        Right st' -> do
+          let (pvst', ppsst') = st' ^. _1 :: (ProtVer, PParams)
+          pv   /== pvst'
+          pv'  === pvst'
+          pps' === ppsst'
+        Left _    -> failure
+
+-- Property #3 for the UPIEC STS
+--
+-- If PVBUMP transitions into a state with a new different protocol
+-- version, the application versions (avs) and registered software
+-- update proposals (raus) components of UPIEC's state stay the same.
+protVerChangeSameComponents :: Property
+protVerChangeSameComponents = property $ do
+  jc <- forAll G.protVerChangeJC
+  let
+    (s_n, st, _) = jc
+    (pv, pps)    = st ^. _1 :: (ProtVer, PParams)
+    fads         = st ^. _2 :: [(Slot, (ProtVer, PParams))]
+  case applySTS @PVBUMP (TRC ((s_n, fads), (pv, pps), ())) of
+    Left  _ -> failure
+    Right _ -> do
+      case applySTS @UPIEC (TRC jc) of
+        Right st' -> do
+          let
+            pvst' = fst (st' ^. _1) :: ProtVer
+
+            avs   = st  ^. _3
+            avs'  = st' ^. _3
+
+            raus  = st  ^. _5
+            raus' = st' ^. _5
+
+          pv   /== pvst'
+          avs  === avs'
+          raus === raus'
+        Left _    -> failure
+
+-- Property #4 for the UPIEC STS
+--
+-- If PVBUMP transitions into a state with a new different protocol
+-- version, the following components of UPIEC's state are set to an
+-- empty set or map (according to the component's type):
+--
+--   future protocol version adoptions (fads)
+--   registered protocol update proposals (rpus)
+--   confirmed proposals (cps)
+--   proposal votes (vts)
+--   endorsement-key pairs (bvs)
+--   proposal timestamps (pws)
+protVerChangeEmptyComponents :: Property
+protVerChangeEmptyComponents = property $ do
+  jc <- forAll G.protVerChangeJC
+  let
+    (s_n, st, _) = jc
+    (pv, pps)    = st ^. _1 :: (ProtVer, PParams)
+    fads         = st ^. _2 :: [(Slot, (ProtVer, PParams))]
+  case applySTS @PVBUMP (TRC ((s_n, fads), (pv, pps), ())) of
+    Left  _ -> failure
+    Right _ -> do
+      case applySTS @UPIEC (TRC jc) of
+        Right st' -> do
+          let
+            pvst' = fst (st' ^. _1) :: ProtVer
+            fads' = st' ^. _2 :: [(Slot, (ProtVer, PParams))]
+            rpus' = st' ^. _4
+            cps'  = st' ^. _6
+            vts'  = st' ^. _7
+            bvs'  = st' ^. _8
+            pws'  = st' ^. _9 :: Map UpId Slot
+
+          pv /== pvst'
+          assert $     null fads'
+          assert $ Map.null rpus'
+          assert $ Map.null cps'
+          assert $ Set.null vts'
+          assert $ Set.null bvs'
+          assert $ Map.null pws'
+        Left _    -> failure

--- a/byron/ledger/executable-spec/test/Ledger/Upiec/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Upiec/Properties.hs
@@ -14,7 +14,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Ledger.Core (Slot)
 import           Ledger.Update (UpId)
-import qualified Ledger.Update.Generators as G
+import qualified Ledger.Update.Generators as UpdateGen
 import           Hedgehog
 import           Ledger.Update (PVBUMP, UPIEC, ProtVer, PParams)
 
@@ -25,7 +25,7 @@ import           Ledger.Update (PVBUMP, UPIEC, ProtVer, PParams)
 -- the UPIEC STS results in the same state it started in.
 noProtVerChange :: Property
 noProtVerChange = property $ do
-  jc <- forAll G.noProtVerChangeJC
+  jc <- forAll UpdateGen.noProtVerChangeJC
   let (_, st, _) = jc
   case applySTS @UPIEC (TRC jc) of
     Right st' -> st === st'
@@ -38,7 +38,7 @@ noProtVerChange = property $ do
 -- protocol version (pv) and new protocol parameters (pps).
 protVerChangeAdopt :: Property
 protVerChangeAdopt = property $ do
-  jc <- forAll G.protVerChangeJC
+  jc <- forAll UpdateGen.protVerChangeJC
   let
     (s_n, st, _) = jc
     (pv, pps)    = st ^. _1 :: (ProtVer, PParams)
@@ -61,7 +61,7 @@ protVerChangeAdopt = property $ do
 -- update proposals (raus) components of UPIEC's state stay the same.
 protVerChangeSameComponents :: Property
 protVerChangeSameComponents = property $ do
-  jc <- forAll G.protVerChangeJC
+  jc <- forAll UpdateGen.protVerChangeJC
   let
     (s_n, st, _) = jc
     (pv, pps)    = st ^. _1 :: (ProtVer, PParams)
@@ -99,7 +99,7 @@ protVerChangeSameComponents = property $ do
 --   proposal timestamps (pws)
 protVerChangeEmptyComponents :: Property
 protVerChangeEmptyComponents = property $ do
-  jc <- forAll G.protVerChangeJC
+  jc <- forAll UpdateGen.protVerChangeJC
   let
     (s_n, st, _) = jc
     (pv, pps)    = st ^. _1 :: (ProtVer, PParams)

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -2,6 +2,11 @@
 
 module Main
   ( main
+  , testGroupDelegEx
+  , testGroupDeleg
+  , testGroupUtxo
+  , testGroupPvbump
+  , testGroupUpiec
   )
 where
 
@@ -12,9 +17,41 @@ import Test.Tasty.Ingredients.ConsoleReporter (UseColor(Auto))
 import Ledger.Delegation.Examples (deleg)
 import Ledger.Delegation.Properties (dcertsAreTriggered, rejectDupSchedDelegs)
 import Ledger.Pvbump.Properties (emptyPVUpdate, beginningsNoUpdate, lastProposal)
+import Ledger.Upiec.Properties (noProtVerChange, protVerChangeAdopt, protVerChangeSameComponents, protVerChangeEmptyComponents)
 import qualified Ledger.Delegation.Properties as DELEG
 import Ledger.UTxO.Properties (moneyIsConstant)
 import qualified Ledger.UTxO.Properties as UTxO
+
+testGroupDelegEx :: TestTree
+testGroupDelegEx = testGroup "Delegation Examples" deleg
+
+testGroupDeleg :: TestTree
+testGroupDeleg = testGroup "Delegation Properties"
+  [ testProperty "Certificates are triggered"           dcertsAreTriggered
+  , testProperty "Duplicated certificates are rejected" rejectDupSchedDelegs
+  , testProperty "Traces are classified"                DELEG.tracesAreClassified
+  ]
+
+testGroupUtxo :: TestTree
+testGroupUtxo = testGroup "UTxO Properties"
+  [ testProperty "Money is constant" moneyIsConstant
+  , testProperty "Traces are classified" UTxO.tracesAreClassified
+  ]
+
+testGroupPvbump :: TestTree
+testGroupPvbump =  testGroup "PVBUMP properties"
+  [ testProperty "Same state for no updates"         emptyPVUpdate
+  , testProperty "Same state for early on in chain"  beginningsNoUpdate
+  , testProperty "State determined by last proposal" lastProposal
+  ]
+
+testGroupUpiec :: TestTree
+testGroupUpiec = testGroup "UPIEC properties"
+  [ testProperty "Same state for the same protocol version" noProtVerChange
+  , testProperty "New protocol version adopted"   protVerChangeAdopt
+  , testProperty "App. vers and registered sw upd. proposals stay the same" protVerChangeSameComponents
+  , testProperty "fads, rpus, cps, vts, bvs and pws get reset" protVerChangeEmptyComponents
+  ]
 
 main :: IO ()
 main = defaultMain tests
@@ -22,22 +59,9 @@ main = defaultMain tests
   tests :: TestTree
   tests = localOption Auto $ testGroup
     "Ledger"
-    [ testGroup "Delegation Examples" deleg
-    , testGroup
-      "Delegation Properties"
-      [ testProperty "Certificates are triggered"           dcertsAreTriggered
-      , testProperty "Duplicated certificates are rejected" rejectDupSchedDelegs
-      , testProperty "Traces are classified"                DELEG.tracesAreClassified
-      ]
-    , testGroup
-      "PVBUMP properties"
-      [ testProperty "Same state for no updates"         emptyPVUpdate
-      , testProperty "Same state for early on in chain"  beginningsNoUpdate
-      , testProperty "State determined by last proposal" lastProposal
-      ]
-    , testGroup
-      "UTxO Properties"
-      [ testProperty "Money is constant" moneyIsConstant
-      , testProperty "Traces are classified" UTxO.tracesAreClassified
-      ]
+    [ testGroupDelegEx
+    , testGroupDeleg
+    , testGroupUtxo
+    , testGroupPvbump
+    , testGroupUpiec
     ]

--- a/byron/ledger/formal-spec/properties.tex
+++ b/byron/ledger/formal-spec/properties.tex
@@ -222,12 +222,12 @@ Property~\ref{PVBUMP-empty-future-adopt} states that when no proposals are
 available, the system remains in the same state it started with.
 
 \begin{property}[PVBUMP no change on empty future adoptions]\label{PVBUMP-empty-future-adopt}
-  For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such
-  that:
+  \textnormal{For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such
+  that:}
 
   $$fads = \epsilon$$
 
-  we have:
+  \textnormal{we have:}
 
   $$
   \left(
@@ -255,11 +255,12 @@ Property~\ref{prop:pvbump-early-on} states that early on in the lifetime
 of the blockchain the PVBUMP system remains in the same state it started with.
 
 \begin{property}[PVBUMP early on]\label{prop:pvbump-early-on}
-  For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such that:
+  \textnormal{For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$
+    such that:}
 
   $$s_n \leq 2 \cdot k$$
 
-  we have:
+  \textnormal{we have:}
 
   $$
   \left(
@@ -291,18 +292,19 @@ protocol version and protocol parameters that is after a slot with an index
 $2 \cdot k$.
 
 \begin{property}[PVBUMP last proposal]\label{prop:pvbump-last-proposal}
-  For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$ such that:
+  \textnormal{For all $\var{s_n}$, $\var{fads}$, $\var{pv}$ and $\var{pps}$
+    such that:}
 
   $$s_n > 2 \cdot k$$
 
-  and
+  \textnormal{and}
 
   $$
   \wcard ; (\wcard , (\var{pv_c}, \var{pps_c})) \leteq [.., s_n - 2 \cdot k]
   \restrictdom \var{fads}
   $$
 
-  we have:
+  \textnormal{we have:}
 
   $$
   \left(

--- a/byron/ledger/formal-spec/properties.tex
+++ b/byron/ledger/formal-spec/properties.tex
@@ -327,3 +327,294 @@ $2 \cdot k$.
   \right)
   $$
 \end{property}
+
+
+\subsubsection{UPIEC Properties}
+\label{sec:upiec-properties}
+
+Property~\ref{UPIEC-no-change} states that if PVBUMP transitions into a state
+with the same protocol version, the UPIEC STS results in the same state it
+started in.
+
+\begin{property}[UPIEC no change on no protocol change]\label{UPIEC-no-change}
+  \textnormal{If for all $s_n$, $fads$ and update interface states:}
+
+  $$
+  \left(
+    \begin{array}{l}
+      \var{s_n}\\
+      \var{fads}
+    \end{array}
+  \right)
+  \vdash
+  \left(
+    \begin{array}{l}
+      \var{pv}, \var{pps}\\
+    \end{array}
+  \right)
+  \trans{\hyperref[fig:rules:pvbump]{pvbump}}{}
+  \left(
+    \begin{array}{l}
+      \var{pv}, \var{pps'}\\
+    \end{array}
+  \right)
+  $$
+
+  \textnormal{then we have:}
+
+  $$
+  (s_n)
+  \vdash
+  \left(
+    \begin{array}{l}
+      (\var{pv}, \var{pps})\\
+      \var{fads}\\
+      \var{avs}\\
+      \var{rpus}\\
+      \var{raus}\\
+      \var{cps}\\
+      \var{vts}\\
+      \var{bvs}\\
+      \var{pws}
+    \end{array}
+  \right)
+  \trans{\hyperref[fig:rules:upi-ec]{upiec}}{}
+  \left(
+    \begin{array}{l}
+      (\var{pv}, \var{pps})\\
+      \var{fads}\\
+      \var{avs}\\
+      \var{rpus}\\
+      \var{raus}\\
+      \var{cps}\\
+      \var{vts}\\
+      \var{bvs}\\
+      \var{pws}
+    \end{array}
+  \right)
+  $$
+
+\end{property}
+
+
+Property~\ref{UPIEC-new-pv} states that if PVBUMP transitions into a state
+with a new different protocol version, the UPIEC STS results in a state that
+adopts the new protocol version and new protocol parameters.
+
+\begin{property}[UPIEC adopts new protocol version]\label{UPIEC-new-pv}
+  \textnormal{If for all $s_n$, $fads$ and update interface states such that:}
+
+  $$
+  pv \neq pv'
+  $$
+
+  \textnormal{we have:}
+  
+  $$
+  \left(
+    \begin{array}{l}
+      \var{s_n}\\
+      \var{fads}
+    \end{array}
+  \right)
+  \vdash
+  \left(
+    \begin{array}{l}
+      \var{pv}, \var{pps}\\
+    \end{array}
+  \right)
+  \trans{\hyperref[fig:rules:pvbump]{pvbump}}{}
+  \left(
+    \begin{array}{l}
+      \var{pv'}, \var{pps'}\\
+    \end{array}
+  \right)
+  $$
+
+  \textnormal{then:}
+
+  $$
+  (s_n)
+  \vdash
+  \left(
+    \begin{array}{l}
+      (\var{pv}, \var{pps})\\
+      \var{fads}\\
+      \var{avs}\\
+      \var{rpus}\\
+      \var{raus}\\
+      \var{cps}\\
+      \var{vts}\\
+      \var{bvs}\\
+      \var{pws}
+    \end{array}
+  \right)
+  \trans{\hyperref[fig:rules:upi-ec]{upiec}}{}
+  \left(
+    \begin{array}{l}
+      (\var{pv'}, \var{pps'})\\
+      \var{fads'}\\
+      \var{avs'}\\
+      \var{rpus'}\\
+      \var{raus'}\\
+      \var{cps'}\\
+      \var{vts'}\\
+      \var{bvs'}\\
+      \var{pws'}
+    \end{array}
+  \right)
+  $$
+  
+\end{property}
+
+Property~\ref{UPIEC-same-components} states that if PVBUMP transitions into a
+state with a new different protocol version, the application versions and
+registered software update proposals components of the update interface state
+stay the same.
+
+\begin{property}[UPIEC same components]\label{UPIEC-same-components}
+  \textnormal{If for all $s_n$, $fads$ and update interface states such that:}
+
+  $$
+  pv \neq pv'
+  $$
+
+  \textnormal{we have:}
+  
+  $$
+  \left(
+    \begin{array}{l}
+      \var{s_n}\\
+      \var{fads}
+    \end{array}
+  \right)
+  \vdash
+  \left(
+    \begin{array}{l}
+      \var{pv}, \var{pps}\\
+    \end{array}
+  \right)
+  \trans{\hyperref[fig:rules:pvbump]{pvbump}}{}
+  \left(
+    \begin{array}{l}
+      \var{pv'}, \var{pps'}\\
+    \end{array}
+  \right)
+  $$
+
+  \textnormal{then:}
+
+  $$
+  (s_n)
+  \vdash
+  \left(
+    \begin{array}{l}
+      (\var{pv}, \var{pps})\\
+      \var{fads}\\
+      \var{avs}\\
+      \var{rpus}\\
+      \var{raus}\\
+      \var{cps}\\
+      \var{vts}\\
+      \var{bvs}\\
+      \var{pws}
+    \end{array}
+  \right)
+  \trans{\hyperref[fig:rules:upi-ec]{upiec}}{}
+  \left(
+    \begin{array}{l}
+      (\var{pv'}, \var{pps''})\\
+      \var{fads'}\\
+      \var{avs}\\
+      \var{rpus'}\\
+      \var{raus}\\
+      \var{cps'}\\
+      \var{vts'}\\
+      \var{bvs'}\\
+      \var{pws'}
+    \end{array}
+  \right)
+  $$
+  
+\end{property}
+
+
+Property~\ref{UPIEC-empty-components} states that if PVBUMP transitions into a
+state with a new different protocol version, the following components of
+UPIEC's state are set to an empty set or map (according to the component's
+type):
+%
+\begin{itemize}
+\item future protocol version adoptions
+\item registered protocol update proposals
+\item confirmed proposals
+\item proposal votes
+\item endorsement-key pairs
+\item proposal timestamps
+\end{itemize}
+
+\begin{property}[UPIEC empty components]\label{UPIEC-empty-components}
+  \textnormal{If for all $s_n$, $fads$ and update interface states such that:}
+
+  $$
+  pv \neq pv'
+  $$
+
+  \textnormal{we have:}
+  
+  $$
+  \left(
+    \begin{array}{l}
+      \var{s_n}\\
+      \var{fads}
+    \end{array}
+  \right)
+  \vdash
+  \left(
+    \begin{array}{l}
+      \var{pv}, \var{pps}\\
+    \end{array}
+  \right)
+  \trans{\hyperref[fig:rules:pvbump]{pvbump}}{}
+  \left(
+    \begin{array}{l}
+      \var{pv'}, \var{pps'}\\
+    \end{array}
+  \right)
+  $$
+
+  \textnormal{then:}
+
+  $$
+  (s_n)
+  \vdash
+  \left(
+    \begin{array}{l}
+      (\var{pv}, \var{pps})\\
+      \var{fads}\\
+      \var{avs}\\
+      \var{rpus}\\
+      \var{raus}\\
+      \var{cps}\\
+      \var{vts}\\
+      \var{bvs}\\
+      \var{pws}
+    \end{array}
+  \right)
+  \trans{\hyperref[fig:rules:upi-ec]{upiec}}{}
+  \left(
+    \begin{array}{l}
+      (\var{pv'}, \var{pps''})\\
+      \emptyset\\
+      \var{avs'}\\
+      \emptyset\\
+      \var{raus'}\\
+      \emptyset\\
+      \emptyset\\
+      \emptyset\\
+      \emptyset
+    \end{array}
+  \right)
+  $$
+  
+\end{property}

--- a/byron/semantics/executable-spec/src/Control/State/Transition.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition.hs
@@ -52,12 +52,6 @@ newtype IRC sts = IRC (Environment sts)
 -- | Context available to transition rules.
 newtype TRC sts = TRC (Environment sts, State sts, Signal sts)
 
-deriving instance
-  ( Show (Environment sts)
-  , Show (State sts)
-  , Show (Signal sts)
-  ) => Show (TRC sts)
-
 type family RuleContext (t :: RuleType) = (ctx :: Type -> Type) | ctx -> t where
   RuleContext 'Initial = IRC
   RuleContext 'Transition = TRC


### PR DESCRIPTION
This patch formulates and implements four properties for the `UPIEC` STS of the Byron-Shelley era. It:

* renames existing update interface generators to make their naming consistent with a scheme suggested by Nadales
* implements new generators
* reworks `PVBUMP` generators in a way that is more suitable for reusage in `UPIEC` generators
* implements the properties in Haskell
* adds formulation of properties to the ledger specification
* fixes prose formatting in PVBUMP properties in the ledger specification

It closes #512.