### PR TITLE
Clarify discussion of scripts and script addresses.

### DIFF
--- a/shelley/design-spec/CHANGELOG.md
+++ b/shelley/design-spec/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Delegation Design Document Changelog
 
+## 2019-06-07
+Update section on script addresses.
+
 ## 2019-05-17
 Some clarifications in response to review by the auditors.
 

--- a/shelley/design-spec/delegation_design_spec.tex
+++ b/shelley/design-spec/delegation_design_spec.tex
@@ -402,7 +402,7 @@ the \emph{staking key pair} \(K^s=(sks, vks)\). Here, \(skp\) and
 are the public keys used to verify signatures.
 
 Except for special classes of addresses with no stake rights\footnote{Enterprise,
-  script, bootstrap era and AVVM addresses have no corresponding stake
+  bootstrap era and AVVM addresses have no corresponding stake
   rights. AVVM is an acronym for ``Ada Virtual Vending Machine'', and AVVM
   addresses are special addresses used in the initial distribution of Ada.}, all
 addresses have stake rights corresponding to the funds
@@ -583,9 +583,8 @@ Section~\ref{overview-of-delegation}) that has to be used to exercise the
 staking rights for funds in the address.
 
 In addition to those new addresses, the system will continue to support
-\emph{bootstrap addresses} and \emph{script addresses} as introduced in
-Byron. Only the new base and pointer addresses carry stake rights
-however.
+\emph{bootstrap addresses} as introduced in Byron. Only the new base
+and pointer addresses carry stake rights however.
 
 \subsubsection{Base Address}
 \label{base-address}
@@ -750,10 +749,29 @@ features are added to enterprise addresses.
 \subsubsection{Script Address}
 \label{script-address}
 
-Another type of addresses present since Byron are script addresses. For
-those, it is hard to determine to whom the funds actually belong. The
-solution chosen for Shelly is simple: script addresses have no stake
-rights whatsoever.
+Byron does not support scripts. Scripts are \emph{not} included in the
+Shelley design described in this document.
+
+Scripts will however be introduced in future as an extension of the
+Shelley design and we will briefly describe the interaction between the
+future script addresses and stake rights.
+
+Script addresses will have the form
+\[
+\hash{vs} \mathbin{||} \beta
+\]
+where \(\hash{vs}\) is a cryptographic hash of the validation script.
+
+The staking object \(\beta\) can take the same three forms as normal
+pubkey addresses: base, pointer and none. The use of stake rights with
+script addresses is otherwise identical to that of normal addresses.
+
+The use of script addresses with no stake rights has the same behaviour
+as normal addresses with no stake rights, but has different motivating
+use cases. For many scripts it is hard to determine to whom the funds
+actually belong and in such cases the simplest solution is to use an
+address with no stake rights whatsoever. For this reason we do not call
+such addresses enterprise addresses.
 
 \subsubsection{HD Wallet Structure in Shelley}
 \label{hd-wallet-structure-in-shelley}


### PR DESCRIPTION
Clarify that scripts were not supported in Byron, and are not in the first Shelley release either. But do describe how stake rights will work for the future script addresses.