### PR TITLE
[#531] Remove the txid type parameter from UTxO types

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Block.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Block.hs
@@ -16,7 +16,7 @@ import Control.State.Transition.Generator
 import Ledger.Core (Hash(Hash), VKey, Slot, Sig)
 import Ledger.Delegation
 import Ledger.Update (STag, ProtVer, UProp, Vote)
-import Ledger.UTxO (TxWits, TxId, TxIn, TxOut, Wit)
+import Ledger.UTxO (TxWits, TxIn, TxOut, Wit)
 
 data BlockHeader
   = MkBlockHeader
@@ -59,7 +59,7 @@ data BlockBody
   = BlockBody
   { _bDCerts     :: [DCert]
   -- ^ Delegation certificates
-  , _bUtxo       :: [TxWits TxId]
+  , _bUtxo       :: [TxWits]
   -- ^ UTxO payload
   , _bUpdProp    :: Maybe UProp
   -- ^ Update proposal payload
@@ -105,9 +105,9 @@ bBodySize = fromIntegral . abstractSize costs
                          , (typeOf (undefined::ProtVer), 1)
                          , (typeOf (undefined::DCert), 1)
                          , (typeOf (undefined::Vote), 1)
-                         , (typeOf (undefined::TxWits TxId), 1)
-                         , (typeOf (undefined::Wit TxId), 1)
-                         , (typeOf (undefined::TxIn TxId), 1)
+                         , (typeOf (undefined::TxWits), 1)
+                         , (typeOf (undefined::Wit), 1)
+                         , (typeOf (undefined::TxIn), 1)
                          , (typeOf (undefined::TxOut), 1)]
 
 -- | Compute the abstract size (in words) that a block header occupies.

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
@@ -39,7 +39,7 @@ import Ledger.Delegation
   , _dSEnvSlot
   )
 import Ledger.Update (PParams, maxBkSz, UPIState)
-import Ledger.UTxO (UTxO, TxId)
+import Ledger.UTxO (UTxO)
 
 import Cardano.Spec.Chain.STS.Block
 
@@ -49,11 +49,11 @@ instance STS BBODY where
   type Environment BBODY =
     ( PParams
     , Epoch
-    , UTxO TxId
+    , UTxO
     )
 
   type State BBODY =
-    ( UTxOState TxId
+    ( UTxOState
     , DIState
     , UPIState
     )
@@ -67,7 +67,7 @@ instance STS BBODY where
     | InvalidUpdateProposalHash
     | BUPIFailure (PredicateFailure BUPI)
     | DelegationFailure (PredicateFailure DELEG)
-    | UTXOWSFailure (PredicateFailure (UTXOWS TxId))
+    | UTXOWSFailure (PredicateFailure UTXOWS)
     deriving (Eq, Show)
 
   initialRules = []
@@ -97,7 +97,7 @@ instance STS BBODY where
           , ds
           , b ^. bBody ^. bDCerts
           )
-        utxoSt' <- trans @(UTXOWS TxId) $ TRC
+        utxoSt' <- trans @UTXOWS $ TRC
           ( UTxOEnv {utxo0 = utxoGenesis, pps = ppsVal}, utxoSt, b ^. bBody ^. bUtxo )
 
         return $! (utxoSt', ds', us')
@@ -109,5 +109,5 @@ instance Embed BUPI BBODY where
 instance Embed DELEG BBODY where
   wrapFailed = DelegationFailure
 
-instance Embed (UTXOWS TxId) BBODY where
+instance Embed UTXOWS BBODY where
   wrapFailed = UTXOWSFailure

--- a/byron/chain/executable-spec/src/Cardano/Spec/Consensus/Block.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Consensus/Block.hs
@@ -14,7 +14,7 @@ import qualified Cardano.Spec.Chain.STS.Block as CBM -- Concrete Block Module
 import           Ledger.Core
 import           Ledger.Delegation
 import           Ledger.Update (ProtVer, UProp, Vote)
-import           Ledger.UTxO (TxWits, TxId)
+import           Ledger.UTxO (TxWits)
 
 
 class BlockHeader h where
@@ -39,7 +39,7 @@ class BlockBody bb where
   -- | Delegation certificates.
   bbCerts :: bb -> [DCert]
   -- | UTxO payload
-  bbUtxo :: bb -> [TxWits TxId]
+  bbUtxo :: bb -> [TxWits]
   -- | Update proposal payload
   bbUpdProp :: bb -> Maybe UProp
   -- | Update votes payload

--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXO.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXO.hs
@@ -20,30 +20,30 @@ import Control.State.Transition
   , (?!)
   , judgmentContext
   )
-import Data.AbstractSize (HasTypeReps)
 
 import Ledger.Core (Lovelace, (∪), (⊆), (⋪), (◁), dom, range)
 import Ledger.GlobalParams (lovelaceCap)
 import Ledger.Update (PParams)
 import Ledger.UTxO (Tx, UTxO, balance, pcMinFee, txins, txouts, value)
 
-data UTXO id
+data UTXO
 
-data UTxOEnv id = UTxOEnv { utxo0 :: UTxO id
-                          , pps   :: PParams
-                          } deriving (Eq, Show)
+data UTxOEnv = UTxOEnv
+  { utxo0 :: UTxO
+  , pps   :: PParams
+  } deriving (Eq, Show)
 
-data UTxOState id = UTxOState { utxo :: UTxO id
-                              , reserves :: Lovelace
-                              }
-  deriving (Eq, Show)
+data UTxOState = UTxOState
+  { utxo     :: UTxO
+  , reserves :: Lovelace
+  } deriving (Eq, Show)
 
-instance (Ord id, HasTypeReps id) => STS (UTXO id) where
+instance STS UTXO where
 
-  type Environment (UTXO id) = UTxOEnv id
-  type State (UTXO id) = UTxOState id
-  type Signal (UTXO id) = Tx id
-  data PredicateFailure (UTXO id)
+  type Environment UTXO = UTxOEnv
+  type State UTXO = UTxOState
+  type Signal UTXO = Tx
+  data PredicateFailure UTXO
     = EmptyTxInputs
     | FeeTooLow
     | IncreasedTotalBalance

--- a/byron/ledger/executable-spec/test/Ledger/UTxO/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/UTxO/Properties.hs
@@ -24,12 +24,12 @@ import Control.State.Transition.Trace
 
 import Cardano.Ledger.Spec.STS.UTXO (reserves, utxo)
 import Cardano.Ledger.Spec.STS.UTXOW (UTXOW)
-import Ledger.UTxO (TxId, balance, body, inputs, outputs)
+import Ledger.UTxO (balance, body, inputs, outputs)
 
 -- | Check that the money is constant in the system.
 moneyIsConstant :: Property
 moneyIsConstant = withTests 200 . property $ do
-  (st0, st) <- firstAndLastState <$> forAll (trace @(UTXOW TxId) 500)
+  (st0, st) <- firstAndLastState <$> forAll (trace @UTXOW 500)
   reserves st0 + balance (utxo st0) === reserves st + balance (utxo st)
 
 -- To test the performance of the integrated shrinker for UTxO traces one could
@@ -50,7 +50,7 @@ tracesAreClassified :: Property
 -- TODO: we might want to run this only while developing, and not on CI.
 tracesAreClassified = withTests 200 . property $ do
   let (tl, step) = (500, 50)
-  tr <- forAll (trace @(UTXOW TxId) tl)
+  tr <- forAll (trace @UTXOW tl)
   classifyTraceLength tr tl step
   -- Classify the average number of inputs and outputs. Note that the intervals
   -- were arbitrarily determined, since in order to have a good partition of


### PR DESCRIPTION
This PR removes the `txid` parameter on `TxIn`s that was used for hedgehog state machine testing. We've changed our testing approach to use Traces so we no longer need this!

Closes #531 