### PR TITLE
Adds k to STS environments in Byron-Shelley

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
@@ -37,8 +37,9 @@ import Ledger.Delegation
   , _dSEnvAllowedDelegators
   , _dSEnvEpoch
   , _dSEnvSlot
+  , _dSEnvK
   )
-import Ledger.Update (PParams, maxBkSz, UPIState)
+import Ledger.Update (PParams, maxBkSz, UPIState, stableAfter)
 import Ledger.UTxO (UTxO)
 
 import Cardano.Spec.Chain.STS.Block
@@ -83,7 +84,7 @@ instance STS BBODY where
         hash (bUpdPayload b)         == bh ^. bhUpdHash  ?! InvalidUpdateProposalHash
 
         us' <- trans @BUPI $ TRC (
-            (bh ^. bhSlot, _dIStateDelegationMap ds)
+            (bh ^. bhSlot, _dIStateDelegationMap ds, ppsVal ^. stableAfter)
           , us
           , (b ^. bBody ^. bUpdProp, b ^. bBody ^. bUpdVotes, bEndorsment b) )
         ds' <- trans @DELEG $ TRC
@@ -92,6 +93,7 @@ instance STS BBODY where
                     (fromList . keys . _dIStateDelegationMap) ds
                 , _dSEnvEpoch = e_n
                 , _dSEnvSlot = bh ^. bhSlot
+                , _dSEnvK = ppsVal ^. stableAfter
                 }
             )
           , ds

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
@@ -20,6 +20,10 @@ instance STS BHEAD where
   type Environment BHEAD
     = ( Bimap VKeyGenesis VKey
       , Slot
+      , BlockCount -- Chain stability parameter; this is a global
+                   -- constant in the formal specification, which we
+                   -- put in this environment so that we can test with
+                   -- different values of it.
       )
   type State BHEAD = UPIState
 
@@ -40,8 +44,8 @@ instance STS BHEAD where
 
   transitionRules =
     [ do
-        TRC ((_, sLast), us, bh) <- judgmentContext
-        us' <- trans @EPOCH $ TRC (sEpoch sLast, us, bh ^. bhSlot)
+        TRC ((_, sLast, k), us, bh) <- judgmentContext
+        us' <- trans @EPOCH $ TRC ((sEpoch sLast, k), us, bh ^. bhSlot)
         let sMax = snd (us' ^. _1) ^. maxHdrSz
         bHeaderSize bh <= sMax ?! HeaderSizeTooBig
         return $! us'

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -120,10 +120,10 @@ instance STS CHAIN where
 
     notEBBRule :: TransitionRule CHAIN
     notEBBRule = do
-      TRC ((sNow, utxoGenesis, _, _), (sLast, sgs, h, utxoSt, ds, us), b) <- judgmentContext
+      TRC ((sNow, utxoGenesis, _, pps), (sLast, sgs, h, utxoSt, ds, us), b) <- judgmentContext
       let dm = _dIStateDelegationMap ds :: Bimap VKeyGenesis VKey
       us' <-
-        trans @BHEAD $ TRC ((dm, sLast), us, b ^. bHeader)
+        trans @BHEAD $ TRC ((dm, sLast, pps ^. stableAfter), us, b ^. bHeader)
       let ppsUs' = snd (us' ^. _1)
       (h', sgs') <-
         trans @PBFT  $ TRC ((ppsUs', dm, sLast, sNow), (h, sgs), b ^. bHeader)

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
@@ -11,7 +11,6 @@ import qualified Data.Sequence as S
 import Control.State.Transition
 
 import Ledger.Core hiding ((|>))
-import Ledger.GlobalParams (k)
 import Ledger.Update hiding (NotADelegate)
 
 data SIGCNT
@@ -38,7 +37,9 @@ instance STS SIGCNT where
   transitionRules =
     [ do
         TRC ((pps, dms), sgs, vk) <- judgmentContext
-        let t' = pps ^. bkSgnCntT
+        let
+          t' = pps ^. bkSgnCntT
+          k  = pps ^. stableAfter
         case Bimap.lookupR vk dms of
           Just vkG -> do
             let sgs' = S.drop (S.length sgs + 1 - (fromIntegral . unBlockCount $ k)) (sgs |> vkG)

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -1,8 +1,7 @@
 -- | Ledger global parameters.
 
 module Ledger.GlobalParams
-  ( k
-  , lovelaceCap
+  ( lovelaceCap
   , ngk
   )
 where
@@ -10,15 +9,8 @@ where
 import Data.Int (Int64)
 import Data.Word (Word64)
 
-import Ledger.Core (BlockCount (BlockCount), Lovelace (Lovelace))
+import Ledger.Core (Lovelace (Lovelace))
 
-
--- | Chain stability parameter, measured in terms of number of blocks.
---
--- We're fixing this for now. In the future we might want to make this
--- configurable.
-k :: BlockCount
-k = BlockCount 2160
 
 -- | Constant amount of Lovelace in the system.
 lovelaceCap :: Lovelace

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
@@ -14,7 +14,8 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
 import Ledger.Core
-  ( Epoch(Epoch)
+  ( BlockCount(BlockCount)
+  , Epoch(Epoch)
   , Owner(Owner)
   , Sig(Sig)
   , Slot(Slot)
@@ -54,7 +55,7 @@ deleg =
     ]
 
   , testGroup "Scheduling"
-    [ testCase "Example 0" $ checkTrace @SDELEG (DSEnv [gk 0, gk 1, gk 2] (e 8) (s 2)) $
+    [ testCase "Example 0" $ checkTrace @SDELEG (DSEnv [gk 0, gk 1, gk 2] (e 8) (s 2) (BlockCount 2160)) $
 
       pure (DSState [] [])
 

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -69,7 +69,8 @@ import Control.State.Transition.Trace
   , traceEnv
   )
 import Ledger.Core
-  ( Epoch(Epoch)
+  ( BlockCount(BlockCount)
+  , Epoch(Epoch)
   , Owner(Owner)
   , Sig(Sig)
   , Slot(Slot)
@@ -87,7 +88,7 @@ import Ledger.Delegation
   , DCert(DCert)
   , DELEG
   , DIState(DIState)
-  , DSEnv(DSEnv)
+  , DSEnv(DSEnv, _dSEnvK)
   , DSEnv
   , DSState(DSState)
   , DState(DState, _dStateDelegationMap, _dStateLastDelegation)
@@ -110,7 +111,6 @@ import Ledger.Delegation
   , slot
   )
 
-import Ledger.GlobalParams (k)
 import Ledger.Core.Generators (vkGen)
 
 --------------------------------------------------------------------------------
@@ -195,10 +195,10 @@ dcertsAreTriggeredInTrace tr
     -- certificates in the trace' signals.
     trExpectedDms
       = expectedDms lastSlot
-                    ((fromIntegral . unSlotCount . liveAfter) k)
+                    ((fromIntegral . unSlotCount . liveAfter) (_dSEnvK env))
                     slotsAndDcerts
 
-    (_, st) = lastState tr
+    (env, st) = lastState tr
 
     -- | Last slot that was considered for an activation.
     lastSlot :: Int
@@ -256,7 +256,8 @@ instance HasTrace DBLOCK where
     n <- integral (linear 0 14)
     e <- integral (linear 0 1000)
     s <- integral (linear 0 1000)
-    pure $! DSEnv (Set.fromAscList $ gk <$> [0..n]) (Epoch e) (Slot s)
+    k <- integral (linear 1 10000)
+    pure $! DSEnv (Set.fromAscList $ gk <$> [0..n]) (Epoch e) (Slot s) (BlockCount k)
     where
       gk = VKeyGenesis . VKey . Owner
 

--- a/byron/ledger/executable-spec/test/Ledger/Pvbump/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Pvbump/Properties.hs
@@ -7,7 +7,6 @@ import           Data.Maybe (fromMaybe)
 import           Ledger.Update.Generators
 import           Hedgehog
 import           Ledger.Core (BlockCount(..), SlotCount(..), minusSlotMaybe)
-import           Ledger.GlobalParams (k)
 import           Ledger.Update (PVBUMP)
 
 
@@ -59,7 +58,7 @@ lastProposal = property $ do
       <*> pvbumpStateGen
       <*> pure ()
   let
-    TRC ((s_n, fads), _, _) = judgementContext
+    TRC ((s_n, fads, k), _, _) = judgementContext
     s = fromMaybe
       (error
         "An improper slot generator used! Constraint violated: s_n > 2*k")


### PR DESCRIPTION
This patch changes `k` from a global parameter into an STS environment parameter in the Byron-Shelley era executable specification.

Closes #556.