### PR TITLE
Add coverage for delegation traces (via DBLOCK transition system)

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -191,7 +191,7 @@ sigGenChain shouldGenDelegation shouldGenUTxO (_sNow, utxo0, dsEnv, pps) (Slot s
     -- Here we do not want to shrink the issuer, since @Gen.element@ shrinks
     -- towards the first element of the list, which in this case won't provide
     -- us with better shrinks.
-    vkI         <- Gen.prune $ Gen.element $ Bimap.elems (ds ^. dms)
+    vkI         <- Gen.prune $ Gen.element $ Bimap.elems (ds ^. dmsL)
     nextSlot    <- gNextSlot
 
     delegationPayload <- case shouldGenDelegation of

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -195,7 +195,7 @@ sigGenChain shouldGenDelegation shouldGenUTxO (_sNow, utxo0, dsEnv, pps) (Slot s
     nextSlot    <- gNextSlot
 
     delegationPayload <- case shouldGenDelegation of
-      GenDelegation   -> dcertsGen dsEnv
+      GenDelegation   -> dcertsGen dsEnv ds
       NoGenDelegation -> pure []
 
     utxoPayload <- case shouldGenUTxO of

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -100,7 +100,7 @@ test-suite ledger-rules-test
                , tasty
                , tasty-hunit
                , tasty-hedgehog
-               , Unique
+               , Unique >= 0.4.7.6
                -- Local deps
                , cs-ledger
                , small-steps

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -100,6 +100,7 @@ test-suite ledger-rules-test
                , tasty
                , tasty-hunit
                , tasty-hedgehog
+               , Unique
                -- Local deps
                , cs-ledger
                , small-steps

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -122,7 +122,7 @@ verify (VKey vk) vd (Sig sd sk) = vk == sk && vd == sd
 
 newtype Epoch = Epoch Word64
   deriving stock (Show, Generic)
-  deriving newtype (Eq, Ord, Hashable)
+  deriving newtype (Eq, Ord, Hashable, Num)
   deriving anyclass (HasTypeReps)
 
 newtype Slot = Slot { unSlot :: Word64 }

--- a/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
@@ -4,6 +4,8 @@ module Ledger.Core.Generators
   , vkgenesisGen
   , addrGen
   , slotGen
+  , epochGen
+  , blockCountGen
   )
 where
 
@@ -14,10 +16,12 @@ import qualified Hedgehog.Range as Range
 
 import Ledger.Core
   ( Addr(Addr)
+  , BlockCount(BlockCount)
+  , Epoch(Epoch)
   , Owner(Owner)
+  , Slot(Slot)
   , VKey(VKey)
   , VKeyGenesis(VKeyGenesis)
-  , Slot(Slot)
   )
 
 vkGen :: Gen VKey
@@ -33,3 +37,13 @@ addrGen = Addr <$> vkGen
 slotGen :: Word64 -> Word64 -> Gen Slot
 slotGen lower upper =
   Slot <$> Gen.word64 (Range.linear lower upper)
+
+-- | Generates an epoch within the given bound
+epochGen :: Word64 -> Word64 -> Gen Epoch
+epochGen lower upper =
+  Epoch <$> Gen.word64 (Range.linear lower upper)
+
+-- | Generates a block count within the given bound
+blockCountGen :: Word64 -> Word64 -> Gen BlockCount
+blockCountGen lower upper =
+  BlockCount <$> Gen.word64 (Range.linear lower upper)

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -408,7 +408,8 @@ instance STS ADELEG where
           else do
             case Map.lookup vks dws of
               Just sp -> sp >= s ?! AfterExistingDelegation
-              Nothing -> False ?! NoLastDelegation
+              Nothing -> error $  "This can't happen since otherwise "
+                               ++ "the previous rule would have been triggered."
             return st
     ]
 

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -56,6 +56,7 @@ module Ledger.Delegation
   , liveAfter
   -- * State lens fields
   , slot
+  , epoch
   , delegationMap
   -- * State lens type classes
   , HasScheduledDelegations

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -120,7 +120,7 @@ import Control.State.Transition.Generator
   , sigGen
   )
 import Ledger.Core
-  ( BlockCount(BlockCount)
+  ( BlockCount
   , Epoch(Epoch)
   , HasHash
   , Hash(Hash)
@@ -137,7 +137,13 @@ import Ledger.Core
   , owner
   , unBlockCount
   )
-import Ledger.Core.Generators (vkGen, vkgenesisGen)
+import Ledger.Core.Generators
+  ( blockCountGen
+  , epochGen
+  , slotGen
+  , vkGen
+  , vkgenesisGen
+  )
 
 
 --------------------------------------------------------------------------------
@@ -192,9 +198,13 @@ delegate c = c ^. dwho . _2
 -- | Delegation scheduling environment
 data DSEnv = DSEnv
   { _dSEnvAllowedDelegators :: Set VKeyGenesis
+  -- ^ Set of allowed delegators
   , _dSEnvEpoch :: Epoch
+  -- ^ Current epoch
   , _dSEnvSlot :: Slot
+  -- ^ Current slot
   , _dSEnvK :: BlockCount
+  -- ^ Chain stability parameter
   } deriving (Show, Eq)
 
 makeFields ''DSEnv
@@ -526,8 +536,8 @@ instance HasTrace DELEG where
     -- A similar remark applies to the ranges chosen for slot and slot count
     -- generators.
     <$> Gen.set (linear 1 7) vkgenesisGen
-    <*> (Epoch <$> Gen.integral (linear 0 100))
-    <*> (Slot <$> Gen.integral (linear 0 10000))
-    <*> (BlockCount <$> Gen.integral (linear 1 10000))
+    <*> epochGen 0 10
+    <*> slotGen 0 100
+    <*> blockCountGen 0 100
 
   sigGen e _st = dcertsGen e

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -536,10 +536,10 @@ dcertGen env st =
     candidates = Set.toList $ preCandidates \\ eks st
     -- Next, we choose to whom these keys delegate.
     target :: [VKey]
-    -- TODO: we might want to make this configurable for now we chose an upper
-    -- bound equal to three time the number of genesis keys to increase the
+    -- NOTE: we might want to make this configurable for now we chose an upper
+    -- bound equal to two times the number of genesis keys to increase the
     -- chance of having two genesis keys delegating to the same key.
-    target = VKey . Owner <$> [0 .. (3 * fromIntegral (length allowed))]
+    target = VKey . Owner <$> [0 .. (2 * fromIntegral (length allowed))]
 
     mkDCert' ((e, vkg), vk) = DCert (vk, e) (Sig vkg (owner vkg)) (vkg, vk) e
   in

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -501,18 +501,14 @@ instance STS DELEG where
         sds <- trans @SDELEGS $ TRC (env, st ^. dIStateDSState, sig)
         let slots = filter ((<= (env ^. slot)) . fst) $ sds ^. scheduledDelegations
         as <- trans @ADELEGS $ TRC (env ^. allowedDelegators, st ^. dIStateDState, slots)
-        let d = liveAfter (env ^. k)
         return $ DIState
           (as ^. delegationMap)
           (as ^. lastDelegation)
-          (filter (aboutSlot (env ^. slot) d . fst)
+          (filter (((env ^. slot) `addSlot` 1 <=) . fst)
             $ sds ^. scheduledDelegations)
           (Set.filter ((env ^. epoch <=) . fst)
             $ sds ^. keyEpochDelegations)
     ]
-    where
-      aboutSlot :: Slot -> SlotCount -> (Slot -> Bool)
-      aboutSlot a b c = a < c && c <= (a `addSlot` b)
 
 instance Embed SDELEGS DELEG where
   wrapFailed = SDelegSFailure

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -553,6 +553,10 @@ dcertsGen :: DSEnv -> DIState -> Gen [DCert]
 dcertsGen env st =
   -- NOTE: alternatively we could define a HasTrace instance for SDELEG and use
   -- trace here.
+  --
+  -- This generator can result in an empty list of delegation certificates if
+  -- no delegation certificates can be produced, according to the delegation
+  -- rules, given the initial state and environment.
   catMaybes <$> Gen.list (constant 1 n) (dcertGen env st)
   where n = env ^. allowedDelegators . to length
 

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -3,13 +3,14 @@
 module Ledger.GlobalParams
   ( lovelaceCap
   , ngk
+  , slotsPerEpoch
   )
 where
 
 import Data.Int (Int64)
 import Data.Word (Word64)
 
-import Ledger.Core (Lovelace (Lovelace))
+import Ledger.Core (BlockCount(BlockCount), Lovelace(Lovelace))
 
 
 -- | Constant amount of Lovelace in the system.
@@ -19,3 +20,9 @@ lovelaceCap = Lovelace $ 45 * fromIntegral ((10 :: Int64) ^ (15 :: Int64))
 -- | Number of genesis keys
 ngk :: Word64
 ngk = 7
+
+-- | Given the chain stability parameter, often referred to as @k@, which is
+-- expressed in an amount of blocks, return the number of slots contained in an
+-- epoch.
+slotsPerEpoch :: Integral n => BlockCount -> n
+slotsPerEpoch (BlockCount c) = fromIntegral $ c * 10

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
@@ -25,6 +25,7 @@ import Ledger.Core
   )
 import Ledger.Delegation
   ( ADELEG
+  , ADELEGS
   , DCert(DCert)
   , DSEnv(DSEnv)
   , DSState(DSState)
@@ -47,15 +48,80 @@ deleg =
       .- (s 1, (gk 1, k 11)) .-> DState (Bimap.fromList [(gk 0, k 10), (gk 1, k 11)])
                                         [(gk 0, s 0), (gk 1, s 1)]
 
-      .- (s 2, (gk 0, k 11)) .-> DState (Bimap.fromList [(gk 0, k 11)])
-                                        [(gk 0, s 2), (gk 1, s 1)]
+      -- Here we try to delegate to a key @k 11@ that is already delegated (by
+      -- @gk 0@), so the state remains unaltered.
+      .- (s 2, (gk 0, k 11)) .-> DState (Bimap.fromList [(gk 0, k 10), (gk 1, k 11)])
+                                        [(gk 0, s 0), (gk 1, s 1)]
 
-      .- (s 3, (gk 2, k 12)) .-> DState (Bimap.fromList [(gk 0, k 11), (gk 2, k 12)])
-                                        [(gk 0, s 2), (gk 1, s 1), (gk 2, s 3)]
+      .- (s 3, (gk 2, k 12)) .-> DState (Bimap.fromList [(gk 0, k 10), (gk 1, k 11), (gk 2, k 12)])
+                                        [(gk 0, s 0), (gk 1, s 1), (gk 2, s 3)]
+
+    , testCase "Example 1" $ checkTrace @ADELEG genKeys $
+
+      pure (DState (Bimap.fromList []) [])
+
+      .- (s 0, (gk 0, k 2)) .-> DState (Bimap.fromList [(gk 0, k 2)])
+                                       [(gk 0, s 0)]
+
+      -- Trying to delegate to a key that was delegated already has no effect
+      -- should be a no-op on the delegation state.
+      .- (s 1, (gk 1, k 2)) .-> DState (Bimap.fromList [(gk 0, k 2)])
+                                       [(gk 0, s 0)]
+    , testCase "Example 2" $ checkTrace @ADELEG genKeys $
+
+      pure (DState (Bimap.fromList []) [])
+
+      .- (s 4, (gk 1, k 2)) .-> DState (Bimap.fromList [(gk 1, k 2)])
+                                       [(gk 1, s 4)]
+
+      .- (s 10, (gk 1, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
+                                       [(gk 1, s 10)]
+
+      .- (s 13, (gk 2, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
+                                       [(gk 1, s 10)]
+    , testCase "Example 2" $ checkTrace @ADELEG genKeys $
+
+      pure (DState (Bimap.fromList []) [])
+
+      .- (s 6, (gk 1, k 2)) .-> DState (Bimap.fromList [(gk 1, k 2)])
+                                       [(gk 1, s 6)]
+
+      .- (s 7, (gk 2, k 2)) .-> DState (Bimap.fromList [(gk 1, k 2)])
+                                       [(gk 1, s 6)]
+
+      .- (s 16, (gk 1, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
+                                        [(gk 1, s 16)]
+
+      .- (s 19, (gk 2, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
+                                        [(gk 1, s 16)]
+
+    , testCase "Example 3" $ checkTrace @ADELEG genKeys $
+
+      pure (DState (Bimap.fromList []) [])
+
+      .- (s 4, (gk 1, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
+                                       [(gk 1, s 4)]
+      .- (s 5, (gk 2, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
+                                       [(gk 1, s 4)]
+      .- (s 5, (gk 1, k 1)) .-> DState (Bimap.fromList [(gk 1, k 1)])
+                                       [(gk 1, s 5)]
+
+    ]
+
+  , testGroup "Multiple Activations"
+    [ testCase "Example 0" $ checkTrace @ADELEGS genKeys $
+
+      pure (DState (Bimap.fromList []) [])
+
+      .- [ (s 4, (gk 1, k 0))
+         , (s 5, (gk 2, k 0))
+         , (s 5, (gk 1, k 1)) ] .-> DState (Bimap.fromList [(gk 1, k 1)])
+                                           [(gk 1, s 5)]
+
     ]
 
   , testGroup "Scheduling"
-    [ testCase "Example 0" $ checkTrace @SDELEG (DSEnv [gk 0, gk 1, gk 2] (e 8) (s 2) (BlockCount 2160)) $
+    [ testCase "Example 0" $ checkTrace @SDELEG (DSEnv [gk 0, gk 1, gk 2] (e 8) (s 2) (bk 2160)) $
 
       pure (DSState [] [])
 
@@ -81,6 +147,9 @@ deleg =
 
     e :: Word64 -> Epoch
     e = Epoch
+
+    bk :: Word64 -> BlockCount
+    bk = BlockCount
 
     dc :: VKeyGenesis -> VKey -> Epoch -> DCert
     dc vkg vk ep = DCert (vk, ep) (Sig vkg (owner vkg)) (vkg, vk) ep

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
@@ -71,18 +71,6 @@ deleg =
 
       pure (DState (Bimap.fromList []) [])
 
-      .- (s 4, (gk 1, k 2)) .-> DState (Bimap.fromList [(gk 1, k 2)])
-                                       [(gk 1, s 4)]
-
-      .- (s 10, (gk 1, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
-                                       [(gk 1, s 10)]
-
-      .- (s 13, (gk 2, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
-                                       [(gk 1, s 10)]
-    , testCase "Example 2" $ checkTrace @ADELEG genKeys $
-
-      pure (DState (Bimap.fromList []) [])
-
       .- (s 6, (gk 1, k 2)) .-> DState (Bimap.fromList [(gk 1, k 2)])
                                        [(gk 1, s 6)]
 
@@ -94,17 +82,6 @@ deleg =
 
       .- (s 19, (gk 2, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
                                         [(gk 1, s 16)]
-
-    , testCase "Example 3" $ checkTrace @ADELEG genKeys $
-
-      pure (DState (Bimap.fromList []) [])
-
-      .- (s 4, (gk 1, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
-                                       [(gk 1, s 4)]
-      .- (s 5, (gk 2, k 0)) .-> DState (Bimap.fromList [(gk 1, k 0)])
-                                       [(gk 1, s 4)]
-      .- (s 5, (gk 1, k 1)) .-> DState (Bimap.fromList [(gk 1, k 1)])
-                                       [(gk 1, s 5)]
 
     ]
 

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -11,6 +11,7 @@ module Ledger.Delegation.Properties
   , rejectDupSchedDelegs
   , tracesAreClassified
   , dblockTracesAreClassified
+  , DBLOCK
   )
 where
 
@@ -272,8 +273,8 @@ instance HasTrace DBLOCK where
       -- We scale the number of delegators linearly up to twice the number of
       -- genesis keys we use in production. Factor 2 is chosen ad-hoc here.
       allowedDelegators = do
-        n <- integral (linear 0 14)
-        pure $! Set.fromAscList $ gk <$> [0 .. n]
+        n <- integral (linear 1 14)
+        pure $! Set.fromAscList $ gk <$> [1 .. n]
       gk = VKeyGenesis . VKey . Owner
 
   sigGen _ (env, st) = do
@@ -301,14 +302,17 @@ dblockTracesAreClassified = property $ do
     -- Total number of delegation certificates found in the trace
     totalDCerts :: [DCert]
     totalDCerts = concat $ _blockCerts <$> traceSignals OldestFirst tr
-  classify "[0, 3)" $ length totalDCerts < 3
-  classify "[3, 5)" $ 3 <= length totalDCerts && length totalDCerts <= 5
-  classify "[5, 10)" $ 5 <= length totalDCerts && length totalDCerts < 10
-  classify "[10, 15)" $ 10 <= length totalDCerts && length totalDCerts < 15
-  classify "[15, 20)" $ 15 <= length totalDCerts && length totalDCerts < 20
-  classify "[20, 30)" $ 20 <= length totalDCerts && length totalDCerts < 30
-  classify "[30, 100)" $ 30 <= length totalDCerts && length totalDCerts < 100
-  classify "[100, 200)" $ 100 <= length totalDCerts && length totalDCerts < 200
+  -- TODO: generalize this as classifyListLength (or foldableLength) (and
+  -- classifyTraceLength can use this function)
+  classify "total dcerts [0, 3)" $ length totalDCerts < 3
+  classify "total dcerts [3, 5)" $ 3 <= length totalDCerts && length totalDCerts <= 5
+  classify "total dcerts [5, 10)" $ 5 <= length totalDCerts && length totalDCerts < 10
+  classify "total dcerts [10, 15)" $ 10 <= length totalDCerts && length totalDCerts < 15
+  classify "total dcerts [15, 20)" $ 15 <= length totalDCerts && length totalDCerts < 20
+  classify "total dcerts [20, 30)" $ 20 <= length totalDCerts && length totalDCerts < 30
+  classify "total dcerts [30, 50)" $ 30 <= length totalDCerts && length totalDCerts < 50
+  classify "total dcerts [50, 100)" $ 30 <= length totalDCerts && length totalDCerts < 100
+  classify "total dcerts [100, 200)" $ 100 <= length totalDCerts && length totalDCerts < 200
   success
 
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -387,7 +387,7 @@ relevantCasesAreCovered = withTests 200 $ property $ do
         multipleDelegations = length
                             $ filter ((2 <=) . snd)
                             -- Count the occurrences. If we have more than one
-                            -- occurence for a key they we know that
+                            -- occurrence for a key they we know that
                             $ count
                             -- Keep the delegators. Since we applied nub
                             -- before, we know that if there are two keys in

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -313,7 +313,7 @@ dcertsAreTriggered = withTests 300 $ property $
   forAll (nonTrivialTrace 1000) >>= dcertsAreTriggeredInTrace
 
 dblockTracesAreClassified :: Property
-dblockTracesAreClassified = property $ do
+dblockTracesAreClassified = withTests 200 $ property $ do
   let (tl, step) = (1000, 100)
   tr <- forAll (trace @DBLOCK tl)
   classifyTraceLength tr tl step

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -27,7 +27,7 @@ import Hedgehog
   , Property
   , (===)
   , assert
-  , classify
+--  , classify
   , forAll
   , property
   , success
@@ -57,6 +57,7 @@ import Control.State.Transition.Generator
   ( HasSizeInfo
   , HasTrace
   , classifyTraceLength
+  , classifySize
   , initEnvGen
   , isTrivial
   , nonTrivialTrace
@@ -309,22 +310,13 @@ dblockTracesAreClassified = property $ do
   let (tl, step) = (1000, 100)
   tr <- forAll (trace @DBLOCK tl)
   classifyTraceLength tr tl step
-  -- Let's see what happens if we filter the empty signals.
+  -- Classify the traces by the total number of delegation certificates on
+  -- them.
   let
     -- Total number of delegation certificates found in the trace
     totalDCerts :: [DCert]
     totalDCerts = concat $ _blockCerts <$> traceSignals OldestFirst tr
-  -- TODO: generalize this as classifyListLength (or foldableLength) (and
-  -- classifyTraceLength can use this function)
-  classify "total dcerts [0, 3)" $ length totalDCerts < 3
-  classify "total dcerts [3, 5)" $ 3 <= length totalDCerts && length totalDCerts <= 5
-  classify "total dcerts [5, 10)" $ 5 <= length totalDCerts && length totalDCerts < 10
-  classify "total dcerts [10, 15)" $ 10 <= length totalDCerts && length totalDCerts < 15
-  classify "total dcerts [15, 20)" $ 15 <= length totalDCerts && length totalDCerts < 20
-  classify "total dcerts [20, 30)" $ 20 <= length totalDCerts && length totalDCerts < 30
-  classify "total dcerts [30, 50)" $ 30 <= length totalDCerts && length totalDCerts < 50
-  classify "total dcerts [50, 100)" $ 30 <= length totalDCerts && length totalDCerts < 100
-  classify "total dcerts [100, 200)" $ 100 <= length totalDCerts && length totalDCerts < 200
+  classifySize "total dcerts" totalDCerts length 100 10
   success
 
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -335,7 +335,7 @@ traceDCerts :: Trace DBLOCK -> [DCert]
 traceDCerts tr = concat $ _blockCerts <$> traceSignals OldestFirst tr
 
 relevantCasesAreCovered :: Property
-relevantCasesAreCovered = withTests 500 $ property $ do
+relevantCasesAreCovered = withTests 200 $ property $ do
   let tl = 1000
   tr <- forAll (trace @DBLOCK tl)
   -- There are as many delegation certificates as blocks.
@@ -356,8 +356,8 @@ relevantCasesAreCovered = withTests 500 $ property $ do
 
   -- There are delegations to the next epoch.
   cover 50
-        "at least 30% of the certificates delegate in the next epoch"
-        (0.3 <= nextEpochDelegationPcnt tr)
+        "at least 50% of the certificates delegate in the next epoch"
+        (0.5 <= nextEpochDelegationPcnt tr)
 
   -- 25% of the cases must contain at least 20% of self-delegations.
   cover 25

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -31,6 +31,7 @@ main = defaultMain tests
     , testGroup
       "Delegation Properties"
       [ testProperty "Certificates are triggered"           dcertsAreTriggered
+      , testProperty "DBLOCK Traces are classified"         DELEG.dblockTracesAreClassified
       , testProperty "Duplicated certificates are rejected" rejectDupSchedDelegs
       , testProperty "Traces are classified"                DELEG.tracesAreClassified
       ]

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -32,6 +32,7 @@ main = defaultMain tests
       "Delegation Properties"
       [ testProperty "Certificates are triggered"           dcertsAreTriggered
       , testProperty "DBLOCK Traces are classified"         DELEG.dblockTracesAreClassified
+      , testProperty "relevant DBLOCK traces generated"     DELEG.relevantCasesAreCovered
       , testProperty "Duplicated certificates are rejected" rejectDupSchedDelegs
       , testProperty "Traces are classified"                DELEG.tracesAreClassified
       ]

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -104,7 +104,6 @@
     \label{eq:rule:delegation-interface}
     \inference
     {
-      d \leteq 2 \cdot k \\
       {\left(\begin{array}{l}
          \mathcal{K} \\
          e\\
@@ -174,7 +173,7 @@
           \begin{array}{l}
             \var{dms'}\\
             \var{dws'}\\
-            \var{[s-d,~ s+d]} \restrictdom \var{sds'}\\
+            \var{[s+1, ..]} \restrictdom \var{sds'}\\
             \var{[e, ..]} \restrictdom \var{eks'}
           \end{array}
         \right)

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -245,6 +245,14 @@ classifyTraceLength
   -> PropertyT IO ()
 classifyTraceLength tr = classifySize "trace length:" tr traceLength
 
+-- | Classify the value size as either:
+--
+-- - being empty
+-- - being a singleton
+-- - having the given maximum size
+-- - belonging to one of the intervals between 2 and the maximum size - 1. The
+--   number of intervals are determined by the @step@ parameter.
+--
 classifySize
   :: String
   -- ^ Prefix to be added to the label intervals

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -54,6 +54,7 @@
             (hsPkgs.tasty)
             (hsPkgs.tasty-hunit)
             (hsPkgs.tasty-hedgehog)
+            (hsPkgs.Unique)
             (hsPkgs.cs-ledger)
             (hsPkgs.small-steps)
             ];

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -4,6 +4,7 @@
       packages = {
         "sequence" = (((hackage.sequence)."0.9.8").revisions).default;
         "tasty-hedgehog" = (((hackage.tasty-hedgehog)."1.0.0.1").revisions).default;
+        "Unique" = (((hackage.Unique)."0.4.7.6").revisions).default;
         "base58-bytestring" = (((hackage.base58-bytestring)."0.1.0").revisions).default;
         "hedgehog" = (((hackage.hedgehog)."1.0").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,7 @@ packages:
 extra-deps:
 - sequence-0.9.8
 - tasty-hedgehog-1.0.0.1 # Needed due to https://github.com/qfpl/tasty-hedgehog/issues/30
+- Unique-0.4.7.6
 
 nix:
   shell-file: nix/stack-shell.nix


### PR DESCRIPTION
- Sync the executable spec with the formal spec:
  - We didn't check injectivity of the delegation map
  - We didn't check that we delegation epoch didn't lie past the next epoch.
- Fix the implementation of the `SDELEGS` and `ADELEGS` rule, where the
  delegation certificates where applied in the reverse order.
- Delete the applied delegation certificates. We used to keep past delegation
  certificates. However this led to unexpected behavior where an invalid
  certificate would be re-applied resulting in a delegation behavior that was
  hard to predict and reason with. 
- Improved the delegation certificate generators:
  - Take into account the allowed delegators that can delegate.
- In the tests adapt `expectedDms` so that the injectiviy constraint is taken
  into account when applying a sequence of delegation certificates.
  

Closes #562 
Closes #297 