### PR TITLE
[523] Test/fix HasTypeReps instances for TxWits and related types

### DIFF
--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -87,6 +87,7 @@ test-suite ledger-rules-test
   main-is: Main.hs
   other-modules: Ledger.Delegation.Examples
                , Ledger.Delegation.Properties
+               , Ledger.HasTypeReps.Properties
                , Ledger.Pvbump.Properties
                , Ledger.UTxO.Properties
   type: exitcode-stdio-1.0

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -31,27 +31,20 @@ import Ledger.Update (PParams (PParams), _factorA, _factorB)
 
 -- |A unique ID of a transaction, which is computable from the transaction.
 newtype TxId = TxId { getTxId :: Hash }
-  deriving stock (Show)
+  deriving stock (Show, Generic)
   deriving newtype (Eq, Ord, Hashable)
-
-instance HasTypeReps TxId where
-  typeReps x = typeOf x <| typeOf (getTxId x) <| empty
+  deriving anyclass (HasTypeReps)
 
 -- |The input of a UTxO.
 --
 --     * __TODO__ - is it okay to use list indices instead of implementing the Ix Type?
-data TxIn = TxIn TxId Natural deriving (Show, Eq, Ord, Generic, Hashable)
-
-instance HasTypeReps TxIn where
-  typeReps x@(TxIn i' n) = typeOf x <| typeOf i' <| typeOf n <| empty
+data TxIn = TxIn TxId Natural
+  deriving (Show, Eq, Ord, Generic, Hashable, HasTypeReps)
 
 -- |The output of a UTxO.
 data TxOut = TxOut { addr  :: Addr
                    , value :: Lovelace
-                   } deriving (Show, Eq, Ord, Generic, Hashable)
-
-instance HasTypeReps TxOut where
-  typeReps o = typeOf o <| empty
+                   } deriving (Show, Eq, Ord, Generic, Hashable, HasTypeReps)
 
 -- |The unspent transaction outputs.
 newtype UTxO = UTxO
@@ -118,7 +111,8 @@ txsize = abstractSize costs
 ---------------------------------------------------------------------------------
 
 -- |Proof/Witness that a transaction is authorized by the given key holder.
-data Wit = Wit VKey (Sig Tx) deriving (Show, Eq, Ord, Generic, Hashable)
+data Wit = Wit VKey (Sig Tx)
+  deriving (Show, Eq, Ord, Generic, Hashable, HasTypeReps)
 
 -- |A fully formed transaction.
 --
@@ -126,10 +120,7 @@ data Wit = Wit VKey (Sig Tx) deriving (Show, Eq, Ord, Generic, Hashable)
 data TxWits = TxWits
   { body      :: Tx
   , witnesses :: [Wit]
-  } deriving (Show, Eq, Generic, Hashable)
-
-instance HasTypeReps TxWits where
-  typeReps (TxWits b w) = typeOf b <| typeOf w <| empty
+  } deriving (Show, Eq, Generic, Hashable, HasTypeReps)
 
 instance HasHash [TxWits] where
   hash = Hash . H.hash

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -15,19 +15,18 @@
 
 module Ledger.UTxO where
 
-import Data.AbstractSize (HasTypeReps, typeReps, abstractSize)
-import Data.Hashable (Hashable)
-import qualified Data.Hashable as H
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe)
-import Data.Sequence ((<|), empty)
-import Data.Typeable (typeOf)
-import GHC.Generics (Generic)
-import Numeric.Natural (Natural)
+import           Data.AbstractSize (HasTypeReps, abstractSize)
+import           Data.Hashable     (Hashable)
+import qualified Data.Hashable     as H
+import           Data.Map.Strict   (Map)
+import qualified Data.Map.Strict   as Map
+import           Data.Maybe        (fromMaybe)
+import           Data.Typeable     (typeOf)
+import           GHC.Generics      (Generic)
+import           Numeric.Natural   (Natural)
 
-import Ledger.Core hiding ((<|))
-import Ledger.Update (PParams (PParams), _factorA, _factorB)
+import           Ledger.Core       hiding ((<|))
+import           Ledger.Update     (PParams (PParams), _factorA, _factorB)
 
 -- |A unique ID of a transaction, which is computable from the transaction.
 newtype TxId = TxId { getTxId :: Hash }

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -104,7 +104,8 @@ instance HasTypeReps PParams
 
 newtype UpId = UpId Int
   deriving stock (Generic, Show)
-  deriving newtype (Eq, Ord, Hashable, HasTypeReps)
+  deriving newtype (Eq, Ord, Hashable)
+  deriving anyclass (HasTypeReps)
 
 -- | Protocol version
 data ProtVer = ProtVer

--- a/byron/ledger/executable-spec/test/Ledger/HasTypeReps/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/HasTypeReps/Properties.hs
@@ -1,0 +1,170 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Ledger.HasTypeReps.Properties
+    (testTxHasTypeReps)
+  where
+
+import           Data.AbstractSize
+
+import           Data.Map.Strict                    (Map)
+import qualified Data.Map.Strict                    as Map
+import           Data.Sequence                      (empty, (<|), (><))
+import qualified Data.Sequence                      as Seq
+import           Data.Typeable                      (TypeRep, typeOf)
+import           Numeric.Natural                    (Natural)
+
+import           Hedgehog                           (MonadTest, Property,
+                                                     forAll, property,
+                                                     withTests, (===))
+import           Test.Tasty.Hedgehog
+
+import           Control.State.Transition.Generator (trace)
+import           Control.State.Transition.Trace     (TraceOrder (OldestFirst),
+                                                     traceSignals)
+
+import           Ledger.Core                        hiding ((<|))
+import           Ledger.UTxO
+
+import           Cardano.Ledger.Spec.STS.UTXOW      (UTXOW)
+
+import           Test.Tasty                         (TestTree, testGroup)
+import           Test.Tasty.HUnit                   (Assertion, testCase, (@?=))
+
+--------------------------------------------------------------------------------
+-- Example HasTypeReps.typeReps for TxIn, Tx
+--------------------------------------------------------------------------------
+
+aTx :: Tx
+aTx = undefined
+
+aTxId :: TxId
+aTxId = TxId (hash aTx)
+
+-- | 'TxIn' has a generic instance for 'HasTypeReps', which recursively adds
+--   'typeReps' for all types within 'TxIn'.
+exampleTypeRepsTxIn :: Assertion
+exampleTypeRepsTxIn =
+  let txIn = TxIn aTxId 0
+  in (typeReps txIn) @?= typeOf (undefined::TxIn)
+                         <| typeOf (undefined::TxId)
+                         <| typeOf (undefined::Hash)
+                         <| typeOf (undefined::Int)
+                         <| typeOf (undefined::Natural)
+                         <| empty
+
+-- | A 'TxWits' term may contain multiple inputs/outputs/witnesses.
+--   In this example, we have 2 inputs and show how the 'typeReps' for
+--   'TxIn' is repeated twice.
+exampleTypeRepsTx :: Assertion
+exampleTypeRepsTx =
+  let
+    (in0,in1) = (TxIn aTxId 0, TxIn aTxId 1)
+    outs = []
+    wits = []
+    tx = TxWits (Tx [in0, in1] outs) wits
+  in (typeReps tx) @?= typeOf (undefined::TxWits)
+                       <| typeOf (undefined::Tx)
+                       <| typeOf (undefined::[TxIn])
+                       <| typeReps in0
+                       >< typeReps in1
+                       >< (Seq.fromList [ typeOf (undefined::[TxOut])
+                                        , typeOf (undefined::[Wit]) ])
+
+--------------------------------------------------------------------------------
+-- Properties of abstractSize of TxWits / TxIn /TxOut / Wit
+--------------------------------------------------------------------------------
+
+-- | Since 'VKey' appears in both Wit and TxOut (as part of Addr), we
+--   need to use the same "cost" for this type in the following tests.
+vKeyCost :: Size
+vKeyCost = 17
+
+-- | Example costs for types in a 'TxIn'.
+costsTxIn :: Map TypeRep Size
+costsTxIn = Map.fromList [ (typeOf (undefined :: TxIn), 2)
+                         , (typeOf (undefined :: TxId), 3)
+                         , (typeOf (undefined :: Hash), 5) ]
+
+-- | Example costs for types in a 'TxOut'.
+costsTxOut :: Map TypeRep Size
+costsTxOut = Map.fromList [ (typeOf (undefined :: TxOut), 11)
+                          , (typeOf (undefined :: Addr), 13)
+                          , (typeOf (undefined :: VKey), vKeyCost)
+                          , (typeOf (undefined :: Lovelace), 23) ]
+
+-- | Example costs for types in a 'Wit'.
+costsWit :: Map TypeRep Size
+costsWit = Map.fromList [ (typeOf (undefined :: Wit), 31)
+                        , (typeOf (undefined :: VKey), vKeyCost)
+                        , (typeOf (undefined :: Sig Tx), 41)]
+
+-- | This property tests that 'abstractSize' accounts for multiple occurences
+--   of any type represented in the given "cost map".
+--
+--   'abstractSize' uses a "cost map" to compute the size of a term.
+--   For types that contain multiple occurrences of other types, 'abstractSize'
+--   should count each occurence (e.g. a 'Tx' may contain multiple 'TxIn' and
+--   when computing the size of Tx, we should account for the size of each
+--   'TxIn' occurence).
+--
+--  Precondition: this test assumes that the "cost map" only accounts for types
+--  that occur within the "inner" type of multiples that we are targeting, e.g.
+--  if we include a type in the cost map that occurs in 'TxIn' _and_ 'Tx',
+--  this property would have to be weakened to
+--  abstractSize costs x - n * unitCost > 0
+propMultiplesOfSize
+  :: (MonadTest m, HasTypeReps a)
+  => Map TypeRep Size
+  -- ^ a "cost map" for some type that may occur multiple times in the
+  --   given term of type 'a'
+  -> a
+  -- ^ term for which we will compute 'abstractSize'
+  -> Int
+  -- ^ the number of occurences of the "costed types" in given the term
+  -> m ()
+propMultiplesOfSize costs x n
+  = abstractSize costs x === n * unitCost
+  where
+    unitCost = sum (Map.elems costs)
+
+-- | Tests that the size of a 'TxWits' term, computed with the combined costs
+--   of 'TxIn/TxOut/Wit', is the sum of costs of all 'TxIn/TxOut/Wit' contained
+--   in the 'TxWits'.
+propSumOfSizesTxWits
+  :: MonadTest m => TxWits -> m ()
+propSumOfSizesTxWits txw
+  = (abstractSize (costsTxIn <> costsTxOut <> costsWit) txw)
+         === abstractSize costsTxIn (body txw)
+             + abstractSize costsTxOut (body txw)
+             + abstractSize costsWit (witnesses txw)
+
+-- | A combination of several properties
+--   (1) If we "cost" just the 'TxIn' type, then the abstract size of a 'Tx'
+--       term is a multiple of the unit cost for a 'TxIn'
+--   (2) Similarly, for 'Tx' and 'TxOut'
+--   (3) Similarly, for 'Tx' and 'Wit'
+--   (4) The abstract size of a 'TxWits' term is the sum of sizes of
+--       the 'TxIn/TxOut/Wit' parts.
+propTxAbstractSize :: Property
+propTxAbstractSize
+  = withTests 50 $ property $ do
+    tr <- forAll (trace @UTXOW 100)
+    let txs = traceSignals OldestFirst tr :: [TxWits]
+    mapM_ propSize txs
+  where
+    propSize txw
+      = let
+          body_ = (body txw)
+          wits_ = witnesses txw
+        in propMultiplesOfSize costsTxIn body_ (length $ inputs body_) -- (1)
+           >> propMultiplesOfSize costsTxOut body_ (length $ outputs body_) -- (2)
+           >> propMultiplesOfSize costsWit wits_ (length wits_) -- (3)
+           >> propSumOfSizesTxWits txw -- (4)
+
+testTxHasTypeReps :: TestTree
+testTxHasTypeReps = testGroup "Test HasTypeReps instances"
+  [ testCase "exampleTypeRepsTxIn - HasTypeReps" exampleTypeRepsTxIn
+  , testCase "exampleTypeRepsTx - HasTypeReps" exampleTypeRepsTx
+
+  , testProperty "AbstractSize and HasTypeReps" propTxAbstractSize
+  ]

--- a/byron/ledger/executable-spec/test/Ledger/UTxO/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/UTxO/Properties.hs
@@ -1,33 +1,26 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeApplications  #-}
 
 module Ledger.UTxO.Properties where
 
-import Control.Lens ((^.))
-import Control.Monad (when)
-import Hedgehog
-  ( Property
-  , (===)
-  , classify
-  , forAll
-  , property
-  , success
-  , withTests
-  )
+import           Control.Lens                       ((^.))
+import           Control.Monad                      (when)
+import           Hedgehog                           (Property, classify, forAll,
+                                                     property, success,
+                                                     withTests, (===))
 
-import Control.State.Transition.Generator (classifyTraceLength, trace)
-import Control.State.Transition.Trace
-  ( TraceOrder(OldestFirst)
-  , firstAndLastState
-  , traceEnv
-  , traceLength
-  , traceSignals
-  )
+import           Control.State.Transition.Generator (classifyTraceLength, trace)
+import           Control.State.Transition.Trace     (TraceOrder (OldestFirst),
+                                                     firstAndLastState,
+                                                     traceEnv, traceLength,
+                                                     traceSignals)
 
-import Cardano.Ledger.Spec.STS.UTXO (pps, reserves, utxo)
-import Cardano.Ledger.Spec.STS.UTXOW (UTXOW)
-import Ledger.UTxO
-  (Tx(Tx), TxIn(TxIn), balance, body, inputs, outputs, pcMinFee)
+import           Cardano.Ledger.Spec.STS.UTXO       (pps, reserves, utxo)
+import           Cardano.Ledger.Spec.STS.UTXOW      (UTXOW)
+import           Ledger.UTxO                        (Tx (Tx), TxIn (TxIn),
+                                                     TxOut (TxOut), balance,
+                                                     body, inputs, outputs,
+                                                     pcMinFee)
 
 -- | Check that the money is constant in the system.
 moneyIsConstant :: Property
@@ -59,7 +52,7 @@ tracesAreClassified = withTests 200 . property $ do
   let
     pparams = pps (tr ^. traceEnv)
     -- Transaction with one input and one output
-    unitTx = Tx [TxIn undefined undefined] [undefined]
+    unitTx = Tx [TxIn undefined 0] [TxOut undefined 100]
     unitTxFee = pcMinFee pparams unitTx
   classify "Unit transaction cost == 0" $ unitTxFee == 0
   classify "Unit transaction cost == 1" $ unitTxFee == 1

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -5,16 +5,21 @@ module Main
   )
 where
 
-import Test.Tasty (TestTree, defaultMain, testGroup, localOption)
-import Test.Tasty.Hedgehog (testProperty)
-import Test.Tasty.Ingredients.ConsoleReporter (UseColor(Auto))
+import           Test.Tasty                             (TestTree, defaultMain,
+                                                         localOption, testGroup)
+import           Test.Tasty.Hedgehog                    (testProperty)
+import           Test.Tasty.Ingredients.ConsoleReporter (UseColor (Auto))
 
-import Ledger.Delegation.Examples (deleg)
-import Ledger.Delegation.Properties (dcertsAreTriggered, rejectDupSchedDelegs)
-import Ledger.Pvbump.Properties (emptyPVUpdate, beginningsNoUpdate, lastProposal)
-import qualified Ledger.Delegation.Properties as DELEG
-import Ledger.UTxO.Properties (moneyIsConstant)
-import qualified Ledger.UTxO.Properties as UTxO
+import           Ledger.Delegation.Examples             (deleg)
+import           Ledger.Delegation.Properties           (dcertsAreTriggered,
+                                                         rejectDupSchedDelegs)
+import qualified Ledger.Delegation.Properties           as DELEG
+import           Ledger.HasTypeReps.Properties          (testTxHasTypeReps)
+import           Ledger.Pvbump.Properties               (beginningsNoUpdate,
+                                                         emptyPVUpdate,
+                                                         lastProposal)
+import           Ledger.UTxO.Properties                 (moneyIsConstant)
+import qualified Ledger.UTxO.Properties                 as UTxO
 
 main :: IO ()
 main = defaultMain tests
@@ -40,4 +45,5 @@ main = defaultMain tests
       [ testProperty "Money is constant" moneyIsConstant
       , testProperty "Traces are classified" UTxO.tracesAreClassified
       ]
+    , testTxHasTypeReps
     ]

--- a/byron/semantics/executable-spec/src/Data/AbstractSize.hs
+++ b/byron/semantics/executable-spec/src/Data/AbstractSize.hs
@@ -149,6 +149,9 @@ instance HasTypeReps Char where
 instance HasTypeReps Int where
   typeReps x = [typeOf x]
 
+instance HasTypeReps Integer where
+  typeReps x = [typeOf x]
+
 instance HasTypeReps Double where
   typeReps x = [typeOf x]
 

--- a/byron/semantics/executable-spec/src/Data/AbstractSize.hs
+++ b/byron/semantics/executable-spec/src/Data/AbstractSize.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE OverloadedLists   #-}
+{-# LANGUAGE TypeOperators     #-}
 
 -- | An approach to computing the abstract size of data using 'TypeRep'.
 --
@@ -14,24 +14,16 @@ module Data.AbstractSize
   , Size
   ) where
 
-import qualified Crypto.Hash as Crypto
-import Data.Map.Strict (Map)
+import qualified Crypto.Hash     as Crypto
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Data.Sequence (Seq, (<|), (><), empty)
-import Data.Set (Set)
-import Data.Typeable (TypeRep, Typeable, typeOf)
-import Data.Word (Word64)
-import GHC.Generics
-  ( (:*:)((:*:))
-  , (:+:)(L1, R1)
-  , Generic
-  , K1(K1)
-  , M1(M1)
-  , Rep
-  , U1(U1)
-  , from
-  )
-import GHC.Natural
+import           Data.Sequence   (Seq, empty, (<|), (><))
+import           Data.Set        (Set)
+import           Data.Typeable   (TypeRep, Typeable, typeOf)
+import           Data.Word       (Word64)
+import           GHC.Generics    ((:*:) ((:*:)), (:+:) (L1, R1), Generic,
+                                  K1 (K1), M1 (M1), Rep, U1 (U1), from)
+import           GHC.Natural
 
 -- | @abstractSize m a@ computes the abstract size of @a@, using the accounting
 -- map @m@. The map @m@ determines the abstract size of each 'TypeRep'
@@ -73,8 +65,19 @@ type AccountingMap = Map TypeRep Size
 -- | The 'typeReps' function retrieves all the type representations found while
 -- traversing the data given as parameter.
 --
--- If you custom data type in an instance of 'Generics', a default
--- implementation is provided for you.
+-- CAUTION: for newtypes, do not use 'deriving newtype (HasTypeReps)' to derive
+-- instances, rather use 'deriving anyclass (HasTypeReps)'.
+-- This is because we use these instances in 'abstractSize', and for that
+-- we prefer to have the newtype wrapper type available for "costing".
+-- The difference between 'newtype' and 'anyclass' instances is as follows:
+--
+--  newtype Hash = Hash { unHash :: Int }
+--      deriving newtype (..., HasTypeReps)
+--  > typeReps someHash = Seq.fromList [Int]
+--  vs
+--  newtype Hash = Hash { unHash :: Int }
+--      deriving stock (...,Generics); deriving anyclass (HasTypeReps)
+--  > typeReps someHash = Seq.fromList [Hash, Int]
 --
 -- Examples:
 --


### PR DESCRIPTION
Closes https://github.com/input-output-hk/cardano-ledger-specs/issues/523

This PR tests/fixes the HasTypeReps instances for TxWits and related types, along with testing `abstractSize` as it relates to `HasTypeReps`.
