### PR TITLE
Issue #565 genesis delegation map header stability

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1505,6 +1505,7 @@ which takes the Byron ledger state and creates the Shelley ledger state.
                             \emptyset \\
                             \emptyset \\
                             \emptyset \\
+                            \emptyset \\
                             \fun{dms}~\var{ds} \\
                           \end{array}
                         \right) \\

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -196,6 +196,7 @@ state transition types. We define two separate parts of the ledger state.
         pool to which is delegates.
       \item $\var{ptrs}$ maps stake keys to the position of the registration certificate
         in the blockchain. This is needed to lookup the stake hashkey of a pointer address.
+      \item $\var{fdms}$ future genesis keys delegations.
       \item $\var{dms}$ maps genesis keys to the cold key delegates.
     \end{itemize}
   \item $\PState$ keeps track of the stake pool information:
@@ -230,6 +231,7 @@ and the protocol parameters.
       \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
       \var{delegations} & \HashKey_{stake} \mapsto \HashKey_{pool} & \text{delegations}\\
       \var{ptrs} & \Ptr \mapsto \HashKey & \text{pointer to hashkey}\\
+      \var{fdms} & (\Slot\times\VKeyGen) \mapsto \VKey & \text{future genesis key delegations}\\
       \var{dms} & \VKeyGen \mapsto \VKey & \text{genesis key delegations}\\
     \end{array}\right)
     \\
@@ -331,7 +333,8 @@ a stake pool, though these concerns are independent of the ledger rules.
     There is a precondition that the genesis key is already in the mapping $\var{dms}$.
     Genesis delegation causes the following state transformation:
     \begin{itemize}
-      \item The genesis delegation relation is updated with the new pair.
+      \item The future genesis delegation relation is updated with the new delegate
+        to be adopted in $\SlotsPrior$-many slots.
     \end{itemize}
 \end{itemize}
 
@@ -359,6 +362,7 @@ a stake pool, though these concerns are independent of the ledger rules.
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
+        \var{fdms} \\
         \var{dms} \\
       \end{array}
       \right)
@@ -369,6 +373,7 @@ a stake pool, though these concerns are independent of the ledger rules.
         \varUpdate{\var{rewards}} & \varUpdate{\union} & \varUpdate{\{\addrRw \var{hk} \mapsto 0\}}\\
         \var{delegations} \\
         \varUpdate{\var{ptrs}} & \varUpdate{\union} & \varUpdate{\{ptr \mapsto \var{hk}\}} \\
+        \var{fdms} \\
         \var{dms} \\
       \end{array}
       \right)
@@ -393,6 +398,7 @@ a stake pool, though these concerns are independent of the ledger rules.
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
+        \var{fdms} \\
         \var{dms} \\
       \end{array}
       \right)
@@ -403,6 +409,7 @@ a stake pool, though these concerns are independent of the ledger rules.
         \varUpdate{\{\addrRw \var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{rewards}} \\
         \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{delegations}} \\
         \varUpdate{\{ptr\}} & \varUpdate{\subtractdom} & \varUpdate{\var{ptrs}} \\
+        \var{fdms} \\
         \var{dms} \\
       \end{array}
       \right)
@@ -426,6 +433,7 @@ a stake pool, though these concerns are independent of the ledger rules.
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
+        \var{fdms} \\
         \var{dms} \\
       \end{array}
       \right)
@@ -437,6 +445,7 @@ a stake pool, though these concerns are independent of the ledger rules.
         \varUpdate{\var{delegations}} & \varUpdate{\unionoverrideRight}
                                       & \varUpdate{\{\var{hk} \mapsto \dpool c\}} \\
         \var{ptrs} \\
+        \var{fdms} \\
         \var{dms} \\
       \end{array}
       \right)
@@ -449,6 +458,8 @@ a stake pool, though these concerns are independent of the ledger rules.
       \var{c}\in \DCertGen
       & (\var{gkey},~\var{vk})\leteq\fun{genDel}~{c}
       & \var{gkey}\in\dom{dms}
+      \\
+      s'\leteq\var{slot}+\SlotsPrior
     }
     {
       \begin{array}{r}
@@ -462,6 +473,7 @@ a stake pool, though these concerns are independent of the ledger rules.
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
+        \var{fdms} \\
         \var{dms} \\
       \end{array}
       \right)
@@ -472,8 +484,9 @@ a stake pool, though these concerns are independent of the ledger rules.
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
-        \varUpdate{\var{dms}} & \varUpdate{\unionoverrideRight}
-                              & \varUpdate{\{\var{gkey} \mapsto \var{vk}\}} \\
+        \varUpdate{\var{fdms}} & \varUpdate{\unionoverrideRight}
+                               & \varUpdate{\{(\var{s'},~\var{gkey}) \mapsto \var{vk}\}} \\
+        \var{dms} \\
       \end{array}
       \right)
     }
@@ -831,6 +844,10 @@ will be invalid.
     The base case triggers the following state transformation:
     \begin{itemize}
       \item Reward accounts are set to zero for each corresponding withdrawal.
+      \item The genesis key delegation mapping is updated accourding to the future delegation
+        mapping. For each genesis key, we take the most recent delegation in $\var{fdms}$
+        that is past the current slot.
+      \item The future genesis key delegation has any items past the current slots removed.
     \end{itemize}
   \item The inductive case, when the list is non-empty, is captured by \cref{eq:delegs-induct}.
     It constructs a certificate pointer given the current slot and transaction index,
@@ -853,10 +870,29 @@ will be invalid.
       \var{wdrls} \subseteq \var{rewards}
       \\
       \var{rewards'} \leteq \var{rewards} \unionoverrideRight \{(w, 0) \mid w \in \dom \var{wdrls}\}
+      \\~\\
+      \var{curr}\leteq
+      \left\{
+        (\var{s},~\var{gkey})\mapsto\var{vkey}\in\var{fdms}
+        ~\mathrel{\Bigg|}~
+        {
+          \begin{array}{r}
+            \var{s}\geq\var{slot}\\
+            \var{s}=\max\{s'~\mid~(s',~\var{gkey})\in\dom{\var{fdms}}\}
+          \end{array}
+        }
+      \right\}
+      \\
+      \var{dms'}\leteq
+      \{
+        \var{gkey}\mapsto\var{vkey}
+        ~\mid~
+        (\var{s},~\var{gkey})\mapsto\var{vkey}\in\var{curr}
+      \}
     }
     {
       \left(
-      \begin{array}{r}
+      \begin{array}{c}
         \var{slot} \\
         \var{txIx} \\
         \var{pp} \\
@@ -864,17 +900,19 @@ will be invalid.
     \right)
       \vdash
       \left(
-      \begin{array}{r}
+      \begin{array}{c}
         \left(
         \begin{array}{r}
           \var{stkeys} \\
           \var{rewards} \\
           \var{delegations} \\
           \var{ptrs} \\
+          \var{fdms} \\
+          \var{dms} \\
         \end{array}
         \right) \\~\\
         \left(
-        \begin{array}{r}
+        \begin{array}{c}
           \var{stpools} \\
           \var{poolParams} \\
           \var{retiring} \\
@@ -885,17 +923,19 @@ will be invalid.
       \right)
       \trans{delegs}{\epsilon}
       \left(
-      \begin{array}{r}
+      \begin{array}{c}
         \left(
-        \begin{array}{r}
+        \begin{array}{c}
           \var{stkeys} \\
           \varUpdate{\var{rewards'}} \\
           \var{delegations} \\
           \var{ptrs} \\
+          \varUpdate{\var{fdms}\setminus\var{curr}} \\
+          \varUpdate{\var{dms}\unionoverrideRight\var{dms'}} \\
         \end{array}
         \right) \\~\\
         \left(
-        \begin{array}{r}
+        \begin{array}{c}
           \var{stpools} \\
           \var{poolParams} \\
           \var{retiring} \\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -281,7 +281,8 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
       & \fun{stakeDistr}~{utxo}~{dstate}~{pstate} =
       (\dom{\var{activeDelegs}})\restrictdom\left(\fun{aggregate_{+}}~\var{stakeRelation}\right)\\
       & \where \\
-      & ~~~~ (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},~\wcard) = \var{dstate} \\
+      & ~~~~ (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},~\wcard,~\wcard)
+        = \var{dstate} \\
       & ~~~~ (\var{stpools},~\wcard,~\wcard,~\wcard,~\wcard) = \var{pstate} \\
       & ~~~~ \var{stakeRelation} = \left(
         \left(\fun{stakeHK_b}^{-1}\cup\left(\fun{addrPtr}\circ\var{ptr}\right)^{-1}\right)
@@ -397,7 +398,7 @@ This transition has no preconditions and results in the following state change:
       {
       \begin{array}{r@{~\leteq~}l}
         (\var{utxo},~\var{deposits},~\var{fees},~\wcard) & \var{utxoSt}\\
-        (\var{stkeys},~\wcard,~\var{delegations},~\wcard,~\wcard) & \var{dstate}\\
+        (\var{stkeys},~\wcard,~\var{delegations},~\wcard,~\wcard,~\wcard) & \var{dstate}\\
         (\var{stpools},~\var{poolParams},~\wcard,~\wcard) & \var{pstate}\\
         \var{stake} & \stakeDistr{utxo}{dstate}{pstate} \\
         \var{slot} & \firstSlot{e} \\

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -73,7 +73,7 @@ then calls the $\mathsf{DELEGS}$ transition.
       dpstate \trans{\hyperref[fig:rules:delegation-sequence]{delegs}}{\var{tx}} dpstate'
       \\~\\
       (\var{dstate}, \var{pstate}) \leteq \var{dpstate'} \\
-      (\var{stkeys}, \_, \_, \_, \var{dms}) \leteq \var{dstate} \\
+      (\var{stkeys}, \_, \_, \_, \_, \var{dms}) \leteq \var{dstate} \\
       (\var{stpools}, \_, \_, \_) \leteq \var{pstate} \\
       \\~\\
       \left({

--- a/weekly-reports/2019-06-14/milestone.org
+++ b/weekly-reports/2019-06-14/milestone.org
@@ -2,6 +2,6 @@
 ** TODO Update the formal spec with the new update mechanism.
    - [X] Issue #448
 ** TODO Update the formal spec to get the new header validation properties.
-   - [ ] Issue #565
+   - [X] Issue #565
 ** TODO update executable spec with changes not affected by changes to the update mechanism.
    - [ ] Issue #TBD


### PR DESCRIPTION
This PR fixes an issue with the genesis key delegation mapping. In particular, this delegation mapping caused a violation of a property that we wanted for header validation (see #535 for more information on this property, which has now been written down in the Byron ledger spec).

In addition to the genesis delegation mapping `dms` in the delegation state, we now have a future delegation mapping of type `(Slot x VKeyGen) |-> VKey`. The slot in the first part of the domain's pair represents the first slot when a new delegation can be adopted.

The `DELEG` rule now updates `fdms` instead of `dms`:

![deleg](https://user-images.githubusercontent.com/943479/59532194-07f1f400-8eb6-11e9-9035-a4c0bfd299ae.png)

The `dms` mapping is updated in the base case of the `DELEGS` rule:

![delegs](https://user-images.githubusercontent.com/943479/59532247-2d7efd80-8eb6-11e9-9246-6e5f031be791.png)

closes #565 