### PR TITLE
Align the UP*VOTE formal and executable specs

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BBody.hs
@@ -9,6 +9,7 @@ import Cardano.Spec.Chain.STS.Rule.Bupi
 import Control.Lens ((^.))
 import Data.Bimap (keys)
 import Data.Set (fromList)
+import Data.Word (Word8)
 
 import Cardano.Ledger.Spec.STS.UTXO (UTxOEnv(UTxOEnv, pps, utxo0), UTxOState)
 import Cardano.Ledger.Spec.STS.UTXOWS (UTXOWS)
@@ -51,6 +52,7 @@ instance STS BBODY where
     ( PParams
     , Epoch
     , UTxO
+    , Word8
     )
 
   type State BBODY =
@@ -75,7 +77,7 @@ instance STS BBODY where
 
   transitionRules =
     [ do
-        TRC ((ppsVal, e_n, utxoGenesis), (utxoSt, ds, us), b) <- judgmentContext
+        TRC ((ppsVal, e_n, utxoGenesis, ngk), (utxoSt, ds, us), b) <- judgmentContext
         let bMax = ppsVal ^. maxBkSz
         bSize b <= bMax ?! InvalidBlockSize
         let bh = b ^. bHeader
@@ -84,7 +86,7 @@ instance STS BBODY where
         hash (bUpdPayload b)         == bh ^. bhUpdHash  ?! InvalidUpdateProposalHash
 
         us' <- trans @BUPI $ TRC (
-            (bh ^. bhSlot, _dIStateDelegationMap ds, ppsVal ^. stableAfter)
+            (bh ^. bhSlot, _dIStateDelegationMap ds, ppsVal ^. stableAfter, ngk)
           , us
           , (b ^. bBody ^. bUpdProp, b ^. bBody ^. bUpdVotes, bEndorsment b) )
         ds' <- trans @DELEG $ TRC

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -172,7 +172,7 @@ instance HasTrace CHAIN where
     (,,,,)
       <$> gCurrentSlot
       <*> (utxo0 <$> initEnvGen @UTXOWS)
-      <*> initialEnviromentFromNumberOfGenesisKeys ngk
+      <*> initialEnvFromGenesisKeys ngk
       <*> UpdateGen.pparamsGen
       <*> pure ngk
     where

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -227,6 +227,7 @@ class Relation m where
 
   -- | Domain
   dom :: Ord (Domain m) => m -> Set (Domain m)
+
   -- | Range
   range :: Ord (Range m) => m -> Set (Range m)
 

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -65,7 +65,7 @@ module Ledger.Delegation
   -- * Generators
   , dcertGen
   , dcertsGen
-  , initialEnviromentFromNumberOfGenesisKeys
+  , initialEnvFromGenesisKeys
   -- * Functions on delegation state
   , delegatorOf
   )
@@ -566,14 +566,17 @@ instance HasTrace DELEG where
 
   initEnvGen = do
     ngk <- Gen.integral (linear 1 14)
-    initialEnviromentFromNumberOfGenesisKeys ngk
+    initialEnvFromGenesisKeys ngk
 
   sigGen = dcertsGen
 
 -- | Generate an initial 'DELEG' environment from the given number of genesis
 -- keys.
-initialEnviromentFromNumberOfGenesisKeys :: Word8 -> Gen DSEnv
-initialEnviromentFromNumberOfGenesisKeys ngk =
+initialEnvFromGenesisKeys
+  :: Word8
+  -- ^ Number of genesis keys.
+  -> Gen DSEnv
+initialEnvFromGenesisKeys ngk =
   DSEnv
     -- We need at least one delegator in the environment to be able to generate
     -- delegation certificates.

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1168,7 +1168,7 @@ instance STS UPIVOTE where
           stblCps = dom (cps' ▷<= sn -. 2 *. k)
           stblRaus = stblCps ◁ raus
           avsnew = [ (an, (av, sn, m))
-                   | (an, av, m) <- toList $ stblRaus
+                   | (an, av, m) <- toList stblRaus
                    ]
         pure $! ( (pv, pps)
                 , fads

--- a/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
@@ -44,7 +44,7 @@ pparamsGen =
     (bkSgnCntT :: Double)
     ((bkSlotsPerEpoch, upTtl, stableAfter) :: (SlotCount, SlotCount, BlockCount))
     (scriptVersion :: Natural)
-    (cfmThd :: Int)
+    (_cfmThd :: Double)
     (upAdptThd :: Double)
     (factorA :: Int)
     (factorB :: Int)
@@ -57,7 +57,7 @@ pparamsGen =
       bkSlotsPerEpoch
       upTtl
       scriptVersion
-      cfmThd
+      upAdptThd -- We want to unify @cfmThd@ and @upAdptThd@.
       upAdptThd
       stableAfter
       factorA
@@ -67,7 +67,7 @@ pparamsGen =
     <*> doubleInc                                       -- bkSgnCntT
     <*> slotBlockGen
     <*> Gen.integral (Range.linear (0 :: Natural) 1000) -- scriptVersion
-    <*> Gen.integral (Range.linear 0 1000)              -- cfmThd
+    <*> Gen.double (Range.constant 0 1)                 -- cfmThd
     <*> Gen.double (Range.constant 0 1)                 -- upAdptThd
     <*> Gen.int (Range.linear 0 100)                    -- factor @a@
     <*> Gen.int (Range.linear 0 10)                     -- factor @b@

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -372,14 +372,14 @@ relevantCasesAreCovered = withTests 400 $ property $ do
         "at least 50% of the certificates delegate in the next epoch"
         (0.5 <= ratio nextEpochDelegations tr)
 
-  -- 90% of the traces must contain at least 30% of self-delegations.
+  -- 80% of the traces must contain at least 30% of self-delegations.
   cover 80
        "at least 30% of the certificates self delegate"
        (0.3 <= ratio selfDelegations tr)
 
-  -- 20% of the traces must contain at least 10% of delegations to the same
+  -- 15% of the traces must contain at least 10% of delegations to the same
   -- delegate.
-  cover 20
+  cover 15
         "at least 10% of the certificates delegate to the same key"
         (0.1 <= ratio multipleDelegations tr)
   where

--- a/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
@@ -246,7 +246,7 @@ upiregRelevantTracesAreCovered = withTests 300 $ property $ do
         deviationFromExpectation numberOfProposalsPerKey =
           abs (fromIntegral numberOfProposalsPerKey - expectedNumberOfUpdateProposalsPerKey traceSample)
 
-    delegationMap (_, dms, _) = dms
+    delegationMap (_, dms, _, _) = dms
 
     safeMaximum xs = if null xs then 0 else maximum xs
 

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -399,12 +399,12 @@ given application name $\var{an}$.
           \end{array}
         \right)
       }\\
-      \var{stbl_{cps}} \leteq \dom~(cps' \restrictrange [.., s_n - 2 \cdot k])
-      \\
-      \var{avs_{new}} \leteq \{ \var{an} \mapsto (\var{av}, \var{s_n}, m)
-      \mid \var{pid} \mapsto (\var{an}, \var{av}, m) \in \var{raus}
-      ,~ \var{pid} \in \var{stbl_{cps}}
-      \}
+      {\begin{array}{r@{~\leteq~}l}
+        \var{stbl_{cps}} & \dom~(cps' \restrictrange [.., s_n - 2 \cdot k])\\
+        \var{stbl_{raus}} & \var{stbl_{cps}} \restrictdom \var{raus}\\
+        \var{avs_{new}} & \{ \var{an} \mapsto (\var{av}, \var{s_n}, m)
+        \mid (\var{an}, \var{av}, m) \in \var{stbl_{raus}} \}
+      \end{array}}
     }
     {
       {\left(


### PR DESCRIPTION
Update the formal and executable specs for the `UPIVOTE` transition system:

- before:
![image](https://user-images.githubusercontent.com/175315/59772536-3acc2b80-92ac-11e9-87ea-e67aa33d29b3.png)

- now:
![image](https://user-images.githubusercontent.com/175315/59772025-4bc86d00-92ab-11e9-978b-a08561c33623.png)

In addition the `ngk` global constant is added to the executable specs's environment so that we can test with different values of it.

Part of #550.