### PR TITLE
Add an `UPIVOTES` signal generator 

### DIFF
--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -75,6 +75,7 @@ import qualified Ledger.Core.Generators as CoreGen
 
 import Prelude hiding (min)
 
+
 -- TODO: remove after PR 591 is merged.
 import Data.Word (Word8)
 
@@ -1231,14 +1232,14 @@ instance HasTrace UPIVOTES where
 -- | Determine the votes needed for confirming the unconfirmed update
 -- proposals.
 votesNeededForConfirmation
-  :: Word8
-  -- ^ Total number of genesis keys.
-  -> Double
-  -- ^ Confirmation threshold.
+  :: [Core.VKeyGenesis]
+  -- ^ Genesis keys that can vote
   -> Set UpId
   -- ^ Update proposals registered so far
   -> Set (UpId, Core.VKeyGenesis)
-  -- ^ Votes for the update registered proposals.
+  -- ^ Votes for the update registered proposals
+  -> Word8
+  -- ^ Number of votes needed for confirmation
   -> [(UpId, [Core.VKeyGenesis])]
 votesNeededForConfirmation _ngk _cfmThd _rups _vts = undefined
 

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1213,8 +1213,8 @@ instance STS UPIVOTES where
         case (sig :: [Vote]) of
           []     -> return us
           (x:xs) -> do
-            us'  <- trans @UPIVOTES $ TRC (env, us, xs)
-            us'' <- trans @UPIVOTE  $ TRC (env, us', x)
+            us'  <- trans @UPIVOTE $ TRC (env, us, x)
+            us'' <- trans @UPIVOTES  $ TRC (env, us', xs)
             return us''
     ]
 

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1238,17 +1238,8 @@ completeVotes
   -> Map UpId (Set Core.VKeyGenesis)
   -- ^ Votes for the registered update proposals
   -> Map UpId (Set Core.VKeyGenesis)
-completeVotes _genesisKeys _votes =
-  undefined
-
--- | Given a sequence of update proposals ID's and the votes needed for
--- confirmation, generate a sequence of votes that will confirm a subsequence
--- of the given proposal ID's.
-genVotesTillConfirmation :: [(UpId, [Core.VKeyGenesis])] -> Gen [Vote]
-genVotesTillConfirmation = undefined
-  -- To implement this we might want to use the same approach as
-  -- @genVotesOnMostVotedProposals@, but taking the whole bunch of votes we
-  -- need, instead of a subsequence.
+completeVotes genesisKeys votes =
+  (genesisKeys \\) <$> votes
 
 -- | Given a sequence of update proposals ID's and the genesis keys that need
 -- to vote for confirmation, generate votes on the most voted proposals.
@@ -1269,6 +1260,19 @@ genVotesOnMostVotedProposals votesNeeded = do
     votes :: [(UpId, [Core.VKeyGenesis])]
     votes = take numberOfProposals $ sortOn (length. snd) votesNeeded
   zip (fst <$> votes) <$> traverse Gen.subsequence (snd <$> votes)
+
+
+-- TODO: we might want to do this only if we don't get enough coverage.
+--
+-- -- | Given a sequence of update proposals ID's and the votes needed for
+-- -- confirmation, generate a sequence of votes that will confirm a subsequence
+-- -- of the given proposal ID's.
+-- genVotesTillConfirmation :: [(UpId, [Core.VKeyGenesis])] -> Gen [Vote]
+-- genVotesTillConfirmation = undefined
+--   -- To implement this we might want to use the same approach as
+--   -- @genVotesOnMostVotedProposals@, but taking the whole bunch of votes we
+--   -- need, instead of a subsequence.
+
 
 --  undefined votes
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1247,6 +1247,9 @@ votesNeededForConfirmation _ngk _cfmThd _rups _vts = undefined
 -- of the given proposal ID's.
 genVotesTillConfirmation :: [(UpId, [Core.VKeyGenesis])] -> Gen [Vote]
 genVotesTillConfirmation = undefined
+  -- To implement this we might want to use the same approach as
+  -- @genVotesOnMostVotedProposals@, but taking the whole bunch of votes we
+  -- need, instead of a subsequence.
 
 -- | Given a sequence of update proposals ID's and the votes needed for
 -- confirmation, generate votes on the most voted proposals.
@@ -1259,7 +1262,12 @@ genVotesTillConfirmation = undefined
 -- @n@), say @[(p_0, vs_0), ..., (p_n-1, vs_(n-1))]@ and generates votes of the
 -- form, @(p_i, vs_i_j)@, where @vs_i_j@ is an arbitrary element of @vs_i@.
 genVotesOnMostVotedProposals :: [(UpId, [Core.VKeyGenesis])] -> Gen [Vote]
-genVotesOnMostVotedProposals = undefined
+genVotesOnMostVotedProposals _votesNeeded = undefined
+  -- A way to implement this:
+  --
+  -- - Sort @_votesNeeded@ increasingly by @length . snd@.
+  -- - Pick a number @n@
+  -- - traverse @_votesNeeded@ applying @Gen.subsequence@
 
 --------------------------------------------------------------------------------
 -- End TODO: TMP: sigGen UPIVOTES auxiliary defs

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -75,6 +75,9 @@ import qualified Ledger.Core.Generators as CoreGen
 
 import Prelude hiding (min)
 
+-- TODO: remove after PR 591 is merged.
+import Data.Word (Word8)
+
 -- | Protocol parameters.
 --
 data PParams = PParams -- TODO: this should be a module of @cs-ledger@.
@@ -1213,6 +1216,55 @@ instance STS UPIVOTES where
 
 instance Embed UPIVOTE UPIVOTES where
   wrapFailed = UpivoteFailure
+
+instance HasTrace UPIVOTES where
+
+  initEnvGen = undefined -- TODO: factor out the 'initEnvGen' of UPUREG and use it here.
+
+  sigGen (_slot, _dms, _k) ((_pv, _pps), _fads, _avs, _rpus, _raus, _cps, _vts, _bvs, _pws) =
+    undefined
+
+--------------------------------------------------------------------------------
+-- TODO: TMP: sigGen UPIVOTES auxiliary defs
+--------------------------------------------------------------------------------
+
+-- | Determine the votes needed for confirming the unconfirmed update
+-- proposals.
+votesNeededForConfirmation
+  :: Word8
+  -- ^ Total number of genesis keys.
+  -> Double
+  -- ^ Confirmation threshold.
+  -> Set UpId
+  -- ^ Update proposals registered so far
+  -> Set (UpId, Core.VKeyGenesis)
+  -- ^ Votes for the update registered proposals.
+  -> [(UpId, [Core.VKeyGenesis])]
+votesNeededForConfirmation _ngk _cfmThd _rups _vts = undefined
+
+-- | Given a sequence of update proposals ID's and the votes needed for
+-- confirmation, generate a sequence of votes that will confirm a subsequence
+-- of the given proposal ID's.
+genVotesTillConfirmation :: [(UpId, [Core.VKeyGenesis])] -> Gen [Vote]
+genVotesTillConfirmation = undefined
+
+-- | Given a sequence of update proposals ID's and the votes needed for
+-- confirmation, generate votes on the most voted proposals.
+--
+--  Given a sequence of update proposals ID's and the votes needed for
+-- confirmation, a proposal is said to be most voted, if it is associated to
+-- the minimal number of votes needed for confirmation.
+--
+-- This basically takes the top @n@ most voted proposals (for some arbitrary
+-- @n@), say @[(p_0, vs_0), ..., (p_n-1, vs_(n-1))]@ and generates votes of the
+-- form, @(p_i, vs_i_j)@, where @vs_i_j@ is an arbitrary element of @vs_i@.
+genVotesOnMostVotedProposals :: [(UpId, [Core.VKeyGenesis])] -> Gen [Vote]
+genVotesOnMostVotedProposals = undefined
+
+--------------------------------------------------------------------------------
+-- End TODO: TMP: sigGen UPIVOTES auxiliary defs
+--------------------------------------------------------------------------------
+
 
 
 data UPIEND

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1225,7 +1225,7 @@ instance HasTrace UPIVOTES where
 
   initEnvGen = upiEnvGen
 
-  sigGen (_slot, dms, _k) ((_pv, _pps), _fads, _avs, rpus, _raus, _cps, vts, _bvs, _pws) =
+  sigGen (_slot, dms, _k, _ngk) ((_pv, _pps), _fads, _avs, rpus, _raus, _cps, vts, _bvs, _pws) =
     (uncurry mkVote <$>) . concatMap replicateFst
       <$> genVotesOnMostVotedProposals completedVotes
       where

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -384,7 +384,7 @@ instance STS UPV where
         rpus' <- trans @UPPVV $ TRC ((pv, pps), rpus, up)
         let SwVer an av = up ^. upSwVer
         inMap an av (swVer <$> avs) ?! AVChangedInPVUpdate an av
-        return $! (rpus', raus)
+        pure $! (rpus', raus)
     , do
         TRC ( (pv, pps, avs)
             , (rpus, raus)
@@ -393,7 +393,7 @@ instance STS UPV where
         pv == up ^. upPV ?! PVChangedInSVUpdate
         up ^. upParams == pps ?! ParamsChangedInSVUpdate
         raus' <- trans @UPSVV $ TRC (avs, raus, up)
-        return $! (rpus, raus')
+        pure $! (rpus, raus')
     , do
         TRC ( (pv, pps, avs)
             , (rpus, raus)
@@ -401,7 +401,7 @@ instance STS UPV where
             ) <- judgmentContext
         rpus' <- trans @UPPVV $ TRC ((pv, pps), rpus, up)
         raus' <- trans @UPSVV $ TRC (avs, raus, up)
-        return $! (rpus', raus')
+        pure $! (rpus', raus')
     ]
     where
       swVer (x, _, _) = x
@@ -938,12 +938,11 @@ instance HasTrace UPIREG where
           possibleNextVersions = Set.toList $ nextVersions \\ registeredNextVersions
             where
               nextVersions :: Set (ApName, ApVer)
-              nextVersions = Set.fromList $ zip currentAppNames appNextVersions
+              nextVersions = Set.fromList $ zip currentAppNames nextAppVersions
                 where
-                  currentAppNames :: [ApName]
-                  currentAppNames = Set.toList (dom avs)
-                  appNextVersions :: [ApVer]
-                  appNextVersions = (+1) . fst3 <$> Set.toList (range avs)
+                  (currentAppNames, currentAppVersions) = unzip $ Map.toList avs
+                  nextAppVersions :: [ApVer]
+                  nextAppVersions = (+1) . fst3 <$> currentAppVersions
               registeredNextVersions :: Set (ApName, ApVer)
               registeredNextVersions = Set.map (fst3 &&& snd3) (range raus)
 

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -735,7 +735,7 @@ emptyUPIState =
                              -- wrong.
      , _upTtl = 10
      , _scriptVersion = 0
-     , _cfmThd = 4           -- TODO: this should be a double
+     , _cfmThd = 0.6         -- TODO: this should be a double
      , _upAdptThd = 0.6      -- Value currently used in mainet
      , _stableAfter = 5      -- TODO: the k stability parameter needs to be
                              -- removed from here as well!
@@ -798,6 +798,10 @@ protocolParameters ((_, pps), _, _, _, _, _, _, _, _) = pps
 
 applicationVersions :: UPIState -> Map ApName (ApVer, Core.Slot, Metadata)
 applicationVersions ((_, _), _, avs, _, _, _, _, _, _) = avs
+
+confirmedProposals :: UPIState -> Map UpId Core.Slot
+confirmedProposals ((_, _), _, _, _, _, cps, _, _, _) = cps
+
 
 data UPIREG
 

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1387,10 +1387,10 @@ instance STS PVBUMP where
                 Nothing -> []
                 Just s  -> filter ((<= s) . fst) fads
         if r == []
-          then return $! (pv, pps)
+          then pure $! (pv, pps)
           else do
             let (_, (pv_c, pps_c)) = last r
-            return $! (pv_c, pps_c)
+            pure $! (pv_c, pps_c)
     ]
 
 data UPIEC

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -188,8 +188,6 @@ instance STS DBLOCK where
           let nextSlot = dblock ^. blockSlot
           env ^. slot < nextSlot ?! NotIncreasingBlockSlot
           stNext <- trans @DELEG $ TRC (env, st, dblock ^. blockCerts)
-          -- We fix the number of slots per epoch to 10. This is the same
-          -- constant used in production.
           let nextEpoch = if _dSEnvK env == 0
                           then 0
                           else Epoch $ unSlot nextSlot `div` slotsPerEpoch (_dSEnvK env)

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -316,7 +316,8 @@ instance HasTrace DBLOCK where
                       [ (1, Gen.integral (Range.constant 1 10))
                       , (2, pure $! slotsPerEpoch (_dSEnvK env))
                       ]
-      incSlot c = (env ^.slot) `addSlot` SlotCount c
+        where
+          incSlot c = (env ^.slot) `addSlot` SlotCount c
 
 instance HasSizeInfo DBlock where
   isTrivial = null . view blockCerts

--- a/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
@@ -256,3 +256,22 @@ data Change = Increases | Decreases | RemainsTheSame
 onlyValidSignalsAreGenerated :: Property
 onlyValidSignalsAreGenerated =
   withTests 300 $ TransitionGenerator.onlyValidSignalsAreGenerated @UPIREG 100
+
+
+-- | Dummy transition system to test blocks with update payload only.
+data UBLOCK
+
+-- | An update block
+data UBlock
+  = UBlock
+    { slot :: Slot
+    , optionalUpdateProposal :: Maybe UProp
+    , votes :: [Vote]
+    }
+
+-- | Update block state
+data State
+  = State
+    { upienv :: UPIEnv
+    , upist :: UPIState
+    }

--- a/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
@@ -381,7 +381,7 @@ instance HasTrace UBLOCK where
           -- TODO: factor out duplication w.r.t. Ledger.Delegation.Properties
           incSlot <$> Gen.frequency
                       [ (1, Gen.integral (Range.constant 1 10))
-                      , (2, pure $! slotsPerEpoch k)
+                      , (2, pure $! slotsPerEpoch k + 1)
                       ]
           where
             incSlot c = sn `Core.addSlot` Core.SlotCount c

--- a/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
@@ -403,14 +403,14 @@ ublockOnlyValidSignalsAreGenerated =
   withTests 300 $ TransitionGenerator.onlyValidSignalsAreGenerated @UBLOCK 100
 
 ublockRelevantTracesAreCovered :: Property
-ublockRelevantTracesAreCovered = withTests 200 $ property $ do
-  sample <- forAll (trace @UBLOCK 1000)
+ublockRelevantTracesAreCovered = withTests 300 $ property $ do
+  sample <- forAll (trace @UBLOCK 600)
 
   cover 75
     "at least 50% of the proposals get confirmed"
     (0.50 <= confirmedProposals sample / totalProposals sample)
 
-  cover 30
+  cover 20
     "at least 20% of the proposals get unconfirmed"
     (0.20 <= 1 - (confirmedProposals sample / totalProposals sample))
 

--- a/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
@@ -9,7 +9,10 @@ module Ledger.Update.Properties
   , upiregRelevantTracesAreCovered
   , onlyValidSignalsAreGenerated
   , ublockTraceLengthsAreClassified
+  , ublockOnlyValidSignalsAreGenerated
   ) where
+
+import GHC.Stack (HasCallStack)
 
 import qualified Data.Bimap as Bimap
 import Data.Function ((&))
@@ -388,3 +391,7 @@ instance HasTrace UBLOCK where
 ublockTraceLengthsAreClassified :: Property
 ublockTraceLengthsAreClassified =
   withTests 100 $ traceLengthsAreClassified @UBLOCK 500 50
+
+ublockOnlyValidSignalsAreGenerated :: HasCallStack => Property
+ublockOnlyValidSignalsAreGenerated =
+  withTests 300 $ TransitionGenerator.onlyValidSignalsAreGenerated @UBLOCK 100

--- a/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
@@ -406,13 +406,13 @@ ublockRelevantTracesAreCovered :: Property
 ublockRelevantTracesAreCovered = withTests 100 $ property $ do
   sample <- forAll (trace @UBLOCK 500)
 
-  cover 10
+  cover 75
     "at least 50% of the proposals get confirmed"
-    (0.01 <= confirmedProposals sample / totalProposals sample)
+    (0.50 <= confirmedProposals sample / totalProposals sample)
 
-  cover 90
-    "at least 50% of the proposals get unconfirmed"
-    (0.50 <= 1 - (confirmedProposals sample / totalProposals sample))
+  cover 30
+    "at least 20% of the proposals get unconfirmed"
+    (0.20 <= 1 - (confirmedProposals sample / totalProposals sample))
 
     where
       confirmedProposals :: Trace UBLOCK -> Double

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -54,7 +54,8 @@ main = defaultMain tests
     , testTxHasTypeReps
     , testGroup
       "Update UPIREG properties"
-      [ testProperty "Traces are classified" UPDATE.upiregTracesAreClassified
+      [ testProperty "UPIREG traces are classified" UPDATE.upiregTracesAreClassified
+      , testProperty "UBLOCK traces are classified" UPDATE.ublockTraceLengthsAreClassified
       , testProperty "Relevant cases are classified" UPDATE.upiregRelevantTracesAreCovered
       , testProperty "Only valid signals are generated" UPDATE.onlyValidSignalsAreGenerated
       ]

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -58,6 +58,7 @@ main = defaultMain tests
       , testProperty "UBLOCK traces are classified" UPDATE.ublockTraceLengthsAreClassified
       , testProperty "Relevant cases are classified" UPDATE.upiregRelevantTracesAreCovered
       , testProperty "Only valid signals are generated" UPDATE.onlyValidSignalsAreGenerated
+      , testProperty "Only valid signals are generated for UBLOCK" UPDATE.ublockOnlyValidSignalsAreGenerated
       ]
     -- TODO move this out of here (these are not properties of the transition
     -- systems) and also move the Relation class and instances out of Ledger.Core

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -36,7 +36,7 @@ main = defaultMain tests
       "Delegation properties"
       [ testProperty "Certificates are triggered"           dcertsAreTriggered
       , testProperty "DBLOCK Traces are classified"         DELEG.dblockTracesAreClassified
-      , testProperty "relevant DBLOCK traces generated"     DELEG.relevantCasesAreCovered
+      , testProperty "Relevant DBLOCK traces covered"     DELEG.relevantCasesAreCovered
       , testProperty "Duplicated certificates are rejected" rejectDupSchedDelegs
       , testProperty "Traces are classified"                DELEG.tracesAreClassified
       ]
@@ -56,9 +56,10 @@ main = defaultMain tests
       "Update UPIREG properties"
       [ testProperty "UPIREG traces are classified" UPDATE.upiregTracesAreClassified
       , testProperty "UBLOCK traces are classified" UPDATE.ublockTraceLengthsAreClassified
-      , testProperty "Relevant cases are classified" UPDATE.upiregRelevantTracesAreCovered
+      , testProperty "Relevant UPIREG traces are covered" UPDATE.upiregRelevantTracesAreCovered
       , testProperty "Only valid signals are generated" UPDATE.onlyValidSignalsAreGenerated
       , testProperty "Only valid signals are generated for UBLOCK" UPDATE.ublockOnlyValidSignalsAreGenerated
+      , testProperty "Relevant UBLOCK traces are covered" UPDATE.ublockRelevantTracesAreCovered
       ]
     -- TODO move this out of here (these are not properties of the transition
     -- systems) and also move the Relation class and instances out of Ledger.Core

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -59,7 +59,6 @@ import Hedgehog
   , forAll
   , property
   , success
-  , (===)
   )
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -82,7 +81,6 @@ import Control.State.Transition
   , State
   , TRC(TRC)
   , applySTS
-  , applySTSIndifferently
   )
 import Control.State.Transition.Trace
   ( Trace, _traceEnv

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -398,9 +398,12 @@ onlyValidSignalsAreGenerated maximumTraceLength = property $ do
     st' :: State s
     st' = lastState tr
   sig <- forAll (sigGen @s env st')
-  -- snd (applySTSIndifferently @s (TRC(env, st', sig))) === []
-  -- footnoteShow $ snd (applySTSIndifferently @s (TRC(env, st', sig)))
-  True === False
+  let result = applySTS @s (TRC(env, st', sig))
+  -- TODO: For some reason the result that led to the failure is not shown
+  -- (even without using tasty, and setting the condition to True === False)
+  footnoteShow result
+  void $ evalEither $ result
+
 
 --------------------------------------------------------------------------------
 -- Temporary definitions till hedgehog exposes these

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -49,8 +49,9 @@ import Control.Monad.Trans.Maybe (MaybeT)
 import Data.Foldable (traverse_)
 import Data.Functor.Identity (Identity)
 import Data.String (fromString)
+import GHC.Stack (HasCallStack)
 import Hedgehog
-  ( Gen
+  ( Gen, footnoteShow
   , Property
   , PropertyT
   , classify
@@ -58,6 +59,7 @@ import Hedgehog
   , forAll
   , property
   , success
+  , (===)
   )
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -80,6 +82,7 @@ import Control.State.Transition
   , State
   , TRC(TRC)
   , applySTS
+  , applySTSIndifferently
   )
 import Control.State.Transition.Trace
   ( Trace, _traceEnv
@@ -382,7 +385,7 @@ traceLengthsAreClassified maximumTraceLength intervalSize =
 -- | Check that the signal generator of 's' only generate valid signals.
 onlyValidSignalsAreGenerated
   :: forall s
-   . (HasTrace s, Show (Environment s), Show (State s), Show (Signal s))
+   . (HasTrace s, Show (Environment s), Show (State s), Show (Signal s), HasCallStack)
   => Int
   -- ^ Maximum trace length.
   -> Property
@@ -395,7 +398,9 @@ onlyValidSignalsAreGenerated maximumTraceLength = property $ do
     st' :: State s
     st' = lastState tr
   sig <- forAll (sigGen @s env st')
-  void $ evalEither $ applySTS @s (TRC(env, st', sig))
+  -- snd (applySTSIndifferently @s (TRC(env, st', sig))) === []
+  -- footnoteShow $ snd (applySTSIndifferently @s (TRC(env, st', sig)))
+  True === False
 
 --------------------------------------------------------------------------------
 -- Temporary definitions till hedgehog exposes these

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -357,7 +357,8 @@ mkIntervals low high step
 
 -- | Given a function that computes an integral value from a trace, return that
 -- value as a ratio of the trace length.
-ratio :: Integral a
+ratio
+  :: Integral a
   => (Trace s -> a)
   -> Trace s
   -> Double


### PR DESCRIPTION
- Add a `HasTrace` instance for `UPIVOTES`
- Add coverage testing for the traces that contain update proposal registrations and votes on those update proposals.

Closes #550 