### PR TITLE
small typo with upSTags

### DIFF
--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -146,7 +146,7 @@ and `UpdateData` contains the software hash for a specific platform).
       \fun{upSwVer} & \UProp \to \SWVer & \text{software-version update proposal}\\
       \fun{upSig} & \UProp \to \Sig & \text{update proposal signature}\\
       \fun{upSigData} & \UProp \to \UPropSD & \text{update proposal signed data}\\
-      \fun{upSTags} & \powerset{\STag} & \text{update proposal system tags}\\
+      \fun{upSTags} & \UProp \to \powerset{\STag} & \text{update proposal system tags}\\
       \fun{upMdt} & \UProp \to \Metadata & \text{software update metadata}
     \end{array}
   \end{equation*}


### PR DESCRIPTION
miro PR! :microscope:

`upSTags` definition was missing its parameter