### PR TITLE
added versioning checks

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -63,6 +63,8 @@
 \newcommand{\ProtVer}{\ensuremath{\type{ProtVer}}}
 \newcommand{\ApName}{\ensuremath{\type{ApName}}}
 \newcommand{\ApVer}{\ensuremath{\type{ApVer}}}
+\newcommand{\SystemTag}{\ensuremath{\type{SystemTag}}}
+\newcommand{\UpdateData}{\ensuremath{\type{UpdateData}}}
 \newcommand{\Metadata}{\ensuremath{\type{Mdt}}}
 \newcommand{\PPUpdate}{\type{PPUpdate}}
 \newcommand{\Applications}{\type{Applications}}

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -44,7 +44,8 @@ This function must produce a unique id for each unique transaction.
     \begin{array}{r@{~\in~}lr}
       \var{txid} & \TxId & \text{transaction id}\\
       \var{an} & \ApName & \text{application name}\\
-      \var{m} & \Metadata & \text{metadata}\\
+      \var{st} & \SystemTag & \text{system tag}\\
+      \var{ud} & \UpdateData & \text{update data}\\
     \end{array}
   \end{equation*}
   \emph{Derived types}
@@ -80,6 +81,11 @@ This function must produce a unique id for each unique transaction.
       & \ApVer
       & \N
       & \text{application versions}
+      \\
+      \var{md}
+      & \Metadata
+      & \SystemTag\mapsto\UpdateData
+      & \text{application metadata}
       \\
       \var{apps}
       & \Applications

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -14,8 +14,9 @@ The adoption of new application versions is what triggers software updates.
 Therefore $\mathsf{UPDATE}$ is the combination of the
 $\mathsf{PPUP}$ transition for the protocol parameters and the
 the $\mathsf{AVUP}$ transition for the application versions.
-Recall that $\PPUpdate$, $\AVUpdate$, and $\Update$ were defined in
-Figure~\ref{fig:defs:utxo-shelley}
+Note that $\PPUpdate$, $\AVUpdate$, and $\Update$ were defined in
+Figure~\ref{fig:defs:utxo-shelley}, and that $\fun{pvCanFollow}$
+was defined in \cite{byron_ledger_spec}.
 
 
 The signature for the keys in the proposal will be checked in the
@@ -69,6 +70,8 @@ $\mathsf{UTXOW}$ transition.
       &
       \dom{pup}\subseteq\dom{dms}
       \\
+      \var{ppv}\mapsto\var{v}\in\var{pup}\implies\fun{pvCanFollow}~(\fun{ppv}~\var{pup_s})~\var{v}
+      \\
       \var{slot} < \firstSlot{((\epoch{slot}) + 1) - \SlotsPrior}
     }
     {
@@ -96,6 +99,8 @@ the consensus value of update proposals in the event that at least five
 genesis keys agree.
 This function will also be used for the protocol parameters later in Section~\ref{sec:epoch}.
 Note that $\type{T}$ is an arbitrary type.
+The function $\fun{validAV}$ uses three functions from \cite{byron_ledger_spec}, namely
+$\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
 
 %%
 %% Figure - Helper Function for Consensus of Update Proposals
@@ -111,12 +116,24 @@ Note that $\type{T}$ is an arbitrary type.
   \end{align*}
 
   \begin{align*}
+      & \fun{validAV} \in \ApName \to \ApVer \to \Metadata \to \Applications \to \Bool\\
+      & \fun{validAV}~\var{an}~\var{av}~\var{md}~\var{avs} = \\
+      & ~~~~\fun{apNameValid}~\var{an}
+        ~\land~\fun{svCanFollow}~\var{avs}~(\var{an},~\var{av})
+        ~\land~\forall\var{st}\in\dom{md},~\fun{sTagValid}~\var{st}
+  \end{align*}
+
+  \begin{align*}
       & \fun{newAVs} \in \Applications \to (\Slot\mapsto\Applications) \to \Applications \\
       & \fun{newAVs}~\var{avs}~\var{favs} =
         \begin{cases}
-          \var{avs}' & \var{favs}\neq\emptyset
-                       ,~s_m\mapsto\var{avs'}\in\var{favs}
-                       ,~s_m=\max(\dom{\var{favs}})\\
+          \var{avs}\unionoverrideRight\var{avs}'
+                     & \var{favs}\neq\emptyset \\
+                     & ~\land~s_m\mapsto\var{avs'}\in\var{favs} \\
+                     & ~\land~s_m=\max(\dom{\var{favs}}) \\
+                     & ~\land~\forall(an\mapsto(av, mdt)\in\var{avs}'),
+                         ~\fun{validAV}~\var{an}~\var{av}~\var{md}~\var{avs}
+          \\
           \var{avs} & \text{otherwise}
         \end{cases}
   \end{align*}


### PR DESCRIPTION
This PR adds some checks for the protocol version and application versions consistent with the Byron ledger.

The application metadata type `Mdt` is no longer an abstract type, but instead a mapping of `SystemTag` to `UpdateData`, which are two new abstract types.

To provide checks that the protocol versions increase in a reasonable way, I added the Bryon method`pvCanFollow` check to Figure 9.

To provide checks that the application version increase in a reasonable way, I created a new method/predicate `validAV` which calls the Bryon methods `apNameValid`, `svCanFollow`, and `sTagValid`. The `validAV` check is used inside the `newAVS` method, so that only properly increasing versions will be accepted from the `favs`, which is used in figure 10.

closes #572