### PR TITLE
Rewrite and some fixes in non-integer test code.

### DIFF
--- a/shelley/chain-and-ledger/dependencies/non-integer/test/Spec.hs
+++ b/shelley/chain-and-ledger/dependencies/non-integer/test/Spec.hs
@@ -4,375 +4,307 @@
 {-# LANGUAGE EmptyDataDecls        #-}
 
 import qualified Data.Fixed as FP
-import           Data.Ratio ((%))
-
 import           Test.QuickCheck
-
 import           NonIntegral
 
-data E16
-data E20
 data E34
 
-instance FP.HasResolution E16 where
-    resolution _ = 10000000000000000
-
-instance FP.HasResolution E20 where
-    resolution _ = 100000000000000000000
-
 instance FP.HasResolution E34 where
-    resolution _ = 10000000000000000000000000000000000
+    resolution _ = 10^(34::Int)
 
-type Digits34 = FP.Fixed E34
-
-type FixedPoint = Digits34
+type FixedPoint = FP.Fixed E34
 
 epsD :: Double
-epsD   = 1.0 / 10.0^(12::Integer)
+epsD = 1 / 10^(12::Int)
 
 epsFP :: FixedPoint
-epsFP = 1 / 10^(16::Integer)
+epsFP = 1 / 10^(16::Int)
 
 eps :: Rational
-eps = 1 / 10^(16::Integer)
+eps = 1 / 10^(16::Int)
 
--- | Normalizes the integers, return a pair of integers, both non-negative and
--- fst >= snd.
-normalizeInts :: Integer -> Integer -> (Integer, Integer)
-normalizeInts x y = (x'', y'')
-    where x' = abs x
-          y' = abs y
-          x'' = max x' y'
-          y'' = min x' y'
+map2 :: (a -> b) -> (a,a) -> (b,b)
+map2 f (x,y) = (f x, f y)
 
-type PosInt = Positive Integer
+both :: (a -> Bool) -> (a,a) -> Bool
+both p (x,y) = p x && p y
+
+type Diff a = (a,a)
+
+absDiff :: Num a => Diff a -> a
+absDiff (x,y) = abs (x - y)
+
+(~=) :: (Ord a, Num a) => Diff a -> a -> Bool
+w ~= epsilon = absDiff w < epsilon
+
+newtype Normalized a = Norm (a,a) deriving Show
+newtype UnitInterval a = Unit a deriving Show
+
+instance (Fractional a, Arbitrary a) => Arbitrary (Normalized a) where
+    arbitrary = return . Norm . normalize =<< arbitrary
+
+instance (Fractional a, Arbitrary a) => Arbitrary (UnitInterval a) where
+    arbitrary = return . Unit . toUnit =<< arbitrary
+
+type NonNegInts = (NonNegative Integer, Positive Integer)
+
+-- | Normalizes the integers, return a pair of integers, such that:
+-- fst >= 0, snd > 0, fst <= snd.
+normalizeInts :: NonNegInts -> (Integer,Integer)
+normalizeInts (NonNegative x, Positive y) = (min x y, max x y)
+
+normalize :: Fractional a => NonNegInts -> (a,a)
+normalize = map2 fromInteger . normalizeInts
+
+toUnit :: Fractional a => NonNegInts -> a
+toUnit = uncurry (/) . normalize -- [0,1]
+
+------------------------
+-- Generic Properties --
+------------------------
+
+type Monotonic a = (a -> Bool) -> (a -> a) -> a -> a -> Property
+
+monotonic :: (Ord a, Ord b) => (a -> b) -> a -> a -> Bool
+monotonic f x y =
+    if x < y
+    then f x < f y
+    else f x >= f y
+
+log_pow :: (RealFrac a, Show a, Enum a) => a -> a -> Diff a
+log_pow x y = (ln' (x *** y) , y * ln' x)
+
+log_law :: (RealFrac a, Show a, Enum a) => a -> a -> Diff a
+log_law x y = (ln' (x * y) , ln' x + ln' y)
+
+exp_law :: (RealFrac a, Show a) => a -> a -> Diff a
+exp_law x y = (exp' (x + y) , exp' x * exp' y)
+
+exp_log,log_exp :: (RealFrac a, Show a, Enum a) => a -> Diff a
+exp_log x = (exp' (ln' x), x)
+log_exp x = (ln' (exp' x), x)
+
+exp_UnitInterval :: (RealFrac a, Show a, Enum a) => a -> a -> Bool
+exp_UnitInterval x y = let z = x *** y in z >= 0 && z <= 1
+
+findD :: (RealFrac a, Show a) => a -> Bool
+findD x = e ^^ n <= x && x < e ^^ (n + 1)
+    where n = findE e x
+          e = exp' 1
+
+pow_Diff :: (RealFrac a, Enum a, Show a) => a -> (a,a) -> Diff a
+pow_Diff z (y,x) = ((z *** (1/x)) *** y , (z *** y) *** (1/x))
+
+leader :: (RealFrac a, Show a, Enum a) => a -> a -> a
+leader f sigma = 1 - ((1 - f) *** sigma)
+
+taylor :: (RealFrac a, Show a, Enum a) => a -> a -> a -> a -> Bool
+taylor f a p sigma = case taylorExpCmp 3 (1/q) (-sigma*c) of
+                        ABOVE _ _ -> p >= a
+                        BELOW _ _ -> p <  a
+                        UNKNOWN   -> False
+                        where c = ln' (1 - f)
+                              q = 1 - p
+
 
 ---------------------------------------
 -- FixedPoint Versions of Properties --
 ---------------------------------------
 
-expdiffFP :: Integer -> Integer -> Integer -> Integer -> (FixedPoint, FixedPoint)
-expdiffFP x'' y'' a'' b'' =
-    (e1, e2)
-      where e1 = base1 *** (fromIntegral y''::FixedPoint)
-            e2 = base2 *** (1 / fromIntegral x''::FixedPoint)
-            base = (fromIntegral b''::FixedPoint) / (fromIntegral a''::FixedPoint)
-            base1 = base *** (1 / (fromIntegral x'')::FixedPoint)
-            base2 = base *** (fromIntegral y''::FixedPoint)
-
-
-prop_FPExpLaw :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_FPExpLaw (Positive x) (Positive y) (Positive a) (Positive b) =
-    b'' > 0 && y'' > 0 && a'' > 0 && x'' > 0 ==>
-        let diff = abs(e1 - e2) in
-        classify (diff < epsFP) "OK 10e-16" $
-        classify (diff < epsFP * 1000 && diff >= epsFP) "OK 10e-12" $
-        classify (diff >= epsFP * 1000) "KO" $
-        True === True
-        --(e1 >= epsFP * 1000 && e2 >= epsFP * 1000 ==> abs(e1 - e2) < epsFP * 100000)
-    where (x'', y'') = normalizeInts x y
-          (a'', b'') = normalizeInts a b
-          (e1, e2)   = expdiffFP x'' y'' a'' b''
-
-prop_FPMonotonic ::
-     (FixedPoint -> Bool) -> (FixedPoint -> FixedPoint) -> FixedPoint -> FixedPoint -> Property
+prop_FPMonotonic :: Monotonic FixedPoint
 prop_FPMonotonic constrain f x y =
-  (constrain x && constrain y) ==>
-  classify (bothZero x y) "both zero case" $
-  (bothZero x y ||
-   if x <= y
-   then f x <= f y
-   else f x > f y) === True
-        where bothZero a b = f a < epsFP && f b < epsFP
+    both constrain (x,y) ==>
+    classify zeroes "both zero case" $
+    (zeroes || monotonic f x y) === True
+    where zeroes = both zero (x,y)
+          zero a = (f a, 0) ~= epsFP
 
-prop_FPExpLaw' :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_FPExpLaw' (Positive x) (Positive y) (Positive a) (Positive b) =
-    (abs (exp' (a'/b' + x'/y') - (exp'(a'/b') * exp'(x'/y'))) < epsFP) === True
-        where (b'', a'') = normalizeInts a b
-              (y'', x'') = normalizeInts x y
-              a' = fromIntegral a''
-              b' = fromIntegral b''
-              x' = fromIntegral x''
-              y' = fromIntegral y''
+prop_FPPowDiff :: UnitInterval FixedPoint -> Normalized FixedPoint -> Property
+prop_FPPowDiff (Unit z) (Norm w) = let e = absDiff (pow_Diff z w) in
+    classify (e < epsFP) "OK 10e-16" $
+    classify (e < epsFP * 1000 && e >= epsFP) "OK 10e-12" $
+    classify (e >= epsFP * 1000) "KO" $
+    True === True
 
-prop_FPExpUnitInterval :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_FPExpUnitInterval (Positive x) (Positive y) (Positive a) (Positive b) =
-    a'' > 0 && x'' > 0 ==> result >= 0 && result <= 1
-    where (x'', y'') = normalizeInts x y
-          (a'', b'') = normalizeInts a b
-          a' = fromIntegral a'':: FixedPoint
-          b' = fromIntegral b'':: FixedPoint
-          x' = fromIntegral x'':: FixedPoint
-          y' = fromIntegral y'':: FixedPoint
-          result = (b' / a') *** (y' / x')
+prop_FPExpLaw :: UnitInterval FixedPoint -> UnitInterval FixedPoint -> Property
+prop_FPExpLaw (Unit x) (Unit y) = (exp_law x y ~= epsFP) === True
+
+prop_FPlnLaw :: Positive FixedPoint -> Positive FixedPoint -> Property
+prop_FPlnLaw (Positive x) (Positive y) = (log_law x y ~= epsFP) === True
+
+prop_FPExpUnitInterval :: UnitInterval FixedPoint -> UnitInterval FixedPoint -> Property
+prop_FPExpUnitInterval (Unit x) (Unit y) = exp_UnitInterval x y === True
 
 prop_FPIdemPotent :: Positive FixedPoint -> Property
-prop_FPIdemPotent (Positive a) =
-    a > 0 ==> (exp' $ ln' a) - a < epsFP
+prop_FPIdemPotent (Positive x) = (exp_log x ~= epsFP) === True
 
-prop_FPIdemPotent' :: PosInt -> PosInt -> Property
-prop_FPIdemPotent' (Positive a) (Positive b) =
-    b'' > 0 && a'' > 0 ==> (ln' $ exp' (fromIntegral b'' / fromIntegral a'')::FixedPoint) - ((fromIntegral b'' / fromIntegral a'')::FixedPoint) < epsFP
-    where (a'', b'') = normalizeInts a b
-
-prop_FPlnLaw :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_FPlnLaw (Positive x) (Positive y) (Positive a) (Positive b) =
-    ((ln' ((a''/b'') *** (x''/y'')) - (x''/y'') * ln' (a''/b'')) < epsFP) === True
-    where (b', a') = normalizeInts a b
-          (y', x') = normalizeInts x y
-          a'' = fromIntegral a'
-          b'' = fromIntegral b'
-          x'' = fromIntegral x'
-          y'' = fromIntegral y'
-
-prop_LeaderCmp :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_LeaderCmp (Positive q) (Positive q') (Positive a) (Positive a') =
-  p_ < 1 && sigma < 1 ==>
-    classify (p_ < (1 - ((1 - f) *** sigma))) "is leader" $
-    let result = taylorExpCmp 3 (1/(1 - p_)) (-sigma*c) in
-      (case result of
-        ABOVE _ _ -> p_ >= (1 - ((1 - f) *** sigma))
-        BELOW _ _ -> p_ < (1 - ((1 - f) *** sigma))
-        UNKNOWN -> False
-        )
-  where (p, p') = normalizeInts q q'
-        (s, s') = normalizeInts a a'
-        p'''    = fromIntegral p' :: FixedPoint
-        p''     = fromIntegral p
-        s'''    = fromIntegral s' :: FixedPoint
-        s''     = fromIntegral s
-        p_      = p''' / p''
-        sigma   = s''' / s''
-        f       = 1 / (10 :: FixedPoint)
-        c       = ln' (1 - f)
-
------------------------------------
--- Double versions of properties --
------------------------------------
-
-prop_DMonotonic ::
-     (Double -> Bool) -> (Double -> Double) -> Double -> Double -> Property
-prop_DMonotonic constrain f x y =
-  (constrain x && constrain y) ==>
-  if x <= y
-    then f x <= f y
-    else f x > f y
-
--- | Takes very long, but (e *** b) *** c is not an operation that we use.
-prop_DExpLaw :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_DExpLaw (Positive x) (Positive y) (Positive a) (Positive b) =
-    b'' > 0 && y'' > 0 && a'' > 0 && x'' > 0 ==> expdiffD x'' y'' a'' b'' < epsD
-    where (x'', y'') = normalizeInts x y
-          (a'', b'') = normalizeInts a b
-
-prop_DExpLaw' :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_DExpLaw' (Positive x) (Positive y) (Positive a) (Positive b) =
-    (abs (exp' (a'/b' + x'/y') - (exp'(a'/b') * exp'(x'/y'))) < epsD) === True
-        where (b'', a'') = normalizeInts a b
-              (y'', x'') = normalizeInts x y
-              a' = fromIntegral a''
-              b' = fromIntegral b''
-              x' = fromIntegral x''
-              y' = fromIntegral y''
-
-expdiffD :: Integer -> Integer -> Integer -> Integer -> Double
-expdiffD x'' y'' a'' b'' =
-    -- trace (show x'' ++ " "++ show y'' ++ " "
-    --     ++ show a'' ++ " " ++ show b'' ++ " e1: "
-    --     ++ show e1 ++ " e2: " ++ show e2) $
-    abs(e1 - e2)
-      where e1 = (((fromIntegral b'' / fromIntegral a'') *** (1.0 / fromIntegral x'')) *** fromIntegral y'')
-            e2 = (((fromIntegral b'' / fromIntegral a'') *** fromIntegral y'') *** (1.0/ fromIntegral x''))
-
-prop_DExpUnitInterval :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_DExpUnitInterval (Positive x) (Positive y) (Positive a) (Positive b) =
-    a'' > 0 && x'' > 0 ==> result >= 0 && result <= 1
-    where (x'', y'') = normalizeInts x y
-          (a'', b'') = normalizeInts a b
-          a' = fromIntegral a'':: Double
-          b' = fromIntegral b'':: Double
-          x' = fromIntegral x'':: Double
-          y' = fromIntegral y'':: Double
-          result = (b' / a') *** (y' / x')
-
-prop_DIdemPotent :: Positive Double -> Property
-prop_DIdemPotent (Positive a) =
-    a > 0 ==> (exp' $ ln' a) - a < epsD
-
-prop_DIdemPotent' :: PosInt -> PosInt -> Property
-prop_DIdemPotent' (Positive a) (Positive b) =
-    b'' > 0 && a'' > 0 ==> (ln' $ exp' (fromIntegral b'' / fromIntegral a'')::Double) - ((fromIntegral b'' / fromIntegral a'')::Double) < epsD
-    where (a'', b'') = normalizeInts a b
-
-prop_DfindD :: Positive Double -> Property
-prop_DfindD (Positive a) = (e ^^ n <= a && e ^^ (n + 1) > a) === True
-    where e = exp' 1
-          n = findE e a
+prop_FPIdemPotent' :: Positive FixedPoint -> Property
+prop_FPIdemPotent' (Positive x) = (log_exp x ~= epsFP) === True
 
 prop_FPfindD :: Positive FixedPoint -> Property
-prop_FPfindD (Positive a) = (e ^^ n <= a && e ^^ (n + 1) > a) === True
-    where e = exp' 1
-          n = findE e a
+prop_FPfindD (Positive x) = findD x === True
 
-prop_DlnLaw :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_DlnLaw (Positive x) (Positive y) (Positive a) (Positive b) =
-    ((ln' ((a''/b'') *** (x''/y'')) - (x''/y'') * ln' (a''/b'')) < epsD) === True
-    where (b', a') = normalizeInts a b
-          (y', x') = normalizeInts x y
-          a'' = fromIntegral a'
-          b'' = fromIntegral b'
-          x'' = fromIntegral x'
-          y'' = fromIntegral y'
+prop_FPlnPow :: UnitInterval FixedPoint -> UnitInterval FixedPoint -> Property
+prop_FPlnPow (Unit x) (Unit y) = (x > 0) ==> (log_pow x y ~= epsFP) === True
+
+prop_LeaderCmp :: UnitInterval FixedPoint -> UnitInterval FixedPoint -> Property
+prop_LeaderCmp (Unit p) (Unit s) =
+    both (\x -> 0 < x && x < 1) (p,s) ==>
+    classify (p < a) "is leader" $ taylor f a p s
+    where a = leader f s
+          f = 1 / 10
+
+-----------------------------------
+-- Double Versions of Properties --
+-----------------------------------
+
+prop_DMonotonic :: Monotonic Double
+prop_DMonotonic constrain f x y =
+    both constrain (x,y) ==> monotonic f x y
+
+-- | Takes very long, but (e *** b) *** c is not an operation that we use.
+prop_DPowDiff :: UnitInterval Double -> Normalized Double -> Property
+prop_DPowDiff (Unit z) (Norm w) = (pow_Diff z w ~= epsD) === True
+
+prop_DExpLaw :: UnitInterval Double -> UnitInterval Double -> Property
+prop_DExpLaw (Unit x) (Unit y) = (exp_law x y ~= epsD) === True
+
+prop_DlnLaw :: Positive Double -> Positive Double -> Property
+prop_DlnLaw (Positive x) (Positive y) = (log_law x y ~= epsD) === True
+
+prop_DExpUnitInterval :: UnitInterval Double -> UnitInterval Double -> Property
+prop_DExpUnitInterval (Unit x) (Unit y) = exp_UnitInterval x y === True
+
+prop_DIdemPotent :: Positive Double -> Property
+prop_DIdemPotent (Positive x) = (exp_log x ~= epsD) === True
+
+prop_DIdemPotent' :: Positive Double -> Property
+prop_DIdemPotent' (Positive x) = (log_exp x ~= epsD) === True
+
+prop_DfindD :: Positive Double -> Property
+prop_DfindD (Positive x) = findD x === True
+
+prop_DlnPow :: UnitInterval Double -> UnitInterval Double -> Property
+prop_DlnPow (Unit x) (Unit y) = (x > 0) ==> (log_pow x y ~= epsD) === True
 
 -----------------------------
 -- Properties for Rational --
 -----------------------------
 
-prop_Monotonic ::
-     (Double -> Bool) -> (Double -> Double) -> Double -> Double -> Property
+prop_Monotonic :: Monotonic Rational
 prop_Monotonic constrain f x y =
-  (constrain x && constrain y) ==>
-  if x <= y
-    then f x <= f y
-    else f x > f y
+    both constrain (x,y) ==> monotonic f x y
 
-prop_ExpLaw :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_ExpLaw (Positive x) (Positive y) (Positive a) (Positive b) =
-    b'' > 0 && y'' > 0 && a'' > 0 && x'' > 0 ==> expdiff x'' y'' a'' b'' < eps
-    where (x'', y'') = normalizeInts x y
-          (a'', b'') = normalizeInts a b
+prop_PowDiff :: UnitInterval Rational -> Normalized Rational -> Property
+prop_PowDiff (Unit z) (Norm w) = (pow_Diff z w ~= eps) === True
 
-prop_ExpLaw' :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_ExpLaw' (Positive x) (Positive y) (Positive a) (Positive b) =
-    (abs (exp' (a'/b' + x'/y') - (exp'(a'/b') * exp'(x'/y'))) < eps) === True
-        where (b'', a'') = normalizeInts a b
-              (y'', x'') = normalizeInts x y
-              a' = fromIntegral a''
-              b' = fromIntegral b''
-              x' = fromIntegral x''
-              y' = fromIntegral y''
+prop_ExpLaw :: UnitInterval Rational -> UnitInterval Rational -> Property
+prop_ExpLaw (Unit x) (Unit y) = (exp_law x y ~= eps) === True
 
-expdiff :: Integer -> Integer -> Integer -> Integer -> Rational
-expdiff x'' y'' a'' b'' =
-    abs(e1 - e2)
-      where e1 = (((fromIntegral b'' / fromIntegral a'') *** (1.0 / fromIntegral x'')) *** fromIntegral y'')
-            e2 = (((fromIntegral b'' / fromIntegral a'') *** fromIntegral y'') *** (1.0/ fromIntegral x''))
+prop_lnLaw :: Positive Rational -> Positive Rational -> Property
+prop_lnLaw (Positive x) (Positive y) = (log_law x y ~= eps) === True
 
-prop_ExpUnitInterval :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_ExpUnitInterval (Positive x) (Positive y) (Positive a) (Positive b) =
-    a'' > 0 && x'' > 0 ==> result >= 0 && result <= 1
-    where (x'', y'') = normalizeInts x y
-          (a'', b'') = normalizeInts a b
-          result = (b'' % a'') *** (y'' % x'')
+prop_ExpUnitInterval :: UnitInterval Rational -> UnitInterval Rational -> Property
+prop_ExpUnitInterval (Unit x) (Unit y) = exp_UnitInterval x y === True
 
 prop_IdemPotent :: Positive Rational -> Property
-prop_IdemPotent (Positive a) =
-    a > 0 ==> (exp' $ ln' a) - a < eps
+prop_IdemPotent (Positive x) = (exp_log x ~= eps) === True
 
-prop_IdemPotent' :: PosInt -> PosInt -> Property
-prop_IdemPotent' (Positive a) (Positive b) =
-    b'' > 0 && a'' > 0 ==> (ln' $ exp' (fromIntegral b'' / fromIntegral a'')::Rational) - ((fromIntegral b'' / fromIntegral a'')::Rational) < eps
-    where (a'', b'') = normalizeInts a b
+prop_IdemPotent' :: Positive Rational -> Property
+prop_IdemPotent' (Positive x) = (log_exp x ~= eps) === True
 
-prop_RfindD :: Positive Rational -> Property
-prop_RfindD (Positive a) = (e ^^ n <= a && e ^^ (n + 1) > a) === True
-    where e = exp' 1
-          n = findE e a
+prop_findD :: Positive Rational -> Property
+prop_findD (Positive x) = findD x === True
 
-prop_lnLaw :: PosInt -> PosInt -> PosInt -> PosInt -> Property
-prop_lnLaw (Positive x) (Positive y) (Positive a) (Positive b) =
-    ((ln' ((a''/b'') *** (x''/y'')) - (x''/y'') * ln' (a''/b'')) < eps) === True
-    where (b', a') = normalizeInts a b
-          (y', x') = normalizeInts x y
-          a'' = fromIntegral a'
-          b'' = fromIntegral b'
-          x'' = fromIntegral x'
-          y'' = fromIntegral y'
+prop_lnPow :: UnitInterval Rational -> UnitInterval Rational -> Property
+prop_lnPow (Unit x) (Unit y) = (x > 0) ==> (log_pow x y ~= eps) === True
 
 
-qcWithLabel :: Testable prop => String -> prop -> IO ()
-qcWithLabel str prop = do
-  putStrLn str
-  quickCheck prop
-
-qcWithLabelDisabled :: Testable prop => String -> prop -> IO ()
-qcWithLabelDisabled str prop = do
-  putStrLn str
-  if False
-    then quickCheck prop
-    else putStrLn "skipped, takes too long"
+qcWithLabel :: Testable prop => String -> Int -> prop -> IO ()
+qcWithLabel text count prop = do
+  putStrLn text
+  if count > 0
+    then quickCheck (withMaxSuccess count prop)
+    else putStrLn "--- SKIPPED, takes too long"
 
 main :: IO ()
 main = do
-  putStrLn "quickcheck properties for non-integral calculation\n"
+  putStrLn "QuickCheck properties for non-integral calculation"
+  putStrLn ""
 
-  putStrLn "------------------------"
-  putStrLn "-- Test of `Double` --"
-  putStrLn "------------------------"
-  qcWithLabel "property exp is monotonic"
-    (withMaxSuccess 1000 $ prop_DMonotonic (const True) exp')
-  qcWithLabel "property ln is monotonic"
-    (withMaxSuccess 1000 $ prop_DMonotonic (> 0) ln')
-  qcWithLabel "property p,q in (0,1) -> p^q in (0,1)"
-    (withMaxSuccess 1000 prop_DExpUnitInterval)
-  qcWithLabel "property q > 0 -> exp(ln(q)) - q < eps"
-    (withMaxSuccess 1000 prop_DIdemPotent)
-  qcWithLabel "property q > 0 -> ln(exp(q)) - q < eps"
-    (withMaxSuccess 1000 prop_DIdemPotent')
-  qcWithLabel "property exponential law in [0,1]: (((a/b)^1/x)^y) = (((a/b)^y)^1/x)"
-    (withMaxSuccess 1000 prop_DExpLaw)
-  qcWithLabel "property exponential law in [0,1]: exp(q + p) = exp(q) * exp(p)"
-    (withMaxSuccess 1000 prop_DExpLaw')
-  qcWithLabel "property ln law in [0,1]: ln(q^p) = p*ln(q)"
-    (withMaxSuccess 1000 prop_DlnLaw)
-  qcWithLabel "check bound of `findE` :: Double"
-    (withMaxSuccess 1000 prop_DfindD)
-  qcWithLabel "check bound of `findE` :: Rational"
-    (withMaxSuccess 1000 prop_RfindD)
-  qcWithLabel "check bound of `findE` :: FixedPoint"
-    (withMaxSuccess 1000 prop_FPfindD)
+  putStrLn "---------------------"
+  putStrLn "-- Test of Double  --"
+  putStrLn "---------------------"
+  qcWithLabel "property exponential is monotonic"
+    1000 $ prop_DMonotonic (const True) exp'
+  qcWithLabel "property logarithm is monotonic"
+    1000 $ prop_DMonotonic (> 0) ln'
+  qcWithLabel "property x,y in [0,1] -> x^y in [0,1]"
+    1000 prop_DExpUnitInterval
+  qcWithLabel "property x > 0 -> exp(ln(x)) = x"
+    1000 prop_DIdemPotent
+  qcWithLabel "property x > 0 -> ln(exp(x)) = x"
+    1000 prop_DIdemPotent'
+  qcWithLabel "property pow diff in [0,1]: (a^(1/x))^y = (a^y)^(1/x)"
+    1000 prop_DPowDiff
+  qcWithLabel "property exponential law in [0,1]: exp(x + y) = exp(x) · exp(y)"
+    1000 prop_DExpLaw
+  qcWithLabel "property logarithm law in (0,..): ln(x · y) = ln(x) + ln(y)"
+    1000 prop_DlnLaw
+  qcWithLabel "property logarithm of pow in [0,1]: ln(x^y) = y · ln(x)"
+    1000 prop_DlnPow
+  qcWithLabel "check bound of `findE`"
+    1000 prop_DfindD
   putStrLn ""
 
   putStrLn "-------------------------------------------"
   putStrLn "-- Test of 34 Decimal Digits Fixed Point --"
   putStrLn "-------------------------------------------"
-  qcWithLabel "property exp is monotonic"
-    (withMaxSuccess 1000 $ prop_FPMonotonic (const True) exp')
-  qcWithLabel "property ln is monotonic"
-    (withMaxSuccess 1000 $ prop_FPMonotonic (> 0) ln')
-  qcWithLabel "property p,q in (0,1) -> p^q in (0,1)"
-    (withMaxSuccess 1000 prop_FPExpUnitInterval)
-  qcWithLabel "property q > 0 -> exp(ln(q)) - q < eps"
-    (withMaxSuccess 1000 prop_FPIdemPotent)
-  qcWithLabel "property q > 0 -> ln(exp(q)) - q < eps"
-    (withMaxSuccess 1000 prop_FPIdemPotent')
-  qcWithLabel "property exponential law in [0,1]: (((a/b)^1/x)^y) = (((a/b)^y)^1/x)"
-    (withMaxSuccess 1000 prop_FPExpLaw)
-  qcWithLabel "property exponential law in [0,1]: exp(q + p) = exp(q) * exp(p)"
-    (withMaxSuccess 1000 prop_FPExpLaw')
-  qcWithLabel "property ln law in [0,1]: ln(q^p) = p*ln(q)"
-    (withMaxSuccess 1000 prop_FPlnLaw)
-  qcWithLabel "property σ, p ∈ [0,1]: p < 1 - (1 - f)^σ <=> taylorExpCmp 3 (1/(1 - p)) (-sigma * ln (1 - f))"
-    (withMaxSuccess 10000 prop_LeaderCmp)
+  qcWithLabel "property exponential is monotonic"
+    1000 $ prop_FPMonotonic (const True) exp'
+  qcWithLabel "property logarithm is monotonic"
+    1000 $ prop_FPMonotonic (> 0) ln'
+  qcWithLabel "property x,y in [0,1] -> x^y in [0,1]"
+    1000 prop_FPExpUnitInterval
+  qcWithLabel "property x > 0 -> exp(ln(x)) = x"
+    1000 prop_FPIdemPotent
+  qcWithLabel "property x > 0 -> ln(exp(x)) = x"
+    1000 prop_FPIdemPotent'
+  qcWithLabel "property pow diff in [0,1]: (a^(1/x))^y = (a^y)^(1/x)"
+    1000 prop_FPPowDiff
+  qcWithLabel "property exponential law in [0,1]: exp(x + y) = exp(x) · exp(y)"
+    1000 prop_FPExpLaw
+  qcWithLabel "property logarithm law in (0,..): ln(x · y) = ln(x) + ln(y)"
+    1000 prop_FPlnLaw
+  qcWithLabel "property logarithm of pow in [0,1]: ln(x^y) = y · ln(x)"
+    1000 prop_FPlnPow
+  qcWithLabel "check bound of `findE`"
+    1000 prop_FPfindD
+  qcWithLabel "property σ,p in [0,1]: p < 1 - (1 - f)^σ <=> taylorExpCmp 3 (1/(1 - p)) (-σ · ln (1 - f))"
+    10000 prop_LeaderCmp
   putStrLn ""
 
   putStrLn "------------------------------"
   putStrLn "-- Test of Rational Numbers --"
   putStrLn "------------------------------"
-  qcWithLabel "property exp is monotonic"
-    (withMaxSuccess 10 $ prop_Monotonic (const True) exp')
-  qcWithLabel "property ln is monotonic"
-    (withMaxSuccess 10 $ prop_Monotonic (> 0) ln')
-  qcWithLabel "property p,q in (0,1) -> p^q in (0,1)"
-    (withMaxSuccess 10 prop_ExpUnitInterval)
-  qcWithLabel "property q > 0 -> exp(ln(q)) - q < eps"
-    (withMaxSuccess 10 prop_IdemPotent)
-  qcWithLabel "property q > 0 -> ln(exp(q)) - q < eps"
-    (withMaxSuccess 10 prop_IdemPotent')
-  qcWithLabelDisabled "property exponential law in [0,1]: (((a/b)^1/x)^y) = (((a/b)^y)^1/x)"
-    (withMaxSuccess 5 prop_ExpLaw)
-  qcWithLabel "property exponential law in [0,1]: exp(q + p) = exp(q) * exp(p)"
-    (withMaxSuccess 10 prop_ExpLaw')
-  qcWithLabelDisabled "property ln law in [0,1]: ln(q^p) = p*ln(q)"
-    (withMaxSuccess 100 prop_lnLaw)
+  qcWithLabel "property exponential is monotonic"
+    10 $ prop_Monotonic (const True) exp'
+  qcWithLabel "property logarithm is monotonic"
+    10 $ prop_Monotonic (> 0) ln'
+  qcWithLabel "property x,y in [0,1] -> x^y in [0,1]"
+    10 prop_ExpUnitInterval
+  qcWithLabel "property x > 0 -> exp(ln(x)) = x"
+    10 prop_IdemPotent
+  qcWithLabel "property x > 0 -> ln(exp(x)) = x"
+    10 prop_IdemPotent'
+  qcWithLabel "property pow diff in [0,1]: (a^(1/x))^y = (a^y)^(1/x)"
+    0 prop_PowDiff
+  qcWithLabel "property exponential law in [0,1]: exp(x + y) = exp(x) · exp(y)"
+    10 prop_ExpLaw
+  qcWithLabel "property logarithm law in (0,..): ln(x · y) = ln(x) + ln(y)"
+    10 prop_lnLaw
+  qcWithLabel "property logarithm of pow in [0,1]: ln(x^y) = y · ln(x)"
+    0 prop_lnPow
+  qcWithLabel "check bound of `findE`"
+    100 prop_findD
   putStrLn ""

--- a/shelley/chain-and-ledger/formal-spec/non-integral.tex
+++ b/shelley/chain-and-ledger/formal-spec/non-integral.tex
@@ -105,13 +105,13 @@ $x \approx y \Leftrightarrow \lvert x - y\rvert < \epsilon$.
   The following mathematical laws state the requirements for the approximations
   of the $\ln'$ and $\exp'$ function:
   \begin{itemize}
+  \item $\exp'(x + y) \approx \exp'(x) \cdot \exp'(y)$
   \item $\ln'(x\cdot y) \approx \ln'(x) + \ln'(y)$
-  \item $\ln'(x^{y}) \approx y\cdot \ln'(x)$
+  \item $\ln'(x\star y) \approx y\cdot \ln'(x)$
   \item $\ln'(\exp'(x)) \approx \exp'(\ln'(x)) \approx x$
   \item $x, y \in [0,1] \implies x \star y \in [0, 1]$
   \item $x, y, z \in [0,1], x > 0 \implies
     (z\star\frac{1}{x})\star y \approx (z\star y)\star\frac{1}{x}$
-  \item $\exp'(x + y) = \exp'(x) \cdot \exp'(y)$
   \end{itemize}
 \end{property}
 


### PR DESCRIPTION
## Improvements

* Avoid inconsistencies and repetition:
Avoid abuse of (x,x',x'',x''').
Inconsistent use of `normalizeInts` (sometimes swapped, others not).

* Simplified expressions.
Factorized common code patterns.
Try to use the same notation conventions througout all code.

* No need to check `(x > 0)` for `(Positive x)` as the QuickCheck type guaranties just that.

* Added Arbitrary instance for interval `[0,1]`

* Generic polymorphic properties defined in one place.
Then, particularize generic properties for each concrete type (FixedPoint, Double, Rational).

* Notation change: Use "Pow" for `x^y` to avoid confusion with "Exp" for `exp`.
Name "lnLaw" as a law analogous to "ExpLaw", ...

* Added property for logarithm law: `ln(x · y) = ln(x) + ln(y)`

* ~~Missing check props `FPFindE`, `findE`~~ (already in previous commit)

* Some simplifications also in NonIntegral.hs (-Wall).
In `cf`, use same notation in the comments as in the formal spec and the code.

## Fixes

* Missing `abs` in comparison to *epsilon* in props: `FPMonotonic`, `IdemPotent`, `lnLaw`.
* Rational `prop_Monotonic` was using Double instead of Rational.
