### PR TITLE
[#595] Replace signing primitives with type class abstractions

### DIFF
--- a/.stack-to-nix.cache
+++ b/.stack-to-nix.cache
@@ -1,4 +1,0 @@
-https://github.com/well-typed/cborg 80fbe0ee5e67a5622e2cb9eaa9d8594a2214322d cborg 1khd1v9yh6jdkcvzvknvhxpc1qvxvww0pp7c43w4hbvdyhs1q8wh cborg cborg.nix
-https://github.com/input-output-hk/cardano-crypto 3c707936ba0a665375acf5bd240dc4b6eaa6c0bc . 0g8ln8k8wx4csdv92bz09pr7v9dp4lcyv1334b09c9rgwdwhqg1b cardano-crypto cardano-crypto.nix
-https://github.com/hedgehogqa/haskell-hedgehog 2505055760d06ba6343f803783ed023fb0ed6c48 hedgehog 0m29y881kbqvs12vjcbaaqrpbqbc2rvg3ffwx5wfaymbn1djyz9q hedgehog hedgehog.nix
-http://github.com/nc6/canonical-json a9dc9b893649bc2e2a770ab22d278a780f7e3a3c . 0alwbi9xqaj6fmwzs6lr2drqrnhlnp13d9k2qkl5ga7h4grz9zcr canonical-json canonical-json.nix

--- a/nix/.stack.nix/canonical-json.nix
+++ b/nix/.stack.nix/canonical-json.nix
@@ -3,7 +3,7 @@
     flags = {};
     package = {
       specVersion = "1.10";
-      identifier = { name = "canonical-json"; version = "0.5.0.2"; };
+      identifier = { name = "canonical-json"; version = "0.6.0.0"; };
       license = "BSD-3-Clause";
       copyright = "Copyright 2015-2017 Well-Typed LLP";
       maintainer = "duncan@well-typed.com, edsko@well-typed.com";
@@ -20,6 +20,7 @@
           (hsPkgs.base)
           (hsPkgs.bytestring)
           (hsPkgs.containers)
+          (hsPkgs.deepseq)
           (hsPkgs.parsec)
           (hsPkgs.pretty)
           ];
@@ -30,6 +31,7 @@
             (hsPkgs.base)
             (hsPkgs.bytestring)
             (hsPkgs.canonical-json)
+            (hsPkgs.containers)
             (hsPkgs.aeson)
             (hsPkgs.vector)
             (hsPkgs.unordered-containers)
@@ -39,11 +41,22 @@
             ];
           };
         };
+      benchmarks = {
+        "parse-bench" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.canonical-json)
+            (hsPkgs.containers)
+            (hsPkgs.criterion)
+            ];
+          };
+        };
       };
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
-      url = "http://github.com/nc6/canonical-json";
-      rev = "a9dc9b893649bc2e2a770ab22d278a780f7e3a3c";
-      sha256 = "0alwbi9xqaj6fmwzs6lr2drqrnhlnp13d9k2qkl5ga7h4grz9zcr";
+      url = "http://github.com/well-typed/canonical-json";
+      rev = "ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f";
+      sha256 = "02fzn1xskis1lc1pkz0j92v6ipd89ww0k2p3dvwpm3yap5dpnm7k";
       });
     }

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -1,0 +1,66 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { development = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-binary"; version = "1.5.0"; };
+      license = "MIT";
+      copyright = "2019 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK";
+      homepage = "";
+      url = "";
+      synopsis = "Binary serialization for Cardano";
+      description = "This package includes the binary serialization format for Cardano";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.aeson)
+          (hsPkgs.bytestring)
+          (hsPkgs.cardano-prelude)
+          (hsPkgs.cborg)
+          (hsPkgs.containers)
+          (hsPkgs.digest)
+          (hsPkgs.formatting)
+          (hsPkgs.recursion-schemes)
+          (hsPkgs.safe-exceptions)
+          (hsPkgs.tagged)
+          (hsPkgs.text)
+          (hsPkgs.time)
+          (hsPkgs.vector)
+          ];
+        };
+      tests = {
+        "test" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.cardano-binary)
+            (hsPkgs.cardano-prelude)
+            (hsPkgs.cardano-prelude-test)
+            (hsPkgs.cborg)
+            (hsPkgs.containers)
+            (hsPkgs.formatting)
+            (hsPkgs.hedgehog)
+            (hsPkgs.hspec)
+            (hsPkgs.pretty-show)
+            (hsPkgs.QuickCheck)
+            (hsPkgs.quickcheck-instances)
+            (hsPkgs.tagged)
+            (hsPkgs.text)
+            (hsPkgs.vector)
+            ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/cardano-base";
+      rev = "501d91e426ae84ce0ae056be38bd3db594af9fc2";
+      sha256 = "0f58kabypp3fnw856izycpxdnimc0h3x6pp46rc2v2nnd1gkf6w7";
+      });
+    postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -1,0 +1,53 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { development = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-crypto-class"; version = "2.0.0"; };
+      license = "MIT";
+      copyright = "2019 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK";
+      homepage = "";
+      url = "";
+      synopsis = "Type classes abstracting over cryptography primitives for Cardano";
+      description = "Type classes abstracting over cryptography primitives for Cardano";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.base16-bytestring)
+          (hsPkgs.bytestring)
+          (hsPkgs.cardano-binary)
+          (hsPkgs.cryptonite)
+          (hsPkgs.memory)
+          (hsPkgs.reflection)
+          (hsPkgs.vector)
+          ];
+        };
+      tests = {
+        "test-crypto" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.cardano-binary)
+            (hsPkgs.cardano-crypto-class)
+            (hsPkgs.cborg)
+            (hsPkgs.cryptonite)
+            (hsPkgs.QuickCheck)
+            (hsPkgs.tasty)
+            (hsPkgs.tasty-quickcheck)
+            ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/cardano-base";
+      rev = "501d91e426ae84ce0ae056be38bd3db594af9fc2";
+      sha256 = "0f58kabypp3fnw856izycpxdnimc0h3x6pp46rc2v2nnd1gkf6w7";
+      });
+    postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
+    }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -1,0 +1,75 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = { development = false; };
+    package = {
+      specVersion = "1.10";
+      identifier = { name = "cardano-prelude"; version = "0.1.0.0"; };
+      license = "MIT";
+      copyright = "2018 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK";
+      homepage = "";
+      url = "";
+      synopsis = "A Prelude replacement for the Cardano project";
+      description = "A Prelude replacement for the Cardano project";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.aeson)
+          (hsPkgs.array)
+          (hsPkgs.base16-bytestring)
+          (hsPkgs.bytestring)
+          (hsPkgs.canonical-json)
+          (hsPkgs.cborg)
+          (hsPkgs.containers)
+          (hsPkgs.formatting)
+          (hsPkgs.ghc-heap)
+          (hsPkgs.ghc-prim)
+          (hsPkgs.hashable)
+          (hsPkgs.integer-gmp)
+          (hsPkgs.mtl)
+          (hsPkgs.nonempty-containers)
+          (hsPkgs.protolude)
+          (hsPkgs.tagged)
+          (hsPkgs.text)
+          (hsPkgs.time)
+          (hsPkgs.vector)
+          ];
+        };
+      tests = {
+        "cardano-prelude-test" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.aeson)
+            (hsPkgs.aeson-pretty)
+            (hsPkgs.attoparsec)
+            (hsPkgs.base16-bytestring)
+            (hsPkgs.bytestring)
+            (hsPkgs.canonical-json)
+            (hsPkgs.cardano-prelude)
+            (hsPkgs.containers)
+            (hsPkgs.cryptonite)
+            (hsPkgs.formatting)
+            (hsPkgs.ghc-heap)
+            (hsPkgs.hedgehog)
+            (hsPkgs.hspec)
+            (hsPkgs.pretty-show)
+            (hsPkgs.QuickCheck)
+            (hsPkgs.quickcheck-instances)
+            (hsPkgs.text)
+            (hsPkgs.template-haskell)
+            (hsPkgs.time)
+            ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/cardano-prelude";
+      rev = "a21f83d9407b2955fbaea4ce8a79b262361112aa";
+      sha256 = "07iv6bcyrg3s4lqklcr628476p66h84ip626scmrcnyxsv6xkpn5";
+      });
+    }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -10,21 +10,22 @@
         "hedgehog" = (((hackage.hedgehog)."1.0").revisions).default;
         "micro-recursion-schemes" = (((hackage.micro-recursion-schemes)."5.0.2.2").revisions).default;
         "streaming-binary" = (((hackage.streaming-binary)."0.3.0.1").revisions).default;
-        "transformers" = (((hackage.transformers)."0.5.6.2").revisions).default;
-        "process" = (((hackage.process)."1.6.5.0").revisions).default;
         } // {
         delegation = ./delegation.nix;
         cs-blockchain = ./cs-blockchain.nix;
         cs-ledger = ./cs-ledger.nix;
         small-steps = ./small-steps.nix;
         non-integer = ./non-integer.nix;
+        cardano-prelude = ./cardano-prelude.nix;
+        cardano-binary = ./cardano-binary.nix;
+        cardano-crypto-class = ./cardano-crypto-class.nix;
         cborg = ./cborg.nix;
         cardano-crypto = ./cardano-crypto.nix;
         canonical-json = ./canonical-json.nix;
         };
-      compiler.version = "8.6.4";
-      compiler.nix-name = "ghc864";
+      compiler.version = "8.6.5";
+      compiler.nix-name = "ghc865";
       };
-  resolver = "lts-13.16";
-  compiler = "ghc-8.6.4";
+  resolver = "lts-13.24";
+  compiler = "ghc-8.6.5";
   }

--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -27,6 +27,8 @@
           (hsPkgs.microlens-th)
           (hsPkgs.non-integer)
           (hsPkgs.cs-ledger)
+          (hsPkgs.cardano-binary)
+          (hsPkgs.cardano-crypto-class)
           ];
         };
       tests = {
@@ -43,6 +45,7 @@
             (hsPkgs.text)
             (hsPkgs.microlens)
             (hsPkgs.cs-ledger)
+            (hsPkgs.cardano-crypto-class)
             ];
           };
         };

--- a/release.nix
+++ b/release.nix
@@ -69,15 +69,15 @@ localLib.nix-tools.release-nix {
 
     # Windows cross-compilation targets
 
-    jobs.nix-tools.libs.x86_64-pc-mingw32-cs-blockchain.x86_64-linux
-    jobs.nix-tools.libs.x86_64-pc-mingw32-cs-ledger.x86_64-linux
-    jobs.nix-tools.libs.x86_64-pc-mingw32-small-steps.x86_64-linux
+    # jobs.nix-tools.libs.x86_64-pc-mingw32-cs-blockchain.x86_64-linux
+    # jobs.nix-tools.libs.x86_64-pc-mingw32-cs-ledger.x86_64-linux
+    # jobs.nix-tools.libs.x86_64-pc-mingw32-small-steps.x86_64-linux
 
     ## Doctests don't work in Windows.
     # jobs.nix-tools.tests.x86_64-pc-mingw32-small-steps.doctests.x86_64-linux
-    jobs.nix-tools.tests.x86_64-pc-mingw32-small-steps.examples.x86_64-linux
-    jobs.nix-tools.tests.x86_64-pc-mingw32-cs-blockchain.chain-rules-test.x86_64-linux
-    jobs.nix-tools.tests.x86_64-pc-mingw32-cs-ledger.ledger-rules-test.x86_64-linux
+    # jobs.nix-tools.tests.x86_64-pc-mingw32-small-steps.examples.x86_64-linux
+    # jobs.nix-tools.tests.x86_64-pc-mingw32-cs-blockchain.chain-rules-test.x86_64-linux
+    # jobs.nix-tools.tests.x86_64-pc-mingw32-cs-ledger.ledger-rules-test.x86_64-linux
     ];
 
 } (builtins.removeAttrs args ["cardano-ledger-specs"])

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -74,12 +74,15 @@ library
     microlens,
     microlens-th,
     non-integer,
-    cs-ledger
+    cs-ledger,
+    cardano-binary,
+    cardano-crypto-class
 
 test-suite delegation-test
     type:                exitcode-stdio-1.0
     main-is:             Tests.hs
     other-modules:       UnitTests
+                         MockTypes
                          Mutator
                          Generator
                          PropertyTests
@@ -107,4 +110,5 @@ test-suite delegation-test
       multiset,
       text,
       microlens,
-      cs-ledger
+      cs-ledger,
+      cardano-crypto-class

--- a/shelley/chain-and-ledger/executable-spec/src/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Coin.hs
@@ -7,9 +7,11 @@ module Coin
     , splitCoin
     ) where
 
+import           Cardano.Binary (ToCBOR)
+
 -- |The amount of value held by a transaction output.
 newtype Coin = Coin Integer
-  deriving (Show, Eq, Ord, Num, Integral, Real, Enum)
+  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, ToCBOR)
 
 splitCoin :: Coin -> Integer -> (Coin, Coin)
 splitCoin (Coin n) 0 = (Coin 0, Coin n)

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Delegation.PoolParams
@@ -25,36 +27,62 @@ import           Data.Set      (Set)
 import           Lens.Micro    ((^.))
 import           Lens.Micro.TH (makeLenses)
 
+import           Cardano.Binary (ToCBOR(toCBOR), encodeListLen)
+
 import           BaseTypes
 import           Coin          (Coin)
 import           Keys
 
 -- |An account based address for a rewards
-newtype RewardAcnt = RewardAcnt
-  { getRwdHK :: HashKey
-  } deriving (Show, Eq, Ord)
+newtype RewardAcnt hashAlgo signAlgo = RewardAcnt
+  { getRwdHK :: HashKey hashAlgo signAlgo
+  } deriving (Show, Eq, Ord, ToCBOR)
+
 
 -- |A stake pool.
-data PoolParams = PoolParams
-  { _poolPubKey  :: VKey
-  , _poolPledge  :: Coin
-  , _poolPledges :: Map VKey Coin -- TODO not updated currently
-  , _poolCost    :: Coin
-  , _poolMargin  :: UnitInterval
-  , _poolAltAcnt :: Maybe HashKey
-  , _poolRAcnt   :: RewardAcnt
-  , _poolOwners  :: Set HashKey
-  } deriving (Show, Eq, Ord)
+data PoolParams hashAlgo dsignAlgo =
+  PoolParams
+    { _poolPubKey  :: VKey dsignAlgo
+    , _poolPledge  :: Coin
+    , _poolPledges :: Map (VKey dsignAlgo) Coin -- TODO not updated currently
+    , _poolCost    :: Coin
+    , _poolMargin  :: UnitInterval
+    , _poolAltAcnt :: Maybe (HashKey hashAlgo dsignAlgo)
+    , _poolRAcnt   :: RewardAcnt hashAlgo dsignAlgo
+    , _poolOwners  :: Set (HashKey hashAlgo dsignAlgo)
+    } deriving (Show, Eq, Ord)
 
 makeLenses ''PoolParams
 
-poolSpec :: PoolParams -> (Coin, UnitInterval, Coin)
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => ToCBOR (PoolParams hashAlgo dsignAlgo)
+ where
+  toCBOR poolParams =
+    encodeListLen 8
+      <> toCBOR (_poolPubKey poolParams)
+      <> toCBOR (_poolPledge poolParams)
+      <> toCBOR (_poolPledges poolParams)
+      <> toCBOR (_poolCost poolParams)
+      <> toCBOR (_poolMargin poolParams)
+      <> toCBOR (_poolAltAcnt poolParams)
+      <> toCBOR (_poolRAcnt poolParams)
+      <> toCBOR (_poolOwners poolParams)
+
+
+poolSpec :: PoolParams hashAlgo dsignAlgo -> (Coin, UnitInterval, Coin)
 poolSpec pool = (pool ^. poolCost, pool ^. poolMargin, pool ^. poolPledge)
 
 -- |The delegation of one stake key to another.
-data Delegation = Delegation
-  { _delegator :: VKey
-  , _delegatee :: VKey
+data Delegation dsignAlgo = Delegation
+  { _delegator :: VKey dsignAlgo
+  , _delegatee :: VKey dsignAlgo
   } deriving (Show, Eq, Ord)
+
+instance DSIGNAlgorithm dsignAlgo => ToCBOR (Delegation dsignAlgo) where
+  toCBOR delegation =
+    encodeListLen 2
+      <> toCBOR (_delegator delegation)
+      <> toCBOR (_delegatee delegation)
 
 makeLenses ''Delegation

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -1,69 +1,241 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
 module Keys
-  ( Owner(..)
+  ( HashAlgorithm
+  , Hash
+  , hash
+
+  , DSIGNAlgorithm
+  , Signable
   , SKey(..)
   , VKey(..)
-  , VKeyGenesis(..)
-  , GKeys(..)
-  , Dms(..)
-  , KeyPair(..)
-  , keyPair
   , HashKey(..)
+  , KeyPair(..)
+  , VKeyGenesis(..)
   , Sig
   , hashKey
   , hashGenesisKey
   , sign
   , verify
+
+  , GKeys(..)
+  , Dms(..)
+
+  , KESAlgorithm
+  , KESignable
+  , SKeyES(..)
+  , VKeyES(..)
+  , HashKeyES(..)
   , KESig
+  , hashKeyES
   , signKES
   , verifyKES
   )
 where
 
+import           Crypto.Random         (drgNewSeed, seedFromInteger, withDRG)
+import           Data.Maybe            (fromJust)
+import           Data.Typeable         (Typeable)
 import           Numeric.Natural       (Natural)
-
-import           Ledger.Core           (VKey(..)
-                                       , VKeyGenesis(..)
-                                       , Owner(..)
-                                       , SKey(..)
-                                       , Sig(..)
-                                       , Hash
-                                       , hash
-                                       , KeyPair(..)
-                                       , keyPair)
 
 import qualified Data.Map.Strict       as Map
 import qualified Data.Set              as Set
 
--- |The hash of public Key
-newtype HashKey = HashKey Hash deriving (Show, Eq, Ord)
+import           Cardano.Binary        (ToCBOR(toCBOR))
+import           Cardano.Crypto.DSIGN  ( DSIGNAlgorithm
+                                         ( Signable
+                                         , SignKeyDSIGN
+                                         , VerKeyDSIGN
+                                         , encodeSigDSIGN
+                                         , encodeVerKeyDSIGN
+                                         )
+                                       , SignedDSIGN(SignedDSIGN)
+                                       , signedDSIGN
+                                       , verifySignedDSIGN
+                                       )
+import           Cardano.Crypto.Hash   ( Hash
+                                       , HashAlgorithm
+                                       , hash
+                                       , hashWithSerialiser
+                                       )
+import qualified Cardano.Crypto.KES    as KES
+import           Cardano.Crypto.KES    ( KESAlgorithm
+                                         ( SignKeyKES
+                                         , VerKeyKES
+                                         , encodeVerKeyKES
+                                         , encodeSigKES
+                                         )
+                                       , SignedKES(SignedKES)
+                                       , signedKES
+                                       , verifySignedKES
+                                       )
 
-data KESig a = KESig (Sig a) Natural deriving (Show, Eq, Ord)
+newtype SKey dsignAlgo = SKey (SignKeyDSIGN dsignAlgo)
+
+deriving instance DSIGNAlgorithm dsignAlgo => Show (SKey dsignAlgo)
+deriving instance DSIGNAlgorithm dsignAlgo => Eq   (SKey dsignAlgo)
+deriving instance DSIGNAlgorithm dsignAlgo => Ord  (SKey dsignAlgo)
+deriving instance Num (SignKeyDSIGN dsignAlgo) => Num (SKey dsignAlgo)
+
+newtype VKey dsignAlgo = VKey (VerKeyDSIGN dsignAlgo)
+
+deriving instance DSIGNAlgorithm dsignAlgo => Show (VKey dsignAlgo)
+deriving instance DSIGNAlgorithm dsignAlgo => Eq   (VKey dsignAlgo)
+deriving instance DSIGNAlgorithm dsignAlgo => Ord  (VKey dsignAlgo)
+deriving instance Num (VerKeyDSIGN dsignAlgo) => Num (VKey dsignAlgo)
+
+instance DSIGNAlgorithm dsignAlgo => ToCBOR (VKey dsignAlgo) where
+  toCBOR (VKey vk) = encodeVerKeyDSIGN vk
+
+
+data KeyPair dsignAlgo
+  = KeyPair
+      { vKey :: VKey dsignAlgo
+      , sKey :: SKey dsignAlgo
+      } deriving (Show, Eq, Ord)
+
+
+newtype VKeyGenesis dsignAlgo = VKeyGenesis (VerKeyDSIGN dsignAlgo)
+
+deriving instance (DSIGNAlgorithm dsignAlgo) => Show (VKeyGenesis dsignAlgo)
+deriving instance (DSIGNAlgorithm dsignAlgo) => Eq   (VKeyGenesis dsignAlgo)
+deriving instance (DSIGNAlgorithm dsignAlgo) => Ord  (VKeyGenesis dsignAlgo)
+
+instance DSIGNAlgorithm dsignAlgo => ToCBOR (VKeyGenesis dsignAlgo) where
+  toCBOR (VKeyGenesis vKeyGenesis) = encodeVerKeyDSIGN vKeyGenesis
+
+
+newtype Sig dsignAlgo a = Sig (SignedDSIGN dsignAlgo a)
+
+deriving instance (DSIGNAlgorithm dsignAlgo) => Show (Sig dsignAlgo a)
+deriving instance (DSIGNAlgorithm dsignAlgo) => Eq   (Sig dsignAlgo a)
+deriving instance (DSIGNAlgorithm dsignAlgo) => Ord  (Sig dsignAlgo a)
+
+instance (DSIGNAlgorithm dsignAlgo, Typeable a) => ToCBOR (Sig dsignAlgo a) where
+  toCBOR (Sig (SignedDSIGN sigDSIGN)) = encodeSigDSIGN sigDSIGN
+
+
+-- |The hash of public Key
+newtype HashKey hashAlgo dsignAlgo =
+  HashKey (Hash hashAlgo (VerKeyDSIGN dsignAlgo))
+  deriving (Show, Eq, Ord, ToCBOR)
+
 
 -- |Hash a given public key
-hashKey :: VKey -> HashKey
-hashKey key = HashKey $ hash key
+hashKey
+  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => VKey dsignAlgo
+  -> HashKey hashAlgo dsignAlgo
+hashKey (VKey vk) = HashKey $ hashWithSerialiser encodeVerKeyDSIGN vk
 
 -- |Produce a digital signature
-sign :: SKey -> a -> Sig a
-sign (SKey k) d = Sig d k
-
--- |Produce a key evolving signature
-signKES :: SKey -> a -> Natural -> KESig a
-signKES (SKey k) d n = KESig (Sig d k) n
+sign
+  :: (DSIGNAlgorithm dsignAlgo, Signable dsignAlgo a, ToCBOR a)
+  => SKey dsignAlgo
+  -> a
+  -> Sig dsignAlgo a
+sign (SKey k) d =
+  Sig
+    . fst
+    . withDRG (drgNewSeed (seedFromInteger 0))
+    $ signedDSIGN toCBOR d k
 
 -- |Verify a digital signature
-verify :: Eq a => VKey -> a -> Sig a -> Bool
-verify (VKey vk) vd (Sig sd sk) = vk == sk && vd == sd
+verify
+  :: (DSIGNAlgorithm dsignAlgo, Signable dsignAlgo a, ToCBOR a)
+  => VKey dsignAlgo
+  -> a
+  -> Sig dsignAlgo a
+  -> Bool
+verify (VKey vk) vd (Sig sigDSIGN) =
+  either (const False) (const True) $ verifySignedDSIGN toCBOR vk vd sigDSIGN
+
+
+newtype SKeyES kesAlgo = SKeyES (SignKeyKES kesAlgo)
+
+deriving instance (KESAlgorithm kesAlgo) => Show (SKeyES kesAlgo)
+deriving instance (KESAlgorithm kesAlgo) => Eq   (SKeyES kesAlgo)
+deriving instance (KESAlgorithm kesAlgo) => Ord  (SKeyES kesAlgo)
+
+
+newtype VKeyES kesAlgo = VKeyES (VerKeyKES kesAlgo)
+
+deriving instance (KESAlgorithm kesAlgo) => Show (VKeyES kesAlgo)
+deriving instance (KESAlgorithm kesAlgo) => Eq   (VKeyES kesAlgo)
+deriving instance (KESAlgorithm kesAlgo) => Ord  (VKeyES kesAlgo)
+
+instance KESAlgorithm kesAlgo => ToCBOR (VKeyES kesAlgo) where
+  toCBOR (VKeyES vKeyES) = encodeVerKeyKES vKeyES
+
+
+type KESignable kesAlgo a = KES.Signable kesAlgo a
+
+newtype KESig kesAlgo a = KESig (SignedKES kesAlgo a)
+
+deriving instance (KESAlgorithm kesAlgo) => Show (KESig kesAlgo a)
+deriving instance (KESAlgorithm kesAlgo) => Eq   (KESig kesAlgo a)
+deriving instance (KESAlgorithm kesAlgo) => Ord  (KESig kesAlgo a)
+
+instance (KESAlgorithm kesAlgo, Typeable a) => ToCBOR (KESig kesAlgo a) where
+  toCBOR (KESig (SignedKES sigKES)) = encodeSigKES sigKES
+
+
+-- |The hash of KES verification Key
+newtype HashKeyES hashAlgo kesAlgo =
+  HashKeyES (Hash hashAlgo (VerKeyKES kesAlgo))
+  deriving (Show, Eq, Ord, ToCBOR)
+
+
+-- |Hash a given public key
+hashKeyES
+  :: (HashAlgorithm hashAlgo, KESAlgorithm kesAlgo)
+  => VKeyES kesAlgo
+  -> HashKeyES hashAlgo kesAlgo
+hashKeyES (VKeyES vKeyES) =
+  HashKeyES $ hashWithSerialiser encodeVerKeyKES vKeyES
+
+-- |Produce a key evolving signature
+signKES
+  :: (KESAlgorithm kesAlgo, KES.Signable kesAlgo a, ToCBOR a)
+  => SignKeyKES kesAlgo
+  -> a
+  -> Natural
+  -> KESig kesAlgo a
+signKES k d n =
+  KESig
+    . fst
+    . fromJust
+    . fst
+    . withDRG (drgNewSeed (seedFromInteger 0))
+    $ signedKES toCBOR n d k
 
 -- |Verify a key evolving signature
-verifyKES :: Eq a => VKey -> a -> KESig a -> Natural -> Bool
-verifyKES (VKey vk) vd (KESig (Sig sd sk) m) n = vk == sk && vd == sd && m == n
+verifyKES
+  :: (KESAlgorithm kesAlgo, KES.Signable kesAlgo a, ToCBOR a)
+  => VKeyES kesAlgo
+  -> a
+  -> KESig kesAlgo a
+  -> Natural
+  -> Bool
+verifyKES (VKeyES vKeyES) vd (KESig sigKES) n =
+  either (const False) (const True)
+    $ verifySignedKES toCBOR vKeyES n vd sigKES
 
-newtype Dms = Dms (Map.Map VKeyGenesis VKey)
+newtype Dms dsignAlgo =
+  Dms (Map.Map (VKeyGenesis dsignAlgo) (VKey dsignAlgo))
   deriving (Show, Ord, Eq)
 
-newtype GKeys = GKeys (Set.Set VKeyGenesis)
+newtype GKeys dsignAlgo = GKeys (Set.Set (VKeyGenesis dsignAlgo))
   deriving (Show, Ord, Eq)
 
-hashGenesisKey :: VKeyGenesis -> HashKey
-hashGenesisKey = HashKey . hash
+hashGenesisKey
+  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => VKeyGenesis dsignAlgo
+  -> HashKey hashAlgo dsignAlgo
+hashGenesisKey (VKeyGenesis vKeyGenesis) =
+  HashKey $ hashWithSerialiser encodeVerKeyDSIGN vKeyGenesis

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE EmptyDataDecls        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 
 module STS.Avup
@@ -18,20 +17,22 @@ import           Updates
 
 import           Control.State.Transition
 
-data AVUP
+data AVUP dsignAlgo
 
-instance STS AVUP where
-  type State AVUP = (AVUpdate, Map.Map Slot Applications, Applications)
-  type Signal AVUP = AVUpdate
-  type Environment AVUP = (Slot, Dms)
-  data PredicateFailure AVUP = NonGenesisUpdateAVUP
+instance DSIGNAlgorithm dsignAlgo => STS (AVUP dsignAlgo) where
+  type State (AVUP dsignAlgo)
+    = (AVUpdate dsignAlgo, Map.Map Slot Applications, Applications)
+  type Signal (AVUP dsignAlgo) = AVUpdate dsignAlgo
+  type Environment (AVUP dsignAlgo) = (Slot, Dms dsignAlgo)
+  data PredicateFailure (AVUP dsignAlgo)
+    = NonGenesisUpdateAVUP
+    deriving (Show, Eq)
 
-                             deriving (Show, Eq)
   initialRules = []
 
   transitionRules = [avupTransition]
 
-avupTransition :: TransitionRule AVUP
+avupTransition :: DSIGNAlgorithm dsignAlgo => TransitionRule (AVUP dsignAlgo)
 avupTransition = do
   TRC ((_slot, Dms _dms), src@(AVUpdate aupS, favs, avs), AVUpdate _aup) <-
     judgmentContext

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE EmptyDataDecls        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 
@@ -22,21 +23,32 @@ import           STS.Rupd
 
 import           Control.State.Transition
 
-data BHEAD
+data BHEAD hashAlgo dsignAlgo kesAlgo
 
-instance STS BHEAD where
-  type State BHEAD = NewEpochState
-  type Signal BHEAD = BHeader
-  type Environment BHEAD = (Seed, Set.Set VKeyGenesis)
-  data PredicateFailure BHEAD = HeaderSizeTooLargeBHEAD
-                              | BlockSizeTooLargeBHEAD
-                              | NewEpochFailure (PredicateFailure NEWEPOCH)
-                              | RupdFailure (PredicateFailure RUPD)
-                                deriving (Show, Eq)
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo)
+  => STS (BHEAD hashAlgo dsignAlgo kesAlgo)
+ where
+  type State (BHEAD hashAlgo dsignAlgo kesAlgo)
+    = NewEpochState hashAlgo dsignAlgo
+  type Signal (BHEAD hashAlgo dsignAlgo kesAlgo)
+    = BHeader hashAlgo dsignAlgo kesAlgo
+  type Environment (BHEAD hashAlgo dsignAlgo kesAlgo)
+    = (Seed, Set.Set (VKeyGenesis dsignAlgo))
+  data PredicateFailure (BHEAD hashAlgo dsignAlgo kesAlgo)
+    = HeaderSizeTooLargeBHEAD
+    | BlockSizeTooLargeBHEAD
+    | NewEpochFailure (PredicateFailure (NEWEPOCH hashAlgo dsignAlgo))
+    | RupdFailure (PredicateFailure (RUPD hashAlgo dsignAlgo))
+    deriving (Show, Eq)
+
   initialRules = []
   transitionRules = [bheadTransition]
 
-bheadTransition :: TransitionRule BHEAD
+bheadTransition
+  :: forall hashAlgo dsignAlgo kesAlgo
+   . (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo)
+  => TransitionRule (BHEAD hashAlgo dsignAlgo kesAlgo)
 bheadTransition = do
   TRC ((etaC, gkeys), nes@(NewEpochState _ _ bprev _ es ru _ _), bh@(BHeader bhb _)) <-
     judgmentContext
@@ -46,15 +58,21 @@ bheadTransition = do
   fromIntegral (bHeaderSize bh) > _maxBHSize pp ?! HeaderSizeTooLargeBHEAD
   fromIntegral (hBbsize bhb) > _maxBBSize pp ?! BlockSizeTooLargeBHEAD
 
-  nes' <- trans @NEWEPOCH
+  nes' <- trans @(NEWEPOCH hashAlgo dsignAlgo)
     $ TRC ((NewEpochEnv etaC slot gkeys), nes, epochFromSlot slot)
 
-  ru' <- trans @RUPD $ TRC ((bprev, es), ru, slot)
+  ru' <- trans @(RUPD hashAlgo dsignAlgo) $ TRC ((bprev, es), ru, slot)
   let nes'' = nes' { nesRu = ru' }
   pure nes''
 
-instance Embed NEWEPOCH BHEAD where
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo)
+  => Embed (NEWEPOCH hashAlgo dsignAlgo) (BHEAD hashAlgo dsignAlgo kesAlgo)
+ where
   wrapFailed = NewEpochFailure
 
-instance Embed RUPD BHEAD where
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo)
+  => Embed (RUPD hashAlgo dsignAlgo) (BHEAD hashAlgo dsignAlgo kesAlgo)
+ where
   wrapFailed = RupdFailure

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -17,23 +17,29 @@ import           UTxO
 
 import           Control.State.Transition
 
-data DELEG
+data DELEG hashAlgo dsignAlgo
 
-instance STS DELEG where
-  type State DELEG = DState
-  type Signal DELEG = DCert
-  type Environment DELEG = (Slot, Ptr)
-  data PredicateFailure DELEG = StakeKeyAlreadyRegisteredDELEG
-                            | StakeKeyNotRegisteredDELEG
-                            | StakeDelegationImpossibleDELEG
-                            | WrongCertificateTypeDELEG
-                            | GenesisKeyNotInpMappingDELEG
-                                deriving (Show, Eq)
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => STS (DELEG hashAlgo dsignAlgo)
+ where
+  type State (DELEG hashAlgo dsignAlgo) = DState hashAlgo dsignAlgo
+  type Signal (DELEG hashAlgo dsignAlgo) = DCert hashAlgo dsignAlgo
+  type Environment (DELEG hashAlgo dsignAlgo) = (Slot, Ptr)
+  data PredicateFailure (DELEG hashAlgo dsignAlgo)
+    = StakeKeyAlreadyRegisteredDELEG
+    | StakeKeyNotRegisteredDELEG
+    | StakeDelegationImpossibleDELEG
+    | WrongCertificateTypeDELEG
+    | GenesisKeyNotInpMappingDELEG
+    deriving (Show, Eq)
 
   initialRules = [pure emptyDState]
   transitionRules = [delegationTransition]
 
-delegationTransition :: TransitionRule DELEG
+delegationTransition
+  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => TransitionRule (DELEG hashAlgo dsignAlgo)
 delegationTransition = do
   TRC ((_slot, p), d@(DState _ _ _ _ genMap (Dms _dms)), c) <- judgmentContext
   case c of

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE EmptyDataDecls        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 
@@ -8,6 +9,7 @@ module STS.Delpl
   )
 where
 
+import           Keys
 import           LedgerState
 import           Delegation.Certificates
 import           UTxO
@@ -19,44 +21,63 @@ import           Control.State.Transition
 import           STS.Deleg
 import           STS.Pool
 
-data DELPL
+data DELPL hashAlgo dsignAlgo
 
-instance STS DELPL where
-    type State DELPL       = DPState
-    type Signal DELPL      = DCert
-    type Environment DELPL = (Slot, Ptr, PParams)
-    data PredicateFailure DELPL = PoolFailure (PredicateFailure POOL)
-                                | DelegFailure (PredicateFailure DELEG)
-                   deriving (Show, Eq)
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => STS (DELPL hashAlgo dsignAlgo)
+ where
+  type State (DELPL hashAlgo dsignAlgo)       = DPState hashAlgo dsignAlgo
+  type Signal (DELPL hashAlgo dsignAlgo)      = DCert hashAlgo dsignAlgo
+  type Environment (DELPL hashAlgo dsignAlgo) = (Slot, Ptr, PParams)
+  data PredicateFailure (DELPL hashAlgo dsignAlgo)
+    = PoolFailure (PredicateFailure (POOL hashAlgo dsignAlgo))
+    | DelegFailure (PredicateFailure (DELEG hashAlgo dsignAlgo))
+    deriving (Show, Eq)
 
-    initialRules    = [ pure emptyDelegation ]
-    transitionRules = [ delplTransition      ]
+  initialRules    = [ pure emptyDelegation ]
+  transitionRules = [ delplTransition      ]
 
-delplTransition :: TransitionRule DELPL
+delplTransition
+  :: forall hashAlgo dsignAlgo
+   . (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => TransitionRule (DELPL hashAlgo dsignAlgo)
 delplTransition = do
   TRC ((slotIx, ptr, pp), d, c) <- judgmentContext
   case c of
     RegPool _ -> do
-      ps <- trans @POOL $ TRC ((slotIx, ptr, pp), _pstate d, c)
+      ps <-
+        trans @(POOL hashAlgo dsignAlgo) $ TRC ((slotIx, ptr, pp), _pstate d, c)
       pure $ d { _pstate = ps }
     RetirePool _ _ -> do
-      ps <- trans @POOL $ TRC ((slotIx, ptr, pp), _pstate d, c)
+      ps <-
+        trans @(POOL hashAlgo dsignAlgo) $ TRC ((slotIx, ptr, pp), _pstate d, c)
       pure $ d { _pstate = ps }
     RegKey _ -> do
-      ds <- trans @DELEG $ TRC ((slotIx, ptr), _dstate d, c)
+      ds <-
+        trans @(DELEG hashAlgo dsignAlgo) $ TRC ((slotIx, ptr), _dstate d, c)
       pure $ d { _dstate = ds }
     DeRegKey _ -> do
-      ds <- trans @DELEG $ TRC ((slotIx, ptr), _dstate d, c)
+      ds <-
+        trans @(DELEG hashAlgo dsignAlgo) $ TRC ((slotIx, ptr), _dstate d, c)
       pure $ d { _dstate = ds }
     Delegate _ -> do
-      ds <- trans @DELEG $ TRC ((slotIx, ptr), _dstate d, c)
+      ds <-
+        trans @(DELEG hashAlgo dsignAlgo) $ TRC ((slotIx, ptr), _dstate d, c)
       pure $ d { _dstate = ds }
     GenesisDelegate _ -> do
-      ds <- trans @DELEG $ TRC ((slotIx, ptr), _dstate d, c)
+      ds <-
+        trans @(DELEG hashAlgo dsignAlgo) $ TRC ((slotIx, ptr), _dstate d, c)
       pure $ d { _dstate = ds }
 
-instance Embed POOL DELPL where
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => Embed (POOL hashAlgo dsignAlgo) (DELPL hashAlgo dsignAlgo)
+ where
   wrapFailed = PoolFailure
 
-instance Embed DELEG DELPL where
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => Embed (DELEG hashAlgo dsignAlgo) (DELPL hashAlgo dsignAlgo)
+ where
   wrapFailed = DelegFailure

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE EmptyDataDecls        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE TypeFamilies          #-}
 
@@ -19,44 +20,49 @@ import           STS.Newpp
 import           STS.PoolReap
 import           STS.Snap
 
-data EPOCH
+data EPOCH hashAlgo dsignAlgo
 
-instance STS EPOCH where
-    type State EPOCH = EpochState
-    type Signal EPOCH = Epoch
-    type Environment EPOCH = BlocksMade
-    data PredicateFailure EPOCH = PoolReapFailure (PredicateFailure POOLREAP)
-                                | SnapFailure (PredicateFailure SNAP)
-                                | NewPpFailure (PredicateFailure NEWPP)
-                   deriving (Show, Eq)
+instance STS (EPOCH hashAlgo dsignAlgo) where
+    type State (EPOCH hashAlgo dsignAlgo) = EpochState hashAlgo dsignAlgo
+    type Signal (EPOCH hashAlgo dsignAlgo) = Epoch
+    type Environment (EPOCH hashAlgo dsignAlgo) = BlocksMade hashAlgo dsignAlgo
+    data PredicateFailure (EPOCH hashAlgo dsignAlgo)
+      = PoolReapFailure (PredicateFailure (POOLREAP hashAlgo dsignAlgo))
+      | SnapFailure (PredicateFailure (SNAP hashAlgo dsignAlgo))
+      | NewPpFailure (PredicateFailure (NEWPP hashAlgo dsignAlgo))
+      deriving (Show, Eq)
 
     initialRules = [ initialEpoch ]
     transitionRules = [ epochTransition ]
 
-initialEpoch :: InitialRule EPOCH
+initialEpoch :: InitialRule (EPOCH hashAlgo dsignAlgo)
 initialEpoch =
   pure $ EpochState emptyAccount emptySnapShots emptyLedgerState emptyPParams
 
-epochTransition :: TransitionRule EPOCH
+epochTransition :: forall hashAlgo dsignAlgo . TransitionRule (EPOCH hashAlgo dsignAlgo)
 epochTransition = do
   TRC (blocks, EpochState as ss ls pp, e) <- judgmentContext
   let us            = _utxoState ls
   let DPState ds ps = _delegationState ls
-  (ss', us')      <- trans @SNAP $ TRC ((pp, ds, ps, blocks), (ss, us), e)
-  (as', ds', ps') <- trans @POOLREAP $ TRC (pp, (as, ds, ps), e)
+  (ss', us') <-
+    trans @(SNAP hashAlgo dsignAlgo) $ TRC ((pp, ds, ps, blocks), (ss, us), e)
+  (as', ds', ps') <-
+    trans @(POOLREAP hashAlgo dsignAlgo) $ TRC (pp, (as, ds, ps), e)
   let ppNew = undefined -- TODO: result from votedValuePParams
-  (us'', as'', pp') <- trans @NEWPP $ TRC ((ppNew, ds', ps'), (us', as', pp), e)
+  (us'', as'', pp') <-
+    trans @(NEWPP hashAlgo dsignAlgo)
+      $ TRC ((ppNew, ds', ps'), (us', as', pp), e)
   pure $ EpochState
     as''
     ss'
     (ls { _utxoState = us'', _delegationState = DPState ds' ps' })
     pp'
 
-instance Embed SNAP EPOCH where
+instance Embed (SNAP hashAlgo dsignAlgo) (EPOCH hashAlgo dsignAlgo) where
     wrapFailed = SnapFailure
 
-instance Embed POOLREAP EPOCH where
+instance Embed (POOLREAP hashAlgo dsignAlgo) (EPOCH hashAlgo dsignAlgo) where
     wrapFailed = PoolReapFailure
 
-instance Embed NEWPP EPOCH where
+instance Embed (NEWPP hashAlgo dsignAlgo) (EPOCH hashAlgo dsignAlgo) where
     wrapFailed = NewPpFailure

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
@@ -20,25 +20,29 @@ import           Coin
 
 import           Control.State.Transition
 
-data NEWPP
+data NEWPP hashAlgo dsignAlgo
 
-instance STS NEWPP where
-  type State NEWPP = (UTxOState, AccountState, PParams)
-  type Signal NEWPP = Epoch
-  type Environment NEWPP = (Maybe PParams, DState, PState)
-  data PredicateFailure NEWPP = FailureNEWPP
-                                deriving (Show, Eq)
+instance STS (NEWPP hashAlgo dsignAlgo) where
+  type State (NEWPP hashAlgo dsignAlgo)
+    = (UTxOState hashAlgo dsignAlgo, AccountState, PParams)
+  type Signal (NEWPP hashAlgo dsignAlgo) = Epoch
+  type Environment (NEWPP hashAlgo dsignAlgo)
+    = (Maybe PParams, DState hashAlgo dsignAlgo, PState hashAlgo dsignAlgo)
+  data PredicateFailure (NEWPP hashAlgo dsignAlgo)
+    = FailureNEWPP
+    deriving (Show, Eq)
+
   initialRules = [initialNewPp]
   transitionRules = [newPpTransition]
 
-initialNewPp :: InitialRule NEWPP
+initialNewPp :: InitialRule (NEWPP hashAlgo dsignAlgo)
 initialNewPp = pure
   ( UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) (emptyUpdateState)
   , emptyAccount
   , emptyPParams
   )
 
-newPpTransition :: TransitionRule NEWPP
+newPpTransition :: TransitionRule (NEWPP hashAlgo dsignAlgo)
 newPpTransition = do
   TRC ((ppNew, ds, ps), (utxoSt, acnt, pp), e) <- judgmentContext
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
@@ -23,18 +23,20 @@ import           Coin
 
 import           Control.State.Transition
 
-data POOLREAP
+data POOLREAP hashAlgo dsignAlgo
 
-instance STS POOLREAP where
-  type State POOLREAP = (AccountState, DState, PState)
-  type Signal POOLREAP = Epoch
-  type Environment POOLREAP = PParams
-  data PredicateFailure POOLREAP = FailurePOOLREAP
-                                   deriving (Show, Eq)
+instance STS (POOLREAP hashAlgo dsignAlgo) where
+  type State (POOLREAP hashAlgo dsignAlgo)
+    = (AccountState, DState hashAlgo dsignAlgo, PState hashAlgo dsignAlgo)
+  type Signal (POOLREAP hashAlgo dsignAlgo) = Epoch
+  type Environment (POOLREAP hashAlgo dsignAlgo) = PParams
+  data PredicateFailure (POOLREAP hashAlgo dsignAlgo)
+    = FailurePOOLREAP
+    deriving (Show, Eq)
   initialRules = [pure (emptyAccount, emptyDState, emptyPState)]
   transitionRules = [poolReapTransition]
 
-poolReapTransition :: TransitionRule POOLREAP
+poolReapTransition :: TransitionRule (POOLREAP hashAlgo dsignAlgo)
 poolReapTransition = do
   TRC (pp, (a, ds, ps), e) <- judgmentContext
   let retired  = Map.keysSet $ Map.filter (== e) $ ps ^. retiring

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -18,20 +18,22 @@ import           Updates
 
 import           Control.State.Transition
 
-data PPUP
+data PPUP dsignAlgo
 
-instance STS PPUP where
-  type State PPUP = PPUpdate
-  type Signal PPUP = PPUpdate
-  type Environment PPUP = (Slot, Dms)
-  data PredicateFailure PPUP = NonGenesisUpdatePPUP
-                             | PPUpdateTooLatePPUP
-                             deriving (Show, Eq)
+instance DSIGNAlgorithm dsignAlgo => STS (PPUP dsignAlgo) where
+  type State (PPUP dsignAlgo) = PPUpdate dsignAlgo
+  type Signal (PPUP dsignAlgo) = PPUpdate dsignAlgo
+  type Environment (PPUP dsignAlgo) = (Slot, Dms dsignAlgo)
+  data PredicateFailure (PPUP dsignAlgo)
+    = NonGenesisUpdatePPUP
+    | PPUpdateTooLatePPUP
+    deriving (Show, Eq)
+
   initialRules = []
 
   transitionRules = [ppupTransition]
 
-ppupTransition :: TransitionRule PPUP
+ppupTransition :: DSIGNAlgorithm dsignAlgo => TransitionRule (PPUP dsignAlgo)
 ppupTransition = do
   TRC ((s, Dms _dms), pupS@(PPUpdate pupS'), pup@(PPUpdate pup')) <-
     judgmentContext

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
@@ -13,18 +13,21 @@ import           Slot
 
 import           Control.State.Transition
 
-data RUPD
+data RUPD hashAlgo dsignAlgo
 
-instance STS RUPD where
-  type State RUPD = Maybe RewardUpdate
-  type Signal RUPD = Slot.Slot
-  type Environment RUPD = (BlocksMade, EpochState)
-  data PredicateFailure RUPD = FailureRUPD
-                               deriving (Show, Eq)
+instance STS (RUPD hashAlgo dsignAlgo) where
+  type State (RUPD hashAlgo dsignAlgo) = Maybe (RewardUpdate hashAlgo dsignAlgo)
+  type Signal (RUPD hashAlgo dsignAlgo) = Slot.Slot
+  type Environment (RUPD hashAlgo dsignAlgo)
+    = (BlocksMade hashAlgo dsignAlgo, EpochState hashAlgo dsignAlgo)
+  data PredicateFailure (RUPD hashAlgo dsignAlgo)
+    = FailureRUPD
+    deriving (Show, Eq)
+
   initialRules = [pure Nothing]
   transitionRules = [rupdTransition]
 
-rupdTransition :: TransitionRule RUPD
+rupdTransition :: TransitionRule (RUPD hashAlgo dsignAlgo)
 rupdTransition = do
   TRC ((b, es), ru, s) <- judgmentContext
   let slot = (firstSlot $ epochFromSlot s) +* startRewards

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
@@ -24,19 +24,27 @@ import           UTxO
 
 import           Control.State.Transition
 
-data SNAP
+data SNAP hashAlgo dsignAlgo
 
-instance STS SNAP where
-  type State SNAP = (SnapShots, UTxOState)
-  type Signal SNAP = Epoch
-  type Environment SNAP = (PParams, DState, PState, BlocksMade)
-  data PredicateFailure SNAP = FailureSNAP
-                               deriving (Show, Eq)
+instance STS (SNAP hashAlgo dsignAlgo) where
+  type State (SNAP hashAlgo dsignAlgo)
+    = (SnapShots hashAlgo dsignAlgo, UTxOState hashAlgo dsignAlgo)
+  type Signal (SNAP hashAlgo dsignAlgo) = Epoch
+  type Environment (SNAP hashAlgo dsignAlgo)
+    = ( PParams
+      , DState hashAlgo dsignAlgo
+      , PState hashAlgo dsignAlgo
+      , BlocksMade hashAlgo dsignAlgo
+      )
+  data PredicateFailure (SNAP hashAlgo dsignAlgo)
+    = FailureSNAP
+    deriving (Show, Eq)
+
   initialRules =
     [pure (emptySnapShots, UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState)]
   transitionRules = [snapTransition]
 
-snapTransition :: TransitionRule SNAP
+snapTransition :: TransitionRule (SNAP hashAlgo dsignAlgo)
 snapTransition = do
   TRC ((pparams, d, p, blocks), (s, u), eNew) <- judgmentContext
   let pooledStake = poolDistr (u ^. utxo) d p

--- a/shelley/chain-and-ledger/executable-spec/src/Slot.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Slot.hs
@@ -19,11 +19,13 @@ module Slot
 import           Data.Monoid             (Sum(..))
 import           Numeric.Natural         (Natural)
 
+import           Cardano.Binary          (ToCBOR)
+
 import qualified Ledger.Core           as Byron (Slot(..))
 
 -- |A Slot
 newtype Slot = Slot Natural
-  deriving (Show, Eq, Ord, Num)
+  deriving (Show, Eq, Ord, Num, ToCBOR)
   deriving (Semigroup, Monoid) via (Sum Natural)
 
 newtype Duration = Duration Natural
@@ -42,7 +44,7 @@ newtype Duration = Duration Natural
 
 -- |An Epoch
 newtype Epoch = Epoch Natural
-  deriving (Show, Eq, Ord)
+  deriving (Show, Eq, Ord, ToCBOR)
   deriving (Semigroup, Monoid) via (Sum Natural)
 
 slotFromEpoch :: Epoch -> Slot

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -1,6 +1,8 @@
-{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 {-|
 Module      : UTxO
@@ -55,17 +57,18 @@ module UTxO
   , txup
   ) where
 
-import           Crypto.Hash             (Digest, SHA256, hash)
-import qualified Data.ByteArray          as BA
-import qualified Data.ByteString.Char8   as BS
 import           Data.Map.Strict         (Map)
 import qualified Data.Map.Strict         as Map
 import           Data.Set                (Set)
 import qualified Data.Set                as Set
+import           Data.Typeable           (Typeable)
+import           Data.Word               (Word8)
 import           Numeric.Natural         (Natural)
 
 import           Lens.Micro ((^.))
 import           Lens.Micro.TH (makeLenses)
+
+import           Cardano.Binary          (ToCBOR(toCBOR), encodeListLen)
 
 import           Coin                    (Coin (..))
 import           Keys
@@ -76,120 +79,257 @@ import           Updates                 (Update)
 import           Delegation.Certificates (StakePools(..), DCert (..), dvalue)
 import           Delegation.PoolParams (poolPubKey, RewardAcnt(..))
 
--- |A hash
-type Hash = Digest SHA256
-
 -- |A unique ID of a transaction, which is computable from the transaction.
-newtype TxId = TxId { _TxId :: Hash }
-  deriving (Show, Eq, Ord)
+newtype TxId hashAlgo dsignAlgo
+  = TxId { _TxId :: Hash hashAlgo (TxBody hashAlgo dsignAlgo) }
+  deriving (Show, Eq, Ord, ToCBOR)
 
 type Ix  = Natural
 
 -- | Pointer to a slot, transaction index and index in certificate list.
-data Ptr = Ptr Slot Ix Ix
-         deriving (Show, Eq, Ord)
+data Ptr
+  = Ptr Slot Ix Ix
+  deriving (Show, Eq, Ord)
+
+instance ToCBOR Ptr where
+  toCBOR (Ptr slot txIx certIx) =
+    encodeListLen 3
+      <> toCBOR slot
+      <> toCBOR txIx
+      <> toCBOR certIx
 
 -- |An address for UTxO.
-data Addr = AddrTxin { _payHK   :: HashKey, _stakeHK :: HashKey }
-          | AddrPtr { _stakePtr :: Ptr }
-          deriving (Show, Eq, Ord)
+data Addr hashAlgo dsignAlgo
+  = AddrTxin
+      { _payHK :: HashKey hashAlgo dsignAlgo
+      , _stakeHK :: HashKey hashAlgo dsignAlgo
+      }
+  | AddrPtr
+      { _stakePtr :: Ptr
+      }
+  deriving (Show, Eq, Ord)
 
-mkRwdAcnt :: KeyPair -> RewardAcnt
+instance
+  (Typeable dsignAlgo, HashAlgorithm hashAlgo)
+  => ToCBOR (Addr hashAlgo dsignAlgo)
+ where
+  toCBOR = \case
+    AddrTxin payHK stakeHK ->
+      encodeListLen 3
+        <> toCBOR (0 :: Word8)
+        <> toCBOR payHK
+        <> toCBOR stakeHK
+    AddrPtr stakePtr ->
+      encodeListLen 2
+        <> toCBOR (1 :: Word8)
+        <> toCBOR stakePtr
+
+mkRwdAcnt
+  :: ( HashAlgorithm hashAlgo
+     , DSIGNAlgorithm dsignAlgo
+     )
+  => KeyPair dsignAlgo
+  -> RewardAcnt hashAlgo dsignAlgo
 mkRwdAcnt keys = RewardAcnt $ hashKey $ vKey keys
 
 -- |The input of a UTxO.
-data TxIn = TxIn TxId Natural deriving (Show, Eq, Ord)
+data TxIn hashAlgo dsignAlgo
+  = TxIn (TxId hashAlgo dsignAlgo) Natural
+  deriving (Show, Eq, Ord)
+
+instance
+  (Typeable dsignAlgo, HashAlgorithm hashAlgo)
+  => ToCBOR (TxIn hashAlgo dsignAlgo)
+ where
+  toCBOR (TxIn txId index) =
+    encodeListLen 2
+      <> toCBOR txId
+      <> toCBOR index
 
 -- |The output of a UTxO.
-data TxOut = TxOut Addr Coin deriving (Show, Eq, Ord)
+data TxOut hashAlgo dsignAlgo
+  = TxOut (Addr hashAlgo dsignAlgo) Coin
+  deriving (Show, Eq, Ord)
+
+instance
+  (Typeable dsignAlgo, HashAlgorithm hashAlgo)
+  => ToCBOR (TxOut hashAlgo dsignAlgo)
+ where
+  toCBOR (TxOut addr coin) =
+    encodeListLen 2
+      <> toCBOR addr
+      <> toCBOR coin
 
 -- |The unspent transaction outputs.
-newtype UTxO = UTxO (Map TxIn TxOut) deriving (Show, Eq, Ord)
+newtype UTxO hashAlgo dsignAlgo
+  = UTxO (Map (TxIn hashAlgo dsignAlgo) (TxOut hashAlgo dsignAlgo))
+  deriving (Show, Eq, Ord)
 
-type Wdrl = Map RewardAcnt Coin
+type Wdrl hashAlgo dsignAlgo = Map (RewardAcnt hashAlgo dsignAlgo) Coin
 
 -- |A raw transaction
-data TxBody = TxBody { _inputs  :: !(Set TxIn)
-                     , _outputs :: [TxOut]
-                     , _certs   :: ![DCert]
-                     , _wdrls   :: Wdrl
-                     , _txfee   :: Coin
-                     , _ttl     :: Slot
-                     , _txUpdate:: Update
-                     } deriving (Show, Eq, Ord)
+data TxBody hashAlgo dsignAlgo
+  = TxBody
+      { _inputs   :: !(Set (TxIn hashAlgo dsignAlgo))
+      , _outputs  :: [TxOut hashAlgo dsignAlgo]
+      , _certs    :: ![DCert hashAlgo dsignAlgo]
+      , _wdrls    :: Wdrl hashAlgo dsignAlgo
+      , _txfee    :: Coin
+      , _ttl      :: Slot
+      , _txUpdate :: Update dsignAlgo
+      } deriving (Show, Eq, Ord)
 
 makeLenses ''TxBody
 
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => ToCBOR (TxBody hashAlgo dsignAlgo)
+ where
+  toCBOR txbody =
+    encodeListLen 6
+      <> toCBOR (_inputs txbody)
+      <> toCBOR (_outputs txbody)
+      <> toCBOR (_certs txbody)
+      <> toCBOR (_wdrls txbody)
+      <> toCBOR (_txfee txbody)
+      <> toCBOR (_ttl txbody)
+      <> toCBOR (_txUpdate txbody)
+
 -- |Compute the id of a transaction.
-txid :: TxBody -> TxId
+txid
+  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => TxBody hashAlgo dsignAlgo
+  -> TxId hashAlgo dsignAlgo
 txid = TxId . hash
 
 -- |Compute the UTxO inputs of a transaction.
-txins :: TxBody -> Set TxIn
+txins :: TxBody hashAlgo dsignAlgo -> Set (TxIn hashAlgo dsignAlgo)
 txins = flip (^.) inputs
 
 -- |Compute the transaction outputs of a transaction.
-txouts :: TxBody -> UTxO
+txouts
+  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => TxBody hashAlgo dsignAlgo
+  -> UTxO hashAlgo dsignAlgo
 txouts tx = UTxO $
   Map.fromList [(TxIn transId idx, out) | (out, idx) <- zip (tx ^. outputs) [0..]]
   where
     transId = txid tx
 
 -- |Lookup a txin for a given UTxO collection
-txinLookup :: TxIn -> UTxO -> Maybe TxOut
+txinLookup
+  :: TxIn hashAlgo dsignAlgo
+  -> UTxO hashAlgo dsignAlgo
+  -> Maybe (TxOut hashAlgo dsignAlgo)
 txinLookup txin (UTxO utxo') = Map.lookup txin utxo'
 
 -- |Proof/Witness that a transaction is authorized by the given key holder.
-data Wit = Wit VKey !(Sig TxBody) deriving (Show, Eq, Ord)
+data Wit hashAlgo dsignAlgo
+  = Wit (VKey dsignAlgo) !(Sig dsignAlgo (TxBody hashAlgo dsignAlgo))
+  deriving (Show, Eq, Ord)
+
+instance
+  (Typeable hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => ToCBOR (Wit hashAlgo dsignAlgo)
+ where
+  toCBOR (Wit vk sig) =
+    encodeListLen 2
+      <> toCBOR vk
+      <> toCBOR sig
 
 -- |Verify a transaction body witness
-verifyWit :: TxBody -> Wit -> Bool
+verifyWit
+  :: ( HashAlgorithm hashAlgo
+     , DSIGNAlgorithm dsignAlgo
+     , Signable dsignAlgo (TxBody hashAlgo dsignAlgo)
+     )
+  => TxBody hashAlgo dsignAlgo
+  -> Wit hashAlgo dsignAlgo
+  -> Bool
 verifyWit tx (Wit vkey sig) = verify vkey tx sig
 
 -- |A fully formed transaction.
-data Tx = Tx
-          { _body       :: !TxBody
-          , _witnessSet :: !(Set Wit)
-          } deriving (Show, Eq, Ord)
+data Tx hashAlgo dsignAlgo
+  = Tx
+      { _body       :: !(TxBody hashAlgo dsignAlgo)
+      , _witnessSet :: !(Set (Wit hashAlgo dsignAlgo))
+      } deriving (Show, Eq, Ord)
 
 makeLenses ''Tx
 
+instance
+  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => ToCBOR (Tx hashAlgo dsignAlgo)
+ where
+  toCBOR tx =
+    encodeListLen 2
+      <> toCBOR (_body tx)
+      <> toCBOR (_witnessSet tx)
+
 -- |Create a witness for transaction
-makeWitness :: TxBody -> KeyPair -> Wit
+makeWitness
+  :: ( HashAlgorithm hashAlgo
+     , DSIGNAlgorithm dsignAlgo
+     , Signable dsignAlgo (TxBody hashAlgo dsignAlgo)
+     )
+  => TxBody hashAlgo dsignAlgo
+  -> KeyPair dsignAlgo
+  -> Wit hashAlgo dsignAlgo
 makeWitness tx keys = Wit (vKey keys) (sign (sKey keys) tx)
 
 -- |Create witnesses for transaction
-makeWitnesses :: TxBody -> [KeyPair] -> Set Wit
+makeWitnesses
+  :: ( HashAlgorithm hashAlgo
+     , DSIGNAlgorithm dsignAlgo
+     , Signable dsignAlgo (TxBody hashAlgo dsignAlgo)
+     )
+  => TxBody hashAlgo dsignAlgo
+  -> [KeyPair dsignAlgo]
+  -> Set (Wit hashAlgo dsignAlgo)
 makeWitnesses tx = Set.fromList . fmap (makeWitness tx)
 
 -- |Domain restriction
-(<|) :: Set TxIn -> UTxO -> UTxO
+(<|)
+  :: Set (TxIn hashAlgo dsignAlgo)
+  -> UTxO hashAlgo dsignAlgo
+  -> UTxO hashAlgo dsignAlgo
 ins <| (UTxO utxo) =
   UTxO $ Map.filterWithKey (\k _ -> k `Set.member` ins) utxo
 
 -- |Domain exclusion
-(</|) :: Set TxIn -> UTxO -> UTxO
+(</|)
+  :: Set (TxIn hashAlgo dsignAlgo)
+  -> UTxO hashAlgo dsignAlgo
+  -> UTxO hashAlgo dsignAlgo
 ins </| (UTxO utxo) =
   UTxO $ Map.filterWithKey (\k _ -> k `Set.notMember` ins) utxo
 
 -- | Domain of UTxO
-dom :: UTxO -> Set TxIn
+dom :: UTxO hashAlgo dsignAlgo -> Set (TxIn hashAlgo dsignAlgo)
 dom (UTxO utxo) = Map.keysSet utxo
 
 -- |Combine two collections of UTxO.
 --
 --     * TODO - Should we return 'Maybe UTxO' so that we can return
 -- Nothing when the collections are not disjoint?
-union :: UTxO -> UTxO -> UTxO
+union
+  :: UTxO hashAlgo dsignAlgo
+  -> UTxO hashAlgo dsignAlgo
+  -> UTxO hashAlgo dsignAlgo
 union (UTxO a) (UTxO b) = UTxO $ Map.union a b
 
 -- |Determine the total balance contained in the UTxO.
-balance :: UTxO -> Coin
+balance :: UTxO hashAlgo dsignAlgo -> Coin
 balance (UTxO utxo) = foldr addCoins 0 utxo
   where addCoins (TxOut _ a) b = a + b
 
 -- |Determine the total deposit amount needed
-deposits :: PParams -> StakePools -> [DCert] -> Coin
+deposits
+  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => PParams
+  -> StakePools hashAlgo dsignAlgo
+  -> [DCert hashAlgo dsignAlgo]
+  -> Coin
 deposits pc (StakePools stpools) cs = foldl f (Coin 0) cs'
   where
     f coin cert = coin + dvalue cert pc
@@ -197,9 +337,5 @@ deposits pc (StakePools stpools) cs = foldl f (Coin 0) cs'
     notRegisteredPool _ = True
     cs' = filter notRegisteredPool cs
 
-instance BA.ByteArrayAccess TxBody where
-  length        = BA.length . BS.pack . show
-  withByteArray = BA.withByteArray . BS.pack  . show
-
-txup :: Tx -> Update
+txup :: Tx hashAlgo dsignAlgo -> Update dsignAlgo
 txup (Tx txbody _ ) = _txUpdate txbody

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -1,0 +1,46 @@
+module MockTypes where
+
+import           Cardano.Crypto.DSIGN (MockDSIGN)
+import           Cardano.Crypto.Hash (ShortHash)
+
+import qualified Delegation.Certificates
+import qualified Delegation.PoolParams
+import qualified Keys
+import qualified LedgerState
+import qualified UTxO
+
+type DCert = Delegation.Certificates.DCert ShortHash MockDSIGN
+
+type Delegation = Delegation.PoolParams.Delegation MockDSIGN
+
+type PoolParams = Delegation.PoolParams.PoolParams ShortHash MockDSIGN
+
+type RewardAcnt = Delegation.PoolParams.RewardAcnt ShortHash MockDSIGN
+
+type HashKey = Keys.HashKey ShortHash MockDSIGN
+
+type KeyPair = Keys.KeyPair MockDSIGN
+
+type VKey = Keys.VKey MockDSIGN
+
+type KeyPairs = LedgerState.KeyPairs MockDSIGN
+
+type LedgerState = LedgerState.LedgerState ShortHash MockDSIGN
+
+type LedgerValidation = LedgerState.LedgerValidation ShortHash MockDSIGN
+
+type UTxOState = LedgerState.UTxOState ShortHash MockDSIGN
+
+type DPState = LedgerState.DPState ShortHash MockDSIGN
+
+type Addr = UTxO.Addr ShortHash MockDSIGN
+
+type Tx = UTxO.Tx ShortHash MockDSIGN
+
+type TxBody = UTxO.TxBody ShortHash MockDSIGN
+
+type TxIn = UTxO.TxIn ShortHash MockDSIGN
+
+type TxOut = UTxO.TxOut ShortHash MockDSIGN
+
+type UTxO = UTxO.UTxO ShortHash MockDSIGN

--- a/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 {-|
 Module
 Description : Generators for mutating data.
@@ -24,15 +26,20 @@ import Hedgehog
 import qualified Hedgehog.Gen    as Gen
 import qualified Hedgehog.Range  as Range
 
-import BaseTypes
-import Coin
-import           Delegation.Certificates  (DCert(..))
+import           BaseTypes
+import           Coin
+import           Delegation.Certificates  (pattern Delegate, pattern DeRegKey,
+                     pattern GenesisDelegate, pattern RegKey, pattern RegPool,
+                     pattern RetirePool)
 import           Delegation.PoolParams
-import Keys
-import LedgerState (DPState(..), KeyPairs)
-import Updates
-import UTxO        (TxBody(..), Tx(..), TxIn(..), TxOut(..))
+import           Keys (vKey)
+import           Updates
+import           UTxO (pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut,
+                     _body, _certs, _inputs, _outputs, _ttl, _txfee, _wdrls,
+                     _witnessSet)
 import           Slot
+
+import           MockTypes
 
 -- | Identity mutator that does not change the input value.
 mutateId :: a -> Gen a

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE BangPatterns      #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DoAndIfThenElse   #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE DoAndIfThenElse #-}
 
 module PropertyTests (propertyTests) where
 
@@ -17,13 +17,16 @@ import           Hedgehog.Internal.Property (LabelName(..))
 import           Hedgehog
 import qualified Hedgehog.Gen    as Gen
 
-import           Generator
-
 import           Coin
 import           LedgerState hiding (dms)
 import           Slot
 import           PParams
-import           UTxO
+import           UTxO (pattern TxIn, pattern TxOut, (<|), _body, _witnessSet,
+                     balance, body, certs, deposits, inputs, makeWitness,
+                     outputs, txid, txins, txouts, verifyWit, witnessSet)
+
+import           Generator
+import           MockTypes
 
 
 -- | Take 'addr |-> c' pair from 'TxOut' and insert into map or add 'c' to value

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/a136c4242b9c9f6124b811329bc8ccdfd86c514e/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/a21f83d9407b2955fbaea4ce8a79b262361112aa/snapshot.yaml
 
 packages:
 - shelley/chain-and-ledger/executable-spec
@@ -12,6 +12,15 @@ extra-deps:
 - tasty-hedgehog-1.0.0.1 # Needed due to https://github.com/qfpl/tasty-hedgehog/issues/30
 - Unique-0.4.7.6
 - bimap-0.4.0
+
+- git: https://github.com/input-output-hk/cardano-prelude
+  commit: a21f83d9407b2955fbaea4ce8a79b262361112aa
+
+- git: https://github.com/input-output-hk/cardano-base
+  commit: 501d91e426ae84ce0ae056be38bd3db594af9fc2
+  subdirs:
+    - binary
+    - cardano-crypto-class
 
 nix:
   shell-file: nix/stack-shell.nix


### PR DESCRIPTION
This replaces hashing, signing, and KES, with the versions from `cardano-crypto-class`. `cardano-crypto-class` hasn't yet been merged, but contains the type classes defined in `ouroboros-consensus` for crypto.

The changes involve propagating `hashAlgo`, `dsignAlgo`, and `kesAlgo` type parameters to all relevant types, and then adding constraints at all usage sites. This gives us full provenance for all cryptographic operations in the spec.

For testing I use the `MockTypes` module to redefine all the parameterised types in terms of the `ShortHash` and `MockDSIGN` implementations of hashing and signing, which led to no changes in the actual test code!

This currently fails CI as it is pointing to a local branch, but I wanted to get review on this early. I will push the upstream `cardano-crypto-class` library by the end of today and point this PR to that.

Closes #595 
Closes #594 
Closes #593 