### PR TITLE
Make initial environment generators trace-length aware

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/BHead.hs
@@ -1,18 +1,18 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Spec.Chain.STS.Rule.BHead where
 
-import Control.Lens ((^.), _1)
-import Data.Bimap (Bimap)
+import           Control.Lens ((^.), _1)
+import           Data.Bimap (Bimap)
 
-import Control.State.Transition
-import Ledger.Core
-import Ledger.Update
+import           Control.State.Transition
+import           Ledger.Core
+import           Ledger.Update
 
-import Cardano.Spec.Chain.STS.Block
-import Cardano.Spec.Chain.STS.Rule.Epoch
+import           Cardano.Spec.Chain.STS.Block
+import           Cardano.Spec.Chain.STS.Rule.Epoch
 
 data BHEAD
 
@@ -45,7 +45,7 @@ instance STS BHEAD where
   transitionRules =
     [ do
         TRC ((_, sLast, k), us, bh) <- judgmentContext
-        us' <- trans @EPOCH $ TRC ((sEpoch sLast, k), us, bh ^. bhSlot)
+        us' <- trans @EPOCH $ TRC ((sEpoch sLast k, k), us, bh ^. bhSlot)
         let sMax = snd (us' ^. _1) ^. maxHdrSz
         bHeaderSize bh <= sMax ?! HeaderSizeTooBig
         return $! us'

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -38,7 +38,6 @@ import           Cardano.Spec.Chain.STS.Rule.BBody
 import           Cardano.Spec.Chain.STS.Rule.BHead
 import           Cardano.Spec.Chain.STS.Rule.Epoch (sEpoch)
 import           Cardano.Spec.Chain.STS.Rule.Pbft
--- TODO: do not use this transition system, but use rather BHEAD (which could call SIGCNT)
 import qualified Cardano.Spec.Chain.STS.Rule.SigCnt as SigCntGen
 
 data CHAIN
@@ -182,8 +181,8 @@ instance HasTrace CHAIN where
       <$> gCurrentSlot
       <*> (utxo0 <$> envGen @UTXOWS chainLength)
       <*> pure (mkVkGenesisSet ngk)
+      -- TODO: for now we're returning a constant set of parameters, where only '_bkSgnCntT' varies.
       <*> pure initialPParams { _bkSgnCntT = sigCntT }
-          -- TODO: for now we're returning a constant set of parameters
       <*> pure k
     where
       -- If we want to generate large traces, we need to set up the value of the

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
@@ -1,19 +1,20 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Spec.Chain.STS.Rule.Epoch where
 
--- import Control.Lens ((^.), _2)
-import Control.State.Transition
-import Ledger.Core
-import Ledger.Update
+import           Control.State.Transition
+import           Ledger.Core
+import           Ledger.GlobalParams (slotsPerEpoch)
+import           Ledger.Update
 
-
--- | Compute the epoch for the given _absolute_ slot
-sEpoch :: Slot -> Epoch
-sEpoch (Slot s) = Epoch $ s `div` 21600
-
+-- | Compute the epoch for the given _absolute_ slot and chain stability parameter.
+sEpoch
+  :: Slot
+  -> BlockCount
+  -> Epoch
+sEpoch (Slot s) k = Epoch $ s `div` slotsPerEpoch k
 
 data EPOCH
 
@@ -36,8 +37,8 @@ instance STS EPOCH where
 
   transitionRules =
     [ do
-        TRC ((e_c, _), _, s) <- judgmentContext
-        case e_c >= sEpoch s of
+        TRC ((e_c, k), _, s) <- judgmentContext
+        case e_c >= sEpoch s k of
           True  -> onOrAfterCurrentEpoch
           False -> beforeCurrentEpoch
     ]

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
@@ -64,7 +64,8 @@ instance STS SIGCNT where
 -- | Generate an issuer that can still issue blocks according to the @SIGCNT@ rule. The issuers are
 -- taken from the range of the delegation map passed as parameter.
 --
--- This generator can fail if no suitable issuer can be found.
+-- This generator will throw an error if no suitable issuer can be found, which means that the block
+-- production halted.
 issuer
   :: Environment SIGCNT
   -> State SIGCNT
@@ -92,7 +93,7 @@ issuer (pps, dms, k) sgs =
 -- genesis keys @ngk@.
 --
 -- This threshold must allow that all the (honest) genesis keys can issue enough blocks to fill the
--- rolling window of @k@. If this is not possible, then the block production will halt, since there
+-- rolling window of @k@. If this is not possible, then the block production will halt since there
 -- will not be valid issuers. So the threshold must make it possible to find an integer @n@ such
 -- that:
 --

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
@@ -3,9 +3,6 @@
 
 module Cardano.Spec.Chain.STS.Rule.SigCnt where
 
-
-import           Data.Word
-
 import           Control.Arrow ((|||))
 import           Control.Lens ((^.))
 import           Data.Bimap (Bimap)
@@ -65,13 +62,11 @@ instance STS SIGCNT where
 genIssuer
   :: Environment SIGCNT
   -> State SIGCNT
-  -> Word8 -- TODO: remove
   -> Gen VKey
-genIssuer (pps, dms, k) sgs ngk =
+genIssuer (pps, dms, k) sgs =
   if null validIssuers
   then error $ "No valid issuers!" ++ "\n"
              ++ "k = " ++ show k ++ "\n"
-             ++ "ngk = " ++ show ngk ++ "\n"
              ++ "keys = " ++ show (Bimap.elems dms) ++ "\n"
              ++ "sgs = " ++ show sgs ++ "\n"
              ++ "length sgs = " ++ show (length sgs) ++ "\n"

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/SigCnt.hs
@@ -9,8 +9,10 @@ import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
 import           Data.Sequence (Seq, (|>))
 import qualified Data.Sequence as S
+import           Data.Word (Word8)
 import           Hedgehog (Gen)
 import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 import           Control.State.Transition
 
@@ -55,15 +57,19 @@ instance STS SIGCNT where
             pure $! sgs -- TODO: this is a quite inconvenient encoding for this transition system!
     ]
 
+----------------------------------------------------------------------------------------------------
+-- Generators
+----------------------------------------------------------------------------------------------------
+
 -- | Generate an issuer that can still issue blocks according to the @SIGCNT@ rule. The issuers are
 -- taken from the range of the delegation map passed as parameter.
 --
 -- This generator can fail if no suitable issuer can be found.
-genIssuer
+issuer
   :: Environment SIGCNT
   -> State SIGCNT
   -> Gen VKey
-genIssuer (pps, dms, k) sgs =
+issuer (pps, dms, k) sgs =
   if null validIssuers
   then error $ "No valid issuers!" ++ "\n"
              ++ "k = " ++ show k ++ "\n"
@@ -80,3 +86,39 @@ genIssuer (pps, dms, k) sgs =
     canIssueABlock :: VKey -> Bool
     canIssueABlock vk =
       (const False ||| const True) $ applySTS @SIGCNT (TRC ((pps, dms, k), sgs, vk))
+
+
+-- | Generate a signature count threshold given a chain stability parameter @k@ and number of
+-- genesis keys @ngk@.
+--
+-- This threshold must allow that all the (honest) genesis keys can issue enough blocks to fill the
+-- rolling window of @k@. If this is not possible, then the block production will halt, since there
+-- will not be valid issuers. So the threshold must make it possible to find an integer @n@ such
+-- that:
+--
+-- > n <= k * t
+--
+-- and
+--
+-- > k < ngk * n
+-- > = { algebra }
+-- > k / ngk < n
+--
+-- We know there must be an integer in the interval
+--
+-- > (k/ngk, k/ngk + 1]
+--
+-- So to satisfy the requirements above, we can pick a @t@ such that:
+--
+-- > k/ngk + 1 <= k * t
+-- > = { algebra }
+-- > 1/ngk + 1/k <= t
+--
+-- To pick a value for @t@ we vary the proportion of honest keys.
+--
+sigCntT :: BlockCount -> Word8 -> Gen Double
+sigCntT (BlockCount k) ngk =
+  Gen.double (Range.constant lower upper)
+  where
+    lower = 1 / (fromIntegral ngk * 0.7) + 1 / fromIntegral k
+    upper = 1 / (fromIntegral ngk * 0.5) + 1 / fromIntegral k

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -30,8 +30,9 @@ slotsIncreaseInTrace tr = slots === nubSortBy (comparing Down) slots
 blockIssuersAreDelegates :: Property
 blockIssuersAreDelegates =
   withTests 200 $ property $ do
-    tr <- forAll $ traceSigGen (Maximum 200) (sigGenChain GenDelegation NoGenUTxO)
-    classifyTraceLength tr 200 50
+    let (maxTraceLength, step) = (1000, 100)
+    tr <- forAll $ traceSigGen (Maximum maxTraceLength) (sigGenChain GenDelegation NoGenUTxO)
+    classifyTraceLength tr maxTraceLength step
     checkBlockIssuersAreDelegates tr
   where
     checkBlockIssuersAreDelegates :: MonadTest m => Trace CHAIN -> m ()

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -10,7 +10,7 @@ import           Hedgehog (MonadTest, Property, assert, failure, forAll, propert
 
 import           Control.State.Transition
 import           Control.State.Transition.Generator (TraceLength (Maximum), classifyTraceLength,
-                     trace, traceSigGen)
+                     traceSigGen)
 import qualified Control.State.Transition.Generator as TransitionGenerator
 import           Control.State.Transition.Trace
 
@@ -55,19 +55,19 @@ blockIssuersAreDelegates =
 
 onlyValidSignalsAreGenerated :: Property
 onlyValidSignalsAreGenerated =
-  withTests 300 $ TransitionGenerator.onlyValidSignalsAreGenerated @CHAIN 100
+  withTests 200 $ TransitionGenerator.onlyValidSignalsAreGenerated @CHAIN 200
 
 signersListIsBoundedByK :: Property
 signersListIsBoundedByK = property $ do
   let maxTraceLength = 1000
-  tr <- forAll $ trace @CHAIN maxTraceLength
+  tr <- forAll $ traceSigGen (Maximum maxTraceLength) (sigGenChain GenDelegation NoGenUTxO)
   signersListIsBoundedByKInTrace tr
   where
     signersListIsBoundedByKInTrace :: MonadTest m => Trace CHAIN -> m ()
     signersListIsBoundedByKInTrace tr =
       traverse_ (signersListIsBoundedByKInState k) $ traceStates OldestFirst tr
       where
-        (_, _, _, _, _, k) = _traceEnv @CHAIN tr
+        (_, _, _, _, k) = _traceEnv @CHAIN tr
 
         signersListIsBoundedByKInState :: MonadTest m => BlockCount -> State CHAIN -> m ()
         signersListIsBoundedByKInState (BlockCount k') (_sLast, sgs, _h, _utxoSt, _ds, _us) =

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -47,7 +47,7 @@ blockIssuersAreDelegates =
          checkIssuer :: MonadTest m => (State CHAIN, Signal CHAIN) -> m ()
          checkIssuer (st, bk) =
            case delegatorOf dm issuer of
-             Just _ -> pure $! ()
+             Just _ -> pure ()
              Nothing -> failure
            where
              issuer = bk ^. bHeader . bhIssuer
@@ -55,7 +55,7 @@ blockIssuersAreDelegates =
 
 onlyValidSignalsAreGenerated :: Property
 onlyValidSignalsAreGenerated =
-  withTests 200 $ TransitionGenerator.onlyValidSignalsAreGenerated @CHAIN 200
+  withTests 300 $ TransitionGenerator.onlyValidSignalsAreGenerated @CHAIN 100
 
 signersListIsBoundedByK :: Property
 signersListIsBoundedByK = property $ do

--- a/byron/chain/executable-spec/test/Main.hs
+++ b/byron/chain/executable-spec/test/Main.hs
@@ -5,8 +5,7 @@ import           Test.Tasty (TestTree, defaultMain, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
 
 import           Cardano.AbstractSize.Properties (testAbstractSize)
-import           Cardano.Spec.Chain.STS.Properties (blockIssuersAreDelegates,
-                     onlyValidSignalsAreGenerated, slotsIncrease)
+import           Cardano.Spec.Chain.STS.Properties as CHAIN
 
 main :: IO ()
 main = defaultMain tests
@@ -15,9 +14,10 @@ main = defaultMain tests
   tests =
     testGroup "Chain"
     [ testGroup "Properties"
-      [ testProperty "Increasing slots" slotsIncrease
-      , testProperty "Block issuers are delegates" blockIssuersAreDelegates
+      [ testProperty "Increasing slots" CHAIN.slotsIncrease
+      , testProperty "Block issuers are delegates" CHAIN.blockIssuersAreDelegates
       , testAbstractSize
-      , testProperty "Only valid signals are generated" onlyValidSignalsAreGenerated
+      , testProperty "Only valid signals are generated" CHAIN.onlyValidSignalsAreGenerated
+      , testProperty "Signers list is bounded by k " CHAIN.signersListIsBoundedByK
       ]
     ]

--- a/byron/chain/executable-spec/test/Main.hs
+++ b/byron/chain/executable-spec/test/Main.hs
@@ -4,8 +4,9 @@ module Main (main) where
 import           Test.Tasty (TestTree, defaultMain, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
 
-import           Cardano.AbstractSize.Properties
-import           Cardano.Spec.Chain.STS.Properties
+import           Cardano.AbstractSize.Properties (testAbstractSize)
+import           Cardano.Spec.Chain.STS.Properties (blockIssuersAreDelegates,
+                     onlyValidSignalsAreGenerated, slotsIncrease)
 
 main :: IO ()
 main = defaultMain tests
@@ -16,7 +17,7 @@ main = defaultMain tests
     [ testGroup "Properties"
       [ testProperty "Increasing slots" slotsIncrease
       , testProperty "Block issuers are delegates" blockIssuersAreDelegates
-
       , testAbstractSize
+      , testProperty "Only valid signals are generated" onlyValidSignalsAreGenerated
       ]
     ]

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -626,7 +626,7 @@ During PBFT processing of the block header, we do the following:
 \newcommand{\ETEnv}{\type{ETEnv}}
 
 \newcommand{\sepochname}{sEpoch}
-\newcommand{\sepoch}[1]{\fun{\sepochname}\ #1}
+\newcommand{\sepoch}[2]{\fun{\sepochname}\ #1\ #2}
 
 During each block transition, we must determine whether that block sits on an
 epoch boundary and, if so, carry out various actions which are done on that
@@ -660,7 +660,7 @@ updates the update state to the correct version.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \fun{\sepochname}
-      & \Slot \totalf \Epoch
+      & \Slot \totalf \mathbb{N} \totalf \Epoch
       & \text{epoch containing this slot} \\
       \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
     \end{array}
@@ -703,7 +703,7 @@ updates the update state to the correct version.
   \begin{equation*}
     \inference
     {
-      \var{e_c} \geq \sepoch{s}
+      \var{e_c} \geq \sepoch{s}{k}
     }
     {\var{e_c}
       \vdash
@@ -726,7 +726,7 @@ updates the update state to the correct version.
 \begin{equation*}
   \inference
   {
-    \var{e_c} < \sepoch{s}
+    \var{e_c} < \sepoch{s}{k}
     &
     s\vdash \var{us} \trans{\hyperlink{byron_ledger_spec_link}{upiec}}{} \var{us'}
   }
@@ -886,7 +886,7 @@ rules. During header processing we verify the following things:
       {\left(
         \begin{array}{l}
           \var{dms}\\
-          \sepoch{s_{last}}\\
+          \sepoch{s_{last}}{k}\\
         \end{array}
       \right)}
       \vdash
@@ -1248,7 +1248,7 @@ body according to the rules in figures \ref{fig:rules:bhead} and
         {\left(
         \begin{array}{l}
           \fun{pps} ~  us' \\
-          \sepoch{(\bslot{b})} \\
+          \sepoch{(\bslot{b})}{k} \\
           \var{utxo_0}
         \end{array}
         \right)}

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -85,7 +85,8 @@ test-suite doctests
 test-suite ledger-rules-test
   hs-source-dirs: test
   main-is: Main.hs
-  other-modules: Ledger.Delegation.Examples
+  other-modules: Ledger.Core.Generators.Properties
+               , Ledger.Delegation.Examples
                , Ledger.Delegation.Properties
                , Ledger.AbstractSize.Properties
                , Ledger.Update.Properties

--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | UTXO transition system with witnessing
 
@@ -11,50 +11,19 @@ module Cardano.Ledger.Spec.STS.UTXOW where
 
 import qualified Data.Map as Map
 
-import Control.State.Transition
-  ( Embed
-  , Environment
-  , IRC(IRC)
-  , PredicateFailure
-  , STS
-  , Signal
-  , State
-  , TRC(TRC)
-  , (?!)
-  , initialRules
-  , judgmentContext
-  , trans
-  , transitionRules
-  , wrapFailed
-  )
-import Control.State.Transition.Generator (HasTrace, initEnvGen, sigGen)
+import           Control.State.Transition (Embed, Environment, IRC (IRC), PredicateFailure, STS,
+                     Signal, State, TRC (TRC), initialRules, judgmentContext, trans,
+                     transitionRules, wrapFailed, (?!))
+import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
-import Ledger.Core
-  ( Addr(Addr)
-  , KeyPair(KeyPair)
-  , VKey
-  , keyPair
-  , mkAddr
-  , owner
-  , sign
-  , verify
-  )
+import           Ledger.Core (Addr (Addr), KeyPair (KeyPair), VKey, keyPair, mkAddr, owner, sign,
+                     verify)
 import qualified Ledger.Update.Generators as UpdateGen
-import Ledger.UTxO
-  ( Tx
-  , TxIn
-  , TxOut(TxOut)
-  , TxWits(TxWits)
-  , UTxO(UTxO)
-  , Wit(Wit)
-  , body
-  , fromTxOuts
-  , inputs
-  , pcMinFee
-  )
+import           Ledger.UTxO (Tx, TxIn, TxOut (TxOut), TxWits (TxWits), UTxO (UTxO), Wit (Wit),
+                     body, fromTxOuts, inputs, pcMinFee)
 import qualified Ledger.UTxO.Generators as UTxOGen
 
-import Cardano.Ledger.Spec.STS.UTXO
+import           Cardano.Ledger.Spec.STS.UTXO
 
 data UTXOW
 
@@ -108,7 +77,7 @@ traceAddrs :: [Addr]
 traceAddrs = mkAddr <$> [0 .. 10]
 
 instance HasTrace UTXOW where
-  initEnvGen
+  envGen _
     = UTxOEnv <$> genUTxO <*> UpdateGen.pparamsGen
     where
       genUTxO = do

--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOWS.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOWS.hs
@@ -1,35 +1,22 @@
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Transition system that models the application of multiple transactions to
 -- the UTxO part of the ledger state.
 
 module Cardano.Ledger.Spec.STS.UTXOWS where
 
-import Control.State.Transition
-  ( Embed
-  , Environment
-  , IRC(IRC)
-  , PredicateFailure
-  , STS
-  , Signal
-  , State
-  , TRC(TRC)
-  , initialRules
-  , judgmentContext
-  , trans
-  , transitionRules
-  , wrapFailed
-  )
-import Control.State.Transition.Generator
-  (HasTrace, genTrace, initEnvGen, sigGen)
-import Control.State.Transition.Trace (TraceOrder(NewestFirst), traceSignals)
-import Cardano.Ledger.Spec.STS.UTXO (UTxOEnv, UTxOState)
-import Cardano.Ledger.Spec.STS.UTXOW (UTXOW)
-import Ledger.UTxO (TxWits)
+import           Cardano.Ledger.Spec.STS.UTXO (UTxOEnv, UTxOState)
+import           Cardano.Ledger.Spec.STS.UTXOW (UTXOW)
+import           Control.State.Transition (Embed, Environment, IRC (IRC), PredicateFailure, STS,
+                     Signal, State, TRC (TRC), initialRules, judgmentContext, trans,
+                     transitionRules, wrapFailed)
+import           Control.State.Transition.Generator (HasTrace, envGen, genTrace, sigGen)
+import           Control.State.Transition.Trace (TraceOrder (NewestFirst), traceSignals)
+import           Ledger.UTxO (TxWits)
 
 data UTXOWS
 
@@ -62,7 +49,7 @@ instance Embed UTXOW UTXOWS where
   wrapFailed = UtxowFailure
 
 instance HasTrace UTXOWS where
-  initEnvGen = initEnvGen @UTXOW
+  envGen n = envGen @UTXOW n
 
   -- We generate signal for UTXOWS as a list of signals from UTXOW
   sigGen env st =

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -85,6 +85,9 @@ newtype VKeyGenesis = VKeyGenesis { unVKeyGenesis :: VKey}
 instance HasOwner VKeyGenesis where
   owner (VKeyGenesis vk) = owner vk
 
+mkVKeyGenesis :: Natural -> VKeyGenesis
+mkVKeyGenesis = VKeyGenesis . VKey . Owner
+
 -- |Key Pair.
 data KeyPair = KeyPair
   { sKey :: SKey

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -22,7 +22,7 @@ import qualified Data.Map.Strict as Map
 import Data.Monoid (Sum(..))
 import Data.Set (Set, isSubsetOf, intersection)
 import qualified Data.Set as Set
-import Data.Word (Word64)
+import Data.Word (Word64, Word8)
 import Data.Foldable (toList, elem)
 import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
@@ -87,6 +87,14 @@ instance HasOwner VKeyGenesis where
 
 mkVKeyGenesis :: Natural -> VKeyGenesis
 mkVKeyGenesis = VKeyGenesis . VKey . Owner
+
+-- | Make a set of genesis keys. The genesis keys are continuously numbered from 0 to the given
+-- number of genesis keys minus 1.
+mkVkGenesisSet
+  :: Word8
+  -- ^ Number of genesis keys
+  -> Set VKeyGenesis
+mkVkGenesisSet ngk = Set.fromAscList $ mkVKeyGenesis <$> [0 .. (fromIntegral ngk - 1)]
 
 -- |Key Pair.
 data KeyPair = KeyPair

--- a/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
@@ -6,7 +6,7 @@ module Ledger.Core.Generators
   , slotGen
   , epochGen
   , blockCountGen
-  , kFromChainLength
+  , k
   )
 where
 
@@ -60,13 +60,13 @@ blockCountGen lower upper =
 --
 -- When the number of epochs is greater or equal than the @chainLength@ the resulting @k@ parameter
 -- will be 0.
-kFromChainLength
+k
   :: Word64
   -- ^ Chain length
   -> Word64
   -- ^ Maximum number of epochs
   -> Gen BlockCount
-kFromChainLength chainLength maxNumberOfEpochs =
+k chainLength maxNumberOfEpochs =
   slotsPerEpochToK <$> slotsPerEpoch
     where
       slotsPerEpoch :: Gen Word64

--- a/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
@@ -16,7 +16,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import           Ledger.Core (Addr (Addr), BlockCount (BlockCount), Epoch (Epoch), Owner (Owner),
-                     Slot (Slot), VKey (VKey), VKeyGenesis (VKeyGenesis))
+                     Slot (Slot), VKey (VKey), VKeyGenesis (VKeyGenesis), unBlockCount)
 import           Ledger.GlobalParams (slotsPerEpochToK)
 
 
@@ -71,5 +71,10 @@ k chainLength maxNumberOfEpochs =
     where
       slotsPerEpoch :: Gen Word64
       slotsPerEpoch = do
-        numberOfEpochs <- Gen.integral $ Range.constant 1 (maxNumberOfEpochs `max` 1)
-        pure $! floor $ fromIntegral chainLength / (fromIntegral numberOfEpochs :: Double)
+--        numberOfEpochs <- Gen.integral $ Range.constant 1 (maxNumberOfEpochs `max` 1)
+--        numberOfEpochs <- Gen.integral $ Range.exponential 1 (maxNumberOfEpochs `max` 1)
+        let maxNumberOfEpochsToK = unBlockCount $ slotsPerEpochToK maxNumberOfEpochs
+        numberOfEpochs <- Gen.frequency [ (9, Gen.integral $ Range.linear 1 (maxNumberOfEpochs `max` 1))
+                                        , (1, pure 1)
+                                        ]
+        pure $! round $ fromIntegral chainLength / (fromIntegral numberOfEpochs :: Double)

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -91,8 +91,9 @@ import           Control.State.Transition (Embed, Environment, IRC (IRC), Predic
 import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 import           Ledger.Core (BlockCount, Epoch, HasHash, Hash (Hash), Owner (Owner), Sig,
                      Slot (Slot), SlotCount (SlotCount), VKey (VKey), VKeyGenesis (VKeyGenesis),
-                     addSlot, hash, range, sign, skey, unBlockCount, unVKeyGenesis, (∈), (∉), (⨃))
-import           Ledger.Core.Generators (epochGen, slotGen, vkgenesisGen)
+                     addSlot, hash, mkVKeyGenesis, range, sign, skey, unBlockCount, unVKeyGenesis,
+                     (∈), (∉), (⨃))
+import           Ledger.Core.Generators (epochGen, slotGen)
 import qualified Ledger.Core.Generators as CoreGen
 
 
@@ -528,7 +529,7 @@ initialEnvFromGenesisKeys ngk chainLength =
     --
     -- A similar remark applies to the ranges chosen for slot and slot count
     -- generators.
-    <$> Gen.set (linear 1 (fromIntegral ngk)) vkgenesisGen
+    <$> pure (Set.fromAscList $ mkVKeyGenesis <$> [1 .. fromIntegral ngk])
     <*> epochGen 0 10
     <*> slotGen 0 100
     <*> CoreGen.k chainLength (chainLength `div` 10)

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -2,24 +2,18 @@
 
 module Ledger.GlobalParams
   ( lovelaceCap
-  , ngk
   , slotsPerEpoch
   )
 where
 
-import Data.Int (Int64)
-import Data.Word (Word64)
+import           Data.Int (Int64)
 
-import Ledger.Core (BlockCount(BlockCount), Lovelace(Lovelace))
+import           Ledger.Core (BlockCount (BlockCount), Lovelace (Lovelace))
 
 
 -- | Constant amount of Lovelace in the system.
 lovelaceCap :: Lovelace
 lovelaceCap = Lovelace $ 45 * fromIntegral ((10 :: Int64) ^ (15 :: Int64))
-
--- | Number of genesis keys
-ngk :: Word64
-ngk = 7
 
 -- | Given the chain stability parameter, often referred to as @k@, which is
 -- expressed in an amount of blocks, return the number of slots contained in an

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -3,6 +3,7 @@
 module Ledger.GlobalParams
   ( lovelaceCap
   , slotsPerEpoch
+  , slotsPerEpochToK
   )
 where
 
@@ -20,3 +21,8 @@ lovelaceCap = Lovelace $ 45 * fromIntegral ((10 :: Int64) ^ (15 :: Int64))
 -- epoch.
 slotsPerEpoch :: Integral n => BlockCount -> n
 slotsPerEpoch (BlockCount c) = fromIntegral $ c * 10
+
+-- | The inverse of 'slotsPerEpoch': given a number of slots per-epoch, return the chain stability
+-- parameter @k@. This function does not check for underflow or overflow.
+slotsPerEpochToK :: (Integral n) => n -> BlockCount
+slotsPerEpochToK n = BlockCount $ floor $ (fromIntegral n :: Double) / 10

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -23,6 +23,6 @@ slotsPerEpoch :: Integral n => BlockCount -> n
 slotsPerEpoch (BlockCount c) = fromIntegral $ c * 10
 
 -- | The inverse of 'slotsPerEpoch': given a number of slots per-epoch, return the chain stability
--- parameter @k@. This function does not check for underflow or overflow.
+-- parameter @k@.
 slotsPerEpochToK :: (Integral n) => n -> BlockCount
 slotsPerEpochToK n = BlockCount $ floor $ (fromIntegral n :: Double) / 10

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -46,7 +46,7 @@ import qualified Hedgehog.Range as Range
 import           Numeric.Natural
 
 import           Control.State.Transition
-import           Control.State.Transition.Generator (HasTrace, initEnvGen, sigGen)
+import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 import           Data.AbstractSize (HasTypeReps)
 
 import           Ledger.Core (BlockCount (..), HasHash, Owner (Owner), Relation (..),
@@ -839,7 +839,7 @@ instance Embed UPREG UPIREG where
 
 instance HasTrace UPIREG where
 
-  initEnvGen = upiEnvGen
+  envGen _ = upiEnvGen
 
   sigGen (_slot, dms, _k, _ngk) ((pv, pps), _fads, avs, rpus, raus, _cps, _vts, _bvs, _pws)
     = do
@@ -1217,7 +1217,7 @@ instance Embed UPIVOTE UPIVOTES where
 
 instance HasTrace UPIVOTES where
 
-  initEnvGen = upiEnvGen
+  envGen _ = upiEnvGen
 
   sigGen (_slot, dms, _k, _ngk) ((_pv, _pps), _fads, _avs, rpus, _raus, _cps, vts, _bvs, _pws) =
     (mkVote <$>) . concatMap replicateFst

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -86,8 +86,6 @@ data PParams = PParams -- TODO: this should be a module of @cs-ledger@.
   , _upAdptThd :: !Double
   -- ^ Update adoption threshold: a proportion of block issuers that have to
   -- endorse a given version to become candidate for adoption
-  , _stableAfter :: !Core.BlockCount
-  -- ^ Chain stability parameter
   , _factorA :: !Int
   -- ^ Minimum fees per transaction
   , _factorB :: !Int
@@ -719,8 +717,6 @@ emptyUPIState =
      , _scriptVersion = 0
      , _cfmThd = 0.6
      , _upAdptThd = 0.6      -- Value currently used in mainet
-     , _stableAfter = 5      -- TODO: the k stability parameter needs to be
-                             -- removed from here as well!
 
      -- To determine the factors @A@ and @B@ used in the calculation of the
      -- transaction fees we need to know the constant @C@ that we use to bound
@@ -1043,7 +1039,6 @@ ppsUpdateFrom pps = do
     <*> nextScriptVersion
     <*> nextCfmThd
     <*> nextUpAdptThd
-    <*> pure _stableAfter     -- This parameter should be removed from 'PParams'
     <*> nextFactorA
     <*> nextFactorB
 
@@ -1058,7 +1053,6 @@ ppsUpdateFrom pps = do
            , _scriptVersion
            , _cfmThd
            , _upAdptThd
-           , _stableAfter
            , _factorA
            , _factorB
            } = pps

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -703,7 +703,20 @@ type UPIState =
 emptyUPIState :: UPIState
 emptyUPIState =
   (( ProtVer 0 0 0
-   , PParams                 -- TODO: choose more sensible default values
+   , initialPParams
+   )
+  , []
+  , Map.empty
+  , Map.empty
+  , Map.empty
+  , Map.empty
+  , Set.empty
+  , Set.empty
+  , Map.empty)
+
+initialPParams :: PParams
+initialPParams =
+  PParams                 -- TODO: choose more sensible default values
      { _maxBkSz = 100        -- max sizes chosen as non-zero to allow progress
      , _maxHdrSz = 10
      , _maxTxSz = 50
@@ -758,15 +771,6 @@ emptyUPIState =
      , _factorA = 1 -- In mainet this value is set to 43946000000 (A_C in the derivation above)
      , _factorB = 2 -- In mainet this value is set to 155381000000000
      }
-   )
-  , []
-  , Map.empty
-  , Map.empty
-  , Map.empty
-  , Map.empty
-  , Set.empty
-  , Set.empty
-  , Map.empty)
 
 protocolVersion :: UPIState -> ProtVer
 protocolVersion ((pv, _), _, _, _, _, _, _, _, _) = pv

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -717,9 +717,9 @@ emptyUPIState =
 initialPParams :: PParams
 initialPParams =
   PParams                 -- TODO: choose more sensible default values
-     { _maxBkSz = 100        -- max sizes chosen as non-zero to allow progress
-     , _maxHdrSz = 10
-     , _maxTxSz = 50
+     { _maxBkSz = 1000        -- max sizes chosen as non-zero to allow progress
+     , _maxHdrSz = 100
+     , _maxTxSz = 500
      , _maxPropSz = 10
      , _bkSgnCntT = 0.22     -- As defined in the spec.
      , _bkSlotsPerEpoch = 10 -- TODO: we need to remove this, since this should

--- a/byron/ledger/executable-spec/test/Ledger/Core/Generators/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Core/Generators/Properties.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Ledger.Core.Generators.Properties
+  (relevantKValuesAreGenerated)
+where
+
+import           Control.Monad (when)
+import           Data.Word (Word64)
+import           Hedgehog (Property, cover, forAll, property, withTests)
+import qualified Hedgehog.Gen as Gen
+
+import qualified Ledger.Core.Generators as CoreGen
+import qualified Ledger.GlobalParams as GP
+
+
+-- | Coverage test to check that we're generating relevant 'k' values.
+relevantKValuesAreGenerated :: Property
+relevantKValuesAreGenerated = withTests 300 $ property $ do
+  -- chainLength <- forAll $ Gen.element [ 0 :: Word64
+  --                                     , 10
+  --                                     , 100
+  --                                     , 500
+  --                                     , 1000
+  --                                     ]
+  let chainLength = 1000 :: Word64
+  k <- forAll $ CoreGen.k chainLength (chainLength `div` 10)
+  cover 10
+    "k == 0"
+    (k == 0)
+  cover 70
+    "k /= 0"
+    (k /= 0)
+  let slotsPerEpoch :: Word64
+      slotsPerEpoch = GP.slotsPerEpoch k
+  when (slotsPerEpoch /= 0) $ do
+    let
+      epochs :: Double
+      epochs = fromIntegral chainLength / fromIntegral slotsPerEpoch
+    cover 20
+      "1 epochs "
+      (epochs == 1)
+
+    cover 20
+      "[2, 10)"
+      (2 <= epochs && epochs < 10)
+
+    cover 20
+      "[10, 20)"
+      (10 <= epochs && epochs < 20)
+
+    cover 20
+      "[20, 30)"
+      (20 <= epochs && epochs < 30)
+
+    cover 20
+      "[30, 40)"
+      (30 <= epochs && epochs < 40)
+
+    cover 20
+      "[40, 50)"
+      (40 <= epochs && epochs < 50)
+
+    cover 20
+      "[50, 100)"
+      (50 <= epochs && epochs < 100)

--- a/byron/ledger/executable-spec/test/Ledger/Core/Generators/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Core/Generators/Properties.hs
@@ -6,7 +6,6 @@ where
 import           Control.Monad (when)
 import           Data.Word (Word64)
 import           Hedgehog (Property, cover, forAll, property, withTests)
-import qualified Hedgehog.Gen as Gen
 
 import qualified Ledger.Core.Generators as CoreGen
 import qualified Ledger.GlobalParams as GP
@@ -14,51 +13,47 @@ import qualified Ledger.GlobalParams as GP
 
 -- | Coverage test to check that we're generating relevant 'k' values.
 relevantKValuesAreGenerated :: Property
-relevantKValuesAreGenerated = withTests 300 $ property $ do
-  -- chainLength <- forAll $ Gen.element [ 0 :: Word64
-  --                                     , 10
-  --                                     , 100
-  --                                     , 500
-  --                                     , 1000
-  --                                     ]
+relevantKValuesAreGenerated = withTests 500 $ property $ do
   let chainLength = 1000 :: Word64
+
   k <- forAll $ CoreGen.k chainLength (chainLength `div` 10)
-  cover 10
-    "k == 0"
-    (k == 0)
-  cover 70
-    "k /= 0"
-    (k /= 0)
+
   let slotsPerEpoch :: Word64
       slotsPerEpoch = GP.slotsPerEpoch k
+
   when (slotsPerEpoch /= 0) $ do
     let
-      epochs :: Double
-      epochs = fromIntegral chainLength / fromIntegral slotsPerEpoch
-    cover 20
+      epochs :: Word64
+      epochs = round $ fromIntegral chainLength / (fromIntegral slotsPerEpoch :: Double)
+
+    cover 10
       "1 epochs "
       (epochs == 1)
 
-    cover 20
-      "[2, 10)"
-      (2 <= epochs && epochs < 10)
+    cover 30
+      "epochs in [2, 25)"
+      (2 <= epochs && epochs < 25)
 
-    cover 20
-      "[10, 20)"
-      (10 <= epochs && epochs < 20)
+    cover 10
+      "epochs in [25, 50)"
+      (25 <= epochs && epochs < 50)
 
-    cover 20
-      "[20, 30)"
-      (20 <= epochs && epochs < 30)
+    cover 10
+      "50 epochs "
+      (epochs == 50)
 
-    cover 20
-      "[30, 40)"
-      (30 <= epochs && epochs < 40)
+    -- Note that we will not get any epochs between 50 and 100 since this will require the value of
+    -- @k@ to be a fraction. For instance, to get a @k@ value that will produce 70 epochs for a
+    -- chain of length 1000, we need (assuming @10k@ slots per-epoch):
+    --
+    -- > 1000 / (10 * 70) ~ 1.428
+    --
+    -- So if we round this value up, we get 50 epochs:
+    --
+    -- > 1000 / (10 * 2) == 50
+    --
+    -- And if we round this value down we get 100 epochs.
 
-    cover 20
-      "[40, 50)"
-      (40 <= epochs && epochs < 50)
-
-    cover 20
-      "[50, 100)"
-      (50 <= epochs && epochs < 100)
+    cover 10
+      "100 epochs "
+      (epochs == 100)

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -39,7 +39,8 @@ import           Control.State.Transition.Generator (HasSizeInfo, HasTrace, clas
 import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst), lastState,
                      preStatesAndSignals, traceEnv, traceLength, traceSignals)
 import           Ledger.Core (Epoch (Epoch), Owner (Owner), Sig (Sig), Slot, SlotCount (SlotCount),
-                     VKey (VKey), VKeyGenesis (VKeyGenesis), addSlot, owner, unSlot, unSlotCount)
+                     VKey (VKey), VKeyGenesis (VKeyGenesis), addSlot, mkVKeyGenesis, owner, unSlot,
+                     unSlotCount)
 import           Ledger.Delegation (DCert, DELEG, DIState (DIState),
                      DSEnv (DSEnv, _dSEnvEpoch, _dSEnvK), DSState (DSState),
                      DState (DState, _dStateDelegationMap, _dStateLastDelegation),
@@ -258,8 +259,7 @@ instance HasTrace DBLOCK where
       -- production. Factor 2 is chosen ad-hoc here.
       allowedDelegators = do
         n <- Gen.integral (Range.linear 0 13)
-        pure $! Set.fromAscList $ gk <$> [0 .. n]
-      gk = VKeyGenesis . VKey . Owner
+        pure $! Set.fromAscList $ mkVKeyGenesis <$> [0 .. n]
 
   sigGen _ (env, st) =
     DBlock <$> nextSlotGen <*> sigGen @DELEG env st

--- a/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
@@ -28,6 +28,7 @@ import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes, fromMaybe, isNothing)
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Word (Word64)
 import           Hedgehog (Property, cover, forAll, property, withTests)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -36,7 +37,7 @@ import           Numeric.Natural (Natural)
 import           Control.State.Transition (Embed, Environment, IRC (IRC), PredicateFailure, STS,
                      Signal, State, TRC (TRC), applySTS, initialRules, judgmentContext, trans,
                      transitionRules, wrapFailed, (?!))
-import           Control.State.Transition.Generator (HasTrace, initEnvGen, randomTraceOfSize, ratio,
+import           Control.State.Transition.Generator (HasTrace, envGen, randomTraceOfSize, ratio,
                      sigGen, trace, traceLengthsAreClassified, traceOfLength)
 import qualified Control.State.Transition.Generator as TransitionGenerator
 import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst), traceLength,
@@ -359,7 +360,7 @@ instance Embed UPIEND UBLOCK where
   wrapFailed = UPIENDFailure
 
 instance HasTrace UBLOCK where
-  initEnvGen =
+  envGen _ =
     do
       let numberOfGenesisKeys = 7
       dms <- Update.dmapGen numberOfGenesisKeys
@@ -563,7 +564,7 @@ proposalsScheduledForAdoption sample = traceStates OldestFirst sample
 
 -- | Sample a 'UBLOCK' trace, and print different metrics. This can be used in the REPL, and it is
 -- useful for understanding the traces produced by the 'UBLOCK' transition system.
-ublockSampleTraceMetrics :: Int -> IO ()
+ublockSampleTraceMetrics :: Word64 -> IO ()
 ublockSampleTraceMetrics maxTraceSize = do
   sample <- randomTraceOfSize @UBLOCK maxTraceSize
   let

--- a/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
@@ -100,7 +100,7 @@ upiregRelevantTracesAreCovered = withTests 300 $ property $ do
     "at least 30% of the update proposals increase the maximum block-size"
     (0.3 <= ratio (wrtCurrentProtocolParameters Update._maxBkSz Increases) sample)
 
-  cover 50
+  cover 40
     "at least 10% of the update proposals do not change the maximum block-size"
     (0.1 <= ratio (wrtCurrentProtocolParameters Update._maxBkSz RemainsTheSame) sample)
 

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -36,6 +36,7 @@ main = defaultMain tests
       , testProperty "Relevant DBLOCK traces covered"       DELEG.relevantCasesAreCovered
       , testProperty "Duplicated certificates are rejected" DELEG.rejectDupSchedDelegs
       , testProperty "Traces are classified"                DELEG.tracesAreClassified
+      , testProperty "Only valid DBLOCK signals are generated" DELEG.onlyValidSignalsAreGenerated
       ]
     , testGroup
       "PVBUMP properties"
@@ -54,8 +55,8 @@ main = defaultMain tests
       [ testProperty "UPIREG traces are classified" UPDATE.upiregTracesAreClassified
       , testProperty "UBLOCK traces are classified" UPDATE.ublockTraceLengthsAreClassified
       , testProperty "Relevant UPIREG traces are covered" UPDATE.upiregRelevantTracesAreCovered
-      , testProperty "Only valid signals are generated" UPDATE.onlyValidSignalsAreGenerated
-      , testProperty "Only valid signals are generated for UBLOCK" UPDATE.ublockOnlyValidSignalsAreGenerated
+      , testProperty "Only valid UPIREG signals are generated" UPDATE.onlyValidSignalsAreGenerated
+      , testProperty "Only valid UBLOCK signals are generated" UPDATE.ublockOnlyValidSignalsAreGenerated
       , testProperty "Relevant UBLOCK traces are covered" UPDATE.ublockRelevantTracesAreCovered
       ]
     -- TODO move this out of here (these are not properties of the transition

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -10,13 +10,12 @@ import           Test.Tasty.Hedgehog (testProperty)
 import           Test.Tasty.Ingredients.ConsoleReporter (UseColor (Auto))
 
 import           Ledger.AbstractSize.Properties (testTxHasTypeReps)
+import qualified Ledger.Core.Generators.Properties as CoreGen
 import           Ledger.Delegation.Examples (deleg)
 import qualified Ledger.Delegation.Properties as DELEG
 import           Ledger.Pvbump.Properties (beginningsNoUpdate, emptyPVUpdate, lastProposal)
-
-import qualified Ledger.Update.Properties as UPDATE
-
 import           Ledger.Relation.Properties (testRelation)
+import qualified Ledger.Update.Properties as UPDATE
 import           Ledger.UTxO.Properties (moneyIsConstant)
 import qualified Ledger.UTxO.Properties as UTxO
 
@@ -26,7 +25,9 @@ main = defaultMain tests
   tests :: TestTree
   tests = localOption Auto $ testGroup
     "Ledger"
-    [ testGroup "Delegation Examples" deleg
+    [ testGroup "Core generators properties"
+      [ testProperty "Relevant k values are generated"  CoreGen.relevantKValuesAreGenerated ]
+    , testGroup "Delegation Examples" deleg
     , testGroup
       "Delegation properties"
       [ testProperty "Certificates are triggered"           DELEG.dcertsAreTriggered

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -22,6 +22,7 @@
 module Control.State.Transition.Generator
   ( HasTrace
   , initEnvGen
+  , initEnvForTraceLengthGen
   , sigGen
   , trace
   , traceSigGen
@@ -76,6 +77,11 @@ import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst)
 
 class STS s => HasTrace s where
   initEnvGen :: Gen (Environment s)
+
+  initEnvForTraceLengthGen
+    :: TraceLength
+    -> Gen (Environment s)
+  initEnvForTraceLengthGen _  = initEnvGen @s
 
   sigGen :: Environment s -> State s -> Gen (Signal s)
 

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -78,8 +78,10 @@ import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst)
 class STS s => HasTrace s where
   initEnvGen :: Gen (Environment s)
 
+  -- | Generate an initial environment that is based on the given trace length.
   initEnvForTraceLengthGen
-    :: TraceLength
+    :: Int
+    -- ^ Trace length that will be used by 'trace' or 'traceOfLength'.
     -> Gen (Environment s)
   initEnvForTraceLengthGen _  = initEnvGen @s
 

--- a/byron/semantics/executable-spec/test/Control/State/Transition/Examples/Sum.hs
+++ b/byron/semantics/executable-spec/test/Control/State/Transition/Examples/Sum.hs
@@ -1,18 +1,18 @@
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies     #-}
+{-# LANGUAGE TypeFamilies #-}
 
  -- | Simple example of a transition system whose states contain the sum of the
 -- integers seen in the signals.
 --
 module Control.State.Transition.Examples.Sum where
 
-import Hedgehog (Property, forAll, property, withTests, assert)
+import           Hedgehog (Property, assert, forAll, property, withTests)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-import Control.State.Transition
-import Control.State.Transition.Generator
-import Control.State.Transition.Trace
+import           Control.State.Transition
+import           Control.State.Transition.Generator
+import           Control.State.Transition.Trace
 
 
 data SUM
@@ -36,7 +36,7 @@ instance STS SUM where
     ]
 
 instance HasTrace SUM where
-  initEnvGen = pure ()
+  envGen _ = pure ()
 
   sigGen _ _ =
     Gen.list (Range.constant 1 100) (Gen.integral (Range.constant (-3) 3))


### PR DESCRIPTION
- Add a generator for `k` values given a chain length.
- Check that only valid chain signals are generated.
- Remove `stableAfter` from the protocol parameters.
- Have `sEpoch` take the `k` value as parameter.
- Weaken the environment of the chain: `DSEnv` is not needed, only the set of allowed delegators.
- Fix error with initial `sgs` being set to the list of genesis keys, instead of an empty list.
- Change the way block issuers are generated: now only valid issuers are returned (or an error if no valid issuer is found, which means that the block production halted)
- Fix underflow error in `instace STS SDELEG` when calculating the difference between current and certificate epochs.
- Make the delegation certificates generator return only valid delegation certificates.
- Bump the maximum block, header, and transaction size in the initial protocol parameters to allow progress

Closes #617