### PR TITLE
Rename HashKey to KeyHash

### DIFF
--- a/byron/ledger/formal-spec/crypto-primitives.tex
+++ b/byron/ledger/formal-spec/crypto-primitives.tex
@@ -14,7 +14,7 @@ type suffix, and use simply $\serialised{\wcard}$.
     \begin{array}{r@{~\in~}lr}
       \var{vk} & \SKey & \text{signing key}\\
       \var{vk} & \VKey & \text{verifying key}\\
-      \var{hk} & \HashKey & \text{hash of a key}\\
+      \var{hk} & \KeyHash & \text{hash of a key}\\
       \sigma & \Sig  & \text{signature}\\
       \var{d} & \Data  & \text{data}\\
     \end{array}
@@ -29,7 +29,7 @@ type suffix, and use simply $\serialised{\wcard}$.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \hash{} & \VKey \to \HashKey
+      \hash{} & \VKey \to \KeyHash
       & \text{hash function} \\
       %
       \fun{verify} & \VKey \times \Data \times \Sig

--- a/byron/ledger/formal-spec/ledger-spec.tex
+++ b/byron/ledger/formal-spec/ledger-spec.tex
@@ -48,7 +48,7 @@
 \newcommand{\TxOut}{\type{TxOut}}
 \newcommand{\VKey}{\type{VKey}}
 \newcommand{\SKey}{\type{SKey}}
-\newcommand{\HashKey}{\type{HashKey}}
+\newcommand{\KeyHash}{\type{KeyHash}}
 \newcommand{\SkVk}{\type{SkVk}}
 \newcommand{\Sig}{\type{Sig}}
 \newcommand{\Data}{\type{Data}}

--- a/byron/ledger/formal-spec/utxo.tex
+++ b/byron/ledger/formal-spec/utxo.tex
@@ -261,7 +261,7 @@ here is arbitrary.
     \begin{array}{r@{~\in~}lr}
       \fun{wits} & \Tx \to \powerset{(\VKey \times \Sig)}
       & \text{witnesses of a transaction}\\
-      \fun{hash_{vkey}} & \Addr \mapsto \HashKey
+      \fun{hash_{vkey}} & \Addr \mapsto \KeyHash
       & \text{hash of a verifying key in an address}\\
     \end{array}
   \end{equation*}
@@ -273,7 +273,7 @@ here is arbitrary.
     & \addr{}{} \in \UTxO \to \TxIn \mapsto \Addr & \text{addresses of inputs}\\
     & \addr{utxo} = \{ i \mapsto a \mid i \mapsto (a, \wcard) \in \var{utxo} \} \\
     \nextdef
-    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \HashKey & \text{verifying key hashes}\\
+    & \fun{addr_h} \in \UTxO \to \TxIn \mapsto \KeyHash & \text{verifying key hashes}\\
     & \fun{addr_h}~utxo = \{ i \mapsto h \mid i \mapsto (a, \wcard) \in \var{utxo}
       \wedge a \mapsto h \in \fun{hash_{vkey}} \}
   \end{align*}

--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -236,7 +236,7 @@ hBbsize = bsize
 
 incrBlocks
   :: Bool
-  -> HashKey hashAlgo dsignAlgo
+  -> KeyHash hashAlgo dsignAlgo
   -> BlocksMade hashAlgo dsignAlgo
   -> BlocksMade hashAlgo dsignAlgo
 incrBlocks isOverlay hk b'@(BlocksMade b)

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -37,11 +37,11 @@ import           Data.Word (Word8)
 import           Lens.Micro ((^.))
 
 newtype StakeKeys hashAlgo dsignAlgo =
-  StakeKeys (Map.Map (HashKey hashAlgo dsignAlgo) Slot)
+  StakeKeys (Map.Map (KeyHash hashAlgo dsignAlgo) Slot)
   deriving (Show, Eq)
 
 newtype StakePools hashAlgo dsignAlgo =
-  StakePools (Map.Map (HashKey hashAlgo dsignAlgo) Slot)
+  StakePools (Map.Map (KeyHash hashAlgo dsignAlgo) Slot)
   deriving (Show, Eq)
 
 -- | A heavyweight certificate.
@@ -49,7 +49,7 @@ data DCert hashAlgo dsignAlgo
     -- | A stake key registration certificate.
   = RegKey (VKey dsignAlgo)
     -- | A stake key deregistration certificate.
-  | DeRegKey (VKey dsignAlgo) --TODO this is actually HashKey on page 13, is that what we want?
+  | DeRegKey (VKey dsignAlgo) --TODO this is actually KeyHash on page 13, is that what we want?
     -- | A stake pool registration certificate.
   | RegPool (PoolParams hashAlgo dsignAlgo)
     -- | A stake pool retirement certificate.
@@ -100,7 +100,7 @@ instance
 cwitness
   :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => DCert hashAlgo dsignAlgo
-  -> HashKey hashAlgo dsignAlgo
+  -> KeyHash hashAlgo dsignAlgo
 cwitness (RegKey k)            = hashKey k
 cwitness (DeRegKey k)          = hashKey k
 cwitness (RegPool pool)        = hashKey $ pool ^. poolPubKey
@@ -156,5 +156,5 @@ decayPool pc = (pval, pmin, lambdap)
           lambdap = pc ^. poolDecayRate
 
 newtype PoolDistr hashAlgo dsignAlgo =
-  PoolDistr (Map.Map (HashKey hashAlgo dsignAlgo) Rational)
+  PoolDistr (Map.Map (KeyHash hashAlgo dsignAlgo) Rational)
   deriving (Show, Eq)

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
@@ -35,7 +35,7 @@ import           Keys
 
 -- |An account based address for a rewards
 newtype RewardAcnt hashAlgo signAlgo = RewardAcnt
-  { getRwdHK :: HashKey hashAlgo signAlgo
+  { getRwdHK :: KeyHash hashAlgo signAlgo
   } deriving (Show, Eq, Ord, ToCBOR)
 
 
@@ -47,9 +47,9 @@ data PoolParams hashAlgo dsignAlgo =
     , _poolPledges :: Map (VKey dsignAlgo) Coin -- TODO not updated currently
     , _poolCost    :: Coin
     , _poolMargin  :: UnitInterval
-    , _poolAltAcnt :: Maybe (HashKey hashAlgo dsignAlgo)
+    , _poolAltAcnt :: Maybe (KeyHash hashAlgo dsignAlgo)
     , _poolRAcnt   :: RewardAcnt hashAlgo dsignAlgo
-    , _poolOwners  :: Set (HashKey hashAlgo dsignAlgo)
+    , _poolOwners  :: Set (KeyHash hashAlgo dsignAlgo)
     } deriving (Show, Eq, Ord)
 
 makeLenses ''PoolParams

--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -52,16 +52,16 @@ import           Ledger.Core ((◁), (▷), dom)
 
 -- | Blocks made
 newtype BlocksMade hashAlgo dsignAlgo
-  = BlocksMade (Map.Map (HashKey hashAlgo dsignAlgo) Natural)
+  = BlocksMade (Map.Map (KeyHash hashAlgo dsignAlgo) Natural)
   deriving (Show, Eq)
 
 -- | Type of stake as map from hash key to coins associated.
 newtype Stake hashAlgo dsignAlgo
-  = Stake (Map.Map (HashKey hashAlgo dsignAlgo) Coin)
+  = Stake (Map.Map (KeyHash hashAlgo dsignAlgo) Coin)
   deriving (Show, Eq, Ord)
 
 -- | Extract hash of staking key from base address.
-getStakeHK :: Addr hashAlgo dsignAlgo -> Maybe (HashKey hashAlgo dsignAlgo)
+getStakeHK :: Addr hashAlgo dsignAlgo -> Maybe (KeyHash hashAlgo dsignAlgo)
 getStakeHK (AddrTxin _ hk) = Just hk
 getStakeHK _               = Nothing
 
@@ -76,7 +76,7 @@ baseStake vals =
  where
    convert
      :: (Addr hashAlgo dsignAlgo, Coin)
-     -> Maybe (HashKey hashAlgo dsignAlgo, Coin)
+     -> Maybe (KeyHash hashAlgo dsignAlgo, Coin)
    convert (a, c) =
      (,c) <$> getStakeHK a
 
@@ -89,14 +89,14 @@ getStakePtr _             = Nothing
 ptrStake
   :: forall hashAlgo dsignAlgo
    . Map.Map (Addr hashAlgo dsignAlgo) Coin
-  -> Map.Map Ptr (HashKey hashAlgo dsignAlgo)
+  -> Map.Map Ptr (KeyHash hashAlgo dsignAlgo)
   -> Stake hashAlgo dsignAlgo
 ptrStake vals pointers =
   Stake $ Map.fromListWith (+) (mapMaybe convert $ Map.toList vals)
   where
     convert
       :: (Addr hashAlgo dsignAlgo, Coin)
-      -> Maybe (HashKey hashAlgo dsignAlgo, Coin)
+      -> Maybe (KeyHash hashAlgo dsignAlgo, Coin)
     convert (a, c) =
       case getStakePtr a of
         Nothing -> Nothing
@@ -114,8 +114,8 @@ rewardStake rewards =
 
 -- | Get stake of one pool
 poolStake
-  :: HashKey hashAlgo dsignAlgo
-  -> Map.Map (HashKey hashAlgo dsignAlgo) (HashKey hashAlgo dsignAlgo)
+  :: KeyHash hashAlgo dsignAlgo
+  -> Map.Map (KeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo)
   -> Stake hashAlgo dsignAlgo
   -> Stake hashAlgo dsignAlgo
 poolStake hk delegs (Stake stake) =
@@ -124,9 +124,9 @@ poolStake hk delegs (Stake stake) =
 -- | Calculate pool refunds
 poolRefunds
   :: PParams
-  -> Map.Map (HashKey hashAlgo dsignAlgo) Epoch
+  -> Map.Map (KeyHash hashAlgo dsignAlgo) Epoch
   -> Slot
-  -> Map.Map (HashKey hashAlgo dsignAlgo) Coin
+  -> Map.Map (KeyHash hashAlgo dsignAlgo) Coin
 poolRefunds pp retirees cslot =
   Map.map
     (\e ->
@@ -165,11 +165,11 @@ maxPool pc (Coin r) sigma pR = floor $ factor1 * factor2
 
 -- | Pool individual reward
 groupByPool
-  :: Map.Map (HashKey hashAlgo dsignAlgo) Coin
-  -> Map.Map (HashKey hashAlgo dsignAlgo) (HashKey hashAlgo dsignAlgo)
+  :: Map.Map (KeyHash hashAlgo dsignAlgo) Coin
+  -> Map.Map (KeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo)
   -> Map.Map
-       (HashKey hashAlgo dsignAlgo)
-       (Map.Map (HashKey hashAlgo dsignAlgo) Coin)
+       (KeyHash hashAlgo dsignAlgo)
+       (Map.Map (KeyHash hashAlgo dsignAlgo) Coin)
 groupByPool active delegs =
   Map.fromListWith
     Map.union
@@ -181,18 +181,18 @@ data SnapShots hashAlgo dsignAlgo
   = SnapShots
     { _pstakeMark
       :: ( Stake hashAlgo dsignAlgo
-         , Map.Map (HashKey hashAlgo dsignAlgo) (HashKey hashAlgo dsignAlgo)
+         , Map.Map (KeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo)
          )
     , _pstakeSet
       :: ( Stake hashAlgo dsignAlgo
-         , Map.Map (HashKey hashAlgo dsignAlgo) (HashKey hashAlgo dsignAlgo)
+         , Map.Map (KeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo)
          )
     , _pstakeGo
       :: ( Stake hashAlgo dsignAlgo
-         , Map.Map (HashKey hashAlgo dsignAlgo) (HashKey hashAlgo dsignAlgo)
+         , Map.Map (KeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo)
          )
     , _poolsSS
-      :: Map.Map (HashKey hashAlgo dsignAlgo) (PoolParams hashAlgo dsignAlgo)
+      :: Map.Map (KeyHash hashAlgo dsignAlgo) (PoolParams hashAlgo dsignAlgo)
     , _blocksSS :: BlocksMade hashAlgo dsignAlgo
     , _feeSS :: Coin
     } deriving (Show, Eq)

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -14,7 +14,7 @@ module Keys
   , Signable
   , SKey(..)
   , VKey(..)
-  , HashKey(..)
+  , KeyHash(..)
   , KeyPair(..)
   , VKeyGenesis(..)
   , Sig
@@ -30,7 +30,7 @@ module Keys
   , KESignable
   , SKeyES(..)
   , VKeyES(..)
-  , HashKeyES(..)
+  , KeyHashES(..)
   , KESig
   , hashKeyES
   , signKES
@@ -121,8 +121,8 @@ instance (DSIGNAlgorithm dsignAlgo, Typeable a) => ToCBOR (Sig dsignAlgo a) wher
 
 
 -- |The hash of public Key
-newtype HashKey hashAlgo dsignAlgo =
-  HashKey (Hash hashAlgo (VerKeyDSIGN dsignAlgo))
+newtype KeyHash hashAlgo dsignAlgo =
+  KeyHash (Hash hashAlgo (VerKeyDSIGN dsignAlgo))
   deriving (Show, Eq, Ord, ToCBOR)
 
 
@@ -130,8 +130,8 @@ newtype HashKey hashAlgo dsignAlgo =
 hashKey
   :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => VKey dsignAlgo
-  -> HashKey hashAlgo dsignAlgo
-hashKey (VKey vk) = HashKey $ hashWithSerialiser encodeVerKeyDSIGN vk
+  -> KeyHash hashAlgo dsignAlgo
+hashKey (VKey vk) = KeyHash $ hashWithSerialiser encodeVerKeyDSIGN vk
 
 -- |Produce a digital signature
 sign
@@ -186,8 +186,8 @@ instance (KESAlgorithm kesAlgo, Typeable a) => ToCBOR (KESig kesAlgo a) where
 
 
 -- |The hash of KES verification Key
-newtype HashKeyES hashAlgo kesAlgo =
-  HashKeyES (Hash hashAlgo (VerKeyKES kesAlgo))
+newtype KeyHashES hashAlgo kesAlgo =
+  KeyHashES (Hash hashAlgo (VerKeyKES kesAlgo))
   deriving (Show, Eq, Ord, ToCBOR)
 
 
@@ -195,9 +195,9 @@ newtype HashKeyES hashAlgo kesAlgo =
 hashKeyES
   :: (HashAlgorithm hashAlgo, KESAlgorithm kesAlgo)
   => VKeyES kesAlgo
-  -> HashKeyES hashAlgo kesAlgo
+  -> KeyHashES hashAlgo kesAlgo
 hashKeyES (VKeyES vKeyES) =
-  HashKeyES $ hashWithSerialiser encodeVerKeyKES vKeyES
+  KeyHashES $ hashWithSerialiser encodeVerKeyKES vKeyES
 
 -- |Produce a key evolving signature
 signKES
@@ -236,6 +236,6 @@ newtype GKeys dsignAlgo = GKeys (Set.Set (VKeyGenesis dsignAlgo))
 hashGenesisKey
   :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => VKeyGenesis dsignAlgo
-  -> HashKey hashAlgo dsignAlgo
+  -> KeyHash hashAlgo dsignAlgo
 hashGenesisKey (VKeyGenesis vKeyGenesis) =
-  HashKey $ hashWithSerialiser encodeVerKeyDSIGN vKeyGenesis
+  KeyHash $ hashWithSerialiser encodeVerKeyDSIGN vKeyGenesis

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -212,9 +212,9 @@ data DState hashAlgo dsignAlgo = DState
       -- |The active accounts.
     ,  _rewards    :: RewardAccounts hashAlgo dsignAlgo
       -- |The current delegations.
-    , _delegations :: Map.Map (HashKey hashAlgo dsignAlgo) (HashKey hashAlgo dsignAlgo)
+    , _delegations :: Map.Map (KeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo)
       -- |The pointed to hash keys.
-    , _ptrs        :: Map.Map Ptr (HashKey hashAlgo dsignAlgo)
+    , _ptrs        :: Map.Map Ptr (KeyHash hashAlgo dsignAlgo)
       -- | future genesis key delegations
     , _fdms        :: Map.Map (Slot, VKeyGenesis dsignAlgo) (VKey dsignAlgo)
       -- |Genesis key delegations
@@ -225,11 +225,11 @@ data PState hashAlgo dsignAlgo = PState
     { -- |The active stake pools.
       _stPools     :: StakePools hashAlgo dsignAlgo
       -- |The pool parameters.
-    , _pParams     :: Map.Map (HashKey hashAlgo dsignAlgo) (PoolParams hashAlgo dsignAlgo)
+    , _pParams     :: Map.Map (KeyHash hashAlgo dsignAlgo) (PoolParams hashAlgo dsignAlgo)
       -- |A map of retiring stake pools to the epoch when they retire.
-    , _retiring    :: Map.Map (HashKey hashAlgo dsignAlgo) Epoch
+    , _retiring    :: Map.Map (KeyHash hashAlgo dsignAlgo) Epoch
       -- | Operational Certificate Counters.
-    , _cCounters   :: Map.Map (HashKey hashAlgo dsignAlgo) Natural
+    , _cCounters   :: Map.Map (KeyHash hashAlgo dsignAlgo) Natural
     } deriving (Show, Eq)
 
 -- |The state associated with the current stake delegation.
@@ -552,7 +552,7 @@ witsNeeded
   => UTxO hashAlgo dsignAlgo
   -> Tx hashAlgo dsignAlgo
   -> Dms dsignAlgo
-  -> Set (HashKey hashAlgo dsignAlgo)
+  -> Set (KeyHash hashAlgo dsignAlgo)
 witsNeeded utxo' tx@(Tx txbody _) _dms =
     inputAuthors `Set.union`
     wdrlAuthors  `Set.union`
@@ -641,7 +641,7 @@ propWits
   :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => Updates.Update dsignAlgo
   -> Dms dsignAlgo
-  -> Set.Set (HashKey hashAlgo dsignAlgo)
+  -> Set.Set (KeyHash hashAlgo dsignAlgo)
 propWits (Updates.Update (Updates.PPUpdate pup) (Updates.AVUpdate aup)) (Dms _dms) =
   Set.fromList $ Map.elems $ Map.map hashKey updateKeys
   where updateKeys = (Map.keysSet pup `Set.union` Map.keysSet aup) ◁ _dms
@@ -938,7 +938,7 @@ applyDCertPState _ _ ps = ps
 -- |Compute how much stake each active stake pool controls.
 delegatedStake
   :: LedgerState hashAlgo dsignAlgo
-  -> Map.Map (HashKey hashAlgo dsignAlgo) Coin
+  -> Map.Map (KeyHash hashAlgo dsignAlgo) Coin
 delegatedStake ls@(LedgerState _ ds _) = Map.fromListWith (+) delegatedOutputs
   where
     getOutputs (UTxO utxo') = Map.elems utxo'
@@ -958,7 +958,7 @@ delegatedStake ls@(LedgerState _ ds _) = Map.fromListWith (+) delegatedOutputs
 
 -- | Calculate pool reward
 poolRewards
-  :: HashKey hashAlgo dsignAlgo
+  :: KeyHash hashAlgo dsignAlgo
   -> UnitInterval
   -> Natural
   -> Natural
@@ -1005,7 +1005,7 @@ rewardOnePool
   -> Coin
   -> Natural
   -> Natural
-  -> HashKey hashAlgo dsignAlgo
+  -> KeyHash hashAlgo dsignAlgo
   -> PoolParams hashAlgo dsignAlgo
   -> Stake hashAlgo dsignAlgo
   -> Coin
@@ -1041,9 +1041,9 @@ reward
   -> BlocksMade hashAlgo dsignAlgo
   -> Coin
   -> Set.Set (RewardAcnt hashAlgo dsignAlgo)
-  -> Map.Map (HashKey hashAlgo dsignAlgo) (PoolParams hashAlgo dsignAlgo)
+  -> Map.Map (KeyHash hashAlgo dsignAlgo) (PoolParams hashAlgo dsignAlgo)
   -> Stake hashAlgo dsignAlgo
-  -> Map.Map (HashKey hashAlgo dsignAlgo) (HashKey hashAlgo dsignAlgo)
+  -> Map.Map (KeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo)
   -> Map.Map (RewardAcnt hashAlgo dsignAlgo) Coin
 reward pp (BlocksMade b) r addrsRew poolParams stake@(Stake stake') delegs =
   rewards'
@@ -1088,7 +1088,7 @@ poolDistr
   -> DState hashAlgo dsignAlgo
   -> PState hashAlgo dsignAlgo
   -> ( Stake hashAlgo dsignAlgo
-     , Map.Map (HashKey hashAlgo dsignAlgo) (HashKey hashAlgo dsignAlgo)
+     , Map.Map (KeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo)
      )
 poolDistr u ds ps = (stake, delegs)
     where
@@ -1149,7 +1149,7 @@ overlaySchedule = undefined
 -- | Set issue numbers
 setIssueNumbers
   :: LedgerState hashAlgo dsignAlgo
-  -> Map.Map (HashKey hashAlgo dsignAlgo) Natural
+  -> Map.Map (KeyHash hashAlgo dsignAlgo) Natural
   -> LedgerState hashAlgo dsignAlgo
 setIssueNumbers (LedgerState u
                  (DPState _dstate

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ocert.hs
@@ -28,7 +28,7 @@ instance
   => STS (OCERT hashAlgo dsignAlgo kesAlgo)
  where
   type State (OCERT hashAlgo dsignAlgo kesAlgo)
-    = Map.Map (HashKey hashAlgo dsignAlgo) Natural
+    = Map.Map (KeyHash hashAlgo dsignAlgo) Natural
   type Signal (OCERT hashAlgo dsignAlgo kesAlgo)
     = BHeader hashAlgo dsignAlgo kesAlgo
   type Environment (OCERT hashAlgo dsignAlgo kesAlgo) = ()
@@ -38,7 +38,7 @@ instance
     | KESPeriodWrongOCERT
     | InvalidSignatureOCERT
     | InvalidKesSignatureOCERT
-    | NoCounterForHashKeyOCERT
+    | NoCounterForKeyHashOCERT
     deriving (Show, Eq)
 
   initialRules = [pure Map.empty]
@@ -66,7 +66,7 @@ ocertTransition = do
   let hkEntry = Map.lookup hk cs
   case hkEntry of
     Nothing -> do
-      failBecause NoCounterForHashKeyOCERT
+      failBecause NoCounterForKeyHashOCERT
       pure cs
     Just m -> do
       m > n ?! KESPeriodWrongOCERT

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Overlay.hs
@@ -37,7 +37,7 @@ instance
   => STS (OVERLAY hashAlgo dsignAlgo kesAlgo)
  where
   type State (OVERLAY hashAlgo dsignAlgo kesAlgo)
-    = Map.Map (HashKey hashAlgo dsignAlgo) Natural
+    = Map.Map (KeyHash hashAlgo dsignAlgo) Natural
 
   type Signal (OVERLAY hashAlgo dsignAlgo kesAlgo)
     = BHeader hashAlgo dsignAlgo kesAlgo

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Prtcl.hs
@@ -38,7 +38,7 @@ instance
   => STS (PRTCL hashAlgo dsignAlgo kesAlgo)
  where
   type State (PRTCL hashAlgo dsignAlgo kesAlgo)
-    = ( Map.Map (HashKey hashAlgo dsignAlgo) Natural
+    = ( Map.Map (KeyHash hashAlgo dsignAlgo) Natural
       , HashHeader hashAlgo dsignAlgo kesAlgo
       , Slot
       , Seed

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -101,8 +101,8 @@ instance ToCBOR Ptr where
 -- |An address for UTxO.
 data Addr hashAlgo dsignAlgo
   = AddrTxin
-      { _payHK :: HashKey hashAlgo dsignAlgo
-      , _stakeHK :: HashKey hashAlgo dsignAlgo
+      { _payHK :: KeyHash hashAlgo dsignAlgo
+      , _stakeHK :: KeyHash hashAlgo dsignAlgo
       }
   | AddrPtr
       { _stakePtr :: Ptr

--- a/shelley/chain-and-ledger/executable-spec/test/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator.hs
@@ -78,7 +78,7 @@ genKeyPairs lower upper = do
 
 -- | Hashes all pairs of pay, stake key pairs of a list into a list of pairs of
 -- hashed keys
-hashKeyPairs :: KeyPairs -> [(HashKey, HashKey)]
+hashKeyPairs :: KeyPairs -> [(KeyHash, KeyHash)]
 hashKeyPairs keyPairs =
     (\(a, b) -> (hashKey $ vKey a, hashKey $ vKey b)) <$> keyPairs
 
@@ -239,7 +239,7 @@ findPayKeyPair (AddrTxin addr _) keyList =
 findPayKeyPair _ _ = error "currently no such keys should be generated"
 
 -- | Find first matching key pair for stake key in 'AddrTxin'.
-findStakeKeyPair :: HashKey -> KeyPairs -> KeyPair
+findStakeKeyPair :: KeyHash -> KeyPairs -> KeyPair
 findStakeKeyPair addr keyList =
     snd $ head $ filter (\(_, stake) -> addr == (hashKey $ vKey stake)) keyList
 

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -17,7 +17,7 @@ type PoolParams = Delegation.PoolParams.PoolParams ShortHash MockDSIGN
 
 type RewardAcnt = Delegation.PoolParams.RewardAcnt ShortHash MockDSIGN
 
-type HashKey = Keys.HashKey ShortHash MockDSIGN
+type KeyHash = Keys.KeyHash ShortHash MockDSIGN
 
 type KeyPair = Keys.KeyPair MockDSIGN
 

--- a/shelley/chain-and-ledger/formal-spec/address.tex
+++ b/shelley/chain-and-ledger/formal-spec/address.tex
@@ -50,22 +50,22 @@ Section~\ref{sec:utxo} and follows \cite{chimeric}.
       \\
       \var{addr}
       & \AddrB
-      & \HashKey_{pay}\times\HashKey_{stake}
+      & \KeyHash_{pay}\times\KeyHash_{stake}
       & \text{base address}
       \\
       \var{addr}
       & \AddrP
-      & \HashKey_{pay}\times\Ptr
+      & \KeyHash_{pay}\times\Ptr
       & \text{pointer address}
       \\
       \var{addr}
       & \AddrE
-      & \HashKey_{pay}
+      & \KeyHash_{pay}
       & \text{enterprise address}
       \\
       \var{addr}
       & \AddrBS
-      & \HashKey_{pay}
+      & \KeyHash_{pay}
       & \text{bootstrap address}
       \\
       \var{addr}
@@ -79,7 +79,7 @@ Section~\ref{sec:utxo} and follows \cite{chimeric}.
       \\
       \var{acct}
       & \AddrRWD
-      & \HashKey_{stake}
+      & \KeyHash_{stake}
       & \text{reward account}
       \\
     \end{array}
@@ -89,11 +89,11 @@ Section~\ref{sec:utxo} and follows \cite{chimeric}.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{paymentHK} & \Addr \to \HashKey_{pay}
+      \fun{paymentHK} & \Addr \to \KeyHash_{pay}
                       & \text{hash of payment key from addr}\\
-      \fun{stakeHK_b} & \AddrB \to \HashKey_{stake}
+      \fun{stakeHK_b} & \AddrB \to \KeyHash_{stake}
                       & \text{hash of stake key from base addr}\\
-      \fun{stakeHK_r} & \AddrRWD \to \HashKey_{stake}
+      \fun{stakeHK_r} & \AddrRWD \to \KeyHash_{stake}
                       & \text{hash of stake key from reward account}\\
       \fun{addrPtr} & \AddrP \to \Ptr
                     & \text{pointer from pointer addr}\\
@@ -105,7 +105,7 @@ Section~\ref{sec:utxo} and follows \cite{chimeric}.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \fun{addr_{rwd}}
-        & \HashKey_{stake} \to \AddrRWD
+        & \KeyHash_{stake} \to \AddrRWD
         & \text{construct a reward account}
     \end{array}
   \end{equation*}

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -89,7 +89,7 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
   %
   \emph{Derived Types}
   \begin{align*}
-    \PoolDistr = \HashKey \mapsto [0, 1] \text{ \hspace{3cm}stake pool distribution}
+    \PoolDistr = \KeyHash \mapsto [0, 1] \text{ \hspace{3cm}stake pool distribution}
   \end{align*}
   %
 
@@ -749,7 +749,7 @@ operation certificate issue numbers.  Its signal is a block header.
   \emph{Operational Certificate Transitions}
   \begin{equation*}
     \vdash \var{\_} \trans{ocert}{\_} \var{\_} \subseteq
-    \powerset (\HashKey_{pool} \mapsto \N \times \BHeader \times \HashKey_{pool} \mapsto \N)
+    \powerset (\KeyHash_{pool} \mapsto \N \times \BHeader \times \KeyHash_{pool} \mapsto \N)
   \end{equation*}
   \caption{OCert transition-system types}
   \label{fig:ts-types:ocert}
@@ -906,8 +906,8 @@ The states for this transition consist only of the mapping of certificate issue 
   \emph{Overlay Transitions}
   \begin{equation*}
     \_ \vdash \var{\_} \trans{overlay}{\_} \var{\_} \subseteq
-    \powerset (\OverlayEnv \times (\HashKey_{pool} \mapsto \N) \times \BHeader \times
-    (\HashKey_{pool} \mapsto \N))
+    \powerset (\OverlayEnv \times (\KeyHash_{pool} \mapsto \N) \times \BHeader \times
+    (\KeyHash_{pool} \mapsto \N))
   \end{equation*}
   \caption{Overlay transition-system types}
   \label{fig:ts-types:overlay}
@@ -1008,7 +1008,7 @@ followed by the transition to update the evolving and candidate nonces.
     \PrtclState =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{cs} & \HashKey_{pool} \mapsto \N & \text{operational certificate issues numbers} \\
+        \var{cs} & \KeyHash_{pool} \mapsto \N & \text{operational certificate issues numbers} \\
         \var{h} & \HashHeader & \text{latest header hash} \\
         \var{s_\ell} & \Slot & \text{last slot} \\
         \eta_v & \Seed & \text{evolving nonce} \\
@@ -1146,7 +1146,7 @@ produced by each stake pool.
   %
   \emph{BBody helper function}
   \begin{align*}
-      & \fun{incrBlocks} \in \Bool \to \HashKey \to
+      & \fun{incrBlocks} \in \Bool \to \KeyHash \to
           \BlocksMade \to \BlocksMade \\
       & \fun{incrBlocks}~\var{isOverlay}~\var{hk}~\var{b} =
         \begin{cases}
@@ -1304,7 +1304,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
   \end{align*}
   %
   \begin{align*}
-      & \fun{setIssueNumbers} \in \LState \to (\HashKey\to\N) \to \LState \\
+      & \fun{setIssueNumbers} \in \LState \to (\KeyHash\to\N) \to \LState \\
       & \fun{setIssueNumbers}~
           (\var{utxoSt},
           ~(\var{dstate},~(\var{stpools},~\var{poolParams},~\var{retiring},~\wcard)))

--- a/shelley/chain-and-ledger/formal-spec/combined-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/combined-spec.tex
@@ -96,7 +96,7 @@
 \newcommand{\TxOut}{\type{TxOut}}
 \newcommand{\VKey}{\type{VKey}}
 \newcommand{\SKey}{\type{SKey}}
-\newcommand{\HashKey}{\type{HashKey}}
+\newcommand{\KeyHash}{\type{KeyHash}}
 \newcommand{\KeyPair}{\type{KeyPair}}
 \newcommand{\Sig}{\type{Sig}}
 \newcommand{\Data}{\type{Data}}

--- a/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
+++ b/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
@@ -41,7 +41,7 @@ organization chosen for an implementation.
     \begin{array}{r@{~\in~}lr}
       \var{sk} & \SKey & \text{private signing key}\\
       \var{vk} & \VKey & \text{public verifying key}\\
-      \var{hk} & \HashKey & \text{hash of a key}\\
+      \var{hk} & \KeyHash & \text{hash of a key}\\
       \sigma & \Sig  & \text{signature}\\
       \var{d} & \Data  & \text{data}\\
     \end{array}
@@ -56,7 +56,7 @@ organization chosen for an implementation.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \hashKey{} & \VKey \to \HashKey
+      \hashKey{} & \VKey \to \KeyHash
                  & \text{hashKey function} \\
                  %
       \fun{verify} & \powerset{\left(\VKey \times \Data \times \Sig\right)}

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -116,15 +116,15 @@ It does the following:
   \begin{equation*}
     \begin{array}{l@{\qquad=\qquad}lr}
       \StakeKeys
-      & \HashKey \mapsto \Slot
+      & \KeyHash \mapsto \Slot
       & \text{registered stake keys} \\
       %
       \StakePools
-      & \HashKey \mapsto \Slot
+      & \KeyHash \mapsto \Slot
       & \text{registered stake pools} \\
       %
       \PoolParam
-      & \powerset{\HashKey} \times \Coin \times \unitInterval \times \Coin \times \AddrRWD
+      & \powerset{\KeyHash} \times \Coin \times \unitInterval \times \Coin \times \AddrRWD
       & \text{stake pool parameters} \\
     \end{array}
   \end{equation*}
@@ -133,10 +133,10 @@ It does the following:
   %
   \begin{equation*}
   \begin{array}{r@{~\in~}lr}
-    \cwitness{} & \DCert \to \HashKey
+    \cwitness{} & \DCert \to \KeyHash
   & \text{certificate witness}
   \\
-  \fun{dpool} & \DCertDeleg \to \HashKey
+  \fun{dpool} & \DCertDeleg \to \KeyHash
   & \text{pool being delegated to}
   \\
   \fun{poolParam} & \DCertRegPool \to \PoolParam
@@ -154,7 +154,7 @@ It does the following:
   %
   \begin{equation*}
   \begin{array}{r@{~\in~}lr}
-    \fun{poolOwners} & \PoolParam \to \powerset{\HashKey}
+    \fun{poolOwners} & \PoolParam \to \powerset{\KeyHash}
                      & \text{stake pool owners}
     \\
     \fun{poolCost} & \PoolParam \to \Coin
@@ -229,8 +229,8 @@ and the protocol parameters.
     \left(\begin{array}{r@{~\in~}lr}
       \var{stkeys} & \StakeKeys & \text{registered stake keys}\\
       \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
-      \var{delegations} & \HashKey_{stake} \mapsto \HashKey_{pool} & \text{delegations}\\
-      \var{ptrs} & \Ptr \mapsto \HashKey & \text{pointer to hashkey}\\
+      \var{delegations} & \KeyHash_{stake} \mapsto \KeyHash_{pool} & \text{delegations}\\
+      \var{ptrs} & \Ptr \mapsto \KeyHash & \text{pointer to hashkey}\\
       \var{fdms} & (\Slot\times\VKeyGen) \mapsto \VKey & \text{future genesis key delegations}\\
       \var{dms} & \VKeyGen \mapsto \VKey & \text{genesis key delegations}\\
     \end{array}\right)
@@ -239,10 +239,10 @@ and the protocol parameters.
     \PState =
     \left(\begin{array}{r@{~\in~}lr}
       \var{stpools} & \StakePools & \text{registered pools to creation time}\\
-      \var{poolParams} & \HashKey_{pool} \mapsto \PoolParam
+      \var{poolParams} & \KeyHash_{pool} \mapsto \PoolParam
         & \text{registered pools to pool parameters}\\
-      \var{retiring} & \HashKey_{pool} \mapsto \Epoch & \text{retiring stake pools}\\
-      \var{cs} & \HashKey_{pool} \mapsto \N & \text{certificate issue numbers}\\
+      \var{retiring} & \KeyHash_{pool} \mapsto \Epoch & \text{retiring stake pools}\\
+      \var{cs} & \KeyHash_{pool} \mapsto \N & \text{certificate issue numbers}\\
     \end{array}\right)
     \end{array}
   \end{equation*}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -153,8 +153,8 @@ throughout the rest of the section.
   \end{align*}
   \emph{Pool refunds}
   \begin{align*}
-      & \fun{poolRefunds} \in \PParams \to (\HashKey_{pool} \mapsto \Epoch) \to \Slot \to
-      (\HashKey_{pool} \mapsto \Coin) \\
+      & \fun{poolRefunds} \in \PParams \to (\KeyHash_{pool} \mapsto \Epoch) \to \Slot \to
+      (\KeyHash_{pool} \mapsto \Coin) \\
       & \poolRefunds{pp}{retiring}{cslot} = \left\{
         \var{hk}\mapsto
           \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda}{(\slotminus{cslot}{(\fun{slot}~e)})}
@@ -167,7 +167,7 @@ throughout the rest of the section.
 
   \emph{Filter Stake to one Pool}
   \begin{align*}
-      & \fun{poolStake} \in \HashKey_{pool} \to (\HashKey_{stake} \mapsto \HashKey_{pool})
+      & \fun{poolStake} \in \KeyHash_{pool} \to (\KeyHash_{stake} \mapsto \KeyHash_{pool})
         \to \Stake \to \Stake \\
       & \poolStake{hk}{delegs}{stake} =
         \dom{(\var{delegs}\restrictrange\{hk\})\restrictdom\var{stake}}
@@ -230,11 +230,11 @@ Figure~\ref{fig:epoch-defs} introduces three new derived types:
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
       \var{blocks}
       & \BlocksMade
-      & \HashKey_{pool} \mapsto \N
+      & \KeyHash_{pool} \mapsto \N
       & \text{blocks made by stake pools} \\
       \var{stake}
       & \Stake
-      & \HashKey_{stake} \mapsto \Coin
+      & \KeyHash_{stake} \mapsto \Coin
       & \text{stake} \\
     \end{array}
   \end{equation*}
@@ -336,13 +336,13 @@ information needing to be saved on the epoch boundary:
     \Snapshots =
     \left(
       \begin{array}{r@{~\in~}ll}
-        \var{pstake_{mark}} & \Stake\times(\HashKey_{stake}\mapsto\HashKey_{pool})
+        \var{pstake_{mark}} & \Stake\times(\KeyHash_{stake}\mapsto\KeyHash_{pool})
                             & \text{newest stake}\\
-        \var{pstake_{set}} & \Stake\times(\HashKey_{stake}\mapsto\HashKey_{pool})
+        \var{pstake_{set}} & \Stake\times(\KeyHash_{stake}\mapsto\KeyHash_{pool})
                            & \text{middle stake}\\
-        \var{pstake_{go}} & \Stake\times(\HashKey_{stake}\mapsto\HashKey_{pool})
+        \var{pstake_{go}} & \Stake\times(\KeyHash_{stake}\mapsto\KeyHash_{pool})
                           & \text{oldest stake}\\
-        \var{poolsSS} & \HashKey \mapsto \PoolParam & \text{pool parameters }\\
+        \var{poolsSS} & \KeyHash \mapsto \PoolParam & \text{pool parameters }\\
         \var{blocksSS} & \BlocksMade & \text{blocks made }\\
         \var{feeSS} & \Coin & \text{fee snapshot}\\
       \end{array}
@@ -1111,7 +1111,7 @@ The calculation is done pool-by-pool.
   \emph{Calculation to reward a single stake pool}
   %
   \begin{align*}
-    & \fun{rewardOnePool} \in \PParams \to \Coin \to \N \to \N \to \HashKey \to \PoolParam\\
+    & \fun{rewardOnePool} \in \PParams \to \Coin \to \N \to \N \to \KeyHash \to \PoolParam\\
       & ~~~\to \Stake \to \Coin \to \powerset{\AddrRWD}
            \to (\AddrRWD \mapsto \Coin) \\
       & \rewardOnePool{pp}{R}{n}{\overline{N}}{poolHK}{pool}{stake}{tot}{addrs_{rew}} =
@@ -1148,8 +1148,8 @@ The calculation is done pool-by-pool.
   %
   \begin{align*}
       & \fun{reward} \in \PParams \to \BlocksMade \to \Coin\to \powerset{\AddrRWD}
-      \to (\HashKey \mapsto \PoolParam) \\
-      & ~~~\to \Stake \to (\HashKey_{stake} \mapsto \HashKey_{pool}) \to
+      \to (\KeyHash \mapsto \PoolParam) \\
+      & ~~~\to \Stake \to (\KeyHash_{stake} \mapsto \KeyHash_{pool}) \to
       (\AddrRWD \mapsto \Coin)\\
       & \reward{pp}{blocks}{R}{addrs_{rew}}{poolParams}{stake}{delegs}
           = \var{rewards}\\

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -110,7 +110,7 @@
 \newcommand{\VKeyGen}{\type{VKey_G}}
 \newcommand{\SKey}{\type{SKey}}
 \newcommand{\SKeyEv}{\type{SKey_{ev}}}
-\newcommand{\HashKey}{\type{HashKey}}
+\newcommand{\KeyHash}{\type{KeyHash}}
 \newcommand{\KeyPair}{\type{KeyPair}}
 \newcommand{\KeyPairEv}{\type{KeyPair_{ev}}}
 \newcommand{\Sig}{\type{Sig}}

--- a/shelley/chain-and-ledger/formal-spec/multi-sig.tex
+++ b/shelley/chain-and-ledger/formal-spec/multi-sig.tex
@@ -105,7 +105,7 @@
 \newcommand{\VKeyGen}{\type{VKey_G}}
 \newcommand{\SKey}{\type{SKey}}
 \newcommand{\SKeyEv}{\type{SKey_{ev}}}
-\newcommand{\HashKey}{\type{HashKey}}
+\newcommand{\KeyHash}{\type{KeyHash}}
 \newcommand{\KeyPair}{\type{KeyPair}}
 \newcommand{\KeyPairEv}{\type{KeyPair_{ev}}}
 \newcommand{\Sig}{\type{Sig}}
@@ -320,12 +320,12 @@ required signatures for a specific unspent transaction output.
 
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{paymentHK} & \AddrVKey \to \HashKey_{pay}
+      \fun{paymentHK} & \AddrVKey \to \KeyHash_{pay}
       & \text{hash of payment key from addr}\\
       \fun{validatorHash} & \AddrScr \to \HashScr & \text{hash of validator
                                                      script} \\
       \fun{stakeHK_{b}} & (\AddrVKeyB \uniondistinct \AddrScrBase) \to
-                          \HashKey_{stake} & \text{hash of stake key for base
+                          \KeyHash_{stake} & \text{hash of stake key for base
                                              addresses}\\
       \fun{addrPtr} & (\AddrVKeyP \uniondistinct \AddrScrPtr) \to \Ptr &
                                                                      \text{pointer
@@ -609,7 +609,7 @@ according to Figure~\ref{fig:types_defs_plutus}.
 
   \begin{equation*}
     \begin{array}{rll}
-      \var{msig} & \in \ScriptMSig = & \,\,\,\type{SingleSig}~\HashKey \\
+      \var{msig} & \in \ScriptMSig = & \,\,\,\type{SingleSig}~\KeyHash \\
        && \vert\,\,\type{MultSig}~Int~[\ScriptMSig]
     \end{array}
   \end{equation*}
@@ -625,7 +625,7 @@ according to Figure~\ref{fig:types_defs_plutus}.
                          & \fun{evalMultiSigScript}~msig~vhks\\
   \end{align*}
   \begin{align*}
-    \fun{evalMultiSigScript} & \in\ScriptMSig\to\powerset\HashKey\to\Bool & \\
+    \fun{evalMultiSigScript} & \in\ScriptMSig\to\powerset\KeyHash\to\Bool & \\
     \fun{evalMultiSigScript} & ~(\type{SingleSig}~hk)~\var{vhks} =  hk \in vhks \\
     \fun{evalMultiSigScript} & ~(\type{MultiSig}~m~ts)~\var{vhks} = \\
                              & m \leq \Sigma

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -190,7 +190,7 @@ each output of a transition is spent at most once.
 \begin{figure}[ht]
   \centering
   \begin{align*}
-    \fun{getStKeys} & \in & \ledgerState \to \powerset \HashKey \\
+    \fun{getStKeys} & \in & \ledgerState \to \powerset \KeyHash \\
     \fun{getStKeys} & \coloneqq & (\wcard, (\var{stKeys}, \wcard, \wcard),
                                   \wcard) \to \var{stkeys} \\
                     &&\\
@@ -198,16 +198,16 @@ each output of a transition is spent at most once.
     \fun{getRewards} & \coloneqq & (\wcard, (\wcard, \var{rewards}, \wcard),
                                    \wcard) \to \var{rewards} \\
                     &&\\
-    \fun{getDelegations} & \in & \ledgerState \to \HashKey \mapsto \HashKey \\
+    \fun{getDelegations} & \in & \ledgerState \to \KeyHash \mapsto \KeyHash \\
     \fun{getDelegations} & \coloneqq & (\wcard, (\wcard, \wcard,
                                        \var{delegations}), \wcard) \to
                                        \var{delegations} \\
                     &&\\
-    \fun{getStPools} & \in & \ledgerState \to \HashKey \mapsto \DCertRegPool \\
+    \fun{getStPools} & \in & \ledgerState \to \KeyHash \mapsto \DCertRegPool \\
     \fun{getStPools} & \coloneqq & (\wcard, \wcard,
                                    (\var{stpools}, \wcard)) \to \var{stpools} \\
                     &&\\
-    \fun{getRetiring} & \in & \ledgerState \to \HashKey \mapsto \Epoch \\
+    \fun{getRetiring} & \in & \ledgerState \to \KeyHash \mapsto \Epoch \\
     \fun{getRetiring} & \coloneqq & (\wcard, \wcard,
                                     (\wcard, \var{retiring})) \to \var{retiring} \\
   \end{align*}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -551,7 +551,7 @@ This consists of:
 
 \begin{figure}[htb]
   \begin{align*}
-    & \fun{propWits} \in \Update \to (\VKeyGen\mapsto\VKey) \to \powerset{\HashKey}
+    & \fun{propWits} \in \Update \to (\VKeyGen\mapsto\VKey) \to \powerset{\KeyHash}
     & \text{hashkeys for proposals} \\
     & \fun{propWits}~(\var{pup},~\var{aup}) \var{dms} = \\
     & ~~\left\{
@@ -563,7 +563,7 @@ This consists of:
   \end{align*}
 
   \begin{align*}
-    & \fun{witsNeeded} \in \UTxO \to \Tx \to (\VKeyGen\mapsto\VKey) \to \powerset{\HashKey}
+    & \fun{witsNeeded} \in \UTxO \to \Tx \to (\VKeyGen\mapsto\VKey) \to \powerset{\KeyHash}
     & \text{hashkeys for needed witnesses} \\
     & \fun{witsNeeded}~\var{utxo}~\var{tx}~\var{dms} = \\
     & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\txins{tx} \}~\cup \\


### PR DESCRIPTION
This PR renames HashKey to KeyHash across Byron and Shelley specs.

It closes #517.