### PR TITLE
Support for invalid signal generation and traces with failure profiles

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -189,7 +189,7 @@ instance HasTrace CHAIN where
       -- current slot to a sufficiently large value.
       gCurrentSlot = Slot <$> Gen.integral (Range.constant 32768 2147483648)
 
-  sigGen = sigGenChain GenDelegation GenUTxO
+  sigGen _ = sigGenChain GenDelegation GenUTxO Nothing
 
 data ShouldGenDelegation = GenDelegation | NoGenDelegation
 
@@ -198,10 +198,11 @@ data ShouldGenUTxO = GenUTxO | NoGenUTxO
 sigGenChain
   :: ShouldGenDelegation
   -> ShouldGenUTxO
+  -> Maybe (PredicateFailure CHAIN)
   -> Environment CHAIN
   -> State CHAIN
   -> Gen (Signal CHAIN)
-sigGenChain shouldGenDelegation shouldGenUTxO (_sNow, utxo0, ads, pps, k) (Slot s, sgs, h, utxo, ds, _us)
+sigGenChain shouldGenDelegation shouldGenUTxO _ (_sNow, utxo0, ads, pps, k) (Slot s, sgs, h, utxo, ds, _us)
   = do
     -- Here we do not want to shrink the issuer, since @Gen.element@ shrinks
     -- towards the first element of the list, which in this case won't provide
@@ -222,7 +223,7 @@ sigGenChain shouldGenDelegation shouldGenUTxO (_sNow, utxo0, ads, pps, k) (Slot 
       NoGenDelegation -> pure []
 
     utxoPayload <- case shouldGenUTxO of
-      GenUTxO   -> sigGen @UTXOWS utxoEnv utxo
+      GenUTxO   -> sigGen @UTXOWS Nothing utxoEnv utxo
       NoGenUTxO -> pure []
 
     let

--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
@@ -87,7 +87,7 @@ instance HasTrace UTXOW where
         -- come from we use the hash of the address as transaction id.
         pure $ fromTxOuts txOuts
 
-  sigGen UTxOEnv { pps } st = do
+  sigGen _ UTxOEnv { pps } st = do
     tx <- UTxOGen.genTxFromUTxO traceAddrs (pcMinFee pps) (utxo st)
     let wits = witnessForTxIn tx (utxo st) <$> inputs tx
     pure $ TxWits tx wits

--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOWS.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOWS.hs
@@ -49,8 +49,8 @@ instance Embed UTXOW UTXOWS where
   wrapFailed = UtxowFailure
 
 instance HasTrace UTXOWS where
-  envGen n = envGen @UTXOW n
+  envGen = envGen @UTXOW
 
   -- We generate signal for UTXOWS as a list of signals from UTXOW
-  sigGen env st =
+  sigGen _ env st =
     traceSignals NewestFirst <$> genTrace @UTXOW 20 env st (sigGen @UTXOW)

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -96,6 +96,9 @@ mkVkGenesisSet
   -> Set VKeyGenesis
 mkVkGenesisSet ngk = Set.fromAscList $ mkVKeyGenesis <$> [0 .. (fromIntegral ngk - 1)]
 
+signWithGenesisKey :: VKeyGenesis -> a -> Sig a
+signWithGenesisKey vkg = sign (skey (unVKeyGenesis vkg))
+
 -- |Key Pair.
 data KeyPair = KeyPair
   { sKey :: SKey

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -841,7 +841,7 @@ instance HasTrace UPIREG where
 
   envGen _ = upiEnvGen
 
-  sigGen (_slot, dms, _k, _ngk) ((pv, pps), _fads, avs, rpus, raus, _cps, _vts, _bvs, _pws)
+  sigGen _ (_slot, dms, _k, _ngk) ((pv, pps), _fads, avs, rpus, raus, _cps, _vts, _bvs, _pws)
     = do
     (vk, pv', pps', sv') <- (,,,) <$> issuerGen
                                   <*> pvGen
@@ -1217,7 +1217,7 @@ instance HasTrace UPIVOTES where
 
   envGen _ = upiEnvGen
 
-  sigGen (_slot, dms, _k, _ngk) ((_pv, _pps), _fads, _avs, rpus, _raus, _cps, vts, _bvs, _pws) =
+  sigGen _ (_slot, dms, _k, _ngk) ((_pv, _pps), _fads, _avs, rpus, _raus, _cps, vts, _bvs, _pws) =
     (mkVote <$>) . concatMap replicateFst
       <$> genVotesOnMostVotedProposals completedVotes
       where

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -26,22 +26,25 @@ import           Data.List (foldl', last, nub)
 import           Data.List.Unique (count, repeated)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import           Hedgehog (MonadTest, Property, assert, cover, forAll, property, success, withTests,
-                     (===))
+import           Hedgehog (Gen, MonadTest, Property, assert, cover, forAll, property, success,
+                     withTests, (===))
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import           Control.State.Transition (Embed, Environment, IRC (IRC), PredicateFailure, STS,
                      Signal, State, TRC (TRC), applySTS, initialRules, judgmentContext, trans,
                      transitionRules, wrapFailed, (?!))
-import           Control.State.Transition.Generator (HasSizeInfo, HasTrace, classifySize,
-                     classifyTraceLength, envGen, isTrivial, nonTrivialTrace, ratio, sigGen,
-                     suchThatLastState, trace, traceLengthsAreClassified)
+import           Control.State.Transition.Generator (HasSizeInfo, HasTrace,
+                     TraceProfile (TraceProfile), classifySize, classifyTraceLength, envGen,
+                     failures, isTrivial, nonTrivialTrace, proportionOfInvalidSignals,
+                     proportionOfValidSignals, ratio, sigGen, suchThatLastState, trace,
+                     traceLengthsAreClassified, traceWithProfile)
 import qualified Control.State.Transition.Generator as TransitionGenerator
 import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst), lastState,
                      preStatesAndSignals, traceEnv, traceLength, traceSignals)
-import           Ledger.Core (Epoch (Epoch), Sig (Sig), Slot, SlotCount (SlotCount), VKey,
-                     VKeyGenesis, addSlot, mkVKeyGenesis, owner, unSlot, unSlotCount)
+import           Ledger.Core (Epoch (Epoch), Owner (Owner), Sig (Sig), Slot, SlotCount (SlotCount),
+                     VKey (VKey), VKeyGenesis, addSlot, mkVKeyGenesis, owner, signWithGenesisKey,
+                     unSlot, unSlotCount)
 import           Ledger.Delegation (DCert, DELEG, DIState (DIState),
                      DSEnv (DSEnv, _dSEnvEpoch, _dSEnvK), DSState (DSState),
                      DState (DState, _dStateDelegationMap, _dStateLastDelegation),
@@ -49,8 +52,8 @@ import           Ledger.Delegation (DCert, DELEG, DIState (DIState),
                      delegate, delegationMap, delegator, depoch, epoch, liveAfter, mkDCert,
                      scheduledDelegations, slot, _dIStateDelegationMap,
                      _dIStateKeyEpochDelegations, _dIStateLastDelegation,
-                     _dIStateScheduledDelegations, _dSStateKeyEpochDelegations,
-                     _dSStateScheduledDelegations)
+                     _dIStateScheduledDelegations, _dSEnvAllowedDelegators,
+                     _dSStateKeyEpochDelegations, _dSStateScheduledDelegations)
 
 import           Ledger.Core.Generators (epochGen, slotGen, vkGen)
 import qualified Ledger.Core.Generators as CoreGen
@@ -106,6 +109,7 @@ instance STS DBLOCK where
   data PredicateFailure DBLOCK
     = DPF (PredicateFailure DELEG)
     | NotIncreasingBlockSlot
+    | InvalidDelegationCertificate -- We need this to be able to use the trace profile.
     deriving (Eq, Show)
 
   initialRules
@@ -216,8 +220,11 @@ delegatorDelegate = delegator &&& delegate
 
 -- | Check that there are no duplicated certificates in the trace.
 dcertsAreNotReplayed :: Property
-dcertsAreNotReplayed = withTests 300 $ property $
-  forAll (trace @DBLOCK 1000) >>= dcertsAreNotReplayedInTrace
+dcertsAreNotReplayed = withTests 300 $ property $ do
+  let (thisTraceLength, step) = (1000, 100)
+  sample <- forAll (traceWithProfile @DBLOCK thisTraceLength profile)
+  classifyTraceLength sample thisTraceLength step
+  dcertsAreNotReplayedInTrace sample
   where
     dcertsAreNotReplayedInTrace
       :: MonadTest m
@@ -229,7 +236,12 @@ dcertsAreNotReplayed = withTests 300 $ property $
         traceDelegationCertificates = traceSignals OldestFirst traceSample
                                     & fmap _blockCerts
                                     & concat
-                                    & repeated
+    profile
+      = TraceProfile
+        { proportionOfValidSignals = 95
+        , proportionOfInvalidSignals = 5
+        , failures = [(1, InvalidDelegationCertificate)]
+        }
 
 instance HasTrace DBLOCK where
 
@@ -259,18 +271,40 @@ instance HasTrace DBLOCK where
         n <- Gen.integral (Range.linear 0 13)
         pure $! Set.fromAscList $ mkVKeyGenesis <$> [0 .. n]
 
-  sigGen _ (env, st) =
-    DBlock <$> nextSlotGen <*> sigGen @DELEG env st
+  sigGen (Just InvalidDelegationCertificate) _ (env, _st) =
+    DBlock <$> nextSlotGen env <*> Gen.list (Range.constant 0 10) randomDCertGen
     where
-      -- We want the resulting trace to include a large number of epoch
-      -- changes, so we generate an epoch change with higher frequency.
-      nextSlotGen =
-        incSlot <$> Gen.frequency
-                      [ (1, Gen.integral (Range.constant 1 10))
-                      , (2, pure $! slotsPerEpoch (_dSEnvK env))
-                      ]
+      -- | Generate a random delegation certificate, which has a probability of failing, since we do
+      -- not consider the current delegation state. So for instance, we could generate a delegation
+      -- dedicate for a genesis key that already delegated in this epoch.
+      randomDCertGen :: Gen DCert
+      randomDCertGen = do
+        (vkg, vk, e) <- (,,) <$> vkgGen' <*> vkGen' <*> epochGen'
+        pure $! mkDCert vkg (signWithGenesisKey vkg (vk, e)) vk e
         where
-          incSlot c = (env ^.slot) `addSlot` SlotCount c
+          vkgGen' = Gen.element $ Set.toList allowed
+          allowed = _dSEnvAllowedDelegators env
+          vkGen' = Gen.element $ VKey . Owner <$> [0 .. (2 * fromIntegral (length allowed))]
+          -- | Delegate in an epoch past the next one with probability 1/2.
+          epochGen' =  Epoch
+                    .  fromIntegral
+                    .  (fromIntegral n +)
+                   <$> Gen.integral (Range.constant (-2 :: Int) 2)
+            where Epoch n = _dSEnvEpoch env
+  sigGen _ _ (env, st) =
+    DBlock <$> nextSlotGen env <*> sigGen @DELEG Nothing env st
+
+
+-- We want the resulting trace to include a large number of epoch
+-- changes, so we generate an epoch change with higher frequency.
+nextSlotGen :: DSEnv -> Gen Slot
+nextSlotGen env =
+  incSlot <$> Gen.frequency
+                [ (1, Gen.integral (Range.constant 1 10))
+                , (2, pure $! slotsPerEpoch (_dSEnvK env))
+                ]
+  where
+    incSlot c = (env ^.slot) `addSlot` SlotCount c
 
 instance HasSizeInfo DBlock where
   isTrivial = null . view blockCerts

--- a/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Properties.hs
@@ -369,7 +369,7 @@ instance HasTrace UBLOCK where
       -- about the trace size, and @k@ should be a function of it.
       pure (Slot 0, dms, BlockCount 10, numberOfGenesisKeys)
 
-  sigGen _env UBlockState {upienv, upistate} = do
+  sigGen _ _env UBlockState {upienv, upistate} = do
     let rpus = Update.registeredProtocolUpdateProposals upistate
     (anOptionalUpdateProposal, aListOfVotes) <-
       -- We want to generate update proposals when there is none registered. Otherwise we won't get
@@ -424,16 +424,16 @@ instance HasTrace UBLOCK where
       <*> pure anOptionalUpdateProposal
       <*> pure aListOfVotes
       where
-        generateOnlyVotes = (Nothing,) <$> sigGen @UPIVOTES upienv upistate
+        generateOnlyVotes = (Nothing,) <$> sigGen @UPIVOTES Nothing upienv upistate
         generateUpdateProposalAndVotes = do
-          updateProposal <- sigGen @UPIREG upienv upistate
+          updateProposal <- sigGen @UPIREG Nothing upienv upistate
           -- We want to have the possibility of generating votes for the proposal we
           -- registered.
           case applySTS @UPIREG (TRC (upienv, upistate, updateProposal)) of
             Left _ ->
-              (Just updateProposal, ) <$> sigGen @UPIVOTES upienv upistate
+              (Just updateProposal, ) <$> sigGen @UPIVOTES Nothing upienv upistate
             Right upistateAfterRegistration ->
-              (Just updateProposal, ) <$> sigGen @UPIVOTES upienv upistateAfterRegistration
+              (Just updateProposal, ) <$> sigGen @UPIVOTES Nothing upienv upistateAfterRegistration
         nextSlotGen =
           incSlot <$> Gen.frequency
                       [ (5, Gen.integral (Range.constant 1 10))

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -86,8 +86,8 @@ class STS s => HasTrace s where
     -> Gen (Environment s)
 
   -- | Generate a signal that __might__ result in the given failure, given an environment and a
-  -- pre-state. Note that the failure generation algorithm might be probabilistic, so the signal is
-  -- not guaranteed to generate a given failure.
+  -- pre-state. Note that the failure generation algorithm can be probabilistic, so the signal is
+  -- not guaranteed to generate the given failure.
   --
   -- If 'Nothing' is passed, then the generator should produce a valid signal (according to the
   -- environment, pre-state, and operational rules of the @sts@ transition system).

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -23,9 +23,10 @@ module Control.State.Transition.Generator
   ( HasTrace
   , envGen
   , sigGen
-  , trace
   , traceSigGen
   , genTrace
+  , trace
+  , traceWithProfile
   , traceOfLength
   , traceSuchThat
   , suchThatLastState
@@ -36,6 +37,7 @@ module Control.State.Transition.Generator
   , randomTrace
   , randomTraceOfSize
   , TraceLength (Maximum, Desired)
+  , TraceProfile (TraceProfile, proportionOfValidSignals, proportionOfInvalidSignals, failures)
   -- * Trace classification
   , classifyTraceLength
   , classifySize
@@ -47,6 +49,7 @@ module Control.State.Transition.Generator
   )
 where
 
+import           Control.Arrow (second)
 import           Control.Monad (forM, void)
 import           Control.Monad.Trans.Maybe (MaybeT)
 import           Data.Foldable (traverse_)
@@ -69,8 +72,8 @@ import           Hedgehog.Internal.Tree
 -- END: Temporary imports till hedgehog exposes interleaveTreeT and withGenT
 --------------------------------------------------------------------------------
 
-import           Control.State.Transition (Environment, IRC (IRC), STS, Signal, State, TRC (TRC),
-                     applySTS)
+import           Control.State.Transition (Environment, IRC (IRC), PredicateFailure, STS, Signal,
+                     State, TRC (TRC), applySTS)
 import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst), closure,
                      lastState, mkTrace, traceLength, traceSignals, _traceEnv)
 
@@ -82,23 +85,71 @@ class STS s => HasTrace s where
     -- ^ Trace length that will be used by 'trace' or 'traceOfLength'.
     -> Gen (Environment s)
 
-  sigGen :: Environment s -> State s -> Gen (Signal s)
+  -- | Generate a signal that __might__ result in the given failure, given an environment and a
+  -- pre-state. Note that the failure generation algorithm might be probabilistic, so the signal is
+  -- not guaranteed to generate a given failure.
+  --
+  -- If 'Nothing' is passed, then the generator should produce a valid signal (according to the
+  -- environment, pre-state, and operational rules of the @sts@ transition system).
+  sigGen
+    :: Maybe (PredicateFailure s)
+    -- ^ Failure that should be generated.
+    -> Environment s
+    -> State s
+    -> Gen (Signal s)
 
   trace
     :: Word64
     -- ^ Maximum length of the generated traces. The actual length will be between 0 and this
     -- maximum.
     -> Gen (Trace s)
-  trace n = traceSigGen (Maximum n) (sigGen @s)
+  trace n = traceWithProfile @s n allValid
+
+  traceWithProfile
+    :: Word64
+    -> TraceProfile s
+    -> Gen (Trace s)
+  traceWithProfile n p = traceSigGenWithProfile (Maximum n) p (sigGen @s)
 
   traceOfLength
     :: Word64
     -- ^ Desired length of the generated trace. If the signal generator can generate invalid signals
     -- then the resulting trace might not have the given length.
     -> Gen (Trace s)
-  traceOfLength n = traceSigGen (Desired n) (sigGen @s)
+  traceOfLength n = traceSigGenWithProfile (Desired n) allValid (sigGen @s)
 
 data TraceLength = Maximum Word64 | Desired Word64
+
+data TraceProfile sts
+  = TraceProfile
+  { proportionOfValidSignals :: Int
+    -- ^ Proportion of valid signals to generate.
+  , proportionOfInvalidSignals :: Int
+    -- ^ Proportion of invalid signals to generate.
+  , failures :: [(Int, PredicateFailure sts)]
+    -- ^ List of failure conditions to try generate when generating an invalid signal, and the
+    -- proportion of each failure.
+  }
+
+allValid :: TraceProfile sts
+allValid
+  = TraceProfile
+    { proportionOfValidSignals = 1
+    , proportionOfInvalidSignals = 0
+    , failures = []
+    }
+
+generateSignalWithFailureProportions
+  :: [(Int, PredicateFailure s)]
+  -- ^ Failure proportions. See 'failures' in 'TraceProfile'.
+  -> (Maybe (PredicateFailure s) -> Environment s -> State s -> Gen (Signal s))
+  -> Environment s
+  -> State s
+  -> Gen (Signal s)
+generateSignalWithFailureProportions proportions aSigGen env st =
+  Gen.frequency $ second aSigGenWithFailure <$> proportions
+  where
+    aSigGenWithFailure predicateFailure = aSigGen (Just predicateFailure) env st
 
 -- | Extract the maximum or desired integer value of the trace length.
 traceLengthValue :: TraceLength -> Word64
@@ -109,9 +160,18 @@ traceSigGen
   :: forall s
    . HasTrace s
   => TraceLength
-  -> (Environment s -> State s -> Gen (Signal s))
+  -> (Maybe (PredicateFailure s) -> Environment s -> State s -> Gen (Signal s))
   -> Gen (Trace s)
-traceSigGen aTraceLength gen = do
+traceSigGen aTraceLength = traceSigGenWithProfile aTraceLength allValid
+
+traceSigGenWithProfile
+  :: forall s
+   . HasTrace s
+  => TraceLength
+  -> TraceProfile s
+  -> (Maybe (PredicateFailure s) -> Environment s -> State s -> Gen (Signal s))
+  -> Gen (Trace s)
+traceSigGenWithProfile aTraceLength profile gen = do
   env <- envGen @s (traceLengthValue aTraceLength)
   case applySTS @s (IRC env) of
     -- Hedgehog will give up if the generators fail to produce any valid
@@ -122,8 +182,8 @@ traceSigGen aTraceLength gen = do
     -- validate that state, so we do not care which state 'applySTS' returns.
     Right st ->
       case aTraceLength of
-        Maximum n -> genTrace n env st gen
-        Desired n -> genTraceOfLength n env st gen
+        Maximum n -> genTraceWithProfile n profile env st gen
+        Desired n -> genTraceOfLength n profile env st gen
 
 
 -- | Return a (valid) trace generator given an initial state, environment, and
@@ -139,11 +199,31 @@ genTrace
   -- ^ Environment, which remains constant in the system.
   -> State s
   -- ^ Initial state.
-  -> (Environment s -> State s -> Gen (Signal s))
+  -> (Maybe (PredicateFailure s) -> Environment s -> State s -> Gen (Signal s))
   -- ^ Signal generator. This generator relies on an environment and a state to
   -- generate a signal.
   -> Gen (Trace s)
-genTrace ub env st0 aSigGen = do
+genTrace ub = genTraceWithProfile ub allValid
+
+-- | Return a trace generator given an initial state, environment, and signal generator.
+--
+genTraceWithProfile
+  :: forall s
+   . STS s
+  => Word64
+  -- ^ Trace upper bound. This will be linearly scaled as a function of the
+  -- generator size.
+  -> TraceProfile s
+  -> Environment s
+  -- ^ Environment, which remains constant in the system.
+  -> State s
+  -- ^ Initial state.
+  -> (Maybe (PredicateFailure s) -> Environment s -> State s -> Gen (Signal s))
+  -- ^ Signal generator. This generator relies on an environment and a state to
+  -- generate a signal.
+  -> Gen (Trace s)
+genTraceWithProfile ub profile env st0 aSigGen =
+  do
   -- Generate the initial size of the trace, but don't shrink it (notice the
   -- use of 'integral_') since we will be shrinking the traces manually (so it
   -- doesn't make sense to shrink the trace size).
@@ -159,7 +239,7 @@ genTrace ub env st0 aSigGen = do
                      , (85, integral_ $ Range.linear 1 ub)
                      , (5, pure ub)
                      ]
-  genTraceOfLength n env st0 aSigGen
+  genTraceOfLength n profile env st0 aSigGen
 
 -- | Return a (valid) trace generator that generates traces of the given size. If the signal
 -- generator can generate invalid signals, then the size of resulting trace is not guaranteed.
@@ -169,15 +249,16 @@ genTraceOfLength
    . STS s
   => Word64
   -- ^ Desired trace length.
+  -> TraceProfile s
   -> Environment s
   -- ^ Environment, which remains constant in the system.
   -> State s
   -- ^ Initial state.
-  -> (Environment s -> State s -> Gen (Signal s))
+  -> (Maybe (PredicateFailure s) -> Environment s -> State s -> Gen (Signal s))
   -- ^ Signal generator. This generator relies on an environment and a state to
   -- generate a signal.
   -> Gen (Trace s)
-genTraceOfLength aTraceLength env st0 aSigGen =
+genTraceOfLength aTraceLength profile env st0 aSigGen =
   mapGenT (TreeT . interleaveSigs . runTreeT) $ loop aTraceLength st0 []
   where
     loop
@@ -188,7 +269,15 @@ genTraceOfLength aTraceLength env st0 aSigGen =
     loop 0 _ acc = pure acc
     loop d sti acc = do
       sigTree :: TreeT (MaybeT Identity) (Signal s)
-        <- toTreeMaybeT $ aSigGen env sti
+        <- toTreeMaybeT $
+             Gen.frequency
+               [ ( proportionOfValidSignals profile
+                 , aSigGen Nothing env sti
+                 )
+               , ( proportionOfInvalidSignals profile
+                 , generateSignalWithFailureProportions @s (failures profile) aSigGen env sti
+                 )
+               ]
       let
         --  Take the root of the next-state signal tree.
         mSig = treeValue $ runDiscardEffectT sigTree
@@ -429,12 +518,12 @@ onlyValidSignalsAreGenerated maximumTraceLength = property $ do
 
     st' :: State s
     st' = lastState tr
-  sig <- forAll (sigGen @s env st')
+  sig <- forAll (sigGen @s Nothing env st')
   let result = applySTS @s (TRC(env, st', sig))
   -- TODO: For some reason the result that led to the failure is not shown
   -- (even without using tasty, and setting the condition to True === False)
   footnoteShow result
-  void $ evalEither $ result
+  void $ evalEither result
 
 
 --------------------------------------------------------------------------------

--- a/byron/semantics/executable-spec/test/Control/State/Transition/Examples/Sum.hs
+++ b/byron/semantics/executable-spec/test/Control/State/Transition/Examples/Sum.hs
@@ -38,7 +38,7 @@ instance STS SUM where
 instance HasTrace SUM where
   envGen _ = pure ()
 
-  sigGen _ _ =
+  sigGen _ _ _ =
     Gen.list (Range.constant 1 100) (Gen.integral (Range.constant (-3) 3))
 
 -- | This property is intended to be used to manually inspect the


### PR DESCRIPTION
- Modify the types of the `HasTrace`  functions to support generators that can produce failures, and traces with a given failure profile.
- Add a trace profile to `dcertsAreNotReplayed` that allow us to uncover errors in the `DELEG` STS.

Closes #604.