### PR TITLE
Adds two UTxO properties

### DIFF
--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXO.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXO.hs
@@ -3,7 +3,16 @@
 {-# LANGUAGE TypeFamilies               #-}
 
 -- | UTXO transition system
-module Cardano.Ledger.Spec.STS.UTXO where
+module Cardano.Ledger.Spec.STS.UTXO
+  ( UTXO
+  , UTxOEnv (UTxOEnv)
+  , UTxOState (UTxOState)
+  , utxo
+  , utxo0
+  , pps
+  , reserves
+  )
+where
 
 import qualified Data.Set as Set
 
@@ -20,7 +29,6 @@ import Control.State.Transition
   , (?!)
   , judgmentContext
   )
-
 import Ledger.Core (Lovelace, (∪), (⊆), (⋪), (◁), dom, range)
 import Ledger.GlobalParams (lovelaceCap)
 import Ledger.Update (PParams)

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -48,6 +48,8 @@ main = defaultMain tests
       "UTxO properties"
       [ testProperty "Money is constant" moneyIsConstant
       , testProperty "Relevant UTxO traces are generated" UTxO.relevantCasesAreCovered
+      , testProperty "No double spending" UTxO.noDoubleSpending
+      , testProperty "UTxO is outputs minus inputs" UTxO.utxoDiff
       ]
     , testTxHasTypeReps
     , testGroup


### PR DESCRIPTION
This pull request implements two properties for UTxO:

* no double spending
* UTxO is outputs minuts inputs

It closes #263.

@dnadales , @uroboros: is there anything to add or change to improve this PR?