### PR TITLE
[546] Coverage tests for Chain Traces + refactor Deleg Trace coverage…

### DIFF
--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -14,8 +14,8 @@ import           Hedgehog (MonadTest, Property, assert, cover, failure, forAll, 
                      (===))
 
 import           Control.State.Transition
-import           Control.State.Transition.Generator (TraceLength (Maximum), classifyTraceLength,
-                     traceSigGen)
+import           Control.State.Transition.Generator (TraceLength (Desired, Maximum),
+                     classifyTraceLength, traceSigGen)
 import qualified Control.State.Transition.Generator as TransitionGenerator
 import           Control.State.Transition.Trace
 
@@ -89,76 +89,76 @@ signersListIsBoundedByK = property $ do
 
 relevantCasesAreCovered :: Property
 relevantCasesAreCovered = withTests 400 $ property $ do
-  tr <- forAll $ traceSigGen (Maximum 250) (sigGenChain GenDelegation NoGenUTxO NoGenUpdate)
+  tr <- forAll $ traceSigGen (Desired 250) (sigGenChain GenDelegation NoGenUTxO NoGenUpdate)
   let certs = traceDCerts tr
 
-  -- for at least 5% of traces...
-  cover 5
+  -- for at least 1% of traces...
+  cover 1
         "there are more certificates than blocks"
         (traceLength tr <= length certs)
 
   -- for at least 10% of traces...
-  cover 5
-        "at most 70% of blocks have no certificates"
-        (emptyDelegationPayloadRatio (traceDCertsByBlock tr) <= 0.7)
-
-  -- for at least 50% of traces...
-  cover 50
-        "at least 15% of delegates will delegate to this epoch"
-        (0.15 <= thisEpochDelegationsRatio (epochDelegationEpoch tr))
-
-  -- for at least 50% of traces...
-  cover 50
-        "at least 50% of delegations will delegate to the next epoch"
-        (0.5 <= nextEpochDelegationsRatio (epochDelegationEpoch tr))
-
-  -- for at least 10% of traces...
   cover 10
-       "at most 25% of certificates will self-delegate"
-       (selfDelegationsRatio certs <= 0.25)
-
-  -- for at least 50% of traces...
-  cover 50
-        "at least 25% delegates have multiple delegators"
-        (0.25 <= multipleDelegationsRatio certs)
-
-  -- for at least 10% of traces...
-  cover 10
-        "some delegates have at least 5 corresponding delegators"
-        (5 <= maxDelegationsTo certs)
-
-  -- for at least 8% of traces...
-  cover 8
-        "at most 25% of delegators change their delegation"
-        (changedDelegationsRatio certs <= 0.25)
-
-  -- for at least 10% of traces...
-  cover 10
-        "some delegators have changed their delegation 5 or more times"
-        (5 <= maxChangedDelegations certs)
-
-  -- for at least 20% of traces...
-  cover 20
-        "at most 25% of delegations are repeats"
-        (repeatedDelegationsRatio certs <= 0.25)
-
-  -- for at least 5% of traces...
-  cover 5
-        "some delegations are repeated 10 or more times"
-        (10 <= maxRepeatedDelegations certs)
-
-  -- for at least 10% of traces...
-  cover 10
-        "some blocks have 5 or more certificates"
-        (5 <= maxCertsPerBlock (traceDCertsByBlock tr))
+        "at most 75% of blocks have no certificates"
+        (emptyDelegationPayloadRatio (traceDCertsByBlock tr) <= 0.75)
 
   -- for at least 25% of traces...
   cover 25
+        "at least 25% of delegates will delegate to this epoch"
+        (0.25 <= thisEpochDelegationsRatio (epochDelegationEpoch tr))
+
+  -- for at least 60% of traces...
+  cover 60
+        "at least 50% of delegations will delegate to the next epoch"
+        (0.5 <= nextEpochDelegationsRatio (epochDelegationEpoch tr))
+
+  -- for at least 20% of traces...
+  cover 20
+       "at most 30% of certificates will self-delegate"
+       (selfDelegationsRatio certs <= 0.3)
+
+  -- for at least 60% of traces...
+  cover 60
+        "at least 25% delegates have multiple delegators"
+        (0.25 <= multipleDelegationsRatio certs)
+
+  -- for at least 20% of traces...
+  cover 20
+        "some delegates have at least 5 corresponding delegators"
+        (5 <= maxDelegationsTo certs)
+
+  -- for at least ?% of traces...
+  cover 5
+        "at most 50% of delegators change their delegation"
+        (changedDelegationsRatio certs <= 0.5)
+
+  -- for at least 20% of traces...
+  cover 20
+        "some delegators have changed their delegation 5 or more times"
+        (5 <= maxChangedDelegations certs)
+
+  -- for at least 2% of traces...
+  cover 2
+        "at most 25% of delegations are repeats"
+        (repeatedDelegationsRatio certs <= 0.25)
+
+  -- for at least 30% of traces...
+  cover 30
+        "some delegations are repeated 10 or more times"
+        (10 <= maxRepeatedDelegations certs)
+
+  -- for at least 15% of traces...
+  cover 15
+        "some blocks have 5 or more certificates"
+        (5 <= maxCertsPerBlock (traceDCertsByBlock tr))
+
+  -- for at least 50% of traces...
+  cover 50
         "there is at least one change of epoch in the trace"
         (2 <= epochBoundariesInTrace tr)
 
-  -- for at least 10% of traces...
-  cover 10
+  -- for at least 30% of traces...
+  cover 30
         "there are at least 5 epoch changes in the trace"
         (5 <= epochBoundariesInTrace tr)
   where

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -112,10 +112,10 @@ relevantCasesAreCovered = withTests 400 $ property $ do
         "at least 50% of delegations will delegate to the next epoch"
         (0.5 <= nextEpochDelegationsRatio (epochDelegationEpoch tr))
 
-  -- for at least 20% of traces...
-  cover 20
+  -- for at least 10% of traces...
+  cover 10
        "at most 30% of certificates will self-delegate"
-       (selfDelegationsRatio certs <= 0.3)
+       (selfDelegationsRatio certs <= 0.30)
 
   -- for at least 60% of traces...
   cover 60
@@ -127,7 +127,7 @@ relevantCasesAreCovered = withTests 400 $ property $ do
         "some delegates have at least 5 corresponding delegators"
         (5 <= maxDelegationsTo certs)
 
-  -- for at least ?% of traces...
+  -- for at least 5% of traces...
   cover 5
         "at most 50% of delegators change their delegation"
         (changedDelegationsRatio certs <= 0.5)

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -89,18 +89,18 @@ signersListIsBoundedByK = property $ do
 
 relevantCasesAreCovered :: Property
 relevantCasesAreCovered = withTests 400 $ property $ do
-  tr <- forAll $ traceSigGen (Maximum 250) (sigGenChain GenDelegation NoGenUTxO)
+  tr <- forAll $ traceSigGen (Maximum 250) (sigGenChain GenDelegation NoGenUTxO NoGenUpdate)
   let certs = traceDCerts tr
-
-  -- for at least 15% of traces...
-  cover 15
-        "there are more certificates than blocks"
-        (traceLength tr <= length certs)
 
   -- for at least 5% of traces...
   cover 5
-        "at least 75% of blocks have certificates"
-        (emptyDelegationPayloadRatio (traceDCertsByBlock tr) <= 0.25)
+        "there are more certificates than blocks"
+        (traceLength tr <= length certs)
+
+  -- for at least 10% of traces...
+  cover 5
+        "at most 70% of blocks have no certificates"
+        (emptyDelegationPayloadRatio (traceDCertsByBlock tr) <= 0.7)
 
   -- for at least 50% of traces...
   cover 50
@@ -142,8 +142,8 @@ relevantCasesAreCovered = withTests 400 $ property $ do
         "at most 25% of delegations are repeats"
         (repeatedDelegationsRatio certs <= 0.25)
 
-  -- for at least 10% of traces...
-  cover 10
+  -- for at least 5% of traces...
+  cover 5
         "some delegations are repeated 10 or more times"
         (10 <= maxRepeatedDelegations certs)
 

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -11,11 +11,11 @@ import           Data.List.Ordered (nubSortBy)
 import           Data.Ord (Down (Down), comparing)
 
 import           Hedgehog (MonadTest, Property, assert, cover, failure, forAll, property, withTests,
-                           (===))
+                     (===))
 
 import           Control.State.Transition
 import           Control.State.Transition.Generator (TraceLength (Maximum), classifyTraceLength,
-                                                     traceSigGen)
+                     traceSigGen)
 import qualified Control.State.Transition.Generator as TransitionGenerator
 import           Control.State.Transition.Trace
 
@@ -99,27 +99,27 @@ relevantCasesAreCovered = withTests 400 $ property $ do
 
   -- for at least 5% of traces...
   cover 5
-        "the majority of blocks (at least 75%) have certificates"
+        "at least 75% of blocks have certificates"
         (emptyDelegationPayloadRatio (traceDCertsByBlock tr) <= 0.25)
 
   -- for at least 50% of traces...
   cover 50
-        "some delegations (at least 15%) delegate to this epoch"
+        "at least 15% of delegates will delegate to this epoch"
         (0.15 <= thisEpochDelegationsRatio (epochDelegationEpoch tr))
 
   -- for at least 50% of traces...
   cover 50
-        "the majority of delegations (at least 50%) delegate to the next epoch"
+        "at least 50% of delegations will delegate to the next epoch"
         (0.5 <= nextEpochDelegationsRatio (epochDelegationEpoch tr))
 
   -- for at least 10% of traces...
   cover 10
-       "not too many certificates (at most 25%) self-delegate"
+       "at most 25% of certificates will self-delegate"
        (selfDelegationsRatio certs <= 0.25)
 
   -- for at least 50% of traces...
   cover 50
-        "some delegates (at least 25%) have multiple delegators"
+        "at least 25% delegates have multiple delegators"
         (0.25 <= multipleDelegationsRatio certs)
 
   -- for at least 10% of traces...
@@ -129,7 +129,7 @@ relevantCasesAreCovered = withTests 400 $ property $ do
 
   -- for at least 8% of traces...
   cover 8
-        "not too many delegators (at most 25%) change their delegation"
+        "at most 25% of delegators change their delegation"
         (changedDelegationsRatio certs <= 0.25)
 
   -- for at least 10% of traces...
@@ -139,7 +139,7 @@ relevantCasesAreCovered = withTests 400 $ property $ do
 
   -- for at least 20% of traces...
   cover 20
-        "not too many delegations (at most 25%) are repeats"
+        "at most 25% of delegations are repeats"
         (repeatedDelegationsRatio certs <= 0.25)
 
   -- for at least 10% of traces...

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -1,24 +1,31 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+
 module Cardano.Spec.Chain.STS.Properties where
 
-import           Control.Lens ((^.), (^..))
+import           Control.Arrow ((***))
+import           Control.Lens (view, (&), (^.), (^..), _1, _5)
 import           Data.Foldable (traverse_)
 import           Data.List.Ordered (nubSortBy)
 import           Data.Ord (Down (Down), comparing)
-import           Hedgehog (MonadTest, Property, assert, failure, forAll, property, withTests, (===))
+
+import           Hedgehog (MonadTest, Property, assert, cover, failure, forAll, property, withTests,
+                           (===))
 
 import           Control.State.Transition
 import           Control.State.Transition.Generator (TraceLength (Maximum), classifyTraceLength,
-                     traceSigGen)
+                                                     traceSigGen)
 import qualified Control.State.Transition.Generator as TransitionGenerator
 import           Control.State.Transition.Trace
 
+import           Ledger.Core (BlockCount (BlockCount), Epoch, Slot (unSlot))
 import           Ledger.Delegation
+import           Ledger.GlobalParams (slotsPerEpoch)
 
 import           Cardano.Spec.Chain.STS.Block
 import           Cardano.Spec.Chain.STS.Rule.Chain
-import           Ledger.Core (BlockCount (BlockCount))
+import           Cardano.Spec.Chain.STS.Rule.Epoch (sEpoch)
 
 slotsIncrease :: Property
 slotsIncrease = property $ do
@@ -78,3 +85,110 @@ signersListIsBoundedByK = property $ do
         signersListIsBoundedByKInState :: MonadTest m => BlockCount -> State CHAIN -> m ()
         signersListIsBoundedByKInState (BlockCount k') (_sLast, sgs, _h, _utxoSt, _ds, _us) =
           assert $ length sgs <= fromIntegral k'
+
+
+relevantCasesAreCovered :: Property
+relevantCasesAreCovered = withTests 400 $ property $ do
+  tr <- forAll $ traceSigGen (Maximum 250) (sigGenChain GenDelegation NoGenUTxO)
+  let certs = traceDCerts tr
+
+  -- for at least 15% of traces...
+  cover 15
+        "there are more certificates than blocks"
+        (traceLength tr <= length certs)
+
+  -- for at least 5% of traces...
+  cover 5
+        "the majority of blocks (at least 75%) have certificates"
+        (emptyDelegationPayloadRatio (traceDCertsByBlock tr) <= 0.25)
+
+  -- for at least 50% of traces...
+  cover 50
+        "some delegations (at least 15%) delegate to this epoch"
+        (0.15 <= thisEpochDelegationsRatio (epochDelegationEpoch tr))
+
+  -- for at least 50% of traces...
+  cover 50
+        "the majority of delegations (at least 50%) delegate to the next epoch"
+        (0.5 <= nextEpochDelegationsRatio (epochDelegationEpoch tr))
+
+  -- for at least 10% of traces...
+  cover 10
+       "not too many certificates (at most 25%) self-delegate"
+       (selfDelegationsRatio certs <= 0.25)
+
+  -- for at least 50% of traces...
+  cover 50
+        "some delegates (at least 25%) have multiple delegators"
+        (0.25 <= multipleDelegationsRatio certs)
+
+  -- for at least 10% of traces...
+  cover 10
+        "some delegates have at least 5 corresponding delegators"
+        (5 <= maxDelegationsTo certs)
+
+  -- for at least 8% of traces...
+  cover 8
+        "not too many delegators (at most 25%) change their delegation"
+        (changedDelegationsRatio certs <= 0.25)
+
+  -- for at least 10% of traces...
+  cover 10
+        "some delegators have changed their delegation 5 or more times"
+        (5 <= maxChangedDelegations certs)
+
+  -- for at least 20% of traces...
+  cover 20
+        "not too many delegations (at most 25%) are repeats"
+        (repeatedDelegationsRatio certs <= 0.25)
+
+  -- for at least 10% of traces...
+  cover 10
+        "some delegations are repeated 10 or more times"
+        (10 <= maxRepeatedDelegations certs)
+
+  -- for at least 10% of traces...
+  cover 10
+        "some blocks have 5 or more certificates"
+        (5 <= maxCertsPerBlock (traceDCertsByBlock tr))
+
+  -- for at least 25% of traces...
+  cover 25
+        "there is at least one change of epoch in the trace"
+        (2 <= epochBoundariesInTrace tr)
+
+  -- for at least 10% of traces...
+  cover 10
+        "there are at least 5 epoch changes in the trace"
+        (5 <= epochBoundariesInTrace tr)
+  where
+   -- Get the epoch in which the delegation certificates of the trace were
+   -- applied, paired with the epoch of the delegation certificate.
+   epochDelegationEpoch :: Trace CHAIN -> [(Epoch, Epoch)]
+   epochDelegationEpoch tr = preStatesAndSignals @CHAIN OldestFirst tr
+                           & fmap (sEpoch_ . view _1 *** (fmap depoch . (_bDCerts . _bBody)))
+                           & fmap (\(e, es) -> zip (repeat e) es)
+                           & concat
+                           where
+                             blockCount = _traceEnv tr ^. _5
+                             sEpoch_ = flip sEpoch blockCount
+
+   -- Count the number of epoch boundaries in the trace
+   epochBoundariesInTrace :: Trace CHAIN -> Int
+   epochBoundariesInTrace tr
+     = length $
+         filter (== 0) (isAtBoundary <$> slots)
+     where blocks = traceSignals NewestFirst tr
+           slots = blocks ^.. traverse . bHeader . bhSlot
+           k = _traceEnv tr ^. _5
+           isAtBoundary = (`rem` slotsPerEpoch k) . unSlot
+
+-- | Extract the delegation certificates in the blocks, in the order they would
+-- have been applied.
+traceDCertsByBlock :: Trace CHAIN -> [[DCert]]
+traceDCertsByBlock tr = _bDCerts . _bBody <$> traceSignals OldestFirst tr
+
+-- | Flattended list of DCerts for the given Trace
+traceDCerts :: Trace CHAIN -> [DCert]
+traceDCerts = concat . traceDCertsByBlock
+

--- a/byron/chain/executable-spec/test/Main.hs
+++ b/byron/chain/executable-spec/test/Main.hs
@@ -19,5 +19,6 @@ main = defaultMain tests
       , testAbstractSize
       , testProperty "Only valid signals are generated" CHAIN.onlyValidSignalsAreGenerated
       , testProperty "Signers list is bounded by k " CHAIN.signersListIsBoundedByK
+      , testProperty "We are generating reasonable Chain Traces" CHAIN.relevantCasesAreCovered
       ]
     ]

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -41,6 +41,7 @@ library
                      , hashable
                      , hedgehog >= 1.0
                      , lens
+                     , Unique >= 0.4.7.6
                      -- Local deps
                      , small-steps
   default-language:    Haskell2010

--- a/byron/ledger/executable-spec/test/Ledger/Core/Generators/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Core/Generators/Properties.hs
@@ -54,6 +54,6 @@ relevantKValuesAreGenerated = withTests 500 $ property $ do
     --
     -- And if we round this value down we get 100 epochs.
 
-    cover 10
+    cover 6
       "100 epochs "
       (epochs == 100)

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -26,42 +26,35 @@ import           Data.List.Unique (repeated)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Hedgehog (Gen, MonadTest, Property, assert, cover, forAll, property, success,
-                           withTests, (===))
+                     withTests, (===))
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import           Control.State.Transition (Embed, Environment, IRC (IRC), PredicateFailure, STS,
-                                           Signal, State, TRC (TRC), applySTS, initialRules,
-                                           judgmentContext, trans, transitionRules, wrapFailed,
-                                           (?!))
+                     Signal, State, TRC (TRC), applySTS, initialRules, judgmentContext, trans,
+                     transitionRules, wrapFailed, (?!))
 import           Control.State.Transition.Generator (HasSizeInfo, HasTrace,
-                                                     TraceProfile (TraceProfile), classifySize,
-                                                     classifyTraceLength, envGen, failures,
-                                                     isTrivial, nonTrivialTrace,
-                                                     proportionOfInvalidSignals,
-                                                     proportionOfValidSignals, sigGen,
-                                                     suchThatLastState, trace,
-                                                     traceLengthsAreClassified, traceWithProfile)
+                     TraceProfile (TraceProfile), classifySize, classifyTraceLength, envGen,
+                     failures, isTrivial, nonTrivialTrace, proportionOfInvalidSignals,
+                     proportionOfValidSignals, sigGen, suchThatLastState, trace,
+                     traceLengthsAreClassified, traceWithProfile)
 import qualified Control.State.Transition.Generator as TransitionGenerator
 import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst), lastState,
-                                                 preStatesAndSignals, traceEnv, traceLength,
-                                                 traceSignals)
+                     preStatesAndSignals, traceEnv, traceLength, traceSignals)
 import           Ledger.Core (Epoch (Epoch), Owner (Owner), Sig (Sig), Slot, SlotCount (SlotCount),
-                              VKey (VKey), VKeyGenesis, addSlot, mkVKeyGenesis, owner,
-                              signWithGenesisKey, unSlot, unSlotCount)
+                     VKey (VKey), VKeyGenesis, addSlot, mkVKeyGenesis, owner, signWithGenesisKey,
+                     unSlot, unSlotCount)
 import           Ledger.Delegation (DCert, DELEG, DIState (DIState),
-                                    DSEnv (DSEnv, _dSEnvAllowedDelegators, _dSEnvEpoch, _dSEnvK),
-                                    DSState (DSState),
-                                    DState (DState, _dStateDelegationMap, _dStateLastDelegation),
-                                    PredicateFailure (IsAlreadyScheduled, SDelegFailure, SDelegSFailure),
-                                    delegationMap, delegatorDelegate, depoch,
-                                    emptyDelegationPayloadRatio, epoch, liveAfter, mkDCert,
-                                    multipleDelegationsRatio, nextEpochDelegationsRatio,
-                                    scheduledDelegations, selfDelegationsRatio, slot,
-                                    thisEpochDelegationsRatio, _dIStateDelegationMap,
-                                    _dIStateKeyEpochDelegations, _dIStateLastDelegation,
-                                    _dIStateScheduledDelegations, _dSStateKeyEpochDelegations,
-                                    _dSStateScheduledDelegations)
+                     DSEnv (DSEnv, _dSEnvAllowedDelegators, _dSEnvEpoch, _dSEnvK),
+                     DSState (DSState),
+                     DState (DState, _dStateDelegationMap, _dStateLastDelegation),
+                     PredicateFailure (IsAlreadyScheduled, SDelegFailure, SDelegSFailure),
+                     delegationMap, delegatorDelegate, depoch, emptyDelegationPayloadRatio, epoch,
+                     liveAfter, mkDCert, multipleDelegationsRatio, nextEpochDelegationsRatio,
+                     scheduledDelegations, selfDelegationsRatio, slot, thisEpochDelegationsRatio,
+                     _dIStateDelegationMap, _dIStateKeyEpochDelegations, _dIStateLastDelegation,
+                     _dIStateScheduledDelegations, _dSStateKeyEpochDelegations,
+                     _dSStateScheduledDelegations)
 
 import           Ledger.Core.Generators (epochGen, slotGen, vkGen)
 import qualified Ledger.Core.Generators as CoreGen

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Properties.hs
@@ -17,42 +17,51 @@ module Ledger.Delegation.Properties
   )
 where
 
-import           Control.Arrow (first, (&&&), (***))
+import           Control.Arrow (first, (***))
 import           Control.Lens (makeLenses, to, view, (&), (.~), (^.))
 import           Data.Bimap (Bimap)
 import qualified Data.Bimap as Bimap
-import           Data.List (foldl', last, nub)
-import           Data.List.Unique (count, repeated)
+import           Data.List (foldl', last)
+import           Data.List.Unique (repeated)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import           Hedgehog (Gen, MonadTest, Property, assert, cover, forAll, property, success,
-                     withTests, (===))
+                           withTests, (===))
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import           Control.State.Transition (Embed, Environment, IRC (IRC), PredicateFailure, STS,
-                     Signal, State, TRC (TRC), applySTS, initialRules, judgmentContext, trans,
-                     transitionRules, wrapFailed, (?!))
+                                           Signal, State, TRC (TRC), applySTS, initialRules,
+                                           judgmentContext, trans, transitionRules, wrapFailed,
+                                           (?!))
 import           Control.State.Transition.Generator (HasSizeInfo, HasTrace,
-                     TraceProfile (TraceProfile), classifySize, classifyTraceLength, envGen,
-                     failures, isTrivial, nonTrivialTrace, proportionOfInvalidSignals,
-                     proportionOfValidSignals, ratio, sigGen, suchThatLastState, trace,
-                     traceLengthsAreClassified, traceWithProfile)
+                                                     TraceProfile (TraceProfile), classifySize,
+                                                     classifyTraceLength, envGen, failures,
+                                                     isTrivial, nonTrivialTrace,
+                                                     proportionOfInvalidSignals,
+                                                     proportionOfValidSignals, sigGen,
+                                                     suchThatLastState, trace,
+                                                     traceLengthsAreClassified, traceWithProfile)
 import qualified Control.State.Transition.Generator as TransitionGenerator
 import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst), lastState,
-                     preStatesAndSignals, traceEnv, traceLength, traceSignals)
+                                                 preStatesAndSignals, traceEnv, traceLength,
+                                                 traceSignals)
 import           Ledger.Core (Epoch (Epoch), Owner (Owner), Sig (Sig), Slot, SlotCount (SlotCount),
-                     VKey (VKey), VKeyGenesis, addSlot, mkVKeyGenesis, owner, signWithGenesisKey,
-                     unSlot, unSlotCount)
+                              VKey (VKey), VKeyGenesis, addSlot, mkVKeyGenesis, owner,
+                              signWithGenesisKey, unSlot, unSlotCount)
 import           Ledger.Delegation (DCert, DELEG, DIState (DIState),
-                     DSEnv (DSEnv, _dSEnvEpoch, _dSEnvK), DSState (DSState),
-                     DState (DState, _dStateDelegationMap, _dStateLastDelegation),
-                     PredicateFailure (IsAlreadyScheduled, SDelegFailure, SDelegSFailure),
-                     delegate, delegationMap, delegator, depoch, epoch, liveAfter, mkDCert,
-                     scheduledDelegations, slot, _dIStateDelegationMap,
-                     _dIStateKeyEpochDelegations, _dIStateLastDelegation,
-                     _dIStateScheduledDelegations, _dSEnvAllowedDelegators,
-                     _dSStateKeyEpochDelegations, _dSStateScheduledDelegations)
+                                    DSEnv (DSEnv, _dSEnvAllowedDelegators, _dSEnvEpoch, _dSEnvK),
+                                    DSState (DSState),
+                                    DState (DState, _dStateDelegationMap, _dStateLastDelegation),
+                                    PredicateFailure (IsAlreadyScheduled, SDelegFailure, SDelegSFailure),
+                                    delegationMap, delegatorDelegate, depoch,
+                                    emptyDelegationPayloadRatio, epoch, liveAfter, mkDCert,
+                                    multipleDelegationsRatio, nextEpochDelegationsRatio,
+                                    scheduledDelegations, selfDelegationsRatio, slot,
+                                    thisEpochDelegationsRatio, _dIStateDelegationMap,
+                                    _dIStateKeyEpochDelegations, _dIStateLastDelegation,
+                                    _dIStateScheduledDelegations, _dSStateKeyEpochDelegations,
+                                    _dSStateScheduledDelegations)
 
 import           Ledger.Core.Generators (epochGen, slotGen, vkGen)
 import qualified Ledger.Core.Generators as CoreGen
@@ -214,9 +223,6 @@ expectedDms s d sbs =
     activationSlot :: Int
     activationSlot = s - d
 
-delegatorDelegate :: DCert -> (VKeyGenesis, VKey)
-delegatorDelegate = delegator &&& delegate
-
 -- | Check that there are no duplicated certificates in the trace.
 dcertsAreNotReplayed :: Property
 dcertsAreNotReplayed = withTests 300 $ property $ do
@@ -325,88 +331,50 @@ dblockTracesAreClassified = withTests 200 $ property $ do
 
 -- | Extract the delegation certificates in the blocks, in the order they would
 -- have been applied.
+traceDCertsByBlock :: Trace DBLOCK -> [[DCert]]
+traceDCertsByBlock tr = _blockCerts <$> traceSignals OldestFirst tr
+
+-- | Flattended list of DCerts for the given Trace
 traceDCerts :: Trace DBLOCK -> [DCert]
-traceDCerts tr = concat $ _blockCerts <$> traceSignals OldestFirst tr
+traceDCerts = concat . traceDCertsByBlock
 
 relevantCasesAreCovered :: Property
 relevantCasesAreCovered = withTests 400 $ property $ do
   let tl = 1000
   tr <- forAll (trace @DBLOCK tl)
 
-  -- 70% of the traces must contain are as many delegation certificates as
-  -- blocks.
-  cover 50
+  -- 40% of the traces must contain as many delegation certificates as blocks.
+  cover 40
         "there are at least as many delegation certificates as blocks"
         (traceLength tr <= length (traceDCerts tr))
 
-  -- 70% of the traces must contain at most 25% of blocks with empty delegation
-  -- payload.
-  cover 70
+  -- 50% of the traces must contain at most 25% of blocks with empty delegation payload.
+  cover 50
         "at most 25% of the blocks can contain empty delegation payload"
-        (ratio emptyDelegationPayload tr <= 0.25)
+        (0.25 >= emptyDelegationPayloadRatio (traceDCertsByBlock tr))
 
   -- 50% of the traces must contain at least 30% of delegations to this epoch.
   cover 50
-        "at least 30% of the certificates delegate in this epoch"
-        (0.3 <= ratio thisEpochDelegations tr)
+        "at least 30% of all certificates delegate in this epoch"
+        (0.3 <= thisEpochDelegationsRatio (epochDelegationEpoch tr))
 
-  -- 50% of the traces must contain at least 50% of delegations to the next
+  -- 70% of the traces must contain at least 50% of delegations to the next
   -- epoch.
-  cover 50
+  cover 70
         "at least 50% of the certificates delegate in the next epoch"
-        (0.5 <= ratio nextEpochDelegations tr)
+        (0.5 <= nextEpochDelegationsRatio (epochDelegationEpoch tr))
 
-  -- 80% of the traces must contain at least 30% of self-delegations.
-  cover 80
+  -- 30% of the traces must contain at least 30% of self-delegations.
+  cover 30
        "at least 30% of the certificates self delegate"
-       (0.3 <= ratio selfDelegations tr)
+       (0.3 <= selfDelegationsRatio (traceDCerts tr))
 
   -- 15% of the traces must contain at least 10% of delegations to the same
   -- delegate.
-  cover 15
-        "at least 5% of the certificates delegate to the same key"
-        (0.05 <= ratio multipleDelegations tr)
+  cover 50
+        "at least 25% of delegates have multiple delegators"
+        (0.05 <= multipleDelegationsRatio (traceDCerts tr))
   where
-    selfDelegations :: Trace DBLOCK -> Int
-    selfDelegations tr = length
-                       $ filter idDeleg
-                       $ fmap delegatorDelegate (traceDCerts tr)
-      where
-        idDeleg (vks, vk) = owner vks == owner vk
-
-    -- Count the number of delegations to the same key in a given trace.
-    multipleDelegations :: Trace DBLOCK -> Int
-    multipleDelegations tr = -- Get the (delegator, delegate) pairs
-                             fmap delegatorDelegate (traceDCerts tr)
-                             -- Remove duplicated elements, since we're not
-                             -- interested in the same genesis key delegating
-                             -- to the same key, i.e. if we have more than one
-                             -- @(vkg, vk)@, for the same genesis key @vkg@ and
-                             -- key @vk@ we keep only one of them.
-                           & nub
-                             -- Keep the delegators. Since we applied nub
-                             -- before, we know that if there are two keys in
-                             -- the result of 'fmap snd' then we know for sure
-                             -- that they were delegated by different keys.
-                           & fmap snd
-                             -- Count the occurrences. If we have more than one
-                             -- occurrence of a key, then we know that it must
-                             -- be because two different genesis keys delegated
-                             -- to it.
-                           & count
-                           & filter ((2 <=) . snd)
-                           & length
-
-    emptyDelegationPayload  :: Trace DBLOCK -> Int
-    emptyDelegationPayload tr =  _blockCerts <$> traceSignals OldestFirst tr
-                              & filter null
-                              & length
-
-    thisEpochDelegations  :: Trace DBLOCK -> Int
-    thisEpochDelegations tr = epochDelegationEpoch tr
-                            & filter (uncurry (==))
-                            & length
-
     -- Get the epoch in which the delegation certificates of the trace were
     -- applied, paired with the epoch of the delegation certificate.
     epochDelegationEpoch :: Trace DBLOCK -> [(Epoch, Epoch)]
@@ -414,13 +382,6 @@ relevantCasesAreCovered = withTests 400 $ property $ do
                             & fmap (_dSEnvEpoch . fst *** (fmap depoch . _blockCerts))
                             & fmap (\(e, es) -> zip (repeat e) es)
                             & concat
-
-
-    nextEpochDelegations  :: Trace DBLOCK -> Int
-    nextEpochDelegations tr =  epochDelegationEpoch tr
-                            & filter (\(e0, e1) -> e0 + 1 == e1)
-                            & length
-
 
 onlyValidSignalsAreGenerated :: Property
 onlyValidSignalsAreGenerated =

--- a/nix/.stack.nix/cs-ledger.nix
+++ b/nix/.stack.nix/cs-ledger.nix
@@ -23,6 +23,7 @@
           (hsPkgs.hashable)
           (hsPkgs.hedgehog)
           (hsPkgs.lens)
+          (hsPkgs.Unique)
           (hsPkgs.small-steps)
           ];
         };


### PR DESCRIPTION
Closes #546 

<img width="868" alt="chain trace coverage" src="https://user-images.githubusercontent.com/8812/61368079-603d5c80-a88d-11e9-8114-dce6d7658bfd.png">

* based the trace coverage tests for Delegation by @dnadales, this PR adapts these coverage tests to Chain Traces
* also refactors the delegation trace tests to include some insights from this PR
* adds coverage tests for: change of delegation, repeated delegations, distribution of certificates over blocks, epoch boundaries

NOTE some coverage properties happen quite rarely given current generators - is it worth addressing this?

* "some blocks have 5 or more certificates" (only true for 10% of traces)
* "not too many delegations (at most 25%) are repeats" (only 20%)
* "not too many delegators (at most 25%) change their delegation" (only 8%)
* "not too many certificates (at most 25%) self-delegate" (only 10%)
* "the majority of blocks (at least 75%) have certificates" (only 5%)
* "there are more certificates than blocks" (only 15%)

