### PR TITLE
Fixed use of development flag

### DIFF
--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -32,7 +32,7 @@
         };
       tests = {
         "delegation-test" = {
-          depends = (pkgs.lib).optionals (!flags.development) [
+          depends = [
             (hsPkgs.base)
             (hsPkgs.cryptonite)
             (hsPkgs.tasty)

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -99,9 +99,9 @@ test-suite delegation-test
       -Wincomplete-record-updates
       -Wincomplete-uni-patterns
       -Wredundant-constraints
-  if (!flag(development))
-    ghc-options:
-      -Werror
+    if (!flag(development))
+      ghc-options:
+        -Werror
     build-depends:
       base,
       cryptonite,


### PR DESCRIPTION
Due to a wrong spacing, setting the `development` flag failed building the
project due to disabling many `build-depends`.