### PR TITLE
Fix the order of transactions applied in UTXOWS

### DIFF
--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOWS.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOWS.hs
@@ -15,7 +15,7 @@ import           Control.State.Transition (Embed, Environment, IRC (IRC), Predic
                      Signal, State, TRC (TRC), initialRules, judgmentContext, trans,
                      transitionRules, wrapFailed)
 import           Control.State.Transition.Generator (HasTrace, envGen, genTrace, sigGen)
-import           Control.State.Transition.Trace (TraceOrder (NewestFirst), traceSignals)
+import           Control.State.Transition.Trace (TraceOrder (OldestFirst), traceSignals)
 import           Ledger.UTxO (TxWits)
 
 data UTXOWS
@@ -40,8 +40,8 @@ instance STS UTXOWS where
         case (txWits :: [TxWits]) of
           []     -> return utxo
           (tx:gamma) -> do
-            utxo'  <- trans @UTXOWS $ TRC (env, utxo, gamma)
-            utxo'' <- trans @UTXOW  $ TRC (env, utxo', tx)
+            utxo'  <- trans @UTXOW  $ TRC (env, utxo, tx)
+            utxo'' <- trans @UTXOWS $ TRC (env, utxo', gamma)
             return utxo''
     ]
 
@@ -53,4 +53,4 @@ instance HasTrace UTXOWS where
 
   -- We generate signal for UTXOWS as a list of signals from UTXOW
   sigGen _ env st =
-    traceSignals NewestFirst <$> genTrace @UTXOW 20 env st (sigGen @UTXOW)
+    traceSignals OldestFirst <$> genTrace @UTXOW 20 env st (sigGen @UTXOW)

--- a/byron/ledger/executable-spec/test/Ledger/UTxO/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/UTxO/Properties.hs
@@ -94,7 +94,7 @@ relevantCasesAreCovered = withTests 400 $ property $ do
     cover 20 "avg. nr. of tx outputs (1,5]" (1 <= avgOutputs && avgOutputs <= 5)
     cover 20 "avg. nr. of tx outputs (5,10]" (5 < avgOutputs && avgOutputs <= 10)
 
-    cover 80 "starting UTxO has no future outputs" (all (== empty) (futureOutputs tr))
+    cover 80 "starting UTxO has no future inputs" (all (== empty) (futureInputs tr))
   where
     -- | The average "fee surplus" for transactions in the trace.
     --   Could be zero if all the transactions had zero surplus fee.
@@ -120,8 +120,8 @@ relevantCasesAreCovered = withTests 400 $ property $ do
 
     -- | The intersection of the starting UTxO and each transaction in
     -- a trace
-    futureOutputs :: Trace UTXOW -> [Set TxIn]
-    futureOutputs tr =
+    futureInputs :: Trace UTXOW -> [Set TxIn]
+    futureInputs tr =
       let
         UTxOState {utxo = utxo0} = _traceInitState tr
         txs = body <$> traceSignals OldestFirst tr


### PR DESCRIPTION
This PR fixes the order in which transactions are applied in the `UTXOWS` STS in the Byron era.

It addresses one half of issue #655.