### PR TITLE
Add `AddrBase` / `AddrEnterprise` types

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Address.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Address
-  ( mkRwdAcnt
+  ( mkVKeyRwdAcnt
   )
 where
 
@@ -10,10 +10,10 @@ import           Cardano.Crypto.Hash   (HashAlgorithm)
 import           Keys
 import           TxData
 
-mkRwdAcnt
+mkVKeyRwdAcnt
   :: ( HashAlgorithm hashAlgo
      , DSIGNAlgorithm dsignAlgo
      )
   => KeyPair dsignAlgo
   -> RewardAcnt hashAlgo dsignAlgo
-mkRwdAcnt keys = RewardAcnt $ KeyHashStake (hashKey $ vKey keys)
+mkVKeyRwdAcnt keys = RewardAcnt $ KeyHashObj (hashKey $ vKey keys)

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -37,12 +37,12 @@ cwitness
   :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => DCert hashAlgo dsignAlgo
   -> StakeCredential hashAlgo dsignAlgo
-cwitness (RegKey hk)           = hk
-cwitness (DeRegKey hk)         = hk
-cwitness (RegPool pool)        = KeyHashStake $ hashKey $ pool ^. poolPubKey
-cwitness (RetirePool k _)      = KeyHashStake k
-cwitness (Delegate delegation) = delegation ^. delegator
-cwitness (GenesisDelegate (gk, _)) = KeyHashStake $ hashGenesisKey gk
+cwitness (RegKey hk)               = hk
+cwitness (DeRegKey hk)             = hk
+cwitness (RegPool pool)            = KeyHashObj $ hashKey $ pool ^. poolPubKey
+cwitness (RetirePool k _)          = KeyHashObj k
+cwitness (Delegate delegation)     = delegation ^. delegator
+cwitness (GenesisDelegate (gk, _)) = KeyHashObj $ hashGenesisKey gk
 
 -- |Retrieve the deposit amount for a certificate
 dvalue :: DCert hashAlgo dsignAlgo -> PParams -> Coin

--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -63,8 +63,7 @@ newtype Stake hashAlgo dsignAlgo
 
 -- | Extract hash of staking key from base address.
 getStakeHK :: Addr hashAlgo dsignAlgo -> Maybe (StakeCredential hashAlgo dsignAlgo)
-getStakeHK (AddrVKey _ hk) = Just $ KeyHashStake hk
-getStakeHK (AddrScr _ hs) = Just $ ScriptHashStake hs
+getStakeHK (AddrBase _ hk) = Just hk
 getStakeHK _               = Nothing
 
 consolidate :: UTxO hashAlgo dsignAlgo -> Map.Map (Addr hashAlgo dsignAlgo) Coin

--- a/shelley/chain-and-ledger/executable-spec/src/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Tx.hs
@@ -122,7 +122,7 @@ extractKeyHash
   -> [KeyHash hashAlgo dsignAlgo]
 extractKeyHash l =
   Maybe.catMaybes $ map (\so -> case so of
-                                 KeyHashStake hk -> Just hk
+                                 KeyHashObj hk -> Just hk
                                  _ -> Nothing) l
 
 extractScriptHash
@@ -130,5 +130,5 @@ extractScriptHash
   -> [ScriptHash hashAlgo dsignAlgo]
 extractScriptHash l =
   Maybe.catMaybes $ map (\so -> case so of
-                                 ScriptHashStake hk -> Just hk
+                                 ScriptHashObj hk -> Just hk
                                  _ -> Nothing) l

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -173,14 +173,15 @@ txup (Tx txbody _ _) = _txUpdate txbody
 
 -- | Extract script hash from value address with script.
 getScriptHash :: Addr hashAlgo dsignAlgo -> Maybe (ScriptHash hashAlgo dsignAlgo)
-getScriptHash (AddrScr hs _) = Just hs
-getScriptHash _              = Nothing
+getScriptHash (AddrBase (ScriptHashObj hs) _)     = Just hs
+getScriptHash (AddrEnterprise (ScriptHashObj hs)) = Just hs
+getScriptHash _                                   = Nothing
 
 scriptStakeCred
   :: StakeCredential hashAlgo dsignAlgo
   -> Maybe (ScriptHash hashAlgo dsignAlgo)
-scriptStakeCred (KeyHashStake _ )    =  Nothing
-scriptStakeCred (ScriptHashStake hs) = Just hs
+scriptStakeCred (KeyHashObj _ )    =  Nothing
+scriptStakeCred (ScriptHashObj hs) = Just hs
 
 -- | Computes the set of script hashes required to unlock the transcation inputs
 -- and the withdrawals.
@@ -208,6 +209,8 @@ txinsScript
   -> Set (TxIn hashAlgo dsignAlgo)
 txinsScript txInps (UTxO u) =
   txInps `Set.intersection`
-  (Map.keysSet $ Map.filter (\(TxOut a _) -> case a of
-                                               AddrScr _ _ -> True
-                                               _           -> False) u)
+  (Map.keysSet $ Map.filter (\(TxOut a _) ->
+                               case a of
+                                 AddrBase (ScriptHashObj _) _     -> True
+                                 AddrEnterprise (ScriptHashObj _) -> True
+                                 _                                -> False) u)

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -83,6 +83,7 @@ type CHAIN = STS.Chain.CHAIN ShortHash MockDSIGN MockKES
 
 type UTXOW = STS.Utxow.UTXOW ShortHash MockDSIGN
 
+type Credential = TxData.Credential ShortHash MockDSIGN
 type StakeCredential = TxData.StakeCredential ShortHash MockDSIGN
 
 type MultiSig = TxData.MultiSig ShortHash MockDSIGN

--- a/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
@@ -38,7 +38,7 @@ import           Slot
 import           Tx (pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut,
                       _body, _certs, _inputs, _outputs, _ttl, _txfee, _wdrls,
                       _witnessVKeySet, _witnessMSigMap)
-import           TxData (StakeCredential(..), PoolParams(..), pattern Delegation)
+import           TxData (Credential(..), PoolParams(..), pattern Delegation)
 
 import           MockTypes
 
@@ -155,10 +155,10 @@ mutateEpoch lower upper (Epoch val) = Epoch <$> mutateNat lower upper val
 -- from the supplied list of keypairs.
 mutateDCert :: KeyPairs -> DPState -> DCert -> Gen DCert
 mutateDCert keys _ (RegKey _) =
-  RegKey . KeyHashStake . hashKey . vKey . snd <$> Gen.element keys
+  RegKey . KeyHashObj . hashKey . vKey . snd <$> Gen.element keys
 
 mutateDCert keys _ (DeRegKey _) =
-  DeRegKey . KeyHashStake . hashKey . vKey . snd <$> Gen.element keys
+  DeRegKey . KeyHashObj . hashKey . vKey . snd <$> Gen.element keys
 
 mutateDCert keys _ (RetirePool _ epoch@(Epoch e)) = do
     epoch' <- mutateEpoch 0 e epoch
@@ -175,7 +175,7 @@ mutateDCert keys _ (RegPool (PoolParams _ pledge pledges cost margin altacnt rwd
 mutateDCert keys _ (Delegate (Delegation _ _)) = do
   delegator' <- getAnyStakeKey keys
   delegatee' <- getAnyStakeKey keys
-  pure $ Delegate $ Delegation (KeyHashStake $ hashKey delegator') (hashKey delegatee')
+  pure $ Delegate $ Delegation (KeyHashObj $ hashKey delegator') (hashKey delegatee')
 
 mutateDCert keys _ (GenesisDelegate (gk, _)) = do
   _delegatee <- getAnyStakeKey keys


### PR DESCRIPTION
Add possibility to have mixed vkey and multi-sig payment and staking objects. Add explicit Base and Enterprise type.