### PR TITLE
cleanup of Shelley exec spec

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Address.hs
@@ -1,5 +1,3 @@
-
-
 module Address
   ( mkVKeyRwdAcnt
   )
@@ -7,8 +5,8 @@ where
 
 import           Cardano.Crypto.Hash (HashAlgorithm)
 
-import           Keys
-import           TxData
+import           Keys (DSIGNAlgorithm, KeyPair, hashKey, vKey)
+import           TxData (Credential (..), RewardAcnt (..))
 
 mkVKeyRwdAcnt
   :: ( HashAlgorithm hashAlgo

--- a/shelley/chain-and-ledger/executable-spec/src/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Address.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+
 
 module Address
   ( mkVKeyRwdAcnt

--- a/shelley/chain-and-ledger/executable-spec/src/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Address.hs
@@ -5,7 +5,7 @@ module Address
   )
 where
 
-import           Cardano.Crypto.Hash   (HashAlgorithm)
+import           Cardano.Crypto.Hash (HashAlgorithm)
 
 import           Keys
 import           TxData

--- a/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
@@ -18,7 +18,7 @@ module BaseTypes
   ) where
 
 
-import qualified Data.Fixed as FP
+import qualified Data.Fixed as FP (Fixed, HasResolution, resolution)
 import           Data.Word (Word8)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)

--- a/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
@@ -21,7 +21,7 @@ module BaseTypes
 import qualified Data.Fixed as FP
 import           Data.Word (Word8)
 
-import           Cardano.Binary (ToCBOR(toCBOR), encodeListLen)
+import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
 
 data E34
 

--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -29,12 +29,12 @@ module BlockChain
   )
 where
 
-import qualified Data.ByteString.Char8         as BS
-import           Numeric.Natural                ( Natural )
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.Map.Strict as Map
 import           Data.Ratio
-import qualified Data.Map.Strict               as Map
+import           Numeric.Natural (Natural)
 
-import           Cardano.Binary           (ToCBOR(toCBOR), encodeListLen)
+import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
 
 import           BaseTypes
 import           Delegation.Certificates
@@ -44,7 +44,7 @@ import           OCert
 import qualified Slot
 import           Tx
 
-import           NonIntegral                    ( (***) )
+import           NonIntegral ((***))
 
 -- |The hash of a Block Header
 newtype HashHeader hashAlgo dsignAlgo kesAlgo =

--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -160,7 +160,7 @@ bHeaderSize
 bHeaderSize = BS.length . BS.pack . show
 
 bBodySize :: DSIGNAlgorithm dsignAlgo => [Tx hashAlgo dsignAlgo] -> Int
-bBodySize txs = foldl (+) 0 (map (BS.length . BS.pack . show) txs)
+bBodySize txs = sum (map (BS.length . BS.pack . show) txs)
 
 slotToSeed :: Slot.Slot -> Seed
 slotToSeed (Slot.Slot s) = mkNonce (fromIntegral s)
@@ -197,7 +197,7 @@ instance VrfProof Seed where
   toSeed = id
 
 instance VrfProof UnitInterval where
-  toSeed u = mkNonce $ (numerator r * denominator r)
+  toSeed u = mkNonce (numerator r * denominator r)
     where r = intervalValue u
 
 vrfChecks
@@ -218,14 +218,14 @@ vrfChecks eta0 (PoolDistr pd) f bhb =
                          (bheaderPrfL bhb)
             && intervalValue (bheaderL bhb)
             <  1
-            -  ((1 - activeSlotsCoeff) *** (fromRational sigma))
+            -  ((1 - activeSlotsCoeff) *** fromRational sigma)
  where
   vk = bvkcold bhb
   hk = hashKey vk
   ss = slotToSeed $ bheaderSlot bhb
   f' = intervalValue f
   activeSlotsCoeff =
-    (fromIntegral $ numerator f') / (fromIntegral $ denominator f')
+    fromIntegral (numerator f') / fromIntegral (denominator f')
 
 seedEta :: Seed
 seedEta = mkNonce 0

--- a/shelley/chain-and-ledger/executable-spec/src/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Coin.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Coin
     (

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -18,16 +18,17 @@ module Delegation.Certificates
   ) where
 
 import           Coin (Coin (..))
-import           Keys
+import           Keys (DSIGNAlgorithm, HashAlgorithm, KeyHash, hashGenesisKey, hashKey)
 import           PParams (PParams (..), keyDecayRate, keyDeposit, keyMinRefund, poolDecayRate,
                      poolDeposit, poolMinRefund)
 import           Slot (Duration (..))
-import           TxData
+import           TxData (Credential (..), DCert (..), StakeCredential, StakeKeys (..),
+                     StakePools (..), delegator, poolPubKey)
 
-import           BaseTypes
+import           BaseTypes (FixedPoint, UnitInterval, fpEpsilon, intervalValue)
 import           NonIntegral (exp')
 
-import qualified Data.Map.Strict as Map
+import           Data.Map.Strict as Map (Map)
 import           Data.Ratio (approxRational)
 
 import           Lens.Micro ((^.))

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase #-}
+
 
 module Delegation.Certificates
   (

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -1,5 +1,3 @@
-
-
 module Delegation.Certificates
   (
     DCert(..)

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
@@ -1,7 +1,3 @@
-
-
-
-
 module Delegation.PoolParams
   ( poolSpec
   ) where

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TemplateHaskell #-}
+
+
+
 
 module Delegation.PoolParams
   ( poolSpec

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
@@ -8,9 +8,9 @@ module Delegation.PoolParams
 
 import           Lens.Micro ((^.))
 
-import           BaseTypes
+import           BaseTypes (UnitInterval)
 import           Coin (Coin)
-import           TxData
+import           TxData (PoolParams, poolCost, poolMargin, poolPledge)
 
 poolSpec :: PoolParams hashAlgo dsignAlgo -> (Coin, UnitInterval, Coin)
 poolSpec pool = (pool ^. poolCost, pool ^. poolMargin, pool ^. poolPledge)

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
@@ -6,10 +6,10 @@ module Delegation.PoolParams
   ( poolSpec
   ) where
 
-import           Lens.Micro    ((^.))
+import           Lens.Micro ((^.))
 
 import           BaseTypes
-import           Coin          (Coin)
+import           Coin (Coin)
 import           TxData
 
 poolSpec :: PoolParams hashAlgo dsignAlgo -> (Coin, UnitInterval, Coin)

--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
 
 {-|
 Module      : EpochBoundary
@@ -31,8 +31,8 @@ module EpochBoundary
   ) where
 
 import           Coin
-import           Delegation.Certificates (StakeKeys (..), StakePools (..),
-                                          decayKey, decayPool, refund)
+import           Delegation.Certificates (StakeKeys (..), StakePools (..), decayKey, decayPool,
+                     refund)
 import           Keys
 import           PParams hiding (a0, nOpt)
 import           Slot
@@ -40,16 +40,16 @@ import           Tx
 import           TxData
 import           UTxO hiding (dom)
 
-import qualified Data.Map.Strict         as Map
-import           Data.Maybe              (mapMaybe)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (mapMaybe)
 import           Data.Ratio
-import qualified Data.Set                as Set
+import qualified Data.Set as Set
 
-import           Numeric.Natural         (Natural)
+import           Numeric.Natural (Natural)
 
-import           Lens.Micro.TH           (makeLenses)
+import           Lens.Micro.TH (makeLenses)
 
-import           Ledger.Core ((◁), (▷), dom)
+import           Ledger.Core (dom, (▷), (◁))
 
 -- | Blocks made
 newtype BlocksMade hashAlgo dsignAlgo

--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -120,7 +120,7 @@ poolStake
   -> Stake hashAlgo dsignAlgo
   -> Stake hashAlgo dsignAlgo
 poolStake hk delegs (Stake stake) =
-  Stake $ (dom (delegs ▷ (Set.singleton hk))) ◁ stake
+  Stake $ dom (delegs ▷ Set.singleton hk) ◁ stake
 
 -- | Calculate pool refunds
 poolRefunds
@@ -174,7 +174,7 @@ groupByPool
 groupByPool active delegs =
   Map.fromListWith
     Map.union
-    [ (delegs Map.! hk, (Set.singleton hk) ◁ active)
+    [ (delegs Map.! hk, Set.singleton hk ◁ active)
     | hk <- Map.keys delegs
     ]
 

--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -30,19 +30,19 @@ module EpochBoundary
   , groupByPool
   ) where
 
-import           Coin
+import           Coin (Coin (..))
 import           Delegation.Certificates (StakeKeys (..), StakePools (..), decayKey, decayPool,
                      refund)
-import           Keys
-import           PParams hiding (a0, nOpt)
-import           Slot
-import           Tx
-import           TxData
-import           UTxO hiding (dom)
+import           Keys (KeyHash)
+import           PParams (PParams (..))
+import           Slot (Epoch, Slot, slotFromEpoch, (-*))
+import           TxData (Addr (..), PoolParams, Ptr, RewardAcnt, StakeCredential, TxOut (..),
+                     getRwdHK)
+import           UTxO (UTxO (..))
 
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (mapMaybe)
-import           Data.Ratio
+import           Data.Ratio ((%))
 import qualified Data.Set as Set
 
 import           Numeric.Natural (Natural)

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -38,42 +38,22 @@ module Keys
   )
 where
 
-import           Crypto.Random         (drgNewSeed, seedFromInteger, withDRG)
-import           Data.Maybe            (fromJust)
-import           Data.Typeable         (Typeable)
-import           Numeric.Natural       (Natural)
+import           Crypto.Random (drgNewSeed, seedFromInteger, withDRG)
+import           Data.Maybe (fromJust)
+import           Data.Typeable (Typeable)
+import           Numeric.Natural (Natural)
 
-import qualified Data.Map.Strict       as Map
-import qualified Data.Set              as Set
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
-import           Cardano.Binary        (ToCBOR(toCBOR))
-import           Cardano.Crypto.DSIGN  ( DSIGNAlgorithm
-                                         ( Signable
-                                         , SignKeyDSIGN
-                                         , VerKeyDSIGN
-                                         , encodeSigDSIGN
-                                         , encodeVerKeyDSIGN
-                                         )
-                                       , SignedDSIGN(SignedDSIGN)
-                                       , signedDSIGN
-                                       , verifySignedDSIGN
-                                       )
-import           Cardano.Crypto.Hash   ( Hash
-                                       , HashAlgorithm
-                                       , hash
-                                       , hashWithSerialiser
-                                       )
-import qualified Cardano.Crypto.KES    as KES
-import           Cardano.Crypto.KES    ( KESAlgorithm
-                                         ( SignKeyKES
-                                         , VerKeyKES
-                                         , encodeVerKeyKES
-                                         , encodeSigKES
-                                         )
-                                       , SignedKES(SignedKES)
-                                       , signedKES
-                                       , verifySignedKES
-                                       )
+import           Cardano.Binary (ToCBOR (toCBOR))
+import           Cardano.Crypto.DSIGN (DSIGNAlgorithm (SignKeyDSIGN, Signable, VerKeyDSIGN, encodeSigDSIGN, encodeVerKeyDSIGN),
+                     SignedDSIGN (SignedDSIGN), signedDSIGN, verifySignedDSIGN)
+import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hash, hashWithSerialiser)
+import           Cardano.Crypto.KES
+                     (KESAlgorithm (SignKeyKES, VerKeyKES, encodeSigKES, encodeVerKeyKES),
+                     SignedKES (SignedKES), signedKES, verifySignedKES)
+import qualified Cardano.Crypto.KES as KES
 
 newtype SKey dsignAlgo = SKey (SignKeyDSIGN dsignAlgo)
 

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
@@ -138,7 +139,7 @@ import           Delegation.PoolParams
 
 import           BaseTypes
 
-import           Ledger.Core ((◁), (▷), (∪+))
+import           Ledger.Core ((∪+), (▷), (◁))
 
 -- | Representation of a list of pairs of key pairs, e.g., pay and stake keys
 type KeyPairs dsignAlgo = [(KeyPair dsignAlgo, KeyPair dsignAlgo)]

--- a/shelley/chain-and-ledger/executable-spec/src/OCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/OCert.hs
@@ -7,10 +7,10 @@ module OCert
   , kesPeriod)
 where
 
-import           Cardano.Binary
+import           Cardano.Binary (ToCBOR, encodeListLen, toCBOR)
 
-import           Keys
-import qualified Slot
+import           Keys (DSIGNAlgorithm, KESAlgorithm, Sig, VKey, VKeyES)
+import           Slot (Slot (..))
 
 import           Numeric.Natural (Natural)
 
@@ -45,5 +45,5 @@ instance
 slotsPerKESPeriod :: Natural
 slotsPerKESPeriod = 90
 
-kesPeriod :: Slot.Slot -> KESPeriod
-kesPeriod (Slot.Slot s) = KESPeriod $ s `div` slotsPerKESPeriod
+kesPeriod :: Slot -> KESPeriod
+kesPeriod (Slot s) = KESPeriod $ s `div` slotsPerKESPeriod

--- a/shelley/chain-and-ledger/executable-spec/src/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/PParams.hs
@@ -28,7 +28,7 @@ module PParams
 
 import           Numeric.Natural (Natural)
 
-import           BaseTypes
+import           BaseTypes (Seed, UnitInterval, interval0, mkNonce)
 import           Coin (Coin (..))
 import           Slot (Epoch (..))
 

--- a/shelley/chain-and-ledger/executable-spec/src/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/PParams.hs
@@ -29,10 +29,10 @@ module PParams
 import           Numeric.Natural (Natural)
 
 import           BaseTypes
-import           Coin            (Coin (..))
-import           Slot            (Epoch(..))
+import           Coin (Coin (..))
+import           Slot (Epoch (..))
 
-import           Lens.Micro.TH   (makeLenses)
+import           Lens.Micro.TH (makeLenses)
 
 data PParams = PParams
   { -- |The linear factor for the minimum fee calculation

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Avup
   ( AVUP
   )
 where
 
-import qualified Data.Map.Strict               as Map
-import qualified Data.Set                      as Set
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 import           BlockChain
 import           Keys

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module STS.Bbody
   ( BBODY
   )
 where
 
-import qualified Data.Map.Strict               as Map
-import qualified Data.Set                      as Set
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 import           BlockChain
 import           EpochBoundary

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
@@ -59,9 +59,9 @@ bbodyTransition
      )
   => TransitionRule (BBODY hashAlgo dsignAlgo kesAlgo)
 bbodyTransition = do
-  TRC ((oslots, pp), (ls, b), (Block (BHeader bhb _) txs)) <- judgmentContext
+  TRC ((oslots, pp), (ls, b), Block (BHeader bhb _) txs) <- judgmentContext
   let hk = hashKey $ bvkcold bhb
-  bBodySize txs == (fromIntegral $ hBbsize bhb) ?! WrongBlockBodySizeBBODY
+  bBodySize txs == fromIntegral (hBbsize bhb) ?! WrongBlockBodySizeBBODY
 
   ls' <-
     trans @(LEDGERS hashAlgo dsignAlgo) $ TRC ((bheaderSlot bhb, pp), ls, txs)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
@@ -59,7 +59,7 @@ bheadTransition = do
   fromIntegral (hBbsize bhb) < _maxBBSize pp ?! BlockSizeTooLargeBHEAD
 
   nes' <- trans @(NEWEPOCH hashAlgo dsignAlgo)
-    $ TRC ((NewEpochEnv etaC slot gkeys), nes, epochFromSlot slot)
+    $ TRC (NewEpochEnv etaC slot gkeys, nes, epochFromSlot slot)
 
   ru' <- trans @(RUPD hashAlgo dsignAlgo) $ TRC ((bprev, es), ru, slot)
   let nes'' = nes' { nesRu = ru' }

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Bhead
   ( BHEAD
   )
 where
 
-import qualified Data.Set                      as Set
+import qualified Data.Set as Set
 
 import           BaseTypes
 import           BlockChain

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module STS.Chain
   ( CHAIN

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delegs.hs
@@ -14,7 +14,7 @@ import qualified Data.Map.Strict as Map
 import           Delegation.Certificates
 import           Keys
 import           LedgerState
-import           PParams hiding (d)
+import           PParams
 import           Slot
 import           Tx
 import           TxData
@@ -49,7 +49,7 @@ delegsTransition
    . (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => TransitionRule (DELEGS hashAlgo dsignAlgo)
 delegsTransition = do
-  TRC (env@(_slot, txIx, pp, (Tx txbody _ _)), dpstate, certificates) <- judgmentContext
+  TRC (env@(_slot, txIx, pp, Tx txbody _ _), dpstate, certificates) <- judgmentContext
   case certificates of
     [] -> do
       let wdrls' = _wdrls txbody

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Delpl
   ( DELPL
   )
 where
 
+import           Delegation.Certificates
 import           Keys
 import           LedgerState
-import           Delegation.Certificates
 import           PParams hiding (d)
 import           Slot
 import           TxData

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Epoch
   ( EPOCH
   )
 where
 
+import           EpochBoundary
 import           LedgerState
 import           PParams
-import           EpochBoundary
 import           Slot
 
 import           Control.State.Transition

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
@@ -1,16 +1,17 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module STS.Ledgers
   ( LEDGERS
   )
 where
 
-import           Control.Monad                  ( foldM )
+import           Control.Monad (foldM)
 
 import           Keys
 import           LedgerState

--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -1,17 +1,16 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.NewEpoch
   ( NEWEPOCH
   )
 where
 
-import qualified Data.Map.Strict               as Map
-import qualified Data.Maybe                    as Maybe
-                                                ( fromMaybe )
+import qualified Data.Map.Strict as Map
+import qualified Data.Maybe as Maybe (fromMaybe)
 
 import           BaseTypes
 import           Coin

--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -42,15 +42,15 @@ instance STS (NEWEPOCH hashAlgo dsignAlgo) where
         (mkNonce 0)
         (BlocksMade Map.empty)
         (BlocksMade Map.empty)
-        (emptyEpochState)
-        (Nothing)
+        emptyEpochState
+        Nothing
         (PoolDistr Map.empty)
-        (Map.empty)]
+        Map.empty]
   transitionRules = [ocertTransition]
 
 ocertTransition :: forall hashAlgo dsignAlgo . TransitionRule (NEWEPOCH hashAlgo dsignAlgo)
 ocertTransition = do
-  TRC ( (NewEpochEnv eta1 _s gkeys)
+  TRC ( NewEpochEnv eta1 _s gkeys
       , src@(NewEpochState (Epoch eL') _ bprev bcur es ru _pd _osched)
       , e@(Epoch e')) <- judgmentContext
   if eL' /= e' + 1
@@ -67,8 +67,8 @@ ocertTransition = do
       let osched'                  = overlaySchedule gkeys eta1 pp
       let es'' = EpochState acnt ss ls (pp { _extraEntropy = neutralSeed })
       let pd' = foldr
-            (\(hk, (Coin c)) m ->
-              Map.insertWith (+) hk ((fromIntegral c) / fromIntegral total) m
+            (\(hk, Coin c) m ->
+              Map.insertWith (+) hk (fromIntegral c / fromIntegral total) m
             )
             Map.empty
             [ (poolKey, Maybe.fromMaybe (Coin 0) (Map.lookup stakeKey stake))

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
@@ -1,22 +1,22 @@
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE TypeFamilies   #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Newpp
   ( NEWPP
   )
 where
 
-import qualified Data.Map.Strict               as Map
+import qualified Data.Map.Strict as Map
 
-import           Lens.Micro                     ( (^.) )
+import           Lens.Micro ((^.))
 
+import           Coin
 import           EpochBoundary
 import           LedgerState hiding (reserves)
 import           PParams
 import           Slot
 import           Updates
 import           UTxO
-import           Coin
 
 import           Control.State.Transition
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
@@ -37,7 +37,7 @@ instance STS (NEWPP hashAlgo dsignAlgo) where
 
 initialNewPp :: InitialRule (NEWPP hashAlgo dsignAlgo)
 initialNewPp = pure
-  ( UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) (emptyUpdateState)
+  ( UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState
   , emptyAccount
   , emptyPParams
   )
@@ -63,17 +63,9 @@ newPpTransition = do
           let utxoSt' = utxoSt { _deposited = Coin oblgNew }
           in  -- TODO: update mechanism
               let acnt' = acnt { _reserves = Coin $ reserves + diff }
-                                       in  pure $ (utxoSt', acnt', ppNew')
+                                       in  pure (utxoSt', acnt', ppNew')
         else
-          pure
-            $ ( (if reserves
-                     +  diff
-                     <  0
-                     || (_maxTxSize ppNew' + _maxBHSize ppNew')
-                     >= _maxBBSize ppNew'
-                  then utxoSt -- TODO update mechanism
-                  else utxoSt
-                )
+          pure ( utxoSt
               , acnt
               , pp
               )

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ocert.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE EmptyDataDecls       #-}
-{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module STS.Ocert
@@ -7,8 +8,8 @@ module STS.Ocert
   )
 where
 
-import qualified Data.Map.Strict               as Map
-import           Numeric.Natural                ( Natural )
+import qualified Data.Map.Strict as Map
+import           Numeric.Natural (Natural)
 
 import           BlockChain
 import           Keys

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Overlay.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module STS.Overlay
   ( OVERLAY
   )
 where
 
-import qualified Data.Map.Strict               as Map
-import           Numeric.Natural                ( Natural )
+import qualified Data.Map.Strict as Map
+import           Numeric.Natural (Natural)
 
 import           BaseTypes
 import           BlockChain

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -39,7 +39,7 @@ poolDelegationTransition
   :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => TransitionRule (POOL hashAlgo dsignAlgo)
 poolDelegationTransition = do
-  TRC ((slot, p@(Ptr _ _ _), pp), ps, c) <- judgmentContext
+  TRC ((slot, p@Ptr{}, pp), ps, c) <- judgmentContext
   case c of
     RegPool _              -> pure $ applyDCertPState p c ps
     RetirePool _ (Epoch e) -> do

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE TypeFamilies   #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Pool
   ( POOL
   )
 where
 
-import           Lens.Micro                     ( (^.) )
+import           Lens.Micro ((^.))
 
 import           Delegation.Certificates
 import           Keys

--- a/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
@@ -46,7 +46,7 @@ poolReapTransition = do
           Just _  -> Just (v ^. poolRAcnt)
         )
         (ps ^. pParams)
-  let rewardAcnts' = (Map.keysSet pr) ◁ rewardAcnts
+  let rewardAcnts' = Map.keysSet pr ◁ rewardAcnts
   let refunds' = Map.foldlWithKey
         (\m k addr -> Map.insert addr (pr Map.! k) m)
         Map.empty
@@ -57,15 +57,15 @@ poolReapTransition = do
   let unclaimed             = Map.foldl (+) (Coin 0) unclaimed'
   let StakePools stakePools = ps ^. stPools
 
-  let treasury' = (_treasury a) + unclaimed
+  let treasury' = _treasury a + unclaimed
 
-  let rewards'  = (_rewards ds) ∪+ refunds
-  let delegations' = Map.filter (flip Set.notMember retired) (_delegations ds)
+  let rewards'  = _rewards ds ∪+ refunds
+  let delegations' = Map.filter (`Set.notMember` retired) (_delegations ds)
 
   let stPools' = StakePools $ retired ⋪ stakePools
-  let pParams' = retired ⋪ (_pParams ps)
-  let retiring' = retired ⋪ (_retiring ps)
-  let cs' = retired ⋪ (_cCounters ps)
+  let pParams' = retired ⋪ _pParams ps
+  let retiring' = retired ⋪ _retiring ps
+  let cs' = retired ⋪ _cCounters ps
   pure
     ( a { _treasury = treasury' }
     , ds { _rewards = rewards'

--- a/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
@@ -1,25 +1,25 @@
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE TypeFamilies   #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.PoolReap
   ( POOLREAP
   )
 where
 
-import qualified Data.Map.Strict               as Map
-import qualified Data.Set                      as Set
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
-import           Lens.Micro                     ((^.))
+import           Lens.Micro ((^.))
 
+import           Coin
+import           Delegation.Certificates
 import           LedgerState
 import           PParams
 import           Slot
-import           Delegation.Certificates
-import           Coin
 
 import           Control.State.Transition
 
-import           Ledger.Core ((◁), (⋪), (∪+))
+import           Ledger.Core ((∪+), (⋪), (◁))
 
 data POOLREAP hashAlgo dsignAlgo
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Ppup
   ( PPUP
   )
 where
 
-import qualified Data.Map.Strict               as Map
-import qualified Data.Set                      as Set
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 import           BlockChain
 import           Keys

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications #-}
+
 {-# LANGUAGE TypeFamilies #-}
 
 module STS.Ppup
@@ -40,7 +40,7 @@ ppupTransition = do
   if Map.null pupS'
     then pure pupS
     else do
-      (not $ Map.keysSet pup' `Set.isSubsetOf` Map.keysSet _dms)
+      not (Map.keysSet pup' `Set.isSubsetOf` Map.keysSet _dms)
         ?! NonGenesisUpdatePPUP
       let Epoch slotEpoch = epochFromSlot (Slot 1)
       s

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-
 {-# LANGUAGE TypeFamilies #-}
 
 module STS.Ppup

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Prtcl.hs
@@ -1,17 +1,18 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module STS.Prtcl
   ( PRTCL
   )
 where
 
-import qualified Data.Map.Strict               as Map
-import           Numeric.Natural                ( Natural )
+import qualified Data.Map.Strict as Map
+import           Numeric.Natural (Natural)
 
 import           BaseTypes
 import           BlockChain

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE TypeFamilies   #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Rupd
   ( RUPD

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
@@ -30,9 +30,9 @@ instance STS (RUPD hashAlgo dsignAlgo) where
 rupdTransition :: TransitionRule (RUPD hashAlgo dsignAlgo)
 rupdTransition = do
   TRC ((b, es), ru, s) <- judgmentContext
-  let slot = (firstSlot $ epochFromSlot s) +* startRewards
+  let slot = firstSlot (epochFromSlot s) +* startRewards
   if s <= slot
     then pure ru
     else case ru of
       Nothing -> pure $ Just (createRUpd b es)
-      Just _  -> pure $ ru
+      Just _  -> pure ru

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
@@ -1,25 +1,21 @@
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE TypeFamilies   #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Snap
   ( SNAP
   )
 where
 
-import qualified Data.Map.Strict               as Map
+import qualified Data.Map.Strict as Map
 
-import           Lens.Micro                     ( (^.)
-                                                , (&)
-                                                , (.~)
-                                                , (%~)
-                                                )
+import           Lens.Micro ((%~), (&), (.~), (^.))
 
 import           Coin
 import           EpochBoundary
 import           LedgerState
 import           PParams hiding (d)
-import           Updates
 import           Slot
+import           Updates
 import           UTxO
 
 import           Control.State.Transition

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Up
   ( UP
   )
 where
 
-import qualified Data.Map.Strict               as Map
+import qualified Data.Map.Strict as Map
 
 import           Keys
 import           Slot

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE TypeFamilies   #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module STS.Updn
   ( UPDN

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
@@ -20,7 +20,7 @@ instance STS UPDN where
   type Environment UPDN = Seed
   data PredicateFailure UPDN = FailureUPDN
                                deriving (Show, Eq)
-  initialRules = [pure $ (mkNonce 0, mkNonce 0)]
+  initialRules = [pure (mkNonce 0, mkNonce 0)]
   transitionRules = [updTransition]
 
 updTransition :: TransitionRule UPDN

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -17,7 +17,7 @@ import           Lens.Micro ((%~), (&), (.~), (^.))
 import           Coin
 import           Delegation.Certificates
 import           Keys
-import           LedgerState hiding (dms)
+import           LedgerState
 import           PParams
 import           Slot
 import           Tx

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -9,13 +10,9 @@ module STS.Utxo
   )
 where
 
-import qualified Data.Map.Strict               as Map
+import qualified Data.Map.Strict as Map
 
-import           Lens.Micro                     ( (%~)
-                                                , (&)
-                                                , (^.)
-                                                , (.~)
-                                                )
+import           Lens.Micro ((%~), (&), (.~), (^.))
 
 import           Coin
 import           Delegation.Certificates

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
@@ -85,11 +85,11 @@ utxoWitnessed = do
   -- check multi-signature scripts
   let utxo' = _utxo u
 
-  (all (\(hs, validator) -> hashScript validator == hs
-      && validateScript validator tx) $ Map.toList $ txwitsScript tx)
+  all (\(hs, validator) -> hashScript validator == hs
+      && validateScript validator tx) (Map.toList $ txwitsScript tx)
     ?!ScriptWitnessNotValidatingUTXOW
 
-  scriptsNeeded utxo' tx == (Map.keysSet $ txwitsScript tx)
+  scriptsNeeded utxo' tx == Map.keysSet (txwitsScript tx)
     ?! MissingScriptWitnessesUTXOW
 
   trans @(UTXO hashAlgo dsignAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
@@ -1,9 +1,10 @@
-{-# LANGUAGE EmptyDataDecls        #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module STS.Utxow
   ( UTXOW
@@ -11,8 +12,8 @@ module STS.Utxow
   )
 where
 
-import qualified Data.Set                  as Set
-import qualified Data.Map.Strict           as Map
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
 import           Delegation.Certificates
 import           Keys

--- a/shelley/chain-and-ledger/executable-spec/src/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Tx.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TemplateHaskell #-}
+
 
 module Tx
   ( -- transaction
@@ -44,7 +44,7 @@ import           Cardano.Crypto.DSIGN (DSIGNAlgorithm)
 import           Data.Word (Word8)
 
 import qualified Data.Map.Strict as Map
-import qualified Data.Maybe as Maybe
+import           Data.Maybe (mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 
@@ -65,9 +65,9 @@ evalNativeMultiSigScript
   -> Bool
 evalNativeMultiSigScript (RequireSignature hk) vhks = Set.member hk vhks
 evalNativeMultiSigScript (RequireAllOf msigs) vhks =
-  all (flip evalNativeMultiSigScript vhks) msigs
+  all (`evalNativeMultiSigScript` vhks) msigs
 evalNativeMultiSigScript (RequireAnyOf msigs) vhks =
-  any (flip evalNativeMultiSigScript vhks) msigs
+  any (`evalNativeMultiSigScript` vhks) msigs
 evalNativeMultiSigScript (RequireMOf m msigs) vhks =
   m <= sum [if evalNativeMultiSigScript msig vhks then 1 else 0 | msig <- msigs]
 
@@ -115,20 +115,20 @@ txwitsVKey tx =
 txwitsScript
   :: Tx hashAlgo dsignAlgo
   -> Map.Map (ScriptHash hashAlgo dsignAlgo) (MultiSig hashAlgo dsignAlgo)
-txwitsScript tx = _witnessMSigMap tx
+txwitsScript = _witnessMSigMap
 
 extractKeyHash
   :: [StakeCredential hashAlgo dsignAlgo]
   -> [KeyHash hashAlgo dsignAlgo]
-extractKeyHash l =
-  Maybe.catMaybes $ map (\so -> case so of
-                                 KeyHashObj hk -> Just hk
-                                 _ -> Nothing) l
+extractKeyHash =
+  mapMaybe (\case
+                KeyHashObj hk -> Just hk
+                _ -> Nothing)
 
 extractScriptHash
   :: [StakeCredential hashAlgo dsignAlgo]
   -> [ScriptHash hashAlgo dsignAlgo]
-extractScriptHash l =
-  Maybe.catMaybes $ map (\so -> case so of
-                                 ScriptHashObj hk -> Just hk
-                                 _ -> Nothing) l
+extractScriptHash =
+  mapMaybe (\case
+                ScriptHashObj hk -> Just hk
+                _ -> Nothing)

--- a/shelley/chain-and-ledger/executable-spec/src/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Tx.hs
@@ -33,7 +33,7 @@ module Tx
 where
 
 
-import           Keys
+import           Keys (KeyHash, Sig, VKey, hashKey)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeWord8)
 
@@ -48,7 +48,9 @@ import           Data.Maybe (mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 
-import           TxData
+import           TxData (Credential (..), MultiSig (..), ScriptHash (..), StakeCredential, Tx (..),
+                     TxBody (..), TxId (..), TxIn (..), TxOut (..), WitVKey (..), body, certs,
+                     inputs, outputs, ttl, txUpdate, txfee, wdrls, witnessMSigMap, witnessVKeySet)
 
 -- | Typeclass for multis-signature script data types. Allows for script
 -- validation and hashing.

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -16,11 +16,11 @@ import           Data.Typeable (Typeable)
 import           Data.Word (Word8)
 import           Numeric.Natural (Natural)
 
-import           BaseTypes
-import           Coin
-import           Keys
-import           Slot
-import           Updates
+import           BaseTypes (UnitInterval)
+import           Coin (Coin)
+import           Keys (DSIGNAlgorithm, Hash, HashAlgorithm, KeyHash (..), Sig, VKey, VKeyGenesis)
+import           Slot (Epoch, Slot)
+import           Updates (Update)
 
 -- |The delegation of one stake key to another.
 data Delegation hashAlgo dsignAlgo = Delegation

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 {-|
 Module      : UTxO
@@ -191,14 +188,14 @@ scriptsNeeded
   -> Tx hashAlgo dsignAlgo
   -> Set (ScriptHash hashAlgo dsignAlgo)
 scriptsNeeded u tx =
-  (Set.fromList $ Map.elems $ Map.mapMaybe (getScriptHash . unTxOut) u'')
+  Set.fromList (Map.elems $ Map.mapMaybe (getScriptHash . unTxOut) u'')
   `Set.union`
-  (Set.fromList $ Maybe.catMaybes $ map (scriptStakeCred . getRwdHK) $ Map.keys withdrawals)
+  Set.fromList (Maybe.catMaybes $ map (scriptStakeCred . getRwdHK) $ Map.keys withdrawals)
   `Set.union`
-  (Set.fromList $ Maybe.catMaybes $ map (scriptStakeCred . cwitness) certificates)
+  Set.fromList (Maybe.catMaybes $ map (scriptStakeCred . cwitness) certificates)
   where unTxOut (TxOut a _) = a
         withdrawals = _wdrls $ _body tx
-        UTxO u'' = (txinsScript (txins $ _body tx) u) <| u
+        UTxO u'' = txinsScript (txins $ _body tx) u <| u
         certificates = _certs $ _body tx
 
 -- | Compute the subset of inputs of the set 'txInps' for which each input is
@@ -209,7 +206,7 @@ txinsScript
   -> Set (TxIn hashAlgo dsignAlgo)
 txinsScript txInps (UTxO u) =
   txInps `Set.intersection`
-  (Map.keysSet $ Map.filter (\(TxOut a _) ->
+  Map.keysSet (Map.filter (\(TxOut a _) ->
                                case a of
                                  AddrBase (ScriptHashObj _) _     -> True
                                  AddrEnterprise (ScriptHashObj _) -> True

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -42,10 +42,12 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 
 import           Coin (Coin (..))
-import           Keys
+import           Keys (DSIGNAlgorithm, HashAlgorithm, KeyPair, Signable, hash, hashKey, sKey, sign,
+                     vKey, verify)
 import           PParams (PParams (..))
-import           Tx
-import           TxData
+import           TxData (Addr (..), Credential (..), ScriptHash, StakeCredential, Tx (..),
+                     TxBody (..), TxId (..), TxIn (..), TxOut (..), WitVKey (..), getRwdHK, inputs,
+                     outputs, poolPubKey, txUpdate)
 import           Updates (Update)
 
 import           Delegation.Certificates (DCert (..), StakePools (..), cwitness, dvalue)

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
@@ -38,20 +38,20 @@ module UTxO
 
 import           Lens.Micro ((^.))
 
-import           Data.Map.Strict         (Map)
-import qualified Data.Map.Strict         as Map
-import qualified Data.Maybe              as Maybe
-import           Data.Set                (Set)
-import qualified Data.Set                as Set
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Maybe as Maybe
+import           Data.Set (Set)
+import qualified Data.Set as Set
 
-import           Coin                    (Coin (..))
+import           Coin (Coin (..))
 import           Keys
-import           PParams                 (PParams(..))
-import           Updates                 (Update)
+import           PParams (PParams (..))
 import           Tx
 import           TxData
+import           Updates (Update)
 
-import           Delegation.Certificates (StakePools(..), DCert (..), dvalue, cwitness)
+import           Delegation.Certificates (DCert (..), StakePools (..), cwitness, dvalue)
 
 -- |The unspent transaction outputs.
 newtype UTxO hashAlgo dsignAlgo

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -25,12 +25,12 @@ import           Data.Word (Word8)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
 
-import           BaseTypes
-import           Coin
-import           Keys
-import           Slot
+import           BaseTypes (Seed, UnitInterval)
+import           Coin (Coin)
+import           Keys (DSIGNAlgorithm, Dms, VKeyGenesis)
+import           Slot (Epoch, Slot)
 
-import           Numeric.Natural
+import           Numeric.Natural (Natural)
 
 import           Ledger.Core ((∪))
 

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -152,7 +152,7 @@ updatePPup
   => PPUpdate dsignAlgo
   -> PPUpdate dsignAlgo
   -> PPUpdate dsignAlgo
-updatePPup (PPUpdate pup0') (PPUpdate pup1') = PPUpdate $ (pup1' ∪ pup0')
+updatePPup (PPUpdate pup0') (PPUpdate pup1') = PPUpdate (pup1' ∪ pup0')
 
 newAVs :: Applications -> Map.Map Slot Applications -> Applications
 newAVs avs favs = if not $ Map.null favs

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -18,13 +18,12 @@ module Updates
   )
 where
 
-import           Data.ByteString                  (ByteString)
-import qualified Data.Map.Strict               as Map
-import qualified Data.List                     as List
-                                                ( group )
+import           Data.ByteString (ByteString)
+import qualified Data.List as List (group)
+import qualified Data.Map.Strict as Map
 import           Data.Word (Word8)
 
-import           Cardano.Binary (ToCBOR(toCBOR), encodeListLen)
+import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
 
 import           BaseTypes
 import           Coin

--- a/shelley/chain-and-ledger/executable-spec/test/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator.hs
@@ -22,33 +22,31 @@ module Generator
     ) where
 
 import qualified Data.Map.Strict as Map
-import qualified Data.Set        as Set
-import Data.Ratio
+import           Data.Ratio
+import qualified Data.Set as Set
 
-import           Lens.Micro              ((^.))
+import           Lens.Micro ((^.))
 
 import           Numeric.Natural
 
 import           Hedgehog
-import qualified Hedgehog.Gen    as Gen
-import qualified Hedgehog.Range  as Range
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
-import           TxData (pattern AddrBase, pattern KeyHashObj, pattern Delegation,
-                         pattern PoolParams, RewardAcnt(..), pattern Delegate,
-                         pattern DeRegKey, pattern RegKey, pattern RegPool,
-                         pattern RetirePool, StakeKeys(..))
 import           BaseTypes
 import           Coin
 import           Keys (pattern KeyPair, hashKey, vKey)
-import           LedgerState (pattern LedgerValidation, ValidationError (..),
-                     _delegationState, _dstate, asStateTransition,
-                     asStateTransition', genesisState, DState(..), utxoState,
-                     utxo, dstate, stKeys)
+import           LedgerState (DState (..), pattern LedgerValidation, ValidationError (..),
+                     asStateTransition, asStateTransition', dstate, genesisState, stKeys, utxo,
+                     utxoState, _delegationState, _dstate)
+import           PParams (PParams (..), emptyPParams)
 import           Slot
+import           Tx (pattern Tx, pattern TxBody, pattern TxOut)
+import           TxData (pattern AddrBase, pattern DeRegKey, pattern Delegate, pattern Delegation,
+                     pattern KeyHashObj, pattern PoolParams, pattern RegKey, pattern RegPool,
+                     pattern RetirePool, RewardAcnt (..), StakeKeys (..))
 import           Updates
-import           Tx(pattern Tx, pattern TxBody, pattern TxOut)
 import           UTxO (pattern UTxO, balance, makeWitnessVKey)
-import           PParams (PParams(..), emptyPParams)
 
 import           MockTypes
 import           Mutator

--- a/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
@@ -17,28 +17,26 @@ module Mutator
     , getAnyStakeKey
     ) where
 
-import Data.Maybe                (fromMaybe)
-import Data.Ratio
-import Data.Set                  as Set
-import Numeric.Natural
+import           Data.Maybe (fromMaybe)
+import           Data.Ratio
+import           Data.Set as Set
+import           Numeric.Natural
 
-import Hedgehog
-import qualified Hedgehog.Gen    as Gen
-import qualified Hedgehog.Range  as Range
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 import           BaseTypes
 import           Coin
-import           Delegation.Certificates  (pattern Delegate, pattern DeRegKey,
-                     pattern GenesisDelegate, pattern RegKey, pattern RegPool,
-                     pattern RetirePool)
-import           Keys (vKey, hashKey)
+import           Delegation.Certificates (pattern DeRegKey, pattern Delegate,
+                     pattern GenesisDelegate, pattern RegKey, pattern RegPool, pattern RetirePool)
+import           Keys (hashKey, vKey)
 import           Updates
 
 import           Slot
-import           Tx (pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut,
-                      _body, _certs, _inputs, _outputs, _ttl, _txfee, _wdrls,
-                      _witnessVKeySet, _witnessMSigMap)
-import           TxData (Credential(..), PoolParams(..), pattern Delegation)
+import           Tx (pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut, _body, _certs,
+                     _inputs, _outputs, _ttl, _txfee, _wdrls, _witnessMSigMap, _witnessVKeySet)
+import           TxData (Credential (..), pattern Delegation, PoolParams (..))
 
 import           MockTypes
 

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -1,31 +1,29 @@
+{-# LANGUAGE DoAndIfThenElse #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE DoAndIfThenElse #-}
 
 module PropertyTests (propertyTests) where
 
-import qualified Data.Map.Strict         as Map
-import           Data.MultiSet           (unions, fromSet, occur, filter, size)
-import qualified Data.Set                as Set
+import qualified Data.Map.Strict as Map
+import           Data.MultiSet (filter, fromSet, occur, size, unions)
+import qualified Data.Set as Set
 
-import           Lens.Micro              ((^.), (&), (%~), (.~))
+import           Lens.Micro ((%~), (&), (.~), (^.))
 
+import           Hedgehog.Internal.Property (LabelName (..))
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
-import           Hedgehog.Internal.Property (LabelName(..))
 
 import           Hedgehog
-import qualified Hedgehog.Gen    as Gen
+import qualified Hedgehog.Gen as Gen
 
 import           Coin
 import           LedgerState hiding (dms)
-import           Slot
 import           PParams
-import           Tx (pattern TxIn, pattern TxOut, _body, _witnessVKeySet, body
-                    , certs, inputs, outputs, witnessVKeySet)
-import           UTxO ( (<|),
-                     balance, deposits, makeWitnessVKey,
-                     txid, txins, txouts, verifyWitVKey)
+import           Slot
+import           Tx (pattern TxIn, pattern TxOut, body, certs, inputs, outputs, witnessVKeySet,
+                     _body, _witnessVKeySet)
+import           UTxO (balance, deposits, makeWitnessVKey, txid, txins, txouts, verifyWitVKey, (<|))
 
 import           Generator
 import           MockTypes

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -3,40 +3,36 @@
 
 module UnitTests (unitTests) where
 
-import           Control.Monad           (foldM)
-import           Data.Map.Strict         (Map)
-import qualified Data.Map.Strict         as Map
-import qualified Data.Set                as Set
-import           Data.Maybe              (fromMaybe)
+import           Control.Monad (foldM)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
+import qualified Data.Set as Set
 
-import           Lens.Micro              ((^.), (&), (.~))
+import           Lens.Micro ((&), (.~), (^.))
 
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
 import           Address
-import           TxData (pattern AddrBase, pattern Ptr, Credential(..),
-                         Delegation (..), pattern PoolParams, pattern RewardAcnt,
-                         _poolAltAcnt, _poolCost, _poolMargin, _poolOwners,
-                         _poolPubKey, _poolPledge, _poolPledges, _poolRAcnt)
 import           BaseTypes
 import           Coin
-import           Delegation.Certificates (pattern Delegate, pattern RegKey,
-                     pattern RegPool, pattern RetirePool, StakePools(..),
-                     StakeKeys(..))
+import           Delegation.Certificates (pattern Delegate, pattern RegKey, pattern RegPool,
+                     pattern RetirePool, StakeKeys (..), StakePools (..))
+import           TxData (pattern AddrBase, Credential (..), Delegation (..), pattern PoolParams,
+                     pattern Ptr, pattern RewardAcnt, _poolAltAcnt, _poolCost, _poolMargin,
+                     _poolOwners, _poolPledge, _poolPledges, _poolPubKey, _poolRAcnt)
 
 import           Keys (pattern Dms, pattern KeyPair, hashKey, vKey)
-import           LedgerState (pattern LedgerState, pattern UTxOState,
-                     ValidationError(..), _delegationState, _dms, _dstate,
-                     asStateTransition, delegations, delegationState, dstate,
-                     emptyDelegation, genesisId, genesisState, minfee, pParams,
-                     pstate, ptrs, retiring, rewards, stKeys, stPools)
+import           LedgerState (pattern LedgerState, pattern UTxOState, ValidationError (..),
+                     asStateTransition, delegationState, delegations, dstate, emptyDelegation,
+                     genesisId, genesisState, minfee, pParams, pstate, ptrs, retiring, rewards,
+                     stKeys, stPools, _delegationState, _dms, _dstate)
 import           PParams
 import           Slot
+import           Tx (pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut, body, ttl)
 import           Updates
-import           UTxO
-                     (pattern UTxO, makeWitnessVKey, makeWitnessesVKey, txid)
-import           Tx (pattern TxBody, pattern TxIn, pattern TxOut, pattern Tx, body, ttl)
+import           UTxO (pattern UTxO, makeWitnessVKey, makeWitnessesVKey, txid)
 
 import           MockTypes
 


### PR DESCRIPTION
- running stylish-haskell on everything. sadly I had to get rid of `via`. (and I had to add `FlexibleContexts` in a few files).
- running hlint on everything. There are still a few warnings in `test/Generators.hs`, `tests/PropertyTests.hs`, and `src/UTxO.hs` that I couldn't get to work.
- switching to explicit imports. I got everything except the `src/STS` folder.
