### PR TITLE
CHAIN example new epoch transition

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
@@ -14,7 +14,6 @@ module BaseTypes
   , Seed(..)
   , mkNonce
   , seedOp
-  , neutralSeed
   ) where
 
 
@@ -80,9 +79,6 @@ seedOp :: Seed -> Seed -> Seed
 seedOp NeutralSeed s = s
 seedOp s NeutralSeed = s
 seedOp a b = SeedOp a b
-
-neutralSeed :: Seed
-neutralSeed = NeutralSeed
 
 mkNonce :: Integer -> Seed
 mkNonce = Nonce

--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -6,6 +6,7 @@ module BlockChain
   , BHeader(..)
   , Block(..)
   , Proof(..)
+  , ProtVer(..)
   , bhHash
   , bhbHash
   , bHeaderSize
@@ -39,7 +40,7 @@ import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
 import           BaseTypes (Seed (..), UnitInterval, intervalValue, mkNonce, seedOp)
 import           Delegation.Certificates (PoolDistr (..))
 import           EpochBoundary (BlocksMade (..))
-import           Keys (DSIGNAlgorithm, Hash, HashAlgorithm, KESAlgorithm, KESig, KeyHash, Sig, VKey,
+import           Keys (DSIGNAlgorithm, Hash, HashAlgorithm, KESAlgorithm, KESig, KeyHash, VKey,
                      hash, hashKey)
 import           OCert (OCert (..))
 import           Slot (Duration, Slot (..))
@@ -101,6 +102,16 @@ instance
        <> toCBOR bHBody
        <> toCBOR kESig
 
+data ProtVer = ProtVer Natural Natural Natural
+  deriving (Show, Eq, Ord)
+
+instance ToCBOR ProtVer where
+  toCBOR (ProtVer x y z) =
+     encodeListLen 3
+       <> toCBOR x
+       <> toCBOR y
+       <> toCBOR z
+
 data BHBody hashAlgo dsignAlgo kesAlgo = BHBody
   { -- | Hash of the previous block header
     -- The first block in a chain will set this field to Nothing.
@@ -120,14 +131,14 @@ data BHBody hashAlgo dsignAlgo kesAlgo = BHBody
   , bheaderL              :: UnitInterval
     -- | proof of leader election
   , bheaderPrfL           :: Proof dsignAlgo UnitInterval
-    -- | signature of block body
-  , bheaderBlockSignature :: Sig dsignAlgo [Tx hashAlgo dsignAlgo]
     -- | Size of the block body
   , bsize                 :: Natural
     -- | Hash of block body
   , bhash                 :: HashBBody hashAlgo dsignAlgo kesAlgo
     -- | operational certificate
   , bheaderOCert          :: OCert dsignAlgo kesAlgo
+    -- | protocol version
+  , bprotvert          :: ProtVer
   } deriving (Show, Eq)
 
 instance
@@ -143,10 +154,10 @@ instance
       <> toCBOR (bheaderPrfEta bhBody)
       <> toCBOR (bheaderL bhBody)
       <> toCBOR (bheaderPrfL bhBody)
-      <> toCBOR (bheaderBlockSignature bhBody)
       <> toCBOR (bsize bhBody)
       <> toCBOR (bhash bhBody)
       <> toCBOR (bheaderOCert bhBody)
+      <> toCBOR (bprotvert bhBody)
 
 data Block hashAlgo dsignAlgo kesAlgo
   = Block

--- a/shelley/chain-and-ledger/executable-spec/src/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/PParams.hs
@@ -28,7 +28,7 @@ module PParams
 
 import           Numeric.Natural (Natural)
 
-import           BaseTypes (Seed, UnitInterval, interval0, mkNonce)
+import           BaseTypes (Seed (NeutralSeed), UnitInterval, interval0)
 import           Coin (Coin (..))
 import           Slot (Epoch (..))
 
@@ -101,6 +101,6 @@ emptyPParams =
      , _tau = interval0
      , _activeSlotCoeff = interval0
      , _d = interval0
-     , _extraEntropy = mkNonce 0
+     , _extraEntropy = NeutralSeed
      , _protocolVersion = (0, 0, 0)
      }

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
@@ -50,7 +50,7 @@ bheadTransition
    . (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo)
   => TransitionRule (BHEAD hashAlgo dsignAlgo kesAlgo)
 bheadTransition = do
-  TRC ((etaC, gkeys), nes@(NewEpochState _ _ bprev _ es ru _ _), bh@(BHeader bhb _)) <-
+  TRC ((etaC, gkeys), nes@(NewEpochState _ _ bprev _ es _ _ _), bh@(BHeader bhb _)) <-
     judgmentContext
   let slot                = bheaderSlot bhb
   let EpochState _ _ _ pp = es
@@ -61,7 +61,7 @@ bheadTransition = do
   nes' <- trans @(NEWEPOCH hashAlgo dsignAlgo)
     $ TRC (NewEpochEnv etaC slot gkeys, nes, epochFromSlot slot)
 
-  ru' <- trans @(RUPD hashAlgo dsignAlgo) $ TRC ((bprev, es), ru, slot)
+  ru' <- trans @(RUPD hashAlgo dsignAlgo) $ TRC ((bprev, es), (nesRu nes'), slot)
   let nes'' = nes' { nesRu = ru' }
   pure nes''
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
@@ -48,7 +48,7 @@ epochTransition = do
     trans @(SNAP hashAlgo dsignAlgo) $ TRC ((pp, ds, ps, blocks), (ss, us), e)
   (as', ds', ps') <-
     trans @(POOLREAP hashAlgo dsignAlgo) $ TRC (pp, (as, ds, ps), e)
-  let ppNew = undefined -- TODO: result from votedValuePParams
+  let ppNew = Just pp -- TODO: result from votedValuePParams
   (us'', as'', pp') <-
     trans @(NEWPP hashAlgo dsignAlgo)
       $ TRC ((ppNew, ds', ps'), (us', as', pp), e)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -46,14 +46,14 @@ instance STS (NEWEPOCH hashAlgo dsignAlgo) where
         Nothing
         (PoolDistr Map.empty)
         Map.empty]
-  transitionRules = [ocertTransition]
+  transitionRules = [newEpochTransition]
 
-ocertTransition :: forall hashAlgo dsignAlgo . TransitionRule (NEWEPOCH hashAlgo dsignAlgo)
-ocertTransition = do
+newEpochTransition :: forall hashAlgo dsignAlgo . TransitionRule (NEWEPOCH hashAlgo dsignAlgo)
+newEpochTransition = do
   TRC ( NewEpochEnv eta1 _s gkeys
       , src@(NewEpochState (Epoch eL') _ bprev bcur es ru _pd _osched)
       , e@(Epoch e')) <- judgmentContext
-  if eL' /= e' + 1
+  if eL' + 1 /= e'
     then pure src
     else do
       let es_ = case ru of
@@ -64,8 +64,8 @@ ocertTransition = do
       let (Stake stake, delegs)    = _pstakeSet ss
       let Coin total               = Map.foldl (+) (Coin 0) stake
       let etaE                     = _extraEntropy pp
-      let osched'                  = overlaySchedule gkeys eta1 pp
-      let es'' = EpochState acnt ss ls (pp { _extraEntropy = neutralSeed })
+      let osched'                  = overlaySchedule e gkeys eta1 pp
+      let es'' = EpochState acnt ss ls (pp { _extraEntropy = NeutralSeed })
       let pd' = foldr
             (\(hk, Coin c) m ->
               Map.insertWith (+) hk (fromIntegral c / fromIntegral total) m

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -33,10 +33,8 @@ data PoolParams hashAlgo dsignAlgo =
   PoolParams
     { _poolPubKey  :: VKey dsignAlgo
     , _poolPledge  :: Coin
-    , _poolPledges :: Map (VKey dsignAlgo) Coin -- TODO not updated currently
     , _poolCost    :: Coin
     , _poolMargin  :: UnitInterval
-    , _poolAltAcnt :: Maybe (KeyHash hashAlgo dsignAlgo)
     , _poolRAcnt   :: RewardAcnt hashAlgo dsignAlgo
     , _poolOwners  :: Set (KeyHash hashAlgo dsignAlgo)
     } deriving (Show, Eq, Ord)
@@ -352,10 +350,8 @@ instance
     encodeListLen 8
       <> toCBOR (_poolPubKey poolParams)
       <> toCBOR (_poolPledge poolParams)
-      <> toCBOR (_poolPledges poolParams)
       <> toCBOR (_poolCost poolParams)
       <> toCBOR (_poolMargin poolParams)
-      <> toCBOR (_poolAltAcnt poolParams)
       <> toCBOR (_poolRAcnt poolParams)
       <> toCBOR (_poolOwners poolParams)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -4,9 +4,12 @@ module Examples
   ( CHAINExample(..)
   , ex1
   , ex2
+  , ex3
+  , ex4
   )
 where
 
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (empty, fromList, singleton)
 import           Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
@@ -15,39 +18,38 @@ import           Data.Word (Word64)
 import           Cardano.Crypto.DSIGN (deriveVerKeyDSIGN, genKeyDSIGN)
 import           Cardano.Crypto.KES (deriveVerKeyKES, genKeyKES)
 import           Crypto.Random (drgNewTest, withDRG)
-import           MockTypes (Addr, BHBody, BHeader, Block, Credential, DState, EpochState,
-                     HashHeader, KeyPair, LedgerState, NewEpochState, PState, SKey, SKeyES, Tx,
-                     TxBody, UTxO, UTxOState, VKey, VKeyES, VKeyGenesis)
+import           MockTypes (Addr, Block, Credential, DState, EpochState, HashHeader, KeyHash,
+                     KeyPair, LedgerState, NewEpochState, PState, PoolParams, SKey, SKeyES,
+                     SnapShots, Tx, TxBody, UTxO, UTxOState, VKey, VKeyES, VKeyGenesis)
+import           Numeric.Natural (Natural)
 
 import           BaseTypes (Seed (..), UnitInterval, mkUnitInterval)
 import           BlockChain (pattern BHBody, pattern BHeader, pattern Block, pattern Proof,
-                     bBodySize, bhHash, bhbHash)
+                     ProtVer (..), bBodySize, bhHash, bhbHash, bheader)
 import           Coin (Coin (..))
-import           Delegation.Certificates (PoolDistr (..), pattern RegKey)
-import           EpochBoundary (BlocksMade (..), emptySnapShots)
+import           Delegation.Certificates (PoolDistr (..), pattern RegKey, pattern RegPool)
+import           EpochBoundary (BlocksMade (..), emptySnapShots, _feeSS, _poolsSS)
 import           Keys (pattern Dms, pattern KeyPair, pattern SKey, pattern SKeyES, pattern VKey,
                      pattern VKeyES, pattern VKeyGenesis, hashKey, sKey, sign, signKES, vKey)
 import           LedgerState (pattern DPState, pattern EpochState, pattern LedgerState,
-                     pattern NewEpochState, pattern UTxOState, emptyAccount, emptyDState,
-                     emptyPState, genesisCoins, genesisId, _cCounters, _dms, _ptrs, _rewards,
-                     _stKeys)
+                     pattern NewEpochState, pattern RewardUpdate, pattern UTxOState, deltaF,
+                     deltaR, deltaT, emptyAccount, emptyDState, emptyPState, genesisCoins,
+                     genesisId, overlaySchedule, rs, _cCounters, _dms, _pParams, _ptrs, _rewards,
+                     _stKeys, _stPools)
 import           OCert (KESPeriod (..), pattern OCert)
 import           PParams (PParams (..), emptyPParams)
 import           Slot (Epoch (..), Slot (..))
-import           TxData (pattern AddrBase, pattern KeyHashObj, Ptr (..), pattern RewardAcnt,
-                     pattern StakeKeys, pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut)
+import           TxData (pattern AddrBase, pattern KeyHashObj, pattern PoolParams, Ptr (..),
+                     pattern RewardAcnt, pattern StakeKeys, pattern StakePools, pattern Tx,
+                     pattern TxBody, pattern TxIn, pattern TxOut, _poolCost, _poolMargin,
+                     _poolOwners, _poolPledge, _poolPubKey, _poolRAcnt)
 import           Updates (emptyUpdate, emptyUpdateState)
 import           UTxO (pattern UTxO, makeWitnessesVKey, txid)
 
 
-data CHAINExample =
-  CHAINExample
-    Slot
-    (NewEpochState, Seed, Seed, Maybe HashHeader, Slot)
-    Block
-    (NewEpochState, Seed, Seed, Maybe HashHeader, Slot)
-
 type ChainState = (NewEpochState, Seed, Seed, Maybe HashHeader, Slot)
+
+data CHAINExample = CHAINExample Slot ChainState Block ChainState
 
 
 -- | Set up keys for all the actors in the examples.
@@ -85,6 +87,13 @@ aliceStake :: KeyPair
 aliceStake = KeyPair vk sk
   where (sk, vk) = mkKeyPair (1, 1, 1, 1, 1)
 
+aliceOperator :: KeyPair
+aliceOperator = KeyPair vk sk
+  where (sk, vk) = mkKeyPair (10, 10, 10, 10, 10)
+
+aliceOperatorHK :: KeyHash
+aliceOperatorHK = hashKey $ vKey aliceOperator
+
 aliceAddr :: Addr
 aliceAddr = mkAddr (alicePay, aliceStake)
 
@@ -108,8 +117,54 @@ aliceInitCoin = 10000
 bobInitCoin :: Coin
 bobInitCoin = 1000
 
+alicePoolParams :: PoolParams
+alicePoolParams =
+  PoolParams
+    { _poolPubKey = vKey aliceOperator
+    , _poolPledge = Coin 1
+    , _poolCost = Coin 5
+    , _poolMargin = unsafeMkUnitInterval 0.1
+    , _poolRAcnt = RewardAcnt aliceSHK
+    , _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake
+    }
+
+
+-- | Helper Functions
+
+
+mkBlock :: Maybe HashHeader -> KeyPair -> (SKeyES, VKeyES) -> [Tx] -> Slot -> Seed -> Seed
+  -> UnitInterval -> Natural -> Block
+mkBlock prev cold (shot, vhot) txns s enonce bnonce l kesPeriod =
+  let
+    bhb = BHBody
+            prev
+            (vKey cold)
+            s
+            bnonce
+            (Proof (vKey cold) enonce)
+            l
+            (Proof (vKey cold) l)
+            (fromIntegral $ bBodySize txns)
+            (bhbHash [txEx2])
+            (OCert
+              vhot
+              (vKey cold)
+              0
+              (KESPeriod 0)
+              (sign (sKey cold) (vhot, 0, KESPeriod 0))
+            )
+            (ProtVer 0 0 0)
+    bh = BHeader bhb (Keys.signKES shot bhb kesPeriod)
+  in
+    Block bh txns
+
+unsafeMkUnitInterval :: Rational -> UnitInterval
+unsafeMkUnitInterval r =
+  fromMaybe (error "could not construct unit interval") $ mkUnitInterval r
+
 
 -- | Example 1 - apply CHAIN transition to an empty block
+
 
 utxostEx1 :: UTxOState
 utxostEx1 = UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState
@@ -124,9 +179,12 @@ lsEx1 :: LedgerState
 lsEx1 = LedgerState utxostEx1 (DPState dsEx1 psEx1) 0
 
 ppsEx1 :: PParams
-ppsEx1 = emptyPParams { _maxBBSize = 1000
-                   , _maxBHSize = 1000
-                   , _keyDeposit = Coin 7 }
+ppsEx1 = emptyPParams { _maxBBSize = 10000
+                   , _maxBHSize = 10000
+                   , _keyDeposit = Coin 7
+                   , _poolDeposit = Coin 250
+                   , _d = unsafeMkUnitInterval 0.5
+                   , _activeSlotCoeff = unsafeMkUnitInterval 0.1 }
 
 esEx1 :: EpochState
 esEx1 = EpochState emptyAccount emptySnapShots lsEx1 ppsEx1
@@ -150,35 +208,12 @@ initStEx1 =
   )
 
 zero :: UnitInterval
-zero = fromMaybe (error "could not construct unit interval") $ mkUnitInterval 0
-
-bhbEx1 :: BHBody
-bhbEx1 = BHBody
-        Nothing
-        (vKey gerolamoCold)
-        (Slot 1)
-        (Nonce 1)
-        (Proof (vKey gerolamoCold) (Nonce 0))
-        zero
-        (Proof (vKey gerolamoCold) zero)
-        (sign (sKey gerolamoCold) [])
-        0
-        (bhbHash [])
-        (OCert
-          (snd gerolamoHot)
-          (vKey gerolamoCold)
-          0
-          (KESPeriod 0)
-          (sign (sKey gerolamoCold) (snd gerolamoHot, 0, KESPeriod 0))
-        )
-
-bhEx1 :: BHeader
-bhEx1 = BHeader bhbEx1 (Keys.signKES (fst gerolamoHot) bhbEx1 0)
+zero = unsafeMkUnitInterval 0
 
 blockEx1 :: Block
-blockEx1 = Block bhEx1 []
+blockEx1 = mkBlock Nothing gerolamoCold gerolamoHot [] slot1 (Nonce 0) (Nonce 1) zero 0
 
-expectedStEx1 :: (NewEpochState, Seed, Seed, Maybe HashHeader, Slot)
+expectedStEx1 :: ChainState
 expectedStEx1 =
   ( NewEpochState
       (Epoch 0)
@@ -192,7 +227,7 @@ expectedStEx1 =
       (Map.singleton (Slot 1) (Just gerolamoVKG))
   , SeedOp (Nonce 0) (Nonce 1)
   , SeedOp (Nonce 0) (Nonce 1)
-  , Just (bhHash bhEx1)
+  , Just (bhHash (bheader blockEx1))
   , Slot 1
   )
 
@@ -203,7 +238,7 @@ ex1 :: CHAINExample
 ex1 = CHAINExample slot1 initStEx1 blockEx1 expectedStEx1
 
 
--- | Example 2 - apply CHAIN transition to register a stake key
+-- | Example 2 - apply CHAIN transition to register a stake key and a pool
 
 
 utxoEx2 :: UTxO
@@ -214,15 +249,17 @@ utxoEx2 = genesisCoins
 txbodyEx2 :: TxBody
 txbodyEx2 = TxBody
            (Set.fromList [TxIn genesisId 0])
-           [TxOut aliceAddr (Coin 9990)]
-           [ RegKey $ (KeyHashObj . hashKey) $ vKey aliceStake ]
+           [TxOut aliceAddr (Coin 9740)]
+           [ RegKey $ (KeyHashObj . hashKey) $ vKey aliceStake
+           ,RegPool alicePoolParams
+           ]
            Map.empty
            (Coin 3)
            (Slot 10)
            emptyUpdate
 
 txEx2 :: Tx
-txEx2 = Tx txbodyEx2 (makeWitnessesVKey txbodyEx2 [alicePay, aliceStake]) Map.empty
+txEx2 = Tx txbodyEx2 (makeWitnessesVKey txbodyEx2 [alicePay, aliceStake, aliceOperator]) Map.empty
 
 utxostEx2 :: UTxOState
 utxostEx2 = UTxOState utxoEx2 (Coin 0) (Coin 0) emptyUpdateState
@@ -232,6 +269,12 @@ lsEx2 = LedgerState utxostEx2 (DPState dsEx1 psEx1) 0
 
 esEx2 :: EpochState
 esEx2 = EpochState emptyAccount emptySnapShots lsEx2 ppsEx1
+
+overlayEx2 :: Map Slot (Maybe VKeyGenesis)
+overlayEx2 =
+  Map.fromList [ (Slot 1, Just gerolamoVKG)
+                , (Slot 89, Just gerolamoVKG)
+                ]
 
 initStEx2 :: ChainState
 initStEx2 =
@@ -243,56 +286,42 @@ initStEx2 =
       esEx2
       Nothing
       (PoolDistr Map.empty)
-      (Map.singleton (Slot 1) (Just gerolamoVKG))
-      -- The overlay schedule has one entry, setting Gerolamo to slot 1.
+      overlayEx2
   , Nonce 0
   , Nonce 0
   , Nothing
   , Slot 0
   )
 
-bhbEx2 :: BHBody
-bhbEx2 = BHBody
-        Nothing
-        (vKey gerolamoCold)
-        (Slot 1)
-        (Nonce 1)
-        (Proof (vKey gerolamoCold) (Nonce 0))
-        zero
-        (Proof (vKey gerolamoCold) zero)
-        (sign (sKey gerolamoCold) [])
-        (fromIntegral $ bBodySize [txEx2])
-        (bhbHash [txEx2])
-        (OCert
-          (snd gerolamoHot)
-          (vKey gerolamoCold)
-          0
-          (KESPeriod 0)
-          (sign (sKey gerolamoCold) (snd gerolamoHot, 0, KESPeriod 0))
-        )
-
-bhEx2 :: BHeader
-bhEx2 = BHeader bhbEx2 (Keys.signKES (fst gerolamoHot) bhbEx2 0)
-
 blockEx2 :: Block
-blockEx2 = Block bhEx2 [txEx2]
+blockEx2 = mkBlock Nothing gerolamoCold gerolamoHot [txEx2] slot1 (Nonce 0) (Nonce 1) zero 0
 
-expUtxo :: UTxO
-expUtxo = UTxO $ Map.fromList [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin)
-                              , (TxIn (txid txbodyEx2) 0, TxOut aliceAddr (Coin 9990))
-                              ]
-expectedLS :: LedgerState
-expectedLS = LedgerState
-               (UTxOState expUtxo (Coin 7) (Coin 3) emptyUpdateState)
+expectedLSEx2 :: LedgerState
+expectedLSEx2 = LedgerState
+               (UTxOState
+                 (UTxO . Map.fromList $
+                   [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin)
+                   , (TxIn (txid txbodyEx2) 0, TxOut aliceAddr (Coin 9740))
+                   ])
+                 (Coin 257)
+                 (Coin 3)
+                 emptyUpdateState)
                (DPState
-                 (dsEx1 { _ptrs = Map.singleton (Ptr (Slot 1) 0 0) aliceSHK
+                 (dsEx1
+                     { _ptrs = Map.singleton (Ptr (Slot 1) 0 1) aliceSHK
                      , _stKeys = StakeKeys $ Map.singleton aliceSHK (Slot 1)
                      , _rewards = Map.singleton (RewardAcnt aliceSHK) (Coin 0)
                  })
-                 psEx1)
+                 psEx1
+                     { _stPools = StakePools $ Map.singleton aliceOperatorHK (Slot 1)
+                     , _pParams = Map.singleton aliceOperatorHK alicePoolParams
+                 })
                0
 
-expectedStEx2 :: (NewEpochState, Seed, Seed, Maybe HashHeader, Slot)
+blockEx2Hash :: Maybe HashHeader
+blockEx2Hash = Just (bhHash (bheader blockEx2))
+
+expectedStEx2 :: ChainState
 expectedStEx2 =
   ( NewEpochState
       (Epoch 0)
@@ -300,15 +329,123 @@ expectedStEx2 =
       (BlocksMade Map.empty)
       (BlocksMade Map.empty)
       -- Note that blocks in the overlay schedule do not add to this count.
-      (EpochState emptyAccount emptySnapShots expectedLS ppsEx1)
+      (EpochState emptyAccount emptySnapShots expectedLSEx2 ppsEx1)
       Nothing
       (PoolDistr Map.empty)
-      (Map.singleton (Slot 1) (Just gerolamoVKG))
+      overlayEx2
   , SeedOp (Nonce 0) (Nonce 1)
   , SeedOp (Nonce 0) (Nonce 1)
-  , Just (bhHash bhEx2)
+  , blockEx2Hash
   , Slot 1
   )
 
 ex2 :: CHAINExample
 ex2 = CHAINExample slot1 initStEx2 blockEx2 expectedStEx2
+
+
+-- | Example 3 - continuing on after example 2, process an empty block late enough
+-- in the epoch in order to create a reward update
+
+
+blockEx3 :: Block
+blockEx3 = mkBlock blockEx2Hash gerolamoCold gerolamoHot [] (Slot 89) (Nonce 0) (Nonce 2) zero 0
+
+blockEx3Hash :: Maybe HashHeader
+blockEx3Hash = Just (bhHash (bheader blockEx3))
+
+expectedStEx3 :: ChainState
+expectedStEx3 =
+  ( NewEpochState
+      (Epoch 0)
+      (Nonce 0)
+      (BlocksMade Map.empty)
+      (BlocksMade Map.empty)
+      -- Note that blocks in the overlay schedule do not add to this count.
+      (EpochState emptyAccount emptySnapShots expectedLSEx2 ppsEx1)
+      (Just RewardUpdate { deltaT = Coin 0
+                           , deltaR = Coin 0
+                           , rs     = Map.empty
+                           , deltaF = Coin 0
+                           })
+      (PoolDistr Map.empty)
+      overlayEx2
+  , SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 2)
+  , SeedOp (Nonce 0) (Nonce 1)
+  , blockEx3Hash
+  , Slot 89
+  )
+
+ex3 :: CHAINExample
+ex3 = CHAINExample (Slot 89) expectedStEx2 blockEx3 expectedStEx3
+
+
+-- | Example 4 - continuing on after example 3, process an empty block in the next epoch
+-- so that the (empty) reward update is applied and a stake snapshot is made.
+
+
+blockEx4 :: Block
+blockEx4 = mkBlock
+             blockEx3Hash
+             gerolamoCold
+             gerolamoHot
+             []
+             (Slot 110)
+             (Nonce 77)
+             (Nonce 88)
+             zero
+             1
+
+epoch1OSchedEx4 :: Map Slot (Maybe VKeyGenesis)
+epoch1OSchedEx4 = overlaySchedule
+                    (Epoch 1)
+                    (Set.singleton gerolamoVKG)
+                    (SeedOp (Nonce 0) (Nonce 1))
+                    ppsEx1
+
+snapsEx4 :: SnapShots
+snapsEx4 = emptySnapShots { _poolsSS = Map.singleton aliceOperatorHK alicePoolParams
+                          , _feeSS = Coin 260
+                          }
+
+expectedLSEx4 :: LedgerState
+expectedLSEx4 = LedgerState
+               (UTxOState
+                 (UTxO . Map.fromList $
+                   [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin)
+                   , (TxIn (txid txbodyEx2) 0, TxOut aliceAddr (Coin 9740))
+                   ])
+                 (Coin 0)   -- TODO check that both deposits really decayed completely
+                 (Coin 260) -- TODO shouldn't this pot have moved to the treasury?
+                 emptyUpdateState)
+               (DPState
+                 (dsEx1
+                     { _ptrs = Map.singleton (Ptr (Slot 1) 0 1) aliceSHK
+                     , _stKeys = StakeKeys $ Map.singleton aliceSHK (Slot 1)
+                     , _rewards = Map.singleton (RewardAcnt aliceSHK) (Coin 0)
+                 })
+                 psEx1
+                     { _stPools = StakePools $ Map.singleton aliceOperatorHK (Slot 1)
+                     , _pParams = Map.singleton aliceOperatorHK alicePoolParams
+                 })
+               0
+
+expectedStEx4 :: ChainState
+expectedStEx4 =
+  ( NewEpochState
+      (Epoch 1)
+      (SeedOp (Nonce 0) (Nonce 1))
+      (BlocksMade Map.empty)
+      (BlocksMade Map.empty)
+      -- Note that blocks in the overlay schedule do not add to this count.
+      (EpochState emptyAccount snapsEx4 expectedLSEx4 ppsEx1)
+      Nothing
+      (PoolDistr Map.empty)
+      epoch1OSchedEx4
+  , SeedOp (SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 2)) (Nonce 88)
+  , SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 88)
+  , Just (bhHash (bheader blockEx4))
+  , Slot 110
+  )
+
+ex4 :: CHAINExample
+ex4 = CHAINExample (Slot 110) expectedStEx3 blockEx4 expectedStEx4

--- a/shelley/chain-and-ledger/executable-spec/test/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator.hs
@@ -322,7 +322,7 @@ genStakePool keys = do
   let interval = case mkUnitInterval $ fromIntegral marginPercent % 100 of
                    Just i  -> i
                    Nothing -> interval0
-  pure $ PoolParams poolKey pledge Map.empty cost interval Nothing (RewardAcnt $ KeyHashObj $ hashKey acntKey) Set.empty
+  pure $ PoolParams poolKey pledge cost interval (RewardAcnt $ KeyHashObj $ hashKey acntKey) Set.empty
 
 genDelegation :: KeyPairs -> DPState -> Gen Delegation
 genDelegation keys d = do

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -6,6 +6,7 @@ import           Cardano.Crypto.KES (MockKES)
 
 import qualified BlockChain
 import qualified Delegation.Certificates
+import qualified EpochBoundary
 import qualified Keys
 import qualified LedgerState
 import qualified OCert
@@ -22,6 +23,8 @@ type Delegation = TxData.Delegation ShortHash MockDSIGN
 type PoolParams = TxData.PoolParams ShortHash MockDSIGN
 
 type RewardAcnt = TxData.RewardAcnt ShortHash MockDSIGN
+
+type StakePools = TxData.StakePools ShortHash MockDSIGN
 
 type KeyHash = Keys.KeyHash ShortHash MockDSIGN
 
@@ -85,6 +88,8 @@ type HashHeader = BlockChain.HashHeader ShortHash MockDSIGN MockKES
 
 type NewEpochState = LedgerState.NewEpochState ShortHash MockDSIGN
 
+type RewardUpdate = LedgerState.RewardUpdate ShortHash MockDSIGN
+
 type CHAIN = STS.Chain.CHAIN ShortHash MockDSIGN MockKES
 
 type UTXOW = STS.Utxow.UTXOW ShortHash MockDSIGN
@@ -99,3 +104,5 @@ type ScriptHash = TxData.ScriptHash ShortHash MockDSIGN
 type WitVKey = TxData.WitVKey ShortHash MockDSIGN
 
 type Wdrl = TxData.Wdrl ShortHash MockDSIGN
+
+type SnapShots = EpochBoundary.SnapShots ShortHash MockDSIGN

--- a/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
@@ -163,12 +163,12 @@ mutateDCert keys _ (RetirePool _ epoch@(Epoch e)) = do
     key'   <- getAnyStakeKey keys
     pure $ RetirePool (hashKey key') epoch'
 
-mutateDCert keys _ (RegPool (PoolParams _ pledge pledges cost margin altacnt rwdacnt owners)) = do
+mutateDCert keys _ (RegPool (PoolParams _ pledge cost margin rwdacnt owners)) = do
   key'    <- getAnyStakeKey keys
   cost'   <- mutateCoin 0 100 cost
   p'      <- mutateNat 0 100 (fromIntegral $ numerator $ intervalValue margin)
   let interval = fromMaybe interval0 (mkUnitInterval $ fromIntegral p' % 100)
-  pure $ RegPool (PoolParams key' pledge pledges cost' interval altacnt rwdacnt owners)
+  pure $ RegPool (PoolParams key' pledge cost' interval rwdacnt owners)
 
 mutateDCert keys _ (Delegate (Delegation _ _)) = do
   delegator' <- getAnyStakeKey keys

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -13,7 +13,7 @@ import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Cardano.Crypto.DSIGN (deriveVerKeyDSIGN, genKeyDSIGN)
 import           Crypto.Random (drgNewTest, withDRG)
-import           Examples (CHAINExample (..), ex1, ex2)
+import           Examples (CHAINExample (..), ex1, ex2, ex3, ex4)
 import           MockTypes (Addr, CHAIN, KeyPair, LedgerState, MultiSig, SKey, ScriptHash, Tx,
                      TxBody, TxId, TxIn, UTXOW, UTxOState, VKey, Wdrl)
 
@@ -61,10 +61,16 @@ testCHAINExample (CHAINExample slotNow initSt block expectedSt) =
     applySTS @CHAIN (TRC (slotNow, initSt, block)) @?= Right expectedSt
 
 testCHAINExample1 :: Assertion
-testCHAINExample1 = testCHAINExample ex2
+testCHAINExample1 = testCHAINExample ex1
 
 testCHAINExample2 :: Assertion
-testCHAINExample2 = testCHAINExample ex1
+testCHAINExample2 = testCHAINExample ex2
+
+testCHAINExample3 :: Assertion
+testCHAINExample3 = testCHAINExample ex3
+
+testCHAINExample4 :: Assertion
+testCHAINExample4 = testCHAINExample ex4
 
 stsTests :: TestTree
 stsTests = testGroup "STS Tests"
@@ -72,6 +78,8 @@ stsTests = testGroup "STS Tests"
   , testCase "update nonce late in the epoch" testUPNLate
   , testCase "CHAIN example 1 - empty block" testCHAINExample1
   , testCase "CHAIN example 2 - register stake key" testCHAINExample2
+  , testCase "CHAIN example 3 - create reward update" testCHAINExample3
+  , testCase "CHAIN example 4 - new epoch changes" testCHAINExample4
   , testCase "apply Transaction to genesis UTxO" testInitialUTXO
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -20,8 +20,8 @@ import           Coin
 import           Delegation.Certificates (pattern Delegate, pattern RegKey, pattern RegPool,
                      pattern RetirePool, StakeKeys (..), StakePools (..))
 import           TxData (pattern AddrBase, Credential (..), Delegation (..), pattern PoolParams,
-                     pattern Ptr, pattern RewardAcnt, _poolAltAcnt, _poolCost, _poolMargin,
-                     _poolOwners, _poolPledge, _poolPledges, _poolPubKey, _poolRAcnt)
+                     pattern Ptr, pattern RewardAcnt, _poolCost, _poolMargin, _poolOwners,
+                     _poolPledge, _poolPubKey, _poolRAcnt)
 
 import           Keys (pattern Dms, pattern KeyPair, hashKey, vKey)
 import           LedgerState (pattern LedgerState, pattern UTxOState, ValidationError (..),
@@ -325,10 +325,8 @@ stakePool = PoolParams
             {
               _poolPubKey = vKey stakePoolKey1
             , _poolPledge  = Coin 0
-            , _poolPledges = Map.empty
             , _poolCost = Coin 0      -- TODO: what is a sensible value?
             , _poolMargin = interval0     --          or here?
-            , _poolAltAcnt = Nothing  --          or here?
             , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
             , _poolOwners  = Set.empty
             }
@@ -342,10 +340,8 @@ stakePoolUpdate = PoolParams
                    {
                      _poolPubKey = vKey stakePoolKey1
                    , _poolPledge  = Coin 0
-                   , _poolPledges = Map.empty
                    , _poolCost = Coin 100      -- TODO: what is a sensible value?
                    , _poolMargin = halfInterval     --          or here?
-                   , _poolAltAcnt = Nothing  --          or here?
                    , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
                    , _poolOwners  = Set.empty
                    }

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -36,7 +36,7 @@
 \newcommand{\bleader}[1]{\fun{bleader}~\var{#1}}
 \newcommand{\hBbsize}[1]{\fun{hBbsize}~\var{#1}}
 \newcommand{\bbodyhash}[1]{\fun{bbodyhash}~\var{#1}}
-\newcommand{\overlaySchedule}[3]{\fun{overlaySchedule}~\var{#1}~{#2}~\var{#3}}
+\newcommand{\overlaySchedule}[4]{\fun{overlaySchedule}~\var{#1}~\var{#2}~{#3}~\var{#4}}
 
 \newcommand{\PrtclState}{\type{PrtclState}}
 \newcommand{\PrtclEnv}{\type{PrtclEnv}}
@@ -287,17 +287,18 @@ of which are active.
   %
   \emph{Abstract pseudorandom schedule function}
   \begin{align*}
-    & \fun{overlaySchedule} \in \powerset{\VKeyGen} \to \Seed \to \PParams
+    & \fun{overlaySchedule} \in \Epoch \to \powerset{\VKeyGen} \to \Seed \to \PParams
         \to (\Slot\mapsto\VKeyGen^?) \\
   \end{align*}
   %
   \emph{Constraints}
   \begin{align*}
-    \text{ given: }~\var{osched}\leteq\overlaySchedule{gkeys}{\eta}{pp} \\
+    \text{ given: }~\var{osched}\leteq\overlaySchedule{e}{gkeys}{\eta}{pp} \\
     \range{osched}\subseteq\var{gkeys} \\
     |\var{osched}| = \floor{(\fun{d}~\var{pp})\cdot\SlotsPerEpoch} \\
     |\{s\mapsto k\in\var{osched}~\mid~k\neq\Nothing\}| =
     \floor{(\activeSlotCoeff{pp})\cdot(\fun{d}~\var{pp})\cdot\SlotsPerEpoch} \\
+    \forall s\in\dom{osched},~\epoch{s}=e\\
   \end{align*}
   %
   \emph{New Epoch Transitions}
@@ -367,7 +368,7 @@ In the second case, the new epoch state is updated as follows:
               \end{array}
             }
             \right\}\\
-          \var{osched'} & \overlaySchedule{gkeys}{\eta_1}{pp} \\
+          \var{osched'} & \overlaySchedule{e}{gkeys}{\eta_1}{pp} \\
           \eta_e & \fun{extraEntropy}~\var{pp} \\
           \var{es''} & (\var{acnt},
                        ~\var{ss},


### PR DESCRIPTION
The PR adds two new CHAIN transition examples, and does some syncing with the formal spec.

The first new example adds a block late in the epoch to trigger the creation of a reward update (which is empty, though, since the only PBFT blocks are made).

The second example makes a block in a new epoch in order to trigger a stake distribution snapshot and the application of a reward update.

In terms of modifications to the exec model:
* got `PoolParams` fields in sync
* got `BHBody` fields in sync
* implemented the `overlaySchedule` function with a simple deterministic round-robin schedule that spaces everything out evenly.