### PR TITLE
Add VRF keys to shelley exec model

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -91,5 +91,5 @@ decayPool pc = (pval, pmin, lambdap)
           lambdap = pc ^. poolDecayRate
 
 newtype PoolDistr hashAlgo dsignAlgo =
-  PoolDistr (Map.Map (KeyHash hashAlgo dsignAlgo) Rational)
+  PoolDistr (Map.Map (KeyHash hashAlgo dsignAlgo) (Rational, KeyHash hashAlgo dsignAlgo))
   deriving (Show, Eq)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bhead.hs
@@ -61,7 +61,7 @@ bheadTransition = do
   nes' <- trans @(NEWEPOCH hashAlgo dsignAlgo)
     $ TRC (NewEpochEnv etaC slot gkeys, nes, epochFromSlot slot)
 
-  ru' <- trans @(RUPD hashAlgo dsignAlgo) $ TRC ((bprev, es), (nesRu nes'), slot)
+  ru' <- trans @(RUPD hashAlgo dsignAlgo) $ TRC ((bprev, es), nesRu nes', slot)
   let nes'' = nes' { nesRu = ru' }
   pure nes''
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -18,6 +18,7 @@ import           EpochBoundary
 import           LedgerState
 import           PParams
 import           Slot
+import           TxData
 
 import           STS.Epoch
 
@@ -66,7 +67,7 @@ newEpochTransition = do
       let etaE                     = _extraEntropy pp
       let osched'                  = overlaySchedule e gkeys eta1 pp
       let es'' = EpochState acnt ss ls (pp { _extraEntropy = NeutralSeed })
-      let pd' = foldr
+      let sd = foldr
             (\(hk, Coin c) m ->
               Map.insertWith (+) hk (fromIntegral c / fromIntegral total) m
             )
@@ -74,6 +75,7 @@ newEpochTransition = do
             [ (poolKey, Maybe.fromMaybe (Coin 0) (Map.lookup stakeKey stake))
             | (stakeKey, poolKey) <- Map.toList delegs
             ]
+      let pd' = Map.intersectionWith (,) sd (Map.map _poolVrf (_poolsSS ss))
       pure $ NewEpochState e
                            (seedOp eta1 etaE)
                            bcur

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
@@ -43,7 +43,7 @@ instance STS (SNAP hashAlgo dsignAlgo) where
 snapTransition :: TransitionRule (SNAP hashAlgo dsignAlgo)
 snapTransition = do
   TRC ((pparams, d, p, blocks), (s, u), eNew) <- judgmentContext
-  let pooledStake = poolDistr (u ^. utxo) d p
+  let pooledStake = stakeDistr (u ^. utxo) d p
   let _slot       = firstSlot eNew
   let oblg = obligation pparams (d ^. stKeys) (p ^. stPools) _slot
   let decayed     = (u ^. deposited) - oblg

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -32,6 +32,7 @@ data Delegation hashAlgo dsignAlgo = Delegation
 data PoolParams hashAlgo dsignAlgo =
   PoolParams
     { _poolPubKey  :: VKey dsignAlgo
+    , _poolVrf     :: KeyHash hashAlgo dsignAlgo
     , _poolPledge  :: Coin
     , _poolCost    :: Coin
     , _poolMargin  :: UnitInterval
@@ -347,8 +348,9 @@ instance
   => ToCBOR (PoolParams hashAlgo dsignAlgo)
  where
   toCBOR poolParams =
-    encodeListLen 8
+    encodeListLen 7
       <> toCBOR (_poolPubKey poolParams)
+      <> toCBOR (_poolVrf poolParams)
       <> toCBOR (_poolPledge poolParams)
       <> toCBOR (_poolCost poolParams)
       <> toCBOR (_poolMargin poolParams)

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -18,6 +18,8 @@ import qualified UTxO
 
 type DCert = Delegation.Certificates.DCert ShortHash MockDSIGN
 
+type PoolDistr = Delegation.Certificates.PoolDistr ShortHash MockDSIGN
+
 type Delegation = TxData.Delegation ShortHash MockDSIGN
 
 type PoolParams = TxData.PoolParams ShortHash MockDSIGN

--- a/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
@@ -163,12 +163,12 @@ mutateDCert keys _ (RetirePool _ epoch@(Epoch e)) = do
     key'   <- getAnyStakeKey keys
     pure $ RetirePool (hashKey key') epoch'
 
-mutateDCert keys _ (RegPool (PoolParams _ pledge cost margin rwdacnt owners)) = do
+mutateDCert keys _ (RegPool (PoolParams _ vrfHk pledge cost margin rwdacnt owners)) = do
   key'    <- getAnyStakeKey keys
   cost'   <- mutateCoin 0 100 cost
   p'      <- mutateNat 0 100 (fromIntegral $ numerator $ intervalValue margin)
   let interval = fromMaybe interval0 (mkUnitInterval $ fromIntegral p' % 100)
-  pure $ RegPool (PoolParams key' pledge cost' interval rwdacnt owners)
+  pure $ RegPool (PoolParams key' vrfHk pledge cost' interval rwdacnt owners)
 
 mutateDCert keys _ (Delegate (Delegation _ _)) = do
   delegator' <- getAnyStakeKey keys

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -9,13 +9,14 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2, ex3,
-                     ex4)
+                     ex4, ex5, ex6, ex7)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
 
 import           BaseTypes (Seed (..))
 import           Control.State.Transition (TRC (..), applySTS)
+import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import           Slot (Slot (..))
 import           STS.Updn (UPDN)
 import           STS.Utxow (PredicateFailure (..))
@@ -44,7 +45,7 @@ testUPNLate =
 
 testCHAINExample :: CHAINExample -> Assertion
 testCHAINExample (CHAINExample slotNow initSt block expectedSt) =
-    applySTS @CHAIN (TRC (slotNow, initSt, block)) @?= Right expectedSt
+  checkTrace @CHAIN slotNow $ pure initSt .- block .-> expectedSt
 
 testCHAINExample1 :: Assertion
 testCHAINExample1 = testCHAINExample ex1
@@ -58,14 +59,26 @@ testCHAINExample3 = testCHAINExample ex3
 testCHAINExample4 :: Assertion
 testCHAINExample4 = testCHAINExample ex4
 
+testCHAINExample5 :: Assertion
+testCHAINExample5 = testCHAINExample ex5
+
+testCHAINExample6 :: Assertion
+testCHAINExample6 = testCHAINExample ex6
+
+testCHAINExample7 :: Assertion
+testCHAINExample7 = testCHAINExample ex7
+
 stsTests :: TestTree
 stsTests = testGroup "STS Tests"
   [ testCase "update nonce early in the epoch" testUPNEarly
   , testCase "update nonce late in the epoch" testUPNLate
   , testCase "CHAIN example 1 - empty block" testCHAINExample1
   , testCase "CHAIN example 2 - register stake key" testCHAINExample2
-  , testCase "CHAIN example 3 - create reward update" testCHAINExample3
+  , testCase "CHAIN example 3 - delegate stake and create reward update" testCHAINExample3
   , testCase "CHAIN example 4 - new epoch changes" testCHAINExample4
+  , testCase "CHAIN example 5 - second reward update" testCHAINExample5
+  , testCase "CHAIN example 6 - nonempty pool distr" testCHAINExample6
+  , testCase "CHAIN example 7 - decentralized block" testCHAINExample7
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
   , testCase "Everybody signs in multi-sig" testEverybodySigns


### PR DESCRIPTION
This PR adds separate separate VRF keys to the Shelley exec model, as in the formal spec.

It's also does a bit of other syncing with the formal spec, such as tracking the `cCounters` in the pool state.

Three new examples were added, in continuation to the current running example, culmination in the production of a Praos block (ie non genesis key BFT block).