### PR TITLE
Errata non-integer-calculations.tex : missing term in ln(1+x) cf sequence.

### DIFF
--- a/shelley/chain-and-ledger/dependencies/non-integer/doc/non-integer-calculations.tex
+++ b/shelley/chain-and-ledger/dependencies/non-integer/doc/non-integer-calculations.tex
@@ -261,7 +261,7 @@ For the natural logarithm $\ln(x+1)$, the sequences of $a_{i}$ and $b_{i}$ are
 the following:
 
 \begin{align*}
-  \sigma(a_{i}) & := 1^{2}\cdot x, 1^{2}\cdot x, 2^{2}\cdot x, 2^{2}\cdot x, 3^{2}\cdot
+  \sigma(a_{i}) & := x, 1^{2}\cdot x, 1^{2}\cdot x, 2^{2}\cdot x, 2^{2}\cdot x, 3^{2}\cdot
           x, 3^{2}\cdot x, \ldots\\
   \sigma(b_{i}) & := 1, 2, 3, \ldots
 \end{align*}


### PR DESCRIPTION
Also, the b_0 terms are not specified (which are 0 for ln(1+x) and 1 for exp(x)).