### PR TITLE
Shelley examples - non trivial rewards

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -16,7 +16,6 @@ module EpochBoundary
   , pstakeSet
   , pstakeGo
   , poolsSS
-  , blocksSS
   , feeSS
   , emptySnapShots
   , rewardStake
@@ -194,7 +193,6 @@ data SnapShots hashAlgo dsignAlgo
          )
     , _poolsSS
       :: Map.Map (KeyHash hashAlgo dsignAlgo) (PoolParams hashAlgo dsignAlgo)
-    , _blocksSS :: BlocksMade hashAlgo dsignAlgo
     , _feeSS :: Coin
     } deriving (Show, Eq)
 
@@ -202,8 +200,7 @@ makeLenses ''SnapShots
 
 emptySnapShots :: SnapShots hashAlgo dsignAlgo
 emptySnapShots =
-    SnapShots snapEmpty snapEmpty snapEmpty Map.empty blocksEmpty (Coin 0)
+    SnapShots snapEmpty snapEmpty snapEmpty Map.empty (Coin 0)
     where pooledEmpty = Map.empty
-          blocksEmpty = BlocksMade Map.empty
           stakeEmpty  = Stake Map.empty
           snapEmpty   = (stakeEmpty, pooledEmpty)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
@@ -25,7 +25,7 @@ data EPOCH hashAlgo dsignAlgo
 instance STS (EPOCH hashAlgo dsignAlgo) where
     type State (EPOCH hashAlgo dsignAlgo) = EpochState hashAlgo dsignAlgo
     type Signal (EPOCH hashAlgo dsignAlgo) = Epoch
-    type Environment (EPOCH hashAlgo dsignAlgo) = BlocksMade hashAlgo dsignAlgo
+    type Environment (EPOCH hashAlgo dsignAlgo) = ()
     data PredicateFailure (EPOCH hashAlgo dsignAlgo)
       = PoolReapFailure (PredicateFailure (POOLREAP hashAlgo dsignAlgo))
       | SnapFailure (PredicateFailure (SNAP hashAlgo dsignAlgo))
@@ -41,11 +41,11 @@ initialEpoch =
 
 epochTransition :: forall hashAlgo dsignAlgo . TransitionRule (EPOCH hashAlgo dsignAlgo)
 epochTransition = do
-  TRC (blocks, EpochState as ss ls pp, e) <- judgmentContext
+  TRC (_, EpochState as ss ls pp, e) <- judgmentContext
   let us            = _utxoState ls
   let DPState ds ps = _delegationState ls
   (ss', us') <-
-    trans @(SNAP hashAlgo dsignAlgo) $ TRC ((pp, ds, ps, blocks), (ss, us), e)
+    trans @(SNAP hashAlgo dsignAlgo) $ TRC ((pp, ds, ps), (ss, us), e)
   (as', ds', ps') <-
     trans @(POOLREAP hashAlgo dsignAlgo) $ TRC (pp, (as, ds, ps), e)
   let ppNew = Just pp -- TODO: result from votedValuePParams

--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -52,7 +52,7 @@ instance STS (NEWEPOCH hashAlgo dsignAlgo) where
 newEpochTransition :: forall hashAlgo dsignAlgo . TransitionRule (NEWEPOCH hashAlgo dsignAlgo)
 newEpochTransition = do
   TRC ( NewEpochEnv eta1 _s gkeys
-      , src@(NewEpochState (Epoch eL') _ bprev bcur es ru _pd _osched)
+      , src@(NewEpochState (Epoch eL') _ _ bcur es ru _pd _osched)
       , e@(Epoch e')) <- judgmentContext
   if eL' + 1 /= e'
     then pure src
@@ -60,7 +60,7 @@ newEpochTransition = do
       let es_ = case ru of
             Nothing  -> es
             Just ru' -> applyRUpd ru' es
-      es' <- trans @(EPOCH hashAlgo dsignAlgo) $ TRC (bprev, es_, e)
+      es' <- trans @(EPOCH hashAlgo dsignAlgo) $ TRC ((), es_, e)
       let EpochState acnt ss ls pp = es'
       let (Stake stake, delegs)    = _pstakeSet ss
       let Coin total               = Map.foldl (+) (Coin 0) stake

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
@@ -30,7 +30,6 @@ instance STS (SNAP hashAlgo dsignAlgo) where
     = ( PParams
       , DState hashAlgo dsignAlgo
       , PState hashAlgo dsignAlgo
-      , BlocksMade hashAlgo dsignAlgo
       )
   data PredicateFailure (SNAP hashAlgo dsignAlgo)
     = FailureSNAP
@@ -42,7 +41,7 @@ instance STS (SNAP hashAlgo dsignAlgo) where
 
 snapTransition :: TransitionRule (SNAP hashAlgo dsignAlgo)
 snapTransition = do
-  TRC ((pparams, d, p, blocks), (s, u), eNew) <- judgmentContext
+  TRC ((pparams, d, p), (s, u), eNew) <- judgmentContext
   let pooledStake = stakeDistr (u ^. utxo) d p
   let _slot       = firstSlot eNew
   let oblg = obligation pparams (d ^. stKeys) (p ^. stPools) _slot
@@ -57,8 +56,6 @@ snapTransition = do
     .~ (s ^. pstakeSet)
     &  poolsSS
     .~ (p ^. pParams)
-    &  blocksSS
-    .~ blocks
     &  feeSS
     .~ (u ^. fees)
     +  decayed

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -11,6 +11,7 @@ module Examples
   , ex7
   , ex8
   , ex9
+  , ex10
   -- key pairs and example addresses
   , alicePay
   , aliceStake
@@ -895,3 +896,74 @@ ex9 = CHAINExample (Slot 390) expectedStEx8 blockEx9 expectedStEx9
 
 
 -- | Example 10 - continuing on after example 9, apply the first non-trivial reward update
+
+
+blockEx10 :: Block
+blockEx10 = mkBlock
+              blockEx9Hash
+              gerolamoCold
+              gerolamoVRF
+              gerolamoHot
+              []
+              (Slot 410)
+              (SeedOp
+                (SeedOp (SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 88)) (Nonce 987))
+                (Nonce 888))
+              (Nonce 410)
+              zero
+              4
+
+blockEx10Hash :: Maybe HashHeader
+blockEx10Hash = Just (bhHash (bheader blockEx10))
+
+epoch1OSchedEx10 :: Map Slot (Maybe VKeyGenesis)
+epoch1OSchedEx10 = overlaySchedule
+                     (Epoch 4)
+                     (Map.keysSet genesisDelegations)
+                     (SeedOp
+                       (SeedOp (SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 88)) (Nonce 987))
+                       (Nonce 888))
+                     ppsEx1
+
+acntEx10 :: AccountState
+acntEx10 = AccountState
+            { _treasury = Coin 9374400000264
+            , _reserves = Coin 44990550000000000
+            }
+
+dsEx10 :: DState
+dsEx10 = dsEx3 { _rewards = Map.singleton (RewardAcnt aliceSHK) (Coin 75600000000) }
+
+expectedLSEx10 :: LedgerState
+expectedLSEx10 = LedgerState
+               (UTxOState
+                 utxoEx3
+                 (Coin 0)
+                 (Coin 0)
+                 emptyUpdateState)
+               (DPState dsEx10 psEx2)
+               0
+
+expectedStEx10 :: ChainState
+expectedStEx10 =
+  ( NewEpochState
+      (Epoch 4)
+      (SeedOp (SeedOp (SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 88)) (Nonce 987)) (Nonce 888))
+      (BlocksMade Map.empty)
+      (BlocksMade Map.empty)
+      (EpochState acntEx10 snapsEx8 expectedLSEx10 ppsEx1)
+      Nothing
+      pdEx7
+      epoch1OSchedEx10
+  , SeedOp (SeedOp (SeedOp (SeedOp (SeedOp (SeedOp (SeedOp (SeedOp (SeedOp
+      (Nonce 0) (Nonce 1)) (Nonce 2)) (Nonce 88)) (Nonce 13)) (Nonce 987)) (Nonce 100))
+        (Nonce 888)) (Nonce 889)) (Nonce 410)
+  , SeedOp
+      (SeedOp (SeedOp (SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 88)) (Nonce 987)) (Nonce 888))
+      (Nonce 410)
+  , blockEx10Hash
+  , Slot 410
+  )
+
+ex10 :: CHAINExample
+ex10 = CHAINExample (Slot 410) expectedStEx9 blockEx10 expectedStEx10

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -9,6 +9,7 @@ module Examples
   , ex5
   , ex6
   , ex7
+  , ex8
   -- key pairs and example addresses
   , alicePay
   , aliceStake
@@ -735,3 +736,56 @@ expectedStEx7 =
 
 ex7 :: CHAINExample
 ex7 = CHAINExample (Slot 215) expectedStEx6 blockEx7 expectedStEx7
+
+
+--  | Example 8 - create the first non-trivial reward update by processing an
+--  empty block late in the epoch.
+
+
+blockEx8 :: Block
+blockEx8 = mkBlock
+             blockEx7Hash
+             gerolamoCold
+             gerolamoVRF
+             gerolamoHot
+             []
+             (Slot 290)
+             (SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 88))
+             (Nonce 888)
+             zero
+             3
+
+blockEx8Hash :: Maybe HashHeader
+blockEx8Hash = Just (bhHash (bheader blockEx8))
+
+expectedStEx8 :: ChainState
+expectedStEx8 =
+  ( NewEpochState
+      (Epoch 2)
+      (SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 88))
+      (BlocksMade Map.empty)
+      (BlocksMade $ Map.singleton aliceOperatorHK 1)
+      (EpochState acntEx6 snapsEx6 expectedLSEx6 ppsEx1)
+      (Just RewardUpdate { deltaT = Coin 0
+                         , deltaR = Coin 0
+                         , rs     = Map.empty
+                         , deltaF = Coin 0
+                         })
+      pdEx7
+      epoch1OSchedEx6
+  , SeedOp
+      (SeedOp
+        (SeedOp
+          (SeedOp (SeedOp (SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 2)) (Nonce 88)) (Nonce 13))
+          (Nonce 987))
+        (Nonce 100))
+      (Nonce 888)
+  , SeedOp
+      (SeedOp (SeedOp (SeedOp (Nonce 0) (Nonce 1)) (Nonce 88)) (Nonce 987))
+      (Nonce 100)
+  , blockEx8Hash
+  , Slot 290
+  )
+
+ex8 :: CHAINExample
+ex8 = CHAINExample (Slot 290) expectedStEx7 blockEx8 expectedStEx8

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -108,3 +108,5 @@ type WitVKey = TxData.WitVKey ShortHash MockDSIGN
 type Wdrl = TxData.Wdrl ShortHash MockDSIGN
 
 type SnapShots = EpochBoundary.SnapShots ShortHash MockDSIGN
+
+type Stake = EpochBoundary.Stake ShortHash MockDSIGN

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -9,7 +9,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2, ex3,
-                     ex4, ex5, ex6, ex7)
+                     ex4, ex5, ex6, ex7, ex8)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -68,6 +68,9 @@ testCHAINExample6 = testCHAINExample ex6
 testCHAINExample7 :: Assertion
 testCHAINExample7 = testCHAINExample ex7
 
+testCHAINExample8 :: Assertion
+testCHAINExample8 = testCHAINExample ex8
+
 stsTests :: TestTree
 stsTests = testGroup "STS Tests"
   [ testCase "update nonce early in the epoch" testUPNEarly
@@ -79,6 +82,7 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 5 - second reward update" testCHAINExample5
   , testCase "CHAIN example 6 - nonempty pool distr" testCHAINExample6
   , testCase "CHAIN example 7 - decentralized block" testCHAINExample7
+  , testCase "CHAIN example 8 - non-trivial rewards" testCHAINExample8
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
   , testCase "Everybody signs in multi-sig" testEverybodySigns

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -8,8 +8,8 @@ import qualified Data.Map.Strict as Map (empty, singleton)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
-import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2, ex3,
-                     ex4, ex5, ex6, ex7, ex8, ex9)
+import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex10, ex2,
+                     ex3, ex4, ex5, ex6, ex7, ex8, ex9)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -74,6 +74,9 @@ testCHAINExample8 = testCHAINExample ex8
 testCHAINExample9 :: Assertion
 testCHAINExample9 = testCHAINExample ex9
 
+testCHAINExample10 :: Assertion
+testCHAINExample10 = testCHAINExample ex10
+
 stsTests :: TestTree
 stsTests = testGroup "STS Tests"
   [ testCase "update nonce early in the epoch" testUPNEarly
@@ -86,7 +89,8 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 6 - nonempty pool distr" testCHAINExample6
   , testCase "CHAIN example 7 - decentralized block" testCHAINExample7
   , testCase "CHAIN example 8 - prelude to the first nontrivial rewards" testCHAINExample8
-  , testCase "CHAIN example 9 - create the first nontrivial rewards" testCHAINExample9
+  , testCase "CHAIN example 9 - create a nontrivial rewards" testCHAINExample9
+  , testCase "CHAIN example 10 - apply a nontrivial rewards" testCHAINExample10
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
   , testCase "Everybody signs in multi-sig" testEverybodySigns

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -9,7 +9,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2, ex3,
-                     ex4, ex5, ex6, ex7, ex8)
+                     ex4, ex5, ex6, ex7, ex8, ex9)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -71,6 +71,9 @@ testCHAINExample7 = testCHAINExample ex7
 testCHAINExample8 :: Assertion
 testCHAINExample8 = testCHAINExample ex8
 
+testCHAINExample9 :: Assertion
+testCHAINExample9 = testCHAINExample ex9
+
 stsTests :: TestTree
 stsTests = testGroup "STS Tests"
   [ testCase "update nonce early in the epoch" testUPNEarly
@@ -82,7 +85,8 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 5 - second reward update" testCHAINExample5
   , testCase "CHAIN example 6 - nonempty pool distr" testCHAINExample6
   , testCase "CHAIN example 7 - decentralized block" testCHAINExample7
-  , testCase "CHAIN example 8 - non-trivial rewards" testCHAINExample8
+  , testCase "CHAIN example 8 - prelude to the first nontrivial rewards" testCHAINExample8
+  , testCase "CHAIN example 9 - create the first nontrivial rewards" testCHAINExample9
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
   , testCase "Everybody signs in multi-sig" testEverybodySigns

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -342,7 +342,6 @@ In the second case, the new epoch state is updated as follows:
       e = e_\ell + 1
       \\
       {
-        \var{b_{prev}} \\
         \vdash
         (\fun{applyRUpd}~\var{ru}~\var{es})
           \trans{\hyperref[fig:rules:epoch]{epoch}}{\var{e}}\var{es'}
@@ -350,7 +349,7 @@ In the second case, the new epoch state is updated as follows:
       \\~\\~\\
       {\begin{array}{r@{~\leteq~}l}
           (\var{acnt},~\var{ss},~\var{ls}, \var{pp}) & \var{es'} \\
-         (\wcard,~\var{pstake_{set}},~\wcard,~\var{pools},~\wcard,~\wcard) & \var{ss} \\
+         (\wcard,~\var{pstake_{set}},~\wcard,~\var{pools},~\wcard) & \var{ss} \\
          (\var{stake}, \var{delegs}) & \var{pstake_{set}} \\
          total & \sum_{\_ \mapsto c\in\var{stake}} c \\
           \var{sd} & \fun{aggregate_{+}}~\left(\var{delegs}^{-1}\circ
@@ -725,7 +724,6 @@ If the size checks pass, then three transitions are done:
       }
       \\~\\
       (\wcard,~\wcard,~\var{b_{prev}},~\wcard,~\var{es},~\var{ru},~\wcard,~\wcard)\leteq\var{nes} \\
-      (\wcard,~\wcard,~\wcard,~\var{es})\leteq \var{es}
       \\
       {
         \left(

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -310,7 +310,6 @@ information needing to be saved on the epoch boundary:
     stake distribution snapshots (paired with the corresponding delegation map),
     as explained in Section~\ref{sec:reward-overview}.
   \item $\var{poolsSS}$ stores the pool parameters from the epoch boundary.
-  \item $\var{blocksSS}$ stores the performance of the completed epoch.
   \item $\var{feeSS}$ stores the fees and decayed deposit amounts at the epoch boundary.
 \end{itemize}
 
@@ -326,7 +325,6 @@ information needing to be saved on the epoch boundary:
         \var{pp} & \PParams & \text{protocol parameters}\\
         \var{dstate} & \DState & \text{delegation state}\\
         \var{pstate} & \PState & \text{pool state}\\
-        \var{blocks} & \BlocksMade & \text{blocks made}\\
       \end{array}
     \right)
   \end{equation*}
@@ -343,7 +341,6 @@ information needing to be saved on the epoch boundary:
         \var{pstake_{go}} & \Stake\times(\KeyHash_{stake}\mapsto\KeyHash_{pool})
                           & \text{oldest stake}\\
         \var{poolsSS} & \KeyHash \mapsto \PoolParam & \text{pool parameters }\\
-        \var{blocksSS} & \BlocksMade & \text{blocks made }\\
         \var{feeSS} & \Coin & \text{fee snapshot}\\
       \end{array}
     \right)
@@ -412,7 +409,6 @@ This transition has no preconditions and results in the following state change:
         \var{pp} \\
         \var{dstate} \\
         \var{pstate} \\
-        \var{blocks} \\
       \end{array}
       \vdash
       \left(
@@ -421,7 +417,6 @@ This transition has no preconditions and results in the following state change:
           \var{pstake_{set}}\\
           \var{pstake_{go}}\\
           \var{poolsSS}\\
-          \var{blocksSS}\\
           \var{feeSS} \\
           ~ \\
           \var{utxo} \\
@@ -437,7 +432,6 @@ This transition has no preconditions and results in the following state change:
           \varUpdate{\var{pstake_{mark}}} \\
           \varUpdate{\var{pstake_{set}}} \\
           \varUpdate{\var{poolParams}} \\
-          \varUpdate{\var{blocks}} \\
           \varUpdate{\var{fees} + \var{decayed}} \\
           ~ \\
           \var{utxo} \\
@@ -803,7 +797,7 @@ for ease of reading.
 
 Finally, it is possible to define the complete epoch boundary transition type,
 which is defined in Figure~\ref{fig:ts-types:epoch}.
-The environment of this transition consists of the blocks made during this epoch.
+The transition has no evironment.
 The state is made up of the the accounting state, the snapshots, the ledger state and the
 protocol parameters.
 
@@ -826,9 +820,9 @@ protocol parameters.
   %
   \emph{Epoch transitions}
   \begin{equation*}
-    \_ \vdash
+    \vdash
     \var{\_} \trans{epoch}{\_} \var{\_}
-    \subseteq \powerset (\BlocksMade \times \EpochState \times \Epoch \times \EpochState)
+    \subseteq \powerset (\EpochState \times \Epoch \times \EpochState)
   \end{equation*}
   %
   \caption{Epoch transition-system types}
@@ -851,7 +845,6 @@ in sequence.
           \var{pp}\\
           \var{dstate} \\
           \var{pstate} \\
-          \var{blocks}\\
         \end{array}
       }
       \vdash
@@ -932,7 +925,6 @@ in sequence.
       \var{ls}' \leteq (\var{utxoSt}'',~(\var{dstate}',~\var{pstate}'))
     }
     {
-      \var{blocks}
       \vdash
       \left(
       \begin{array}{r}
@@ -1325,8 +1317,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
         \Delta t_1+\Delta t_2,-~\Delta r,~\var{rs},~-\var{feeSS} \right) \\
       & ~~~\where \\
       &~~~~~~~~(\var{acnt},~\var{ss},~\var{ls},~\var{pp}) = \var{es} \\
-      & ~~~~~~~(\wcard,~\wcard,~\var{pstake_{go}},~\var{poolsSS},~\var{blocksSS},~\var{feeSS})
-        = \var{ss}\\
+      & ~~~~~~~(\wcard,~\wcard,~\var{pstake_{go}},~\var{poolsSS},~\var{feeSS}) = \var{ss}\\
       & ~~~~~~~(\var{stake},~\var{delegs}) = \var{pstate_{go}} \\
       & ~~~~~~~(\wcard,~\var{reserves}) = \var{acnt} \\
       & ~~~~~~~\left(
@@ -1343,7 +1334,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
       & ~~~~~~~\Delta t_1 = \floor*{(\fun{tau}~{pp}) \cdot \var{rewardPot}} \\
       & ~~~~~~~\var{R} = \var{rewardPot} - \Delta t_1 \\
       & ~~~~~~~\var{rs}
-           = \reward{pp}{blocksSS}{R}{(\dom{rewards})}{poolsSS}{stake}{delegs} \\
+           = \reward{pp}{b}{R}{(\dom{rewards})}{poolsSS}{stake}{delegs} \\
       & ~~~~~~~\Delta t_{2} = R - \left(\sum\limits_{\_\mapsto c\in\var{rs}}c\right) \\
       & ~~~~~~~blocksMade = \sum_{\wcard \mapsto m \in b}m
   \end{align*}


### PR DESCRIPTION
I've added three new examples to the Shelley STS tests. These continue the running block by block progress of a new Shelley chain. By this point in the state progression, there is now delegated stake, stake snapshots, and a pool distribution to judge performance of the current epoch.

* example 8 is pretty uneventful, just starting the epoch when the first nontrivial reward update can be created.
* example 9 creates the first nontrivial reward update
* example 10 applies the first nontrivial reward update on the next epoch boundary.

I also made an attempt to make the examples a bit more realistic by having three genesis keys instead of just one.

There was a bit of tweaking/syncing of the exec model. The reward calculation needed to be adjusted to take the pool leader stake from the owners listed in the pool reg cert instead of by the operator hashkey.

I realized that there was a redundant copy of the `BlocksMade` being saved. One was in the Snapshot, and the other was in the `NewEpochState`. The one in the `NewEpochState` is preferred, since there it is clear which one is the current/running tally, and which one is from the previous epoch. Therefore I removed the `blocksSS` from the Snapshots, from the `SNAP` environment, and from the `EPOCH` environment (in both the latex and the haskell).