### PR TITLE
Fix errors discovered during conformance testing

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
@@ -37,22 +37,14 @@ instance STS EPOCH where
 
   transitionRules =
     [ do
-        TRC ((e_c, k), _, s) <- judgmentContext
-        case e_c >= sEpoch s k of
-          True  -> onOrAfterCurrentEpoch
-          False -> beforeCurrentEpoch
+        TRC ((e_c, k), us, s) <- judgmentContext
+        if sEpoch s k <= e_c
+          then do
+            pure $! us
+          else do
+            us' <- trans @UPIEC $ TRC ((s, k), us, ())
+            pure $! us'
     ]
-   where
-    beforeCurrentEpoch :: TransitionRule EPOCH
-    beforeCurrentEpoch = do
-      TRC ((_, k), us, s) <- judgmentContext
-      us' <- trans @UPIEC $ TRC ((s, k), us, ())
-      return $! us'
-
-    onOrAfterCurrentEpoch :: TransitionRule EPOCH
-    onOrAfterCurrentEpoch = do
-      TRC (_, us, _) <- judgmentContext
-      return $! us
 
 instance Embed UPIEC EPOCH where
   wrapFailed = UPIECFailure

--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
@@ -39,7 +39,7 @@ instance STS EPOCH where
     [ do
         TRC ((e_c, k), us, s) <- judgmentContext
         if sEpoch s k <= e_c
-          then do
+          then
             pure $! us
           else do
             us' <- trans @UPIEC $ TRC ((s, k), us, ())

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -89,6 +89,7 @@ test-suite ledger-rules-test
                , Ledger.Delegation.Examples
                , Ledger.Delegation.Properties
                , Ledger.AbstractSize.Properties
+               , Ledger.Update.Examples
                , Ledger.Update.Properties
                , Ledger.Pvbump.Properties
                , Ledger.Relation.Properties

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -407,7 +407,7 @@ instance Relation [(a, b)] where
 
   s ⋪ r = filter ((`Set.notMember` toSet s) . fst) r
 
-  r ▷ s = filter ((`Set.notMember` toSet s) . snd) r
+  r ▷ s = filter ((`Set.member` toSet s) . snd) r
 
   (∪) = (++)
 

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -269,6 +269,12 @@ class Relation m where
   -- | Union Override
   (⨃) :: (Ord (Domain m), Ord (Range m), Foldable f) => m -> f (Domain m, Range m) -> m
 
+  -- | Restrict domain to values less or equal than the given value.
+  --
+  -- Unicode: 25c1
+  (<=◁) :: Ord (Domain m) => Domain m -> m -> m
+  infixl 5 <=◁
+
   -- | Restrict range to values less or equal than the given value
   --
   -- Unicode: 25b7
@@ -317,9 +323,11 @@ instance (Ord k, Ord v) => Relation (Bimap k v) where
   d0 ∪ d1 = Bimap.fold Bimap.insert d0 d1
   d0 ⨃ d1 = foldr (uncurry Bimap.insert) d0 (toList d1)
 
+  vmax <=◁ r = Bimap.filter (\v _ -> v <= vmax) r
+
   r ▷<= vmax = Bimap.filter (\_ v -> v <= vmax) r
 
-  r ▷>= vmax = Bimap.filter (\_ v -> v >= vmax) r
+  r ▷>= vmin = Bimap.filter (\_ v -> v >= vmin) r
 
   size = fromIntegral . Bimap.size
 
@@ -343,9 +351,11 @@ instance Relation (Map k v) where
   -- left biased.
   d0 ⨃ d1 = Map.union (Map.fromList . toList $ d1) d0
 
+  vmax <=◁ r = Map.filterWithKey (\k _ -> k <= vmax) r
+
   r ▷<= vmax = Map.filter (<= vmax) r
 
-  r ▷>= vmax = Map.filter (>= vmax) r
+  r ▷>= vmin = Map.filter (>= vmin) r
 
   size = fromIntegral . Map.size
 
@@ -360,6 +370,7 @@ instance Relation (Set (a, b)) where
   singleton a b = Set.singleton (a,b)
 
   dom = Set.map fst
+
   range = Set.map snd
 
   s ◁ r = Set.filter (\(k,_) -> k `Set.member` toSet s) r
@@ -374,12 +385,42 @@ instance Relation (Set (a, b)) where
     where
       d1' = toSet d1
 
+  vmax <=◁ r = Set.filter ((<= vmax) . fst) $ r
+
   r ▷<= vmax = Set.filter ((<= vmax) . snd) $ r
 
   r ▷>= vmax = Set.filter ((>= vmax) . snd) $ r
 
   size = fromIntegral . Set.size
 
+instance Relation [(a, b)] where
+  type Domain [(a, b)] = a
+  type Range [(a, b)] = b
+
+  singleton a b = [(a, b)]
+
+  dom = toSet . fmap fst
+
+  range = toSet . fmap snd
+
+  s ◁ r = filter ((`Set.member` toSet s) . fst) r
+
+  s ⋪ r = filter ((`Set.notMember` toSet s) . fst) r
+
+  r ▷ s = filter ((`Set.notMember` toSet s) . snd) r
+
+  (∪) = (++)
+
+  -- In principle a list of pairs allows for duplicated keys.
+  d0 ⨃ d1 = d0 ++ toList d1
+
+  vmax <=◁ r = filter ((<= vmax) . fst) r
+
+  r ▷<= vmax = filter ((<= vmax) . snd) r
+
+  r ▷>= vmin = filter ((vmin <=) . snd) r
+
+  size = fromIntegral . length
 
 ---------------------------------------------------------------------------------
 -- Aliases

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -22,6 +22,7 @@ module Ledger.Delegation
   , depoch
   , dwho
   , mkDCert
+  , signature
     -- * Delegation activation
   , ADELEG
   , ADELEGS

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -337,6 +337,7 @@ instance STS ADELEG where
         , _dStateLastDelegation = Map.fromSet (const (Slot 0)) env
         }
     ]
+
   transitionRules =
     [ do
         TRC ( _env

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -4,10 +4,12 @@ module Ledger.GlobalParams
   ( lovelaceCap
   , slotsPerEpoch
   , slotsPerEpochToK
+  , c
   )
 where
 
 import           Data.Int (Int64)
+import           Data.Word (Word64)
 
 import           Ledger.Core (BlockCount (BlockCount), Lovelace (Lovelace))
 
@@ -20,9 +22,22 @@ lovelaceCap = Lovelace $ 45 * fromIntegral ((10 :: Int64) ^ (15 :: Int64))
 -- expressed in an amount of blocks, return the number of slots contained in an
 -- epoch.
 slotsPerEpoch :: Integral n => BlockCount -> n
-slotsPerEpoch (BlockCount c) = fromIntegral $ c * 10
+slotsPerEpoch (BlockCount bc) = fromIntegral $ bc * 10
 
--- | The inverse of 'slotsPerEpoch': given a number of slots per-epoch, return the chain stability
--- parameter @k@.
+-- | The inverse of 'slotsPerEpoch': given a number of slots per-epoch, return
+-- the chain stability parameter @k@.
 slotsPerEpochToK :: (Integral n) => n -> BlockCount
 slotsPerEpochToK n = BlockCount $ floor $ (fromIntegral n :: Double) / 10
+
+-- | Factor used to bound the concrete size by the abstract size.
+--
+-- This constant should satisfy that given an elaboration function 'elaborate'
+-- which elaborates abstract values intro concrete ones, for each abstract data
+-- value 'a' we have:
+--
+-- > size (elaborate a) <= c * abstractSize a
+--
+-- TODO: we need to investigate what this factor is, and probably use different
+-- factors for different data types (update, UTxO transactions, etc).
+c :: Word64
+c = 4096

--- a/byron/ledger/executable-spec/src/Ledger/UTxO/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO/Generators.hs
@@ -1,24 +1,24 @@
-{-# LANGUAGE DerivingStrategies  #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Ledger.UTxO.Generators where
 
-import Control.Applicative (empty)
-import Data.Bitraversable (bitraverse)
+import           Control.Applicative (empty)
+import           Data.Bitraversable (bitraverse)
 import qualified Data.Map.Strict as M
 
-import Ledger.Core hiding (Range, range)
-import Ledger.UTxO
+import           Ledger.Core hiding (Range, range)
+import           Ledger.UTxO
 
-import Hedgehog (Gen, Property, Range, (===), assert, forAll, property)
+import           Hedgehog (Gen, Property, Range, assert, forAll, property, (===))
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
-import Hedgehog.Internal.Gen
-  (atLeast, ensure, mapGenT, runDiscardEffectT, toTree, toTreeMaybeT)
-import Hedgehog.Internal.Tree (NodeT(..), TreeT(..), treeValue)
+import           Hedgehog.Internal.Gen (atLeast, ensure, mapGenT, runDiscardEffectT, toTree,
+                     toTreeMaybeT)
+import           Hedgehog.Internal.Tree (NodeT (..), TreeT (..), treeValue)
 import qualified Hedgehog.Internal.Tree as Tree
 
 
@@ -32,7 +32,12 @@ genInitialTxOuts = Gen.filter (not . null)
   . genTraverseSubsequence (\a -> TxOut a <$> genLovelace)
 
 genLovelace :: Gen Lovelace
-genLovelace = Lovelace . fromIntegral <$> Gen.word32 (Range.linear 1 10000)
+genLovelace =
+  Lovelace . fromIntegral <$> Gen.word32 (Range.linearFrom mid mn mx)
+  where
+    mn = 1
+    mx = 10000
+    mid = floor (fromIntegral (mx - mn) / 2 :: Double)
 
 -- | Generate a subsequence of a list of values and traverse the subsequence
 --   with a generator producer

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -717,8 +717,8 @@ delegationMap (_, dms, _, _) = dms
 -- | The update interface state is shared amongst various rules, so we define it
 -- as an alias here.
 type UPIState =
-  ( (ProtVer, PParams) -- pv
-  , [(Core.Slot, (ProtVer, PParams))] -- pps
+  ( (ProtVer, PParams) -- (pv, pps)
+  , [(Core.Slot, (ProtVer, PParams))] -- fads
   , Map ApName (ApVer, Core.Slot, Metadata) -- avs
   , Map UpId (ProtVer, PParams) -- rpus
   , Map UpId (ApName, ApVer, Metadata) -- raus

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -21,8 +21,6 @@ module Ledger.Update
   (module Ledger.Update)
 where
 
--- import qualified Debug.Trace as Debug
-
 import           Control.Arrow (second, (&&&))
 import           Control.Lens
 import           Data.Bimap (Bimap, empty, lookupR)

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -84,7 +84,7 @@ data PParams = PParams -- TODO: this should be a module of @cs-ledger@.
   , _upAdptThd :: !Double
   -- ^ Update adoption threshold: a proportion of block issuers that have to
   -- endorse a given version to become candidate for adoption
-  , _factorA :: !Int -- TODO: these should have type 'Word64', like in the implementation.
+  , _factorA :: !Int -- TODO: these should have type 'Word64', like in `cardano-ledger`.
   -- ^ Minimum fees per transaction
   , _factorB :: !Int
   -- ^ Additional fees per transaction size

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -868,7 +868,7 @@ instance HasTrace UPIREG where
 
   envGen _ = upiEnvGen
 
-  sigGen _ (_slot, dms, _k, _ngk) ((pv, pps), _fads, avs, rpus, raus, _cps, _vts, _bvs, _pws)
+  sigGen _ (_slot, dms, _k, _ngk) ((pv, pps), _fads, avs, rpus, raus, _cps, _vts, _bvs, pws)
     = do
     (vk, pv', pps', sv') <- (,,,) <$> issuerGen
                                   <*> pvGen
@@ -904,7 +904,7 @@ instance HasTrace UPIREG where
         -- Chose an increment for the maximum version seen in the update
         -- proposal IDs.
         inc <- Gen.integral (Range.constant 1 10)
-        case Set.toDescList $ dom rpus of
+        case Set.toDescList $ dom pws of
           [] -> UpId <$> Gen.element [0 .. inc]
           (UpId maxId:_) -> pure $ UpId (maxId + inc)
 
@@ -1521,7 +1521,11 @@ instance STS UPIEC where
             , []          :: [(Core.Slot, (ProtVer, PParams))]
             , us ^. _3    :: Map ApName (ApVer, Core.Slot, Metadata)
             , Map.empty   :: Map UpId (ProtVer, PParams)
-            , us ^. _5    :: Map UpId (ApName, ApVer, Metadata)
+            -- Note that delete the registered application proposals from the
+            -- state on epoch change, since adopting these depend on the @cps@
+            -- and @pws@ sets, which are deleted as well. So it doesn't seem
+            -- sensible to keep @raus@ around.
+            , Map.empty   :: Map UpId (ApName, ApVer, Metadata)
             , Map.empty   :: Map UpId Core.Slot
             , Set.empty   :: Set (UpId, Core.VKeyGenesis)
             , Set.empty   :: Set (ProtVer, Core.VKeyGenesis)

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -84,7 +84,7 @@ data PParams = PParams -- TODO: this should be a module of @cs-ledger@.
   , _upAdptThd :: !Double
   -- ^ Update adoption threshold: a proportion of block issuers that have to
   -- endorse a given version to become candidate for adoption
-  , _factorA :: !Int -- TODO: shouldn't these be unsigned ints like Word64? In the concrete implementation they are Word64!
+  , _factorA :: !Int -- TODO: these should have type 'Word64', like in the implementation.
   -- ^ Minimum fees per transaction
   , _factorB :: !Int
   -- ^ Additional fees per transaction size
@@ -1523,8 +1523,8 @@ instance STS UPIEC where
             , []          :: [(Core.Slot, (ProtVer, PParams))]
             , us ^. _3    :: Map ApName (ApVer, Core.Slot, Metadata)
             , Map.empty   :: Map UpId (ProtVer, PParams)
-            -- Note that delete the registered application proposals from the
-            -- state on epoch change, since adopting these depend on the @cps@
+            -- Note that we delete the registered application proposals from the
+            -- state on epoch change, since adopting these depends on the @cps@
             -- and @pws@ sets, which are deleted as well. So it doesn't seem
             -- sensible to keep @raus@ around.
             , Map.empty   :: Map UpId (ApName, ApVer, Metadata)

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -50,8 +50,8 @@ import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 import           Data.AbstractSize (HasTypeReps)
 
 import           Ledger.Core (BlockCount (..), HasHash, Owner (Owner), Relation (..), Slot,
-                     SlotCount (..), VKey (VKey), VKeyGenesis (VKeyGenesis), dom, hash,
-                     minusSlotMaybe, skey, (*.), (-.), (∈), (∉), (⋪), (▷), (▷<=), (▷>=), (◁), (⨃))
+                     SlotCount (..), VKey (VKey), VKeyGenesis (VKeyGenesis), dom, hash, skey, (*.),
+                     (-.), (∈), (∉), (⋪), (▷), (▷<=), (▷>=), (◁), (⨃))
 import qualified Ledger.Core as Core
 import qualified Ledger.Core.Generators as CoreGen
 
@@ -1446,15 +1446,10 @@ instance STS PVBUMP where
   transitionRules =
     [ do
         TRC ((s_n, fads, k), (pv, pps), ()) <- judgmentContext
-        let
-          mFirstStableSlot = minusSlotMaybe s_n (SlotCount . (2 *) . unBlockCount $ k)
-          r = case mFirstStableSlot of
-                Nothing -> []
-                Just s  -> filter ((<= s) . fst) fads
-        if r == []
-          then pure $! (pv, pps)
-          else do
-            let (_, (pv_c, pps_c)) = last r
+        case s_n  -. 2 *. k <=◁ fads of
+          [] ->
+            pure $! (pv, pps)
+          (_s, (pv_c, pps_c)): _xs ->
             pure $! (pv_c, pps_c)
     ]
 

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -283,7 +283,7 @@ svCanFollow avs (an,av) =
     (case Map.lookup an avs of
       Nothing -> True
       Just (x, _, _) -> av == x + 1
-    ) && (an `Set.notMember` dom avs ==> av == ApVer 0)
+    ) && (an `Set.notMember` dom avs ==> av == ApVer 1)
   where
 
 ------------------------------------------------------------------------
@@ -972,7 +972,7 @@ instance HasTrace UPIREG where
           -- Generate a new application
           genNewApp :: Gen SwVer
           genNewApp
-            =  (`SwVer` 0) . ApName
+            =  (`SwVer` 1) . ApName
            <$> Gen.filter ((`notElem` usedNames) . ApName)
                           (Gen.list (Range.constant 0 12) Gen.ascii)
             where

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1437,9 +1437,9 @@ instance STS PVBUMP where
     (ProtVer, PParams)
 
   type Signal PVBUMP = ()
-  data PredicateFailure PVBUMP
-    = NewEpoch
-    | OldEpoch
+
+  -- PVBUMP has no predicate failures
+  data PredicateFailure PVBUMP = NoPVBUMPFailure
     deriving (Eq, Show)
 
   initialRules = []

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1188,7 +1188,7 @@ instance STS UPIVOTE where
   initialRules = []
   transitionRules =
     [ do
-        TRC ( (sn, dms, k, ngk)
+        TRC ( (sn, dms, _k, ngk)
             , ( (pv, pps)
               , fads
               , avs
@@ -1209,17 +1209,11 @@ instance STS UPIVOTE where
                                               , vts
                                               )
                                             , v)
-        let
-          stblCps = dom (cps' ▷<= sn -. 2 *. k)
-          stblRaus = stblCps ◁ raus
-          avsnew = [ (an, (av, sn, m))
-                   | (an, av, m) <- toList stblRaus
-                   ]
         pure $! ( (pv, pps)
                 , fads
-                , avs ⨃ avsnew
+                , avs
                 , rpus
-                , stblCps ⋪ raus
+                , raus
                 , cps'
                 , vts'
                 , bvs
@@ -1276,7 +1270,34 @@ instance STS UPIVOTES where
     [ do
         TRC (env, us, xs) <- judgmentContext
         us' <- trans @APPLYVOTES  $ TRC (env, us, xs)
-        return us'
+        -- Check which proposals are confirmed and stable, and update the
+        -- application versions map.
+        let
+          (sn, _dms, k, _ngk) = env
+          ( (pv, pps)
+            , fads
+            , avs
+            , rpus
+            , raus
+            , cps
+            , vts
+            , bvs
+            , pws) = us'
+          stblCps = dom (cps ▷<= sn -. 2 *. k)
+          stblRaus = stblCps ◁ raus
+          avsNew = [ (an, (av, sn, m))
+                   | (an, av, m) <- toList stblRaus
+                   ]
+        pure $! ( (pv, pps)
+                , fads
+                , avs ⨃ avsNew
+                , rpus
+                , stblCps ⋪ raus
+                , cps
+                , vts
+                , bvs
+                , pws
+                )
     ]
 
 instance Embed APPLYVOTES UPIVOTES where

--- a/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
@@ -57,7 +57,6 @@ pparamsGen =
       bkSlotsPerEpoch
       upTtl
       scriptVersion
-      upAdptThd -- We want to unify @cfmThd@ and @upAdptThd@.
       upAdptThd
       factorA
       factorB

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TypeApplications #-}
+
 -- | Examples of the application of the delegation rules.
 module Ledger.Delegation.Examples
   ( deleg

--- a/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Delegation/Examples.hs
@@ -16,8 +16,11 @@ import           Test.Tasty.HUnit (testCase)
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import           Ledger.Core (BlockCount (BlockCount), Epoch (Epoch), Owner (Owner), Sig (Sig),
                      Slot (Slot), VKey (VKey), VKeyGenesis (VKeyGenesis), owner)
-import           Ledger.Delegation (ADELEG, ADELEGS, DCert (DCert), DSEnv (DSEnv),
-                     DSState (DSState), DState (DState), SDELEG)
+import           Ledger.Delegation (ADELEG, ADELEGS, DCert (DCert), DELEG, DIState (DIState),
+                     DSEnv (DSEnv), DSState (DSState), DState (DState), SDELEG,
+                     _dIStateDelegationMap, _dIStateKeyEpochDelegations, _dIStateLastDelegation,
+                     _dIStateScheduledDelegations, _dSEnvAllowedDelegators, _dSEnvEpoch, _dSEnvK,
+                     _dSEnvSlot)
 
 -- | Delegation examples.
 deleg :: [TestTree]
@@ -95,6 +98,57 @@ deleg =
 
     .- dc (gk 2) (k 10) (e 8) .-> DSState [(s 4322, (gk 0, k 10)), (s 4322, (gk 1, k 11)), (s 4322, (gk 2, k 10))]
                                           [(e 8, gk 0), (e 8, gk 1), (e 8, gk 2)]
+    ]
+  , testGroup "Interface"
+    [ testCase "Non-injective scheduled delegations are ignored." $
+      let
+        env = DSEnv
+                { _dSEnvAllowedDelegators = [gk 0, gk 1]
+                , _dSEnvEpoch = e 0
+                , _dSEnvSlot = s 21
+                , _dSEnvK = bk 5
+                }
+        st = DIState
+              { _dIStateDelegationMap =
+                    [ ( gk 0
+                      , k 0
+                      )
+                    , ( gk 1
+                      , k 1
+                      )
+                    ]
+              , _dIStateLastDelegation =
+                    [ ( gk 0
+                      , s 15
+                      )
+                    , ( gk 1
+                      , s 0
+                      )
+                    ]
+              , _dIStateScheduledDelegations =
+                  [ ( s 21
+                    , ( gk 1
+                      , k 0
+                      )
+                    )
+                  ]
+              , _dIStateKeyEpochDelegations =
+                  fromList
+                    [ ( e 0
+                      , gk 0
+                      )
+                    , ( e 0
+                      , gk 1
+                      )
+                    , ( e 1
+                      , gk 0
+                      )
+                    ]
+              }
+      in
+      checkTrace @DELEG env $
+        pure st .- [] .-> st { _dIStateScheduledDelegations = [] }
+
     ]
   ]
   where

--- a/byron/ledger/executable-spec/test/Ledger/Relation/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Relation/Properties.hs
@@ -1,28 +1,27 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Ledger.Relation.Properties
     (testRelation)
   where
 
-import           Data.Bimap          (Bimap)
-import qualified Data.Bimap          as Bimap
-import           Data.Map.Strict     (Map)
-import           Data.Set            (Set, union, (\\))
+import           Data.Bimap (Bimap)
+import qualified Data.Bimap as Bimap
+import           Data.Map.Strict (Map)
+import           Data.Set (Set, union, (\\))
 
-import           Hedgehog            (Gen, MonadTest, Property, PropertyT,
-                                      forAll, property, withTests, (===))
+import           Hedgehog (Gen, MonadTest, Property, PropertyT, forAll, property, withTests, (===))
 
-import qualified Hedgehog.Gen        as Gen
-import qualified Hedgehog.Range      as Range
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 import           Test.Tasty.Hedgehog
 
-import           Ledger.Core         hiding ((<|))
+import           Ledger.Core hiding ((<|))
 
-import           Test.Tasty          (TestTree, testGroup)
+import           Test.Tasty (TestTree, testGroup)
 
 --------------------------------------------------------------------------------
 -- Properties on Relations
@@ -143,8 +142,12 @@ genMap = Gen.map aRange $ (,) <$> genInt <*> genInt
 genSet :: Gen (Set (Int, Int))
 genSet = genSetOf ((,) <$> genInt <*> genInt)
 
+genPairsList :: Gen [(Int, Int)]
+genPairsList = Gen.list aRange ((,) <$> genInt <*> genInt)
+
+
 genBimap :: Gen (Bimap Int Int)
-genBimap = Bimap.fromList <$> Gen.list aRange ((,) <$> genInt <*> genInt)
+genBimap = Bimap.fromList <$> genPairsList
 
 --------------------------------------------------------------------------------
 -- Property Tests
@@ -187,6 +190,18 @@ testRelation = testGroup "Test Relation instances"
                    (propRelation genIntS genBimap propRangeRestrictionAndIntersection)
     , testProperty "RangeRestrictionAndIntersectionB"
                    (propRelation genIntS genBimap propRangeRestrictionAndIntersectionB) ]
+
+  , testGroup "Relation - Pairs list"
+    [ testProperty "DomainRestrictionAndIntersection"
+                   (propRelation genIntS genPairsList propDomainRestrictionAndIntersection)
+    , testProperty "DomainRestrictionAndIntersectionB"
+                   (propRelation genIntS genPairsList propDomainRestrictionAndIntersectionB)
+    , testProperty "DomainExclusionAndSetDifference"
+                   (propRelation genIntS genPairsList propDomainExclusionAndSetDifference)
+    , testProperty "RangeRestrictionAndIntersection"
+                   (propRelation genIntS genPairsList propRangeRestrictionAndIntersection)
+    , testProperty "RangeRestrictionAndIntersectionB"
+                   (propRelation genIntS genPairsList propRangeRestrictionAndIntersectionB) ]
 
   , testGroup "Relations"
     [ testProperty "Set instance"

--- a/byron/ledger/executable-spec/test/Ledger/UTxO/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/UTxO/Properties.hs
@@ -9,19 +9,20 @@ import           Control.Arrow ((***))
 import           Control.Lens (view, (&), (^.), _2)
 import           Control.Monad (when)
 import           Data.Foldable (foldl', traverse_)
-import           Hedgehog (Property, classify, cover, forAll, property, success, withTests, (===), MonadTest)
+import           Hedgehog (MonadTest, Property, classify, cover, forAll, property, success,
+                     withTests, (===))
 
-import           Control.State.Transition.Generator (classifyTraceLength, trace)
-import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst), firstAndLastState, _traceInitState,
-                     preStatesAndSignals, traceEnv, traceLength, traceSignals)
+import           Control.State.Transition.Generator (classifyTraceLength, trace, traceOfLength)
+import           Control.State.Transition.Trace (Trace, TraceOrder (OldestFirst), firstAndLastState,
+                     preStatesAndSignals, traceEnv, traceLength, traceSignals, _traceInitState)
 
-import           Cardano.Ledger.Spec.STS.UTXO (UTxOState(UTxOState), pps, reserves, utxo)
+import           Cardano.Ledger.Spec.STS.UTXO (UTxOState (UTxOState), pps, reserves, utxo)
 import           Cardano.Ledger.Spec.STS.UTXOW (UTXOW)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set, empty, fromList, union)
-import           Ledger.Core (Lovelace, unLovelace, (◁), (⋪), (∪), (∩), dom)
-import           Ledger.UTxO (Tx (Tx), TxIn (TxIn), TxOut (TxOut), TxWits, UTxO(UTxO), balance, body, inputs,
-                     outputs, pcMinFee, txins, txouts)
+import           Ledger.Core (Lovelace, dom, unLovelace, (∩), (∪), (⋪), (◁))
+import           Ledger.UTxO (Tx (Tx), TxIn (TxIn), TxOut (TxOut), TxWits, UTxO (UTxO), balance,
+                     body, inputs, outputs, pcMinFee, txins, txouts)
 
 --------------------------------------------------------------------------------
 -- UTxO Properties
@@ -72,8 +73,8 @@ utxoDiff = property $ do
 
 relevantCasesAreCovered :: Property
 relevantCasesAreCovered = withTests 400 $ property $ do
-  let tl = 100
-  tr <- forAll (trace @UTXOW tl)
+  let tl = 300
+  tr <- forAll (traceOfLength @UTXOW tl)
   let n :: Integer
       n = fromIntegral $ traceLength tr
 

--- a/byron/ledger/executable-spec/test/Ledger/Update/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Examples.hs
@@ -1,0 +1,159 @@
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | Examples of the application of the update rules.
+module Ledger.Update.Examples where
+
+import           GHC.Exts (fromList)
+
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit (testCase)
+
+import           Ledger.Core
+import           Ledger.Update
+
+import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
+
+upiendExamples :: [TestTree]
+upiendExamples =
+  [ testGroup "UPIEND"
+    [ testCase "Example 0" $
+      let
+        oldPParams =
+          PParams
+          { _maxBkSz = 10000
+          , _maxHdrSz = 1000
+          , _maxTxSz = 500
+          , _maxPropSz = 10
+          , _bkSgnCntT = 0.7857142857142857
+          , _bkSlotsPerEpoch = SlotCount { unSlotCount = 10 }
+          , _upTtl = SlotCount { unSlotCount = 10 }
+          , _scriptVersion = 0
+          , _cfmThd = 0.6
+          , _upAdptThd = 0.6
+          , _factorA = 1
+          , _factorB = 2
+          }
+        newPParams =
+          PParams
+          { _maxBkSz = 9900
+          , _maxHdrSz = 1000
+          , _maxTxSz = 489
+          , _maxPropSz = 10
+          , _bkSgnCntT = 0.7857142857142857
+          , _bkSlotsPerEpoch = SlotCount { unSlotCount = 10 }
+          , _upTtl = SlotCount { unSlotCount = 2 }
+          , _scriptVersion = 0
+          , _cfmThd = 0.0
+          , _upAdptThd = 0.0
+          , _factorA = 0
+          , _factorB = 0
+          }
+      in
+        checkTrace @UPIEND
+          ( Slot { unSlot = 15 }
+          , [ ( VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 0 } }
+              , VKey Owner { unOwner = 0 }
+              )
+            , ( VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 1 } }
+              , VKey Owner { unOwner = 1 }
+              )
+            , ( VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 2 } }
+              , VKey Owner { unOwner = 2 }
+              )
+            , ( VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 3 } }
+              , VKey Owner { unOwner = 3 }
+              )
+            , ( VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 4 } }
+              , VKey Owner { unOwner = 4 }
+              )
+            ]
+          , BlockCount { unBlockCount = 2 }
+          , 5
+          ) $
+
+          pure
+          ( ( ProtVer { _pvMaj = 0 , _pvMin = 0 , _pvAlt = 0 }
+            , oldPParams
+            )
+          , []
+          , fromList []
+          , fromList
+              [ ( UpId 1
+                , ( ProtVer { _pvMaj = 1 , _pvMin = 0 , _pvAlt = 0 }
+                  , newPParams
+                  )
+                )
+              ]
+          , fromList [ ( UpId 1 , ( ApName "" , ApVer 0 , Metadata ) ) ]
+          , fromList [ ( UpId 1 , Slot { unSlot = 5 } ) ]
+          , fromList
+              [ ( UpId 1
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 1 } }
+                )
+              , ( UpId 1
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 2 } }
+                )
+              , ( UpId 1
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 3 } }
+                )
+              ]
+          , fromList
+              [ ( ProtVer { _pvMaj = 1 , _pvMin = 0 , _pvAlt = 0 }
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 1 } }
+                )
+              , ( ProtVer { _pvMaj = 1 , _pvMin = 0 , _pvAlt = 0 }
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 3 } }
+                )
+              ]
+          , fromList [ ( UpId 1 , Slot { unSlot = 2 } ) ]
+          )
+
+        .- (ProtVer { _pvMaj = 1 , _pvMin = 0 , _pvAlt = 0 }, VKey Owner { unOwner = 0 }) .->
+
+          ( ( ProtVer { _pvMaj = 0 , _pvMin = 0 , _pvAlt = 0 }
+            , oldPParams
+            )
+          , [ ( Slot {unSlot = 15}
+                       , ( ProtVer {_pvMaj = 1, _pvMin = 0, _pvAlt = 0}
+                         , newPParams
+                         )
+                       )
+                     ]
+          , fromList []
+          , fromList
+              [ ( UpId 1
+                , ( ProtVer { _pvMaj = 1 , _pvMin = 0 , _pvAlt = 0 }
+                  , newPParams
+                  )
+                )
+              ]
+          , fromList [ ( UpId 1 , ( ApName "" , ApVer 0 , Metadata ) ) ]
+          , fromList [ ( UpId 1 , Slot { unSlot = 5 } ) ]
+          , fromList
+              [ ( UpId 1
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 1 } }
+                )
+              , ( UpId 1
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 2 } }
+                )
+              , ( UpId 1
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 3 } }
+                )
+              ]
+          , fromList
+              [ ( ProtVer { _pvMaj = 1 , _pvMin = 0 , _pvAlt = 0 }
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 0 } }
+                )
+              , ( ProtVer { _pvMaj = 1 , _pvMin = 0 , _pvAlt = 0 }
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 1 } }
+                )
+              , ( ProtVer { _pvMaj = 1 , _pvMin = 0 , _pvAlt = 0 }
+                , VKeyGenesis { unVKeyGenesis = VKey Owner { unOwner = 3 } }
+                )
+              ]
+          , fromList [ ( UpId 1 , Slot { unSlot = 2 } ) ]
+          )
+
+    ]
+  ]

--- a/byron/ledger/executable-spec/test/Ledger/Update/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Examples.hs
@@ -9,8 +9,13 @@ import           GHC.Exts (fromList)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (testCase)
 
-import           Ledger.Core
-import           Ledger.Update
+import           Ledger.Core (BlockCount (BlockCount), Owner (Owner), Slot (Slot),
+                     SlotCount (SlotCount), VKey (VKey), VKeyGenesis (VKeyGenesis), unBlockCount,
+                     unOwner, unSlot, unSlotCount, unVKeyGenesis)
+import           Ledger.Update (ApName (ApName), ApVer (ApVer), Metadata (Metadata),
+                     PParams (PParams), ProtVer (ProtVer), UPIEND, UpId (UpId), _bkSgnCntT,
+                     _bkSlotsPerEpoch, _factorA, _factorB, _maxBkSz, _maxHdrSz, _maxPropSz,
+                     _maxTxSz, _pvAlt, _pvMaj, _pvMin, _scriptVersion, _upAdptThd, _upTtl)
 
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 

--- a/byron/ledger/executable-spec/test/Ledger/Update/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Examples.hs
@@ -29,7 +29,6 @@ upiendExamples =
           , _bkSlotsPerEpoch = SlotCount { unSlotCount = 10 }
           , _upTtl = SlotCount { unSlotCount = 10 }
           , _scriptVersion = 0
-          , _cfmThd = 0.6
           , _upAdptThd = 0.6
           , _factorA = 1
           , _factorB = 2
@@ -44,7 +43,6 @@ upiendExamples =
           , _bkSlotsPerEpoch = SlotCount { unSlotCount = 10 }
           , _upTtl = SlotCount { unSlotCount = 2 }
           , _scriptVersion = 0
-          , _cfmThd = 0.0
           , _upAdptThd = 0.0
           , _factorA = 0
           , _factorB = 0

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -13,7 +13,7 @@ import           Ledger.AbstractSize.Properties (testTxHasTypeReps)
 import qualified Ledger.Core.Generators.Properties as CoreGen
 import           Ledger.Delegation.Examples (deleg)
 import qualified Ledger.Delegation.Properties as DELEG
-import           Ledger.Pvbump.Properties (beginningsNoUpdate, emptyPVUpdate, lastProposal)
+import           Ledger.Pvbump.Properties (beginningsNoUpdate, emptyPVUpdate, firstProposal)
 import           Ledger.Relation.Properties (testRelation)
 import qualified Ledger.Update.Properties as UPDATE
 import           Ledger.UTxO.Properties (moneyIsConstant)
@@ -42,7 +42,7 @@ main = defaultMain tests
       "PVBUMP properties"
       [ testProperty "Same state for no updates"         emptyPVUpdate
       , testProperty "Same state for early on in chain"  beginningsNoUpdate
-      , testProperty "State determined by last proposal" lastProposal
+      , testProperty "State determined by first proposal" firstProposal
       ]
     , testGroup
       "UTxO properties"

--- a/byron/ledger/executable-spec/test/Main.hs
+++ b/byron/ledger/executable-spec/test/Main.hs
@@ -15,6 +15,7 @@ import           Ledger.Delegation.Examples (deleg)
 import qualified Ledger.Delegation.Properties as DELEG
 import           Ledger.Pvbump.Properties (beginningsNoUpdate, emptyPVUpdate, firstProposal)
 import           Ledger.Relation.Properties (testRelation)
+import           Ledger.Update.Examples (upiendExamples)
 import qualified Ledger.Update.Properties as UPDATE
 import           Ledger.UTxO.Properties (moneyIsConstant)
 import qualified Ledger.UTxO.Properties as UTxO
@@ -52,6 +53,7 @@ main = defaultMain tests
       , testProperty "UTxO is outputs minus inputs" UTxO.utxoDiff
       ]
     , testTxHasTypeReps
+    , testGroup "Update examples" upiendExamples
     , testGroup
       "Update properties"
       [ testProperty "UPIREG traces are classified" UPDATE.upiregTracesAreClassified

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -347,25 +347,7 @@ In these rules we make use of the abstract constant $\var{ngk}$, defined in
 
 \clearpage
 
-Rule~\ref{eq:rule:upi-vote} models the effect of voting on an update proposal:
-after a vote, a proposal might get confirmed, which means that it will be added
-to the set $\var{cps'}$. In such case, the mapping of application names to
-their latest version known to the ledger will be updated to include the
-information in the confirmed proposal. Note that, unlike protocol updates,
-software updates take effect as soon as a proposal is confirmed and stable
-(i.e. its confirmation occurred at least $2\cdot k$ slots ago). In this rule,
-we also delete the confirmed and stable proposals id's from the set of
-registered application update proposals ($\var{raus}$), since this information
-is no longer needed once the application-name to software-version map
-($\var{avs}$) is updated.
-
-Also note that, unlike the rules of \cref{fig:rules:upi-ec}, we need not remove
-other update proposals that refer to the software names whose versions were
-changed in $\var{avs_{new}}$. The reason for this is that the map $\var{raus}$
-can contain only one pair of the form $(\var{an}, \wcard)$ for any given
-application name $\var{an}$: in Rule~\ref{eq:rule:up-av-validity} function
-$\fun{svCanFollow}$ ensures that there is only one allowed version for any
-given application name $\var{an}$.
+Rule~\ref{eq:rule:upi-vote} models the effect of voting on an update proposal.
 
 \begin{figure}[htb]
   \begin{equation}
@@ -501,7 +483,26 @@ Figure~\ref{fig:st-diagram-pt-up}.
 \clearpage
 
 A sequence of votes can be applied using $\trans{upivotes}{}$ transitions. The
-inference rules for them are presented in \cref{fig:rules:apply-votes}.
+inference rules for them are presented in \cref{fig:rules:apply-votes}. After
+applying a sequence of votes, proposals might get confirmed, which means that
+they will be added to the set $\var{cps'}$. In such case, the mapping of
+application names to their latest version known to the ledger will be updated to
+include the information about the confirmed proposals. Note that, unlike protocol
+updates, software updates take effect as soon as a proposal is confirmed and
+stable (i.e. its confirmation occurred at least $2\cdot k$ slots ago). In this
+rule, we also delete the confirmed and stable proposals id's from the set of
+registered application update proposals ($\var{raus}$), since this information
+is no longer needed once the application-name to software-version map
+($\var{avs}$) is updated.
+
+Also note that, unlike the rules of \cref{fig:rules:upi-ec}, we need not remove
+other update proposals that refer to the software names whose versions were
+changed in $\var{avs_{new}}$. The reason for this is that the map $\var{raus}$
+can contain only one pair of the form $(\var{an}, \wcard)$ for any given
+application name $\var{an}$: in Rule~\ref{eq:rule:up-av-validity} function
+$\fun{svCanFollow}$ ensures that there is only one allowed version for any
+given application name $\var{an}$.
+
 
 \begin{figure}[htb]
   \begin{equation}

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -372,7 +372,7 @@ given application name $\var{an}$.
     \label{eq:rule:upi-vote}
     \inference
     {
-      \var{cfmThd} \mapsto q \in \var{pps}\\
+      \var{upAdptThd} \mapsto q \in \var{pps}\\
       {\left(
         \begin{array}{l}
           s_n\\
@@ -398,13 +398,7 @@ given application name $\var{an}$.
             \var{vts'}
           \end{array}
         \right)
-      }\\
-      {\begin{array}{r@{~\leteq~}l}
-        \var{stbl_{cps}} & \dom~(cps' \restrictrange [.., s_n - 2 \cdot k])\\
-        \var{stbl_{raus}} & \var{stbl_{cps}} \restrictdom \var{raus}\\
-        \var{avs_{new}} & \{ \var{an} \mapsto (\var{av}, \var{s_n}, m)
-        \mid (\var{an}, \var{av}, m) \in \var{stbl_{raus}} \}
-      \end{array}}
+      }
     }
     {
       {\left(
@@ -435,9 +429,9 @@ given application name $\var{an}$.
           \begin{array}{l}
             (\var{pv}, \var{pps})\\
             \var{fads}\\
-            \var{avs} \unionoverrideRight \var{avs_{new}}\\
+            \var{avs}\\
             \var{rpus}\\
-            \var{stbl_{cps}} \subtractdom \var{raus}\\
+            \var{raus}\\
             \var{cps'}\\
             \var{vts'}\\
             \var{bvs}\\
@@ -507,11 +501,11 @@ Figure~\ref{fig:st-diagram-pt-up}.
 \clearpage
 
 A sequence of votes can be applied using $\trans{upivotes}{}$ transitions. The
-inference rules for them are presented in \cref{fig:rules:upi-votes}.
+inference rules for them are presented in \cref{fig:rules:apply-votes}.
 
 \begin{figure}[htb]
   \begin{equation}
-    \label{eq:rule:upi-votes-base}
+    \label{eq:rule:apply-votes-base}
     \inference
     {
     }
@@ -524,13 +518,15 @@ inference rules for them are presented in \cref{fig:rules:upi-votes}.
       \right)}
       \vdash
       \var{us}
-      \trans{upivotes}{\epsilon}
+      \trans{applyvotes}{\epsilon}
       \var{us}
     }
   \end{equation}
   %
+  \nextdef
+  %
   \begin{equation}
-    \label{eq:rule:upi-votes-ind}
+    \label{eq:rule:apply-votes-ind}
     \inference
     {
       {\left(
@@ -541,7 +537,7 @@ inference rules for them are presented in \cref{fig:rules:upi-votes}.
       \right)}
       \vdash
       \var{us}
-      \trans{upivotes}{\Gamma}
+      \trans{applyvotes}{\Gamma}
       \var{us'}
       &
       {\left(
@@ -564,12 +560,96 @@ inference rules for them are presented in \cref{fig:rules:upi-votes}.
       \right)}
       \vdash
       \var{us}
-      \trans{upivotes}{\Gamma;v}
+      \trans{applyvotes}{\Gamma;v}
       \var{us''}
     }
   \end{equation}
+  %
+  \nextdef
+  %
+  \begin{equation}
+    \label{eq:rule:upivotes}
+    \inference{
+      {\left(
+        \begin{array}{l}
+          s_n\\
+          \var{dms}
+        \end{array}
+      \right)}
+      \vdash
+      {\left(
+          \begin{array}{l}
+            (\var{pv}, \var{pps})\\
+            \var{fads}\\
+            \var{avs}\\
+            \var{rpus}\\
+            \var{raus}\\
+            \var{cps}\\
+            \var{vts}\\
+            \var{bvs}\\
+            \var{pws}
+          \end{array}
+        \right)}
+      \trans{applyvotes}{\Gamma}
+      {\left(
+          \begin{array}{l}
+            (\var{pv'}, \var{pps'})\\
+            \var{fads'}\\
+            \var{avs'}\\
+            \var{rpus'}\\
+            \var{raus'}\\
+            \var{cps'}\\
+            \var{vts'}\\
+            \var{bvs'}\\
+            \var{pws'}
+          \end{array}
+      \right)}\\
+      %
+      {\begin{array}{r@{~\leteq~}l}
+        \var{stbl_{cps}} & \dom~(cps' \restrictrange [.., s_n - 2 \cdot k])\\
+        \var{stbl_{raus}} & \var{stbl_{cps}} \restrictdom \var{raus}\\
+        \var{avs_{new}} & \{ \var{an} \mapsto (\var{av}, \var{s_n}, m)
+        \mid (\var{an}, \var{av}, m) \in \var{stbl_{raus}} \}
+      \end{array}}
+    }{
+      {\left(
+        \begin{array}{l}
+          s_n\\
+          \var{dms}
+        \end{array}
+      \right)}
+      \vdash
+      {\left(
+          \begin{array}{l}
+            (\var{pv}, \var{pps})\\
+            \var{fads}\\
+            \var{avs}\\
+            \var{rpus}\\
+            \var{raus}\\
+            \var{cps}\\
+            \var{vts}\\
+            \var{bvs}\\
+            \var{pws}
+          \end{array}
+      \right)}
+      \trans{upivotes}{\Gamma}
+      {\left(
+          \begin{array}{l}
+            (\var{pv'}, \var{pps'})\\
+            \var{fads'}\\
+            \var{avs'} \unionoverrideRight \var{avs_{new}}\\
+            \var{rpus'}\\
+            \var{stbl_{cps}} \subtractdom \var{raus'}\\
+            \var{cps'}\\
+            \var{vts'}\\
+            \var{bvs'}\\
+            \var{pws'}
+          \end{array}
+      \right)}
+    }
+  \end{equation}
   \caption{Applying multiple votes on update-proposals rules}
-  \label{fig:rules:upi-votes}
+  \label{fig:rules:apply-votes}
 \end{figure}
 \clearpage
 

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -166,21 +166,16 @@ keys, some of which correspond with fields of the
 \item Transaction fee policy: $\var{txFeePolicy}$
 \item Script version: $\var{scriptVersion}$
 \item Update adoption threshold: $\var{upAdptThd}$. This represents the minimum
-  percentage of the total number of genesis keys that have to endorse a
-  protocol version to be able to become adopted. There is no corresponding
-  parameter in the `cardano-sl` protocol parameters, however we do have a
-  soft-fork minimum threshold parameter (`srMinThd` in `bvdSoftforkRule`). When
-  divided by, $1\times 10^{15}$, it determines the minimum portion of the total
-  stake that is needed for the adoption of a new protocol version. On mainnet,
-  this number is set to $6 \times 10^{14}$, so the minimum portion becomes
-  $0.6$. This number can be multiplied by the total number of genesis keys to
-  obtain how many keys are needed to reach a majority.
-\item Confirmation threshold $\var{cfmThd}$: This represents the minimum
-  percentage of the total number of genesis keys that have to vote on a
-  proposal for it to become confirmed. As with $\var{upAdptThd}$ there is no
-  corresponding protocol parameter in the `cardano-sl` protocol parameters, so
-  in the implementation we will be using `srMinThd` as well to get the portion
-  of keys that need to vote on a proposal to be confirmed.
+  percentage of the total number of genesis keys that have to endorse a protocol
+  version to be able to become adopted. We use this parameter to determine the
+  confirmation threshold as well. There is no corresponding parameter in the
+  `cardano-sl` protocol parameters, however we do have a soft-fork minimum
+  threshold parameter (`srMinThd` in `bvdSoftforkRule`). When divided by,
+  $1\times 10^{15}$, it determines the minimum portion of the total stake that
+  is needed for the adoption of a new protocol version. On mainnet, this number
+  is set to $6 \times 10^{14}$, so the minimum portion becomes $0.6$. This
+  number can be multiplied by the total number of genesis keys to obtain how
+  many keys are needed to reach a majority.
 \item Update proposal time-to-live: $\var{upropTTL}$. This would correspond to
   the number of slots specified by `bvdUpdateImplicit`. In `cardano-sl` the
   rule was that after `bvdUpdateImplicit` slots, if a proposal did not reach a
@@ -204,7 +199,6 @@ The protocol parameters are formally defined in \cref{fig:prot-params-defs}.
       \var{maxHeaderSize} \mapsto \mathbb{N} & \PPMMap & \text{maximum header size}\\
       \var{scriptVersion} \mapsto \mathbb{N} & \PPMMap & \text{script version}\\
       \var{upAdptThd} \mapsto \mathbb{Q} & \PPMMap & \text{update proposal adoption threshold}\\
-      \var{cfmThd} \mapsto \mathbb{Q} & \PPMMap & \text{update proposal confirmation threshold}\\
       \var{upropTTL} \mapsto \mathbb{\Slot} & \PPMMap & \text{update proposal time-to-live}\\
     \end{array}
   \end{equation*}
@@ -1215,7 +1209,7 @@ rule by $\var{bv}$:
     {
       \var{bvs'} \leteq \var{bvs} \cup
       \{ (\var{bv}, \var{vk_s}) \mid \var{vk_s} \mapsto \var{vk} \in \var{dms} \}
-      & \size{\{\var{bv}\} \restrictdom \var{bvs}} < t\\
+      & \size{\{\var{bv}\} \restrictdom \var{bvs'}} < t\\
       \var{pid} \mapsto (\var{bv}, \wcard) \in \var{rpus}
       & \var{pid} \in \dom~(\var{cps} \restrictrange [.., s_n - 2 \cdot k])
     }
@@ -1258,7 +1252,7 @@ rule by $\var{bv}$:
     {
       \var{bvs'} \leteq \var{bvs} \cup
       \{ (\var{bv}, \var{vk_s}) \mid \var{vk_s} \mapsto \var{vk} \in \var{dms} \}
-      & t \leq \size{\{\var{bv}\} \restrictdom \var{bvs}}\\
+      & t \leq \size{\{\var{bv}\} \restrictdom \var{bvs'}}\\
       \var{pid} \mapsto (\var{bv}, \var{pps_c}) \in \var{rpus}
       & \var{pid} \in \dom~(\var{cps} \restrictrange [.., s_n - 2 \cdot k])\\
       (\var{fads}) \trans{fads}{(s_n, (\var{bv}, \var{pps_c}))} (\var{fads'})

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -342,7 +342,7 @@ functions:
       \fun{svCanFollow}~\var{avs}~(\var{an}, \var{av}) & =
       & (\var{an} \mapsto (\var{av_c}, \wcard, \wcard) \in \var{avs}
         \Rightarrow \var{av} = \var{av_c} + 1)\\
-      & \wedge & (\var{an} \notin \dom~\var{avs} \Rightarrow \var{av} = 0)
+      & \wedge & (\var{an} \notin \dom~\var{avs} \Rightarrow \var{av} = 1)
     \end{array}
   \end{equation}
   \caption{Update validity functions}


### PR DESCRIPTION
Fix errors discovered during conformance testing of valid chains against the implementation in `cardano-ledger`.

- Fix the implementation of `PVBUMP`: the last proposal was being taken instead of the first one.
- Simplify the `EPOCH` rule.
- Count the block endorsement when registering it.
- Remove `cfmThd` use `upAdptThd` instead, since these are the same value, and we have no compelling reasons for using different ones here. This closes #623 
- Perform application version change, even when there are not votes in the block.
- Generate the update id's based on the `pwd` set (otherwise we would be generating duplicated proposal id's).
- Add a constant `c` to `GlobalParams` which is used to bound the concrete size. We use this constant when choosing the next `B` factor, and when elaborating this factor into a concrete one.
