### PR TITLE
update proposal example and cleanup nonces

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
@@ -13,7 +13,7 @@ module BaseTypes
   , interval1
   , Seed(..)
   , mkNonce
-  , seedOp
+  , (⭒)
   ) where
 
 
@@ -75,10 +75,10 @@ instance ToCBOR Seed where
     SeedOp s1 s2 ->
       encodeListLen 3 <> toCBOR (4 :: Word8) <> toCBOR s1 <> toCBOR s2
 
-seedOp :: Seed -> Seed -> Seed
-seedOp NeutralSeed s = s
-seedOp s NeutralSeed = s
-seedOp a b = SeedOp a b
+(⭒) :: Seed -> Seed -> Seed
+NeutralSeed ⭒ s = s
+s ⭒ NeutralSeed = s
+a ⭒ b = SeedOp a b
 
 mkNonce :: Integer -> Seed
 mkNonce = Nonce

--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -41,7 +41,7 @@ import           Numeric.Natural (Natural)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
 
-import           BaseTypes (Seed (..), UnitInterval, intervalValue, mkNonce, seedOp)
+import           BaseTypes (Seed (..), UnitInterval, intervalValue, mkNonce, (⭒))
 import           Delegation.Certificates (PoolDistr (..))
 import           EpochBoundary (BlocksMade (..))
 import           Keys (DSIGNAlgorithm, Hash, HashAlgorithm, KESAlgorithm, KESig, KeyHash, VKey,
@@ -229,10 +229,10 @@ vrfChecks eta0 (PoolDistr pd) f bhb =
         Just (sigma, vrfHK) ->
           vrfHK == hashKey vrfK
             && verifyVrf vrfK
-                         ((eta0 `seedOp` ss) `seedOp` SeedEta)
+                         ((eta0 ⭒ ss) ⭒ SeedEta)
                          (bheaderEta bhb, bheaderPrfEta bhb)
             && verifyVrf vrfK
-                         ((eta0 `seedOp` ss) `seedOp` SeedL)
+                         ((eta0 ⭒ ss) ⭒ SeedL)
                          (bheaderL bhb, bheaderPrfL bhb)
             && intervalValue (bheaderL bhb)
             <  1

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -25,6 +25,7 @@ module LedgerState
   , EpochState(..)
   , emptyEpochState
   , emptyLedgerState
+  , clearPpup
   , dstate
   , pstate
   , ptrs
@@ -300,6 +301,14 @@ emptyDState =
 emptyPState :: PState hashAlgo dsignAlgo
 emptyPState =
   PState (StakePools Map.empty) Map.empty Map.empty Map.empty
+
+-- |Clear the protocol parameter updates
+clearPpup
+  :: UTxOState hashAlgo dsignAlgo
+  -> UTxOState hashAlgo dsignAlgo
+clearPpup utxoSt =
+  let (_, avup, faps, aps) = _ups utxoSt
+  in utxoSt {_ups = (PPUpdate Map.empty, avup, faps, aps)}
 
 data UTxOState hashAlgo dsignAlgo =
     UTxOState

--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -77,7 +77,7 @@ newEpochTransition = do
             ]
       let pd' = Map.intersectionWith (,) sd (Map.map _poolVrf (_poolsSS ss))
       pure $ NewEpochState e
-                           (seedOp eta1 etaE)
+                           (eta1 ⭒ etaE)
                            bcur
                            (BlocksMade Map.empty)
                            es''

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
@@ -63,10 +63,10 @@ newPpTransition = do
           let utxoSt' = utxoSt { _deposited = Coin oblgNew }
           in  -- TODO: update mechanism
               let acnt' = acnt { _reserves = Coin $ reserves + diff }
-                                       in  pure (utxoSt', acnt', ppNew')
+              in pure (clearPpup utxoSt', acnt', ppNew')
         else
-          pure ( utxoSt
+          pure ( clearPpup utxoSt
               , acnt
               , pp
               )
-    Nothing -> pure (utxoSt, acnt, pp)
+    Nothing -> pure (clearPpup utxoSt, acnt, pp)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
@@ -28,5 +28,5 @@ updTransition = do
   TRC (eta, (eta_v, eta_c), s) <- judgmentContext
   let Epoch e = epochFromSlot s
   if s +* slotsPrior < firstSlot (Epoch (e + 1))
-    then pure (seedOp eta_v eta, seedOp eta_c eta)
-    else pure (seedOp eta_v eta, eta_c)
+    then pure (eta_v ⭒ eta, eta_v ⭒ eta)
+    else pure (eta_v ⭒ eta, eta_c)

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -22,7 +22,7 @@ where
 import           Data.ByteString (ByteString)
 import qualified Data.List as List (group)
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import           Data.Set (Set)
 import           Data.Word (Word8)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
@@ -144,7 +144,7 @@ instance ToCBOR Ppm where
       encodeListLen 2 <> toCBOR (18 :: Word8) <> toCBOR protocolVersion
 
 newtype PPUpdate dsignAlgo
-  = PPUpdate (Map.Map (VKeyGenesis dsignAlgo) (Set.Set Ppm))
+  = PPUpdate (Map.Map (VKeyGenesis dsignAlgo) (Set Ppm))
   deriving (Show, Ord, Eq, ToCBOR)
 
 -- | Update Protocol Parameter update with new values, prefer value from `pup1`

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Updates
-  ( PPUpdateEnv(..)
+  ( Ppm(..)
+  , PPUpdateEnv(..)
   , PPUpdate(..)
   , updatePPup
   , ApName(..)
@@ -21,6 +22,7 @@ where
 import           Data.ByteString (ByteString)
 import qualified Data.List as List (group)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 import           Data.Word (Word8)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
@@ -142,7 +144,7 @@ instance ToCBOR Ppm where
       encodeListLen 2 <> toCBOR (18 :: Word8) <> toCBOR protocolVersion
 
 newtype PPUpdate dsignAlgo
-  = PPUpdate (Map.Map (VKeyGenesis dsignAlgo) (Map.Map Ppm Seed))
+  = PPUpdate (Map.Map (VKeyGenesis dsignAlgo) (Set.Set Ppm))
   deriving (Show, Ord, Eq, ToCBOR)
 
 -- | Update Protocol Parameter update with new values, prefer value from `pup1`

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -352,7 +352,7 @@ ex1 :: CHAINExample
 ex1 = CHAINExample (Slot 1) initStEx1 blockEx1 expectedStEx1
 
 
--- | Example 2 - apply CHAIN transition to register a stake keys and a pool
+-- | Example 2 - apply CHAIN transition to register stake keys and a pool
 
 
 utxoEx2 :: UTxO

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -14,6 +14,7 @@ import qualified STS.Chain
 import qualified STS.Utxow
 import qualified Tx
 import qualified TxData
+import qualified Updates
 import qualified UTxO
 
 type DCert = Delegation.Certificates.DCert ShortHash MockDSIGN
@@ -110,3 +111,9 @@ type Wdrl = TxData.Wdrl ShortHash MockDSIGN
 type SnapShots = EpochBoundary.SnapShots ShortHash MockDSIGN
 
 type Stake = EpochBoundary.Stake ShortHash MockDSIGN
+
+type Update = Updates.Update MockDSIGN
+
+type PPUpdate = Updates.PPUpdate MockDSIGN
+
+type AVUpdate = Updates.AVUpdate MockDSIGN

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -14,7 +14,7 @@ import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
 
-import           BaseTypes (Seed (..))
+import           BaseTypes (Seed (..), (⭒))
 import           Control.State.Transition (TRC (..), applySTS)
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import           Slot (Slot (..))
@@ -25,13 +25,16 @@ import           TxData (pattern RewardAcnt, pattern ScriptHashObj)
 
 -- | The UPDN transition should update both the evolving nonce and
 -- the candidate nonce during the first two-thirds of the epoch.
+-- In order for the candidate nonce to catch up with the evolving
+-- nonce after and epoch change, the candidate nonce is set to
+-- the same value as the evolving nonce during this time.
 -- Note that the number of slots per epoch is hard-coded in the Slot module.
 testUPNEarly :: Assertion
 testUPNEarly =
   let
     st = applySTS @UPDN (TRC (Nonce 1, (Nonce 2, Nonce 3), Slot.Slot 5))
   in
-    st @?= Right (SeedOp (Nonce 2) (Nonce 1), SeedOp (Nonce 3) (Nonce 1))
+    st @?= Right (Nonce 2 ⭒ Nonce 1, Nonce 2 ⭒ Nonce 1)
 
 -- | The UPDN transition should update only the evolving nonce
 -- in the last thirds of the epoch.

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -26,7 +26,7 @@ import           TxData (pattern RewardAcnt, pattern ScriptHashObj)
 -- | The UPDN transition should update both the evolving nonce and
 -- the candidate nonce during the first two-thirds of the epoch.
 -- In order for the candidate nonce to catch up with the evolving
--- nonce after and epoch change, the candidate nonce is set to
+-- nonce after an epoch change, the candidate nonce is set to
 -- the same value as the evolving nonce during this time.
 -- Note that the number of slots per epoch is hard-coded in the Slot module.
 testUPNEarly :: Assertion


### PR DESCRIPTION
In this PR I have cleaned up the nonces so that the examples are readable. There was one subtlety in the `UPDN` transition that needed fixing. The nonce candidate was not catching up with the epoch nonce after the new epoch transition. The fix was to let the candidate nonce always be set to the evolving nonce in the first rule.

I've added an example of using a protocol parameter update proposal. I needed to change the `NEWPP` transition to clear out the `ppup`s in every case.

I changed the type of `PPUpdate` from `Map Ppm Seed` to `Set Ppm`. This may still not be perfect. In the spec we use a record.

I also changed the `PPUD` transition to use two rules instead of one rule with an `if _ then _ else _`, so that now we have `transitionRules = [ppupTransitionEmpty, ppupTransitionNonEmpty]`. We probably want to do this for more of our transitions.

Finally, I made it so that the non-trivial reward update in the running shelley example/tests now calculates member stake as well (ie I added a member to the existing stake pool).