### PR TITLE
Add `threaded` and `N` flags to ghc-options in the Byron cabal files.

### DIFF
--- a/byron/chain/executable-spec/cs-blockchain.cabal
+++ b/byron/chain/executable-spec/cs-blockchain.cabal
@@ -77,6 +77,7 @@ test-suite chain-rules-test
                        -Wredundant-constraints
                        -- See `cs-ledger.cabal` for an explanation of the
                        -- options below.
-                       "-with-rtsopts=-K4m -M300m"
+                       -threaded
+                       "-with-rtsopts=-K4m -M300m -N2"
   if (!flag(development))
     ghc-options:       -Werror

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -77,7 +77,7 @@ test-suite doctests
                       -Wincomplete-uni-patterns
                       -Wredundant-constraints
                       -threaded
-
+                      "-with-rtsopts=-N2"
 
   if (!flag(development))
     ghc-options:      -Werror
@@ -118,6 +118,7 @@ test-suite ledger-rules-test
                --
                -- The 4 megabytes stack bound and 150 megabytes heap bound were
                -- determined ad-hoc.
-               "-with-rtsopts=-K4m -M150m"
+               -threaded
+               "-with-rtsopts=-K4m -M150m -N2"
   if (!flag(development))
     ghc-options: -Werror

--- a/byron/semantics/executable-spec/small-steps.cabal
+++ b/byron/semantics/executable-spec/small-steps.cabal
@@ -73,7 +73,7 @@ test-suite doctests
                       -Wincomplete-uni-patterns
                       -Wredundant-constraints
                       -threaded
-                      -"-with-rtsopts=-N2"
+                      "-with-rtsopts=-N2"
 
   if (!flag(development))
     ghc-options:      -Werror
@@ -99,7 +99,7 @@ test-suite examples
                       -Wincomplete-uni-patterns
                       -Wredundant-constraints
                       -threaded
-                      -"-with-rtsopts=-N2"
+                      "-with-rtsopts=-N2"
 
   if (!flag(development))
     ghc-options:      -Werror

--- a/byron/semantics/executable-spec/small-steps.cabal
+++ b/byron/semantics/executable-spec/small-steps.cabal
@@ -73,6 +73,7 @@ test-suite doctests
                       -Wincomplete-uni-patterns
                       -Wredundant-constraints
                       -threaded
+                      -"-with-rtsopts=-N2"
 
   if (!flag(development))
     ghc-options:      -Werror
@@ -98,6 +99,7 @@ test-suite examples
                       -Wincomplete-uni-patterns
                       -Wredundant-constraints
                       -threaded
+                      -"-with-rtsopts=-N2"
 
   if (!flag(development))
     ghc-options:      -Werror

--- a/ci/buildkite/rebuild.hs
+++ b/ci/buildkite/rebuild.hs
@@ -1,19 +1,19 @@
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import Control.Exception
-import Control.Monad.Trans.Maybe
+import           Control.Exception
+import           Control.Monad.Trans.Maybe
 import qualified Data.Text as T
-import Safe
-import System.Exit (exitWith)
-import Turtle
+import           Safe
+import           System.Exit (exitWith)
+import           Turtle
 
 
 -- | Run build and upload coverage information when successful
 main :: IO ()
 main = do
-  buildResult <- buildStep Nothing
+  buildResult <- buildStep "-j2"
 
   when (buildResult == ExitSuccess) coverageUploadStep
 

--- a/ci/buildkite/rebuild.hs
+++ b/ci/buildkite/rebuild.hs
@@ -13,7 +13,7 @@ import           Turtle
 -- | Run build and upload coverage information when successful
 main :: IO ()
 main = do
-  buildResult <- buildStep "-j2"
+  buildResult <- buildStep (Just "-j2")
 
   when (buildResult == ExitSuccess) coverageUploadStep
 

--- a/ci/buildkite/rebuild.hs
+++ b/ci/buildkite/rebuild.hs
@@ -13,7 +13,7 @@ import           Turtle
 -- | Run build and upload coverage information when successful
 main :: IO ()
 main = do
-  buildResult <- buildStep (Just "-j2")
+  buildResult <- buildStep (Just ["-j2"])
 
   when (buildResult == ExitSuccess) coverageUploadStep
 


### PR DESCRIPTION
According to `tasty` README, we need to add the `threaded` flags and specify the
number of cores to be used. On, my machine, using the maximum number of cores
did not improve the performance, but setting this to `2` did (quite considerably
in fact). So I'm testing this on CI.