### PR TITLE
Update non-integral.tex

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/non-integral.tex
+++ b/shelley/chain-and-ledger/formal-spec/non-integral.tex
@@ -106,12 +106,12 @@ $x \approx y \Leftrightarrow \lvert x - y\rvert < \epsilon$.
   of the $\ln'$ and $\exp'$ function:
   \begin{itemize}
   \item $\ln'(x\cdot y) \approx \ln'(x) + \ln'(y)$
-  \item $\ln'(x^{y}) \approx y\cdot \ln'(x)$
+  \item $\ln'(x\star y) \approx y\cdot \ln'(x)$
   \item $\ln'(\exp'(x)) \approx \exp'(\ln'(x)) \approx x$
   \item $x, y \in [0,1] \implies x \star y \in [0, 1]$
   \item $x, y, z \in [0,1], x > 0 \implies
     (z\star\frac{1}{x})\star y \approx (z\star y)\star\frac{1}{x}$
-  \item $\exp'(x + y) = \exp'(x) \cdot \exp'(y)$
+  \item $\exp'(x + y) \approx \exp'(x) \cdot \exp'(y)$
   \end{itemize}
 \end{property}
 


### PR DESCRIPTION
Use 'approx' versions of operators in non-integral formulas.

This is a copy of #694 because buildkite apparently does not run on 3rd party forked repos.

solves #694