### PR TITLE
add examples for AVUP and fix AVUP

### DIFF
--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -34,6 +34,7 @@
         "delegation-test" = {
           depends = [
             (hsPkgs.base)
+            (hsPkgs.bytestring)
             (hsPkgs.cryptonite)
             (hsPkgs.tasty)
             (hsPkgs.tasty-hunit)

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -112,6 +112,7 @@ test-suite delegation-test
         -Werror
     build-depends:
       base,
+      bytestring,
       cryptonite,
       tasty,
       tasty-hunit,

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
@@ -37,20 +37,18 @@ avupTransition = do
   TRC ((_slot, Dms _dms), src@(AVUpdate aupS, favs, avs), AVUpdate _aup) <-
     judgmentContext
 
-  if Map.null aupS
+  if Map.null _aup
     then pure src
     else do
       Map.keysSet _aup `Set.isSubsetOf` Map.keysSet _dms ?! NonGenesisUpdateAVUP
 
       let aup'         = Map.union _aup aupS
-      let (cur, favs') = Map.partitionWithKey (\s _ -> s >= _slot) favs
-      let avs'         = newAVs avs cur
       let fav          = votedValue aup'
       case fav of
-        Nothing -> pure (AVUpdate aup', favs', avs')
+        Nothing -> pure (AVUpdate aup', favs, avs)
         Just fav' ->
           pure
             ( AVUpdate Map.empty
-            , Map.insert (_slot +* slotsPrior) fav' favs'
-            , avs'
+            , Map.insert (_slot +* slotsPrior) fav' favs
+            , avs
             )

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -8,7 +8,7 @@ module Updates
   , updatePPup
   , ApName(..)
   , ApVer(..)
-  , Metadata
+  , Metadata(..)
   , Applications(..)
   , AVUpdate(..)
   , Update(..)
@@ -32,7 +32,7 @@ import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
 import           BaseTypes (Seed, UnitInterval)
 import           Coin (Coin)
 import           Keys (DSIGNAlgorithm, Dms, VKeyGenesis)
-import           PParams (PParams(..))
+import           PParams (PParams (..))
 import           Slot (Epoch, Slot)
 
 import           Numeric.Natural (Natural)

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -9,7 +9,7 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
-                     ex2C, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex3A, ex3B, ex3C)
+                     ex2C, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -89,6 +89,15 @@ testCHAINExample3B = testCHAINExample ex3B
 testCHAINExample3C :: Assertion
 testCHAINExample3C = testCHAINExample ex3C
 
+testCHAINExample4A :: Assertion
+testCHAINExample4A = testCHAINExample ex4A
+
+testCHAINExample4B :: Assertion
+testCHAINExample4B = testCHAINExample ex4B
+
+testCHAINExample4C :: Assertion
+testCHAINExample4C = testCHAINExample ex4C
+
 stsTests :: TestTree
 stsTests = testGroup "STS Tests"
   [ testCase "update nonce early in the epoch" testUPNEarly
@@ -106,6 +115,9 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 3A - get 3/7 votes for a pparam update" testCHAINExample3A
   , testCase "CHAIN example 3B - get 5/7 votes for a pparam update" testCHAINExample3B
   , testCase "CHAIN example 3C - processes a pparam update" testCHAINExample3C
+  , testCase "CHAIN example 4A - get 3/7 votes for a version update" testCHAINExample4A
+  , testCase "CHAIN example 4B - create a future app version" testCHAINExample4B
+  , testCase "CHAIN example 4C - adopt a future app version" testCHAINExample4C
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
   , testCase "Everybody signs in multi-sig" testEverybodySigns

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -930,7 +930,7 @@ The states for this transition consist only of the mapping of certificate issue 
 
 This transition establishes that a block producer is in fact authorized.
 Since there are three key pairs involved (cold keys, VRF keys, and hot KES keys)
-it is worth examinng the interaction in Equation~\ref{eq:decentralized} closely.
+it is worth examining the interaction in Equation~\ref{eq:decentralized} closely.
 
 \begin{itemize}
   \item First we check the operational certificate with $\mathsf{OCERT}$.

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -121,6 +121,10 @@ then calls the $\mathsf{DELEGS}$ transition.
 
 The transition system $\mathsf{LEDGER}$ in Figure~\ref{fig:rules:ledger} is iterated
 in $\mathsf{LEDGERS}$ in order to process a list of transactions.
+The base case also adopts new application versions at the appropriate times
+and cleans up the future application versions mapping.
+Note that it is better to handle this logic here than in the $\mathsf{AVUP}$ transiton,
+because here it will happen even if the block contains no transactions.
 
 \begin{figure}[htb]
   \emph{Ledger Sequence transitions}
@@ -129,7 +133,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transactions.
     \var{\_} \trans{ledgers}{\_} \var{\_}
     \subseteq \powerset ((\Slot\times\PParams) \times \LState \times \seqof{\Tx} \times \LState)
   \end{equation*}
-  \caption{Ledger transition-system types}
+  \caption{Ledger Sequence transition-system types}
   \label{fig:ts-types:ledgers}
 \end{figure}
 
@@ -137,7 +141,21 @@ in $\mathsf{LEDGERS}$ in order to process a list of transactions.
   \begin{equation}
     \label{eq:ledgers-base}
     \inference[Seq-ledger-base]
-    {}
+    {
+      ((\var{utxo},~\var{deposits},~\var{fees},~\var{us}),~\var{dp})\leteq\var{ls}
+      \\
+      (\var{pup},~\var{aup},~\var{favs},~\var{avs}) \leteq\var{us}
+      \\~\\
+      {\begin{array}{r@{~\leteq~}l}
+        \var{favs'} & \{\var{s}\mapsto\var{v}\in\var{favs} ~\mid~ s>\var{slot}\}
+        \\
+        \var{avs'} & \fun{newAVs}~\var{avs}~(\var{favs}\setminus\var{favs'})
+      \end{array}}
+      \\~\\
+      \var{us'}\leteq(\var{pup},~\var{aup},~\var{favs'},~\var{avs'})
+      \\
+      \var{ls'}\leteq((\var{utxo},~\var{deposits},~\var{fees},~\var{us'}),~\var{dp})
+    }
     {
       \left(
         \begin{array}{r}
@@ -145,7 +163,7 @@ in $\mathsf{LEDGERS}$ in order to process a list of transactions.
           \var{pp}\\
         \end{array}
       \right)
-      \vdash \var{ls} \trans{ledgers}{\epsilon} \var{ls}
+      \vdash \var{ls} \trans{ledgers}{\epsilon} \varUpdate{\var{ls'}}
     }
   \end{equation}
 

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -235,10 +235,6 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
       \var{fav}\leteq\fun{votedValue_{Applications}}~\var{aup'}
       \\
       \var{fav}=\Nothing
-      \\
-      \var{cur}\leteq\{\var{sl}\mapsto\var{v}\in\var{favs} ~\mid~ \var{sl}\geq\var{slot}\}
-      \\
-      \var{avs'}\leteq\fun{newAVs}~\var{avs}~\var{cur}
     }
     {
       \begin{array}{l}
@@ -257,8 +253,8 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
       \left(
       \begin{array}{l}
         \varUpdate{\var{aup'}}\\
-        \varUpdate{\var{cur}}\\
-        \varUpdate{\var{avs'}}\\
+        \var{favs}\\
+        \var{avs}\\
       \end{array}
       \right)
     }
@@ -278,11 +274,7 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
       \var{fav}\leteq\fun{votedValue_{Applications}}~\var{aup'}
       \\
       \var{fav}\neq\Nothing
-      \\
-      \var{cur}\leteq\{\var{s}\mapsto\var{v}\in\var{favs} ~\mid~ s\geq\var{slot}\}
-      \\
-      \var{avs'}\leteq\fun{newAVs}~\var{avs}~\var{cur}
-      \\
+      &
       s\leteq\var{slot}+\SlotsPrior
     }
     {
@@ -302,8 +294,8 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
       \left(
       \begin{array}{l}
         \varUpdate{\emptyset}\\
-        \varUpdate{\var{cur}\unionoverrideRight\{\var{s}\mapsto\var{fav}\}}\\
-        \varUpdate{\var{avs'}}\\
+        \varUpdate{\var{fav}\unionoverrideRight\{\var{s}\mapsto\var{fav}\}}\\
+        \var{avs}\\
       \end{array}
       \right)
     }


### PR DESCRIPTION
This PR adds examples showing how the application versions are updated. While writing the example, I uncovered and fixed a problem with the `AVUP` transition in the formal spec.

The problem was that the future adoptions were only getting accepted when a block was processed that 1) had at least one transaction, and 2) contained an app version update. But we want to adopt future versions as soon as possible!

Therefore I have moved this logic into the base case of the `LEDGERS` transition. To be specific, the base case of the `LEDGERS` transition now cleans out the old "future application versions" and updates the current app versions when appropriate.


closes #719 