### PR TITLE
Fix error in refund calculation

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
@@ -35,7 +35,7 @@ fpPrecision :: FixedPoint
 fpPrecision = (10::FixedPoint)^(34::Integer)
 
 fpEpsilon :: FixedPoint
-fpEpsilon = (10::FixedPoint)^(17::Integer)
+fpEpsilon = (10::FixedPoint)^(17::Integer) / fpPrecision
 
 -- | Type to represent a value in the unit interval [0; 1]
 newtype UnitInterval = UnitInterval Rational

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -54,7 +54,7 @@ refund :: Coin -> UnitInterval -> Rational -> Duration -> Coin
 refund (Coin dval) dmin lambda delta = floor refund'
   where
     pow     = fromRational (-lambda * fromIntegral delta) :: FixedPoint
-    refund' = fromIntegral dval * (dmin' + (1 - dmin')) * dCay
+    refund' = fromIntegral dval * (dmin' + (1 - dmin') * dCay)
     dmin'   = intervalValue dmin
     dCay    = approxRational (exp' pow) fpEpsilon
 

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -747,10 +747,10 @@ expectedStEx2D =
       (BlocksMade Map.empty)
       (BlocksMade Map.empty)
       (EpochState acntEx2A snapsEx2C expectedLSEx2C ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 168
+      (Just RewardUpdate { deltaT = Coin 20
                          , deltaR = Coin 0
                          , rs     = Map.empty
-                         , deltaF = Coin (-168)
+                         , deltaF = Coin (-20)
                          })
       (PoolDistr Map.empty)
       epoch1OSchedEx2C
@@ -790,15 +790,15 @@ snapsEx2E :: SnapShots
 snapsEx2E = emptySnapShots { _pstakeMark = snapEx2C
                           , _pstakeSet = snapEx2C
                           , _poolsSS = Map.singleton (hk alicePool) alicePoolParams
-                          , _feeSS = Coin 0
+                          , _feeSS = Coin 13
                           }
 
 expectedLSEx2E :: LedgerState
 expectedLSEx2E = LedgerState
                (UTxOState
                  utxoEx2B
-                 (Coin 0)
-                 (Coin 0)
+                 (Coin 238)
+                 (Coin 13)
                  emptyUpdateState)
                (DPState dsEx2B psEx2A)
                0
@@ -808,7 +808,7 @@ blockEx2EHash = Just (bhHash (bheader blockEx2E))
 
 acntEx2E :: AccountState
 acntEx2E = AccountState
-            { _treasury = Coin 271
+            { _treasury = Coin 20
             , _reserves = Coin 45*1000*1000*1000*1000*1000
             }
 
@@ -865,10 +865,10 @@ expectedStEx2F =
       (BlocksMade Map.empty)
       (BlocksMade $ Map.singleton (hk alicePool) 1)
       (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 0
+      (Just RewardUpdate { deltaT = Coin 13
                          , deltaR = Coin 0
                          , rs     = Map.empty
-                         , deltaF = Coin 0
+                         , deltaF = Coin (-13)
                          })
       pdEx2F
       epoch1OSchedEx2E
@@ -908,7 +908,18 @@ epoch1OSchedEx2G = overlaySchedule
                     ppsEx1
 
 snapsEx2G :: SnapShots
-snapsEx2G = snapsEx2E { _pstakeGo = snapEx2C }
+snapsEx2G = snapsEx2E { _pstakeGo = snapEx2C
+                      , _feeSS = 10}
+
+expectedLSEx2G :: LedgerState
+expectedLSEx2G = LedgerState
+               (UTxOState
+                 utxoEx2B
+                 (Coin 228)
+                 (Coin 10)
+                 emptyUpdateState)
+               (DPState dsEx2B psEx2A)
+               0
 
 expectedStEx2G :: ChainState
 expectedStEx2G =
@@ -917,7 +928,7 @@ expectedStEx2G =
       (mkSeqNonce 5)
       (BlocksMade $ Map.singleton (hk alicePool) 1)
       (BlocksMade Map.empty)
-      (EpochState acntEx2E snapsEx2G expectedLSEx2E ppsEx1)
+      (EpochState (acntEx2E { _treasury = 33}) snapsEx2G expectedLSEx2G ppsEx1)
       Nothing
       pdEx2F
       epoch1OSchedEx2G
@@ -959,11 +970,11 @@ expectedStEx2H =
       (mkSeqNonce 5)
       (BlocksMade $ Map.singleton (hk alicePool) 1)
       (BlocksMade Map.empty)
-      (EpochState acntEx2E snapsEx2G expectedLSEx2E ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 8637405315535
+      (EpochState (acntEx2E { _treasury = Coin 33 }) snapsEx2G expectedLSEx2G ppsEx1)
+      (Just RewardUpdate { deltaT = Coin 8637405315545
                          , deltaR = Coin (-9450000000000)
                          , rs = rewardsEx2H
-                         , deltaF = Coin 0
+                         , deltaF = Coin (-10)
                          })
       pdEx2F
       epoch1OSchedEx2G
@@ -1003,7 +1014,7 @@ epoch1OSchedEx2I = overlaySchedule
 
 acntEx2I :: AccountState
 acntEx2I = AccountState
-            { _treasury = Coin 8637405315806
+            { _treasury = Coin 8637405315578
             , _reserves = Coin 44990550000000000
             }
 
@@ -1014,8 +1025,8 @@ expectedLSEx2I :: LedgerState
 expectedLSEx2I = LedgerState
                (UTxOState
                  utxoEx2B
-                 (Coin 0)
-                 (Coin 0)
+                 (Coin 219)
+                 (Coin 9)
                  emptyUpdateState)
                (DPState dsEx2I psEx2A)
                0
@@ -1027,7 +1038,7 @@ expectedStEx2I =
       (mkSeqNonce 7)
       (BlocksMade Map.empty)
       (BlocksMade Map.empty)
-      (EpochState acntEx2I snapsEx2G expectedLSEx2I ppsEx1)
+      (EpochState acntEx2I (snapsEx2G { _feeSS = Coin 9 }) expectedLSEx2I ppsEx1)
       Nothing
       pdEx2F
       epoch1OSchedEx2I

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -9,7 +9,8 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
-                     ex2C, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C)
+                     ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex3A,
+                     ex3B, ex3C, ex4A, ex4B, ex4C)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -62,6 +63,15 @@ testCHAINExample2B = testCHAINExample ex2B
 testCHAINExample2C :: Assertion
 testCHAINExample2C = testCHAINExample ex2C
 
+testCHAINExample2Cbis :: Assertion
+testCHAINExample2Cbis = testCHAINExample ex2Cbis
+
+testCHAINExample2Cter :: Assertion
+testCHAINExample2Cter = testCHAINExample ex2Cter
+
+testCHAINExample2Cquater :: Assertion
+testCHAINExample2Cquater = testCHAINExample ex2Cquater
+
 testCHAINExample2D :: Assertion
 testCHAINExample2D = testCHAINExample ex2D
 
@@ -106,6 +116,9 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 2A - register stake key" testCHAINExample2A
   , testCase "CHAIN example 2B - delegate stake and create reward update" testCHAINExample2B
   , testCase "CHAIN example 2C - new epoch changes" testCHAINExample2C
+  , testCase "CHAIN example 2Cbis - as 2C but no decay" testCHAINExample2Cbis
+  , testCase "CHAIN example 2Cter - as 2C but full refund" testCHAINExample2Cter
+  , testCase "CHAIN example 2Cquater - as 2C but with instant decay" testCHAINExample2Cquater
   , testCase "CHAIN example 2D - second reward update" testCHAINExample2D
   , testCase "CHAIN example 2E - nonempty pool distr" testCHAINExample2E
   , testCase "CHAIN example 2F - decentralized block" testCHAINExample2F

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -99,8 +99,9 @@ The two main transition systems in this section are:
   \item The transition system named $\mathsf{EPOCH}$, which is defined in
     Section~\ref{sec:total-epoch}, covers what happens at the epoch boundary,
     such as at (A), (C), (D) and (G).
-  \item The transition named $\mathsf{REWARD}$, which is defined in Section~\ref{sec:reward-calc},
-    covers the reward calculation that happens between (E) and (F).
+  \item The transition named $\mathsf{RUPD}$, which is defined in
+    Section~\ref{sec:reward-update-trans}, covers the reward calculation that
+    happens between (E) and (F).
 \end{itemize}
 
 

--- a/shelley/chain-and-ledger/formal-spec/non-integral.tex
+++ b/shelley/chain-and-ledger/formal-spec/non-integral.tex
@@ -31,7 +31,7 @@ rules that use non-integral calculations and which type.
                                             &&\\
     \fun{rewardOnePool}
          & \pageref{fig:functions:reward-calc} & \checkmark & \checkmark &&\\
-    \fun{REWARD}
+    \fun{RUPD}
          &\pageref{fig:rules:reward-update} & \checkmark &&& \\
     \bottomrule
   \end{tabular}


### PR DESCRIPTION
This fixes an error in the refund calculation, effectively it used `(d + (1 - d)) *exp(x)` instead of `(d + (1 - d)*exp(x))`. Also the `fpEpsilon` constant was wrong, making all decay instantaneous.

This also adds examples for different ways to use 
 - no decay
 - instant decay
 - full refund (minimal refund 100%)