### PR TITLE
[731] Sync executable with formal spec - UTXO STS

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -12,16 +12,19 @@ where
 
 import           Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
 
-import           Lens.Micro ((%~), (&), (.~), (^.))
+import           Lens.Micro ((^.))
 
 import           Coin
 import           Delegation.Certificates
 import           Keys
+import           Ledger.Core (dom, range, (∪), (⊆), (⋪))
 import           LedgerState
 import           PParams
 import           Slot
 import           Tx
+
 import           Updates
 import           UTxO
 
@@ -47,9 +50,11 @@ instance
   data PredicateFailure (UTXO hashAlgo dsignAlgo)
     = BadInputsUTxO
     | ExpiredUTxO Slot Slot
+    | MaxTxSizeUTxO Integer Integer
     | InputSetEmptyUTxO
     | FeeTooSmallUTxO Coin Coin
     | ValueNotConservedUTxO Coin Coin
+    | NonPositiveOutputsUTxO
     | UnexpectedFailureUTXO [ValidationError] -- TODO maybe restructure Validity
                                               -- to prevent these predicate
                                               -- failures?
@@ -69,52 +74,45 @@ utxoInductive
    . (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => TransitionRule (UTXO hashAlgo dsignAlgo)
 utxoInductive = do
-  TRC ((_slot, pp, stakeKeys, stakePools, _dms), u, tx) <- judgmentContext
+  TRC ((slot_, pp, stakeKeys, stakePools, dms_), u, tx) <- judgmentContext
+  let txBody = _body tx
 
-  let txbody = _body tx
-  validInputs txbody u == Valid ?! BadInputsUTxO
-  _ttl txbody >= _slot ?! ExpiredUTxO (_ttl txbody) _slot
-  validNoReplay txbody == Valid ?! InputSetEmptyUTxO
+  _ttl txBody >= slot_ ?! ExpiredUTxO (_ttl txBody) slot_
 
-  let validateFee = validFee pp txbody
-  validateFee == Valid ?! unwrapFailureUTXO validateFee
+  txins txBody /= Set.empty ?! InputSetEmptyUTxO
 
-  let validateBalance = preserveBalance stakePools stakeKeys pp txbody u
-  validateBalance == Valid ?! unwrapFailureUTXO validateBalance
+  let minFee = minfee pp txBody
+      txFee  = txBody ^. txfee
+  minFee <= txFee ?! FeeTooSmallUTxO minFee txFee
 
-  let refunded = keyRefunds pp stakeKeys txbody
-  let decayed  = decayedTx pp stakeKeys txbody
-  let depositChange =
-        deposits pp stakePools (toList $ txbody ^. certs) - (refunded + decayed)
+  txins txBody ⊆ dom (u ^. utxo) ?! BadInputsUTxO
 
-  let u' = applyUTxOUpdate u txbody  -- change UTxO
+  let consumed_ = consumed pp (u ^. utxo) stakeKeys txBody
+      produced_ = produced pp stakePools txBody
+  consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
 
   -- process Update Proposals
-  ups' <- trans @(UP dsignAlgo) $ TRC ((_slot, _dms), u ^. ups, txup tx)
+  ups' <- trans @(UP dsignAlgo) $ TRC ((slot_, dms_), u ^. ups, txup tx)
 
-  pure
-    $  u'
-    &  deposited
-    %~ (+) depositChange
-    &  fees
-    %~ (+) ((txbody ^. txfee) + decayed)
-    &  ups
-    .~ ups'
+  let outputCoins = [c | (TxOut _ c) <- Set.toList (range (txouts txBody))]
+  all (0<) outputCoins ?! NonPositiveOutputsUTxO
 
-unwrapFailureUTXO :: Validity -> PredicateFailure (UTXO hashAlgo dsignAlgo)
-unwrapFailureUTXO (Invalid [e]) = unwrapFailureUTXO' e
-unwrapFailureUTXO Valid         = UnexpectedSuccessUTXO
-unwrapFailureUTXO (Invalid x)   = UnexpectedFailureUTXO x
+  let maxTxSize_ = fromIntegral (_maxTxSize pp)
+      txSize_ = txsize txBody
+  txSize_ <= maxTxSize_ ?! MaxTxSizeUTxO txSize_ maxTxSize_
 
-unwrapFailureUTXO'
-  :: ValidationError
-  -> PredicateFailure (UTXO hashAlgo dsignAlgo)
-unwrapFailureUTXO' BadInputs                = BadInputsUTxO
-unwrapFailureUTXO' (Expired s s')           = ExpiredUTxO s s'
-unwrapFailureUTXO' InputSetEmpty            = InputSetEmptyUTxO
-unwrapFailureUTXO' (FeeTooSmall       c c') = FeeTooSmallUTxO c c'
-unwrapFailureUTXO' (ValueNotConserved c c') = ValueNotConservedUTxO c c'
-unwrapFailureUTXO' x                        = UnexpectedFailureUTXO [x]
+  let refunded = keyRefunds pp stakeKeys txBody
+      decayed = decayedTx pp stakeKeys txBody
+      txCerts = toList $ txBody ^. certs
+
+      depositChange = deposits pp stakePools txCerts - (refunded + decayed)
+
+  pure $ UTxOState
+          { _utxo      = (txins txBody ⋪ (u ^. utxo)) ∪ txouts txBody
+          , _deposited = _deposited u + depositChange
+          , _fees      = _fees u + (txBody ^. txfee) + decayed
+          , _ups       = ups'
+          }
 
 instance
   (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)

--- a/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
@@ -25,7 +25,7 @@ import           Keys (pattern Dms)
 import           LedgerState (genesisId, genesisState, _utxoState)
 import           MockTypes (Addr, KeyPair, LedgerState, MultiSig, ScriptHash, Tx, TxBody, TxId,
                      TxIn, UTXOW, UTxOState, Wdrl)
-import           PParams (emptyPParams)
+import           PParams (PParams (..), emptyPParams)
 import           Slot (Slot (..))
 import           Tx (hashScript)
 import           TxData (pattern AddrBase, pattern KeyHashObj, pattern RequireAllOf,
@@ -105,6 +105,9 @@ genesis = genesisState
            [ TxOut aliceAddr aliceInitCoin
            , TxOut bobAddr bobInitCoin]
 
+initPParams :: PParams
+initPParams = emptyPParams {_maxTxSize = 1000}
+
 -- | Create an initial UTxO state where Alice has 'aliceInitCoin' and Bob
 -- 'bobInitCoin' to spend. Then create and apply a transaction which, if
 -- 'aliceKeep' is greater than 0, gives that amount to Alice and creates outputs
@@ -125,7 +128,7 @@ initialUTxOState aliceKeep msigs =
                   [alicePay, bobPay]
                   Map.empty in
   (txid $ _body tx, applySTS @UTXOW (TRC( (Slot 0
-                                           , emptyPParams
+                                           , initPParams
                                            , StakeKeys Map.empty
                                            , StakePools Map.empty
                                            , Dms Map.empty)
@@ -150,7 +153,7 @@ applyTxWithScript lockScripts unlockScripts wdrl aliceKeep signers = utxoSt'
   where (txId, initUtxo) = initialUTxOState aliceKeep lockScripts
         utxoSt = case initUtxo of
                    Right utxoSt'' -> utxoSt''
-                   _                      -> error ("must fail test before"
+                   _                      -> error ("must fail test before: "
                                                    ++ show initUtxo)
         txbody = makeTxBody inputs [(aliceAddr, aliceInitCoin + bobInitCoin + sum wdrl)] wdrl
         inputs = [TxIn txId (fromIntegral n) | n <-
@@ -161,7 +164,7 @@ applyTxWithScript lockScripts unlockScripts wdrl aliceKeep signers = utxoSt'
               signers
               (Map.fromList $ map (\scr -> (hashScript scr, scr)) unlockScripts)
         utxoSt' = applySTS @UTXOW (TRC( (Slot 0
-                                        , emptyPParams
+                                        , initPParams
                                         , StakeKeys Map.empty
                                         , StakePools Map.empty
                                         , Dms Map.empty)

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -19,12 +19,13 @@ import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 
 import           Coin
+import           Ledger.Core ((<|))
 import           LedgerState hiding (dms)
 import           PParams
 import           Slot
 import           Tx (pattern TxIn, pattern TxOut, body, certs, inputs, outputs, witnessVKeySet,
                      _body, _witnessVKeySet)
-import           UTxO (balance, deposits, makeWitnessVKey, txid, txins, txouts, verifyWitVKey, (<|))
+import           UTxO (balance, deposits, makeWitnessVKey, txid, txins, txouts, verifyWitVKey)
 
 import           Generator
 import           MockTypes


### PR DESCRIPTION
Closes #731 

* add missing predicates from exec. spec (txize <= maxTxSize + coins are all positive)
* add a Relation instance for `UTxO hashAlgo dsignAlgo`
* general refactoring of UTxO STS to more closely match formal spec
  - more inline functionality (e.g. replace `validNoReplay tx` with `txins /= empty`) 
  - update STS state with record syntax (instead of using lenses)

@mgudemann With the maxTxSize predicate added, the MultiSig examples were failing since it was using `emptyPParams` (with maxTxSize = 0) to run the STS step.

I added an `initPParams` (with maxTxSize = 1000) to be used in the multi-sig examples (the examples were producing Tx's with size roughly around 400-600)
 
 