### PR TITLE
Sync executable with formal spec - PPUP

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
@@ -14,6 +14,7 @@ module BaseTypes
   , Seed(..)
   , mkNonce
   , (⭒)
+  , (==>)
   ) where
 
 
@@ -82,3 +83,7 @@ a ⭒ b = SeedOp a b
 
 mkNonce :: Integer -> Seed
 mkNonce = Nonce
+
+(==>) :: Bool -> Bool -> Bool
+a ==> b = not a || b
+infix 1 ==>

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -13,6 +13,7 @@ import qualified Data.Set as Set
 import           BaseTypes
 import           BlockChain
 import           Keys
+import           Ledger.Core (dom, (⊆))
 import           PParams
 import           Slot
 import           Updates
@@ -62,7 +63,7 @@ ppupTransitionNonEmpty = do
   do
     pup' /= Map.empty ?! PPUpdateEmpty
     all (all (pvCanFollow (_protocolVersion pp))) pup' ?! PVCannotFollowPPUP
-    (Map.keysSet pup' `Set.isSubsetOf` Map.keysSet _dms)
+    (dom pup' ⊆ dom _dms)
       ?! NonGenesisUpdatePPUP (Map.keysSet pup') (Map.keysSet _dms)
     let Epoch slotEpoch = epochFromSlot (Slot 1)
     s

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
@@ -12,6 +12,7 @@ where
 import qualified Data.Map.Strict as Map
 
 import           Keys
+import           PParams
 import           Slot
 import           Updates
 
@@ -30,7 +31,7 @@ instance DSIGNAlgorithm dsignAlgo => STS (UP dsignAlgo) where
       , Applications
       )
   type Signal (UP dsignAlgo) = Update dsignAlgo
-  type Environment (UP dsignAlgo) = (Slot, Dms dsignAlgo)
+  type Environment (UP dsignAlgo) = (Slot, PParams, Dms dsignAlgo)
   data PredicateFailure (UP dsignAlgo)
     = NonGenesisUpdateUP
     | AvupFailure (PredicateFailure (AVUP dsignAlgo))
@@ -45,11 +46,11 @@ upTransition
    . DSIGNAlgorithm dsignAlgo
   => TransitionRule (UP dsignAlgo)
 upTransition = do
-  TRC (env, (pupS, aupS, favs, avs), Update pup _aup) <- judgmentContext
+  TRC ((_slot, pp, _dms), (pupS, aupS, favs, avs), Update pup _aup) <- judgmentContext
 
-  pup' <- trans @(PPUP dsignAlgo) $ TRC (env, pupS, pup)
+  pup' <- trans @(PPUP dsignAlgo) $ TRC ((_slot, pp, _dms), pupS, pup)
   (aup', favs', avs') <-
-    trans @(AVUP dsignAlgo) $ TRC (env, (aupS, favs, avs), _aup)
+    trans @(AVUP dsignAlgo) $ TRC ((_slot, _dms), (aupS, favs, avs), _aup)
 
   pure (pup', aup', favs', avs')
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -92,7 +92,7 @@ utxoInductive = do
   consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
 
   -- process Update Proposals
-  ups' <- trans @(UP dsignAlgo) $ TRC ((slot_, dms_), u ^. ups, txup tx)
+  ups' <- trans @(UP dsignAlgo) $ TRC ((slot_, pp, dms_), u ^. ups, txup tx)
 
   let outputCoins = [c | (TxOut _ c) <- Set.toList (range (txouts txBody))]
   all (0<) outputCoins ?! NonPositiveOutputsUTxO

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -30,6 +30,7 @@ $\mathsf{UTXOW}$ transition.
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
+        \var{pp} & \PParams & \text{protocol parameters}\\
         \var{dms} & \VKeyGen\mapsto\VKey & \text{genesis key delegations} \\
       \end{array}
     \right)
@@ -55,6 +56,7 @@ $\mathsf{UTXOW}$ transition.
     {
       \begin{array}{l}
         \var{slot}\\
+        \var{pp}\\
         \var{dms}\\
       \end{array}
       \vdash \var{pup_s}\trans{ppup}{pup}\var{pup_s}
@@ -70,13 +72,15 @@ $\mathsf{UTXOW}$ transition.
       &
       \dom{pup}\subseteq\dom{dms}
       \\
-      \var{ppv}\mapsto\var{v}\in\var{pup}\implies\fun{pvCanFollow}~(\fun{ppv}~\var{pup_s})~\var{v}
+      \forall\var{ps}\in\range{pup},~
+        \var{pv}\mapsto\var{v}\in\var{ps}\implies\fun{pvCanFollow}~(\fun{pv}~\var{pp})~\var{v}
       \\
       \var{slot} < \firstSlot{((\epoch{slot}) + 1) - \SlotsPrior}
     }
     {
       \begin{array}{l}
         \var{slot}\\
+        \var{pp}\\
         \var{dms}\\
       \end{array}
       \vdash
@@ -321,6 +325,7 @@ The AVUP rule has one predicate failure:
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
+        \var{pp} & \PParams & \text{protocol parameters}\\
         \var{dms} & \VKeyGen\mapsto\VKey & \text{genesis key delegations} \\
       \end{array}
     \right)
@@ -360,6 +365,7 @@ The AVUP rule has one predicate failure:
         \left(
           \begin{array}{r}
             \var{slot} \\
+            \var{pp} \\
             \var{dms} \\
           \end{array}
         \right)
@@ -401,6 +407,7 @@ The AVUP rule has one predicate failure:
     {
       \begin{array}{l}
         \var{slot}\\
+        \var{pp} \\
         \var{dms}\\
       \end{array}
       \vdash

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -98,12 +98,12 @@ The PPUP rule has three predicate failures:
 \begin{itemize}
 \item In the case of \var{slot} being smaller than
   $\fun{firstSlot}~((\fun{epoch}~\var{slot}) + 1) - \fun{SlotsPrior}$, there is
-  a \em{PPUpdateTooEarly} failure.
+  a {\em PPUpdateTooEarly} failure.
 \item In the case of \var{pup} being non-empty, if the check $\dom pup \subseteq
-  \dom dms$ fails, there is a \em{NonGenesisUpdate} failure as only genesis keys
+  \dom dms$ fails, there is a {\em NonGenesisUpdate} failure as only genesis keys
   can be used in the protocol parameter update.
 \item If a protocol parameter update in \var{pup} cannot follow the current
-  protocol paramter, there is a \em{PVCannotFollow} failure.
+  protocol parameter, there is a {\em PVCannotFollow} failure.
 \end{itemize}
 
 \clearpage
@@ -312,7 +312,7 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
 The AVUP rule has one predicate failure:
 \begin{itemize}
 \item In the case of \var{aup} being non-empty, if the check $\dom aup \subseteq
-  \dom dms$ fails, there is a \em{NonGenesisUpdate} failure as only genesis keys
+  \dom dms$ fails, there is a {\em NonGenesisUpdate} failure as only genesis keys
   can be used in the application version update.
 \end{itemize}
 

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -301,6 +301,7 @@ requests).
         \left(
           \begin{array}{r}
             \var{slot} \\
+            \var{pp} \\
             \var{dms} \\
           \end{array}
         \right)


### PR DESCRIPTION
While syncing the `PPUP` transition in the exec spec with the formal spec (ie, adding the two missing predicates), I found two problems with the formal spec.

First, since a protocol proposal update (`ppup`) is a _mapping_ of (soon to be hashes) of genesis keys to a mapping of new protocol parameters, the `pvCanFollow` check needs to be done for every element of the range of a `ppup`, not just once on the whole `ppup`.

Second, the `pvCanFollow` check needs to be compared against the current protocol version in the protocol parameters, not against the staged votes. This means that the `UP` and `PPUP` transitions both needed the protocol parameters added to the environment.

As for implementing the two needed predicates, one was straight-forward, but the other was not quite as expected. I would have liked to have used the elegant
`ppv -> v elem pup ==> ...`
listed in the issue, but the newly proposed protocol parameters are not actually implemented as a map. The collection of protocol parameters is implemented as a record, since the values have different types. In order to _only_ have to specify the parameters that you want to change, we have implemented the updates as `Set Ppm`, where the different protocol parameters correspond to different constructors of `Ppm`. Maybe we want to do something different? If we do like the current design, then the check can be implemented as
`all (all (pvCanFollow (_protocolVersion pp))) pup'`

closes #729 