### PR TITLE
Issue #730 - sync AVUP

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
@@ -17,11 +17,12 @@ import qualified Data.Map.Strict as Map
 import           Data.Sequence (Seq)
 
 import           Keys
+import           Ledger.Core ((⨃))
 import           LedgerState
 import           PParams
 import           Slot
 import           Tx
-import           Updates (newAVs)
+import           Updates (Applications (..), apps, newAVs)
 
 import           Control.State.Transition
 
@@ -67,7 +68,7 @@ ledgersTransition = do
 
   let UTxOState utxo' dep fee (ppup, aup, favs, avs) = u''
   let (favs', ready) = Map.partitionWithKey (\s _ -> s > slot) favs
-  let avs' = newAVs avs ready
+  let avs' = Applications $ apps avs ⨃ (Map.toList . apps $ newAVs avs ready)
   let u''' = UTxOState utxo' dep fee (ppup, aup, favs', avs')
   pure $ LedgerState u''' dw'' (_txSlotIx ls)
 

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1585,7 +1585,7 @@ which takes the Byron ledger state and creates the Shelley ledger state.
                               \emptyset \\
                               \emptyset \\
                               \emptyset \\
-                              \emptyset \\
+                              \fun{avs}~\var{us}\\
                             \end{array}
                           \right) \\
                         \end{array}

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -149,7 +149,8 @@ because here it will happen even if the block contains no transactions.
       {\begin{array}{r@{~\leteq~}l}
         \var{favs'} & \{\var{s}\mapsto\var{v}\in\var{favs} ~\mid~ s>\var{slot}\}
         \\
-        \var{avs'} & \fun{newAVs}~\var{avs}~(\var{favs}\setminus\var{favs'})
+        \var{avs'}
+        & \var{avs}\unionoverrideRight\fun{newAVs}~\var{avs}~(\var{favs}\setminus\var{favs'})
       \end{array}}
       \\~\\
       \var{us'}\leteq(\var{pup},~\var{aup},~\var{favs'},~\var{avs'})

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -132,26 +132,33 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
   \end{align*}
 
   \begin{align*}
-      & \fun{validAV} \in \ApName \to \ApVer \to \Metadata \to \Applications \to \Bool\\
-      & \fun{validAV}~\var{an}~\var{av}~\var{md}~\var{avs} = \\
-      & ~~~~\fun{apNameValid}~\var{an}
-        ~\land~\fun{svCanFollow}~\var{avs}~(\var{an},~\var{av})
-        ~\land~\forall\var{st}\in\dom{md},~\fun{sTagValid}~\var{st}
+      & \fun{maxVer} \in \ApName \to \Applications \to (\Slot\mapsto\Applications)
+        \to (\ApVer, \Metadata)\\
+      & \fun{maxVer}~\var{an}~\var{avs}~\var{avs} = \\
+      & ~~~~\fun{max_{first}} \Bigg(
+        \Big\{(0, \emptyset)\Big\}
+        \cup
+        \range{avs}
+        \cup
+        \bigcup_{\var{fav}\in\var{favs}}
+        \range{favs}
+        \Bigg)
+  \end{align*}
+
+  \begin{align*}
+      & \fun{svCanFollow} \in \Applications \to (\Slot\mapsto\Applications)
+        \to \ApName \to \ApVer \to \Bool\\
+      & \fun{svCanFollow}~\var{avs}~\var{favs}~\var{an}~\var{av}= av = 1 + v' \\
+      & ~~~~\where (v',~\wcard) = \fun{maxVer}~\var{an}~\var{avs}~\var{favs}
   \end{align*}
 
   \begin{align*}
       & \fun{newAVs} \in \Applications \to (\Slot\mapsto\Applications) \to \Applications \\
-      & \fun{newAVs}~\var{avs}~\var{favs} =
-        \begin{cases}
-          \var{avs}\unionoverrideRight\var{avs}'
-                     & \var{favs}\neq\emptyset \\
-                     & ~\land~s_m\mapsto\var{avs'}\in\var{favs} \\
-                     & ~\land~s_m=\max(\dom{\var{favs}}) \\
-                     & ~\land~\forall(an\mapsto(av, mdt)\in\var{avs}'),
-                         ~\fun{validAV}~\var{an}~\var{av}~\var{md}~\var{avs}
-          \\
-          \var{avs} & \text{otherwise}
-        \end{cases}
+      & \fun{newAVs}~\var{avs}~\var{favs} = \\
+      & ~~~~\Bigg\{\var{an}\mapsto\fun{maxVer}~\var{an}~\var{avs}~\var{favs}
+            ~\mid~
+            \var{an}\in\Big(\dom{avs}\cup\bigcup_{\var{fav}\in\var{favs}}\dom{fav}\Big)
+            \Bigg\}
   \end{align*}
 
   \caption{Epoch Helper Functions}
@@ -234,10 +241,16 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
       &
       \dom{\var{aup}}\subseteq\dom{\var{dms}}
       \\
-      \var{aup'}\leteq\var{aup_s}\unionoverrideRight\var{aup}
-      &
-      \var{fav}\leteq\fun{votedValue_{Applications}}~\var{aup'}
+      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\in\dom{vote},~
+        \fun{apNameValid}~\var{v}
       \\
+      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\mapsto(v,~\wcard)\in\var{vote},~
+      \fun{svCanFollow}~\var{avs}~\var{favs}~\var{n}~\var{v}
+      \\
+      \var{aup'}\leteq\var{aup_s}\unionoverrideRight\var{aup}
+      \\
+      \var{fav}\leteq\fun{votedValue_{Applications}}~\var{aup'}
+      &
       \var{fav}=\Nothing
     }
     {
@@ -273,12 +286,18 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
       &
       \dom{\var{aup}}\subseteq\dom{\var{dms}}
       \\
-      \var{aup'}\leteq\var{aup_s}\unionoverrideRight\var{aup}
-      &
-      \var{fav}\leteq\fun{votedValue_{Applications}}~\var{aup'}
+      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\in\dom{vote},~
+        \fun{apNameValid}~\var{v}
       \\
-      \var{fav}\neq\Nothing
+      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\mapsto(v,~\wcard)\in\var{vote},~
+        \fun{svCanFollow}~\var{avs}~\var{favs}~\var{n}~\var{v}
+      \\
+      \var{aup'}\leteq\var{aup_s}\unionoverrideRight\var{aup}
+      \\
+      \var{fav}\leteq\fun{votedValue_{Applications}}~\var{aup'}
       &
+      \var{fav}\neq\Nothing
+      \\
       s\leteq\var{slot}+\SlotsPrior
     }
     {
@@ -309,11 +328,17 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
   \label{fig:rules:av-update}
 \end{figure}
 
-The AVUP rule has one predicate failure:
+The AVUP rule has three predicate failures:
 \begin{itemize}
 \item In the case of \var{aup} being non-empty, if the check $\dom aup \subseteq
   \dom dms$ fails, there is a {\em NonGenesisUpdate} failure as only genesis keys
   can be used in the application version update.
+\item In the case of \var{aup} being non-empty, if any of the application names
+  in the proposal are invalid, there is a {\em InvalidName} failure.
+\item In the case of \var{aup} being non-empty, if any of the application versions
+  in the proposal are not exactly one more than the greatest version for the given
+  application name in the current application versions or the future application
+  versions, there is a {\em CannotFollow} failure.
 \end{itemize}
 
 \clearpage


### PR DESCRIPTION
it is now easy (I think/hope) to compare `AVUP` transition between the formal spec and the executable model.  in the process, I found some bugs, fixed some bugs, and cleaned things up.

There was a problem with how the future application versions were being moved into the current application versions. The problem was that we were only taking the most recent pending update that was below the current slot, which is not correct since that update may, for instance, only increase one application. The `AVUP` helper functions now look like:


![AVUPhelpers](https://user-images.githubusercontent.com/943479/63205639-6fbee980-c075-11e9-9edd-ceaacc0d4123.png)

I have moved the checks on the application version updates from the point in time when they are put into the current application versions to the point in time when the proposals first come in (ie in `AVUP`).

Regarding these checks, I have added a `TODO` to look into the system tags. I had previous thought that these tags were in the metadata, but after reviewing the Byron spec I realized that they are actually in the Byron update proposal. I will talk to @dnadales to see if I need to add system tags to the application version updates, and then check them for validity.

There was a second problem with moving the future versions into the current ones. This problem was that old versions that were not being updated were forgotten, and the fix was to use a union override (in the `LEDGERS` transition, where versions are moved from `favs` to `avs`).

There was a problem with the `toShelley` function, in that it did not transfer the application versions from Byron over to Shelley.

closes #730 