### PR TITLE
typos and small fixes

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -755,9 +755,9 @@ If the size checks pass, then three transitions are done:
 The BHEAD rule has two predicate failures:
 \begin{itemize}
 \item If the size of the block header is larger than the maximally allowed size,
-  there is a \em{HeaderSizeTooLarge} failure.
+  there is a \emph{HeaderSizeTooLarge} failure.
 \item If the size of the block body is larger than the maximally allowed size,
-  there is a \em{BlockSizeTooLarge} failure.
+  there is a \emph{BlockSizeTooLarge} failure.
 \end{itemize}
 
 \clearpage
@@ -845,18 +845,18 @@ of the key \var{hk} with the KES period \var{n}.
 The OCERT rule has six predicate failures:
 \begin{itemize}
 \item If the KES period is less than the KES period start in the certificate,
-  there is a \em{KESBeforeStart} failure.
+  there is a \emph{KESBeforeStart} failure.
 \item If the KES period is greater than or equal to the KES period end (start +
-  90) in the certificate, there is a \em{KESAfterEnd} failure.
+  90) in the certificate, there is a \emph{KESAfterEnd} failure.
 \item If the period counter in the original key hash counter mapping is larger
-  than the period number in the certificate, there is a \em{KESPeriodWrong}
+  than the period number in the certificate, there is a \emph{KESPeriodWrong}
   failure.
 \item If the signature of the hot key, KES period number and period start is
-  incorrect, there is an \em{InvalidSignature} failure.
+  incorrect, there is an \emph{InvalidSignature} failure.
 \item I the KES signature using the hot key of the block header body is
-  incorrect, there is an \em{InvalideKesSignature} failure.
+  incorrect, there is an \emph{InvalideKesSignature} failure.
 \item If there is no entry in the key hash to counter mapping for the cold key,
-  there is a \em{NoCounterForKeyHash} failure.
+  there is a \emph{NoCounterForKeyHash} failure.
 \end{itemize}
 
 \subsection{Verifiable Random Function}
@@ -1049,15 +1049,15 @@ it is worth examining the interaction in Equation~\ref{eq:decentralized} closely
 The OVERLAY rule has four predicate failures:
 \begin{itemize}
 \item In the case of the slot not being part of a OBFT schedule, if the VRF
-  leader check does not verify, there is a \em{NotPraosLeader} failure.
+  leader check does not verify, there is a \emph{NotPraosLeader} failure.
 \item In the case of the slot being in the OBFT schedule, but without genesis
-  key (i.e., $Nothing$), there is a \em{NotActiveSlot} failure.
+  key (i.e., $Nothing$), there is a \emph{NotActiveSlot} failure.
 \item In the case of the slot being in the OBFT schedule, if there is a
   specified key, but this key is not in the genesis delegation map, there is a
-  \em{NoGenesisStaking} failure.
+  \emph{NoGenesisStaking} failure.
 \item In the case of the slot being in the OBFT schedule, if there is a
   specified genesis key which is not the same key as in the bock header body,
-  there is a \em{NoGenesisColdKey} failure.
+  there is a \emph{NoGenesisColdKey} failure.
 \end{itemize}
 
 \clearpage
@@ -1181,9 +1181,9 @@ The states for this transition consists of:
 The PRTCL rule has two predicate failures:
 \begin{itemize}
 \item If the slot of the block header body is not larger than the last slot or
-  greater than the current slot, there is a \em{WrongSlotInterval} failure.
+  greater than the current slot, there is a \emph{WrongSlotInterval} failure.
 \item If the hash of the previous header of the block header body is not equal
-  to the hash given in the environment, there is a \em{WrongBlockSequence}
+  to the hash given in the environment, there is a \emph{WrongBlockSequence}
   failure.
 \end{itemize}
 
@@ -1317,7 +1317,7 @@ current slot is not an overlay slot.
 The BBODY rule has one predicate failure:
 \begin{itemize}
 \item if the size of the block body in the header is not equal to the real size
-  of the block body, there is a \em{WrongBlockBodySize} failure.
+  of the block body, there is a \emph{WrongBlockBodySize} failure.
 \end{itemize}
 
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -575,20 +575,19 @@ The signal of the transition rule $\mathsf{RUPD}$ is the slot \var{s}. The
 execution of the transition role is as follows:
 
 \begin{itemize}
-\item If \var{s} is less than or equal to the sum of the first slot of its epoch
-  and the duration to start rewards \StartRewards, then the state is not
-  updated.
-\item If the current reward update \var{ru} is not \Nothing, i.e., a reward
-  update has already been calculated but not yet applied, then the state is not
-  updated.
 \item If the current reward update \var{ru} is empty and \var{s} is greater than
   the sum of the first slot of its epoch and the duration \StartRewards, then a
   new rewards update is calculated and the state is updated.
+\item If the current reward update \var{ru} is not \Nothing, i.e., a reward
+  update has already been calculated but not yet applied, then the state is not updated.
+\item If the current reward update \var{ru} is empty and \var{s} is less than or equal to the sum
+  of the first slot of its epoch and the duration to start rewards \StartRewards,
+  then the state is not updated.
 \end{itemize}
 
 \begin{figure}[ht]
   \begin{equation}\label{eq:reward-update}
-    \inference[Reward-Update]
+    \inference[Create-Reward-Update]
     {
       s > (\firstSlot{\epoch{s}}) + \StartRewards
       &
@@ -611,7 +610,7 @@ execution of the transition role is as follows:
   \nextdef
 
   \begin{equation}\label{eq:no-reward-update}
-    \inference[No-Reward-Update]
+    \inference[Reward-Update-Exists]
     {
       ru \neq \Nothing
     }
@@ -632,6 +631,8 @@ execution of the transition role is as follows:
   \begin{equation}\label{eq:reward-too-early}
     \inference[Reward-Too-Early]
     {
+      ru = \Nothing
+      \\
       s \leq (\firstSlot{\epoch{s}}) + \StartRewards
     }
     {

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -310,17 +310,17 @@ of which are active.
   \label{fig:ts-types:newepoch}
 \end{figure}
 
-Figure~\ref{fig:rules:new-epoch} defines the new epoch state transition. It
-has two rules: the first one deals with the case when the epoch signal $e$ is before the
-current epoch \var{e_\ell}. This rule does not change the state. The second rule
-describes the change in the case of $e$ being equal to the next epoch
+Figure~\ref{fig:rules:new-epoch} defines the new epoch state transition. It has two rules.
+The first rule describes the change in the case of $e$ being equal to the next epoch
 $e_\ell+ 1$. It also calls the $\mathsf{EPOCH}$ rule.
+The second one deals with the case when the epoch signal $e$ is not one greater than the
+current epoch \var{e_\ell}. This rule does not change the state.
 
 In the second case, the new epoch state is updated as follows:
 
 \begin{itemize}
 \item The epoch is set to the new epoch $e$.
-\item The epoch nonce is replaced with the compbination of the new one from the
+\item The epoch nonce is replaced with the combination of the new one from the
   environment and any extra entropy present in the UTxO state.
 \item The mapping for the blocks produced by each stake pool for the previous epoch
   is set to the current such mapping.
@@ -413,7 +413,7 @@ In the second case, the new epoch state is updated as follows:
   \begin{equation}\label{eq:not-new-epoch}
     \inference[Not-New-Epoch]
     {
-      e_\ell \neq e + 1
+      e \neq e_\ell + 1
     }
     {
       \left(
@@ -474,7 +474,7 @@ $\eta_c$ and the evolving nonce $\eta_v$.
 
 The transition rule $\mathsf{UPDN}$ takes the slot \var{s} as signal.
 There are two different cases for $\mathsf{UPDN}$, one where \var{s} is not yet
-\SlotsPrior{} slots from the beginning of the epoch and one where \var{s} is at least
+\SlotsPrior{} slots from the beginning of the next epoch and one where \var{s} is at least
 \SlotsPrior{} slots after the first slot of the epoch.
 
 Note that in \ref{eq:update-both}, the nonce candidate $\eta_c$ transitions to
@@ -486,7 +486,7 @@ start of a new epoch (so that the entropy added near the end of the epoch is not
   \begin{equation}\label{eq:update-both}
     \inference[Update-Both]
     {
-      slot < \firstSlot{((\epoch{slot}) + 1) - \SlotsPrior}
+      s < \firstSlot{((\epoch{s}) + 1) - \SlotsPrior}
     }
     {
       \left(
@@ -590,11 +590,11 @@ execution of the transition role is as follows:
   \begin{equation}\label{eq:reward-update}
     \inference[Reward-Update]
     {
-      ru' \leteq \createRUpd{b}{es}
-      \\~\\
       s > (\firstSlot{\epoch{s}}) + \StartRewards
       &
       ru = \Nothing
+      \\~\\
+      ru' \leteq \createRUpd{b}{es}
     }
     {
       \left(
@@ -827,9 +827,9 @@ of the key \var{hk} with the KES period \var{n}.
       &
       m \leq n
       \\~\\
-      \mathcal{V}_{\var{vk_{cold}}}{\serialised{(\var{vk_{hot}},~n,~c_0)}}_{\sigma}
+      \mathcal{V}_{\var{vk_{cold}}}{\serialised{(\var{vk_{hot}},~n,~c_0)}}_{\tau}
       &
-      \mathcal{V}^{\mathsf{KES}}_{vk_{hot}}{\serialised{bhb}}_{\tau}^{t}
+      \mathcal{V}^{\mathsf{KES}}_{vk_{hot}}{\serialised{bhb}}_{\sigma}^{t}
       \\
     }
     {
@@ -869,8 +869,7 @@ parameters. The function checks:
 
 \begin{itemize}
 \item The validity of the proofs for the leader value and the new nonce.
-\item The verification key is associated to a non-zero relative stake
-  $\sigma$ in the stake distribution.
+\item The verification key is associated with relative stake $\sigma$ in the stake distribution.
 \item The $\fun{bleader}$ value of \var{bhb} indicates a possible leader for
   this slot.
 \end{itemize}
@@ -883,9 +882,11 @@ parameters. The function checks:
       & \begin{array}{cl}
         ~~~~ & \var{hk}\mapsto (\sigma,~\var{hk_{vrf}})\in\var{pd} \\
         ~~~~ \land &
-             \verifyVrf{\Seed}{\var{vrfVk}}{((\eta_0\seedOp ss)\seedOp\Seede)}{(\bprfn{bhb},~\bnonce{bhb}}) \\
+             \verifyVrf{\Seed}{\var{vrfVk}}{((\eta_0\seedOp ss)\seedOp\Seede)}
+               {(\bprfn{bhb},~\bnonce{bhb}}) \\
         ~~~~ \land &
-             \verifyVrf{\unitInterval}{\var{vrfVk}}{((\eta_0\seedOp ss)\seedOp\Seedl)}{(\bprfl{bhb},~\bleader{bhb}}) \\
+             \verifyVrf{\unitInterval}{\var{vrfVk}}{((\eta_0\seedOp ss)\seedOp\Seedl)}
+               {(\bprfl{bhb},~\bleader{bhb}}) \\
         ~~~~ \land &
              \fun{bleader}~\var{bhb} < 1 - (1 - f)^{\sigma} \\
       \end{array} \\
@@ -1231,7 +1232,7 @@ produced by each stake pool.
   %
   \emph{BBody helper function}
   \begin{align*}
-      & \fun{incrBlocks} \in \Bool \to \KeyHash \to
+      & \fun{incrBlocks} \in \Bool \to \KeyHash_{pool} \to
           \BlocksMade \to \BlocksMade \\
       & \fun{incrBlocks}~\var{isOverlay}~\var{hk}~\var{b} =
         \begin{cases}
@@ -1259,10 +1260,7 @@ The transition is executed if the following preconditions are met:
 \begin{itemize}
 \item The size of the block body matches the value given in the block header body.
 \item The hash of the block body matches the value given in the block header body.
-\item Either \var{hk} to \var{n} is in the mapping of produced blocks, or
-  \var{n} is equal to 0.
-\item The transactions \var{txs} were correctly signed by \var{vk}, producing
-  the signature $\sigma$.
+\item The $\mathsf{LEDGERS}$ transition succeeds.
 \end{itemize}
 
 After this, the transition system updates the mapping of the hashed stake pool
@@ -1389,13 +1387,13 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
           & (\wcard,~\wcard,~\var{ls},~\wcard)
           & \var{es}
           \\
-          & (\wcard,~((\wcard,~\wcard,~\wcard,~\wcard,~\var{dms}),~\wcard))
+          & (\wcard,~((\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{dms}),~\wcard))
           & \var{ls}
       \end{array}
   \end{align*}
   %
   \begin{align*}
-      & \fun{setIssueNumbers} \in \LState \to (\KeyHash\to\N) \to \LState \\
+      & \fun{setIssueNumbers} \in \LState \to (\KeyHash_{pool}\to\N) \to \LState \\
       & \fun{setIssueNumbers}~
           (\var{utxoSt},
           ~(\var{dstate},~(\var{stpools},~\var{poolParams},~\var{retiring},~\wcard)))
@@ -1442,7 +1440,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
         \leteq\var{nes'} \\
         (\wcard,~\wcard,\var{ls},~\var{pp})\leteq\var{es}\\
         ( \wcard,
-          ( (\wcard,~\wcard,~\wcard,~\wcard,~\var{dms}),~
+          ( (\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{dms}),~
             (\wcard,~\wcard,~\wcard,~\var{cs})))\leteq\var{ls}\\
       {
         \left(

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -329,7 +329,7 @@ a stake pool, though these concerns are independent of the ledger rules.
     There is a precondition that the key has been registered.
     Delegation causes the following state transformation:
     \begin{itemize}
-      \item The delegation relation is updated so that stake stake key is delegated to the given
+      \item The delegation relation is updated so that stake key is delegated to the given
         stake pool. The use of union override here allows us to use the same rule
         to perform both an initial delegation and an update to an existing delegation.
     \end{itemize}
@@ -507,16 +507,16 @@ a stake pool, though these concerns are independent of the ledger rules.
 The DELEG rule has five predicate failures:
 \begin{itemize}
 \item In the case of a key registration certificate, if the staking key is already
-  registered, there is a a \em{StakeKeyAlreadyRegistered} failure.
+  registered, there is a \emph{StakeKeyAlreadyRegistered} failure.
 \item In the case of a key deregistration certificate, if the key is not
-  registered, there is a \em{StakeKeyNotRegistered} failure.
+  registered, there is a \emph{StakeKeyNotRegistered} failure.
 \item In the case of a non-existing stake pool key in a delegation certificate,
-  there is a \em{StakeDelegationImpossible} failure.
+  there is a \emph{StakeDelegationImpossible} failure.
 \item In the case of a pool delegation certificate, there is a
-  \em{WrongCertificateType} failure.
+  \emph{WrongCertificateType} failure.
 \item  In the case of a genesis key delegation certificate, if the key is not
   in the domain of the genesis delegation mapping, there is a
-  \em{GenesisKeyNotInMapping} failure.
+  \emph{GenesisKeyNotInMapping} failure.
 \end{itemize}
 
 \clearpage
@@ -695,12 +695,12 @@ The POOL rule has three predicate failures:
 \begin{itemize}
 \item In the case of a pool retirement certificate, if the pool key is not in
   the domain of the stake pools mapping, there is a
-  {\em StakePoolNotRegisteredOnKey} failure.
+  {\emph StakePoolNotRegisteredOnKey} failure.
 \item In the case of a pool retirement certificate, if the retirement epoch is
   not between the current epoch and the relative maximal epoch from the current
-  epoch, there is a {\em StakePoolRetirementWrongEpoch} failure.
+  epoch, there is a {\emph StakePoolRetirementWrongEpoch} failure.
 \item If the delegation certificate is not of one of the pool types, there is a
-  {\em WrongCertificateType} failure.
+  {\emph WrongCertificateType} failure.
 \end{itemize}
 
 \clearpage
@@ -1044,10 +1044,10 @@ will be invalid.
 The DELEGS rule has two predicate failures:
 \begin{itemize}
 \item In the case of a key delegation certificate, if the pool key is not
-  registered, there is a \em{DelegateeNotRegistered} failure.
+  registered, there is a \emph{DelegateeNotRegistered} failure.
 \item If the withdrawals mapping of the transaction is not a subset of the
   rewards mapping of the delegation state, there is a
-  \em{WithdrawalsNotInRewards} failure.
+  \emph{WithdrawalsNotInRewards} failure.
 \end{itemize}
 
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -98,12 +98,12 @@ The PPUP rule has three predicate failures:
 \begin{itemize}
 \item In the case of \var{slot} being smaller than
   $\fun{firstSlot}~((\fun{epoch}~\var{slot}) + 1) - \fun{SlotsPrior}$, there is
-  a {\em PPUpdateTooEarly} failure.
+  a \emph{PPUpdateTooEarly} failure.
 \item In the case of \var{pup} being non-empty, if the check $\dom pup \subseteq
-  \dom dms$ fails, there is a {\em NonGenesisUpdate} failure as only genesis keys
+  \dom dms$ fails, there is a \emph{NonGenesisUpdate} failure as only genesis keys
   can be used in the protocol parameter update.
 \item If a protocol parameter update in \var{pup} cannot follow the current
-  protocol parameter, there is a {\em PVCannotFollow} failure.
+  protocol parameter, there is a \emph{PVCannotFollow} failure.
 \end{itemize}
 
 \clearpage
@@ -331,14 +331,14 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
 The AVUP rule has three predicate failures:
 \begin{itemize}
 \item In the case of \var{aup} being non-empty, if the check $\dom aup \subseteq
-  \dom dms$ fails, there is a {\em NonGenesisUpdate} failure as only genesis keys
+  \dom dms$ fails, there is a \emph{NonGenesisUpdate} failure as only genesis keys
   can be used in the application version update.
 \item In the case of \var{aup} being non-empty, if any of the application names
-  in the proposal are invalid, there is a {\em InvalidName} failure.
+  in the proposal are invalid, there is a \emph{InvalidName} failure.
 \item In the case of \var{aup} being non-empty, if any of the application versions
   in the proposal are not exactly one more than the greatest version for the given
   application name in the current application versions or the future application
-  versions, there is a {\em CannotFollow} failure.
+  versions, there is a \emph{CannotFollow} failure.
 \end{itemize}
 
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -357,15 +357,15 @@ requests).
 
 The UTXO rule has five predicate failures:
 \begin{itemize}
-\item In the case of any input not being valid, there is a \em{BadInput} failure.
+\item In the case of any input not being valid, there is a \emph{BadInput} failure.
 \item In the case of the current slot being greater than the time-to-live of the
-  current transaction, there is an \em{Expired} failure.
-\item In the case of an empty input set, there is a \em{InputSetEmpty} failure,
+  current transaction, there is an \emph{Expired} failure.
+\item In the case of an empty input set, there is a \emph{InputSetEmpty} failure,
   in order to prevent replay attacks.
 \item If the fees are smaller than the minimal transaction fees, there is a
-  \em{FeeTooSmall} failure.
+  \emph{FeeTooSmall} failure.
 \item If the transaction does not correctly conserve the balance, there is a
-  \em{ValueNotConserved} failure.
+  \emph{ValueNotConserved} failure.
 \end{itemize}
 
 \clearpage
@@ -643,9 +643,9 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
 
 The UTXOW rule has two predicate failures:
 \begin{itemize}                 %TODO: add multi-sig script failure predicates
-\item In the case of an incorrect witness, there is a \em{InvalidWitnesses}
+\item In the case of an incorrect witness, there is a \emph{InvalidWitnesses}
   failure.
-\item In the case of a missing witness, there is a \em{MissingVKeyWitnesses}
+\item In the case of a missing witness, there is a \emph{MissingVKeyWitnesses}
   failure.
 \end{itemize}
 


### PR DESCRIPTION
This PR address some small typos from four different issues

Make the case distinction in the `RUPD` transition proper
closes #742

Address half of  #744 (the formal spec part, namely that `sigma` and `tau` were swapped)

Fix all the bleeding italics (and catch two typos).
closes #775 

Address several typos from the recent audit report on 2018-08-16.
closes #778