### PR TITLE
polishin' the pointer addresses

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -27,6 +27,7 @@ module EpochBoundary
   , poolRefunds
   , maxPool
   , groupByPool
+  , (⊎)
   ) where
 
 import           Coin (Coin (..))
@@ -60,6 +61,13 @@ newtype Stake hashAlgo dsignAlgo
   = Stake (Map.Map (StakeCredential hashAlgo dsignAlgo) Coin)
   deriving (Show, Eq, Ord)
 
+-- | Add two stake distributions
+(⊎)
+  :: Stake hashAlgo dsignAlgo
+  -> Stake hashAlgo dsignAlgo
+  -> Stake hashAlgo dsignAlgo
+(Stake lhs) ⊎ (Stake rhs) = Stake $ Map.unionWith (+) lhs rhs
+
 -- | Extract hash of staking key from base address.
 getStakeHK :: Addr hashAlgo dsignAlgo -> Maybe (StakeCredential hashAlgo dsignAlgo)
 getStakeHK (AddrBase _ hk) = Just hk
@@ -82,8 +90,8 @@ baseStake vals =
 
 -- | Extract pointer from pointer address.
 getStakePtr :: Addr hashAlgo dsignAlgo -> Maybe Ptr
-getStakePtr (AddrPtr ptr) = Just ptr
-getStakePtr _             = Nothing
+getStakePtr (AddrPtr _ ptr) = Just ptr
+getStakePtr _               = Nothing
 
 -- | Calculate stake of pointer addresses in TxOut set.
 ptrStake

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -72,7 +72,8 @@ data Addr hashAlgo dsignAlgo
   | AddrEnterprise
     { _enterprisePayment :: Credential hashAlgo dsignAlgo }
   | AddrPtr
-      { _stakePtr :: Ptr
+      { _paymentObjP :: Credential hashAlgo dsignAlgo
+      , _stakePtr :: Ptr
       }
   deriving (Show, Eq, Ord)
 
@@ -343,9 +344,10 @@ instance
       encodeListLen 2
         <> toCBOR (1 :: Word8)
         <> toCBOR pay
-    AddrPtr stakePtr ->
-      encodeListLen 2
+    AddrPtr pay stakePtr ->
+      encodeListLen 3
         <> toCBOR (2 :: Word8)
+        <> toCBOR pay
         <> toCBOR stakePtr
 
 instance ToCBOR Ptr where

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -10,7 +10,7 @@ import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
-                     ex3A, ex3B, ex3C, ex4A, ex4B, ex4C)
+                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -93,6 +93,12 @@ testCHAINExample2I = testCHAINExample ex2I
 testCHAINExample2J :: Assertion
 testCHAINExample2J = testCHAINExample ex2J
 
+testCHAINExample2K :: Assertion
+testCHAINExample2K = testCHAINExample ex2K
+
+testCHAINExample2L :: Assertion
+testCHAINExample2L = testCHAINExample ex2L
+
 testCHAINExample3A :: Assertion
 testCHAINExample3A = testCHAINExample ex3A
 
@@ -129,6 +135,8 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 2H - create a nontrivial rewards" testCHAINExample2H
   , testCase "CHAIN example 2I - apply a nontrivial rewards" testCHAINExample2I
   , testCase "CHAIN example 2J - drain reward account and deregister" testCHAINExample2J
+  , testCase "CHAIN example 2K - stage stake pool retirement" testCHAINExample2K
+  , testCase "CHAIN example 2L - reap stake pool" testCHAINExample2L
   , testCase "CHAIN example 3A - get 3/7 votes for a pparam update" testCHAINExample3A
   , testCase "CHAIN example 3B - get 5/7 votes for a pparam update" testCHAINExample3B
   , testCase "CHAIN example 3C - processes a pparam update" testCHAINExample3C


### PR DESCRIPTION
This PR cleans up a couple problems with the pointer addresses.

* The pointer addresses needed a payment object.
* The function that computes the stake distribution, `stakeDistr`, was taking a union of the three places where stake lives: base addresses, pointer addresses, and reward accounts. The problem with this is that `Map.union` a union-override-left, but really we need a union-override-plus. In the formal spec with use the relational `aggregate_+`, which I think is implemented well  in Haskell with `Map.unionWith (+)`.

closes #783 