### PR TITLE
remove stake cert pointers on dereg

### DIFF
--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -265,6 +265,12 @@ class Relation m where
   (▷), (|>) :: Ord (Range m) => m -> Set (Range m) -> m
   s |> r = s ▷ r
 
+  -- | Range exclusion
+  --
+  -- Unicode: 22eb
+  (⋫), (|/>) :: Ord (Range m) => m -> Set (Range m) -> m
+  s |/> r = s ⋫ r
+
   -- | Union
   (∪) :: (Ord (Domain m), Ord (Range m)) => m -> m -> m
 
@@ -322,6 +328,8 @@ instance (Ord k, Ord v) => Relation (Bimap k v) where
 
   r ▷ s = Bimap.filter (\_ v -> Set.member v s) r
 
+  r ⋫ s = Bimap.filter (\_ v -> Set.notMember v s) r
+
   d0 ∪ d1 = Bimap.fold Bimap.insert d0 d1
   d0 ⨃ d1 = foldr (uncurry Bimap.insert) d0 (toList d1)
 
@@ -347,6 +355,8 @@ instance Relation (Map k v) where
   s ⋪ r = Map.filterWithKey (\k _ -> k `Set.notMember` toSet s) r
 
   r ▷ s = Map.filter (flip Set.member s) r
+
+  r ⋫ s = Map.filter (flip Set.notMember s) r
 
   d0 ∪ d1 = Map.union d0 d1
   -- For union override we pass @d1@ as first argument, since 'Map.union' is
@@ -381,6 +391,8 @@ instance Relation (Set (a, b)) where
 
   r ▷ s = Set.filter (\(_,v) -> Set.member v s) r
 
+  r ⋫ s = Set.filter (\(_,v) -> Set.notMember v s) r
+
   (∪) = Set.union
 
   d0 ⨃ d1 = d1' ∪ ((dom d1') ⋪ d0)
@@ -410,6 +422,8 @@ instance Relation [(a, b)] where
   s ⋪ r = filter ((`Set.notMember` toSet s) . fst) r
 
   r ▷ s = filter ((`Set.member` toSet s) . snd) r
+
+  r ⋫ s = filter ((`Set.notMember` toSet s) . snd) r
 
   (∪) = (++)
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -13,7 +13,7 @@ import           BlockChain (slotsPrior)
 import           Coin (Coin (..))
 import           Delegation.Certificates
 import           Keys
-import           Ledger.Core (dom, singleton, (∈), (∉), (∪), (⋪), (⨃))
+import           Ledger.Core (dom, singleton, (∈), (∉), (∪), (⋪), (⋫),(⨃))
 import           LedgerState
 import           Slot
 import           TxData
@@ -67,7 +67,7 @@ delegationTransition = do
         { _stKeys      = Set.singleton key              ⋪ _stKeys ds
         , _rewards     = Set.singleton (RewardAcnt key) ⋪ _rewards ds
         , _delegations = Set.singleton key              ⋪ _delegations ds
-        , _ptrs        = Set.singleton ptr_             ⋪ _ptrs ds
+        , _ptrs        = _ptrs ds                       ⋫ Set.singleton key
         }
 
     Delegate (Delegation delegator_ delegatee_) -> do

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -399,6 +399,8 @@ instance Relation (StakeKeys hashAlgo dsignAlgo) where
 
   (StakeKeys stKeys) ▷ s = StakeKeys $ stKeys ▷ s
 
+  (StakeKeys stKeys) ⋫ s = StakeKeys $ stKeys ⋫ s
+
   (StakeKeys a) ∪ (StakeKeys b) = StakeKeys $ a ∪ b
 
   (StakeKeys a) ⨃ b = StakeKeys $ a ⨃ b

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -44,8 +44,8 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 
 import           Coin (Coin (..))
-import           Keys (KeyDiscriminator(..), DSIGNAlgorithm, HashAlgorithm, KeyPair, Signable, hash, hashKey, sKey, sign,
-                     vKey, verify)
+import           Keys (DSIGNAlgorithm, HashAlgorithm, KeyDiscriminator (..), KeyPair, Signable,
+                     hash, hashKey, sKey, sign, vKey, verify)
 import           Ledger.Core (Relation (..))
 import           PParams (PParams (..))
 import           TxData (Addr (..), Credential (..), ScriptHash, StakeCredential, Tx (..),
@@ -75,6 +75,8 @@ instance Relation (UTxO hashAlgo dsignAlgo) where
   s ⋪ (UTxO utxo) = UTxO $ s ⋪ utxo
 
   (UTxO utxo) ▷ s = UTxO $ utxo ▷ s
+
+  (UTxO utxo) ⋫ s = UTxO $ utxo ⋫ s
 
   (UTxO a) ∪ (UTxO b) = UTxO $ a ∪ b
 

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -9,8 +9,8 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
-                     ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex3A,
-                     ex3B, ex3C, ex4A, ex4B, ex4C)
+                     ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
+                     ex3A, ex3B, ex3C, ex4A, ex4B, ex4C)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -90,6 +90,9 @@ testCHAINExample2H = testCHAINExample ex2H
 testCHAINExample2I :: Assertion
 testCHAINExample2I = testCHAINExample ex2I
 
+testCHAINExample2J :: Assertion
+testCHAINExample2J = testCHAINExample ex2J
+
 testCHAINExample3A :: Assertion
 testCHAINExample3A = testCHAINExample ex3A
 
@@ -125,6 +128,7 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 2G - prelude to the first nontrivial rewards" testCHAINExample2G
   , testCase "CHAIN example 2H - create a nontrivial rewards" testCHAINExample2H
   , testCase "CHAIN example 2I - apply a nontrivial rewards" testCHAINExample2I
+  , testCase "CHAIN example 2J - drain reward account and deregister" testCHAINExample2J
   , testCase "CHAIN example 3A - get 3/7 votes for a pparam update" testCHAINExample3A
   , testCase "CHAIN example 3B - get 5/7 votes for a pparam update" testCHAINExample3B
   , testCase "CHAIN example 3C - processes a pparam update" testCHAINExample3C

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -413,7 +413,7 @@ a stake pool, though these concerns are independent of the ledger rules.
         \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{stkeys}} \\
         \varUpdate{\{\addrRw \var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{rewards}} \\
         \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{delegations}} \\
-        \varUpdate{\{ptr\}} & \varUpdate{\subtractdom} & \varUpdate{\var{ptrs}} \\
+        \varUpdate{\var{ptrs}} & \varUpdate{\subtractrange} & \varUpdate{\{\var{hk}\}} \\
         \var{fdms} \\
         \var{dms} \\
       \end{array}


### PR DESCRIPTION
The `DELEG` transition now properly removes the stake registration certificate pointers on the de-registration of a key.

I added the range exclusion operator (`⋫` or `|/>`) to the `Ledger.Core` `Relation` class.

Both the formal spec and the exec model now remove the cert prt with `ptrs ⋫ {hk}`.

I found another small fix, namely the `UTXO` rule was not allowing zero-valued coins, so now it does.

I added an example (`2J`) which drains a reward account and then de-registers a stake key.

unrelated to the main issue, I made the protocol update example (example 3) a bit more interesting by also voting on extra entropy. This value is a bit special, since after a successful vote, it injects itself into the next epoch nonce and is then set back to the neutral element in the protocol parameters.

closes #785 