### PR TITLE
Merge multi-sig specification into Shelley spec

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/address.tex
+++ b/shelley/chain-and-ledger/formal-spec/address.tex
@@ -7,8 +7,8 @@ There are four types of UTxO addresses:
 \begin{itemize}
 \item Base addresses, $\AddrB$, containing the hash of a payment credential and
   the hash of a staking credential,
-\item Pointer addresses, $\AddrP$,
-  containing the hash of a payment credential and a pointer to a stake key registration certificate,
+\item Pointer addresses, $\AddrP$, containing the hash of a payment credential
+  and a pointer to a stake credential registration certificate,
 \item Enterprise addresses, $\AddrE$,
   containing only the hash of a payment credential (and which have no staking rights).
 \item Bootstrap addresses, $\AddrBS$, corresponding to the addresses in

--- a/shelley/chain-and-ledger/formal-spec/address.tex
+++ b/shelley/chain-and-ledger/formal-spec/address.tex
@@ -5,29 +5,34 @@ Addresses are described in section 4.2 of the delegation design document \cite{d
 The types needed for the addresses are defined in Figure~\ref{fig:defs:addresses}.
 There are four types of UTxO addresses:
 \begin{itemize}
-  \item Base addresses, $\AddrB$,
-        containing the hash of a payment key and the hash of a staking key,
-  \item Pointer addresses, $\AddrP$,
-        containing the hash of a payment key and a pointer to a stake key registration certificate,
-  \item Enterprise addresses, $\AddrE$,
-        containing only the hash of a payment key (and which have no staking rights).
-  \item Bootstrap addresses, $\AddrBS$,
-        corresponding to the addresses in Byron, behaving exactly like enterprise addresses.
+\item Base addresses, $\AddrB$, containing the hash of a payment credential and
+  the hash of a staking credential,
+\item Pointer addresses, $\AddrP$,
+  containing the hash of a payment credential and a pointer to a stake key registration certificate,
+\item Enterprise addresses, $\AddrE$,
+  containing only the hash of a payment credential (and which have no staking rights).
+\item Bootstrap addresses, $\AddrBS$, corresponding to the addresses in
+  Byron, behaving exactly like enterprise addresses with a key hash
+  payment credential.
 \end{itemize}
-Together, these three address types make up the $\Addr$ type, which will be used
-in transaction outputs in Section~\ref{sec:utxo}.
+
+Where a credential is either key or a multi-signature script. Together, these
+three address types make up the $\Addr$ type, which will be used in transaction
+outputs in Section~\ref{sec:utxo}.
 
 Note that for security, privacy and usability reasons, the staking (delegating)
-key pair associated with an address should be different from its payment key pair.
-Before the stake key is registered and delegated to an existing stake pool,
-the payment key can be used for transactions, though it will not receive rewards from staking.
-Once a stake key is registered, the shorter pointer addresses can generated.
+credential associated with an address should be different from its payment
+credential.  Before the stake credential is registered and delegated to an
+existing stake pool, the payment credential can be used for transactions, though
+it will not receive rewards from staking.  Once a stake credential is
+registered, the shorter pointer addresses can be generated.
 
-Finally, there is an account style address $\AddrRWD$ which contains the hash of a staking key.
-These account addresses will only be used for receiving rewards from the proof of
-stake leader election.  Apendix A of \cite{delegation_design} explains this design choice.
-The mechanism for transferring rewards from these accounts will be explained in
-Section~\ref{sec:utxo} and follows \cite{chimeric}.
+Finally, there is an account style address $\AddrRWD$ which contains the hash of
+a staking credential. These account addresses will only be used for receiving
+rewards from the proof of stake leader election. Appendix A
+of~\cite{delegation_design} explains this design choice.  The mechanism for
+transferring rewards from these accounts will be explained in
+Section~\ref{sec:utxo} and follows~\cite{chimeric}.
 
 \begin{figure*}[hbt]
   \emph{Abstract types}
@@ -43,6 +48,7 @@ Section~\ref{sec:utxo} and follows \cite{chimeric}.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
+      \var{cred} & \Credential & \KeyHash\uniondistinct\HashScr \\
       \var{(s,t,c)}
       & \Ptr
       & \Slot\times\Ix\times\Ix

--- a/shelley/chain-and-ledger/formal-spec/address.tex
+++ b/shelley/chain-and-ledger/formal-spec/address.tex
@@ -34,6 +34,10 @@ of~\cite{delegation_design} explains this design choice.  The mechanism for
 transferring rewards from these accounts will be explained in
 Section~\ref{sec:utxo} and follows~\cite{chimeric}.
 
+Base, pointer and enterprise addresses contain a payment credential which is
+either a key hash or a script hash. Base addresses contain a staking credential
+which is also either a key hash or a script hash.
+
 \begin{figure*}[hbt]
   \emph{Abstract types}
   %
@@ -95,12 +99,15 @@ Section~\ref{sec:utxo} and follows~\cite{chimeric}.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \fun{paymentHK} & \Addr \to \KeyHash_{pay}
-                      & \text{hash of payment key from addr}\\
-      \fun{stakeHK_b} & \AddrB \to \KeyHash_{stake}
-                      & \text{hash of stake key from base addr}\\
-      \fun{stakeHK_r} & \AddrRWD \to \KeyHash_{stake}
-                      & \text{hash of stake key from reward account}\\
+      \fun{paymentHK} & \AddrVKey \to \KeyHash_{pay}
+      & \text{hash of payment key from addr}\\
+      \fun{validatorHash} & \AddrScr \to \HashScr & \text{hash of validator
+                                                    script} \\
+            \fun{stakeCred_{b}} & (\AddrVKeyB \uniondistinct \AddrScrBase) \to
+                          \StakeCredential & \text{stake credential from base
+                                      addr}\\
+      \fun{stakeCred_{r}} & \AddrRWD \to \StakeCredential & \text{stake credential
+                                                   from reward addr}\\
       \fun{addrPtr} & \AddrP \to \Ptr
                     & \text{pointer from pointer addr}\\
     \end{array}
@@ -111,7 +118,7 @@ Section~\ref{sec:utxo} and follows~\cite{chimeric}.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \fun{addr_{rwd}}
-        & \KeyHash_{stake} \to \AddrRWD
+        & \Credential_{stake} \to \AddrRWD
         & \text{construct a reward account}
     \end{array}
   \end{equation*}

--- a/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
+++ b/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
@@ -135,6 +135,22 @@ needed for KES.
   \label{fig:kes-defs-shelley}
 \end{figure}
 
+Figure~\ref{fig:types-msig} shows the types for multi-signature
+schemes. Multi-signatures effectively specify one or more combinations of
+cryptographic signatures which are considered valid. This is realized in a
+native way via a script-like DSL which allows for defining terms that can be
+evaluated. The terms form a tree like structure and are evaluated via the
+\fun{evalMultiSigScript} function. The parameters are a script and a set of key
+hashes. The function returns $True$ in the case of the supplied key hashes being
+a valid combination for the script, else it returns $False$.
+
+Use cases for this are for example:
+\begin{itemize}
+\item Require two parties to sign.
+\item Require either of two parties to sign.
+\item Generally, require $m$ out of $n$ ($m \leq n$) parties to sign.
+\end{itemize}
+
 \begin{figure*}[hbt]
   \emph{MultiSig Type}
 
@@ -152,14 +168,6 @@ needed for KES.
 
   \emph{Functions}
 
-  \begin{align*}
-    \fun{validateScript} & \in\Script\to\Tx\to\Bool & \text{validate native
-                                                          script} \\
-    \fun{validateScript} & ~\var{msig}~\var{tx}= \\
-                         & \textrm{let}~\var{vhks}\leteq \{\fun{hashKey}~vk \vert
-                           vk \in \fun{txwitsVKey}~\var{tx}\} \\
-                         & \fun{evalMultiSigScript}~msig~vhks\\
-  \end{align*}
   \begin{align*}
     \fun{evalMultiSigScript} & \in\Script\to\powerset\KeyHash\to\Bool & \\
     \fun{evalMultiSigScript} & ~(\type{RequireSig}~hk)~\var{vhks} =  hk \in vhks \\

--- a/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
+++ b/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
@@ -134,4 +134,49 @@ needed for KES.
   \caption{KES Cryptographic definitions}
   \label{fig:kes-defs-shelley}
 \end{figure}
+
+\begin{figure*}[hbt]
+  \emph{MultiSig Type}
+
+  \begin{equation*}
+    \begin{array}{rll}
+      \var{msig} & \in & \type{RequireSig}~\KeyHash\\
+      & \uniondistinct &
+         \type{RequireAllOf}~[\Script] \\
+      & \uniondistinct&
+         \type{RequireAnyOf}~[\Script] \\
+      & \uniondistinct&
+        \type{RequireMOf}~\N~[\Script]
+    \end{array}
+  \end{equation*}
+
+  \emph{Functions}
+
+  \begin{align*}
+    \fun{validateScript} & \in\Script\to\Tx\to\Bool & \text{validate native
+                                                          script} \\
+    \fun{validateScript} & ~\var{msig}~\var{tx}= \\
+                         & \textrm{let}~\var{vhks}\leteq \{\fun{hashKey}~vk \vert
+                           vk \in \fun{txwitsVKey}~\var{tx}\} \\
+                         & \fun{evalMultiSigScript}~msig~vhks\\
+  \end{align*}
+  \begin{align*}
+    \fun{evalMultiSigScript} & \in\Script\to\powerset\KeyHash\to\Bool & \\
+    \fun{evalMultiSigScript} & ~(\type{RequireSig}~hk)~\var{vhks} =  hk \in vhks \\
+    \fun{evalMultiSigScript} & ~(\type{RequireAllOf}~ts)~\var{vhks} =
+                              \forall t \in ts: \fun{evalMultiSigScript}~t~vhks\\
+    \fun{evalMultiSigScript} & ~(\type{RequireAnyOf}~ts)~\var{vhks} =
+                              \exists t \in ts: \fun{evalMultiSigScript}~t~vhks\\
+    \fun{evalMultiSigScript} & ~(\type{RequireMOf}~m~ts)~\var{vhks} = \\
+                             & m \leq \Sigma
+                               \left(
+                               [\textrm{if}~(\fun{evalMultiSigScript}~\var{t}~\var{vhks})~
+                               \textrm{then}~1~\textrm{else}~0\vert t \leftarrow ts]
+                               \right)
+  \end{align*}
+
+  \caption{Multi-signature via Native Scripts}
+  \label{fig:types-msig}
+\end{figure*}
+
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
+++ b/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
@@ -12,11 +12,11 @@ cryptography outside this work. The types and rules we give here are needed in
 order to guarantee certain security properties of the delegation process, which
 we discuss later.
 
-The cryptographic concepts required for the formal definition
-of witnessing include public-private key pairs, one-way functions
-and signatures. The constraint we introduce states that a signature of
-some data signed with a (private) key is only correct whenever we can verify
-it using the corresponding public key.
+The cryptographic concepts required for the formal definition of witnessing
+include public-private key pairs, one-way functions, signatures and
+multi-signature scripts. The constraint we introduce states that a signature of
+some data signed with a (private) key is only correct whenever we can verify it
+using the corresponding public key.
 
 Besides basic cryptographic abstractions, we also make use of some abstract
 data storage properties in this document in order to build necessary definitions
@@ -44,6 +44,8 @@ organization chosen for an implementation.
       \var{hk} & \KeyHash & \text{hash of a key}\\
       \sigma & \Sig  & \text{signature}\\
       \var{d} & \Data  & \text{data}\\
+      \var{script} & \Script & \text{multi-signature script} \\
+      \var{hs} & \HashScr & \text{hash of a script}
     \end{array}
   \end{equation*}
   \emph{Derived types}
@@ -64,6 +66,7 @@ organization chosen for an implementation.
                    %
       \fun{sign} & \SKey \to \Data \to \Sig
                  & \text{signing function}\\
+      \fun{hashScript} & \Script \to \HashScr & \text{hash a serialized script}
     \end{array}
   \end{equation*}
   \emph{Constraints}
@@ -83,7 +86,7 @@ organization chosen for an implementation.
 
 When we get to the blockchain layer validation, we will use
 key evolving signatures according to the MMM scheme \citep{cryptoeprint:2001:034}.
-Figure~\ref{fig:crypto-defs-shelley} introduces the additional cryptographic abstractions
+Figure~\ref{fig:kes-defs-shelley} introduces the additional cryptographic abstractions
 needed for KES.
 
 

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -53,10 +53,10 @@ Here we introduce the following primitive datatypes used in delegation:
 \end{itemize}
 The following derived types are introduced:
 \begin{itemize}
-  \item $\type{StakeKeys}$ represents registered stake keys and is represented by a finite
-    map from hashkeys to slot when it was registered.
-  \item$\type{StakePools}$ represents registered stake pools and has the same type as
-    $\type{StakeKeys}$.
+\item $\type{StakeDelegs}$ represents registered stake delegations and is
+  represented by a finite map from stake credentials to slot when it was
+  registered.
+\item$\type{StakePools}$ represents registered stake pools
 \item $\PoolParam$ represents the parameters found in a stake pool registration certificate
   that must be tracked:
   \begin{itemize}
@@ -116,9 +116,9 @@ It does the following:
   \emph{Derived types}
   \begin{equation*}
     \begin{array}{l@{\qquad=\qquad}lr}
-      \StakeKeys
-      & \KeyHash \mapsto \Slot
-      & \text{registered stake keys} \\
+      \StakeDeleg
+      & \Credential \mapsto \Slot
+      & \text{registered stake credential} \\
       %
       \StakePools
       & \KeyHash \mapsto \Slot
@@ -190,8 +190,8 @@ state transition types. We define two separate parts of the ledger state.
 \begin{itemize}
   \item $\DState$ keeps track of the delegation state, consisting of:
     \begin{itemize}
-      \item $\var{stkeys}$ tracks the registered stake keys. It consists of a finite
-        mapping from hashkeys to the slot of the registration.
+    \item $\var{stdelegs}$ tracks the registered stake credentials. It consists
+      of a finite mapping from hashkeys to the slot of the registration.
       \item $\var{rewards}$ stores the rewards accumulated by stake keys.
         These are represented by a finite map from reward addresses to the accumulated rewards.
       \item $\var{delegations}$ stores the delegation relation, mapping stake keys to the
@@ -360,7 +360,7 @@ a stake pool, though these concerns are independent of the ledger rules.
   \begin{equation}\label{eq:deleg-reg}
     \inference[Deleg-Reg]
     {
-    \var{c}\in\DCertRegKey & hk \leteq \cwitness{c} & hk \notin \dom \var{stkeys}
+    \var{c}\in\DCertRegKey & hk \leteq \cwitness{c} & hk \notin \dom \var{stdelegs}
     }
     {
       \begin{array}{r}
@@ -370,7 +370,7 @@ a stake pool, though these concerns are independent of the ledger rules.
       \vdash
       \left(
         \begin{array}{r}
-        \var{stkeys} \\
+        \var{stdelegs} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
@@ -381,7 +381,7 @@ a stake pool, though these concerns are independent of the ledger rules.
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \varUpdate{\var{stkeys}} & \varUpdate{\union} & \varUpdate{\{\var{hk} \mapsto slot\}} \\
+        \varUpdate{\var{stdelegs}} & \varUpdate{\union} & \varUpdate{\{\var{hk} \mapsto slot\}} \\
         \varUpdate{\var{rewards}} & \varUpdate{\union} & \varUpdate{\{\addrRw \var{hk} \mapsto 0\}}\\
         \var{delegations} \\
         \varUpdate{\var{ptrs}} & \varUpdate{\union} & \varUpdate{\{ptr \mapsto \var{hk}\}} \\
@@ -396,7 +396,7 @@ a stake pool, though these concerns are independent of the ledger rules.
     \inference[Deleg-Dereg]
     {
       \var{c}\in \DCertDeRegKey  & hk \leteq \cwitness{c} \\
-    hk \in \dom \var{stkeys} & \addrRw \var{hk} \mapsto 0 \in \var{rewards}
+    hk \in \dom \var{stdelegs} & \addrRw \var{hk} \mapsto 0 \in \var{rewards}
     }
     {
       \begin{array}{r}
@@ -406,7 +406,7 @@ a stake pool, though these concerns are independent of the ledger rules.
       \vdash
       \left(
       \begin{array}{r}
-        \var{stkeys} \\
+        \var{stdelegs} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
@@ -417,7 +417,7 @@ a stake pool, though these concerns are independent of the ledger rules.
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{stkeys}} \\
+        \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{stdelegs}} \\
         \varUpdate{\{\addrRw \var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{rewards}} \\
         \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{delegations}} \\
         \varUpdate{\{ptr\}} & \varUpdate{\subtractdom} & \varUpdate{\var{ptrs}} \\
@@ -431,7 +431,7 @@ a stake pool, though these concerns are independent of the ledger rules.
   \begin{equation}\label{eq:deleg-deleg}
     \inference[Deleg-Deleg]
     {
-      \var{c}\in \DCertDeleg & hk \leteq \cwitness{c} & hk \in \dom \var{stkeys}
+      \var{c}\in \DCertDeleg & hk \leteq \cwitness{c} & hk \in \dom \var{stdelegs}
     }
     {
       \begin{array}{r}
@@ -441,7 +441,7 @@ a stake pool, though these concerns are independent of the ledger rules.
       \vdash
       \left(
       \begin{array}{r}
-        \var{stkeys} \\
+        \var{stdelegs} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
@@ -452,7 +452,7 @@ a stake pool, though these concerns are independent of the ledger rules.
       \trans{deleg}{c}
       \left(
       \begin{array}{rcl}
-        \var{stkeys} \\
+        \var{stdelegs} \\
         \var{rewards} \\
         \varUpdate{\var{delegations}} & \varUpdate{\unionoverrideRight}
                                       & \varUpdate{\{\var{hk} \mapsto \dpool c\}} \\
@@ -484,7 +484,7 @@ a stake pool, though these concerns are independent of the ledger rules.
       \vdash
       \left(
       \begin{array}{r}
-        \var{stkeys} \\
+        \var{stdelegs} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
@@ -495,7 +495,7 @@ a stake pool, though these concerns are independent of the ledger rules.
       \trans{deleg}{c}
       \left(
       \begin{array}{rcl}
-        \var{stkeys} \\
+        \var{stdelegs} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
@@ -513,16 +513,8 @@ a stake pool, though these concerns are independent of the ledger rules.
 
 The DELEG rule has five predicate failures:
 \begin{itemize}
-<<<<<<< HEAD
-\item In the case of a key registration certificate, if the staking key is already
-  registered, there is a \emph{StakeKeyAlreadyRegistered} failure.
-||||||| merged common ancestors
-\item In the case of a key registration certificate, if the staking key is already
-  registered, there is a a \em{StakeKeyAlreadyRegistered} failure.
-=======
 \item In the case of a key registration certificate, if the staking key is
   already registered, there is a a \emph{StakeKeyAlreadyRegistered} failure.
->>>>>>> 96833182503fa1cd65e6eb643d3142bc2a505308
 \item In the case of a key deregistration certificate, if the key is not
   registered, there is a \emph{StakeKeyNotRegistered} failure.
 \item In the case of a non-existing stake pool key in a delegation certificate,
@@ -954,7 +946,7 @@ will be invalid.
       \begin{array}{c}
         \left(
         \begin{array}{r}
-          \var{stkeys} \\
+          \var{stdelegs} \\
           \var{rewards} \\
           \var{delegations} \\
           \var{ptrs} \\
@@ -977,7 +969,7 @@ will be invalid.
       \begin{array}{c}
         \left(
         \begin{array}{c}
-          \var{stkeys} \\
+          \var{stdelegs} \\
           \varUpdate{\var{rewards'}} \\
           \var{delegations} \\
           \var{ptrs} \\

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -133,10 +133,8 @@ It does the following:
   \emph{Certificate Accessor functions}
   %
   \begin{equation*}
-  \begin{array}{r@{~\in~}lr}
-    \cwitness{} & \DCert \to \KeyHash
-  & \text{certificate witness}
-  \\
+    \begin{array}{r@{~\in~}lr}
+      \cwitness{} & \DCert \to \StakeDelegs & \text{certificate witness} \\
   \fun{dpool} & \DCertDeleg \to \KeyHash
   & \text{pool being delegated to}
   \\
@@ -226,15 +224,24 @@ and the protocol parameters.
 %% Figure - Delegation Transitions
 %%
 \begin{figure}
+  \emph{Delegation Types}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
+      \var{stakeCred} & \StakeCredential & (\KeyHash_{stake} \uniondistinct
+                                       \HashScr) \\
+      \var{stakeDelegator} & \StakeDelegs & \StakeCredential \mapsto \Slot \\
+    \end{array}
+  \end{equation*}
+  %
   \emph{Delegation States}
   %
   \begin{equation*}
     \begin{array}{l}
     \DState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stkeys} & \StakeKeys & \text{registered stake keys}\\
-      \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
-      \var{delegations} & \KeyHash_{stake} \mapsto \KeyHash_{pool} & \text{delegations}\\
+            \var{stDelegs} & \StakeDelegs & \text{registered stake delegators}\\
+            \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
+            \var{delegations} & \StakeCredential \mapsto \KeyHash_{pool} & \text{delegations}\\
       \var{ptrs} & \Ptr \mapsto \KeyHash & \text{pointer to hashkey}\\
       \var{fdms} & (\Slot\times\KeyHashGen) \mapsto \KeyHash & \text{future genesis key delegations}\\
       \var{dms} & \KeyHashGen \mapsto \KeyHash & \text{genesis key delegations}\\

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -4,32 +4,29 @@
 We briefly describe the motivation and context for delegation.
 The full context is contained in \cite{delegation_design}.
 
-Stake is said to be \textit{active} in the blockchain protocol
-when it is eligible for participation in the leader election. In order for
-stake to become active,
-the associated verification stake key must be registered
-and its staking rights must be delegated to an active stake pool.
-Individuals who wish to participate in the protocol can
-register themselves as a stake pool.
+Stake is said to be \textit{active} in the blockchain protocol when it is
+eligible for participation in the leader election. In order for stake to become
+active, the associated verification stake credential must be registered and its
+staking rights must be delegated to an active stake pool. Individuals who wish
+to participate in the protocol can register themselves as a stake pool.
 
-Stake keys are registered (or deregistered) through the use of
-registration (or deregistration) certificates.
-Registered stake keys are delegated through the use of delegation certificates.
-Finally, stake pools are registered (or retired) through the use of
-registration (or retirement) certificates.
+Stake credentials are registered (or deregistered) through the use of
+registration (or deregistration) certificates. Registered stake credentials are
+delegated through the use of delegation certificates.  Finally, stake pools are
+registered (or retired) through the use of registration (or retirement)
+certificates.
 
-Stake pool retirement is handled a bit differently than stake key deregistration.
-Stake keys are considered inactive as soon as a deregistration certificate
-is applied to the ledger state.
-Stake pool retirement certificates, however, specify the epoch in
-which it will retire.
+Stake pool retirement is handled a bit differently than stake deregistration.
+Stake credentials are considered inactive as soon as a deregistration
+certificate is applied to the ledger state.  Stake pool retirement certificates,
+however, specify the epoch in which it will retire.
 
-Delegation requires the following to be tracked by the ledger state:
-the registered stake keys, the delegation map from registered stake keys to stake
-pools, pointers associated with stake keys,
-the registered stake pools and upcoming stake pool retirements.
-Additionally, the blockchain protocol rewards eligible stake and so we must
-also include a mapping from active stake keys to rewards.
+Delegation requires the following to be tracked by the ledger state: the
+registered stake credentials, the delegation map from registered stake
+credentials to stake pools, pointers associated with stake credentials, the
+registered stake pools and upcoming stake pool retirements.  Additionally, the
+blockchain protocol rewards eligible stake and so we must also include a mapping
+from active stake credentials to rewards.
 
 Finally, there is a type of delegation certificate available only to the genesis
 keys. The genesis keys will still be used for update proposals at the begin of the Shelley
@@ -43,9 +40,9 @@ In \cref{fig:delegation-defs} we give the delegation primitives.
 Here we introduce the following primitive datatypes used in delegation:
 
 \begin{itemize}
-\item $\DCertRegKey$: a stake key registration certificate.
-\item $\DCertDeRegKey$: a stake key de-registration certificate.
-\item $\DCertDeleg$: a stake key delegation certificate.
+\item $\DCertRegKey$: a stake credential registration certificate.
+\item $\DCertDeRegKey$: a stake credential de-registration certificate.
+\item $\DCertDeleg$: a stake credential delegation certificate.
 \item $\DCertRegPool$: a stake pool registration certificate.
 \item $\DCertRetirePool$: a stake pool retirement certificate.
 \item $\DCertGen$: a genesis key delegation certificate.
@@ -192,12 +189,14 @@ state transition types. We define two separate parts of the ledger state.
     \begin{itemize}
     \item $\var{stdelegs}$ tracks the registered stake credentials. It consists
       of a finite mapping from hashkeys to the slot of the registration.
-      \item $\var{rewards}$ stores the rewards accumulated by stake keys.
-        These are represented by a finite map from reward addresses to the accumulated rewards.
-      \item $\var{delegations}$ stores the delegation relation, mapping stake keys to the
-        pool to which is delegates.
-      \item $\var{ptrs}$ maps stake keys to the position of the registration certificate
-        in the blockchain. This is needed to lookup the stake hashkey of a pointer address.
+    \item $\var{rewards}$ stores the rewards accumulated by stake credentials.
+      These are represented by a finite map from reward addresses to the
+      accumulated rewards.
+    \item $\var{delegations}$ stores the delegation relation, mapping stake
+      credentials to the pool to which is delegates.
+    \item $\var{ptrs}$ maps stake credentials to the position of the
+      registration certificate in the blockchain. This is needed to lookup the
+      stake hashkey of a pointer address.
       \item $\var{fdms}$ future genesis keys delegations.
       \item $\var{dms}$ maps genesis key hashes to hashes of the cold key delegates.
     \end{itemize}
@@ -302,29 +301,32 @@ and the protocol parameters.
 \label{sec:deleg-rules}
 
 
-The rules for registering and delegating stake keys are given in \cref{fig:delegation-rules}.
-Note that section 5.2 of \cite{delegation_design} describes how a wallet would help a user choose
-a stake pool, though these concerns are independent of the ledger rules.
+The rules for registering and delegating stake credentials are given in
+\cref{fig:delegation-rules}.  Note that section 5.2 of \cite{delegation_design}
+describes how a wallet would help a user choose a stake pool, though these
+concerns are independent of the ledger rules.
 
 \begin{itemize}
-  \item Stake key registration is handled by \cref{eq:deleg-reg}, since it contains the
-    precondition that the certificate has type $\DCertRegKey$.
-    All the equations in $\mathsf{DELEG}$ and $\mathsf{POOL}$ follow this same pattern of matching
-    on certificate type.
+\item Stake credential registration is handled by \cref{eq:deleg-reg}, since it
+  contains the precondition that the certificate has type $\DCertRegKey$.  All
+  the equations in $\mathsf{DELEG}$ and $\mathsf{POOL}$ follow this same pattern
+  of matching on certificate type.
 
-    There is also a precondition on registration that the hashkey associated with the certificate
-    witness of the certificate is not already found in the current list of stake keys.
+  There is also a precondition on registration that the hashkey associated with
+  the certificate witness of the certificate is not already found in the current
+  list of stake credentials.
 
     Registration causes the following state transformation:
     \begin{itemize}
-      \item The key is added to the set of registered stake keys.
+    \item The key is added to the set of registered stake credentials.
       \item A reward account is created for this key, with a starting balance of zero.
-      \item The certificate pointer is mapped to the new stake key.
+      \item The certificate pointer is mapped to the new stake credential.
     \end{itemize}
 
-  \item Stake key deregistration is handled by \cref{eq:deleg-dereg}.
-    There is a precondition that the key has been registered and that the reward balance is zero.
-    Deregistration causes the following state transformation:
+  \item Stake credential deregistration is handled by \cref{eq:deleg-dereg}.
+    There is a precondition that the credential has been registered and that
+    the reward balance is zero.  Deregistration causes the following state
+    transformation:
     \begin{itemize}
       \item The key is removed from the collection of registered keys.
       \item The reward account is removed.
@@ -332,13 +334,14 @@ a stake pool, though these concerns are independent of the ledger rules.
       \item The certificate pointer is removed.
     \end{itemize}
 
-  \item Stake key delegation is handled by \cref{eq:deleg-deleg}.
+  \item Stake credential delegation is handled by \cref{eq:deleg-deleg}.
     There is a precondition that the key has been registered.
     Delegation causes the following state transformation:
     \begin{itemize}
-      \item The delegation relation is updated so that stake key is delegated to the given
-        stake pool. The use of union override here allows us to use the same rule
-        to perform both an initial delegation and an update to an existing delegation.
+    \item The delegation relation is updated so that the stake credential is
+      delegated to the given stake pool. The use of union override here allows
+      us to use the same rule to perform both an initial delegation and an
+      update to an existing delegation.
     \end{itemize}
 
   \item Genesis key delegation is handled by \cref{eq:deleg-gen}.
@@ -513,8 +516,8 @@ a stake pool, though these concerns are independent of the ledger rules.
 
 The DELEG rule has five predicate failures:
 \begin{itemize}
-\item In the case of a key registration certificate, if the staking key is
-  already registered, there is a a \emph{StakeKeyAlreadyRegistered} failure.
+\item In the case of a key registration certificate, if the staking credential
+  is already registered, there is a a \emph{StakeKeyAlreadyRegistered} failure.
 \item In the case of a key deregistration certificate, if the key is not
   registered, there is a \emph{StakeKeyNotRegistered} failure.
 \item In the case of a non-existing stake pool key in a delegation certificate,
@@ -877,13 +880,14 @@ carrying a certificate that schedules a pool retirement in a past epoch, the who
 will be invalid.
 
 \begin{itemize}
-  \item The base case, when the list is empty, is captured by \cref{eq:delegs-base}.
-    In the base case we address one final accounting detail not yet covered by the UTxO
-    transition, namely setting the reward account balance to zero for any account that made a
-    withdrawal.  There is therefore a precondition that all withdrawals are correct, where
-    correct means that there is a reward account for each stake key and that the balance
-    matches that of the reward being withdrawn.
-    The base case triggers the following state transformation:
+\item The base case, when the list is empty, is captured by
+  \cref{eq:delegs-base}.  In the base case we address one final accounting
+  detail not yet covered by the UTxO transition, namely setting the reward
+  account balance to zero for any account that made a withdrawal.  There is
+  therefore a precondition that all withdrawals are correct, where correct means
+  that there is a reward account for each stake credential and that the balance
+  matches that of the reward being withdrawn.  The base case triggers the
+  following state transformation:
     \begin{itemize}
       \item Reward accounts are set to zero for each corresponding withdrawal.
       \item The genesis key delegation mapping is updated according to the future delegation

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -513,8 +513,16 @@ a stake pool, though these concerns are independent of the ledger rules.
 
 The DELEG rule has five predicate failures:
 \begin{itemize}
+<<<<<<< HEAD
 \item In the case of a key registration certificate, if the staking key is already
   registered, there is a \emph{StakeKeyAlreadyRegistered} failure.
+||||||| merged common ancestors
+\item In the case of a key registration certificate, if the staking key is already
+  registered, there is a a \em{StakeKeyAlreadyRegistered} failure.
+=======
+\item In the case of a key registration certificate, if the staking key is
+  already registered, there is a a \emph{StakeKeyAlreadyRegistered} failure.
+>>>>>>> 96833182503fa1cd65e6eb643d3142bc2a505308
 \item In the case of a key deregistration certificate, if the key is not
   registered, there is a \emph{StakeKeyNotRegistered} failure.
 \item In the case of a non-existing stake pool key in a delegation certificate,
@@ -702,12 +710,12 @@ The POOL rule has three predicate failures:
 \begin{itemize}
 \item In the case of a pool retirement certificate, if the pool key is not in
   the domain of the stake pools mapping, there is a
-  {\emph StakePoolNotRegisteredOnKey} failure.
+  \emph{StakePoolNotRegisteredOnKey} failure.
 \item In the case of a pool retirement certificate, if the retirement epoch is
   not between the current epoch and the relative maximal epoch from the current
-  epoch, there is a {\emph StakePoolRetirementWrongEpoch} failure.
+  epoch, there is a \emph{StakePoolRetirementWrongEpoch} failure.
 \item If the delegation certificate is not of one of the pool types, there is a
-  {\emph WrongCertificateType} failure.
+  \emph{WrongCertificateType} failure.
 \end{itemize}
 
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -1074,8 +1074,9 @@ Finally, the full reward calculation is presented in Figure~\ref{fig:functions:r
 The calculation is done pool-by-pool.
 \begin{itemize}
 \item The $\fun{rewardOnePool}$ function calculates the rewards given out to
-  each member of a given pool. The pool leader is identified by the stake key of
-  the pool operator. The function returns the rewards, calculated as follows:
+  each member of a given pool. The pool leader is identified by the stake
+  credential of the pool operator. The function returns the rewards, calculated
+  as follows:
     \begin{itemize}
       \item $\var{pstake}$, the total amount of stake controlled by the stake pool.
       \item $\var{ostake}$, the total amount of stake controlled by the stake pool operator

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -136,13 +136,13 @@ throughout the rest of the section.
 \begin{figure}[htb]
   \emph{Total possible refunds}
   \begin{align*}
-      & \fun{obligation} \in \PParams \to \StakeKeys \to \StakePools \to \Slot \to \Coin \\
-      & \obligation{pp}{stkeys}{stpools}{cslot} =\\
-      & \sum\limits_{(\_ \mapsto s) \in \var{stkeys}}
-        \refund{d_{\mathsf{val}}}{d_{\min}}{\lambda_d}{(\slotminus{cslot}{s})}
-        + \sum\limits_{(\_ \mapsto s) \in \var{stpools}}
-        \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda_p}{(\slotminus{cslot}{s})} \\
-      &
+    & \fun{obligation} \in \PParams \to \StakeDelegs \to \StakePools \to \Slot \to \Coin \\
+    & \obligation{pp}{stdelegs}{stpools}{cslot} =\\
+    & \sum\limits_{(\_ \mapsto s) \in \var{stdelegs}}
+      \refund{d_{\mathsf{val}}}{d_{\min}}{\lambda_d}{(\slotminus{cslot}{s})}
+      + \sum\limits_{(\_ \mapsto s) \in \var{stpools}}
+      \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda_p}{(\slotminus{cslot}{s})} \\
+    &
       \begin{array}{lr@{~=~}l}
         \where
           & \dval,~d_{\min},~\lambda_d
@@ -282,7 +282,7 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
       & \fun{stakeDistr}~{utxo}~{dstate}~{pstate} =
       (\dom{\var{activeDelegs}})\restrictdom\left(\fun{aggregate_{+}}~\var{stakeRelation}\right)\\
       & \where \\
-      & ~~~~ (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},~\wcard,~\wcard)
+      & ~~~~ (\var{stdelegs},~\var{rewards},~\var{delegations},~\var{ptrs},~\wcard,~\wcard)
         = \var{dstate} \\
       & ~~~~ (\var{stpools},~\wcard,~\wcard,~\wcard,~\wcard) = \var{pstate} \\
       & ~~~~ \var{stakeRelation} = \left(
@@ -291,7 +291,7 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
         \right)
         \cup \left(\fun{stakeCred_r}^{-1}\circ\var{rewards}\right) \\
       & ~~~~ \var{activeDelegs} =
-               (\dom{stkeys}) \restrictdom \var{delegations} \restrictrange (\dom{stpools}) \\
+               (\dom{stdelegs}) \restrictdom \var{delegations} \restrictrange (\dom{stpools}) \\
   \end{align*}
 
   \caption{Stake Distribution Function}
@@ -396,11 +396,11 @@ This transition has no preconditions and results in the following state change:
       {
       \begin{array}{r@{~\leteq~}l}
         (\var{utxo},~\var{deposits},~\var{fees},~\wcard) & \var{utxoSt}\\
-        (\var{stkeys},~\wcard,~\var{delegations},~\wcard,~\wcard,~\wcard) & \var{dstate}\\
+        (\var{stdelegs},~\wcard,~\var{delegations},~\wcard,~\wcard,~\wcard) & \var{dstate}\\
         (\var{stpools},~\var{poolParams},~\wcard,~\wcard) & \var{pstate}\\
         \var{stake} & \stakeDistr{utxo}{dstate}{pstate} \\
         \var{slot} & \firstSlot{e} \\
-        \var{oblg} & \obligation{pp}{stkeys}{stpools}{slot} \\
+        \var{oblg} & \obligation{pp}{stdelegs}{stpools}{slot} \\
         \var{decayed} & \var{deposits} - \var{oblg} \\
       \end{array}
       }
@@ -533,7 +533,7 @@ This transition has no preconditions and results in the following state change:
           \var{treasury} \\
           \var{reserves} \\
           ~ \\
-          \var{stkeys} \\
+          \var{stdelegs} \\
           \var{rewards} \\
           \var{delegations} \\
           \var{ptrs} \\
@@ -551,7 +551,7 @@ This transition has no preconditions and results in the following state change:
           \varUpdate{\var{treasury}} & \varUpdate{+} & \varUpdate{\var{unclaimed}} \\
           \var{reserves} \\
           ~ \\
-          \var{stkeys} \\
+          \var{stdelegs} \\
           \varUpdate{\var{rewards}} & \varUpdate{\unionoverridePlus} & \varUpdate{\var{refunds}} \\
           \varUpdate{\var{delegations}} & \varUpdate{\subtractrange} & \varUpdate{\var{retired}} \\
           \var{ptrs} \\
@@ -663,8 +663,8 @@ for ease of reading.
       \var{pp_{new}}\neq\Nothing \\~\\
       {\begin{array}{rcl}
           \var{slot} & \leteq & \firstSlot{e} \\
-          \var{oblg_{cur}} & \leteq & \obligation{pp}{stkeys}{stpools}{slot} \\
-          \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stkeys}{stpools}{slot} \\
+          \var{oblg_{cur}} & \leteq & \obligation{pp}{stdelegs}{stpools}{slot} \\
+          \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stdelegs}{stpools}{slot} \\
           \var{diff} & \leteq & \var{oblg_{cur}} - \var{oblg_{new}} \\
       \end{array}}
       \\~\\~\\
@@ -741,8 +741,8 @@ for ease of reading.
       \\~\\~\\
       {\begin{array}{rcl}
           \var{slot} & \leteq & \firstSlot{e} \\
-          \var{oblg_{cur}} & \leteq & \obligation{pp}{stkeys}{stpools}{slot} \\
-          \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stkeys}{stpools}{slot} \\
+          \var{oblg_{cur}} & \leteq & \obligation{pp}{stdelegs}{stpools}{slot} \\
+          \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stdelegs}{stpools}{slot} \\
           \var{diff} & \leteq & \var{oblg_{cur}} - \var{oblg_{new}} \\
       \end{array}}
       \\~\\~\\
@@ -1357,7 +1357,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
           \var{treasury} \\
           \var{reserves} \\
           ~ \\
-          \var{stkeys} \\
+          \var{stdelegs} \\
           \var{rewards} \\
           \var{delegations} \\
           \var{ptrs} \\
@@ -1380,7 +1380,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
           \varUpdate{\var{treasury} + \Delta t}\\
           \varUpdate{\var{reserves} + \Delta r}\\
           ~ \\
-          \var{stkeys} \\
+          \var{stdelegs} \\
           \varUpdate{\var{rewards}\unionoverridePlus\var{rs}} \\
           \var{delegations} \\
           \var{ptrs} \\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -254,11 +254,11 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
     Keys that are not both registered and delegated are filtered out.
     The relation passed to $\fun{aggregate_{+}}$ is made up of:
     \begin{itemize}
-      \item $\fun{stakeHK_b}^{-1}$, relating hashkeys to (base) addresses
-      \item $\left(\fun{addrPtr}\circ\var{ptr}\right)^{-1}$, relating hashkeys to (pointer)
+      \item $\fun{stakeCred_b}^{-1}$, relating credentials to (base) addresses
+      \item $\left(\fun{addrPtr}\circ\var{ptr}\right)^{-1}$, relating credentials to (pointer)
         addresses
       \item $\range{utxo}$, relating addresses to coins
-      \item $\fun{stakeHK_r}^{-1}\circ\var{rewards}$, relating (reward) addresses to coins
+      \item $\fun{stakeCred_r}^{-1}\circ\var{rewards}$, relating (reward) addresses to coins
     \end{itemize}
     The notation for relations is explained in Section~\ref{sec:notation-shelley}.
 \end{itemize}
@@ -286,10 +286,10 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
         = \var{dstate} \\
       & ~~~~ (\var{stpools},~\wcard,~\wcard,~\wcard,~\wcard) = \var{pstate} \\
       & ~~~~ \var{stakeRelation} = \left(
-        \left(\fun{stakeHK_b}^{-1}\cup\left(\fun{addrPtr}\circ\var{ptr}\right)^{-1}\right)
+        \left(\fun{stakeCred_b}^{-1}\cup\left(\fun{addrPtr}\circ\var{ptr}\right)^{-1}\right)
         \circ\left(\range{\var{utxo}}\right)
         \right)
-        \cup \left(\fun{stakeHK_r}^{-1}\circ\var{rewards}\right) \\
+        \cup \left(\fun{stakeCred_r}^{-1}\circ\var{rewards}\right) \\
       & ~~~~ \var{activeDelegs} =
                (\dom{stkeys}) \restrictdom \var{delegations} \restrictrange (\dom{stpools}) \\
   \end{align*}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -102,6 +102,11 @@
 \newcommand{\UPIState}{\type{UPIState}}
 \newcommand{\UpdatePayload}{\type{UpdatePayload}}
 
+% multi-signature
+\newcommand{\Script}{\type{Script}}
+\newcommand{\HashScr}{\type{ScriptHash}}
+\newcommand{\Credential}{\type{Credential}}
+
 %% Adding witnesses
 \newcommand{\TxIn}{\type{TxIn}}
 \newcommand{\TxOut}{\type{TxOut}}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -56,7 +56,7 @@
 \newcommand{\SlotsPerKESPeriod}{\mathsf{SlotsPerKESPeriod}}
 \newcommand{\Duration}{\type{Duration}}
 \newcommand{\StakePools}{\type{StakePools}}
-\newcommand{\StakeKeys}{\type{StakeKeys}}
+\newcommand{\StakeDeleg}{\type{StakeDeleg}}
 \newcommand{\Seed}{\type{Seed}}
 \newcommand{\seedOp}{\star}
 \newcommand{\Ppm}{\type{Ppm}}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -103,8 +103,20 @@
 \newcommand{\UpdatePayload}{\type{UpdatePayload}}
 
 % multi-signature
-\newcommand{\Script}{\type{Script}}
+\newcommand{\StakeCredential}{\type{StakeCredential}}
+\newcommand{\AddrVKey}{\type{Addr^{vkey}}}
+\newcommand{\AddrRWDVKey}{\type{Addr_{rwd}^{vkey}}}
+\newcommand{\AddrRWDScr}{\type{Addr_{rwd}^{script}}}
+\newcommand{\AddrVKeyB}{\type{Addr^{vkey}_{base}}}
+\newcommand{\AddrVKeyP}{\type{Addr^{vkey}_{ptr}}}
+\newcommand{\AddrVKeyE}{\type{Addr^{vkey}_{enterprise}}}
+\newcommand{\AddrVKeyBS}{\type{Addr^{vkey}_{bootstrap}}}
+\newcommand{\AddrScr}{\type{Addr^{script}}}
+\newcommand{\AddrScrBase}{\type{Addr_{base}^{script}}}
+\newcommand{\AddrScrEnterprise}{\type{Addr_{enterprise}^{script}}}
+\newcommand{\AddrScrPtr}{\type{Addr_{ptr}^{script}}}
 \newcommand{\HashScr}{\type{ScriptHash}}
+\newcommand{\Script}{\type{Script}}
 \newcommand{\Credential}{\type{Credential}}
 
 %% Adding witnesses

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -107,6 +107,9 @@
 \newcommand{\StakeCredential}{\type{StakeCredential}}
 \newcommand{\StakeDelegs}{\type{StakeDelegs}}
 
+\newcommand{\txwitsVKey}[1]{\fun{txwitsVKey}~\var{#1}}
+\newcommand{\txwitsScript}[1]{\fun{txwitsScript}~\var{#1}}
+
 \newcommand{\AddrVKey}{\type{Addr^{vkey}}}
 \newcommand{\AddrRWDVKey}{\type{Addr_{rwd}^{vkey}}}
 \newcommand{\AddrRWDScr}{\type{Addr_{rwd}^{script}}}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -42,6 +42,7 @@
 \newcommand{\Rnn}{\ensuremath{\mathbb{R}^{\geq 0}}}
 \newcommand{\Tx}{\type{Tx}}
 \newcommand{\TxBody}{\type{TxBody}}
+\newcommand{\TxWitness}{\type{TxWitness}}
 \newcommand{\Ix}{\type{Ix}}
 \newcommand{\TxId}{\type{TxId}}
 \newcommand{\Addr}{\type{Addr}}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -105,6 +105,8 @@
 
 % multi-signature
 \newcommand{\StakeCredential}{\type{StakeCredential}}
+\newcommand{\StakeDelegs}{\type{StakeDelegs}}
+
 \newcommand{\AddrVKey}{\type{Addr^{vkey}}}
 \newcommand{\AddrRWDVKey}{\type{Addr_{rwd}^{vkey}}}
 \newcommand{\AddrRWDScr}{\type{Addr_{rwd}^{script}}}

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -75,14 +75,14 @@ then calls the $\mathsf{DELEGS}$ transition.
                      \fun{txcerts}~\var{tx}} dpstate'
       \\~\\
       (\var{dstate}, \var{pstate}) \leteq \var{dpstate} \\
-      (\var{stkeys}, \_, \_, \_, \_, \var{dms}) \leteq \var{dstate} \\
+      (\var{stdelegs}, \_, \_, \_, \_, \var{dms}) \leteq \var{dstate} \\
       (\var{stpools}, \_, \_, \_) \leteq \var{pstate} \\
       \\~\\
       \left({
         \begin{array}{r}
         \var{slot} \\
         \var{pp} \\
-        \var{stkeys} \\
+        \var{stdelegs} \\
         \var{stpools} \\
         \var{dms} \\
         \end{array}

--- a/shelley/chain-and-ledger/formal-spec/multi-sig.tex
+++ b/shelley/chain-and-ledger/formal-spec/multi-sig.tex
@@ -591,7 +591,7 @@ spent inputs locked by scripts and consumed withdrawals locked by scripts.
       \powerset{\KeyHash}
     & \text{required keyhashes} \\
     &  \hspace{-1cm}\fun{witsVKeyNeeded}~\var{utxo}~\var{tx}~\var{dms} = \\
-    & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\txins{tx} \} \\
+    & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\fun{txinsVKey}~{tx} \} \\
     \cup & ~~
            \left(\{\fun{stakeCred_r}~a\mid a\mapsto \wcard \in \AddrRWDVKey
       \restrictdom \txwdrls{tx}\} \cap \KeyHash_{Stake}  \right)\\

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -62,9 +62,9 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
         \var{maxBlockSize} \mapsto \N & \PParams & \text{max block body size}\\
         \var{maxTxSize} \mapsto \N & \PParams & \text{max transaction size}\\
         \var{maxHeaderSize} \mapsto \N & \PParams & \text{max block header size}\\
-        \var{keyDeposit} \mapsto \Coin & \PParams & \text{stake key deposit}\\
-        \var{keyMinRefund} \mapsto \unitInterval & \PParams & \text{stake key min refund}\\
-        \var{keyDecayRate} \mapsto \nonnegReals & \PParams & \text{stake key decay rate}\\
+        \var{keyDeposit} \mapsto \Coin & \PParams & \text{stake credential deposit}\\
+        \var{keyMinRefund} \mapsto \unitInterval & \PParams & \text{stake credential min refund}\\
+        \var{keyDecayRate} \mapsto \nonnegReals & \PParams & \text{stake credential decay rate}\\
         \var{poolDeposit} \mapsto \Coin & \PParams & \text{stake pool deposit}\\
         \var{poolMinRefund} \mapsto \unitInterval & \PParams & \text{stake pool min refund}\\
         \var{poolDecayRate} \mapsto \nonnegReals & \PParams & \text{stake pool decay rate}\\

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -148,4 +148,27 @@ This function must produce a unique id for each unique transaction.
   \label{fig:defs:utxo-shelley}
 \end{figure*}
 
+\begin{figure*}[htb]
+  \emph{Helper Functions}
+  %
+  \begin{align*}
+    \fun{txinsVKey} & \in \powerset \TxIn \to \UTxO \to \powerset\TxIn & \text{VKey Tx inputs}\\
+    \fun{txinsVKey} & ~\var{txins}~\var{utxo} =
+    \var{txins} \cap \dom (\var{utxo} \restrictrange (\AddrVKey \times Coin))
+    \\
+    \\
+    \fun{txinsScript} & \in \powerset \TxIn \to \UTxO \to \powerset\TxIn & \text{Script Tx inputs}\\
+    \fun{txinsScript} & ~\var{txins}~\var{utxo} =
+                        \var{txins} \cap \dom (\var{utxo} \restrictrange (\AddrScr \times Coin))
+  \end{align*}
+  %
+  \caption{Helper Functions for Transaction Inputs}
+  \label{fig:defs:functions-txins}
+\end{figure*}
+
+Figure~\ref{fig:defs:functions-txins} shows the helper functions
+$\fun{txinsVKey}$ and $\fun{txinsScript}$ which partition the set of transaction
+inputs of the transaction into those that are locked with a private key and
+those that are locked via a script.
+
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -113,10 +113,11 @@ This function must produce a unique id for each unique transaction.
       & \powerset{\TxIn} \times (\Ix \mapsto \TxOut) \times \seqof{\DCert}
         \times \Coin \times \Slot \times \Wdrl \times \Update
       \\
+      \var{wit} & \TxWitness & (\VKey \mapsto \Sig, \HashScr \mapsto \Script)
+      \\
       \var{tx}
       & \Tx
-      & \TxBody \times (\VKey \mapsto \Sig)
-      \\
+      & \TxBody \times \TxWitness
     \end{array}
   \end{equation*}
   %
@@ -130,8 +131,9 @@ This function must produce a unique id for each unique transaction.
       \fun{txttl} & \Tx \to \Slot & \text{time to live} \\
       \fun{txwdrls} & \Tx \to \Wdrl & \text{withdrawals} \\
       \fun{txbody} & \Tx \to \TxBody & \text{transaction body}\\
-      \fun{txwits} & \Tx \to (\VKey \mapsto \Sig) & \text{witnesses} \\
-      \fun{txup} & \Tx \to \Update & \text{protocol parameter update} \\
+      \fun{txwitsVKey} & \Tx \to (\VKey \mapsto \Sig) & \text{VKey witnesses} \\
+      \fun{txwitsScript} & \Tx \to (\HashScr \mapsto \Script) & \text{script witnesses}\\
+      \fun{txup} & \Tx \to \Update & \text{protocol parameter update}
     \end{array}
   \end{equation*}
   %
@@ -139,6 +141,7 @@ This function must produce a unique id for each unique transaction.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \txid{} & \Tx \to \TxId & \text{compute transaction id}\\
+      \fun{validateScript} & \Script \to \Tx \to \Bool & \text{script interpreter}
     \end{array}
   \end{equation*}
   \caption{Definitions used in the UTxO transition system}

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -162,6 +162,15 @@ This function must produce a unique id for each unique transaction.
                         \var{txins} \cap \dom (\var{utxo} \restrictrange (\AddrScr \times Coin))
   \end{align*}
   %
+  \begin{align*}
+    \fun{validateScript} & \in\Script\to\Tx\to\Bool & \text{validate native
+                                                          script} \\
+    \fun{validateScript} & ~\var{msig}~\var{tx}= \\
+                         & \textrm{let}~\var{vhks}\leteq \{\fun{hashKey}~vk \vert
+                           vk \in \fun{txwitsVKey}~\var{tx}\} \\
+                         & \fun{evalMultiSigScript}~msig~vhks
+  \end{align*}
+  %
   \caption{Helper Functions for Transaction Inputs}
   \label{fig:defs:functions-txins}
 \end{figure*}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -52,14 +52,15 @@ Figure~\ref{fig:functions:utxo} defines functions needed for the UTxO transition
     The $\fun{wbalance}$ function calculates the total sum of all the reward withdrawals in a
     transaction.
 
-  \item The calculation $\fun{consumed}$ gives the value consumed by the transaction $\var{tx}$
-    in the context of the protocol parameters, the current UTxO on the ledger and the registered
-    stake keys.  This calculation is a sum of all coin in the inputs of $\var{tx}$,
-    reward withdrawals and stake key deposit refunds.
-    Some of the definitions used in this function will be defined in
-    Section~\ref{sec:deps-refunds}.
-    In particular, $\fun{keyRefunds}$ is defined in Figure~\ref{fig:functions:deposits-refunds}
-    and $\StakeDelegs$ is defined in Figure~\ref{fig:delegation-defs}.
+  \item The calculation $\fun{consumed}$ gives the value consumed by the
+    transaction $\var{tx}$ in the context of the protocol parameters, the
+    current UTxO on the ledger and the registered stake credentials. This
+    calculation is a sum of all coin in the inputs of $\var{tx}$, reward
+    withdrawals and stake credential deposit refunds. Some of the definitions
+    used in this function will be defined in Section~\ref{sec:deps-refunds}. In
+    particular, $\fun{keyRefunds}$ is defined in
+    Figure~\ref{fig:functions:deposits-refunds} and $\StakeDelegs$ is defined in
+    Figure~\ref{fig:delegation-defs}.
 
   \item The calculation $\fun{produced}$ gives the value produced by the transaction $\var{tx}$
     in the context of the protocol parameters and the registered stake pools.
@@ -127,9 +128,8 @@ The environment, $\UTxOEnv$, consists of:
 \begin{itemize}
   \item The current slot.
   \item The protocol parameters.
-  \item The registered stake keys
-    (which will be explained in Section~\ref{sec:delegation-shelley},
-    Figure~\ref{fig:delegation-defs}).
+  \item The registered stake credentials (which will be explained in
+    Section~\ref{sec:delegation-shelley}, Figure~\ref{fig:delegation-defs}).
   \item The registered stake pools
     (also explained in Section~\ref{sec:delegation-shelley},
     Figure~\ref{fig:delegation-defs}).
@@ -374,26 +374,27 @@ The UTXO rule has five predicate failures:
 \subsection{Deposits and Refunds}
 \label{sec:deps-refunds}
 
-Deposits are described in appendix B.2 of the delegation design document \cite{delegation_design}.
-These deposit functions were used above in the UTxO transition,~\ref{sec:utxo-trans}.
-Deposits are used for stake key registration and pool
-registration certificates, which will be explained in Section~\ref{sec:delegation-shelley}.
-In particular, the function $\cwitness{}$, which gets the certificate witness
-from a certificate, will be defined later.
-Figure~\ref{fig:functions:deposits-refunds} defines the deposit and refund functions.
+Deposits are described in appendix B.2 of the delegation design document
+\cite{delegation_design}.  These deposit functions were used above in the UTxO
+transition,~\ref{sec:utxo-trans}. Deposits are used for stake credential
+registration and pool registration certificates, which will be explained in
+Section~\ref{sec:delegation-shelley}.  In particular, the function
+$\cwitness{}$, which gets the certificate witness from a certificate, will be
+defined later.  Figure~\ref{fig:functions:deposits-refunds} defines the deposit
+and refund functions.
 \begin{itemize}
-  \item The function $\fun{deposits}$ returns the total deposits that have to be made
-    by a transaction.  This calculation is based on the protocol parameters.
-    Specifically, for a given transaction, it sums up the values of the stake key deposits
-    and the stake pool deposits.  Those certificates which are
-    updates of stake pool parameters of already registered pool keys should not
-    (and are, in fact, not allowed to) make a deposit.
+\item The function $\fun{deposits}$ returns the total deposits that have to be
+  made by a transaction.  This calculation is based on the protocol parameters.
+  Specifically, for a given transaction, it sums up the values of the stake
+  credential deposits and the stake pool deposits. Those certificates which are
+  updates of stake pool parameters of already registered pool keys should not
+  (and are, in fact, not allowed to) make a deposit.
   \item The function $\fun{refund}$ calculates the deposit refund with an exponential decay.
   \item The function $\fun{keyRefund}$, calculates the refund for an individual
-    stake key registration deposit, based on the slot when it was created and
-    the slot passed to the function. The creation slot should always exist in the map
-    $\var{stdelegs}$ passed to the function and this would be a good property
-    to prove about the transition system.
+    stake credential registration deposit, based on the slot when it was created
+    and the slot passed to the function. The creation slot should always exist
+    in the map $\var{stdelegs}$ passed to the function and this would be a good
+    property to prove about the transition system.
   \item The function $\fun{keyRefunds}$, in turn, uses $\fun{keyRefund}$ to calculate
     the total value to be refunded to all individual key deregistration certificate authors
     in a transaction.
@@ -433,13 +434,14 @@ Figure~\ref{fig:functions:deposits-refunds} defines the deposit and refund funct
 Figure~\ref{fig:functions:deposits-decay} defines the decays functions.
 \begin{itemize}
 
-  \item The function $\fun{decayedKey}$ calculates how much of a stake key deposit
-    has decayed since the last epoch. Again, this is done using the time to live of
-    the transaction (and not the current slot, as explained above).
-    At the epoch boundaries, decayed portions of deposits are moved to the reward pot,
-    so between epochs we need only account for what has decayed since the last epoch.
-    The value is calculated by subtracting the refund calculation based at the epoch boundary
-    from the refund calculation based at the time to live of the transaction.
+\item The function $\fun{decayedKey}$ calculates how much of a stake credential
+  deposit has decayed since the last epoch. Again, this is done using the time
+  to live of the transaction (and not the current slot, as explained above).  At
+  the epoch boundaries, decayed portions of deposits are moved to the reward
+  pot, so between epochs we need only account for what has decayed since the
+  last epoch.  The value is calculated by subtracting the refund calculation
+  based at the epoch boundary from the refund calculation based at the time to
+  live of the transaction.
   \item The function $\fun{decayedTx}$ calculates the total decayed deposits associated
     with all the refunds in a given transaction.  This function was used earlier in the
     UTxO transition in Figure~\ref{fig:rules:utxo-shelley}.
@@ -545,23 +547,24 @@ Replay prevention is an inherent property of UTxO type accounting
 since transaction IDs are unique and we require all transaction to
 consume at least one input.
 
-A transaction is witnessed by a signature and a verification key corresponding to this signature.
-The witnesses, together with the transaction body, form a full transaction.
-Every witness in a transaction signs the transaction body.
-Moreover, the witnesses are represented as finite maps from verification keys to signatures,
-so that any key that is required to sign a transaction only provides a single witness.
-This means that, for example, a transaction which includes a delegation certificate and
-a reward withdrawal corresponding to the same stake key still only includes one signature.
+A transaction is witnessed by a signature and a verification key corresponding
+to this signature.  The witnesses, together with the transaction body, form a
+full transaction.  Every witness in a transaction signs the transaction body.
+Moreover, the witnesses are represented as finite maps from verification keys to
+signatures, so that any key that is required to sign a transaction only provides
+a single witness.  This means that, for example, a transaction which includes a
+delegation certificate and a reward withdrawal corresponding to the same stake
+credential still only includes one signature.
 
 Figure~\ref{fig:functions-witnesses} defines the function which
 gathers all the (hashes of) verification keys needed to witness a given transaction.
 This consists of:
 \begin{itemize}
   \item payment keys for outputs being spent
-  \item stake keys for reward withdrawals
-  \item stake keys for delegation certificates (all five types)
+  \item stake credentials for reward withdrawals
+  \item stake credentials for delegation certificates (all five types)
   \item delegates of the genesis keys for any protocol parameter updates
-  \item stake keys for the pool owners in a pool registration certificate
+  \item stake credentials for the pool owners in a pool registration certificate
 \end{itemize}
 
 \begin{figure}[htb]

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -581,7 +581,7 @@ This consists of:
       \powerset{\KeyHash}
     & \text{required key hashes} \\
     &  \hspace{-0.8cm}\fun{witsVKeyNeeded}~\var{utxo}~\var{tx}~\var{dms} = \\
-    & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\txins{tx} \} \\
+    & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\fun{txinsVKey}~{tx} \} \\
     \cup & ~~
            \left(\{\fun{stakeCred_r}~a\mid a\mapsto \wcard \in \AddrRWDVKey
       \restrictdom \txwdrls{tx}\} \cap \KeyHash_{Stake}  \right)\\

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -576,15 +576,29 @@ This consists of:
       \right\}
   \end{align*}
 
+    \begin{align*}
+    & \hspace{-0.8cm}\fun{witsVKeyNeeded} \in \UTxO \to \Tx \to (\VKeyGen\mapsto\VKey) \to
+      \powerset{\KeyHash}
+    & \text{required key hashes} \\
+    &  \hspace{-0.8cm}\fun{witsVKeyNeeded}~\var{utxo}~\var{tx}~\var{dms} = \\
+    & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\txins{tx} \} \\
+    \cup & ~~
+           \left(\{\fun{stakeCred_r}~a\mid a\mapsto \wcard \in \AddrRWDVKey
+      \restrictdom \txwdrls{tx}\} \cap \KeyHash_{Stake}  \right)\\
+    \cup & ~~\{\cwitness{c} \mid c \in \txcerts{tx}\}~\cup \\
+    \cup & ~~\fun{propWits}~(\fun{txup}~\var{tx}) \\
+    \cup & ~~\bigcup_{\substack{c \in \txcerts{tx} \\ ~c \in\DCertRegPool}} \fun{poolOwners}~{c}
+  \end{align*}
   \begin{align*}
-    & \fun{witsNeeded} \in \UTxO \to \Tx \to (\VKeyGen\mapsto\VKey) \to \powerset{\KeyHash}
-    & \text{hashkeys for needed witnesses} \\
-    & \fun{witsNeeded}~\var{utxo}~\var{tx}~\var{dms} = \\
-    & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\txins{tx} \}~\cup \\
-    & ~~\{\fun{stakeHK_r}~a \mid a\mapsto \wcard \in \txwdrls{tx}\}~\cup \\
-    & ~~\{\cwitness{c} \mid c \in \txcerts{tx}\}~\cup \\
-    & ~~\fun{propWits}~(\fun{txup}~\var{tx})~\cup \\
-    & ~~\bigcup_{\substack{c \in \txcerts{tx} \\ ~c \in\DCertRegPool}} \fun{poolOwners}~{c} \\
+    & \hspace{-0.5cm}\fun{scriptsNeeded} \in \UTxO \to \Tx \to
+      \powerset{\HashScr}
+    & \text{required script hashes} \\
+    &  \hspace{-0.5cm}\fun{scriptsNeeded}~\var{utxo}~\var{tx} = \\
+    & ~~\{ \fun{validatorHash}~a \mid i \mapsto (a, \wcard) \in \var{utxo},\\
+    & ~~~~~i\in\fun{txinsScript}~{(\fun{txins~\var{tx}})}~{utxo}\} \\
+    \cup & ~~\left(\{ \fun{stakeCred_{r}}~\var{a} \mid a \in \dom (\AddrRWDScr
+           \restrictdom \fun{txwdrls}~\var{tx}) \} \cap \HashScr\right) \\
+    \cup & ~~\{\AddrScr \cap \fun{cwitness}~\var{c} \mid c \in \fun{txcerts}~\var{tx}\}
   \end{align*}
   \caption{Functions used in witness rule}
   \label{fig:functions-witnesses}
@@ -619,10 +633,15 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
     \inference[UTxO-wit]
     {
       (utxo, \wcard, \wcard) \leteq \var{utxoSt} \\~\\
-      \forall \var{vk} \mapsto \sigma \in \txwits{tx},
-        \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma} \\
-      \fun{witsNeeded}~\var{utxo}~\var{tx}~\var{dms} =
-        \{ \hashKey \var{vk} \mid \var{vk}\in\dom{(\txwits{tx})} \}\\
+            \forall \var{hs} \mapsto \var{validator} \in \fun{txwitsScript}~{tx},\\
+      \fun{hashScript}~\var{validator} = \var{hs} \wedge
+      \fun{validateScript}~\var{validator}~\var{tx}\\~\\
+      \fun{scriptsNeeded}~\var{utxo}~\var{tx} = \dom (\fun{txwitsScript}~{tx})
+      \\~\\
+      \forall \var{vk} \mapsto \sigma \in \txwitsVKey{tx},
+      \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma} \\
+      \fun{witsVKeyNeeded}~{utxo}~{tx} \subseteq \{ \hashKey \var{vk} \mid
+      \var{vk}\in\dom{(\txwitsVKey{tx})} \}\\~\\
       {
         \begin{array}{l}
         \var{utxoEnv}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -357,7 +357,8 @@ requests).
 
 The UTXO rule has five predicate failures:
 \begin{itemize}
-\item In the case of any input not being valid, there is a \emph{BadInput} failure.
+\item In the case of any input not being valid, there is a \emph{BadInput}
+  failure.
 \item In the case of the current slot being greater than the time-to-live of the
   current transaction, there is an \emph{Expired} failure.
 \item In the case of an empty input set, there is a \emph{InputSetEmpty} failure,

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -59,7 +59,7 @@ Figure~\ref{fig:functions:utxo} defines functions needed for the UTxO transition
     Some of the definitions used in this function will be defined in
     Section~\ref{sec:deps-refunds}.
     In particular, $\fun{keyRefunds}$ is defined in Figure~\ref{fig:functions:deposits-refunds}
-    and $\StakeKeys$ is defined in Figure~\ref{fig:delegation-defs}.
+    and $\StakeDelegs$ is defined in Figure~\ref{fig:delegation-defs}.
 
   \item The calculation $\fun{produced}$ gives the value produced by the transaction $\var{tx}$
     in the context of the protocol parameters and the registered stake pools.
@@ -100,12 +100,12 @@ Registration will be discussed more in Section~\ref{sec:delegation-shelley}.
     & \text{withdrawal balance} \\
     & \fun{wbalance} ~ ws = \sum_{\wcard\mapsto c\in\var{ws}} c
     \nextdef
-    & \fun{consumed} \in \PParams \to \UTxO \to \StakeKeys \to \Wdrl \to \Tx \to \Coin
+    & \fun{consumed} \in \PParams \to \UTxO \to \StakeDelegs \to \Wdrl \to \Tx \to \Coin
     & \text{value consumed} \\
-    & \consumed{pp}{utxo}{stkeys}{rewards}~{tx} = \\
+    & \consumed{pp}{utxo}{stdelegs}{rewards}~{tx} = \\
     & ~~\ubalance{(\txins{tx} \restrictdom \var{utxo})} +
         \fun{wbalance}~(\fun{txwdrls}~{tx}) \\
-    & ~~~~ + \keyRefunds{pp}{stkeys}{tx} \\
+    & ~~~~ + \keyRefunds{pp}{stdelegs}{tx} \\
     \nextdef
     & \fun{produced} \in \PParams \to \StakePools \to \Tx \to \Coin
     & \text{value produced} \\
@@ -155,7 +155,7 @@ The signal for the UTxO transition is a transaction.
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
-        \var{stkeys} & \StakeKeys & \text{stake key}\\
+        \var{stdelegs} & \StakeDeleg & \text{stake credential}\\
         \var{stpools} & \StakePools & \text{stake pool}\\
         \var{dms} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
       \end{array}
@@ -293,7 +293,7 @@ requests).
       & \minfee{pp}{tx} \leq \txfee{tx}
       & \txins{tx} \subseteq \dom \var{utxo}
       \\
-      \consumed{pp}{utxo}{stkeys}{rewards}~{tx} = \produced{pp}{stpools}~{tx}
+      \consumed{pp}{utxo}{stdelegs}{rewards}~{tx} = \produced{pp}{stpools}~{tx}
       \\
       ~
       \\
@@ -316,9 +316,9 @@ requests).
       \\
       ~
       \\
-      \var{refunded} \leteq \keyRefunds{pp}{stkeys}~{tx}
+      \var{refunded} \leteq \keyRefunds{pp}{stdelegs}~{tx}
       \\
-      \var{decayed} \leteq \decayedTx{pp}{stkeys}~{tx}
+      \var{decayed} \leteq \decayedTx{pp}{stdelegs}~{tx}
       \\
       \var{depositChange} \leteq
         (\deposits{pp}~{stpools}~{\txcerts{tx}}) - (\var{refunded} + \var{decayed})
@@ -327,7 +327,7 @@ requests).
       \begin{array}{l}
         \var{slot}\\
         \var{pp}\\
-        \var{stkeys}\\
+        \var{stdelegs}\\
         \var{stpools}\\
         \var{dms}\\
       \end{array}
@@ -392,7 +392,7 @@ Figure~\ref{fig:functions:deposits-refunds} defines the deposit and refund funct
   \item The function $\fun{keyRefund}$, calculates the refund for an individual
     stake key registration deposit, based on the slot when it was created and
     the slot passed to the function. The creation slot should always exist in the map
-    $\var{stkeys}$ passed to the function and this would be a good property
+    $\var{stdelegs}$ passed to the function and this would be a good property
     to prove about the transition system.
   \item The function $\fun{keyRefunds}$, in turn, uses $\fun{keyRefund}$ to calculate
     the total value to be refunded to all individual key deregistration certificate authors
@@ -470,25 +470,25 @@ Section~\ref{sec:epoch}.
             \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
       \nextdef
       & \fun{keyRefund} \in \Coin \to \unitInterval \to \posReals \to \\
-      & ~~~~~\StakeKeys \to \Slot \to \DCertDeRegKey \to \Coin
+      & ~~~~~\StakeDelegs \to \Slot \to \DCertDeRegKey \to \Coin
       & \text{key refund for a certificate} \\
-      & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{slot}{c} =\\
+      & \keyRefund{\dval}{d_{\min}}{\lambda}{stdelegs}{slot}{c} =\\
       & ~~~~~\begin{cases}
-            0 & \text{if}~\cwitness c \notin \dom stkeys\\
+            0 & \text{if}~\cwitness c \notin \dom stdelegs \\
             \refund{\dval}{d_{\min}}{\lambda}{\delta}
             & \text{otherwise}
         \end{cases}\\
       &
       \begin{array}{lr@{~=~}l}
         \where
-        &\delta & \slotminus{slot}{(stkeys~(\cwitness c))}\\
+        &\delta & \slotminus{slot}{(stdelegs~(\cwitness c))}\\
       \end{array}\\
       \nextdef
-      & \fun{keyRefunds} \in \PParams \to \StakeKeys \to \Tx \to \Coin
+      & \fun{keyRefunds} \in \PParams \to \StakeDelegs \to \Tx \to \Coin
       & \text{key refunds for a transaction} \\
-      & \keyRefunds{pp}{stkeys}{tx} =\\
+      & \keyRefunds{pp}{stdelegs}{tx} =\\
       & ~~~~~ \sum\limits_{\substack{c \in \txcerts{tx} \\ c\in\DCertDeRegKey}}
-              \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{(\txttl{tx})}{c}\\
+              \keyRefund{\dval}{d_{\min}}{\lambda}{stdelegs}{(\txttl{tx})}{c}\\
       &
       \begin{array}{lr@{~=~}l}
         \where \\
@@ -504,31 +504,31 @@ Section~\ref{sec:epoch}.
 \begin{figure}[htb]
   \begin{align*}
       & \fun{decayedKey} \in
-      \PParams \to \StakeKeys \to \Slot \to \DCertDeRegKey \to \Coin
+      \PParams \to \StakeDelegs \to \Slot \to \DCertDeRegKey \to \Coin
       & \text{decayed since epoch} \\
-      & \decayedKey{pp}{stkeys}{cslot}{c} =\\
+      & \decayedKey{pp}{stdelegs}{cslot}{c} =\\
       & \begin{cases}
-            0 & \text{if}~\cwitness c \notin \dom stkeys\\
+            0 & \text{if}~\cwitness c \notin \dom stdelegs\\
             \var{epochRefund} - \var{currentRefund}
             & \text{otherwise}
         \end{cases}\\
       &
       \begin{array}{lr@{~=~}l}
         \where
-          & \var{created} & \var{stkeys}~(\cwitness~\var{c}) \\
+          & \var{created} & \var{stdelegs}~(\cwitness~\var{c}) \\
           & \var{start} & \mathsf{max}~(\firstSlot{\epoch{cslot}})~created \\
-          & \var{epochRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{start}{c} \\
-          & \var{currentRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkeys}{cslot}{c} \\
+          & \var{epochRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stdelegs}{start}{c} \\
+          & \var{currentRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stdelegs}{cslot}{c} \\
           & \dval & \fun{keyDeposit}~\var{pp}\\
           & d_{\min} & \fun{keyMinRefund}~\var{pp}\\
           & \lambda & \fun{keyDecayRate}~\var{pp}\\
       \end{array}\\
       \nextdef
-      & \fun{decayedTx} \in \PParams \to \StakeKeys \to \Tx \to \Coin
+      & \fun{decayedTx} \in \PParams \to \StakeDelegs \to \Tx \to \Coin
       & \text{decayed deposit portions} \\
-      & \decayedTx{pp}{stkeys}{tx} =\\
+      & \decayedTx{pp}{stdelegs}{tx} =\\
       &   \sum\limits_{\substack{c \in \txcerts{tx} \\ c \in\DCertDeRegKey}}
-          \decayedKey{pp}{stkeys}{(\txttl{tx})}{c}\\
+          \decayedKey{pp}{stdelegs}{(\txttl{tx})}{c}\\
   \end{align*}
   \caption{Functions used in Deposits - Decay}
   \label{fig:functions:deposits-decay}


### PR DESCRIPTION
This merges the stand-alone multi-sig spec into the Shelley spec, with the native multi-sig scripts as implementation choice for Shelley. The separate spec will be kept, in order to show how different multi-sig approaches and more general, how scripts can be integrated into the ledger rules.