### PR TITLE
Issue #792 #793 #798 key hashes and genesis deleg

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -16,7 +16,7 @@ module Delegation.Certificates
   ) where
 
 import           Coin (Coin (..))
-import           Keys (DSIGNAlgorithm, HashAlgorithm, KeyHash, hashKey)
+import           Keys (KeyHash)
 import           PParams (PParams (..), keyDecayRate, keyDeposit, keyMinRefund, poolDecayRate,
                      poolDeposit, poolMinRefund)
 import           Slot (Duration (..))
@@ -32,16 +32,13 @@ import           Data.Ratio (approxRational)
 import           Lens.Micro ((^.))
 
 -- |Determine the certificate author
-cwitness
-  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => DCert hashAlgo dsignAlgo
-  -> StakeCredential hashAlgo dsignAlgo
+cwitness :: DCert hashAlgo dsignAlgo -> StakeCredential hashAlgo dsignAlgo
 cwitness (RegKey hk)               = hk
 cwitness (DeRegKey hk)             = hk
-cwitness (RegPool pool)            = KeyHashObj . hashKey $ pool ^. poolPubKey
+cwitness (RegPool pool)            = KeyHashObj $ pool ^. poolPubKey
 cwitness (RetirePool k _)          = KeyHashObj k
 cwitness (Delegate delegation)     = delegation ^. delegator
-cwitness (GenesisDelegate (gk, _)) = GenesisHashObj $ hashKey gk
+cwitness (GenesisDelegate (gk, _)) = GenesisHashObj gk
 
 -- |Retrieve the deposit amount for a certificate
 dvalue :: DCert hashAlgo dsignAlgo -> PParams -> Coin

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -25,6 +25,7 @@ module Keys
   , KeyHash
   , pattern KeyHash
   , GenKeyHash
+  , pattern AnyKeyHash
   , AnyKeyHash
   , undiscriminateKeyHash
   , KeyPair(..)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -13,7 +13,7 @@ import           BlockChain (slotsPrior)
 import           Coin (Coin (..))
 import           Delegation.Certificates
 import           Keys
-import           Ledger.Core (dom, singleton, (∈), (∉), (∪), (⋪), (⋫),(⨃))
+import           Ledger.Core (dom, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
 import           LedgerState
 import           Slot
 import           TxData
@@ -22,9 +22,7 @@ import           Control.State.Transition
 
 data DELEG hashAlgo dsignAlgo
 
-instance
-  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => STS (DELEG hashAlgo dsignAlgo)
+instance STS (DELEG hashAlgo dsignAlgo)
  where
   type State (DELEG hashAlgo dsignAlgo) = DState hashAlgo dsignAlgo
   type Signal (DELEG hashAlgo dsignAlgo) = DCert hashAlgo dsignAlgo
@@ -42,8 +40,7 @@ instance
   transitionRules = [delegationTransition]
 
 delegationTransition
-  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => TransitionRule (DELEG hashAlgo dsignAlgo)
+  :: TransitionRule (DELEG hashAlgo dsignAlgo)
 delegationTransition = do
   TRC ((slot_, ptr_), ds, c) <- judgmentContext
 
@@ -78,14 +75,11 @@ delegationTransition = do
 
     GenesisDelegate (gkey, vk) -> do
       let s' = slot_ +* slotsPrior
-          gkeyHash = hashKey gkey
-          vkeyHash = hashKey vk
           (Dms dms_) = _dms ds
 
-      gkeyHash ∈ dom dms_ ?! GenesisKeyNotInpMappingDELEG
-
+      gkey ∈ dom dms_ ?! GenesisKeyNotInpMappingDELEG
       pure $ ds
-        { _fdms = _fdms ds ⨃ [((s', gkeyHash), vkeyHash)]}
+        { _fdms = _fdms ds ⨃ [((s', gkey), vk)]}
 
     _ -> do
       failBecause WrongCertificateTypeDELEG -- this always fails

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -21,9 +21,7 @@ import           Control.State.Transition
 
 data POOL hashAlgo dsignAlgo
 
-instance
-  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => STS (POOL hashAlgo dsignAlgo)
+instance STS (POOL hashAlgo dsignAlgo)
  where
   type State (POOL hashAlgo dsignAlgo) = PState hashAlgo dsignAlgo
   type Signal (POOL hashAlgo dsignAlgo) = DCert hashAlgo dsignAlgo
@@ -37,15 +35,13 @@ instance
   initialRules = [pure emptyPState]
   transitionRules = [poolDelegationTransition]
 
-poolDelegationTransition
-  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => TransitionRule (POOL hashAlgo dsignAlgo)
+poolDelegationTransition :: TransitionRule (POOL hashAlgo dsignAlgo)
 poolDelegationTransition = do
   TRC ((slot, pp), ps, c) <- judgmentContext
   let StakePools stPools_ = _stPools ps
   case c of
     RegPool poolParam -> do
-      let hk = hashKey (poolParam ^. poolPubKey)
+      let hk = poolParam ^. poolPubKey
 
       if hk ∉ dom stPools_
         then -- register new

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
@@ -21,6 +21,7 @@ import           LedgerState hiding (dms)
 import           PParams
 import           Slot
 import           Tx
+import           TxData
 import           UTxO
 
 import           Control.State.Transition
@@ -78,9 +79,7 @@ utxoWitnessed = do
   TRC ((slot, pp, stakeKeys, stakePools, _dms), u, tx@(Tx _ wits _))
     <- judgmentContext
   verifiedWits tx == Valid ?! InvalidWitnessesUTXOW
-  let witnessKeys = Set.map (\(WitVKey vk _)
-                              -> undiscriminateKeyHash $ hashKey vk
-                            ) wits
+  let witnessKeys = Set.map witKeyHash wits
   let needed = witsVKeyNeeded (_utxo u) tx _dms
   needed `Set.isSubsetOf` witnessKeys  ?! MissingVKeyWitnessesUTXOW
 

--- a/shelley/chain-and-ledger/executable-spec/src/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Tx.hs
@@ -32,7 +32,7 @@ module Tx
 where
 
 
-import           Keys (AnyKeyHash, KeyHash, hashKey, undiscriminateKeyHash)
+import           Keys (AnyKeyHash, undiscriminateKeyHash)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeWord8)
 
@@ -49,8 +49,8 @@ import qualified Data.Set as Set
 
 import           TxData (Credential (..), MultiSig (..), ScriptHash (..), StakeCredential, Tx (..),
                      TxBody (..), TxId (..), TxIn (..), TxOut (..), WitVKey (..), body, certs,
-                     inputs, outputs, ttl, txUpdate, txfee, wdrls, witnessMSigMap, witnessVKeySet
-                     )
+                     inputs, outputs, ttl, txUpdate, txfee, wdrls, witKeyHash, witnessMSigMap,
+                     witnessVKeySet)
 
 -- | Typeclass for multis-signature script data types. Allows for script
 -- validation and hashing.
@@ -63,7 +63,7 @@ class (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, ToCBOR a) =>
 -- key hashes that signed the transaction to be validated.
 evalNativeMultiSigScript
   :: MultiSig hashAlgo dsignAlgo
-  -> Set (KeyHash hashAlgo dsignAlgo)
+  -> Set (AnyKeyHash hashAlgo dsignAlgo)
   -> Bool
 evalNativeMultiSigScript (RequireSignature hk) vhks = Set.member hk vhks
 evalNativeMultiSigScript (RequireAllOf msigs) vhks =
@@ -82,7 +82,7 @@ validateNativeMultiSigScript
 validateNativeMultiSigScript msig tx =
   evalNativeMultiSigScript msig vhks
   where witsSet = _witnessVKeySet tx
-        vhks    = Set.map (\(WitVKey vk _) -> hashKey vk) witsSet
+        vhks    = Set.map witKeyHash witsSet
 
 -- | Hashes native multi-signature script, appending the 'nativeMultiSigTag' in
 -- front and then calling the script CBOR function.

--- a/shelley/chain-and-ledger/executable-spec/test/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator.hs
@@ -325,7 +325,7 @@ genStakePool skeys vrfKeys = do
                    Just i  -> i
                    Nothing -> interval0
   pure $ PoolParams
-           poolKey
+           (hashKey poolKey)
            (hashKey vrfKey)
            pledge
            cost

--- a/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
@@ -21,7 +21,7 @@ import qualified Data.Set as Set (fromList)
 
 import           Coin
 import           Control.State.Transition (PredicateFailure, TRC (..), applySTS)
-import           Keys (pattern Dms)
+import           Keys (pattern Dms, undiscriminateKeyHash)
 import           LedgerState (genesisId, genesisState, _utxoState)
 import           MockTypes (Addr, KeyPair, LedgerState, MultiSig, ScriptHash, Tx, TxBody, TxId,
                      TxIn, UTXOW, UTxOState, Wdrl)
@@ -41,7 +41,7 @@ import           Examples (aliceAddr, alicePay, bobAddr, bobPay, carlAddr, daria
 
 -- Multi-signature scripts
 singleKeyOnly :: Addr -> MultiSig
-singleKeyOnly (AddrBase (KeyHashObj pk) _ ) = RequireSignature pk
+singleKeyOnly (AddrBase (KeyHashObj pk) _ ) = RequireSignature $ undiscriminateKeyHash pk
 singleKeyOnly _ = error "use VKey address"
 
 aliceOnly :: MultiSig

--- a/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
@@ -168,7 +168,7 @@ mutateDCert keys _ (RegPool (PoolParams _ vrfHk pledge cost margin rwdacnt owner
   cost'   <- mutateCoin 0 100 cost
   p'      <- mutateNat 0 100 (fromIntegral $ numerator $ intervalValue margin)
   let interval = fromMaybe interval0 (mkUnitInterval $ fromIntegral p' % 100)
-  pure $ RegPool (PoolParams key' vrfHk pledge cost' interval rwdacnt owners)
+  pure $ RegPool (PoolParams (hashKey key') vrfHk pledge cost' interval rwdacnt owners)
 
 mutateDCert keys _ (Delegate (Delegation _ _)) = do
   delegator' <- getAnyStakeKey keys
@@ -177,4 +177,4 @@ mutateDCert keys _ (Delegate (Delegation _ _)) = do
 
 mutateDCert keys _ (GenesisDelegate (gk, _)) = do
   _delegatee <- getAnyStakeKey keys
-  pure $ GenesisDelegate (gk, _delegatee)
+  pure $ GenesisDelegate (gk, hashKey _delegatee)

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -10,7 +10,7 @@ import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
-                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C)
+                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -117,6 +117,12 @@ testCHAINExample4B = testCHAINExample ex4B
 testCHAINExample4C :: Assertion
 testCHAINExample4C = testCHAINExample ex4C
 
+testCHAINExample5A :: Assertion
+testCHAINExample5A = testCHAINExample ex5A
+
+testCHAINExample5B :: Assertion
+testCHAINExample5B = testCHAINExample ex5B
+
 stsTests :: TestTree
 stsTests = testGroup "STS Tests"
   [ testCase "update nonce early in the epoch" testUPNEarly
@@ -143,6 +149,8 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 4A - get 3/7 votes for a version update" testCHAINExample4A
   , testCase "CHAIN example 4B - create a future app version" testCHAINExample4B
   , testCase "CHAIN example 4C - adopt a future app version" testCHAINExample4C
+  , testCase "CHAIN example 5A - stage genesis key delegation" testCHAINExample5A
+  , testCase "CHAIN example 5B - adopt genesis key delegation" testCHAINExample5B
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
   , testCase "Everybody signs in multi-sig" testEverybodySigns

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -330,7 +330,7 @@ stakeKeyRegistration1 = LedgerState.emptyDelegation
 stakePool :: PoolParams
 stakePool = PoolParams
             {
-              _poolPubKey = vKey stakePoolKey1
+              _poolPubKey = hashKey $ vKey stakePoolKey1
             , _poolVrf = hashKey $ vKey stakePoolVRFKey1
             , _poolPledge  = Coin 0
             , _poolCost = Coin 0      -- TODO: what is a sensible value?
@@ -346,7 +346,7 @@ halfInterval =
 stakePoolUpdate :: PoolParams
 stakePoolUpdate = PoolParams
                    {
-                     _poolPubKey = vKey stakePoolKey1
+                     _poolPubKey = hashKey $ vKey stakePoolKey1
                    , _poolVrf = hashKey $ vKey stakePoolVRFKey1
                    , _poolPledge  = Coin 0
                    , _poolCost = Coin 100      -- TODO: what is a sensible value?

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -890,10 +890,6 @@ will be invalid.
   following state transformation:
     \begin{itemize}
       \item Reward accounts are set to zero for each corresponding withdrawal.
-      \item The genesis key delegation mapping is updated according to the future delegation
-        mapping. For each genesis key, we take the most recent delegation in $\var{fdms}$
-        that is past the current slot.
-      \item The future genesis key delegation has any items past the current slots removed.
     \end{itemize}
   \item The inductive case, when the list is non-empty, is captured by \cref{eq:delegs-induct}.
     It constructs a certificate pointer given the current slot and transaction index,
@@ -916,25 +912,6 @@ will be invalid.
       \var{wdrls} \subseteq \var{rewards}
       \\
       \var{rewards'} \leteq \var{rewards} \unionoverrideRight \{(w, 0) \mid w \in \dom \var{wdrls}\}
-      \\~\\
-      \var{curr}\leteq
-      \left\{
-        (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{fdms}
-        ~\mathrel{\Bigg|}~
-        {
-          \begin{array}{r}
-            \var{s}\geq\var{slot}\\
-            \var{s}=\max\{s'~\mid~(s',~\var{gkh})\in\dom{\var{fdms}}\}
-          \end{array}
-        }
-      \right\}
-      \\
-      \var{dms'}\leteq
-      \{
-        \var{gkh}\mapsto\var{vkh}
-        ~\mid~
-        (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{curr}
-      \}
     }
     {
       \left(
@@ -977,8 +954,8 @@ will be invalid.
           \varUpdate{\var{rewards'}} \\
           \var{delegations} \\
           \var{ptrs} \\
-          \varUpdate{\var{fdms}\setminus\var{curr}} \\
-          \varUpdate{\var{dms}\unionoverrideRight\var{dms'}} \\
+          \var{fdms} \\
+          \var{dms} \\
         \end{array}
         \right) \\~\\
         \left(

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -125,6 +125,10 @@ The base case also adopts new application versions at the appropriate times
 and cleans up the future application versions mapping.
 Note that it is better to handle this logic here than in the $\mathsf{AVUP}$ transiton,
 because here it will happen even if the block contains no transactions.
+Similarly, the genesis key delegation mapping is updated according to the future delegation
+mapping. For each genesis key, we adopt the most recent delegation in $\var{fdms}$
+that is past the current slot, and any future genesis key delegations past the current
+slot is removed.
 
 \begin{figure}[htb]
   \emph{Ledger Sequence transitions}
@@ -142,9 +146,14 @@ because here it will happen even if the block contains no transactions.
     \label{eq:ledgers-base}
     \inference[Seq-ledger-base]
     {
-      ((\var{utxo},~\var{deposits},~\var{fees},~\var{us}),~\var{dp})\leteq\var{ls}
+      ((\var{utxo},~\var{deposits},~\var{fees},~\var{us})
+      ,~(\var{ds},~\var{ps}))
+      \leteq\var{ls}
       \\
       (\var{pup},~\var{aup},~\var{favs},~\var{avs}) \leteq\var{us}
+      \\
+      (\var{stkeys},~\var{rewards},~\var{delegations}, ~\var{ptrs},~\var{fdms},~\var{dms})
+      \leteq\var{ds}
       \\~\\
       {\begin{array}{r@{~\leteq~}l}
         \var{favs'} & \{\var{s}\mapsto\var{v}\in\var{favs} ~\mid~ s>\var{slot}\}
@@ -153,9 +162,31 @@ because here it will happen even if the block contains no transactions.
         & \var{avs}\unionoverrideRight\fun{newAVs}~\var{avs}~(\var{favs}\setminus\var{favs'})
       \end{array}}
       \\~\\
+      \var{curr}\leteq
+      \{
+        (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{fdms}
+        ~\mid~
+        \var{s}\geq\var{slot}
+      \}\\
+      \var{dms'}\leteq
+      \left\{
+        \var{gkh}\mapsto\var{vkh}
+        ~\mathrel{\Bigg|}~
+        {
+          \begin{array}{l}
+            (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{curr}\\
+            \var{s}=\max\{s'~\mid~(s',~\var{gkh})\in\dom{\var{curr}}\}
+          \end{array}
+        }
+      \right\}
+      \\~\\
       \var{us'}\leteq(\var{pup},~\var{aup},~\var{favs'},~\var{avs'})
       \\
-      \var{ls'}\leteq((\var{utxo},~\var{deposits},~\var{fees},~\var{us'}),~\var{dp})
+      \var{ds'}\leteq
+      (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},
+      ~\var{fdms}\setminus\var{curr},~\var{dms}\unionoverrideRight\var{dms'})
+      \\
+      \var{ls'}\leteq((\var{utxo},~\var{deposits},~\var{fees},~\var{us'}),~(\var{ds'},~\var{ps}))
     }
     {
       \left(


### PR DESCRIPTION
There were a few issues all related to the genesis key delegation that this PR addresses.

* There were some fields in the delegation certificates that needed to be `KeyHashes` instead of `VKeys`. In particular, the genesis delegation cert and the pool registration had this problem.
* The type for witnesses, `WitVKey`, did not allow for genesis key witnesses.
* The genesis key delegation mapping had the same problem that previously existed with the application versions, namely that it is not updated when there are no transactions in the block. The solution was the same, move this updating of the maps to the `LEDGERS` transition. This was a change in both the spec and the exec model.

There's now an example for re-delegation of a genesis key.

closes #792
closes #793 
closes #798 