### PR TITLE
Issue #808 Metadata is map of tags to installers

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -323,8 +323,8 @@ data UTxOState hashAlgo dsignAlgo =
     , _fees      :: Coin
     , _ups       :: ( PPUpdate hashAlgo dsignAlgo
                     , AVUpdate hashAlgo dsignAlgo
-                    , Map.Map Slot Applications
-                    , Applications)
+                    , Map.Map Slot (Applications hashAlgo)
+                    , Applications hashAlgo)
     } deriving (Show, Eq)
 
 -- | New Epoch state and environment

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
@@ -27,8 +27,8 @@ instance DSIGNAlgorithm dsignAlgo => STS (UP hashAlgo dsignAlgo) where
   type State (UP hashAlgo dsignAlgo)
     = ( PPUpdate hashAlgo dsignAlgo
       , AVUpdate hashAlgo dsignAlgo
-      , Map.Map Slot Applications
-      , Applications
+      , Map.Map Slot (Applications hashAlgo)
+      , Applications hashAlgo
       )
   type Signal (UP hashAlgo dsignAlgo) = Update hashAlgo dsignAlgo
   type Environment (UP hashAlgo dsignAlgo) = (Slot, PParams, Dms hashAlgo dsignAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -63,10 +63,7 @@ newtype InstallerHash hashAlgo = InstallerHash (Hash hashAlgo ByteString)
   deriving (Show, Ord, Eq, ToCBOR)
 
 newtype Mdt hashAlgo = Mdt (Map.Map SystemTag (InstallerHash hashAlgo))
-  deriving (Show, Ord, Eq)
-
-instance HashAlgorithm hashAlgo => ToCBOR (Mdt hashAlgo) where
-  toCBOR _ = toCBOR ()
+  deriving (Show, Ord, Eq, ToCBOR)
 
 newtype Applications hashAlgo = Applications {
   apps :: Map.Map ApName (ApVer, Mdt hashAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -8,7 +8,9 @@ module Updates
   , updatePPup
   , ApName(..)
   , ApVer(..)
-  , Metadata(..)
+  , Mdt(..)
+  , SystemTag(..)
+  , InstallerHash(..)
   , Applications(..)
   , AVUpdate(..)
   , Update(..)
@@ -21,6 +23,7 @@ module Updates
   , emptyUpdate
   , updatePParams
   , svCanFollow
+  , sTagsValid
   )
 where
 
@@ -34,16 +37,17 @@ import qualified Data.Set as Set
 import           Data.Word (Word8)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
+import           Cardano.Crypto.Hash (Hash, HashAlgorithm)
 
 import           BaseTypes (Seed, UnitInterval)
 import           Coin (Coin)
-import           Keys (DSIGNAlgorithm, Dms, GenKeyHash, HashAlgorithm)
+import           Keys (DSIGNAlgorithm, Dms, GenKeyHash)
 import           PParams (PParams (..))
 import           Slot (Epoch, Slot)
 
 import           Numeric.Natural (Natural)
 
-import           Ledger.Core (range, (∪), (◁))
+import           Ledger.Core (dom, range, (∪), (◁))
 
 
 newtype ApVer = ApVer Natural
@@ -52,18 +56,24 @@ newtype ApVer = ApVer Natural
 newtype ApName = ApName ByteString
   deriving (Show, Ord, Eq, ToCBOR)
 
-data Metadata = Metadata -- for now, there are no requirements on Metadata
+newtype SystemTag = SystemTag ByteString
+  deriving (Show, Ord, Eq, ToCBOR)
+
+newtype InstallerHash hashAlgo = InstallerHash (Hash hashAlgo ByteString)
+  deriving (Show, Ord, Eq, ToCBOR)
+
+newtype Mdt hashAlgo = Mdt (Map.Map SystemTag (InstallerHash hashAlgo))
   deriving (Show, Ord, Eq)
 
-instance ToCBOR Metadata where
+instance HashAlgorithm hashAlgo => ToCBOR (Mdt hashAlgo) where
   toCBOR _ = toCBOR ()
 
-newtype Applications = Applications {
-  apps :: Map.Map ApName (ApVer, Metadata)
+newtype Applications hashAlgo = Applications {
+  apps :: Map.Map ApName (ApVer, Mdt hashAlgo)
   } deriving (Show, Ord, Eq, ToCBOR)
 
 newtype AVUpdate hashAlgo dsignAlgo = AVUpdate {
-  aup :: Map.Map (GenKeyHash hashAlgo dsignAlgo) Applications
+  aup :: Map.Map (GenKeyHash hashAlgo dsignAlgo) (Applications hashAlgo)
   } deriving (Show, Eq, ToCBOR)
 
 -- | Update Proposal
@@ -169,27 +179,35 @@ apNameValid :: ApName -> Bool
 apNameValid (ApName an) = all isAscii cs && length cs <= 12
   where cs = unpack an
 
-type Favs = Map.Map Slot Applications
+-- | This is just an example and not neccessarily how we will actually validate system tags
+sTagValid :: SystemTag -> Bool
+sTagValid (SystemTag st) = all isAscii cs && length cs <= 10
+  where cs = unpack st
 
-maxVer :: ApName -> Applications -> Favs -> (ApVer, Metadata)
+sTagsValid :: Mdt hashAlgo -> Bool
+sTagsValid (Mdt md) = all sTagValid (dom md)
+
+type Favs hashAlgo = Map.Map Slot (Applications hashAlgo)
+
+maxVer :: ApName -> Applications hashAlgo -> Favs hashAlgo -> (ApVer, Mdt hashAlgo)
 maxVer an avs favs =
   maximum $ vs an avs : fmap (vs an) (Set.toList (range favs))
     where
       vs n (Applications as) =
-        Map.foldr max (ApVer 0, Metadata) (Set.singleton n ◁ as)
+        Map.foldr max (ApVer 0, Mdt Map.empty) (Set.singleton n ◁ as)
 
-svCanFollow :: Applications -> Favs -> (ApName, (ApVer, Metadata)) -> Bool
+svCanFollow :: Applications hashAlgo -> Favs hashAlgo -> (ApName, (ApVer, Mdt hashAlgo)) -> Bool
 svCanFollow avs favs (an, (ApVer v, _)) = v == 1 + m
   where (ApVer m) = fst $ maxVer an avs favs
 
-allNames :: Applications -> Favs -> Set ApName
+allNames :: Applications hashAlgo -> Favs hashAlgo -> Set ApName
 allNames (Applications avs) favs =
   Prelude.foldr
     (\(Applications fav) acc -> acc `Set.union` Map.keysSet fav)
     (Map.keysSet avs)
     (Map.elems favs)
 
-newAVs :: Applications -> Favs -> Applications
+newAVs :: Applications hashAlgo -> Favs hashAlgo -> Applications hashAlgo
 newAVs avs favs = Applications $
                     Map.fromList [(an, maxVer an avs favs) | an <- Set.toList $ allNames avs favs]
 
@@ -208,8 +226,8 @@ votedValue vs | null elemLists = Nothing
 emptyUpdateState
   :: ( Updates.PPUpdate hashAlgo dsignAlgo
      , Updates.AVUpdate hashAlgo dsignAlgo
-     , Map.Map Slot Updates.Applications
-     , Updates.Applications
+     , Map.Map Slot (Applications hashAlgo)
+     , Applications hashAlgo
      )
 emptyUpdateState =
   (PPUpdate Map.empty, AVUpdate Map.empty, Map.empty, Applications Map.empty)

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -52,10 +52,11 @@ import           Cardano.Crypto.DSIGN (deriveVerKeyDSIGN, genKeyDSIGN)
 import           Cardano.Crypto.Hash (ShortHash)
 import           Cardano.Crypto.KES (deriveVerKeyKES, genKeyKES)
 import           Crypto.Random (drgNewTest, withDRG)
-import           MockTypes (AVUpdate, Addr, Block, Credential, DState, EpochState, GenKeyHash,
-                     HashHeader, KeyHash, KeyPair, LedgerState, NewEpochState, PPUpdate, PState,
-                     PoolDistr, PoolParams, RewardAcnt, SKey, SKeyES, SnapShots, Stake, Tx, TxBody,
-                     UTxO, UTxOState, Update, VKey, VKeyES, VKeyGenesis)
+import           MockTypes (AVUpdate, Addr, Applications, Block, Credential, DState, EpochState,
+                     GenKeyHash, HashHeader, KeyHash, KeyPair, LedgerState, Mdt,
+                     NewEpochState, PPUpdate, PState, PoolDistr, PoolParams, RewardAcnt, SKey,
+                     SKeyES, SnapShots, Stake, Tx, TxBody, UTxO, UTxOState, Update, VKey, VKeyES,
+                     VKeyGenesis)
 import           Numeric.Natural (Natural)
 import           Unsafe.Coerce (unsafeCoerce)
 
@@ -85,9 +86,9 @@ import           TxData (pattern AddrBase, pattern AddrPtr, pattern Delegation, 
                      pattern StakePools, pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut,
                      _paymentObj, _poolCost, _poolMargin, _poolOwners, _poolPledge, _poolPubKey,
                      _poolRAcnt, _poolVrf)
-import           Updates (pattern AVUpdate, ApName (..), ApVer (..), Applications (..),
-                     Metadata (..), pattern PPUpdate, Ppm (..), pattern Update, emptyUpdate,
-                     emptyUpdateState, updatePPup)
+import           Updates (pattern AVUpdate, ApName (..), ApVer (..), pattern Applications,
+                     InstallerHash (..), pattern Mdt, pattern PPUpdate, Ppm (..), SystemTag (..),
+                     pattern Update, emptyUpdate, emptyUpdateState, updatePPup)
 import           UTxO (pattern UTxO, makeWitnessesVKey, txid)
 
 type ChainState = (NewEpochState, Seed, Seed, HashHeader, Slot)
@@ -152,8 +153,8 @@ dms = Map.fromList [ (hashKey gkey, hashKey . vKey $ cold pkeys) | (gkey, pkeys)
 
 byronApps :: Applications
 byronApps = Applications $ Map.fromList
-                            [ (ApName $ pack "Daedalus", (ApVer 16, Metadata))
-                            , (ApName $ pack "Yoroi", (ApVer 4, Metadata))
+                            [ (ApName $ pack "Daedalus", (ApVer 16, Mdt Map.empty))
+                            , (ApName $ pack "Yoroi", (ApVer 4, Mdt Map.empty))
                             ]
 
 alicePay :: KeyPair
@@ -1582,10 +1583,15 @@ ex3C = CHAINExample (Slot 110) expectedStEx3B blockEx3C expectedStEx3C
 -- have three genesis keys vote on the same new version
 
 
+daedalusMDEx4A :: Mdt
+daedalusMDEx4A = Mdt $ Map.singleton
+                              (SystemTag $ pack "DOS")
+                              (InstallerHash $ hash $ pack "ABC")
+
 appsEx4A :: Applications
 appsEx4A = Applications $ Map.singleton
                             (ApName $ pack "Daedalus")
-                            (ApVer 17, Metadata)
+                            (ApVer 17, daedalusMDEx4A)
 
 avupEx4A :: AVUpdate
 avupEx4A = AVUpdate $ Map.fromList [ (hashKey $ coreNodeVKG 0, appsEx4A)
@@ -1791,8 +1797,8 @@ updateStEx4C =
   , AVUpdate Map.empty
   , Map.empty
   , Applications $ Map.fromList
-                     [ (ApName $ pack "Daedalus", (ApVer 17, Metadata))
-                     , (ApName $ pack "Yoroi", (ApVer 4, Metadata))
+                     [ (ApName $ pack "Daedalus", (ApVer 17, daedalusMDEx4A))
+                     , (ApName $ pack "Yoroi", (ApVer 4, Mdt Map.empty))
                      ]
   )
 

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -116,6 +116,10 @@ type SnapShots = EpochBoundary.SnapShots ShortHash MockDSIGN
 
 type Stake = EpochBoundary.Stake ShortHash MockDSIGN
 
+type Mdt = Updates.Mdt ShortHash
+
+type Applications = Updates.Applications ShortHash
+
 type Update = Updates.Update ShortHash MockDSIGN
 
 type PPUpdate = Updates.PPUpdate ShortHash MockDSIGN

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -65,7 +65,7 @@
 \newcommand{\ApName}{\ensuremath{\type{ApName}}}
 \newcommand{\ApVer}{\ensuremath{\type{ApVer}}}
 \newcommand{\SystemTag}{\ensuremath{\type{SystemTag}}}
-\newcommand{\UpdateData}{\ensuremath{\type{UpdateData}}}
+\newcommand{\InstallerHash}{\ensuremath{\type{InstallerHash}}}
 \newcommand{\Metadata}{\ensuremath{\type{Mdt}}}
 \newcommand{\PPUpdate}{\type{PPUpdate}}
 \newcommand{\Applications}{\type{Applications}}

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -45,7 +45,7 @@ This function must produce a unique id for each unique transaction.
       \var{txid} & \TxId & \text{transaction id}\\
       \var{an} & \ApName & \text{application name}\\
       \var{st} & \SystemTag & \text{system tag}\\
-      \var{ud} & \UpdateData & \text{update data}\\
+      \var{ih} & \InstallerHash & \text{update data}\\
     \end{array}
   \end{equation*}
   \emph{Derived types}
@@ -84,7 +84,7 @@ This function must produce a unique id for each unique transaction.
       \\
       \var{md}
       & \Metadata
-      & \SystemTag\mapsto\UpdateData
+      & \SystemTag\mapsto\InstallerHash
       & \text{application metadata}
       \\
       \var{apps}

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -247,6 +247,9 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
       \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\mapsto(v,~\wcard)\in\var{vote},~
       \fun{svCanFollow}~\var{avs}~\var{favs}~\var{n}~\var{v}
       \\
+      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall \wcard\mapsto(\wcard,~m)\in\var{vote},~
+      \forall \var{st}\mapsto\wcard\in\var{m},~ \fun{sTagValid}~\var{st}
+      \\
       \var{aup'}\leteq\var{aup_s}\unionoverrideRight\var{aup}
       \\
       \var{fav}\leteq\fun{votedValue_{Applications}}~\var{aup'}
@@ -291,6 +294,9 @@ $\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$.
       \\
       \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\mapsto(v,~\wcard)\in\var{vote},~
         \fun{svCanFollow}~\var{avs}~\var{favs}~\var{n}~\var{v}
+      \\
+      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall \wcard\mapsto(\wcard,~m)\in\var{vote},~
+      \forall \var{st}\mapsto\wcard\in\var{m},~ \fun{sTagValid}~\var{st}
       \\
       \var{aup'}\leteq\var{aup_s}\unionoverrideRight\var{aup}
       \\
@@ -339,6 +345,8 @@ The AVUP rule has three predicate failures:
   in the proposal are not exactly one more than the greatest version for the given
   application name in the current application versions or the future application
   versions, there is a \emph{CannotFollow} failure.
+\item In the case of \var{aup} being non-empty, if any of the metadata in
+  in the proposal contains an invalid system tag, there is a \emph{InvalidSystemTags} failure.
 \end{itemize}
 
 \clearpage


### PR DESCRIPTION
I've updated the exec spec so that the Metadata in the apps are now a mapping of system tags to installer hashes. And now we validate the system tags as well (both in the formal spec and the exec model).

closes #808 
closes #615