### PR TITLE
[734] POOL STS - sync exec. spec with formal spec

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
@@ -51,11 +51,11 @@ delplTransition = do
   case c of
     RegPool _ -> do
       ps <-
-        trans @(POOL hashAlgo dsignAlgo) $ TRC ((slotIx, ptr, pp), _pstate d, c)
+        trans @(POOL hashAlgo dsignAlgo) $ TRC ((slotIx, pp), _pstate d, c)
       pure $ d { _pstate = ps }
     RetirePool _ _ -> do
       ps <-
-        trans @(POOL hashAlgo dsignAlgo) $ TRC ((slotIx, ptr, pp), _pstate d, c)
+        trans @(POOL hashAlgo dsignAlgo) $ TRC ((slotIx, pp), _pstate d, c)
       pure $ d { _pstate = ps }
     GenesisDelegate _ -> do
       ds <-

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -27,7 +27,7 @@ instance
  where
   type State (POOL hashAlgo dsignAlgo) = PState hashAlgo dsignAlgo
   type Signal (POOL hashAlgo dsignAlgo) = DCert hashAlgo dsignAlgo
-  type Environment (POOL hashAlgo dsignAlgo) = (Slot, Ptr, PParams)
+  type Environment (POOL hashAlgo dsignAlgo) = (Slot, PParams)
   data PredicateFailure (POOL hashAlgo dsignAlgo)
     = StakePoolNotRegisteredOnKeyPOOL
     | StakePoolRetirementWrongEpochPOOL
@@ -41,7 +41,7 @@ poolDelegationTransition
   :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => TransitionRule (POOL hashAlgo dsignAlgo)
 poolDelegationTransition = do
-  TRC ((slot, _, pp), ps, c) <- judgmentContext
+  TRC ((slot, pp), ps, c) <- judgmentContext
   let StakePools stPools_ = _stPools ps
   case c of
     RegPool poolParam -> do


### PR DESCRIPTION
Closes #734 

NOTE I'm re-defining the Relation-operators Union and Union Override in this STS since we lack an ORD instance for `PParams`. 

If it makes sense to pursue that ORD instance, I can tighten this code some more (and use the Relation operators)
