### PR TITLE
[743] [744] BHEAD + OCERT STS's - sync formal and exec. specs

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -724,7 +724,11 @@ If the size checks pass, then three transitions are done:
         \var{nes}'
       }
       \\~\\
-      (\wcard,~\wcard,~\var{b_{prev}},~\wcard,~\var{es},~\var{ru},~\wcard,~\wcard)\leteq\var{nes} \\
+      (\wcard,~\wcard,~\var{b_{prev}},~\wcard,~\var{es},~\wcard,~\wcard,~\wcard)\leteq\var{nes} \\
+      \\
+      (\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{ru},~\wcard,~\wcard)\leteq\var{nes'} \\
+      \\
+      (\wcard,~\wcard,~\wcard,~\var{pp})\leteq\var{es} \\
       \\
       {
         \left(


### PR DESCRIPTION
Closes #743 
Closes #744 

For #743 (BHEAD STS) I changed the following in the formal spec:

* I added the missing assignment `(_,_,_,pp) := es` (@JaredCorduan this might ring a bell - we previously had `(_,_,_,es) := es` in the formal spec, which was incorrect and then removed.)
* in the exec. spec, `ru` was being destructured from `nes'`,  rather than `nes`. I added an assignment of ru from `nes'` (Note: the exec. spec tests failed when I tried to conform to the formal spec's ru assignment from `nes`)


<img width="847" alt="Screenshot 2019-08-30 at 14 26 02" src="https://user-images.githubusercontent.com/8812/64022053-a563d800-cb35-11e9-9a51-823ae0e1094d.png">
