### PR TITLE
[740] UPDN STS - sync formal and exec. spec

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -983,14 +983,16 @@ delegatedStake ls@(LedgerState _ ds _) = Map.fromListWith (+) delegatedOutputs
 
 -- | Calculate pool reward
 poolRewards
-  :: StakeCredential hashAlgo dsignAlgo -- TODO check why this paramater is not used
+  :: UnitInterval
   -> UnitInterval
   -> Natural
   -> Natural
   -> Coin
   -> Coin
-poolRewards _ sigma blocksN blocksTotal (Coin maxP) =
-  floor $ p * fromIntegral maxP
+poolRewards d_ sigma blocksN blocksTotal (Coin maxP) =
+  if intervalValue d_ < 0.8
+    then floor (p * fromIntegral maxP)
+    else 1
   where
     p = beta / intervalValue sigma
     beta = fromIntegral blocksN / fromIntegral (max 1 blocksTotal)
@@ -1005,7 +1007,7 @@ leaderRew
 leaderRew f@(Coin f') pool (StakeShare s) (StakeShare sigma)
   | f' <= c = f
   | otherwise =
-    floor $ fromIntegral (c + (f' - c)) * (m' + (1 - m') * sigma / s)
+    Coin $ c + floor (fromIntegral (f' - c) * (m' + (1 - m') * s / sigma))
   where
     (Coin c, m, _) = poolSpec pool
     m' = intervalValue m
@@ -1019,7 +1021,7 @@ memberRew
   -> Coin
 memberRew (Coin f') pool (StakeShare t) (StakeShare sigma)
   | f' <= c = 0
-  | otherwise = floor $ fromIntegral (f' - c) * (1 - m') * sigma / t
+  | otherwise = floor $ fromIntegral (f' - c) * (1 - m') * t / sigma
   where
     (Coin c, m, _) = poolSpec pool
     m' = intervalValue m
@@ -1052,7 +1054,7 @@ rewardOnePool pp r blocksN blocksTotal poolHK pool (Stake stake) (Coin total) ad
         then maxPool pp r sigma pr
         else 0
     s' = fromMaybe (error "LedgerState.rewardOnePool: Unexpected Nothing") $ mkUnitInterval sigma
-    poolR = poolRewards poolHK s' blocksN blocksTotal maxP
+    poolR = poolRewards (_d pp) s' blocksN blocksTotal maxP
     tot = fromIntegral total
     mRewards = Map.fromList
      [(RewardAcnt hk,

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -989,10 +989,10 @@ blockEx2HHash :: HashHeader
 blockEx2HHash = bhHash (bheader blockEx2H)
 
 aliceRAcnt2H :: Coin
-aliceRAcnt2H = Coin 82593524514
+aliceRAcnt2H = Coin 69258309255
 
 bobRAcnt2H :: Coin
-bobRAcnt2H = Coin 730001159951
+bobRAcnt2H = Coin 6341690744
 
 rewardsEx2H :: Map RewardAcnt Coin
 rewardsEx2H = Map.fromList [ (RewardAcnt aliceSHK, aliceRAcnt2H)
@@ -1006,7 +1006,7 @@ expectedStEx2H =
       (BlocksMade $ Map.singleton (hk alicePool) 1)
       (BlocksMade Map.empty)
       (EpochState (acntEx2E { _treasury = Coin 33 }) snapsEx2G expectedLSEx2G ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 8637405315545
+      (Just RewardUpdate { deltaT = Coin 9374400000011
                          , deltaR = Coin (-9450000000000)
                          , rs = rewardsEx2H
                          , deltaF = Coin (-10)
@@ -1049,7 +1049,7 @@ epoch1OSchedEx2I = overlaySchedule
 
 acntEx2I :: AccountState
 acntEx2I = AccountState
-            { _treasury = Coin 8637405315578
+            { _treasury = Coin 9374400000044
             , _reserves = Coin 44990550000000000
             }
 


### PR DESCRIPTION
Closes #740 

This brings the leader reward calculation in the exec. spec in line with the formal spec. This means some hardcoded coins in the examples needed to change