### PR TITLE
initial genesis key op cert counters

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -13,7 +13,7 @@ import           BlockChain (slotsPrior)
 import           Coin (Coin (..))
 import           Delegation.Certificates
 import           Keys
-import           Ledger.Core (dom, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
+import           Ledger.Core (dom, range, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
 import           LedgerState
 import           Slot
 import           TxData
@@ -34,6 +34,7 @@ instance STS (DELEG hashAlgo dsignAlgo)
     | StakeDelegationImpossibleDELEG
     | WrongCertificateTypeDELEG
     | GenesisKeyNotInpMappingDELEG
+    | DuplicateGenesisDelegateDELEG
     deriving (Show, Eq)
 
   initialRules = [pure emptyDState]
@@ -78,6 +79,7 @@ delegationTransition = do
           (Dms dms_) = _dms ds
 
       gkey ∈ dom dms_ ?! GenesisKeyNotInpMappingDELEG
+      vk ∉ range dms_ ?! DuplicateGenesisDelegateDELEG
       pure $ ds
         { _fdms = _fdms ds ⨃ [((s', gkey), vk)]}
 

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -45,7 +45,7 @@ where
 
 import           Data.ByteString.Char8 (pack)
 import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map (elems, empty, fromList, insert, keysSet, singleton)
+import qualified Data.Map.Strict as Map (delete, elems, empty, fromList, insert, keysSet, singleton)
 import           Data.Maybe (fromMaybe)
 import           Data.Sequence (empty, fromList)
 import qualified Data.Set as Set
@@ -56,10 +56,9 @@ import           Cardano.Crypto.Hash (ShortHash)
 import           Cardano.Crypto.KES (deriveVerKeyKES, genKeyKES)
 import           Crypto.Random (drgNewTest, withDRG)
 import           MockTypes (AVUpdate, Addr, Applications, Block, Credential, DState, EpochState,
-                     GenKeyHash, HashHeader, KeyHash, KeyPair, LedgerState, Mdt,
-                     NewEpochState, PPUpdate, PState, PoolDistr, PoolParams, RewardAcnt, SKey,
-                     SKeyES, SnapShots, Stake, Tx, TxBody, UTxO, UTxOState, Update, VKey, VKeyES,
-                     VKeyGenesis)
+                     GenKeyHash, HashHeader, KeyHash, KeyPair, LedgerState, Mdt, NewEpochState,
+                     PPUpdate, PState, PoolDistr, PoolParams, RewardAcnt, SKey, SKeyES, SnapShots,
+                     Stake, Tx, TxBody, UTxO, UTxOState, Update, VKey, VKeyES, VKeyGenesis)
 import           Numeric.Natural (Natural)
 import           Unsafe.Coerce (unsafeCoerce)
 
@@ -1952,6 +1951,14 @@ dsEx5B = dsEx5A { _fdms = Map.empty
                                  ((hashKey . vKey) newGenDelegate)
                                  dms }
 
+psEx5B :: PState
+psEx5B = psEx1 { _cCounters =
+                              Map.insert
+                                ((hashKey . vKey) newGenDelegate)
+                                0
+                                (Map.delete (hk $ coreNodeKeys 0) (_cCounters psEx1))
+               }
+
 expectedLSEx5B :: LedgerState
 expectedLSEx5B = LedgerState
                (UTxOState
@@ -1959,7 +1966,7 @@ expectedLSEx5B = LedgerState
                  (Coin 0)
                  (Coin 1)
                  (PPUpdate Map.empty , AVUpdate Map.empty , Map.empty , byronApps))
-               (DPState dsEx5B psEx1)
+               (DPState dsEx5B psEx5B)
                0
 
 expectedStEx5B :: ChainState

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1610,7 +1610,7 @@ which takes the Byron ledger state and creates the Shelley ledger state.
                             \emptyset \\
                             \emptyset \\
                             \emptyset \\
-                            \emptyset \\
+                            \var{cs} \\
                           \end{array}
                         \right) \\
                         \end{array}
@@ -1631,7 +1631,8 @@ which takes the Byron ledger state and creates the Shelley ledger state.
           \var{h} \\
           \var{s_{last}} \\
         \end{array}
-      \right)
+      \right) \\
+      & ~~~~\where cs = \{\var{hk}\mapsto 0~\mid~\var{hk}\in\range{(\fun{dms}~\var{ds})}\} \\
   \end{align*}
 
   \caption{Byron to Shelley State Transtition}

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -478,6 +478,7 @@ concerns are independent of the ledger rules.
       \\
       s'\leteq\var{slot}+\SlotsPrior
       & \var{gkh}\in\dom{dms}
+      & \var{vk}\notin\range{dms}
     }
     {
       \begin{array}{r}
@@ -514,7 +515,7 @@ concerns are independent of the ledger rules.
   \label{fig:delegation-rules}
 \end{figure}
 
-The DELEG rule has five predicate failures:
+The DELEG rule has six predicate failures:
 \begin{itemize}
 \item In the case of a key registration certificate, if the staking credential
   is already registered, there is a a \emph{StakeKeyAlreadyRegistered} failure.
@@ -524,9 +525,12 @@ The DELEG rule has five predicate failures:
   there is a \emph{StakeDelegationImpossible} failure.
 \item In the case of a pool delegation certificate, there is a
   \emph{WrongCertificateType} failure.
-\item  In the case of a genesis key delegation certificate, if the key is not
+\item  In the case of a genesis key delegation certificate, if the genesis key is not
   in the domain of the genesis delegation mapping, there is a
   \emph{GenesisKeyNotInMapping} failure.
+\item  In the case of a genesis key delegation certificate, if the delegate key is
+  in the range of the genesis delegation mapping, there is a
+  \emph{DuplicateGenesisDelegate} failure.
 \end{itemize}
 
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -154,6 +154,8 @@ slot is removed.
       \\
       (\var{stkeys},~\var{rewards},~\var{delegations}, ~\var{ptrs},~\var{fdms},~\var{dms})
       \leteq\var{ds}
+      \\
+      (\var{stpools},~\var{poolParams},~\var{retiring},~\var{cs})\leteq\var{ps}
       \\~\\
       {\begin{array}{r@{~\leteq~}l}
         \var{favs'} & \{\var{s}\mapsto\var{v}\in\var{favs} ~\mid~ s>\var{slot}\}
@@ -166,7 +168,7 @@ slot is removed.
       \{
         (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{fdms}
         ~\mid~
-        \var{s}\geq\var{slot}
+        \var{s}\leq\var{slot}
       \}\\
       \var{dms'}\leteq
       \left\{
@@ -186,7 +188,14 @@ slot is removed.
       (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},
       ~\var{fdms}\setminus\var{curr},~\var{dms}\unionoverrideRight\var{dms'})
       \\
-      \var{ls'}\leteq((\var{utxo},~\var{deposits},~\var{fees},~\var{us'}),~(\var{ds'},~\var{ps}))
+      \var{oldGenDelegs}\leteq\range((\dom\var{dms'})\restrictdom\var{dms})
+      \\
+      \var{cs'}\leteq(\var{oldGenDelegs}\subtractdom\var{oldGenDelegs})\unionoverrideRight
+      \{\var{hk}\mapsto 0~\mid~\var{hk}\in\range{dms'}\}
+      \\
+      \var{ps'}\leteq(\var{stpools},~\var{poolParams},~\var{retiring},~\var{cs'})
+      \\
+      \var{ls'}\leteq((\var{utxo},~\var{deposits},~\var{fees},~\var{us'}),~(\var{ds'},~\var{ps'}))
     }
     {
       \left(


### PR DESCRIPTION
The genesis delegates (ie the cold keys that the genesis keys delegate to) are not registered like normal stake pool keys, and were not previously being given initial counters for the operational certificates. Now the `toShelley` method in the formal spec sets a counter of zero for each starting genesis key delegate.

Additionally, while making this change, I noticed a couple related things that also needed fixing:
* We should not allow two different genesis keys to delegate to the same cold key. There is now a check for this.
* When re-delegating a genesis key, the old delegate needs to be removed from the op cert counters.

closes #643 