### PR TITLE
Issues #686 Convert tuples to data types

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -146,7 +146,7 @@ import           TxData (Addr (..), Credential (..), Delegation (..), Ix, PoolPa
                      RewardAcnt (..), StakeCredential, Tx (..), TxBody (..), TxId (..), TxIn (..),
                      TxOut (..), body, certs, getRwdCred, inputs, poolOwners, poolPledge,
                      poolPubKey, poolRAcnt, ttl, txfee, wdrls, witKeyHash)
-import           Updates (AVUpdate (..), Applications, PPUpdate (..), Update (..), emptyUpdate,
+import           Updates (AVUpdate (..), PPUpdate (..), Update (..), UpdateState (..), emptyUpdate,
                      emptyUpdateState)
 import           UTxO (UTxO (..), balance, deposits, txinLookup, txins, txouts, txup, verifyWitVKey)
 
@@ -314,18 +314,15 @@ clearPpup
   :: UTxOState hashAlgo dsignAlgo
   -> UTxOState hashAlgo dsignAlgo
 clearPpup utxoSt =
-  let (_, avup, faps, aps) = _ups utxoSt
-  in utxoSt {_ups = (PPUpdate Map.empty, avup, faps, aps)}
+  let UpdateState _ avup faps aps = _ups utxoSt
+  in utxoSt {_ups = UpdateState (PPUpdate Map.empty) avup faps aps}
 
 data UTxOState hashAlgo dsignAlgo =
     UTxOState
     { _utxo      :: !(UTxO hashAlgo dsignAlgo)
     , _deposited :: Coin
     , _fees      :: Coin
-    , _ups       :: ( PPUpdate hashAlgo dsignAlgo
-                    , AVUpdate hashAlgo dsignAlgo
-                    , Map.Map Slot (Applications hashAlgo)
-                    , Applications hashAlgo)
+    , _ups       :: UpdateState hashAlgo dsignAlgo
     } deriving (Show, Eq)
 
 -- | New Epoch state and environment

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
@@ -8,6 +8,8 @@
 
 module STS.Bbody
   ( BBODY
+  , BbodyState (..)
+  , BbodyEnv (..)
   )
 where
 
@@ -29,6 +31,12 @@ import           STS.Ledgers
 
 data BBODY hashAlgo dsignAlgo kesAlgo
 
+data BbodyState hashAlgo dsignAlgo
+  = BbodyState (LedgerState hashAlgo dsignAlgo) (BlocksMade hashAlgo dsignAlgo)
+
+data BbodyEnv
+  = BbodyEnv (Set.Set Slot) PParams
+
 instance
   ( HashAlgorithm hashAlgo
   , DSIGNAlgorithm dsignAlgo
@@ -36,13 +44,12 @@ instance
   )
   => STS (BBODY hashAlgo dsignAlgo kesAlgo)
  where
-  type State (BBODY hashAlgo dsignAlgo kesAlgo)
-    = (LedgerState hashAlgo dsignAlgo, BlocksMade hashAlgo dsignAlgo)
+  type State (BBODY hashAlgo dsignAlgo kesAlgo) = BbodyState hashAlgo dsignAlgo
 
   type Signal (BBODY hashAlgo dsignAlgo kesAlgo)
     = Block hashAlgo dsignAlgo kesAlgo
 
-  type Environment (BBODY hashAlgo dsignAlgo kesAlgo) = (Set.Set Slot, PParams)
+  type Environment (BBODY hashAlgo dsignAlgo kesAlgo) = BbodyEnv
 
   data PredicateFailure (BBODY hashAlgo dsignAlgo kesAlgo)
     = WrongBlockBodySizeBBODY
@@ -50,7 +57,7 @@ instance
     | LedgersFailure (PredicateFailure (LEDGERS hashAlgo dsignAlgo))
     deriving (Show, Eq)
 
-  initialRules = [pure (emptyLedgerState, BlocksMade Map.empty)]
+  initialRules = [pure $ BbodyState emptyLedgerState (BlocksMade Map.empty)]
   transitionRules = [bbodyTransition]
 
 bbodyTransition
@@ -61,8 +68,8 @@ bbodyTransition
      )
   => TransitionRule (BBODY hashAlgo dsignAlgo kesAlgo)
 bbodyTransition = do
-  TRC ( (oslots, pp)
-      , (ls, b)
+  TRC ( BbodyEnv oslots pp
+      , BbodyState ls b
       , Block (BHeader bhb _) txsSeq@(TxSeq txs)) <- judgmentContext
   let hk = hashKey $ bvkcold bhb
 
@@ -71,10 +78,9 @@ bbodyTransition = do
   bhbHash txsSeq == bhash bhb ?! InvalidBodyHashBBODY
 
   ls' <- trans @(LEDGERS hashAlgo dsignAlgo)
-         $ TRC ((bheaderSlot bhb, pp), ls, txs)
+         $ TRC (LedgersEnv (bheaderSlot bhb) pp, ls, txs)
 
-  pure ( ls'
-       , incrBlocks (bheaderSlot bhb ∈ oslots) hk b)
+  pure $ BbodyState ls' (incrBlocks (bheaderSlot bhb ∈ oslots) hk b)
 
 instance
   ( HashAlgorithm hashAlgo

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -3,6 +3,7 @@
 
 module STS.Deleg
   ( DELEG
+  , DelegEnv (..)
   )
 where
 
@@ -25,11 +26,15 @@ import           Hedgehog (Gen)
 
 data DELEG hashAlgo dsignAlgo
 
+data DelegEnv
+  = DelegEnv Slot Ptr
+  deriving (Show, Eq)
+
 instance STS (DELEG hashAlgo dsignAlgo)
  where
   type State (DELEG hashAlgo dsignAlgo) = DState hashAlgo dsignAlgo
   type Signal (DELEG hashAlgo dsignAlgo) = DCert hashAlgo dsignAlgo
-  type Environment (DELEG hashAlgo dsignAlgo) = (Slot, Ptr)
+  type Environment (DELEG hashAlgo dsignAlgo) = DelegEnv
   data PredicateFailure (DELEG hashAlgo dsignAlgo)
     = StakeKeyAlreadyRegisteredDELEG
     | StakeKeyNotRegisteredDELEG
@@ -46,7 +51,7 @@ instance STS (DELEG hashAlgo dsignAlgo)
 delegationTransition
   :: TransitionRule (DELEG hashAlgo dsignAlgo)
 delegationTransition = do
-  TRC ((slot_, ptr_), ds, c) <- judgmentContext
+  TRC (DelegEnv slot_ ptr_, ds, c) <- judgmentContext
 
   case c of
     RegKey key -> do
@@ -93,5 +98,5 @@ delegationTransition = do
 
 instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => HasTrace (DELEG hashAlgo dsignAlgo) where
-  envGen _ = undefined :: Gen (Slot, Ptr)
+  envGen _ = undefined :: Gen DelegEnv
   sigGen _ _ = undefined :: Gen (DCert hashAlgo dsignAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
@@ -64,16 +64,16 @@ epochTransition :: forall hashAlgo dsignAlgo . TransitionRule (EPOCH hashAlgo ds
 epochTransition = do
   TRC (_, EpochState as ss ls pp, e) <- judgmentContext
   let us = _utxoState ls
-  let (ppup, _, _, _) = _ups us
+  let UpdateState ppup _ _ _ = _ups us
   let DPState ds ps = _delegationState ls
-  (ss', us') <-
-    trans @(SNAP hashAlgo dsignAlgo) $ TRC ((pp, ds, ps), (ss, us), e)
-  (as', ds', ps') <-
-    trans @(POOLREAP hashAlgo dsignAlgo) $ TRC (pp, (as, ds, ps), e)
+  SnapState ss' us' <-
+    trans @(SNAP hashAlgo dsignAlgo) $ TRC (SnapEnv pp ds ps, SnapState ss us, e)
+  PoolreapState as' ds' ps' <-
+    trans @(POOLREAP hashAlgo dsignAlgo) $ TRC (pp, PoolreapState as ds ps, e)
   let ppNew = votedValuePParams ppup pp
-  (us'', as'', pp') <-
+  NewppState us'' as'' pp' <-
     trans @(NEWPP hashAlgo dsignAlgo)
-      $ TRC ((ppNew, ds', ps'), (us', as', pp), e)
+      $ TRC (NewppEnv ppNew ds' ps', NewppState us' as' pp, e)
   pure $ EpochState
     as''
     ss'

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Overlay.hs
@@ -8,6 +8,7 @@
 
 module STS.Overlay
   ( OVERLAY
+  , OverlayEnv(..)
   )
 where
 
@@ -28,6 +29,14 @@ import           Control.State.Transition
 
 data OVERLAY hashAlgo dsignAlgo kesAlgo
 
+data OverlayEnv hashAlgo dsignAlgo kesAlgo
+  = OverlayEnv
+      PParams
+      (Map.Map Slot (Maybe (GenKeyHash hashAlgo dsignAlgo)))
+      Seed
+      (PoolDistr hashAlgo dsignAlgo)
+      (Dms hashAlgo dsignAlgo)
+
 instance
   ( HashAlgorithm hashAlgo
   , DSIGNAlgorithm dsignAlgo
@@ -43,13 +52,7 @@ instance
   type Signal (OVERLAY hashAlgo dsignAlgo kesAlgo)
     = BHeader hashAlgo dsignAlgo kesAlgo
 
-  type Environment (OVERLAY hashAlgo dsignAlgo kesAlgo) =
-    ( PParams
-    , Map.Map Slot (Maybe (GenKeyHash hashAlgo dsignAlgo))
-    , Seed
-    , PoolDistr hashAlgo dsignAlgo
-    , Dms hashAlgo dsignAlgo
-    )
+  type Environment (OVERLAY hashAlgo dsignAlgo kesAlgo) = OverlayEnv hashAlgo dsignAlgo kesAlgo
 
   data PredicateFailure (OVERLAY hashAlgo dsignAlgo kesAlgo)
     = NotPraosLeaderOVERLAY
@@ -73,7 +76,7 @@ overlayTransition
      )
   => TransitionRule (OVERLAY hashAlgo dsignAlgo kesAlgo)
 overlayTransition = do
-  TRC ( (pp, osched, eta0, pd, Dms dms)
+  TRC ( OverlayEnv pp osched eta0 pd (Dms dms)
       , cs
       , bh@(BHeader bhb _)) <- judgmentContext
   let vk = bvkcold bhb

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -3,6 +3,7 @@
 
 module STS.Pool
   ( POOL
+  , PoolEnv (..)
   )
 where
 
@@ -24,11 +25,15 @@ import           Hedgehog (Gen)
 
 data POOL hashAlgo dsignAlgo
 
+data PoolEnv =
+  PoolEnv Slot PParams
+  deriving (Show, Eq)
+
 instance STS (POOL hashAlgo dsignAlgo)
  where
   type State (POOL hashAlgo dsignAlgo) = PState hashAlgo dsignAlgo
   type Signal (POOL hashAlgo dsignAlgo) = DCert hashAlgo dsignAlgo
-  type Environment (POOL hashAlgo dsignAlgo) = (Slot, PParams)
+  type Environment (POOL hashAlgo dsignAlgo) = PoolEnv
   data PredicateFailure (POOL hashAlgo dsignAlgo)
     = StakePoolNotRegisteredOnKeyPOOL
     | StakePoolRetirementWrongEpochPOOL
@@ -40,7 +45,7 @@ instance STS (POOL hashAlgo dsignAlgo)
 
 poolDelegationTransition :: TransitionRule (POOL hashAlgo dsignAlgo)
 poolDelegationTransition = do
-  TRC ((slot, pp), ps, c) <- judgmentContext
+  TRC (PoolEnv slot pp, ps, c) <- judgmentContext
   let StakePools stPools_ = _stPools ps
   case c of
     RegPool poolParam -> do
@@ -85,5 +90,5 @@ m ∪ (k,v) = Map.union m (Map.singleton k v)
 
 instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => HasTrace (POOL hashAlgo dsignAlgo) where
-  envGen _ = undefined :: Gen (Slot, PParams)
+  envGen _ = undefined :: Gen PoolEnv
   sigGen _ _ = undefined :: Gen (DCert hashAlgo dsignAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -4,6 +4,7 @@
 
 module STS.Ppup
   ( PPUP
+  , PPUPEnv(..)
   )
 where
 
@@ -24,10 +25,13 @@ import           Numeric.Natural (Natural)
 
 data PPUP hashAlgo dsignAlgo
 
+data PPUPEnv hashAlgo dsignAlgo
+  = PPUPEnv Slot PParams (Dms hashAlgo dsignAlgo)
+
 instance STS (PPUP hashAlgo dsignAlgo) where
   type State (PPUP hashAlgo dsignAlgo) = PPUpdate hashAlgo dsignAlgo
   type Signal (PPUP hashAlgo dsignAlgo) = PPUpdate hashAlgo dsignAlgo
-  type Environment (PPUP hashAlgo dsignAlgo) = (Slot, PParams, Dms hashAlgo dsignAlgo)
+  type Environment (PPUP hashAlgo dsignAlgo) = PPUPEnv hashAlgo dsignAlgo
   data PredicateFailure (PPUP hashAlgo dsignAlgo)
     = NonGenesisUpdatePPUP (Set.Set (GenKeyHash hashAlgo dsignAlgo)) (Set.Set (GenKeyHash hashAlgo dsignAlgo))
     | PPUpdateTooEarlyPPUP
@@ -50,7 +54,7 @@ pvCanFollow _ _ = True
 
 ppupTransitionEmpty :: TransitionRule (PPUP hashAlgo dsignAlgo)
 ppupTransitionEmpty = do
-  TRC ((_, _, _), pupS, PPUpdate pup') <- judgmentContext
+  TRC (_, pupS, PPUpdate pup') <- judgmentContext
 
   Map.null pup' ?! PPUpdateNonEmpty
 
@@ -58,7 +62,7 @@ ppupTransitionEmpty = do
 
 ppupTransitionNonEmpty :: TransitionRule (PPUP hashAlgo dsignAlgo)
 ppupTransitionNonEmpty = do
-  TRC ((s, pp, Dms _dms), pupS, pup@(PPUpdate pup')) <- judgmentContext
+  TRC (PPUPEnv s pp (Dms _dms), pupS, pup@(PPUpdate pup')) <- judgmentContext
 
   pup' /= Map.empty ?! PPUpdateEmpty
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
@@ -3,6 +3,7 @@
 
 module STS.Rupd
   ( RUPD
+  , RupdEnv(..)
   )
 where
 
@@ -15,11 +16,13 @@ import           Control.State.Transition
 
 data RUPD hashAlgo dsignAlgo
 
+data RupdEnv hashAlgo dsignAlgo
+  = RupdEnv (BlocksMade hashAlgo dsignAlgo) (EpochState hashAlgo dsignAlgo)
+
 instance STS (RUPD hashAlgo dsignAlgo) where
   type State (RUPD hashAlgo dsignAlgo) = Maybe (RewardUpdate hashAlgo dsignAlgo)
   type Signal (RUPD hashAlgo dsignAlgo) = Slot.Slot
-  type Environment (RUPD hashAlgo dsignAlgo)
-    = (BlocksMade hashAlgo dsignAlgo, EpochState hashAlgo dsignAlgo)
+  type Environment (RUPD hashAlgo dsignAlgo) = RupdEnv hashAlgo dsignAlgo
   data PredicateFailure (RUPD hashAlgo dsignAlgo)
     = FailureRUPD
     deriving (Show, Eq)
@@ -29,7 +32,7 @@ instance STS (RUPD hashAlgo dsignAlgo) where
 
 rupdTransition :: TransitionRule (RUPD hashAlgo dsignAlgo)
 rupdTransition = do
-  TRC ((b, es), ru, s) <- judgmentContext
+  TRC (RupdEnv b es, ru, s) <- judgmentContext
   let slot = firstSlot (epochFromSlot s) +* startRewards
   if s <= slot
     then pure ru

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
@@ -3,6 +3,8 @@
 
 module STS.Snap
   ( SNAP
+  , SnapState (..)
+  , SnapEnv (..)
   )
 where
 
@@ -22,36 +24,41 @@ import           Control.State.Transition
 
 data SNAP hashAlgo dsignAlgo
 
+data SnapState hashAlgo dsignAlgo
+  = SnapState
+      (SnapShots hashAlgo dsignAlgo)
+      (UTxOState hashAlgo dsignAlgo)
+
+data SnapEnv hashAlgo dsignAlgo
+  = SnapEnv
+      PParams
+      (DState hashAlgo dsignAlgo)
+      (PState hashAlgo dsignAlgo)
+
 instance STS (SNAP hashAlgo dsignAlgo) where
-  type State (SNAP hashAlgo dsignAlgo)
-    = (SnapShots hashAlgo dsignAlgo, UTxOState hashAlgo dsignAlgo)
+  type State (SNAP hashAlgo dsignAlgo) = SnapState hashAlgo dsignAlgo
   type Signal (SNAP hashAlgo dsignAlgo) = Epoch
-  type Environment (SNAP hashAlgo dsignAlgo)
-    = ( PParams
-      , DState hashAlgo dsignAlgo
-      , PState hashAlgo dsignAlgo
-      )
+  type Environment (SNAP hashAlgo dsignAlgo) = SnapEnv hashAlgo dsignAlgo
   data PredicateFailure (SNAP hashAlgo dsignAlgo)
     = FailureSNAP
     deriving (Show, Eq)
 
   initialRules =
-    [pure (emptySnapShots, UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState)]
+    [pure $ SnapState emptySnapShots (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState)]
   transitionRules = [snapTransition]
 
 snapTransition :: TransitionRule (SNAP hashAlgo dsignAlgo)
 snapTransition = do
-  TRC ((pparams, d, p), (s, u), eNew) <- judgmentContext
+  TRC (SnapEnv pparams d p, SnapState s u, eNew) <- judgmentContext
   let pooledStake = stakeDistr (u ^. utxo) d p
   let _slot = firstSlot eNew
   let oblg = obligation pparams (d ^. stKeys) (p ^. stPools) _slot
   let decayed = (u ^. deposited) - oblg
-  pure
-    ( s { _pstakeMark = pooledStake
-        , _pstakeSet = s ^. pstakeMark
-        , _pstakeGo = s ^. pstakeSet
-        , _poolsSS = p ^. pParams
-        , _feeSS = (u ^. fees) + decayed}
-    , u { _deposited = oblg
-        , _fees = (u ^. fees) + decayed}
-    )
+  pure $ SnapState
+    s { _pstakeMark = pooledStake
+      , _pstakeSet = s ^. pstakeMark
+      , _pstakeGo = s ^. pstakeSet
+      , _poolsSS = p ^. pParams
+      , _feeSS = (u ^. fees) + decayed}
+    u { _deposited = oblg
+      , _fees = (u ^. fees) + decayed}

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
@@ -6,10 +6,9 @@
 
 module STS.Up
   ( UP
+  , UpdateEnv(..)
   )
 where
-
-import qualified Data.Map.Strict as Map
 
 import           Keys
 import           PParams
@@ -23,15 +22,13 @@ import           STS.Ppup
 
 data UP hashAlgo dsignAlgo
 
+data UpdateEnv hashAlgo dsignAlgo
+  = UpdateEnv Slot PParams (Dms hashAlgo dsignAlgo)
+
 instance DSIGNAlgorithm dsignAlgo => STS (UP hashAlgo dsignAlgo) where
-  type State (UP hashAlgo dsignAlgo)
-    = ( PPUpdate hashAlgo dsignAlgo
-      , AVUpdate hashAlgo dsignAlgo
-      , Map.Map Slot (Applications hashAlgo)
-      , Applications hashAlgo
-      )
+  type State (UP hashAlgo dsignAlgo) = UpdateState hashAlgo dsignAlgo
   type Signal (UP hashAlgo dsignAlgo) = Update hashAlgo dsignAlgo
-  type Environment (UP hashAlgo dsignAlgo) = (Slot, PParams, Dms hashAlgo dsignAlgo)
+  type Environment (UP hashAlgo dsignAlgo) = UpdateEnv hashAlgo dsignAlgo
   data PredicateFailure (UP hashAlgo dsignAlgo)
     = NonGenesisUpdateUP
     | AvupFailure (PredicateFailure (AVUP hashAlgo dsignAlgo))
@@ -46,13 +43,13 @@ upTransition
    . DSIGNAlgorithm dsignAlgo
   => TransitionRule (UP hashAlgo dsignAlgo)
 upTransition = do
-  TRC ((_slot, pp, _dms), (pupS, aupS, favs, avs), Update pup _aup) <- judgmentContext
+  TRC (UpdateEnv _slot pp _dms, UpdateState pupS aupS favs avs, Update pup _aup) <- judgmentContext
 
-  pup' <- trans @(PPUP hashAlgo dsignAlgo) $ TRC ((_slot, pp, _dms), pupS, pup)
-  (aup', favs', avs') <-
-    trans @(AVUP hashAlgo dsignAlgo) $ TRC ((_slot, _dms), (aupS, favs, avs), _aup)
+  pup' <- trans @(PPUP hashAlgo dsignAlgo) $ TRC (PPUPEnv _slot pp _dms, pupS, pup)
+  AVUPState aup' favs' avs' <-
+    trans @(AVUP hashAlgo dsignAlgo) $ TRC (AVUPEnv _slot _dms, AVUPState aupS favs avs, _aup)
 
-  pure (pup', aup', favs', avs')
+  pure $ UpdateState pup' aup' favs' avs'
 
 instance DSIGNAlgorithm dsignAlgo => Embed (AVUP hashAlgo dsignAlgo) (UP hashAlgo dsignAlgo) where
   wrapFailed = AvupFailure

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
@@ -3,6 +3,7 @@
 
 module STS.Updn
   ( UPDN
+  , UpdnState(..)
   )
 where
 
@@ -14,19 +15,22 @@ import           Control.State.Transition
 
 data UPDN
 
+data UpdnState = UpdnState Seed Seed
+  deriving (Show, Eq)
+
 instance STS UPDN where
-  type State UPDN = (Seed, Seed)
+  type State UPDN = UpdnState
   type Signal UPDN = Slot.Slot
   type Environment UPDN = Seed
   data PredicateFailure UPDN = FailureUPDN
                                deriving (Show, Eq)
-  initialRules = [pure (mkNonce 0, mkNonce 0)]
+  initialRules = [pure (UpdnState (mkNonce 0) (mkNonce 0))]
   transitionRules = [updTransition]
 
 updTransition :: TransitionRule UPDN
 updTransition = do
-  TRC (eta, (eta_v, eta_c), s) <- judgmentContext
+  TRC (eta, UpdnState eta_v eta_c, s) <- judgmentContext
   let Epoch e = epochFromSlot s
   if s +* slotsPrior < firstSlot (Epoch (e + 1))
-    then pure (eta_v ⭒ eta, eta_v ⭒ eta)
-    else pure (eta_v ⭒ eta, eta_c)
+    then pure $ UpdnState (eta_v ⭒ eta) (eta_v ⭒ eta)
+    else pure $ UpdnState (eta_v ⭒ eta) eta_c

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -14,6 +14,7 @@ module Updates
   , Applications(..)
   , AVUpdate(..)
   , Update(..)
+  , UpdateState(..)
   , Favs
   , apNameValid
   , allNames
@@ -220,14 +221,12 @@ votedValue vs | null elemLists = Nothing
   elemLists =
     filter (\l -> length l >= 5) $ List.group $ map snd $ Map.toList vs
 
-emptyUpdateState
-  :: ( Updates.PPUpdate hashAlgo dsignAlgo
-     , Updates.AVUpdate hashAlgo dsignAlgo
-     , Map.Map Slot (Applications hashAlgo)
-     , Applications hashAlgo
-     )
-emptyUpdateState =
-  (PPUpdate Map.empty, AVUpdate Map.empty, Map.empty, Applications Map.empty)
+emptyUpdateState :: UpdateState hashAlgo dsignAlgo
+emptyUpdateState = UpdateState
+                     (PPUpdate Map.empty)
+                     (AVUpdate Map.empty)
+                     Map.empty
+                     (Applications Map.empty)
 
 emptyUpdate :: Update hashAlgo dsignAlgo
 emptyUpdate = Update (PPUpdate Map.empty) (AVUpdate Map.empty)
@@ -254,3 +253,11 @@ updatePParams = Set.foldr updatePParams'
   updatePParams' (D                     p) pps = pps { _d = p }
   updatePParams' (ExtraEntropy          p) pps = pps { _extraEntropy = p }
   updatePParams' (ProtocolVersion       p) pps = pps { _protocolVersion = p }
+
+data UpdateState hashAlgo dsignAlgo
+  = UpdateState
+      (PPUpdate hashAlgo dsignAlgo)
+      (AVUpdate hashAlgo dsignAlgo)
+      (Map.Map Slot (Applications hashAlgo))
+      (Applications hashAlgo)
+  deriving (Show, Eq)

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -55,10 +55,11 @@ import           Cardano.Crypto.DSIGN (deriveVerKeyDSIGN, genKeyDSIGN)
 import           Cardano.Crypto.Hash (ShortHash)
 import           Cardano.Crypto.KES (deriveVerKeyKES, genKeyKES)
 import           Crypto.Random (drgNewTest, withDRG)
-import           MockTypes (AVUpdate, Addr, Applications, Block, Credential, DState, EpochState,
-                     GenKeyHash, HashHeader, KeyHash, KeyPair, LedgerState, Mdt, NewEpochState,
+import           MockTypes (AVUpdate, Addr, Applications, Block, ChainState, Credential, DState,
+                     EpochState, GenKeyHash, HashHeader, KeyHash, KeyPair, LedgerState, Mdt,
                      PPUpdate, PState, PoolDistr, PoolParams, RewardAcnt, SKey, SKeyES, SnapShots,
-                     Stake, Tx, TxBody, UTxO, UTxOState, Update, VKey, VKeyES, VKeyGenesis)
+                     Stake, Tx, TxBody, UTxO, UTxOState, Update, UpdateState, VKey, VKeyES,
+                     VKeyGenesis)
 import           Numeric.Natural (Natural)
 import           Unsafe.Coerce (unsafeCoerce)
 
@@ -84,6 +85,7 @@ import           LedgerState (AccountState (..), pattern DPState, pattern EpochS
 import           OCert (KESPeriod (..), pattern OCert)
 import           PParams (PParams (..), emptyPParams)
 import           Slot (Epoch (..), Slot (..))
+import           STS.Chain (pattern ChainState)
 import           TxData (pattern AddrBase, pattern AddrPtr, pattern Delegation, pattern KeyHashObj,
                      pattern PoolParams, Ptr (..), pattern RewardAcnt, pattern StakeKeys,
                      pattern StakePools, pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut,
@@ -91,10 +93,10 @@ import           TxData (pattern AddrBase, pattern AddrPtr, pattern Delegation, 
                      _poolRAcnt, _poolVrf)
 import           Updates (pattern AVUpdate, ApName (..), ApVer (..), pattern Applications,
                      InstallerHash (..), pattern Mdt, pattern PPUpdate, Ppm (..), SystemTag (..),
-                     pattern Update, emptyUpdate, emptyUpdateState, updatePPup)
+                     pattern Update, pattern UpdateState, emptyUpdate, emptyUpdateState,
+                     updatePPup)
 import           UTxO (pattern UTxO, makeGenWitnessesVKey, makeWitnessesVKey, txid)
 
-type ChainState = (NewEpochState, Seed, Seed, HashHeader, Slot)
 
 data CHAINExample = CHAINExample Slot ChainState Block ChainState
 
@@ -333,22 +335,21 @@ lastByronHeaderHash :: HashHeader
 lastByronHeaderHash = HashHeader $ unsafeCoerce (hash 0 :: Hash ShortHash Int)
 
 initStEx1 :: ChainState
-initStEx1 =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      esEx1
-      Nothing
-      (PoolDistr Map.empty)
-      (Map.singleton (Slot 1) (Just . hashKey $ coreNodeVKG 0))
-      -- The overlay schedule has one entry, setting Core Node 1 to slot 1.
-  , Nonce 0
-  , Nonce 0
-  , lastByronHeaderHash
-  , Slot 0
-  )
+initStEx1 = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     esEx1
+     Nothing
+     (PoolDistr Map.empty)
+     (Map.singleton (Slot 1) (Just . hashKey $ coreNodeVKG 0)))
+    -- The overlay schedule has one entry, setting Core Node 1 to slot 1.
+  (Nonce 0)
+  (Nonce 0)
+  lastByronHeaderHash
+  (Slot 0)
 
 zero :: UnitInterval
 zero = unsafeMkUnitInterval 0
@@ -365,22 +366,21 @@ blockEx1 = mkBlock
              0
 
 expectedStEx1 :: ChainState
-expectedStEx1 =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      -- Note that blocks in the overlay schedule do not add to this count.
-      esEx1
-      Nothing
-      (PoolDistr Map.empty)
-      (Map.singleton (Slot 1) (Just . hashKey $ coreNodeVKG 0))
-  , Nonce 0 ⭒ Nonce 1
-  , Nonce 0 ⭒ Nonce 1
-  , bhHash (bheader blockEx1)
-  , Slot 1
-  )
+expectedStEx1 = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     -- Note that blocks in the overlay schedule do not add to this count.
+     esEx1
+     Nothing
+     (PoolDistr Map.empty)
+     (Map.singleton (Slot 1) (Just . hashKey $ coreNodeVKG 0)))
+  (Nonce 0 ⭒ Nonce 1)
+  (Nonce 0 ⭒ Nonce 1)
+  (bhHash (bheader blockEx1))
+  (Slot 1)
 
 ex1 :: CHAINExample
 ex1 = CHAINExample (Slot 1) initStEx1 blockEx1 expectedStEx1
@@ -424,8 +424,8 @@ txEx2A = Tx
 alicePtrAddr :: Addr
 alicePtrAddr = AddrPtr (_paymentObj aliceAddr) (Ptr (Slot 10) 0 0)
 
-usEx2A :: (PPUpdate, AVUpdate, Map Slot Applications, Applications)
-usEx2A = (PPUpdate Map.empty, AVUpdate Map.empty, Map.empty, byronApps)
+usEx2A :: UpdateState
+usEx2A = UpdateState (PPUpdate Map.empty) (AVUpdate Map.empty) Map.empty byronApps
 
 utxostEx2A :: UTxOState
 utxostEx2A = UTxOState utxoEx2A (Coin 0) (Coin 0) usEx2A
@@ -451,8 +451,8 @@ overlayEx2A = overlaySchedule
                     ppsEx1
 
 initStEx2A :: ChainState
-initStEx2A =
-  ( NewEpochState
+initStEx2A = ChainState
+  (NewEpochState
       (Epoch 0)
       (Nonce 0)
       (BlocksMade Map.empty)
@@ -460,12 +460,11 @@ initStEx2A =
       esEx2A
       Nothing
       (PoolDistr Map.empty)
-      overlayEx2A
-  , Nonce 0
-  , Nonce 0
-  , lastByronHeaderHash
-  , Slot 0
-  )
+      overlayEx2A)
+  (Nonce 0)
+  (Nonce 0)
+  lastByronHeaderHash
+  (Slot 0)
 
 blockEx2A :: Block
 blockEx2A = mkBlock
@@ -495,15 +494,12 @@ psEx2A = psEx1
           , _cCounters = Map.insert (hk alicePool) 0 (_cCounters psEx1)
           }
 
-updateStEx2A :: ( PPUpdate
-               , AVUpdate
-               , Map Slot Applications
-               , Applications)
-updateStEx2A =
-  ( ppupEx2A
-  , AVUpdate Map.empty
-  , Map.empty
-  , byronApps)
+updateStEx2A :: UpdateState
+updateStEx2A = UpdateState
+  ppupEx2A
+  (AVUpdate Map.empty)
+  Map.empty
+  byronApps
 
 expectedLSEx2A :: LedgerState
 expectedLSEx2A = LedgerState
@@ -522,21 +518,20 @@ blockEx2AHash :: HashHeader
 blockEx2AHash = bhHash (bheader blockEx2A)
 
 expectedStEx2A :: ChainState
-expectedStEx2A =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A emptySnapShots expectedLSEx2A ppsEx1)
-      Nothing
-      (PoolDistr Map.empty)
-      overlayEx2A
-  , Nonce 0 ⭒ Nonce 1
-  , Nonce 0 ⭒ Nonce 1
-  , blockEx2AHash
-  , Slot 10
-  )
+expectedStEx2A = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A emptySnapShots expectedLSEx2A ppsEx1)
+     Nothing
+     (PoolDistr Map.empty)
+     overlayEx2A)
+  (Nonce 0 ⭒ Nonce 1)
+  (Nonce 0 ⭒ Nonce 1)
+  blockEx2AHash
+  (Slot 10)
 
 ex2A :: CHAINExample
 ex2A = CHAINExample (Slot 10) initStEx2A blockEx2A expectedStEx2A
@@ -606,26 +601,24 @@ expectedLSEx2B = LedgerState
                0
 
 expectedStEx2Bgeneric :: PParams -> ChainState
-expectedStEx2Bgeneric pp =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A emptySnapShots expectedLSEx2B pp)
-      (Just RewardUpdate { deltaT = Coin 0
-                         , deltaR = Coin 0
-                         , rs     = Map.empty
-                         , deltaF = Coin 0
-                         })
-      (PoolDistr Map.empty)
-      overlayEx2A
-  , Nonce 0 ⭒ Nonce 1 ⭒ Nonce 2
-  , Nonce 0 ⭒ Nonce 1
-  , blockEx2BHash
-  , Slot 90
-  )
-
+expectedStEx2Bgeneric pp = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A emptySnapShots expectedLSEx2B pp)
+     (Just RewardUpdate { deltaT = Coin 0
+                        , deltaR = Coin 0
+                        , rs     = Map.empty
+                        , deltaF = Coin 0
+                        })
+     (PoolDistr Map.empty)
+     overlayEx2A)
+  (Nonce 0 ⭒ Nonce 1 ⭒ Nonce 2)
+  (Nonce 0 ⭒ Nonce 1)
+  blockEx2BHash
+  (Slot 90)
 
 expectedStEx2B :: ChainState
 expectedStEx2B = expectedStEx2Bgeneric ppsEx1
@@ -713,21 +706,20 @@ blockEx2CHash :: HashHeader
 blockEx2CHash = bhHash (bheader blockEx2C)
 
 expectedStEx2Cgeneric :: SnapShots -> LedgerState -> PParams -> ChainState
-expectedStEx2Cgeneric ss ls pp =
-  ( NewEpochState
-      (Epoch 1)
-      (Nonce 0 ⭒ Nonce 1)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A ss ls pp)
-      Nothing
-      (PoolDistr Map.empty)
-      epoch1OSchedEx2C
-  , mkSeqNonce 3
-  , mkSeqNonce 3
-  , blockEx2CHash
-  , Slot 110
-  )
+expectedStEx2Cgeneric ss ls pp = ChainState
+  (NewEpochState
+     (Epoch 1)
+     (Nonce 0 ⭒ Nonce 1)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A ss ls pp)
+     Nothing
+     (PoolDistr Map.empty)
+     epoch1OSchedEx2C)
+  (mkSeqNonce 3)
+  (mkSeqNonce 3)
+  blockEx2CHash
+  (Slot 110)
 
 expectedStEx2C :: ChainState
 expectedStEx2C = expectedStEx2Cgeneric snapsEx2C expectedLSEx2C ppsEx1
@@ -777,25 +769,24 @@ blockEx2DHash :: HashHeader
 blockEx2DHash = bhHash (bheader blockEx2D)
 
 expectedStEx2D :: ChainState
-expectedStEx2D =
-  ( NewEpochState
-      (Epoch 1)
-      (Nonce 0 ⭒ Nonce 1)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A snapsEx2C expectedLSEx2C ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 20
-                         , deltaR = Coin 0
-                         , rs     = Map.empty
-                         , deltaF = Coin (-20)
-                         })
-      (PoolDistr Map.empty)
-      epoch1OSchedEx2C
-  , mkSeqNonce 4
-  , mkSeqNonce 3
-  , blockEx2DHash
-  , Slot 190
-  )
+expectedStEx2D = ChainState
+  (NewEpochState
+     (Epoch 1)
+     (Nonce 0 ⭒ Nonce 1)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A snapsEx2C expectedLSEx2C ppsEx1)
+     (Just RewardUpdate { deltaT = Coin 20
+                        , deltaR = Coin 0
+                        , rs     = Map.empty
+                        , deltaF = Coin (-20)
+                        })
+     (PoolDistr Map.empty)
+     epoch1OSchedEx2C)
+  (mkSeqNonce 4)
+  (mkSeqNonce 3)
+  blockEx2DHash
+  (Slot 190)
 
 ex2D :: CHAINExample
 ex2D = CHAINExample (Slot 190) expectedStEx2C blockEx2D expectedStEx2D
@@ -850,24 +841,23 @@ acntEx2E = AccountState
             }
 
 expectedStEx2E :: ChainState
-expectedStEx2E =
-  ( NewEpochState
-      (Epoch 2)
-      (mkSeqNonce 3)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1)
-      Nothing
-      (PoolDistr
-        (Map.singleton
-           (hk alicePool)
-           (1, hashKey (vKey $ vrf alicePool))))
-      epoch1OSchedEx2E
-  , mkSeqNonce 5
-  , mkSeqNonce 5
-  , blockEx2EHash
-  , Slot 220
-  )
+expectedStEx2E = ChainState
+  (NewEpochState
+     (Epoch 2)
+     (mkSeqNonce 3)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1)
+     Nothing
+     (PoolDistr
+       (Map.singleton
+          (hk alicePool)
+          (1, hashKey (vKey $ vrf alicePool))))
+     epoch1OSchedEx2E)
+  (mkSeqNonce 5)
+  (mkSeqNonce 5)
+  blockEx2EHash
+  (Slot 220)
 
 ex2E :: CHAINExample
 ex2E = CHAINExample (Slot 220) expectedStEx2D blockEx2E expectedStEx2E
@@ -894,25 +884,24 @@ pdEx2F :: PoolDistr
 pdEx2F = PoolDistr $ Map.singleton (hk alicePool) (1, hashKey $ vKey $ vrf alicePool)
 
 expectedStEx2F :: ChainState
-expectedStEx2F =
-  ( NewEpochState
-      (Epoch 2)
-      (mkSeqNonce 3)
-      (BlocksMade Map.empty)
-      (BlocksMade $ Map.singleton (hk alicePool) 1)
-      (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 13
-                         , deltaR = Coin 0
-                         , rs     = Map.empty
-                         , deltaF = Coin (-13)
-                         })
-      pdEx2F
-      epoch1OSchedEx2E
-  , mkSeqNonce 6
-  , mkSeqNonce 5
-  , blockEx2FHash
-  , Slot 295
-  )
+expectedStEx2F = ChainState
+  (NewEpochState
+     (Epoch 2)
+     (mkSeqNonce 3)
+     (BlocksMade Map.empty)
+     (BlocksMade $ Map.singleton (hk alicePool) 1)
+     (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1)
+     (Just RewardUpdate { deltaT = Coin 13
+                        , deltaR = Coin 0
+                        , rs     = Map.empty
+                        , deltaF = Coin (-13)
+                        })
+     pdEx2F
+     epoch1OSchedEx2E)
+  (mkSeqNonce 6)
+  (mkSeqNonce 5)
+  blockEx2FHash
+  (Slot 295)
 
 ex2F :: CHAINExample
 ex2F = CHAINExample (Slot 295) expectedStEx2E blockEx2F expectedStEx2F
@@ -958,21 +947,20 @@ expectedLSEx2G = LedgerState
                0
 
 expectedStEx2G :: ChainState
-expectedStEx2G =
-  ( NewEpochState
-      (Epoch 3)
-      (mkSeqNonce 5)
-      (BlocksMade $ Map.singleton (hk alicePool) 1)
-      (BlocksMade Map.empty)
-      (EpochState (acntEx2E { _treasury = 33}) snapsEx2G expectedLSEx2G ppsEx1)
-      Nothing
-      pdEx2F
-      epoch1OSchedEx2G
-  , mkSeqNonce 7
-  , mkSeqNonce 7
-  , blockEx2GHash
-  , Slot 310
-  )
+expectedStEx2G = ChainState
+  (NewEpochState
+     (Epoch 3)
+     (mkSeqNonce 5)
+     (BlocksMade $ Map.singleton (hk alicePool) 1)
+     (BlocksMade Map.empty)
+     (EpochState (acntEx2E { _treasury = 33}) snapsEx2G expectedLSEx2G ppsEx1)
+     Nothing
+     pdEx2F
+     epoch1OSchedEx2G)
+  (mkSeqNonce 7)
+  (mkSeqNonce 7)
+  blockEx2GHash
+  (Slot 310)
 
 ex2G :: CHAINExample
 ex2G = CHAINExample (Slot 310) expectedStEx2F blockEx2G expectedStEx2G
@@ -1006,25 +994,24 @@ rewardsEx2H = Map.fromList [ (RewardAcnt aliceSHK, aliceRAcnt2H)
                           , (RewardAcnt bobSHK, bobRAcnt2H) ]
 
 expectedStEx2H :: ChainState
-expectedStEx2H =
-  ( NewEpochState
-      (Epoch 3)
-      (mkSeqNonce 5)
-      (BlocksMade $ Map.singleton (hk alicePool) 1)
-      (BlocksMade Map.empty)
-      (EpochState (acntEx2E { _treasury = Coin 33 }) snapsEx2G expectedLSEx2G ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 9374400000011
-                         , deltaR = Coin (-9450000000000)
-                         , rs = rewardsEx2H
-                         , deltaF = Coin (-10)
-                         })
-      pdEx2F
-      epoch1OSchedEx2G
-  , mkSeqNonce 8
-  , mkSeqNonce 7
-  , blockEx2HHash
-  , Slot 390
-  )
+expectedStEx2H = ChainState
+  (NewEpochState
+     (Epoch 3)
+     (mkSeqNonce 5)
+     (BlocksMade $ Map.singleton (hk alicePool) 1)
+     (BlocksMade Map.empty)
+     (EpochState (acntEx2E { _treasury = Coin 33 }) snapsEx2G expectedLSEx2G ppsEx1)
+     (Just RewardUpdate { deltaT = Coin 9374400000011
+                        , deltaR = Coin (-9450000000000)
+                        , rs = rewardsEx2H
+                        , deltaF = Coin (-10)
+                        })
+     pdEx2F
+     epoch1OSchedEx2G)
+  (mkSeqNonce 8)
+  (mkSeqNonce 7)
+  blockEx2HHash
+  (Slot 390)
 
 ex2H :: CHAINExample
 ex2H = CHAINExample (Slot 390) expectedStEx2G blockEx2H expectedStEx2H
@@ -1083,21 +1070,20 @@ snapsEx2I = snapsEx2G { _pstakeMark =
                       }
 
 expectedStEx2I :: ChainState
-expectedStEx2I =
-  ( NewEpochState
-      (Epoch 4)
-      (mkSeqNonce 7)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2I snapsEx2I expectedLSEx2I ppsEx1)
-      Nothing
-      pdEx2F
-      epoch1OSchedEx2I
-  , mkSeqNonce 9
-  , mkSeqNonce 9
-  , blockEx2IHash
-  , Slot 410
-  )
+expectedStEx2I = ChainState
+  (NewEpochState
+     (Epoch 4)
+     (mkSeqNonce 7)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2I snapsEx2I expectedLSEx2I ppsEx1)
+     Nothing
+     pdEx2F
+     epoch1OSchedEx2I)
+  (mkSeqNonce 9)
+  (mkSeqNonce 9)
+  blockEx2IHash
+  (Slot 410)
 
 ex2I :: CHAINExample
 ex2I = CHAINExample (Slot 410) expectedStEx2H blockEx2I expectedStEx2I
@@ -1167,21 +1153,20 @@ expectedLSEx2J = LedgerState
                0
 
 expectedStEx2J :: ChainState
-expectedStEx2J =
-  ( NewEpochState
-      (Epoch 4)
-      (mkSeqNonce 7)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2I snapsEx2I expectedLSEx2J ppsEx1)
-      Nothing
-      pdEx2F
-      epoch1OSchedEx2I
-  , mkSeqNonce 10
-  , mkSeqNonce 10
-  , blockEx2JHash
-  , Slot 420
-  )
+expectedStEx2J = ChainState
+  (NewEpochState
+     (Epoch 4)
+     (mkSeqNonce 7)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2I snapsEx2I expectedLSEx2J ppsEx1)
+     Nothing
+     pdEx2F
+     epoch1OSchedEx2I)
+  (mkSeqNonce 10)
+  (mkSeqNonce 10)
+  blockEx2JHash
+  (Slot 420)
 
 ex2J :: CHAINExample
 ex2J = CHAINExample (Slot 420) expectedStEx2I blockEx2J expectedStEx2J
@@ -1242,25 +1227,24 @@ expectedLSEx2K = LedgerState
 
 
 expectedStEx2K :: ChainState
-expectedStEx2K =
-  ( NewEpochState
-      (Epoch 4)
-      (mkSeqNonce 7)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2I snapsEx2I expectedLSEx2K ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 9
-                         , deltaR = Coin 0
-                         , rs = Map.empty
-                         , deltaF = Coin (-9)
-                         })
-      pdEx2F
-      epoch1OSchedEx2I
-  , mkSeqNonce 11
-  , mkSeqNonce 10
-  , blockEx2KHash
-  , Slot 490
-  )
+expectedStEx2K = ChainState
+  (NewEpochState
+     (Epoch 4)
+     (mkSeqNonce 7)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2I snapsEx2I expectedLSEx2K ppsEx1)
+     (Just RewardUpdate { deltaT = Coin 9
+                        , deltaR = Coin 0
+                        , rs = Map.empty
+                        , deltaF = Coin (-9)
+                        })
+     pdEx2F
+     epoch1OSchedEx2I)
+  (mkSeqNonce 11)
+  (mkSeqNonce 10)
+  blockEx2KHash
+  (Slot 490)
 
 ex2K :: CHAINExample
 ex2K = CHAINExample (Slot 490) expectedStEx2J blockEx2K expectedStEx2K
@@ -1315,21 +1299,20 @@ expectedLSEx2L = LedgerState
                0
 
 expectedStEx2L :: ChainState
-expectedStEx2L =
-  ( NewEpochState
-      (Epoch 5)
-      (mkSeqNonce 10)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2L snapsEx2L expectedLSEx2L ppsEx1)
-      Nothing
-      pdEx2F
-      (overlaySchedule (Epoch 5) (Map.keysSet dms) (mkSeqNonce 10) ppsEx1)
-  , mkSeqNonce 12
-  , mkSeqNonce 12
-  , blockEx2LHash
-  , Slot 510
-  )
+expectedStEx2L = ChainState
+  (NewEpochState
+     (Epoch 5)
+     (mkSeqNonce 10)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2L snapsEx2L expectedLSEx2L ppsEx1)
+     Nothing
+     pdEx2F
+     (overlaySchedule (Epoch 5) (Map.keysSet dms) (mkSeqNonce 10) ppsEx1))
+  (mkSeqNonce 12)
+  (mkSeqNonce 12)
+  blockEx2LHash
+  (Slot 510)
 
 ex2L :: CHAINExample
 ex2L = CHAINExample (Slot 510) expectedStEx2K blockEx2L expectedStEx2L
@@ -1384,15 +1367,12 @@ blockEx3A = mkBlock
              zero
              0
 
-updateStEx3A :: ( PPUpdate
-               , AVUpdate
-               , Map Slot Applications
-               , Applications)
-updateStEx3A =
-  ( ppupEx3A
-  , AVUpdate Map.empty
-  , Map.empty
-  , byronApps)
+updateStEx3A :: UpdateState
+updateStEx3A = UpdateState
+  ppupEx3A
+  (AVUpdate Map.empty)
+  Map.empty
+  byronApps
 
 expectedLSEx3A :: LedgerState
 expectedLSEx3A = LedgerState
@@ -1411,21 +1391,20 @@ blockEx3AHash :: HashHeader
 blockEx3AHash = bhHash (bheader blockEx3A)
 
 expectedStEx3A :: ChainState
-expectedStEx3A =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A emptySnapShots expectedLSEx3A ppsEx1)
-      Nothing
-      (PoolDistr Map.empty)
-      overlayEx2A
-  , Nonce 0 ⭒ Nonce 1
-  , Nonce 0 ⭒ Nonce 1
-  , blockEx3AHash
-  , Slot 10
-  )
+expectedStEx3A = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A emptySnapShots expectedLSEx3A ppsEx1)
+     Nothing
+     (PoolDistr Map.empty)
+     overlayEx2A)
+  (Nonce 0 ⭒ Nonce 1)
+  (Nonce 0 ⭒ Nonce 1)
+  blockEx3AHash
+  (Slot 10)
 
 ex3A :: CHAINExample
 ex3A = CHAINExample (Slot 10) initStEx2A blockEx3A expectedStEx3A
@@ -1474,15 +1453,12 @@ blockEx3B = mkBlock
              zero
              0
 
-updateStEx3B :: ( PPUpdate
-               , AVUpdate
-               , Map Slot Applications
-               , Applications)
-updateStEx3B =
-  ( ppupEx3A `updatePPup` ppupEx3B
-  , AVUpdate Map.empty
-  , Map.empty
-  , byronApps)
+updateStEx3B :: UpdateState
+updateStEx3B = UpdateState
+  (ppupEx3A `updatePPup` ppupEx3B)
+  (AVUpdate Map.empty)
+  Map.empty
+  byronApps
 
 utxoEx3B :: UTxO
 utxoEx3B = UTxO . Map.fromList $
@@ -1504,21 +1480,20 @@ blockEx3BHash :: HashHeader
 blockEx3BHash = bhHash (bheader blockEx3B)
 
 expectedStEx3B :: ChainState
-expectedStEx3B =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A emptySnapShots expectedLSEx3B ppsEx1)
-      Nothing
-      (PoolDistr Map.empty)
-      overlayEx2A
-  , mkSeqNonce 2
-  , mkSeqNonce 2
-  , blockEx3BHash
-  , Slot 20
-  )
+expectedStEx3B = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A emptySnapShots expectedLSEx3B ppsEx1)
+     Nothing
+     (PoolDistr Map.empty)
+     overlayEx2A)
+  (mkSeqNonce 2)
+  (mkSeqNonce 2)
+  blockEx3BHash
+  (Slot 20)
 
 ex3B :: CHAINExample
 ex3B = CHAINExample (Slot 20) expectedStEx3A blockEx3B expectedStEx3B
@@ -1566,21 +1541,20 @@ ppsEx3C = ppsEx1 { _poolDeposit = Coin 200 }
 -- Note that _extraEntropy is still NeutralSeed
 
 expectedStEx3C :: ChainState
-expectedStEx3C =
-  ( NewEpochState
-      (Epoch 1)
-      (mkSeqNonce 2 ⭒ Nonce 123)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A snapsEx3C expectedLSEx3C ppsEx3C)
-      Nothing
-      (PoolDistr Map.empty)
-      overlayEx3C
-  , mkSeqNonce 3
-  , mkSeqNonce 3
-  , blockEx3CHash
-  , Slot 110
-  )
+expectedStEx3C = ChainState
+  (NewEpochState
+     (Epoch 1)
+     (mkSeqNonce 2 ⭒ Nonce 123)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A snapsEx3C expectedLSEx3C ppsEx3C)
+     Nothing
+     (PoolDistr Map.empty)
+     overlayEx3C)
+  (mkSeqNonce 3)
+  (mkSeqNonce 3)
+  blockEx3CHash
+  (Slot 110)
 
 ex3C :: CHAINExample
 ex3C = CHAINExample (Slot 110) expectedStEx3B blockEx3C expectedStEx3C
@@ -1642,15 +1616,12 @@ blockEx4A = mkBlock
              zero
              0
 
-updateStEx4A :: ( PPUpdate
-               , AVUpdate
-               , Map Slot Applications
-               , Applications)
-updateStEx4A =
-  ( PPUpdate Map.empty
-  , avupEx4A
-  , Map.empty
-  , byronApps)
+updateStEx4A :: UpdateState
+updateStEx4A = UpdateState
+  (PPUpdate Map.empty)
+  avupEx4A
+  Map.empty
+  byronApps
 
 expectedLSEx4A :: LedgerState
 expectedLSEx4A = LedgerState
@@ -1669,21 +1640,20 @@ blockEx4AHash :: HashHeader
 blockEx4AHash = bhHash (bheader blockEx4A)
 
 expectedStEx4A :: ChainState
-expectedStEx4A =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A emptySnapShots expectedLSEx4A ppsEx1)
-      Nothing
-      (PoolDistr Map.empty)
-      overlayEx2A
-  , Nonce 0 ⭒ Nonce 1
-  , Nonce 0 ⭒ Nonce 1
-  , blockEx4AHash
-  , Slot 10
-  )
+expectedStEx4A = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A emptySnapShots expectedLSEx4A ppsEx1)
+     Nothing
+     (PoolDistr Map.empty)
+     overlayEx2A)
+  (Nonce 0 ⭒ Nonce 1)
+  (Nonce 0 ⭒ Nonce 1)
+  blockEx4AHash
+  (Slot 10)
 
 ex4A :: CHAINExample
 ex4A = CHAINExample (Slot 10) initStEx2A blockEx4A expectedStEx4A
@@ -1731,15 +1701,12 @@ blockEx4B = mkBlock
              zero
              0
 
-updateStEx4B :: ( PPUpdate
-               , AVUpdate
-               , Map Slot Applications
-               , Applications)
-updateStEx4B =
-  ( PPUpdate Map.empty
-  , AVUpdate Map.empty
-  , Map.singleton (Slot 53) appsEx4A
-  , byronApps)
+updateStEx4B :: UpdateState
+updateStEx4B = UpdateState
+  (PPUpdate Map.empty)
+  (AVUpdate Map.empty)
+  (Map.singleton (Slot 53) appsEx4A)
+  byronApps
 
 utxoEx4B :: UTxO
 utxoEx4B = UTxO . Map.fromList $
@@ -1761,21 +1728,20 @@ blockEx4BHash :: HashHeader
 blockEx4BHash = bhHash (bheader blockEx4B)
 
 expectedStEx4B :: ChainState
-expectedStEx4B =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A emptySnapShots expectedLSEx4B ppsEx1)
-      Nothing
-      (PoolDistr Map.empty)
-      overlayEx2A
-  , mkSeqNonce 2
-  , mkSeqNonce 2
-  , blockEx4BHash
-  , Slot 20
-  )
+expectedStEx4B = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A emptySnapShots expectedLSEx4B ppsEx1)
+     Nothing
+     (PoolDistr Map.empty)
+     overlayEx2A)
+  (mkSeqNonce 2)
+  (mkSeqNonce 2)
+  blockEx4BHash
+  (Slot 20)
 
 ex4B :: CHAINExample
 ex4B = CHAINExample (Slot 20) expectedStEx4A blockEx4B expectedStEx4B
@@ -1795,19 +1761,15 @@ blockEx4C = mkBlock
              zero
              0
 
-updateStEx4C :: ( PPUpdate
-               , AVUpdate
-               , Map Slot Applications
-               , Applications)
-updateStEx4C =
-  ( PPUpdate Map.empty
-  , AVUpdate Map.empty
-  , Map.empty
-  , Applications $ Map.fromList
+updateStEx4C :: UpdateState
+updateStEx4C = UpdateState
+  (PPUpdate Map.empty)
+  (AVUpdate Map.empty)
+  Map.empty
+  (Applications $ Map.fromList
                      [ (ApName $ pack "Daedalus", (ApVer 17, daedalusMDEx4A))
                      , (ApName $ pack "Yoroi", (ApVer 4, Mdt Map.empty))
-                     ]
-  )
+                     ])
 
 expectedLSEx4C :: LedgerState
 expectedLSEx4C = LedgerState
@@ -1818,29 +1780,29 @@ expectedLSEx4C = LedgerState
                  updateStEx4C)
                (DPState dsEx1 psEx1)
                0
+
 blockEx4CHash :: HashHeader
 blockEx4CHash = bhHash (bheader blockEx4C)
 
 expectedStEx4C :: ChainState
-expectedStEx4C =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A emptySnapShots expectedLSEx4C ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 0
-                         , deltaR = Coin 0
-                         , rs     = Map.empty
+expectedStEx4C = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A emptySnapShots expectedLSEx4C ppsEx1)
+     (Just RewardUpdate { deltaT = Coin 0
+                        , deltaR = Coin 0
+                        , rs     = Map.empty
                          , deltaF = Coin 0
                          })
       (PoolDistr Map.empty)
-      overlayEx2A
-  , mkSeqNonce 3
-  , mkSeqNonce 3
-  , blockEx4CHash
-  , Slot 60
-  )
+      overlayEx2A)
+  (mkSeqNonce 3)
+  (mkSeqNonce 3)
+  blockEx4CHash
+  (Slot 60)
 
 
 ex4C :: CHAINExample
@@ -1903,26 +1865,25 @@ expectedLSEx5A = LedgerState
                  utxoEx5A
                  (Coin 0)
                  (Coin 1)
-                 (PPUpdate Map.empty , AVUpdate Map.empty , Map.empty , byronApps))
+                 (UpdateState (PPUpdate Map.empty) (AVUpdate Map.empty) Map.empty byronApps))
                (DPState dsEx5A psEx1)
                0
 
 expectedStEx5A :: ChainState
-expectedStEx5A =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A emptySnapShots expectedLSEx5A ppsEx1)
-      Nothing
-      (PoolDistr Map.empty)
-      overlayEx2A
-  , Nonce 0 ⭒ Nonce 1
-  , Nonce 0 ⭒ Nonce 1
-  , blockEx5AHash
-  , Slot 10
-  )
+expectedStEx5A = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A emptySnapShots expectedLSEx5A ppsEx1)
+     Nothing
+     (PoolDistr Map.empty)
+     overlayEx2A)
+  (Nonce 0 ⭒ Nonce 1)
+  (Nonce 0 ⭒ Nonce 1)
+  blockEx5AHash
+  (Slot 10)
 
 ex5A :: CHAINExample
 ex5A = CHAINExample (Slot 10) initStEx2A blockEx5A expectedStEx5A
@@ -1965,30 +1926,29 @@ expectedLSEx5B = LedgerState
                  utxoEx5A
                  (Coin 0)
                  (Coin 1)
-                 (PPUpdate Map.empty , AVUpdate Map.empty , Map.empty , byronApps))
+                 (UpdateState (PPUpdate Map.empty) (AVUpdate Map.empty) Map.empty byronApps))
                (DPState dsEx5B psEx5B)
                0
 
 expectedStEx5B :: ChainState
-expectedStEx5B =
-  ( NewEpochState
-      (Epoch 0)
-      (Nonce 0)
-      (BlocksMade Map.empty)
-      (BlocksMade Map.empty)
-      (EpochState acntEx2A emptySnapShots expectedLSEx5B ppsEx1)
-      (Just RewardUpdate { deltaT = Coin 0
-                         , deltaR = Coin 0
-                         , rs     = Map.empty
-                         , deltaF = Coin 0
-                         })
-      (PoolDistr Map.empty)
-      overlayEx2A
-  , mkSeqNonce 2
-  , mkSeqNonce 2
-  , blockEx5BHash
-  , Slot 50
-  )
+expectedStEx5B = ChainState
+  (NewEpochState
+     (Epoch 0)
+     (Nonce 0)
+     (BlocksMade Map.empty)
+     (BlocksMade Map.empty)
+     (EpochState acntEx2A emptySnapShots expectedLSEx5B ppsEx1)
+     (Just RewardUpdate { deltaT = Coin 0
+                        , deltaR = Coin 0
+                        , rs     = Map.empty
+                        , deltaF = Coin 0
+                        })
+     (PoolDistr Map.empty)
+     overlayEx2A)
+  (mkSeqNonce 2)
+  (mkSeqNonce 2)
+  blockEx5BHash
+  (Slot 50)
 
 ex5B :: CHAINExample
 ex5B = CHAINExample (Slot 50) expectedStEx5A blockEx5B expectedStEx5B

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -100,6 +100,8 @@ type NewEpochState = LedgerState.NewEpochState ShortHash MockDSIGN
 
 type RewardUpdate = LedgerState.RewardUpdate ShortHash MockDSIGN
 
+type ChainState = STS.Chain.ChainState ShortHash MockDSIGN MockKES
+
 type CHAIN = STS.Chain.CHAIN ShortHash MockDSIGN MockKES
 
 type UTXOW = STS.Utxow.UTXOW ShortHash MockDSIGN
@@ -132,6 +134,8 @@ type Mdt = Updates.Mdt ShortHash
 type Applications = Updates.Applications ShortHash
 
 type Update = Updates.Update ShortHash MockDSIGN
+
+type UpdateState = Updates.UpdateState ShortHash MockDSIGN
 
 type PPUpdate = Updates.PPUpdate ShortHash MockDSIGN
 

--- a/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
@@ -27,6 +27,7 @@ import           MockTypes (Addr, KeyPair, LedgerState, MultiSig, ScriptHash, Tx
                      TxIn, UTXOW, UTxOState, Wdrl)
 import           PParams (PParams (..), emptyPParams)
 import           Slot (Slot (..))
+import           STS.Utxo (UtxoEnv (..))
 import           Tx (hashScript)
 import           TxData (pattern AddrBase, pattern KeyHashObj, pattern RequireAllOf,
                      pattern RequireAnyOf, pattern RequireMOf, pattern RequireSignature,
@@ -127,11 +128,12 @@ initialUTxOState aliceKeep msigs =
   let tx = makeTx (initTxBody addresses)
                   [alicePay, bobPay]
                   Map.empty in
-  (txid $ _body tx, applySTS @UTXOW (TRC( (Slot 0
-                                           , initPParams
-                                           , StakeKeys Map.empty
-                                           , StakePools Map.empty
-                                           , Dms Map.empty)
+  (txid $ _body tx, applySTS @UTXOW (TRC( UtxoEnv
+                                           (Slot 0)
+                                           initPParams
+                                           (StakeKeys Map.empty)
+                                           (StakePools Map.empty)
+                                           (Dms Map.empty)
                                          , _utxoState genesis
                                          , tx)))
 
@@ -163,10 +165,11 @@ applyTxWithScript lockScripts unlockScripts wdrl aliceKeep signers = utxoSt'
               txbody
               signers
               (Map.fromList $ map (\scr -> (hashScript scr, scr)) unlockScripts)
-        utxoSt' = applySTS @UTXOW (TRC( (Slot 0
-                                        , initPParams
-                                        , StakeKeys Map.empty
-                                        , StakePools Map.empty
-                                        , Dms Map.empty)
+        utxoSt' = applySTS @UTXOW (TRC( UtxoEnv
+                                          (Slot 0)
+                                          initPParams
+                                          (StakeKeys Map.empty)
+                                          (StakePools Map.empty)
+                                          (Dms Map.empty)
                                       , utxoSt
                                       , tx))

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestDeleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestDeleg.hs
@@ -31,13 +31,13 @@ import           Ledger.Core (dom, range, (∈), (∉), (◁))
 -------------------------------
 
 getStDelegs :: DState -> Set StakeCredential
-getStDelegs l = dom $ _stKeys l
+getStDelegs = dom . _stKeys
 
 getRewards :: DState -> Map RewardAcnt Coin
-getRewards l = _rewards l
+getRewards = _rewards
 
 getDelegations :: DState -> Map StakeCredential KeyHash
-getDelegations l = _delegations l
+getDelegations = _delegations
 
 ------------------------------
 -- Constants for Properties --
@@ -68,7 +68,7 @@ rewardZeroAfterReg = withTests (fromIntegral numberOfTests) . property $ do
   where credNewlyRegisteredAndRewardZero (d, RegKey hk, d') =
           (hk ∉ getStDelegs d) ==>
           (   hk ∈ getStDelegs d'
-           && (Maybe.maybe True (== 0) $ Map.lookup (mkRwdAcnt hk) (getRewards d')))
+           && Maybe.maybe True (== 0) (Map.lookup (mkRwdAcnt hk) (getRewards d')))
         credNewlyRegisteredAndRewardZero (_, _, _) = True
 
 -- | Check that when a stake credential is deregistered, it will not be in the
@@ -104,7 +104,7 @@ credentialMappingAfterDelegation = withTests (fromIntegral numberOfTests) . prop
     [] === filter (not . delegatedCredential) tr
 
   where delegatedCredential (_, Delegate (Delegation cred to), d') =
-          let credImage = range ((Set.singleton cred) ◁ (getDelegations d')) in
+          let credImage = range (Set.singleton cred ◁ getDelegations d') in
              cred ∈ getStDelegs d'
           && to ∈ credImage
           && Set.size credImage == 1

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestPool.hs
@@ -20,6 +20,7 @@ import           LedgerState (_retiring, _stPools)
 import           MockTypes (KeyHash, POOL, PState, StakePools)
 import           PParams (_eMax)
 import           Slot (Epoch (..), epochFromSlot)
+import           STS.Pool (PoolEnv (..))
 import           TxData (pattern KeyHashObj, pattern RegPool, pattern RetirePool,
                      pattern StakePools)
 
@@ -31,10 +32,10 @@ import           Ledger.Core (dom, (∈), (∉))
 -------------------------------
 
 getRetiring :: PState -> Map KeyHash Epoch
-getRetiring p = _retiring p
+getRetiring = _retiring
 
 getStPools :: PState -> StakePools
-getStPools p = _stPools p
+getStPools = _stPools
 
 ------------------------------
 -- Constants for Properties --
@@ -80,10 +81,10 @@ poolRetireInEpoch = withTests (fromIntegral numberOfTests) . property $ do
     n :: Integer
     n = fromIntegral $ traceLength t
     tr = sourceSignalTargets t
-    (s, pp) = _traceEnv t
+    PoolEnv s pp = _traceEnv t
 
   when (n > 1) $
-    [] === filter (not . (registeredPoolRetired s pp)) tr
+    [] === filter (not . registeredPoolRetired s pp) tr
 
   where registeredPoolRetired s pp (p, c@(RetirePool _ e), p') =
           case cwitness c of

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestPoolreap.hs
@@ -15,6 +15,7 @@ import           Control.State.Transition.Trace (sourceSignalTargets, traceLengt
 
 import           MockTypes (POOLREAP)
 import           TxData (pattern StakePools)
+import           STS.PoolReap (PoolreapState (..))
 
 import           Rules.TestPool (getRetiring, getStPools)
 
@@ -47,13 +48,13 @@ removedAfterPoolreap = withTests (fromIntegral numberOfTests) . property $ do
   when (n > 1) $
     [] === filter (not . poolRemoved) tr
 
-  where poolRemoved ((_, _, p), e, (_, _, p')) =
+  where poolRemoved (PoolreapState _ _ p, e, PoolreapState _ _ p') =
           let StakePools stp  = getStPools p
               StakePools stp' = getStPools p'
               retiring        = getRetiring p
               retiring'       = getRetiring p'
               retire          = dom $ retiring ▷ Set.singleton e in
              (not . null) retire
-          && (retire `Set.isSubsetOf` (dom stp))
-          && Set.null (retire `Set.intersection` (dom $ stp'))
-          && Set.null (retire `Set.intersection` (dom $ retiring'))
+          && (retire `Set.isSubsetOf` dom stp)
+          && Set.null (retire `Set.intersection` dom stp')
+          && Set.null (retire `Set.intersection` dom retiring')

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -19,7 +19,7 @@ import           BaseTypes (Seed (..), (⭒))
 import           Control.State.Transition (TRC (..), applySTS)
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import           Slot (Slot (..))
-import           STS.Updn (UPDN)
+import           STS.Updn (UPDN, UpdnState (..))
 import           STS.Utxow (PredicateFailure (..))
 import           Tx (hashScript)
 import           TxData (pattern RewardAcnt, pattern ScriptHashObj)
@@ -33,9 +33,9 @@ import           TxData (pattern RewardAcnt, pattern ScriptHashObj)
 testUPNEarly :: Assertion
 testUPNEarly =
   let
-    st = applySTS @UPDN (TRC (Nonce 1, (Nonce 2, Nonce 3), Slot.Slot 5))
+    st = applySTS @UPDN (TRC (Nonce 1, UpdnState (Nonce 2) (Nonce 3), Slot.Slot 5))
   in
-    st @?= Right (Nonce 2 ⭒ Nonce 1, Nonce 2 ⭒ Nonce 1)
+    st @?= Right (UpdnState (Nonce 2 ⭒ Nonce 1) (Nonce 2 ⭒ Nonce 1))
 
 -- | The UPDN transition should update only the evolving nonce
 -- in the last thirds of the epoch.
@@ -43,9 +43,9 @@ testUPNEarly =
 testUPNLate :: Assertion
 testUPNLate =
   let
-    st = applySTS @UPDN (TRC (Nonce 1, (Nonce 2, Nonce 3), Slot.Slot 85))
+    st = applySTS @UPDN (TRC (Nonce 1, UpdnState (Nonce 2) (Nonce 3), Slot.Slot 85))
   in
-    st @?= Right (SeedOp (Nonce 2) (Nonce 1), Nonce 3)
+    st @?= Right (UpdnState (SeedOp (Nonce 2) (Nonce 1)) (Nonce 3))
 
 testCHAINExample :: CHAINExample -> Assertion
 testCHAINExample (CHAINExample slotNow initSt block expectedSt) =


### PR DESCRIPTION
All the tuples used for environments and states in the STS rules have all been replaced with data types.

I had to touch the examples, but only because `ChainState` is now a data type and not a type alias for a tuple.

closes #686 