### PR TITLE
[#788][#817] Add goblins to signal tampering functions

### DIFF
--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
@@ -13,6 +13,9 @@ module Cardano.Ledger.Spec.STS.UTXOW where
 
 import           Data.Data (Data, Typeable)
 import qualified Data.Map as Map
+import           Hedgehog (Gen)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 import           Control.State.Transition (Embed, Environment, IRC (IRC), PredicateFailure, STS,
                      Signal, State, TRC (TRC), initialRules, judgmentContext, trans,
@@ -128,3 +131,8 @@ mkGoblinGens
   , "UtxoFailure_InputsNotInUTxO"
   , "UtxoFailure_NonPositiveOutputs"
   ]
+
+tamperedTxWitsList :: UTxOEnv -> UTxOState -> Gen [TxWits]
+tamperedTxWitsList env st = do
+  gen <- Gen.element (map (\sg -> sg env st) goblinGensUTXOW)
+  Gen.list (Range.linear 0 10) gen

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,7 +23,7 @@ extra-deps:
     - cardano-crypto-class
 
 - git: https://github.com/input-output-hk/goblins
-  commit: 2d922d01289f926295f3b2d515138510b87768dc
+  commit: b5e99cf153a3abb1b764f80095f6a930ba056048
 - moo-1.2
 - gray-code-0.3.1
 


### PR DESCRIPTION
This uses the goblin genomes to tamper with generators. We expose functions which will be used in `cardano-ledger` conformance tests.