### PR TITLE
fix pool cent refund accounting

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -35,7 +35,7 @@ import           Delegation.Certificates (StakeKeys (..), StakePools (..), decay
                      refund)
 import           Keys (KeyHash)
 import           PParams (PParams (..))
-import           Slot (Epoch, Slot, slotFromEpoch, (-*))
+import           Slot (Slot, (-*))
 import           TxData (Addr (..), PoolParams, Ptr, RewardAcnt, StakeCredential, TxOut (..),
                      getRwdCred)
 import           UTxO (UTxO (..))
@@ -134,13 +134,13 @@ poolStake hk delegs (Stake stake) =
 -- | Calculate pool refunds
 poolRefunds
   :: PParams
-  -> Map (KeyHash hashAlgo dsignAlgo) Epoch
+  -> Map (KeyHash hashAlgo dsignAlgo) Slot
   -> Slot
   -> Map (KeyHash hashAlgo dsignAlgo) Coin
 poolRefunds pp retirees cslot =
   Map.map
-    (\e ->
-       refund pval pmin lambda (cslot -* slotFromEpoch e))
+    (\s ->
+       refund pval pmin lambda (cslot -* s))
     retirees
   where
     (pval, pmin, lambda) = decayPool pp

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -28,6 +28,7 @@ module LedgerState
   , EpochState(..)
   , emptyEpochState
   , emptyLedgerState
+  , emptyUTxOState
   , clearPpup
   , dstate
   , pstate
@@ -284,6 +285,9 @@ data EpochState hashAlgo dsignAlgo
       PParams
   deriving (Show, Eq)
 
+emptyUTxOState :: UTxOState hashAlgo dsignAlgo
+emptyUTxOState = UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState
+
 emptyEpochState :: EpochState hashAlgo dsignAlgo
 emptyEpochState =
   EpochState emptyAccount emptySnapShots emptyLedgerState  emptyPParams
@@ -291,7 +295,7 @@ emptyEpochState =
 emptyLedgerState :: LedgerState hashAlgo dsignAlgo
 emptyLedgerState =
   LedgerState
-  (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState)
+  emptyUTxOState
   emptyDelegation
   0
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
@@ -68,16 +68,16 @@ epochTransition = do
   let DPState ds ps = _delegationState ls
   SnapState ss' us' <-
     trans @(SNAP hashAlgo dsignAlgo) $ TRC (SnapEnv pp ds ps, SnapState ss us, e)
-  PoolreapState as' ds' ps' <-
-    trans @(POOLREAP hashAlgo dsignAlgo) $ TRC (pp, PoolreapState as ds ps, e)
+  PoolreapState us'' as' ds' ps' <-
+    trans @(POOLREAP hashAlgo dsignAlgo) $ TRC (pp, PoolreapState us' as ds ps, e)
   let ppNew = votedValuePParams ppup pp
-  NewppState us'' as'' pp' <-
+  NewppState us''' as'' pp' <-
     trans @(NEWPP hashAlgo dsignAlgo)
-      $ TRC (NewppEnv ppNew ds' ps', NewppState us' as' pp, e)
+      $ TRC (NewppEnv ppNew ds' ps', NewppState us'' as' pp, e)
   pure $ EpochState
     as''
     ss'
-    (ls { _utxoState = us'', _delegationState = DPState ds' ps' })
+    (ls { _utxoState = us''', _delegationState = DPState ds' ps' })
     pp'
 
 instance Embed (SNAP hashAlgo dsignAlgo) (EPOCH hashAlgo dsignAlgo) where

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestPoolreap.hs
@@ -14,8 +14,8 @@ import           Control.State.Transition.Generator (trace)
 import           Control.State.Transition.Trace (sourceSignalTargets, traceLength)
 
 import           MockTypes (POOLREAP)
-import           TxData (pattern StakePools)
 import           STS.PoolReap (PoolreapState (..))
+import           TxData (pattern StakePools)
 
 import           Rules.TestPool (getRetiring, getStPools)
 
@@ -48,7 +48,7 @@ removedAfterPoolreap = withTests (fromIntegral numberOfTests) . property $ do
   when (n > 1) $
     [] === filter (not . poolRemoved) tr
 
-  where poolRemoved (PoolreapState _ _ p, e, PoolreapState _ _ p') =
+  where poolRemoved (PoolreapState _ _ _ p, e, PoolreapState _ _ _ p') =
           let StakePools stp  = getStPools p
               StakePools stp' = getStPools p'
               retiring        = getRetiring p

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -10,7 +10,7 @@ import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
-                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B)
+                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, maxLovelaceSupply)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -19,6 +19,7 @@ import           BaseTypes (Seed (..), (⭒))
 import           Control.State.Transition (TRC (..), applySTS)
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import           Slot (Slot (..))
+import           STS.Chain (totalAda)
 import           STS.Updn (UPDN, UpdnState (..))
 import           STS.Utxow (PredicateFailure (..))
 import           Tx (hashScript)
@@ -51,106 +52,59 @@ testCHAINExample :: CHAINExample -> Assertion
 testCHAINExample (CHAINExample slotNow initSt block expectedSt) =
   checkTrace @CHAIN slotNow $ pure initSt .- block .-> expectedSt
 
-testCHAINExample1 :: Assertion
-testCHAINExample1 = testCHAINExample ex1
-
-testCHAINExample2A :: Assertion
-testCHAINExample2A = testCHAINExample ex2A
-
-testCHAINExample2B :: Assertion
-testCHAINExample2B = testCHAINExample ex2B
-
-testCHAINExample2C :: Assertion
-testCHAINExample2C = testCHAINExample ex2C
-
-testCHAINExample2Cbis :: Assertion
-testCHAINExample2Cbis = testCHAINExample ex2Cbis
-
-testCHAINExample2Cter :: Assertion
-testCHAINExample2Cter = testCHAINExample ex2Cter
-
-testCHAINExample2Cquater :: Assertion
-testCHAINExample2Cquater = testCHAINExample ex2Cquater
-
-testCHAINExample2D :: Assertion
-testCHAINExample2D = testCHAINExample ex2D
-
-testCHAINExample2E :: Assertion
-testCHAINExample2E = testCHAINExample ex2E
-
-testCHAINExample2F :: Assertion
-testCHAINExample2F = testCHAINExample ex2F
-
-testCHAINExample2G :: Assertion
-testCHAINExample2G = testCHAINExample ex2G
-
-testCHAINExample2H :: Assertion
-testCHAINExample2H = testCHAINExample ex2H
-
-testCHAINExample2I :: Assertion
-testCHAINExample2I = testCHAINExample ex2I
-
-testCHAINExample2J :: Assertion
-testCHAINExample2J = testCHAINExample ex2J
-
-testCHAINExample2K :: Assertion
-testCHAINExample2K = testCHAINExample ex2K
-
-testCHAINExample2L :: Assertion
-testCHAINExample2L = testCHAINExample ex2L
-
-testCHAINExample3A :: Assertion
-testCHAINExample3A = testCHAINExample ex3A
-
-testCHAINExample3B :: Assertion
-testCHAINExample3B = testCHAINExample ex3B
-
-testCHAINExample3C :: Assertion
-testCHAINExample3C = testCHAINExample ex3C
-
-testCHAINExample4A :: Assertion
-testCHAINExample4A = testCHAINExample ex4A
-
-testCHAINExample4B :: Assertion
-testCHAINExample4B = testCHAINExample ex4B
-
-testCHAINExample4C :: Assertion
-testCHAINExample4C = testCHAINExample ex4C
-
-testCHAINExample5A :: Assertion
-testCHAINExample5A = testCHAINExample ex5A
-
-testCHAINExample5B :: Assertion
-testCHAINExample5B = testCHAINExample ex5B
+testPreservationOfAda :: CHAINExample -> Assertion
+testPreservationOfAda (CHAINExample _ _ _ expectedSt) =
+  totalAda expectedSt @?= maxLovelaceSupply
 
 stsTests :: TestTree
 stsTests = testGroup "STS Tests"
   [ testCase "update nonce early in the epoch" testUPNEarly
   , testCase "update nonce late in the epoch" testUPNLate
-  , testCase "CHAIN example 1 - empty block" testCHAINExample1
-  , testCase "CHAIN example 2A - register stake key" testCHAINExample2A
-  , testCase "CHAIN example 2B - delegate stake and create reward update" testCHAINExample2B
-  , testCase "CHAIN example 2C - new epoch changes" testCHAINExample2C
-  , testCase "CHAIN example 2Cbis - as 2C but no decay" testCHAINExample2Cbis
-  , testCase "CHAIN example 2Cter - as 2C but full refund" testCHAINExample2Cter
-  , testCase "CHAIN example 2Cquater - as 2C but with instant decay" testCHAINExample2Cquater
-  , testCase "CHAIN example 2D - second reward update" testCHAINExample2D
-  , testCase "CHAIN example 2E - nonempty pool distr" testCHAINExample2E
-  , testCase "CHAIN example 2F - decentralized block" testCHAINExample2F
-  , testCase "CHAIN example 2G - prelude to the first nontrivial rewards" testCHAINExample2G
-  , testCase "CHAIN example 2H - create a nontrivial rewards" testCHAINExample2H
-  , testCase "CHAIN example 2I - apply a nontrivial rewards" testCHAINExample2I
-  , testCase "CHAIN example 2J - drain reward account and deregister" testCHAINExample2J
-  , testCase "CHAIN example 2K - stage stake pool retirement" testCHAINExample2K
-  , testCase "CHAIN example 2L - reap stake pool" testCHAINExample2L
-  , testCase "CHAIN example 3A - get 3/7 votes for a pparam update" testCHAINExample3A
-  , testCase "CHAIN example 3B - get 5/7 votes for a pparam update" testCHAINExample3B
-  , testCase "CHAIN example 3C - processes a pparam update" testCHAINExample3C
-  , testCase "CHAIN example 4A - get 3/7 votes for a version update" testCHAINExample4A
-  , testCase "CHAIN example 4B - create a future app version" testCHAINExample4B
-  , testCase "CHAIN example 4C - adopt a future app version" testCHAINExample4C
-  , testCase "CHAIN example 5A - stage genesis key delegation" testCHAINExample5A
-  , testCase "CHAIN example 5B - adopt genesis key delegation" testCHAINExample5B
+  , testCase "CHAIN example 1 - empty block" $ testCHAINExample ex1
+  , testCase "CHAIN example 2A - register stake key" $ testCHAINExample ex2A
+  , testCase "CHAIN example 2B - delegate stake and create reward update" $ testCHAINExample ex2B
+  , testCase "CHAIN example 2C - new epoch changes" $ testCHAINExample ex2C
+  , testCase "CHAIN example 2Cbis - as 2C but no decay" $ testCHAINExample ex2Cbis
+  , testCase "CHAIN example 2Cter - as 2C but full refund" $ testCHAINExample ex2Cter
+  , testCase "CHAIN example 2Cquater - as 2C but with instant decay" $ testCHAINExample ex2Cquater
+  , testCase "CHAIN example 2D - second reward update" $ testCHAINExample ex2D
+  , testCase "CHAIN example 2E - nonempty pool distr" $ testCHAINExample ex2E
+  , testCase "CHAIN example 2F - decentralized block" $ testCHAINExample ex2F
+  , testCase "CHAIN example 2G - prelude to the first nontrivial rewards" $ testCHAINExample ex2G
+  , testCase "CHAIN example 2H - create a nontrivial rewards" $ testCHAINExample ex2H
+  , testCase "CHAIN example 2I - apply a nontrivial rewards" $ testCHAINExample ex2I
+  , testCase "CHAIN example 2J - drain reward account and deregister" $ testCHAINExample ex2J
+  , testCase "CHAIN example 2K - stage stake pool retirement" $ testCHAINExample ex2K
+  , testCase "CHAIN example 2L - reap stake pool" $ testCHAINExample ex2L
+  , testCase "CHAIN example 3A - get 3/7 votes for a pparam update" $ testCHAINExample ex3A
+  , testCase "CHAIN example 3B - get 5/7 votes for a pparam update" $ testCHAINExample ex3B
+  , testCase "CHAIN example 3C - processes a pparam update" $ testCHAINExample ex3C
+  , testCase "CHAIN example 4A - get 3/7 votes for a version update" $ testCHAINExample ex4A
+  , testCase "CHAIN example 4B - create a future app version" $ testCHAINExample ex4B
+  , testCase "CHAIN example 4C - adopt a future app version" $ testCHAINExample ex4C
+  , testCase "CHAIN example 5A - stage genesis key delegation" $ testCHAINExample ex5A
+  , testCase "CHAIN example 5B - adopt genesis key delegation" $ testCHAINExample ex5B
+  , testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda ex1
+  , testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda ex2A
+  , testCase "CHAIN example 2B - Preservation of ADA" $ testPreservationOfAda ex2B
+  , testCase "CHAIN example 2C - Preservation of ADA" $ testPreservationOfAda ex2C
+  , testCase "CHAIN example 2D - Preservation of ADA" $ testPreservationOfAda ex2D
+  , testCase "CHAIN example 2E - Preservation of ADA" $ testPreservationOfAda ex2E
+  , testCase "CHAIN example 2F - Preservation of ADA" $ testPreservationOfAda ex2F
+  , testCase "CHAIN example 2G - Preservation of ADA" $ testPreservationOfAda ex2G
+  , testCase "CHAIN example 2H - Preservation of ADA" $ testPreservationOfAda ex2H
+  , testCase "CHAIN example 2I - Preservation of ADA" $ testPreservationOfAda ex2I
+  , testCase "CHAIN example 2J - Preservation of ADA" $ testPreservationOfAda ex2J
+  , testCase "CHAIN example 2K - Preservation of ADA" $ testPreservationOfAda ex2K
+  , testCase "CHAIN example 2L - Preservation of ADA" $ testPreservationOfAda ex2L
+  , testCase "CHAIN example 3A - Preservation of ADA" $ testPreservationOfAda ex3A
+  , testCase "CHAIN example 3B - Preservation of ADA" $ testPreservationOfAda ex3B
+  , testCase "CHAIN example 3C - Preservation of ADA" $ testPreservationOfAda ex3C
+  , testCase "CHAIN example 4A - Preservation of ADA" $ testPreservationOfAda ex4A
+  , testCase "CHAIN example 4B - Preservation of ADA" $ testPreservationOfAda ex4B
+  , testCase "CHAIN example 4C - Preservation of ADA" $ testPreservationOfAda ex4C
+  , testCase "CHAIN example 5A - Preservation of ADA" $ testPreservationOfAda ex5A
+  , testCase "CHAIN example 5B - Preservation of ADA" $ testPreservationOfAda ex5B
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
   , testCase "Everybody signs in multi-sig" testEverybodySigns

--- a/shelley/chain-and-ledger/formal-spec/Makefile
+++ b/shelley/chain-and-ledger/formal-spec/Makefile
@@ -6,7 +6,7 @@
 
 # Document name
 ifndef DOCNAME
-	DOCNAME = ledger-spec multi-sig
+	DOCNAME = ledger-spec
 endif
 
 # You want latexmk to *always* run, because make does not have all the info.

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -464,6 +464,7 @@ which is responsible for removing pools slated for retirement in the given epoch
     \PlReapState =
     \left(
       \begin{array}{r@{~\in~}ll}
+        \var{utxoSt} & \UTxOState & \text{utxo state}\\
         \var{acnt} & \Acnt & \text{accounting}\\
         \var{dstate} & \DState & \text{delegation state}\\
         \var{pstate} & \PState & \text{pool state}\\
@@ -490,6 +491,7 @@ This transition has no preconditions and results in the following state change:
     pool's registered reward account, provided the reward account is still registered.
   \item The sum of all the refunds attached to unregistered reward accounts are added to the
     treasury.
+  \item The deposit pool is reduced by the amonut of claimed and unclaimed refunds.
   \item Any delegation to a retiring pool is removed.
   \item Each retiring pool is removed from all four maps in the pool state.
 \end{itemize}
@@ -504,7 +506,7 @@ This transition has no preconditions and results in the following state change:
       {
       \begin{array}{r@{~\leteq~}l}
         \var{retired} & \var{retiring}^{-1}~\var{e} \\
-        \var{pr} & \poolRefunds{pp}{retiring}{(\firstSlot{e})} \\
+        \var{pr} & \poolRefunds{pp}{(\dom{\var{retired}}\restrictdom\var{stpools})}{(\firstSlot{e})} \\
         \var{rewardAcnts}
                  & \{\var{hk}\mapsto \fun{poolRAcnt}~\var{pool} \mid
                    \var{hk}\mapsto\var{pool} \in \var{retired}\restrictdom\var{poolParams} \} \\
@@ -521,7 +523,8 @@ This transition has no preconditions and results in the following state change:
                           hk \mapsto c \in \var{pr} \\
                           \var{hk}\mapsto\var{a} \in \var{rewardAcnts}, \\
                           \var{a} \notin \dom{\var{rewards}}
-                          }} c
+                          }} c \\
+        \var{refunded} & \sum\limits_{c\in\range{\var{refunds}}} c
       \end{array}
       }
     }
@@ -530,6 +533,11 @@ This transition has no preconditions and results in the following state change:
       \vdash
       \left(
         \begin{array}{r}
+          \var{utxo} \\
+          \var{deposits} \\
+          \var{fees} \\
+          \var{ups} \\
+          ~ \\
           \var{treasury} \\
           \var{reserves} \\
           ~ \\
@@ -548,6 +556,13 @@ This transition has no preconditions and results in the following state change:
       \trans{poolreap}{e}
       \left(
         \begin{array}{rcl}
+          \var{utxo} \\
+          \varUpdate{\var{deposits}}
+          & \varUpdate{-}
+          & \varUpdate{(\var{unclaimed} + \var{refunded})} \\
+          \var{fees} \\
+          \var{ups} \\
+          ~ \\
           \varUpdate{\var{treasury}} & \varUpdate{+} & \varUpdate{\var{unclaimed}} \\
           \var{reserves} \\
           ~ \\


### PR DESCRIPTION
There were a couple of problems with the pool certificate refunds in the `POOLREAP` transition.

First, the sum total of the (claimed and unclaimed) refunds that was handed out was not deducted from the global deposit pot. In fact, the `UTxOState` wasn't even in scope. Therefore I added the `UTxOState` to the `POOLREAP` state in both the formal spec and the exec model, and the appropriate amount is removed from the deposit pot.

Second, the slot duration given to the refund calculation was incorrect.  For the current epoch `e`, it was calculating `firstSlot e - firstSlot e` for every duration. In other words, the full refund was always being handed back. The fix was to get the slot when the pools were registered from `stpools`.

I added new tests. For each example in `test/Example` there is now a new test that the expected state contains exactly forty-five billion ada. This did mean changing the numbers in the test a little bit, since, for instance, we did not always start off with forty-five billion ada in all the examples. which in turn does effect the reward calculations, etc.

closes #845 