### PR TITLE
STS-based properties for UTXOW

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -95,6 +95,7 @@ test-suite delegation-test
                          Rules.TestDeleg
                          Rules.TestPool
                          Rules.TestPoolreap
+                         Rules.TestUtxow
     hs-source-dirs:      test
     ghc-options:
       -threaded

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -42,6 +42,7 @@ data UtxoEnv hashAlgo dsignAlgo
       (StakeKeys hashAlgo dsignAlgo)
       (StakePools hashAlgo dsignAlgo)
       (Dms hashAlgo dsignAlgo)
+      deriving(Show)
 
 instance
   (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
@@ -17,13 +17,15 @@ import qualified Data.Set as Set
 
 import           Keys
 import           LedgerState hiding (dms)
+import           STS.Utxo
 import           Tx
 import           TxData
 import           UTxO
 
 import           Control.State.Transition
+import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
-import           STS.Utxo
+import           Hedgehog (Gen)
 
 data UTXOW hashAlgo dsignAlgo
 
@@ -95,3 +97,8 @@ instance
   => Embed (UTXO hashAlgo dsignAlgo) (UTXOW hashAlgo dsignAlgo)
  where
   wrapFailed = UtxoFailure
+
+instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, Signable dsignAlgo (TxBody hashAlgo dsignAlgo))
+  => HasTrace (UTXOW hashAlgo dsignAlgo) where
+  envGen _ = undefined :: Gen (UtxoEnv hashAlgo dsignAlgo)
+  sigGen _ _ = undefined :: Gen (Tx hashAlgo dsignAlgo)

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -16,6 +16,7 @@ import qualified STS.Chain
 import qualified STS.Deleg
 import qualified STS.Pool
 import qualified STS.PoolReap
+import qualified STS.Utxo
 import qualified STS.Utxow
 import qualified Tx
 import qualified TxData
@@ -105,6 +106,8 @@ type ChainState = STS.Chain.ChainState ShortHash MockDSIGN MockKES
 type CHAIN = STS.Chain.CHAIN ShortHash MockDSIGN MockKES
 
 type UTXOW = STS.Utxow.UTXOW ShortHash MockDSIGN
+
+type UtxoEnv = STS.Utxo.UtxoEnv ShortHash MockDSIGN
 
 type DELEG = STS.Deleg.DELEG ShortHash MockDSIGN
 

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxow.hs
@@ -58,3 +58,30 @@ preserveBalance = withTests (fromIntegral numberOfTests) . property $ do
         consumed u tx pp stk =
             balance u
           + keyRefunds pp stk (_body tx)
+
+-- | Preserve balance restricted to TxIns and TxOuts of the Tx
+preserveBalanceRestricted :: Property
+preserveBalanceRestricted = withTests (fromIntegral numberOfTests) . property $ do
+  t <- forAll (trace @UTXOW $ fromIntegral traceLen)
+  let
+    n :: Integer
+    n = fromIntegral $ traceLength t
+    tr = sourceSignalTargets t
+    UtxoEnv _ pp stk stp _ = _traceEnv t
+
+  when (n > 1) $
+    [] === filter (not . (createdIsConsumed pp stk stp)) tr
+
+  where createdIsConsumed pp stk stp (UTxOState u _ _ _, tx, UTxOState _ _ _ _) =
+          inps u tx == outs (_body tx) pp stk stp
+        inps u tx = balance $ (_inputs $ _body tx) <| u
+        outs tx pp stk stp =
+            balance (txouts tx)
+          + _txfee tx
+          + depositChange pp stk stp (toList $ _certs tx) tx
+
+        depositChange pp stk stp certs txb =
+            deposits pp stp certs
+          - (refunded pp stk txb + decayed pp stk txb)
+        refunded pp stk txb = keyRefunds pp stk txb
+        decayed pp stk txb  = decayedTx pp stk txb

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxow.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+module Rules.TestUtxow where
+
+import           Control.Monad (when)
+import           Data.Foldable (toList)
+
+import           Hedgehog (Property, forAll, property, withTests, (===))
+
+import           Control.State.Transition.Generator (trace)
+import           Control.State.Transition.Trace (sourceSignalTargets, traceLength, _traceEnv)
+
+import           LedgerState (pattern UTxOState, decayedTx, keyRefunds)
+import           MockTypes (UTXOW)
+import           STS.Utxo (UtxoEnv (..))
+import           TxData (_body, _certs, _inputs, _txfee)
+import           UTxO (balance, deposits, txouts)
+
+import           Ledger.Core ((<|))
+
+------------------------------
+-- Constants for Properties --
+------------------------------
+
+numberOfTests :: Int
+numberOfTests = 300
+
+traceLen :: Int
+traceLen = 100
+
+--------------------------
+-- Properties for UTXOW --
+--------------------------
+
+-- | Preserve the balance in a transaction, i.e., the sum of the consumed value
+-- equals the sum of the created value.
+preserveBalance :: Property
+preserveBalance = withTests (fromIntegral numberOfTests) . property $ do
+  t <- forAll (trace @UTXOW $ fromIntegral traceLen)
+  let
+    n :: Integer
+    n = fromIntegral $ traceLength t
+    tr = sourceSignalTargets t
+    UtxoEnv _ pp stk stp _ = _traceEnv t
+
+  when (n > 1) $
+    [] === filter (not . (createdIsConsumed pp stk stp)) tr
+
+  where createdIsConsumed pp stk stp (UTxOState u _ _ _, tx, UTxOState u' _ _ _) =
+          created u' tx pp stp == consumed u tx pp stk
+        created u tx pp stp =
+            balance u
+          + _txfee (_body tx)
+          + (deposits pp stp (toList $ _certs $ _body tx))
+        consumed u tx pp stk =
+            balance u
+          + keyRefunds pp stk (_body tx)


### PR DESCRIPTION
This adds the UTXOW properties in the formal spec in the form of STS based properties. Currently they are not yet tested as the generators are currently `undefined`.