### PR TITLE
[844] First draft trace generator for LEDGER STS, testing first Shelley property

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -90,10 +90,16 @@ test-suite delegation-test
                          MultiSigExamples
                          Mutator
                          Generator
+                         Generator.Core
+                         Generator.LedgerTrace
+                         Generator.Delegation
+                         Generator.Utxo
                          PropertyTests
                          STSTests
                          Examples
+                         Rules.ClassifyTraces
                          Rules.TestDeleg
+                         Rules.TestLedger
                          Rules.TestPool
                          Rules.TestPoolreap
                          Rules.TestUtxow

--- a/shelley/chain-and-ledger/executable-spec/src/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Address.hs
@@ -3,13 +3,15 @@
 module Address
   ( mkVKeyRwdAcnt
   , mkRwdAcnt
+  , toAddr
+  , toCred
   )
 where
 
 import           Cardano.Crypto.Hash (HashAlgorithm)
 
 import           Keys (DSIGNAlgorithm, KeyDiscriminator (..), KeyPair, hashKey, vKey)
-import           TxData (Credential (..), RewardAcnt (..))
+import           TxData (Addr (..), Credential (..), RewardAcnt (..))
 
 mkVKeyRwdAcnt
   :: ( HashAlgorithm hashAlgo
@@ -26,3 +28,15 @@ mkRwdAcnt script@(ScriptHashObj _) = RewardAcnt script
 mkRwdAcnt key@(KeyHashObj _) = RewardAcnt key
 mkRwdAcnt (GenesisHashObj _) =
   error "cannot construct reward account with genesis key"
+
+toAddr
+  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => (KeyPair 'Regular dsignAlgo, KeyPair 'Regular dsignAlgo)
+  -> Addr hashAlgo dsignAlgo
+toAddr (payKey, stakeKey) = AddrBase (toCred payKey) (toCred stakeKey)
+
+toCred
+  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
+  => KeyPair 'Regular dsignAlgo
+  -> Credential hashAlgo dsignAlgo
+toCred k = KeyHashObj . hashKey $ vKey k

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -400,12 +400,11 @@ genesisCoins outs = UTxO $
 -- |Creates the ledger state for an empty ledger which
 -- contains the specified transaction outputs.
 genesisState
-  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => [TxOut hashAlgo dsignAlgo]
+  :: UTxO hashAlgo dsignAlgo
   -> LedgerState hashAlgo dsignAlgo
-genesisState outs = LedgerState
+genesisState utxo0 = LedgerState
   (UTxOState
-    (genesisCoins outs)
+    utxo0
     (Coin 0)
     (Coin 0)
     emptyUpdateState)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
@@ -13,21 +13,18 @@ module STS.Bbody
   )
 where
 
-import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 
 import           BlockChain
+import           Control.State.Transition
 import           EpochBoundary
 import           Keys
 import           Ledger.Core ((∈))
 import           LedgerState
 import           PParams
 import           Slot
-import           Tx
-
-import           Control.State.Transition
-
 import           STS.Ledgers
+import           Tx
 
 data BBODY hashAlgo dsignAlgo kesAlgo
 
@@ -57,7 +54,7 @@ instance
     | LedgersFailure (PredicateFailure (LEDGERS hashAlgo dsignAlgo))
     deriving (Show, Eq)
 
-  initialRules = [pure $ BbodyState emptyLedgerState (BlocksMade Map.empty)]
+  initialRules = []
   transitionRules = [bbodyTransition]
 
 bbodyTransition

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
@@ -14,22 +14,21 @@ where
 
 import           Lens.Micro ((^.))
 
+import           Control.State.Transition
 import           Keys
 import           LedgerState
 import           PParams hiding (d)
 import           Slot
-import           Tx
-
-import           Control.State.Transition
-
 import           STS.Delegs
 import           STS.Utxo (UtxoEnv (..))
 import           STS.Utxow
+import           Tx
 
 data LEDGER hashAlgo dsignAlgo
 
 data LedgerEnv
   = LedgerEnv Slot Ix PParams
+  deriving (Show)
 
 instance
   ( HashAlgorithm hashAlgo
@@ -47,7 +46,7 @@ instance
     | DelegsFailure (PredicateFailure (DELEGS hashAlgo dsignAlgo))
     deriving (Show, Eq)
 
-  initialRules    = []
+  initialRules = []
   transitionRules = [ledgerTransition]
 
 ledgerTransition

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
@@ -18,17 +18,15 @@ import qualified Data.Map.Strict as Map
 import           Data.Sequence (Seq)
 import qualified Data.Set as Set
 
+import           Control.State.Transition
 import           Keys
 import           Ledger.Core (dom, range, (⋪), (◁), (⨃))
 import           LedgerState
 import           PParams
 import           Slot
+import           STS.Ledger
 import           Tx
 import           Updates (Applications (..), UpdateState (..), apps, newAVs)
-
-import           Control.State.Transition
-
-import           STS.Ledger
 
 data LEDGERS hashAlgo dsignAlgo
 

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -41,6 +41,9 @@ module Examples
   , dariaStake
   , dariaAddr
   , coreNodeSKG -- TODO remove
+  -- helpers
+  , mkKeyPair
+  , unsafeMkUnitInterval
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Generator.Core
+  ( findPayKeyPair
+  , genTxOut
+  , genUtxo0
+  , mkGenesisLedgerState
+  , traceKeyPairs
+  , someKeyPairs
+  , pickStakeKey
+  , toAddr
+  , toCred)
+  where
+
+import           Data.Tuple (swap)
+import           Data.Word (Word64)
+import           Hedgehog (Gen)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import           Address (toAddr, toCred)
+import           Coin (Coin (..))
+import           Examples (mkKeyPair)
+import           Keys (pattern KeyPair, hashKey, vKey)
+import           LedgerState (pattern LedgerState, genesisCoins, genesisState)
+import           MockTypes (Addr, DPState, KeyPair, KeyPairs, LedgerEnv, TxOut, UTxO, UTxOState,
+                     VKey)
+import           Tx (pattern TxOut)
+import           TxData (pattern AddrBase, pattern KeyHashObj)
+
+mkKeyPairs :: Word64 -> (KeyPair, KeyPair)
+mkKeyPairs n
+  = (mkKeyPair_ (2*n), mkKeyPair_ (2*n+1))
+  where
+    mkKeyPair_ n_ = (uncurry KeyPair . swap) (mkKeyPair (n_,n_,n_,n_,n_))
+
+-- | Constant list of KeyPairs intended to be used in the generators.
+traceKeyPairs :: KeyPairs
+traceKeyPairs = mkKeyPairs <$> [1 .. 50]
+
+-- | Select between _lower_ and _upper_ keys from 'traceKeyPairs'
+someKeyPairs :: Int -> Int -> Gen KeyPairs
+someKeyPairs lower upper =
+  take
+    <$> Gen.integral (Range.linear lower upper)
+    <*> Gen.shuffle traceKeyPairs
+
+-- | Find first matching key pair for address. Returns the matching key pair
+-- where the first element of the pair matched the hash in 'addr'.
+findPayKeyPair :: Addr -> KeyPairs -> KeyPair
+findPayKeyPair (AddrBase (KeyHashObj addr) _) keyList =
+    case matches of
+      []    -> error "findPayKeyPair: could not find a match for the given address"
+      (x:_) -> fst x
+    where
+      matches = filter (\(pay, _) -> addr == hashKey (vKey pay)) keyList
+findPayKeyPair _ _ = error "findPayKeyPair: expects only AddrBase addresses"
+
+-- | Select one random verification staking key from list of pairs of KeyPair.
+pickStakeKey :: KeyPairs -> Gen VKey
+pickStakeKey keys = vKey . snd <$> Gen.element keys
+
+-- | Generates a list of coins for the given 'Addr' and produced a 'TxOut' for each 'Addr'
+genTxOut :: [Addr] -> Gen [TxOut]
+genTxOut addrs = do
+  ys <- genCoinList 100 10000 (length addrs) (length addrs)
+  return (uncurry TxOut <$> zip addrs ys)
+
+-- | Generates a list of 'Coin' values of length between 'lower' and 'upper'
+-- and with values between 'minCoin' and 'maxCoin'.
+genCoinList :: Integer -> Integer -> Int -> Int -> Gen [Coin]
+genCoinList minCoin maxCoin lower upper = do
+  xs <- Gen.list (Range.linear lower upper)
+        $ Gen.integral (Range.exponential minCoin maxCoin)
+  return (Coin <$> xs)
+
+genUtxo0 :: Int -> Int -> Gen UTxO
+genUtxo0 lower upper = do
+  genesisKeys <- someKeyPairs lower upper
+  outs <- genTxOut (fmap toAddr genesisKeys)
+  return (genesisCoins outs)
+
+mkGenesisLedgerState
+  :: LedgerEnv
+  -> Gen (UTxOState, DPState)
+mkGenesisLedgerState _ = do
+  utxo0 <- genUtxo0 5 10
+  let (LedgerState utxoSt dpSt _) = genesisState utxo0
+  pure (utxoSt, dpSt)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Generator.Delegation
+  ( genDCerts
+  , genPParams
+  )
+  where
+
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import           Hedgehog (Gen)
+
+import qualified Hedgehog.Gen as Gen
+
+import           Coin (Coin (..))
+import           Delegation.Certificates (pattern RegKey)
+import           Examples (unsafeMkUnitInterval)
+import           Generator.Core (toCred)
+import           Ledger.Core (dom, (∉))
+import           LedgerState (_dstate, _pstate, _stKeys, _stPools)
+import           MockTypes (DCert, DPState, DState, KeyPair, KeyPairs)
+import           PParams (PParams (..), emptyPParams)
+import           Slot (Epoch (..))
+import           UTxO (deposits)
+
+-- TODO @uroboros Generate a range of protocol params
+-- TODO @uroboros for now, keeping minA/B at zero until we generate fees in genTx
+genPParams :: Gen PParams
+genPParams = pure $ emptyPParams {
+                                   _minfeeA = 0
+                                 , _minfeeB = 0
+                                 , _maxBBSize = 50000
+                                 , _maxBHSize = 10000
+                                 , _maxTxSize = 10000
+                                 , _eMax = Epoch 10000
+                                 , _keyDeposit = Coin 7
+                                 , _poolDeposit = Coin 250
+                                 , _d = unsafeMkUnitInterval 0.5
+                                 , _activeSlotCoeff = unsafeMkUnitInterval 0.1
+                                 , _tau = unsafeMkUnitInterval 0.2
+                                 , _rho = unsafeMkUnitInterval 0.0021
+                                 , _keyDecayRate = 0.002
+                                 , _keyMinRefund = unsafeMkUnitInterval 0.5
+                                 , _poolDecayRate = 0.001
+                                 , _poolMinRefund = unsafeMkUnitInterval 0.5
+                                 }
+
+-- | Generate certificates and also return the associated witnesses and
+-- total deposits required.
+genDCerts
+  :: KeyPairs
+  -> PParams
+  -> DPState
+  -> Gen (Seq DCert, [KeyPair], Coin)
+genDCerts keys pparams dpState = do
+  -- TODO @uroboros Generate _multiple_ certs per Tx
+  cert <- genDCert keys (_dstate dpState)
+  case cert of
+    Nothing ->
+      return (Seq.empty, [], Coin 0)
+    Just (cert_, witKey) -> do
+      let certs = [cert_]
+          witKeys = [witKey]
+          deposits_ = deposits pparams (_stPools (_pstate dpState)) certs
+
+      return (Seq.fromList certs, witKeys, deposits_)
+
+
+-- | Occasionally generate a valid certificate
+genDCert
+  :: KeyPairs
+  -> DState
+  -> Gen (Maybe (DCert, KeyPair))
+genDCert keys dState =
+  -- TODO @uroboros Generate _DeregKey_ Certificates
+  -- TODO @uroboros Generate _RegPool_ Certificates
+  -- TODO @uroboros Generate _RetirePool_ Certificates
+  -- TODO @uroboros Generate _Delegate_ Certificates
+  Gen.frequency [ (25, genRegKeyCert keys dState)
+                , (75, pure Nothing)
+                ]
+
+-- | Generate a RegKey certificate along and also returns the stake key
+-- (needed to witness the certificate)
+genRegKeyCert
+  :: KeyPairs
+  -> DState
+  -> Gen (Maybe (DCert, KeyPair))
+genRegKeyCert keys delegSt =
+  case availableKeys of
+    [] -> pure Nothing
+    _ -> do
+           (_payKey, stakeKey) <- Gen.element availableKeys
+           pure $ Just $ (RegKey (toCred stakeKey), stakeKey)
+  where
+    notRegistered k = k ∉ dom (_stKeys delegSt)
+    availableKeys = filter (notRegistered . toCred . snd) keys

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- The HasTrace instance relies on test generators and so cannot
+-- be included with the LEDGER STS
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Generator.LedgerTrace where
+
+import           Cardano.Crypto.DSIGN.Mock (MockDSIGN)
+import           Cardano.Crypto.Hash (ShortHash)
+
+import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
+import           Generator.Core (traceKeyPairs)
+import           Generator.Delegation (genPParams)
+import           Generator.Utxo (genTx)
+import           Slot (Slot (..))
+import           STS.Ledger (LEDGER, LedgerEnv (..))
+
+-- The LEDGER STS combines utxo and delegation rules and allows for generating transactions
+-- with meaningful delegation certificates.
+instance HasTrace (LEDGER ShortHash MockDSIGN)
+  where
+    envGen _ =
+      LedgerEnv <$> pure (Slot 0)
+                <*> pure 0
+                <*> genPParams
+
+    sigGen ledgerEnv ledgerSt =
+      genTx ledgerEnv ledgerSt traceKeyPairs

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Generator.Utxo
+  ( genTx
+  )
+  where
+
+import           Control.Monad (when)
+import qualified Data.Map.Strict as Map
+import           Data.Sequence (Seq)
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           Hedgehog (Gen)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import           Coin (Coin (..), splitCoin)
+import           Generator.Core (findPayKeyPair, toAddr)
+import           Generator.Delegation (genDCerts)
+import           LedgerState (pattern UTxOState)
+import           MockTypes (Addr, DCert, DPState, KeyPair, KeyPairs, Tx, TxBody, TxIn, TxOut, UTxO,
+                     UTxOState)
+import           Slot (Slot (..))
+import           STS.Ledger (LedgerEnv (..))
+import           Tx (pattern Tx, pattern TxBody, pattern TxOut)
+import           Updates (emptyUpdate)
+import           UTxO (pattern UTxO, balance, makeWitnessesVKey)
+
+-- | Generate a new transaction in the context of the LEDGER STS environment and state.
+--
+-- Selects unspent outputs and spends the funds on a some valid addresses.
+-- Also generates valid certificates.
+genTx :: LedgerEnv
+      -> (UTxOState, DPState)
+      -> KeyPairs
+      -> Gen Tx
+genTx (LedgerEnv slot _ pparams) (UTxOState utxo _ _ _, dpState) keys = do
+  keys' <- Gen.shuffle keys
+
+  -- inputs
+  (witnessedInputs, spendingBalance) <- pickSpendingInputs keys' utxo
+  let (inputs, spendWitnesses) = unzip witnessedInputs
+
+  -- output addresses
+  recipientAddrs <- genRecipients keys'
+
+  -- certificates
+  (certs, certWitnesses, deposits_) <- genDCerts keys' pparams dpState
+
+  -- attempt to make provision for certificate deposits (otherwise discard this generator)
+  when (spendingBalance < deposits_) Gen.discard
+  let balance_ = spendingBalance - deposits_
+
+  -- calc. fees and output amounts
+  let (fee, outputs) = calcFeeAndOutputs balance_ recipientAddrs
+
+  -- witnessed transaction
+  txBody <- genTxBody (Set.fromList inputs) outputs certs fee slot
+  let !wits = makeWitnessesVKey txBody (spendWitnesses ++ certWitnesses)
+      multiSig = Map.empty -- TODO @uroboros Generate multi-sig transactions
+
+  return (Tx txBody wits multiSig)
+
+-- | Generate a transaction body with the given inputs/outputs and certificates
+genTxBody
+  :: Set TxIn
+  -> [TxOut]
+  -> Seq DCert
+  -> Coin
+  -> Slot
+  -> Gen TxBody
+genTxBody inputs outputs certs fee slot = do
+  ttl <- Gen.integral $ Range.linear 1 100
+  return $ TxBody
+             inputs
+             outputs
+             certs
+             Map.empty -- TODO @uroboros generate withdrawals
+             fee
+             (slot + Slot ttl)
+             emptyUpdate -- TODO @uroboros generate updates
+
+-- | Calculate the fee and distribute the remainder of the balance
+-- to the given addresses (as transaction outputs)
+calcFeeAndOutputs
+  :: Coin
+  -> [Addr]
+  -> (Coin, [TxOut])
+calcFeeAndOutputs balance_ addrs =
+  ( fee + splitCoinRem
+  , (`TxOut` amountPerOutput) <$> addrs)
+  where
+    -- TODO @uroboros fee=0 works for now since PParams minFeeA/B == 0.
+    --      We need to instead add a "draft" TxBody as argument, which will
+    --      give a measure of the minimum fee for this transaction.
+    --      This estimated fee can then be used to create the actual TxBody,
+    --      with the new fee baked in.
+    fee = 0
+    -- split the available balance into equal portions (one for each address),
+    -- if there is a remainder, then add it to the fee.
+    balanceAfterFee = balance_ - fee
+    (amountPerOutput, splitCoinRem) = splitCoin balanceAfterFee (fromIntegral $ length addrs)
+
+-- | Select unspent output(s) to serve as inputs for a new transaction
+--
+-- Returns the inputs, paired with the KeyPair required to witness the
+-- spending of the input.
+-- Also returns the total spendable balance.
+
+-- NOTE: this function needs access to the keys that the given utxo originated
+-- from (in order to produce the appropriate witnesses to spend these outputs)
+-- If this is not the case, findPayKeyPair will fail by not finding the matching keys.
+pickSpendingInputs
+  :: KeyPairs
+  -> UTxO
+  -> Gen ([(TxIn, KeyPair)], Coin)
+pickSpendingInputs keys (UTxO utxo) = do
+  selectedUtxo <- take <$> Gen.integral (Range.linear 1 5)
+                       <*> Gen.shuffle (Map.toList utxo)
+
+  return ( witnessedInput <$> selectedUtxo
+         , balance (UTxO (Map.fromList selectedUtxo)))
+  where
+    witnessedInput (input, TxOut addr _) = (input, findPayKeyPair addr keys)
+
+-- | Select recipient addresses that will serve as output targets for a new transaction.
+genRecipients
+  :: KeyPairs
+  -> Gen [Addr]
+genRecipients keys = do
+  let n = 1 -- TODO @uroboros select _multiple_ recipients
+      recipients = take n keys
+
+  return $ toAddr <$> recipients

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -14,6 +14,7 @@ import qualified LedgerState
 import qualified OCert
 import qualified STS.Chain
 import qualified STS.Deleg
+import qualified STS.Ledger
 import qualified STS.Pool
 import qualified STS.PoolReap
 import qualified STS.Utxo
@@ -110,6 +111,10 @@ type UTXOW = STS.Utxow.UTXOW ShortHash MockDSIGN
 type UtxoEnv = STS.Utxo.UtxoEnv ShortHash MockDSIGN
 
 type DELEG = STS.Deleg.DELEG ShortHash MockDSIGN
+
+type LEDGER = STS.Ledger.LEDGER ShortHash MockDSIGN
+
+type LedgerEnv = STS.Ledger.LedgerEnv
 
 type POOL = STS.Pool.POOL ShortHash MockDSIGN
 

--- a/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
@@ -22,7 +22,7 @@ import qualified Data.Set as Set (fromList)
 import           Coin
 import           Control.State.Transition (PredicateFailure, TRC (..), applySTS)
 import           Keys (pattern Dms, undiscriminateKeyHash)
-import           LedgerState (genesisId, genesisState, _utxoState)
+import           LedgerState (genesisId, genesisCoins, genesisState, _utxoState)
 import           MockTypes (Addr, KeyPair, LedgerState, MultiSig, ScriptHash, Tx, TxBody, TxId,
                      TxIn, UTXOW, UTxOState, Wdrl)
 import           PParams (PParams (..), emptyPParams)
@@ -102,7 +102,7 @@ bobInitCoin :: Coin
 bobInitCoin = 1000
 
 genesis :: LedgerState
-genesis = genesisState
+genesis = (genesisState . genesisCoins)
            [ TxOut aliceAddr aliceInitCoin
            , TxOut bobAddr bobInitCoin]
 

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -23,6 +23,8 @@ import           Coin
 import           Ledger.Core ((<|))
 import           LedgerState hiding (dms)
 import           PParams
+import           Rules.TestLedger (rewardZeroAfterReg)
+import           Rules.ClassifyTraces (relevantCasesAreCovered)
 import           Slot
 import           Tx (pattern TxIn, pattern TxOut, body, certs, inputs, outputs, witnessVKeySet,
                      _body, _witnessVKeySet)
@@ -152,7 +154,11 @@ classifyInvalidDoubleSpend = withTests 1000 $ property $ do
 -- | 'TestTree' of property-based testing properties.
 propertyTests :: TestTree
 propertyTests = testGroup "Property-Based Testing"
-                [ testGroup "Ledger Genesis State"
+                [ testGroup "Classify Traces"
+                  [testProperty "Ledger trace covers the relevant cases" relevantCasesAreCovered]
+                , testGroup "STS Rules - Delegation Properties"
+                  [testProperty "newly registered key has a reward of 0" rewardZeroAfterReg]
+                , testGroup "Ledger Genesis State"
                   [testProperty
                     "non-empty genesis ledger state has non-zero balance"
                     propPositiveBalance

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Rules.ClassifyTraces where
+
+import           Data.Foldable (toList)
+import qualified Data.Set as Set
+import           Hedgehog (Property, cover, forAll, property, withTests)
+
+import           Control.State.Transition.Generator (traceOfLengthWithInitState)
+import           Control.State.Transition.Trace (TraceOrder (OldestFirst), traceLength,
+                     traceSignals)
+
+import           Delegation.Certificates (pattern RegKey)
+import           Generator.Core (mkGenesisLedgerState)
+import           Generator.LedgerTrace ()
+import           MockTypes (DCert, LEDGER, Tx)
+import           TxData (_body, _certs, _inputs, _outputs)
+
+relevantCasesAreCovered :: Property
+relevantCasesAreCovered = withTests 500 $ property $ do
+  let tl = 100
+  tr <- forAll (traceOfLengthWithInitState @LEDGER tl mkGenesisLedgerState)
+
+  let txs = traceSignals OldestFirst tr
+      certs_ = allCerts txs
+
+  cover 75
+        "there is at least 1 certificate for every 5 transactions"
+        (traceLength tr <= 5 * length certs_)
+
+  cover 75
+        "there is at least 1 RegKey certificate for every 5 transactions"
+        (traceLength tr <= 5 * length (filter isRegKey certs_))
+
+  cover 25
+        "at most 75% of transactions have no certificates"
+        (0.75 >= noCertsRatio (certsByTx txs))
+
+-- | Extract the certificates from the transactions
+certsByTx :: [Tx] -> [[DCert]]
+certsByTx txs = (toList . _certs . _body) <$> txs
+
+-- | Flattended list of DCerts for the given transactions
+allCerts :: [Tx] -> [DCert]
+allCerts = concat . certsByTx
+
+-- | Ratio of the number of empty certificate groups and the number of groups
+noCertsRatio :: [[DCert]] -> Double
+noCertsRatio = lenRatio (filter null)
+
+isRegKey :: DCert -> Bool
+isRegKey (RegKey _) = True
+isRegKey _ = False
+
+-- | Returns the average number of inputs and outputs for a list of transactions.
+avgInputsOutputs :: [Tx] -> (Double, Double)
+avgInputsOutputs txs
+  = case length txs of
+      0 -> (0,0)
+      n -> ( nrInputs  / fromIntegral n
+           , nrOutputs / fromIntegral n)
+  where
+    nrInputs = fromIntegral $ sum (Set.size . _inputs . _body <$> txs)
+    nrOutputs = fromIntegral $ sum (length . _outputs . _body <$> txs)
+
+ratioInt :: Int -> Int -> Double
+ratioInt x y
+  = fromIntegral x / fromIntegral y
+
+-- | Transforms the list and returns the ratio of lengths of
+-- the transformed and original lists.
+lenRatio :: ([a] -> [b]) -> [a] -> Double
+lenRatio f xs
+  = ratioInt (length (f xs))
+             (length xs)

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestLedger.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestLedger.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+module Rules.TestLedger
+  (rewardZeroAfterReg)
+where
+
+import           Data.Foldable (toList)
+import           Hedgehog (Property, forAll, property, withTests)
+
+import           Control.State.Transition.Generator (ofLengthAtLeast, traceOfLengthWithInitState)
+import           Control.State.Transition.Trace (SourceSignalTarget, pattern SourceSignalTarget,
+                     sourceSignalTargets)
+import           Generator.Core (mkGenesisLedgerState)
+import           Generator.LedgerTrace ()
+import           LedgerState (pattern DPState)
+import           MockTypes (DELEG, LEDGER)
+import qualified Rules.TestDeleg as TestDeleg
+import           TxData (_body, _certs)
+
+------------------------------
+-- Constants for Properties --
+------------------------------
+
+numberOfTests :: Int
+numberOfTests = 300
+
+traceLen :: Int
+traceLen = 100
+
+--------------------------
+-- Properties for DELEG --
+--------------------------
+
+-- | Check that a newly registered key has a reward of 0.
+rewardZeroAfterReg :: Property
+rewardZeroAfterReg = withTests (fromIntegral numberOfTests) . property $ do
+  t <- forAll
+       (traceOfLengthWithInitState @LEDGER
+                                   (fromIntegral traceLen)
+                                   mkGenesisLedgerState
+        `ofLengthAtLeast` 1)
+
+  TestDeleg.rewardZeroAfterReg ((concatMap toCerts . sourceSignalTargets) t)
+
+  where toCerts
+          :: SourceSignalTarget LEDGER
+          -> [SourceSignalTarget DELEG]
+        toCerts (SourceSignalTarget (_, DPState d _) (_, DPState d' _) tx) =
+          [SourceSignalTarget d d' cert | cert <- toList . _certs . _body $ tx]

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -49,7 +49,7 @@ testUPNLate =
     st @?= Right (UpdnState (SeedOp (Nonce 2) (Nonce 1)) (Nonce 3))
 
 testCHAINExample :: CHAINExample -> Assertion
-testCHAINExample (CHAINExample slotNow initSt block expectedSt) =
+testCHAINExample (CHAINExample slotNow initSt block expectedSt) = do
   checkTrace @CHAIN slotNow $ pure initSt .- block .-> expectedSt
 
 testPreservationOfAda :: CHAINExample -> Assertion

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -27,7 +27,7 @@ import           TxData (pattern AddrBase, Credential (..), Delegation (..), pat
 import           Keys (pattern Dms, pattern KeyPair, hashKey, vKey)
 import           LedgerState (pattern LedgerState, pattern UTxOState, ValidationError (..),
                      asStateTransition, cCounters, delegationState, delegations, dstate,
-                     emptyDelegation, genesisId, genesisState, minfee, pParams, pstate, ptrs,
+                     emptyDelegation, genesisId, genesisCoins, genesisState, minfee, pParams, pstate, ptrs,
                      retiring, rewards, stKeys, stPools, _delegationState, _dms, _dstate)
 import           PParams
 import           Slot
@@ -73,7 +73,7 @@ bobInitCoin :: Coin
 bobInitCoin = Coin 1000
 
 genesis :: LedgerState
-genesis = genesisState
+genesis = (genesisState . genesisCoins)
             [ TxOut aliceAddr aliceInitCoin
             , TxOut bobAddr bobInitCoin ]
 


### PR DESCRIPTION
Closes #844 

* generates transactions as LEDGER signals (the LEDGER STS level is the lowest level that provides enough context to generate meaningful certs)
* occasionally generate a RegKey DCert for a Tx
* tests the `rewardZeroAfterReg` property using the LEDGER trace
* classifies the LEDGER STS Trace (w.r.t the generated data so far)

NOTES: 

* This PR forms the basis of a series of PRs that will incrementally test properties against the generated LEDGER Tx/Certs. (Each new property test will place new demands on the generators.)
* Generators.Core.hs in this PR is harvested from @mgudemann 's pre-STS property test generators. Over the course of a few PR's, we will remove the pre-STS generator code in favour of Generator.Core and Generator.*
* the classify-trace tests are inspired by @dnadales 's Byron work 🙏  
 