### PR TITLE
Integrate goblins into the conformance tests

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -189,7 +189,7 @@ instance HasTrace CHAIN where
       <*> (utxo0 <$> envGen @UTXOWS chainLength)
       <*> pure (mkVkGenesisSet ngk)
       -- TODO: for now we're returning a constant set of parameters, where only '_bkSgnCntT' varies.
-      <*> pure initialPParams { _bkSgnCntT = sigCntT }
+      <*> pure initialPParams { _bkSgnCntT = Update.BkSgnCntT sigCntT }
       <*> pure k
     where
       -- If we want to generate large traces, we need to set up the value of the

--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
@@ -166,12 +166,18 @@ coverUtxoFailure coverPercentage someData = do
 
   coverFailures
     coverPercentage
-    [ EmptyTxInputs
-    , EmptyTxOutputs
-    , FeeTooLow
-    , IncreasedTotalBalance
+    [ FeeTooLow
     , InputsNotInUTxO
-    , NonPositiveOutputs
     ]
     someData
 
+    -- We do not check coverage of `EmptyTxInputs` & `EmptyTxOutputs`, because
+    -- they such transactions are not constructible in `cardano-ledger`'s types,
+    -- due to usage of `NonEmpty` for the lists of `TxIn` and `TxOut`.
+    --
+    -- We do not check coverage of `NonPositiveOutputs` because it is not
+    -- possible to represent a non-positive Lovelace value in a `TxOut` since
+    -- there is bounds-checking on all constructions of `Lovelace` values.
+    --
+    -- We do not check coverage of `IncreasedTotalBalance` because it is not
+    -- throwable.

--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
@@ -138,7 +138,7 @@ mkGoblinGens
 tamperedTxWitsList :: UTxOEnv -> UTxOState -> Gen [TxWits]
 tamperedTxWitsList env st = do
   gen <- Gen.element (map (\sg -> sg env st) goblinGensUTXOW)
-  Gen.list (Range.linear 0 10) gen
+  Gen.list (Range.linear 1 10) gen
 
 
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
+++ b/byron/ledger/executable-spec/src/Cardano/Ledger/Spec/STS/UTXOW.hs
@@ -13,6 +13,9 @@ module Cardano.Ledger.Spec.STS.UTXOW where
 
 import           Data.Data (Data, Typeable)
 import qualified Data.Map as Map
+import           Hedgehog (Gen)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 import           Control.State.Transition (Embed, Environment, IRC (IRC), PredicateFailure, STS,
                      Signal, State, TRC (TRC), initialRules, judgmentContext, trans,
@@ -128,3 +131,8 @@ mkGoblinGens
   , "UtxoFailure_InputsNotInUTxO"
   , "UtxoFailure_NonPositiveOutputs"
   ]
+
+tamperedTxWitsList :: UTxOEnv -> UTxOState -> Gen [TxWits]
+tamperedTxWitsList env st = do
+  gen <- Gen.element (map (\sg -> sg env st) goblinGensUTXOW)
+  Gen.list (Range.linear 0 10) gen

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -466,13 +466,23 @@ toSet = Set.fromList . toList
 deriveGoblin ''Addr
 deriveGoblin ''BlockCount
 deriveGoblin ''Epoch
-deriveGoblin ''Hash
 deriveGoblin ''Owner
 deriveGoblin ''Sig
 deriveGoblin ''Slot
 deriveGoblin ''SlotCount
 deriveGoblin ''VKey
 deriveGoblin ''VKeyGenesis
+
+instance GeneOps g => Goblin g Hash where
+  tinker gen
+    = tinkerRummagedOrConjureOrSave
+        ((\x -> Hash (modulate x))
+           <$$> tinker ((\(Hash x) -> x) <$> gen))
+  conjure = saveInBagOfTricks =<< (Hash . modulate <$>
+    conjure)
+
+modulate :: Integral a => a -> a
+modulate x = x `mod` 30
 
 instance GeneOps g => Goblin g Lovelace where
   tinker gen

--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NumDecimals #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -33,7 +34,8 @@ import           Numeric.Natural (Natural)
 
 import           Data.AbstractSize
 
-import           Test.Goblin (AddShrinks (..), Goblin (..), SeedGoblin (..))
+import           Test.Goblin (AddShrinks (..), GeneOps, Goblin (..), SeedGoblin (..),
+                     saveInBagOfTricks, tinkerRummagedOrConjureOrSave, (<$$>))
 import           Test.Goblin.TH (deriveAddShrinks, deriveGoblin, deriveSeedGoblin)
 
 
@@ -227,6 +229,10 @@ newtype Lovelace = Lovelace
     deriving newtype (Eq, Ord, Num, Hashable)
     deriving (Semigroup, Monoid) via (Sum Integer)
     deriving anyclass (HasTypeReps)
+
+-- | Maximal possible value of 'Lovelace'
+maxLovelaceVal :: Integer
+maxLovelaceVal = 45e15
 
 ---------------------------------------------------------------------------------
 -- Domain restriction and exclusion
@@ -461,13 +467,20 @@ deriveGoblin ''Addr
 deriveGoblin ''BlockCount
 deriveGoblin ''Epoch
 deriveGoblin ''Hash
-deriveGoblin ''Lovelace
 deriveGoblin ''Owner
 deriveGoblin ''Sig
 deriveGoblin ''Slot
 deriveGoblin ''SlotCount
 deriveGoblin ''VKey
 deriveGoblin ''VKeyGenesis
+
+instance GeneOps g => Goblin g Lovelace where
+  tinker gen
+    = tinkerRummagedOrConjureOrSave
+        ((\x -> Lovelace (x `mod` fromIntegral maxLovelaceVal))
+           <$$> tinker ((\(Lovelace x) -> x) <$> gen))
+  conjure = saveInBagOfTricks =<< (Lovelace . (`mod` maxLovelaceVal) <$>
+    conjure)
 
 
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -87,6 +87,7 @@ module Ledger.Delegation
       , S_BeforeExistingDelegation, S_NoLastDelegation
       , S_AfterExistingDelegation, S_AlreadyADelegateOf
       )
+  , tamperedDcerts
   )
 where
 
@@ -795,3 +796,8 @@ mkGoblinGens
   , "SDelegSFailure_SDelegFailure_IsAlreadyScheduled"
   , "SDelegSFailure_SDelegFailure_IsNotGenesisKey"
   ]
+
+tamperedDcerts :: DIEnv -> DIState -> Gen [DCert]
+tamperedDcerts env st = do
+  sg <- Gen.element goblinGensDELEG
+  sg env st

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -8,15 +8,10 @@ module Ledger.GlobalParams
   )
 where
 
-import           Data.Int (Int64)
 import           Data.Word (Word64)
 
-import           Ledger.Core (BlockCount (BlockCount), Lovelace (Lovelace))
+import           Ledger.Core (BlockCount (BlockCount), lovelaceCap)
 
-
--- | Constant amount of Lovelace in the system.
-lovelaceCap :: Lovelace
-lovelaceCap = Lovelace $ 45 * fromIntegral ((10 :: Int64) ^ (15 :: Int64))
 
 -- | Given the chain stability parameter, often referred to as @k@, which is
 -- expressed in an amount of blocks, return the number of slots contained in an

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -158,7 +158,6 @@ makeTxWits (UTxO utxo) tx = TxWits
 -- Goblins instances
 --------------------------------------------------------------------------------
 
-deriveGoblin ''TxId
 deriveGoblin ''TxIn
 deriveGoblin ''TxOut
 deriveGoblin ''TxWits
@@ -194,6 +193,14 @@ instance GeneOps g => Goblin g Tx where
     inputs <- replicateM listLenI conjure
     outputs <- replicateM listLenO conjure
     pure (Tx inputs outputs)
+
+instance GeneOps g => Goblin g TxId where
+  tinker gen
+    = tinkerRummagedOrConjureOrSave
+        ((\x -> TxId (Hash (modulate x)))
+           <$$> tinker ((\(TxId (Hash x)) -> x) <$> gen))
+  conjure = saveInBagOfTricks =<< (TxId . Hash . modulate <$>
+    conjure)
 
 
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -30,7 +30,7 @@ import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
 
 import           Ledger.Core hiding ((<|))
-import           Ledger.Update (PParams (PParams), _factorA, _factorB)
+import           Ledger.Update (FactorA (..), FactorB (..), PParams (PParams), _factorA, _factorB)
 
 import           Test.Goblin (AddShrinks (..), Goblin (..), SeedGoblin (..))
 import           Test.Goblin.TH (deriveAddShrinks, deriveGoblin, deriveSeedGoblin)
@@ -102,7 +102,7 @@ instance Ledger.Core.HasHash Tx where
 ---------------------------------------------------------------------------------
 
 pcMinFee :: PParams -> Tx -> Lovelace
-pcMinFee PParams {_factorA = a, _factorB = b} tx
+pcMinFee PParams {_factorA = FactorA a, _factorB = FactorB b} tx
   = fromIntegral $ a + b * txsize tx
 
 txsize :: Tx -> Int

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -197,10 +197,9 @@ instance GeneOps g => Goblin g Tx where
 instance GeneOps g => Goblin g TxId where
   tinker gen
     = tinkerRummagedOrConjureOrSave
-        ((\x -> TxId (Hash (modulate x)))
+        ((TxId . Hash . (`mod` 30))
            <$$> tinker ((\(TxId (Hash x)) -> x) <$> gen))
-  conjure = saveInBagOfTricks =<< (TxId . Hash . modulate <$>
-    conjure)
+  conjure = saveInBagOfTricks =<< (TxId . Hash . (`mod` 30) <$> conjure)
 
 
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -18,6 +18,7 @@
 
 module Ledger.UTxO where
 
+import           Control.Monad (replicateM)
 import           Data.AbstractSize (HasTypeReps, abstractSize)
 import           Data.Data (Data, Typeable)
 import           Data.Hashable (Hashable)
@@ -32,7 +33,8 @@ import           Numeric.Natural (Natural)
 import           Ledger.Core hiding ((<|))
 import           Ledger.Update (FactorA (..), FactorB (..), PParams (PParams), _factorA, _factorB)
 
-import           Test.Goblin (AddShrinks (..), Goblin (..), SeedGoblin (..))
+import           Test.Goblin (AddShrinks (..), GeneOps (..), Goblin (..), SeedGoblin (..), TinkerM,
+                     saveInBagOfTricks, tinkerRummagedOrConjureOrSave, (<$$>))
 import           Test.Goblin.TH (deriveAddShrinks, deriveGoblin, deriveSeedGoblin)
 
 -- |A unique ID of a transaction, which is computable from the transaction.
@@ -156,12 +158,42 @@ makeTxWits (UTxO utxo) tx = TxWits
 -- Goblins instances
 --------------------------------------------------------------------------------
 
-deriveGoblin ''Tx
 deriveGoblin ''TxId
 deriveGoblin ''TxIn
 deriveGoblin ''TxOut
 deriveGoblin ''TxWits
 deriveGoblin ''Wit
+
+instance GeneOps g => Goblin g Tx where
+  tinker gen = do
+    fIs <- fillEmptyList
+    fOs <- fillEmptyList
+    is <- tinkerRummagedOrConjureOrSave
+            (fIs <$$>
+              (tinker ((\(Tx x _) -> x) <$> gen)))
+    os <- tinkerRummagedOrConjureOrSave
+            (fOs <$$>
+              (tinker ((\(Tx _ x) -> x) <$> gen)))
+    tinkerRummagedOrConjureOrSave
+      (pure (Tx <$> is <*> os))
+   where
+    -- This function will insert a conjured value to an empty list. We can
+    -- thus use it to ensure that the `txIns` and `txOuts` will never be
+    -- empty.
+    fillEmptyList :: Goblin g a => TinkerM g ([a] -> [a])
+    fillEmptyList = do
+      v <- conjure
+      pure (\xs -> case xs of
+                     [] -> [v]
+                     _  -> xs)
+
+  conjure = saveInBagOfTricks =<< do
+    -- Ensure that these lists are never empty.
+    listLenI <- (+1) <$> transcribeGenesAsInt 15
+    listLenO <- (+1) <$> transcribeGenesAsInt 15
+    inputs <- replicateM listLenI conjure
+    outputs <- replicateM listLenO conjure
+    pure (Tx inputs outputs)
 
 
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1751,18 +1751,18 @@ deriveGoblin ''Vote
 instance GeneOps g => Goblin g FactorA where
   tinker gen
     = tinkerRummagedOrConjureOrSave
-        ((\x -> FactorA (x `mod` fromIntegral Core.maxLovelaceVal))
+        ((\x -> FactorA (x `mod` fromIntegral GP.lovelaceCap))
            <$$> tinker ((\(FactorA x) -> x) <$> gen))
-  conjure = saveInBagOfTricks =<< (FactorA . (`mod` fromIntegral Core.maxLovelaceVal) <$>
-    conjure)
+  conjure = saveInBagOfTricks =<< (FactorA . (`mod` fromIntegral GP.lovelaceCap)
+    <$> conjure)
 
 instance GeneOps g => Goblin g FactorB where
   tinker gen
     = tinkerRummagedOrConjureOrSave
-        ((\x -> FactorB (x `mod` fromIntegral Core.maxLovelaceVal))
+        ((\x -> FactorB (x `mod` fromIntegral GP.lovelaceCap))
            <$$> tinker ((\(FactorB x) -> x) <$> gen))
-  conjure = saveInBagOfTricks =<< (FactorB . (`mod` fromIntegral Core.maxLovelaceVal) <$>
-    conjure)
+  conjure = saveInBagOfTricks =<< (FactorB . (`mod` fromIntegral GP.lovelaceCap)
+    <$> conjure)
 
 instance GeneOps g => Goblin g BkSgnCntT where
   tinker _

--- a/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
@@ -13,7 +13,8 @@ import           Hedgehog.Gen.Aux (doubleInc)
 import qualified Hedgehog.Range as Range
 import           Ledger.Core (BlockCount (BlockCount), SlotCount (SlotCount), unBlockCount,
                      unSlotCount)
-import           Ledger.Update (PParams (PParams))
+import           Ledger.Update (BkSgnCntT (..), FactorA (..), FactorB (..), PParams (PParams),
+                     UpAdptThd (..))
 import           Numeric.Natural (Natural)
 
 
@@ -24,25 +25,25 @@ import           Numeric.Natural (Natural)
 pparamsGen :: Gen PParams
 pparamsGen =
   (\((maxBkSz, maxHdrSz, maxTxSz, maxPropSz) :: (Natural, Natural, Natural, Natural))
-    (bkSgnCntT :: Double)
+    (bkSgnCntTDouble :: Double)
     ((bkSlotsPerEpoch, upTtl) :: (SlotCount, SlotCount))
     (scriptVersion :: Natural)
     (_cfmThd :: Double)
-    (upAdptThd :: Double)
-    (factorA :: Int)
-    (factorB :: Int)
+    (upAdptThdDouble :: Double)
+    (factorAInt :: Int)
+    (factorBInt :: Int)
     -> PParams
       maxBkSz
       maxHdrSz
       maxTxSz
       maxPropSz
-      bkSgnCntT
+      (BkSgnCntT bkSgnCntTDouble)
       bkSlotsPerEpoch
       upTtl
       scriptVersion
-      upAdptThd
-      factorA
-      factorB
+      (UpAdptThd upAdptThdDouble)
+      (FactorA factorAInt)
+      (FactorB factorBInt)
   )
     <$> szGen
     <*> doubleInc                                       -- bkSgnCntT

--- a/byron/ledger/executable-spec/src/Ledger/Update/Test.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Test.hs
@@ -4,6 +4,7 @@
 module Ledger.Update.Test
   ( coverUpiregFailures
   , coverUpivoteFailures
+  , coverDelegFailures
   )
 where
 
@@ -13,6 +14,7 @@ import           GHC.Stack (HasCallStack)
 import           Hedgehog (MonadTest)
 import           Hedgehog.Internal.Property (CoverPercentage)
 
+import           Ledger.Delegation (PredicateFailure (EpochInThePast, EpochPastNextEpoch, IsAlreadyScheduled, IsNotGenesisKey))
 import           Ledger.Update (PredicateFailure (AVSigDoesNotVerify, AlreadyProposedPv, AlreadyProposedSv, CannotFollowPv, CannotFollowSv, CannotUpdatePv, DoesNotVerify, InvalidApplicationName, InvalidSystemTags, NoUpdateProposal, NotGenesisDelegate))
 import           Ledger.Update (UpId (UpId))
 
@@ -69,5 +71,25 @@ coverUpivoteFailures coverPercentage someData =
     coverPercentage
     [ AVSigDoesNotVerify
     , NoUpdateProposal (UpId 0) -- We need to pass a dummy update id here.
+    ]
+    someData
+
+
+coverDelegFailures
+  :: forall m a
+   .  ( MonadTest m
+      , HasCallStack
+      , Data a
+      )
+  => CoverPercentage
+  -> a
+  -> m ()
+coverDelegFailures coverPercentage someData =
+  Generator.coverFailures
+    coverPercentage
+    [ EpochInThePast undefined
+    , EpochPastNextEpoch undefined
+    , IsAlreadyScheduled
+    , IsNotGenesisKey
     ]
     someData

--- a/byron/ledger/executable-spec/test/Ledger/Update/Examples.hs
+++ b/byron/ledger/executable-spec/test/Ledger/Update/Examples.hs
@@ -12,10 +12,11 @@ import           Test.Tasty.HUnit (testCase)
 import           Ledger.Core (BlockCount (BlockCount), Owner (Owner), Slot (Slot),
                      SlotCount (SlotCount), VKey (VKey), VKeyGenesis (VKeyGenesis), unBlockCount,
                      unOwner, unSlot, unSlotCount, unVKeyGenesis)
-import           Ledger.Update (ApName (ApName), ApVer (ApVer), Metadata (Metadata),
-                     PParams (PParams), ProtVer (ProtVer), UPIEND, UpId (UpId), _bkSgnCntT,
-                     _bkSlotsPerEpoch, _factorA, _factorB, _maxBkSz, _maxHdrSz, _maxPropSz,
-                     _maxTxSz, _pvAlt, _pvMaj, _pvMin, _scriptVersion, _upAdptThd, _upTtl)
+import           Ledger.Update (ApName (ApName), ApVer (ApVer), FactorA (..), FactorB (..),
+                     Metadata (Metadata), PParams (PParams), ProtVer (ProtVer), UPIEND,
+                     UpId (UpId), _bkSgnCntT, _bkSlotsPerEpoch, _factorA, _factorB, _maxBkSz,
+                     _maxHdrSz, _maxPropSz, _maxTxSz, _pvAlt, _pvMaj, _pvMin, _scriptVersion,
+                     _upAdptThd, _upTtl)
 
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 
@@ -35,8 +36,8 @@ upiendExamples =
           , _upTtl = SlotCount { unSlotCount = 10 }
           , _scriptVersion = 0
           , _upAdptThd = 0.6
-          , _factorA = 1
-          , _factorB = 2
+          , _factorA = FactorA 1
+          , _factorB = FactorB 2
           }
         newPParams =
           PParams
@@ -49,8 +50,8 @@ upiendExamples =
           , _upTtl = SlotCount { unSlotCount = 2 }
           , _scriptVersion = 0
           , _upAdptThd = 0.0
-          , _factorA = 0
-          , _factorB = 0
+          , _factorA = FactorA 0
+          , _factorB = FactorB 0
           }
       in
         checkTrace @UPIEND

--- a/cabal.project
+++ b/cabal.project
@@ -29,4 +29,4 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/goblins
-  tag: b5e99cf153a3abb1b764f80095f6a930ba056048
+  tag: 545448938bf620bb2a25212e1686916cfa3acee9

--- a/nix/.stack.nix/goblins.nix
+++ b/nix/.stack.nix/goblins.nix
@@ -50,7 +50,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/goblins";
-      rev = "b5e99cf153a3abb1b764f80095f6a930ba056048";
-      sha256 = "14iac7x5d1akd96j2w0m8jg24qhgshyc8m9ljqs8bw73kaiqszzx";
+      rev = "545448938bf620bb2a25212e1686916cfa3acee9";
+      sha256 = "1b9whagxvspzmll7b63ilxvbdq2ha3fkcfmgjnlpn4b939fgpclm";
       });
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,7 +23,7 @@ extra-deps:
     - cardano-crypto-class
 
 - git: https://github.com/input-output-hk/goblins
-  commit: b5e99cf153a3abb1b764f80095f6a930ba056048
+  commit: 545448938bf620bb2a25212e1686916cfa3acee9
 - moo-1.2
 - gray-code-0.3.1
 


### PR DESCRIPTION
Closes #788 and #817. 

This prepares for a PR to `cardano-ledger` which integrates goblins into the conformance tests.

We modify some Goblin instances here to be aware of certain bounds which were not encoded in the types (but were captured, for example, by the valid hedgehog generators).

