### PR TITLE
Gitignore .ghc.environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 dist-newstyle/
 cabal.project.local
 stack.yaml.lock
+.ghc.environment.*
 
 # Editors
 TAGS


### PR DESCRIPTION
Used by `cabal v2-*` commands.