### PR TITLE
Abstract over VRF implementation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,19 +12,19 @@ constraints:
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: ccbc085f1ebdde706feb7955fdebb33260dc5e32
+  tag: bb262f466d659d94ed6e5500c2dc101f7c2c6b1e
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: ccbc085f1ebdde706feb7955fdebb33260dc5e32
+  tag: bb262f466d659d94ed6e5500c2dc101f7c2c6b1e
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 96e8dcb29dc3c29eee99c0d020152fad6071af6d
+  tag: b9bf62f2bab90539809bee13620fe7d29b35928d
 
 source-repository-package
   type: git

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -59,8 +59,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "ccbc085f1ebdde706feb7955fdebb33260dc5e32";
-      sha256 = "0c6qrpch9pc8sir89ddrr1hllm1yksviyw9d4m46x7xbqsby9dcv";
+      rev = "bb262f466d659d94ed6e5500c2dc101f7c2c6b1e";
+      sha256 = "1vmp4lia4s2c20wgfbyvywsdmzg0s1m25zjw7n8a0my7cjg7n3vg";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -23,6 +23,7 @@
           (hsPkgs.cardano-binary)
           (hsPkgs.cardano-prelude)
           (hsPkgs.cryptonite)
+          (hsPkgs.deepseq)
           (hsPkgs.memory)
           (hsPkgs.reflection)
           (hsPkgs.vector)
@@ -47,8 +48,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "ccbc085f1ebdde706feb7955fdebb33260dc5e32";
-      sha256 = "0c6qrpch9pc8sir89ddrr1hllm1yksviyw9d4m46x7xbqsby9dcv";
+      rev = "bb262f466d659d94ed6e5500c2dc101f7c2c6b1e";
+      sha256 = "1vmp4lia4s2c20wgfbyvywsdmzg0s1m25zjw7n8a0my7cjg7n3vg";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -71,7 +71,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "96e8dcb29dc3c29eee99c0d020152fad6071af6d";
-      sha256 = "1ayb5h048qmwvmgzm4ckzg7x8pcscd8znlhrj0438vv8wbvx77rl";
+      rev = "b9bf62f2bab90539809bee13620fe7d29b35928d";
+      sha256 = "0fzk6z3dgnz5wrj7zp3gxzrf11hcik22ibp5z4i8d7d7hg0ngs9h";
       });
     }

--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -29,6 +29,7 @@
           (hsPkgs.cs-ledger)
           (hsPkgs.cardano-binary)
           (hsPkgs.cardano-crypto-class)
+          (hsPkgs.cardano-prelude)
           ];
         };
       tests = {
@@ -47,7 +48,9 @@
             (hsPkgs.text)
             (hsPkgs.microlens)
             (hsPkgs.cs-ledger)
+            (hsPkgs.cardano-binary)
             (hsPkgs.cardano-crypto-class)
+            (hsPkgs.cardano-prelude)
             (hsPkgs.small-steps)
             ];
           };

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -79,7 +79,8 @@ library
     non-integer,
     cs-ledger,
     cardano-binary,
-    cardano-crypto-class
+    cardano-crypto-class,
+    cardano-prelude
 
 test-suite delegation-test
     type:                exitcode-stdio-1.0
@@ -98,6 +99,7 @@ test-suite delegation-test
                          STSTests
                          Examples
                          Rules.ClassifyTraces
+                         Cardano.Crypto.VRF.Fake
                          Rules.TestDeleg
                          Rules.TestLedger
                          Rules.TestNewEpoch
@@ -139,5 +141,7 @@ test-suite delegation-test
       text,
       microlens,
       cs-ledger,
+      cardano-binary,
       cardano-crypto-class,
+      cardano-prelude,
       small-steps

--- a/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
@@ -73,7 +73,7 @@ interval1 = UnitInterval 1
 -- | Evolving nonce type.
 data Nonce
   = Nonce (Hash SHA256 Nonce)
-  | NeutralNonce -- ^ 0 element
+  | NeutralNonce -- ^ Identity element
   deriving (Eq, Ord, Show)
 
 instance ToCBOR Nonce where
@@ -85,12 +85,6 @@ instance ToCBOR Nonce where
 (Nonce a) ⭒ (Nonce b) = Nonce . coerce $ hash @SHA256 (getHash a <> getHash b)
 x ⭒ NeutralNonce = x
 NeutralNonce ⭒ x = x
-
-instance Semigroup Nonce where
-  (<>) = (⭒)
-
-instance Monoid Nonce where
-  mempty = NeutralNonce
 
 -- | Make a nonce from a natural number
 mkNonce :: Natural -> Nonce

--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 
 module BlockChain
   ( HashHeader(..)
   , BHBody(..)
   , BHeader(..)
   , Block(..)
-  , Proof(..)
   , ProtVer(..)
   , TxSeq(..)
   , bhHash
   , bhbHash
   , bHeaderSize
   , bBodySize
-  , slotToSeed
+  , slotToNonce
   , hBbsize
     -- accessor functions
   , bheader
@@ -23,29 +23,33 @@ module BlockChain
     --
   , slotsPrior
   , startRewards
-  , verifyVrf
   , seedEta
   , seedL
   , bvkcold
   , vrfChecks
   , incrBlocks
+  , mkSeed
   )
 where
 
-import qualified Data.ByteString.Char8 as BS (length, pack)
+import qualified Data.ByteString.Char8 as BS
+import           Data.Coerce (coerce)
 import           Data.Foldable (toList)
-import qualified Data.Map.Strict as Map (insert, lookup)
+import qualified Data.Map.Strict as Map
 import           Data.Ratio (denominator, numerator)
 import           Data.Sequence (Seq)
 import           Numeric.Natural (Natural)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
+import           Cardano.Crypto.Hash (SHA256)
+import qualified Cardano.Crypto.Hash.Class as Hash
+import qualified Cardano.Crypto.VRF.Class as VRF
 
-import           BaseTypes (Seed (..), UnitInterval, intervalValue, mkNonce, (⭒))
+import           BaseTypes (Nonce (..), Seed(..), UnitInterval, intervalValue, mkNonce)
 import           Delegation.Certificates (PoolDistr (..))
 import           EpochBoundary (BlocksMade (..))
-import           Keys (DSIGNAlgorithm, Hash, HashAlgorithm, KESAlgorithm, KESig, KeyHash, VKey,
-                     hash, hashKey)
+import           Keys (DSIGNAlgorithm, Hash, HashAlgorithm, KESAlgorithm, KESig, KeyHash,
+                     VKey, VRFAlgorithm, VRFValue(..), hash, hashKey, hashKeyVRF)
 import           OCert (OCert (..))
 import           Slot (Duration, Slot (..))
 import           Tx (Tx (..))
@@ -53,56 +57,61 @@ import           Tx (Tx (..))
 import           NonIntegral ((***))
 
 -- |The hash of a Block Header
-newtype HashHeader hashAlgo dsignAlgo kesAlgo =
-  HashHeader (Hash hashAlgo (BHeader hashAlgo dsignAlgo kesAlgo))
+newtype HashHeader hashAlgo dsignAlgo kesAlgo vrfAlgo =
+  HashHeader (Hash hashAlgo (BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo))
   deriving (Show, Eq, Ord, ToCBOR)
 
-newtype TxSeq hashAlgo dsignAlgo = TxSeq (Seq (Tx hashAlgo dsignAlgo))
+newtype TxSeq hashAlgo dsignAlgo vrfAlgo
+    = TxSeq (Seq (Tx hashAlgo dsignAlgo vrfAlgo))
   deriving (Eq, Show)
 
-instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo) =>
-  ToCBOR (TxSeq hashAlgo dsignAlgo)  where
+instance
+    ( HashAlgorithm hashAlgo
+    , DSIGNAlgorithm dsignAlgo
+    , VRFAlgorithm vrfAlgo
+    ) =>
+  ToCBOR (TxSeq hashAlgo dsignAlgo vrfAlgo)  where
   toCBOR (TxSeq s) = toCBOR $ toList s
 
 -- | Hash of block body
-newtype HashBBody hashAlgo dsignAlgo kesAlgo =
-  HashBBody (Hash hashAlgo (TxSeq hashAlgo dsignAlgo))
+newtype HashBBody hashAlgo dsignAlgo kesAlgo vrfAlgo =
+  HashBBody (Hash hashAlgo (TxSeq hashAlgo dsignAlgo vrfAlgo))
   deriving (Show, Eq, Ord, ToCBOR)
 
 -- |Hash a given block header
 bhHash
-  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo)
-  => BHeader hashAlgo dsignAlgo kesAlgo
-  -> HashHeader hashAlgo dsignAlgo kesAlgo
+  :: ( HashAlgorithm hashAlgo
+     , DSIGNAlgorithm dsignAlgo
+     , KESAlgorithm kesAlgo
+     , VRFAlgorithm vrfAlgo
+     )
+  => BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
+  -> HashHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
 bhHash = HashHeader . hash
 
 -- |Hash a given block body
 bhbHash
-  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => TxSeq hashAlgo dsignAlgo
-  -> HashBBody hashAlgo dsignAlgo kesAlgo
+  :: (HashAlgorithm hashAlgo
+     , DSIGNAlgorithm dsignAlgo
+     , VRFAlgorithm vrfAlgo
+     )
+  => TxSeq hashAlgo dsignAlgo vrfAlgo
+  -> HashBBody hashAlgo dsignAlgo kesAlgo vrfAlgo
 bhbHash = HashBBody . hash
 
-data Proof dsignAlgo a =
-  Proof (VKey dsignAlgo) Seed a
-  deriving (Show, Eq)
-
-instance (DSIGNAlgorithm dsignAlgo, ToCBOR a) => ToCBOR (Proof dsignAlgo a) where
-  toCBOR (Proof key s a) =
-    encodeListLen 3
-      <> toCBOR key
-      <> toCBOR s
-      <> toCBOR a
-
-data BHeader hashAlgo dsignAlgo kesAlgo
+data BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
   = BHeader
-      (BHBody hashAlgo dsignAlgo kesAlgo)
-      (KESig kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo))
+      (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
+      (KESig kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo))
   deriving (Show, Eq)
 
 instance
-  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo)
-  => ToCBOR (BHeader hashAlgo dsignAlgo kesAlgo)
+  ( HashAlgorithm hashAlgo
+  , DSIGNAlgorithm dsignAlgo
+  , KESAlgorithm kesAlgo
+  , VRFAlgorithm vrfAlgo
+  )
+  => ToCBOR (BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo)
  where
    toCBOR (BHeader bHBody kESig) =
      encodeListLen 2
@@ -119,31 +128,27 @@ instance ToCBOR ProtVer where
        <> toCBOR y
        <> toCBOR z
 
-data BHBody hashAlgo dsignAlgo kesAlgo = BHBody
+data BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo = BHBody
   { -- | Hash of the previous block header
     -- The first block in a chain will set this field to Nothing.
     -- TODO Since the Shelley chain will begins with blocks from
     -- the Byron era, we should probably use a sum type here,
     -- so that the first shelley block can point to the last Byron block.
-    bheaderPrev           :: HashHeader hashAlgo dsignAlgo kesAlgo
+    bheaderPrev           :: HashHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
     -- | verification key of block issuer
   , bheaderVk             :: VKey dsignAlgo
     -- | VRF verification key for block issuer
-  , bheaderVrfVk          :: VKey dsignAlgo
+  , bheaderVrfVk          :: VRF.VerKeyVRF vrfAlgo
     -- | block slot
   , bheaderSlot           :: Slot
     -- | block nonce
-  , bheaderEta            :: Seed
-    -- | proof of nonce
-  , bheaderPrfEta         :: Proof dsignAlgo Seed
+  , bheaderEta            :: VRF.CertifiedVRF vrfAlgo Nonce
     -- | leader election value
-  , bheaderL              :: UnitInterval
-    -- | proof of leader election
-  , bheaderPrfL           :: Proof dsignAlgo UnitInterval
+  , bheaderL              :: VRF.CertifiedVRF vrfAlgo UnitInterval
     -- | Size of the block body
   , bsize                 :: Natural
     -- | Hash of block body
-  , bhash                 :: HashBBody hashAlgo dsignAlgo kesAlgo
+  , bhash                 :: HashBBody hashAlgo dsignAlgo kesAlgo vrfAlgo
     -- | operational certificate
   , bheaderOCert          :: OCert dsignAlgo kesAlgo
     -- | protocol version
@@ -151,54 +156,60 @@ data BHBody hashAlgo dsignAlgo kesAlgo = BHBody
   } deriving (Show, Eq)
 
 instance
-  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo)
-  => ToCBOR (BHBody hashAlgo dsignAlgo kesAlgo)
+  ( HashAlgorithm hashAlgo
+  , DSIGNAlgorithm dsignAlgo
+  , KESAlgorithm kesAlgo
+  , VRFAlgorithm vrfAlgo
+  )
+  => ToCBOR (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
  where
   toCBOR bhBody =
-    encodeListLen 12
+    encodeListLen 10
       <> toCBOR (bheaderPrev bhBody)
       <> toCBOR (bheaderVk bhBody)
-      <> toCBOR (bheaderVrfVk bhBody)
+      <> VRF.encodeVerKeyVRF (bheaderVrfVk bhBody)
       <> toCBOR (bheaderSlot bhBody)
       <> toCBOR (bheaderEta bhBody)
-      <> toCBOR (bheaderPrfEta bhBody)
       <> toCBOR (bheaderL bhBody)
-      <> toCBOR (bheaderPrfL bhBody)
       <> toCBOR (bsize bhBody)
       <> toCBOR (bhash bhBody)
       <> toCBOR (bheaderOCert bhBody)
       <> toCBOR (bprotvert bhBody)
 
-data Block hashAlgo dsignAlgo kesAlgo
+data Block hashAlgo dsignAlgo kesAlgo vrfAlgo
   = Block
-    (BHeader hashAlgo dsignAlgo kesAlgo)
-    (TxSeq hashAlgo dsignAlgo)
+    (BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo)
+    (TxSeq hashAlgo dsignAlgo vrfAlgo)
   deriving (Show, Eq)
 
 bHeaderSize
-  :: (DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo)
-  => BHeader hashAlgo dsignAlgo kesAlgo
+  :: (DSIGNAlgorithm dsignAlgo, KESAlgorithm kesAlgo, VRFAlgorithm vrfAlgo)
+  => BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
   -> Int
 bHeaderSize = BS.length . BS.pack . show
 
-bBodySize :: DSIGNAlgorithm dsignAlgo => TxSeq hashAlgo dsignAlgo -> Int
+bBodySize :: DSIGNAlgorithm dsignAlgo => TxSeq hashAlgo dsignAlgo vrfAlgo -> Int
 bBodySize (TxSeq txs) = sum (map (BS.length . BS.pack . show) $ toList txs)
 
-slotToSeed :: Slot -> Seed
-slotToSeed (Slot s) = mkNonce (fromIntegral s)
+slotToNonce :: Slot -> Nonce
+slotToNonce (Slot s) = mkNonce (fromIntegral s)
 
-bheader :: Block hashAlgo dsignAlgo kesAlgo -> BHeader hashAlgo dsignAlgo kesAlgo
+bheader
+  :: Block hashAlgo dsignAlgo kesAlgo vrfAlgo
+  -> BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
 bheader (Block bh _) = bh
 
-bbody :: Block hashAlgo dsignAlgo kesAlgo -> TxSeq hashAlgo dsignAlgo
+bbody :: Block hashAlgo dsignAlgo kesAlgo vrfAlgo -> TxSeq hashAlgo dsignAlgo vrfAlgo
 bbody (Block _ txs) = txs
 
-bhbody :: BHeader hashAlgo dsignAlgo kesAlgo -> BHBody hashAlgo dsignAlgo kesAlgo
+bhbody
+  :: BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
+  -> BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo
 bhbody (BHeader b _) = b
 
 hsig
-  :: BHeader hashAlgo dsignAlgo kesAlgo
-  -> KESig kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo)
+  :: BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
+  -> KESig kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
 hsig (BHeader _ s) = s
 
 slotsPrior :: Duration
@@ -207,54 +218,70 @@ slotsPrior = 33 -- one third of slots per epoch
 startRewards :: Duration
 startRewards = 33 -- see above
 
-verifyVrf
-  :: (DSIGNAlgorithm dsignAlgo, Eq a)
-  => VKey dsignAlgo
+-- | Construct a seed to use in the VRF computation.
+mkSeed
+  :: ( HashAlgorithm hashAlgo
+     , DSIGNAlgorithm dsignAlgo
+     , KESAlgorithm kesAlgo
+     , VRFAlgorithm vrfAlgo
+     )
+  => Nonce -- ^ Universal constant
+  -> Slot
+  -> Nonce -- ^ Epoch nonce
+  -> HashHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
   -> Seed
-  -> (a, Proof dsignAlgo a)
-  -> Bool
-verifyVrf vk seed (val, Proof k s v) = vk == k && seed == s && val == v
+mkSeed (Nonce eta0) slot nonce lastHash =
+  Seed . coerce $ eta0 `Hash.xor` coerce (hash @SHA256 (slot, nonce, lastHash))
+mkSeed NeutralNonce slot nonce lastHash =
+  Seed . coerce $ (hash @SHA256 (slot, nonce, lastHash))
+
 
 vrfChecks
-  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => Seed
-  -> PoolDistr hashAlgo dsignAlgo
+  ::  ( HashAlgorithm hashAlgo
+      , DSIGNAlgorithm dsignAlgo
+      , KESAlgorithm kesAlgo
+      , VRFAlgorithm vrfAlgo
+      , VRF.Signable vrfAlgo Seed
+      )
+  => Nonce
+  -> PoolDistr hashAlgo dsignAlgo vrfAlgo
   -> UnitInterval
-  -> BHBody hashAlgo dsignAlgo kesAlgo
+  -> BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo
   -> Bool
 vrfChecks eta0 (PoolDistr pd) f bhb =
   let sigma' = Map.lookup hk pd
   in  case sigma' of
         Nothing -> False
         Just (sigma, vrfHK) ->
-          vrfHK == hashKey vrfK
-            && verifyVrf vrfK
-                         ((eta0 ⭒ ss) ⭒ SeedEta)
-                         (bheaderEta bhb, bheaderPrfEta bhb)
-            && verifyVrf vrfK
-                         ((eta0 ⭒ ss) ⭒ SeedL)
-                         (bheaderL bhb, bheaderPrfL bhb)
-            && intervalValue (bheaderL bhb)
+          vrfHK == hashKeyVRF vrfK
+            && VRF.verifyCertified vrfK
+                         (mkSeed seedEta slot eta0 prevHash)
+                         (coerce $ bheaderEta bhb)
+            && VRF.verifyCertified vrfK
+                         (mkSeed seedL slot eta0 prevHash)
+                         (coerce $ bheaderL bhb)
+            && intervalValue (fromNatural . VRF.certifiedNatural $ bheaderL bhb)
             <  1
             -  ((1 - activeSlotsCoeff) *** fromRational sigma)
  where
   hk = hashKey $ bvkcold bhb
   vrfK = bheaderVrfVk bhb
-  ss = slotToSeed $ bheaderSlot bhb
+  prevHash = bheaderPrev bhb
+  slot = bheaderSlot bhb
   f' = intervalValue f
   activeSlotsCoeff =
     fromIntegral (numerator f') / fromIntegral (denominator f')
 
-seedEta :: Seed
+seedEta :: Nonce
 seedEta = mkNonce 0
 
-seedL :: Seed
+seedL :: Nonce
 seedL = mkNonce 1
 
-bvkcold :: BHBody hashAlgo dsignAlgo kesAlgo -> VKey dsignAlgo
+bvkcold :: BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo -> VKey dsignAlgo
 bvkcold bhb = ocertVkCold $ bheaderOCert bhb
 
-hBbsize :: BHBody hashAlgo dsignAlgo kesAlgo -> Natural
+hBbsize :: BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo -> Natural
 hBbsize = bsize
 
 incrBlocks

--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -230,8 +230,8 @@ mkSeed
   -> Nonce -- ^ Epoch nonce
   -> HashHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
   -> Seed
-mkSeed (Nonce eta0) slot nonce lastHash =
-  Seed . coerce $ eta0 `Hash.xor` coerce (hash @SHA256 (slot, nonce, lastHash))
+mkSeed (Nonce uc) slot nonce lastHash =
+  Seed . coerce $ uc `Hash.xor` coerce (hash @SHA256 (slot, nonce, lastHash))
 mkSeed NeutralNonce slot nonce lastHash =
   Seed . coerce $ (hash @SHA256 (slot, nonce, lastHash))
 

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
@@ -8,5 +8,5 @@ import           BaseTypes (UnitInterval)
 import           Coin (Coin)
 import           TxData (PoolParams, poolCost, poolMargin, poolPledge)
 
-poolSpec :: PoolParams hashAlgo dsignAlgo -> (Coin, UnitInterval, Coin)
+poolSpec :: PoolParams hashAlgo dsignAlgo vrfAlgo -> (Coin, UnitInterval, Coin)
 poolSpec pool = (pool ^. poolCost, pool ^. poolMargin, pool ^. poolPledge)

--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -74,7 +74,7 @@ getStakeHK :: Addr hashAlgo dsignAlgo -> Maybe (StakeCredential hashAlgo dsignAl
 getStakeHK (AddrBase _ hk) = Just hk
 getStakeHK _               = Nothing
 
-aggregateOuts :: UTxO hashAlgo dsignAlgo -> Map (Addr hashAlgo dsignAlgo) Coin
+aggregateOuts :: UTxO hashAlgo dsignAlgo vrfAlgo -> Map (Addr hashAlgo dsignAlgo) Coin
 aggregateOuts (UTxO u) =
   Map.fromListWith (+) (map (\(_, TxOut a c) -> (a, c)) $ Map.toList u)
 
@@ -187,7 +187,7 @@ groupByPool active delegs =
     | hk <- Map.keys delegs
     ]
 
-data SnapShots hashAlgo dsignAlgo
+data SnapShots hashAlgo dsignAlgo vrfAlgo
   = SnapShots
     { _pstakeMark
       :: ( Stake hashAlgo dsignAlgo
@@ -202,13 +202,13 @@ data SnapShots hashAlgo dsignAlgo
          , Map (StakeCredential hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo)
          )
     , _poolsSS
-      :: Map (KeyHash hashAlgo dsignAlgo) (PoolParams hashAlgo dsignAlgo)
+      :: Map (KeyHash hashAlgo dsignAlgo) (PoolParams hashAlgo dsignAlgo vrfAlgo)
     , _feeSS :: Coin
     } deriving (Show, Eq)
 
 makeLenses ''SnapShots
 
-emptySnapShots :: SnapShots hashAlgo dsignAlgo
+emptySnapShots :: SnapShots hashAlgo dsignAlgo vrfAlgo
 emptySnapShots =
     SnapShots snapEmpty snapEmpty snapEmpty Map.empty (Coin 0)
     where pooledEmpty = Map.empty

--- a/shelley/chain-and-ledger/executable-spec/src/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/PParams.hs
@@ -28,7 +28,7 @@ module PParams
 
 import           Numeric.Natural (Natural)
 
-import           BaseTypes (Seed (NeutralSeed), UnitInterval, interval0)
+import           BaseTypes (Nonce(NeutralNonce), UnitInterval, interval0)
 import           Coin (Coin (..))
 import           Slot (Epoch (..))
 
@@ -72,7 +72,7 @@ data PParams = PParams
     -- | Decentralization parameter
   , _d               :: UnitInterval
     -- | Extra entropy
-  , _extraEntropy    :: Seed
+  , _extraEntropy    :: Nonce
     -- | Protocol version
   , _protocolVersion :: (Natural, Natural, Natural)
   } deriving (Show, Eq)
@@ -101,6 +101,6 @@ emptyPParams =
      , _tau = interval0
      , _activeSlotCoeff = interval0
      , _d = interval0
-     , _extraEntropy = NeutralSeed
+     , _extraEntropy = NeutralNonce
      , _protocolVersion = (0, 0, 0)
      }

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -24,18 +24,18 @@ import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
 import           Hedgehog (Gen)
 
-data DELEG hashAlgo dsignAlgo
+data DELEG hashAlgo dsignAlgo vrfAlgo
 
 data DelegEnv
   = DelegEnv Slot Ptr
   deriving (Show, Eq)
 
-instance STS (DELEG hashAlgo dsignAlgo)
+instance STS (DELEG hashAlgo dsignAlgo vrfAlgo)
  where
-  type State (DELEG hashAlgo dsignAlgo) = DState hashAlgo dsignAlgo
-  type Signal (DELEG hashAlgo dsignAlgo) = DCert hashAlgo dsignAlgo
-  type Environment (DELEG hashAlgo dsignAlgo) = DelegEnv
-  data PredicateFailure (DELEG hashAlgo dsignAlgo)
+  type State (DELEG hashAlgo dsignAlgo vrfAlgo) = DState hashAlgo dsignAlgo
+  type Signal (DELEG hashAlgo dsignAlgo vrfAlgo) = DCert hashAlgo dsignAlgo vrfAlgo
+  type Environment (DELEG hashAlgo dsignAlgo vrfAlgo) = DelegEnv
+  data PredicateFailure (DELEG hashAlgo dsignAlgo vrfAlgo)
     = StakeKeyAlreadyRegisteredDELEG
     | StakeKeyNotRegisteredDELEG
     | StakeKeyNonZeroAccountBalanceDELEG
@@ -49,7 +49,7 @@ instance STS (DELEG hashAlgo dsignAlgo)
   transitionRules = [delegationTransition]
 
 delegationTransition
-  :: TransitionRule (DELEG hashAlgo dsignAlgo)
+  :: TransitionRule (DELEG hashAlgo dsignAlgo vrfAlgo)
 delegationTransition = do
   TRC (DelegEnv slot_ ptr_, ds, c) <- judgmentContext
 
@@ -97,6 +97,6 @@ delegationTransition = do
 
 
 instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => HasTrace (DELEG hashAlgo dsignAlgo) where
+  => HasTrace (DELEG hashAlgo dsignAlgo vrfAlgo) where
   envGen _ = undefined :: Gen DelegEnv
-  sigGen _ _ = undefined :: Gen (DCert hashAlgo dsignAlgo)
+  sigGen _ _ = undefined :: Gen (DCert hashAlgo dsignAlgo vrfAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Epoch.hs
@@ -27,22 +27,22 @@ import           STS.Newpp
 import           STS.PoolReap
 import           STS.Snap
 
-data EPOCH hashAlgo dsignAlgo
+data EPOCH hashAlgo dsignAlgo vrfAlgo
 
-instance STS (EPOCH hashAlgo dsignAlgo) where
-    type State (EPOCH hashAlgo dsignAlgo) = EpochState hashAlgo dsignAlgo
-    type Signal (EPOCH hashAlgo dsignAlgo) = Epoch
-    type Environment (EPOCH hashAlgo dsignAlgo) = ()
-    data PredicateFailure (EPOCH hashAlgo dsignAlgo)
-      = PoolReapFailure (PredicateFailure (POOLREAP hashAlgo dsignAlgo))
-      | SnapFailure (PredicateFailure (SNAP hashAlgo dsignAlgo))
-      | NewPpFailure (PredicateFailure (NEWPP hashAlgo dsignAlgo))
+instance STS (EPOCH hashAlgo dsignAlgo vrfAlgo) where
+    type State (EPOCH hashAlgo dsignAlgo vrfAlgo) = EpochState hashAlgo dsignAlgo vrfAlgo
+    type Signal (EPOCH hashAlgo dsignAlgo vrfAlgo) = Epoch
+    type Environment (EPOCH hashAlgo dsignAlgo vrfAlgo) = ()
+    data PredicateFailure (EPOCH hashAlgo dsignAlgo vrfAlgo)
+      = PoolReapFailure (PredicateFailure (POOLREAP hashAlgo dsignAlgo vrfAlgo))
+      | SnapFailure (PredicateFailure (SNAP hashAlgo dsignAlgo vrfAlgo))
+      | NewPpFailure (PredicateFailure (NEWPP hashAlgo dsignAlgo vrfAlgo))
       deriving (Show, Eq)
 
     initialRules = [ initialEpoch ]
     transitionRules = [ epochTransition ]
 
-initialEpoch :: InitialRule (EPOCH hashAlgo dsignAlgo)
+initialEpoch :: InitialRule (EPOCH hashAlgo dsignAlgo vrfAlgo)
 initialEpoch =
   pure $ EpochState emptyAccount emptySnapShots emptyLedgerState emptyPParams
 
@@ -63,7 +63,7 @@ votedValuePParams (PPUpdate ppup) pps =
       1 -> (Just . updatePParams pps . fst . head . Map.toList) consensus
       _ -> Nothing
 
-epochTransition :: forall hashAlgo dsignAlgo . TransitionRule (EPOCH hashAlgo dsignAlgo)
+epochTransition :: forall hashAlgo dsignAlgo vrfAlgo . TransitionRule (EPOCH hashAlgo dsignAlgo vrfAlgo)
 epochTransition = do
   TRC (_, EpochState { esAccountState = as
                      , esSnapshots = ss
@@ -73,12 +73,12 @@ epochTransition = do
   let UpdateState ppup _ _ _ = _ups us
   let DPState ds ps = _delegationState ls
   SnapState ss' us' <-
-    trans @(SNAP hashAlgo dsignAlgo) $ TRC (SnapEnv pp ds ps, SnapState ss us, e)
+    trans @(SNAP hashAlgo dsignAlgo vrfAlgo) $ TRC (SnapEnv pp ds ps, SnapState ss us, e)
   PoolreapState us'' as' ds' ps' <-
-    trans @(POOLREAP hashAlgo dsignAlgo) $ TRC (pp, PoolreapState us' as ds ps, e)
+    trans @(POOLREAP hashAlgo dsignAlgo vrfAlgo) $ TRC (pp, PoolreapState us' as ds ps, e)
   let ppNew = votedValuePParams ppup pp
   NewppState us''' as'' pp' <-
-    trans @(NEWPP hashAlgo dsignAlgo)
+    trans @(NEWPP hashAlgo dsignAlgo vrfAlgo)
       $ TRC (NewppEnv ppNew ds' ps', NewppState us'' as' pp, e)
   pure $ EpochState
     as''
@@ -86,11 +86,11 @@ epochTransition = do
     (ls { _utxoState = us''', _delegationState = DPState ds' ps' })
     pp'
 
-instance Embed (SNAP hashAlgo dsignAlgo) (EPOCH hashAlgo dsignAlgo) where
+instance Embed (SNAP hashAlgo dsignAlgo vrfAlgo) (EPOCH hashAlgo dsignAlgo vrfAlgo) where
     wrapFailed = SnapFailure
 
-instance Embed (POOLREAP hashAlgo dsignAlgo) (EPOCH hashAlgo dsignAlgo) where
+instance Embed (POOLREAP hashAlgo dsignAlgo vrfAlgo) (EPOCH hashAlgo dsignAlgo vrfAlgo) where
     wrapFailed = PoolReapFailure
 
-instance Embed (NEWPP hashAlgo dsignAlgo) (EPOCH hashAlgo dsignAlgo) where
+instance Embed (NEWPP hashAlgo dsignAlgo vrfAlgo) (EPOCH hashAlgo dsignAlgo vrfAlgo) where
     wrapFailed = NewPpFailure

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
@@ -22,32 +22,32 @@ import           UTxO
 
 import           Control.State.Transition
 
-data NEWPP hashAlgo dsignAlgo
+data NEWPP hashAlgo dsignAlgo vrfAlgo
 
-data NewppState hashAlgo dsignAlgo
-  = NewppState (UTxOState hashAlgo dsignAlgo) AccountState PParams
+data NewppState hashAlgo dsignAlgo vrfAlgo
+  = NewppState (UTxOState hashAlgo dsignAlgo vrfAlgo) AccountState PParams
 
-data NewppEnv hashAlgo dsignAlgo
-  = NewppEnv (Maybe PParams) (DState hashAlgo dsignAlgo) (PState hashAlgo dsignAlgo)
+data NewppEnv hashAlgo dsignAlgo vrfAlgo
+  = NewppEnv (Maybe PParams) (DState hashAlgo dsignAlgo) (PState hashAlgo dsignAlgo vrfAlgo)
 
-instance STS (NEWPP hashAlgo dsignAlgo) where
-  type State (NEWPP hashAlgo dsignAlgo) = NewppState hashAlgo dsignAlgo
-  type Signal (NEWPP hashAlgo dsignAlgo) = Epoch
-  type Environment (NEWPP hashAlgo dsignAlgo) = NewppEnv hashAlgo dsignAlgo
-  data PredicateFailure (NEWPP hashAlgo dsignAlgo)
+instance STS (NEWPP hashAlgo dsignAlgo vrfAlgo) where
+  type State (NEWPP hashAlgo dsignAlgo vrfAlgo) = NewppState hashAlgo dsignAlgo vrfAlgo
+  type Signal (NEWPP hashAlgo dsignAlgo vrfAlgo) = Epoch
+  type Environment (NEWPP hashAlgo dsignAlgo vrfAlgo) = NewppEnv hashAlgo dsignAlgo vrfAlgo
+  data PredicateFailure (NEWPP hashAlgo dsignAlgo vrfAlgo)
     = FailureNEWPP
     deriving (Show, Eq)
 
   initialRules = [initialNewPp]
   transitionRules = [newPpTransition]
 
-initialNewPp :: InitialRule (NEWPP hashAlgo dsignAlgo)
+initialNewPp :: InitialRule (NEWPP hashAlgo dsignAlgo vrfAlgo)
 initialNewPp = pure $ NewppState
   (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState)
   emptyAccount
   emptyPParams
 
-newPpTransition :: TransitionRule (NEWPP hashAlgo dsignAlgo)
+newPpTransition :: TransitionRule (NEWPP hashAlgo dsignAlgo vrfAlgo)
 newPpTransition = do
   TRC (NewppEnv ppNew ds ps, NewppState utxoSt acnt pp, e) <- judgmentContext
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ocert.hs
@@ -19,23 +19,23 @@ import           OCert
 
 import           Control.State.Transition
 
-data OCERT hashAlgo dsignAlgo kesAlgo
+data OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo
 
 instance
   ( HashAlgorithm hashAlgo
   , DSIGNAlgorithm dsignAlgo
   , Signable dsignAlgo (VKeyES kesAlgo, Natural, KESPeriod)
   , KESAlgorithm kesAlgo
-  , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo)
+  , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
   )
-  => STS (OCERT hashAlgo dsignAlgo kesAlgo)
+  => STS (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
  where
-  type State (OCERT hashAlgo dsignAlgo kesAlgo)
+  type State (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
     = Map (KeyHash hashAlgo dsignAlgo) Natural
-  type Signal (OCERT hashAlgo dsignAlgo kesAlgo)
-    = BHeader hashAlgo dsignAlgo kesAlgo
-  type Environment (OCERT hashAlgo dsignAlgo kesAlgo) = ()
-  data PredicateFailure (OCERT hashAlgo dsignAlgo kesAlgo)
+  type Signal (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
+    = BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
+  type Environment (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo) = ()
+  data PredicateFailure (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
     = KESBeforeStartOCERT
     | KESAfterEndOCERT
     | KESPeriodWrongOCERT
@@ -52,9 +52,9 @@ ocertTransition
      , DSIGNAlgorithm dsignAlgo
      , Signable dsignAlgo (VKeyES kesAlgo, Natural, KESPeriod)
      , KESAlgorithm kesAlgo
-     , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo)
+     , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
      )
-  => TransitionRule (OCERT hashAlgo dsignAlgo kesAlgo)
+  => TransitionRule (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
 ocertTransition = do
   TRC (_, cs, BHeader bhb sigma) <- judgmentContext
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -24,18 +24,18 @@ import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
 import           Hedgehog (Gen)
 
-data POOL hashAlgo dsignAlgo
+data POOL hashAlgo dsignAlgo vrfAlgo
 
 data PoolEnv =
   PoolEnv Slot PParams
   deriving (Show, Eq)
 
-instance STS (POOL hashAlgo dsignAlgo)
+instance STS (POOL hashAlgo dsignAlgo vrfAlgo)
  where
-  type State (POOL hashAlgo dsignAlgo) = PState hashAlgo dsignAlgo
-  type Signal (POOL hashAlgo dsignAlgo) = DCert hashAlgo dsignAlgo
-  type Environment (POOL hashAlgo dsignAlgo) = PoolEnv
-  data PredicateFailure (POOL hashAlgo dsignAlgo)
+  type State (POOL hashAlgo dsignAlgo vrfAlgo) = PState hashAlgo dsignAlgo vrfAlgo
+  type Signal (POOL hashAlgo dsignAlgo vrfAlgo) = DCert hashAlgo dsignAlgo vrfAlgo
+  type Environment (POOL hashAlgo dsignAlgo vrfAlgo) = PoolEnv
+  data PredicateFailure (POOL hashAlgo dsignAlgo vrfAlgo)
     = StakePoolNotRegisteredOnKeyPOOL
     | StakePoolRetirementWrongEpochPOOL
     | WrongCertificateTypePOOL
@@ -44,7 +44,7 @@ instance STS (POOL hashAlgo dsignAlgo)
   initialRules = [pure emptyPState]
   transitionRules = [poolDelegationTransition]
 
-poolDelegationTransition :: TransitionRule (POOL hashAlgo dsignAlgo)
+poolDelegationTransition :: TransitionRule (POOL hashAlgo dsignAlgo vrfAlgo)
 poolDelegationTransition = do
   TRC (PoolEnv slot pp, ps, c) <- judgmentContext
   let StakePools stPools_ = _stPools ps
@@ -90,6 +90,6 @@ m ⨃ (k,v) = Map.union (Map.singleton k v) m
 m ∪ (k,v) = Map.union m (Map.singleton k v)
 
 instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => HasTrace (POOL hashAlgo dsignAlgo) where
+  => HasTrace (POOL hashAlgo dsignAlgo vrfAlgo) where
   envGen _ = undefined :: Gen PoolEnv
-  sigGen _ _ = undefined :: Gen (DCert hashAlgo dsignAlgo)
+  sigGen _ _ = undefined :: Gen (DCert hashAlgo dsignAlgo vrfAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
@@ -25,27 +25,27 @@ import           Hedgehog (Gen)
 
 import           Ledger.Core (dom, (∈), (∪+), (⋪), (⋫), (▷), (◁))
 
-data POOLREAP hashAlgo dsignAlgo
+data POOLREAP hashAlgo dsignAlgo vrfAlgo
 
-data PoolreapState hashAlgo dsignAlgo = PoolreapState
-  { prUTxOSt :: UTxOState hashAlgo dsignAlgo
+data PoolreapState hashAlgo dsignAlgo vrfAlgo = PoolreapState
+  { prUTxOSt :: UTxOState hashAlgo dsignAlgo vrfAlgo
   , prAcnt   :: AccountState
   , prDState :: DState hashAlgo dsignAlgo
-  , prPState :: PState hashAlgo dsignAlgo
+  , prPState :: PState hashAlgo dsignAlgo vrfAlgo
   }
   deriving (Show, Eq)
 
-instance STS (POOLREAP hashAlgo dsignAlgo) where
-  type State (POOLREAP hashAlgo dsignAlgo) = PoolreapState hashAlgo dsignAlgo
-  type Signal (POOLREAP hashAlgo dsignAlgo) = Epoch
-  type Environment (POOLREAP hashAlgo dsignAlgo) = PParams
-  data PredicateFailure (POOLREAP hashAlgo dsignAlgo)
+instance STS (POOLREAP hashAlgo dsignAlgo vrfAlgo) where
+  type State (POOLREAP hashAlgo dsignAlgo vrfAlgo) = PoolreapState hashAlgo dsignAlgo vrfAlgo
+  type Signal (POOLREAP hashAlgo dsignAlgo vrfAlgo) = Epoch
+  type Environment (POOLREAP hashAlgo dsignAlgo vrfAlgo) = PParams
+  data PredicateFailure (POOLREAP hashAlgo dsignAlgo vrfAlgo)
     = FailurePOOLREAP
     deriving (Show, Eq)
   initialRules = [pure $ PoolreapState emptyUTxOState emptyAccount emptyDState emptyPState]
   transitionRules = [poolReapTransition]
 
-poolReapTransition :: TransitionRule (POOLREAP hashAlgo dsignAlgo)
+poolReapTransition :: TransitionRule (POOLREAP hashAlgo dsignAlgo vrfAlgo)
 poolReapTransition = do
   TRC (pp, PoolreapState us a ds ps, e) <- judgmentContext
 
@@ -72,6 +72,6 @@ poolReapTransition = do
        , _retiring = retired ⋪ _retiring ps
        , _cCounters = retired ⋪ _cCounters ps}
 
-instance HasTrace (POOLREAP hashAlgo dsignAlgo) where
+instance HasTrace (POOLREAP hashAlgo dsignAlgo vrfAlgo) where
   envGen _ = undefined :: Gen PParams
   sigGen _ _ = undefined :: Gen Epoch

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
@@ -14,23 +14,23 @@ import           Slot
 
 import           Control.State.Transition
 
-data RUPD hashAlgo dsignAlgo
+data RUPD hashAlgo dsignAlgo vrfAlgo
 
-data RupdEnv hashAlgo dsignAlgo
-  = RupdEnv (BlocksMade hashAlgo dsignAlgo) (EpochState hashAlgo dsignAlgo)
+data RupdEnv hashAlgo dsignAlgo vrfAlgo
+  = RupdEnv (BlocksMade hashAlgo dsignAlgo) (EpochState hashAlgo dsignAlgo vrfAlgo)
 
-instance STS (RUPD hashAlgo dsignAlgo) where
-  type State (RUPD hashAlgo dsignAlgo) = Maybe (RewardUpdate hashAlgo dsignAlgo)
-  type Signal (RUPD hashAlgo dsignAlgo) = Slot.Slot
-  type Environment (RUPD hashAlgo dsignAlgo) = RupdEnv hashAlgo dsignAlgo
-  data PredicateFailure (RUPD hashAlgo dsignAlgo)
+instance STS (RUPD hashAlgo dsignAlgo vrfAlgo) where
+  type State (RUPD hashAlgo dsignAlgo vrfAlgo) = Maybe (RewardUpdate hashAlgo dsignAlgo)
+  type Signal (RUPD hashAlgo dsignAlgo vrfAlgo) = Slot.Slot
+  type Environment (RUPD hashAlgo dsignAlgo vrfAlgo) = RupdEnv hashAlgo dsignAlgo vrfAlgo
+  data PredicateFailure (RUPD hashAlgo dsignAlgo vrfAlgo)
     = FailureRUPD
     deriving (Show, Eq)
 
   initialRules = [pure Nothing]
   transitionRules = [rupdTransition]
 
-rupdTransition :: TransitionRule (RUPD hashAlgo dsignAlgo)
+rupdTransition :: TransitionRule (RUPD hashAlgo dsignAlgo vrfAlgo)
 rupdTransition = do
   TRC (RupdEnv b es, ru, s) <- judgmentContext
   let slot = firstSlot (epochFromSlot s) +* startRewards

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
@@ -22,24 +22,24 @@ import           UTxO
 
 import           Control.State.Transition
 
-data SNAP hashAlgo dsignAlgo
+data SNAP hashAlgo dsignAlgo vrfAlgo
 
-data SnapState hashAlgo dsignAlgo
+data SnapState hashAlgo dsignAlgo vrfAlgo
   = SnapState
-      (SnapShots hashAlgo dsignAlgo)
-      (UTxOState hashAlgo dsignAlgo)
+      (SnapShots hashAlgo dsignAlgo vrfAlgo)
+      (UTxOState hashAlgo dsignAlgo vrfAlgo)
 
-data SnapEnv hashAlgo dsignAlgo
+data SnapEnv hashAlgo dsignAlgo vrfAlgo
   = SnapEnv
       PParams
       (DState hashAlgo dsignAlgo)
-      (PState hashAlgo dsignAlgo)
+      (PState hashAlgo dsignAlgo vrfAlgo)
 
-instance STS (SNAP hashAlgo dsignAlgo) where
-  type State (SNAP hashAlgo dsignAlgo) = SnapState hashAlgo dsignAlgo
-  type Signal (SNAP hashAlgo dsignAlgo) = Epoch
-  type Environment (SNAP hashAlgo dsignAlgo) = SnapEnv hashAlgo dsignAlgo
-  data PredicateFailure (SNAP hashAlgo dsignAlgo)
+instance STS (SNAP hashAlgo dsignAlgo vrfAlgo) where
+  type State (SNAP hashAlgo dsignAlgo vrfAlgo) = SnapState hashAlgo dsignAlgo vrfAlgo
+  type Signal (SNAP hashAlgo dsignAlgo vrfAlgo) = Epoch
+  type Environment (SNAP hashAlgo dsignAlgo vrfAlgo) = SnapEnv hashAlgo dsignAlgo vrfAlgo
+  data PredicateFailure (SNAP hashAlgo dsignAlgo vrfAlgo)
     = FailureSNAP
     deriving (Show, Eq)
 
@@ -47,7 +47,7 @@ instance STS (SNAP hashAlgo dsignAlgo) where
     [pure $ SnapState emptySnapShots (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState)]
   transitionRules = [snapTransition]
 
-snapTransition :: TransitionRule (SNAP hashAlgo dsignAlgo)
+snapTransition :: TransitionRule (SNAP hashAlgo dsignAlgo vrfAlgo)
 snapTransition = do
   TRC (SnapEnv pparams d p, SnapState s u, eNew) <- judgmentContext
   let pooledStake = stakeDistr (u ^. utxo) d p

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Updn.hs
@@ -15,13 +15,13 @@ import           Control.State.Transition
 
 data UPDN
 
-data UpdnState = UpdnState Seed Seed
+data UpdnState = UpdnState Nonce Nonce
   deriving (Show, Eq)
 
 instance STS UPDN where
   type State UPDN = UpdnState
   type Signal UPDN = Slot.Slot
-  type Environment UPDN = Seed
+  type Environment UPDN = Nonce
   data PredicateFailure UPDN = FailureUPDN
                                deriving (Show, Eq)
   initialRules = [pure (UpdnState (mkNonce 0) (mkNonce 0))]

--- a/shelley/chain-and-ledger/executable-spec/src/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Tx.hs
@@ -56,7 +56,7 @@ import           TxData (Credential (..), MultiSig (..), ScriptHash (..), StakeC
 -- validation and hashing.
 class (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, ToCBOR a) =>
   MultiSignatureScript a hashAlgo dsignAlgo where
-  validateScript :: a -> Tx hashAlgo dsignAlgo -> Bool
+  validateScript :: a -> Tx hashAlgo dsignAlgo vrfAlgo -> Bool
   hashScript :: a -> ScriptHash hashAlgo dsignAlgo
 
 -- | Script evaluator for native multi-signature scheme. 'vhks' is the set of
@@ -77,7 +77,7 @@ evalNativeMultiSigScript (RequireMOf m msigs) vhks =
 validateNativeMultiSigScript
   :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
   => MultiSig hashAlgo dsignAlgo
-  -> Tx hashAlgo dsignAlgo
+  -> Tx hashAlgo dsignAlgo vrfAlgo
   -> Bool
 validateNativeMultiSigScript msig tx =
   evalNativeMultiSigScript msig vhks
@@ -107,7 +107,7 @@ instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo) =>
 
 -- | Multi-signature script witness accessor function for Transactions
 txwitsScript
-  :: Tx hashAlgo dsignAlgo
+  :: Tx hashAlgo dsignAlgo vrfAlgo
   -> Map (ScriptHash hashAlgo dsignAlgo) (MultiSig hashAlgo dsignAlgo)
 txwitsScript = _witnessMSigMap
 

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -41,7 +41,7 @@ import           Data.Word (Word8)
 import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm)
 
-import           BaseTypes (Seed, UnitInterval)
+import           BaseTypes (Nonce, UnitInterval)
 import           Coin (Coin)
 import           Keys (DSIGNAlgorithm, Dms, GenKeyHash)
 import           PParams (PParams (..))
@@ -106,7 +106,7 @@ data Ppm = MinFeeA Integer
   | Tau UnitInterval
   | ActiveSlotCoefficient UnitInterval
   | D UnitInterval
-  | ExtraEntropy Seed
+  | ExtraEntropy Nonce
   | ProtocolVersion (Natural, Natural, Natural)
   deriving (Show, Ord, Eq)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Cardano/Crypto/VRF/Fake.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Cardano/Crypto/VRF/Fake.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+-- | Fake implementation of VRF, where the random value isn't random but given
+-- by the creator.
+module Cardano.Crypto.VRF.Fake
+  ( FakeVRF
+  , VerKeyVRF (..)
+  , SignKeyVRF (..)
+  , WithResult(..)
+  ) where
+
+import BaseTypes (Seed)
+import Cardano.Binary (FromCBOR(..), ToCBOR (..), encodeListLen, enforceSize)
+import Cardano.Crypto.Hash
+import Cardano.Crypto.Util (nonNegIntR)
+import Cardano.Crypto.VRF.Class
+import Cardano.Prelude (NoUnexpectedThunks, UseIsNormalForm(..))
+import Data.Proxy (Proxy (..))
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+
+data FakeVRF
+
+-- | A class for seeds which sneakily contain the certified natural we wish to
+-- "randomly" derive from them.
+class ToCBOR (Payload a) => SneakilyContainResult a where
+  type Payload a
+  sneakilyExtractResult :: a -> Natural
+  unsneakilyExtractPayload :: a -> Payload a
+
+data WithResult a = WithResult !a !Natural
+  deriving (Eq, Show)
+
+instance ToCBOR a => SneakilyContainResult (WithResult a) where
+  type Payload (WithResult a) = a
+  sneakilyExtractResult (WithResult _ nat) = nat
+  unsneakilyExtractPayload (WithResult p _) = p
+
+-- | An instance to allow this to be used in the way of `Mock` where no result
+-- has been provided. Though note that the key isn't used at all here.
+instance SneakilyContainResult Seed where
+  type Payload Seed = Seed
+  sneakilyExtractResult = fromHash . hashWithSerialiser @MD5 id . toCBOR
+  unsneakilyExtractPayload = id
+
+instance VRFAlgorithm FakeVRF where
+
+  type Signable FakeVRF = SneakilyContainResult
+
+  newtype VerKeyVRF FakeVRF = VerKeyFakeVRF Int
+    deriving (Show, Eq, Ord, Generic, ToCBOR, FromCBOR, NoUnexpectedThunks)
+  newtype SignKeyVRF FakeVRF = SignKeyFakeVRF Int
+    deriving (Show, Eq, Ord, Generic, ToCBOR, FromCBOR, NoUnexpectedThunks)
+  data CertVRF FakeVRF = CertFakeVRF Int Natural
+    deriving (Show, Eq, Ord, Generic)
+    deriving NoUnexpectedThunks via UseIsNormalForm (CertVRF FakeVRF)
+
+  maxVRF _ = 2 ^ (8 * byteCount (Proxy :: Proxy MD5)) - 1
+  genKeyVRF = SignKeyFakeVRF <$> nonNegIntR
+  deriveVerKeyVRF (SignKeyFakeVRF n) = VerKeyFakeVRF n
+  evalVRF a sk = return $ evalVRF' a sk
+  -- This implementation of `verifyVRF` checks the real result, which is hidden
+  -- in the certificate, but ignores the produced value, which is set to be the
+  -- result of the sneaking.
+  verifyVRF (VerKeyFakeVRF n) a c = snd (evalVRF' a (SignKeyFakeVRF n)) == snd c
+  encodeVerKeyVRF = toCBOR
+
+evalVRF' :: SneakilyContainResult a => a -> SignKeyVRF FakeVRF -> (Natural, CertVRF FakeVRF)
+evalVRF' a (SignKeyFakeVRF n) =
+  let y = sneakilyExtractResult a
+      p = unsneakilyExtractPayload a
+      realValue = fromHash . hashWithSerialiser @MD5 id $ toCBOR p
+  in (y, CertFakeVRF n realValue)
+
+instance FromCBOR (CertVRF FakeVRF) where
+  fromCBOR = do
+    enforceSize "FakeVRFCert should have two entries" 2
+    CertFakeVRF <$> fromCBOR <*> fromCBOR
+
+instance ToCBOR (CertVRF FakeVRF) where
+  toCBOR (CertFakeVRF i n) = encodeListLen 2 <> toCBOR i <> toCBOR n

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
@@ -12,6 +12,7 @@ module Generator.LedgerTrace where
 
 import           Cardano.Crypto.DSIGN.Mock (MockDSIGN)
 import           Cardano.Crypto.Hash (ShortHash)
+import           Cardano.Crypto.VRF.Fake (FakeVRF)
 
 import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 import           Generator.Core (traceKeyPairs)
@@ -22,7 +23,7 @@ import           STS.Ledger (LEDGER, LedgerEnv (..))
 
 -- The LEDGER STS combines utxo and delegation rules and allows for generating transactions
 -- with meaningful delegation certificates.
-instance HasTrace (LEDGER ShortHash MockDSIGN)
+instance HasTrace (LEDGER ShortHash MockDSIGN FakeVRF)
   where
     envGen _ =
       LedgerEnv <$> pure (Slot 0)

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -5,6 +5,7 @@ module MockTypes where
 import           Cardano.Crypto.DSIGN (MockDSIGN)
 import           Cardano.Crypto.Hash (ShortHash)
 import           Cardano.Crypto.KES (MockKES)
+import           Cardano.Crypto.VRF.Fake (FakeVRF)
 
 import qualified BlockChain
 import qualified Delegation.Certificates
@@ -26,13 +27,13 @@ import qualified TxData
 import qualified Updates
 import qualified UTxO
 
-type DCert = Delegation.Certificates.DCert ShortHash MockDSIGN
+type DCert = Delegation.Certificates.DCert ShortHash MockDSIGN FakeVRF
 
-type PoolDistr = Delegation.Certificates.PoolDistr ShortHash MockDSIGN
+type PoolDistr = Delegation.Certificates.PoolDistr ShortHash MockDSIGN FakeVRF
 
 type Delegation = TxData.Delegation ShortHash MockDSIGN
 
-type PoolParams = TxData.PoolParams ShortHash MockDSIGN
+type PoolParams = TxData.PoolParams ShortHash MockDSIGN FakeVRF
 
 type RewardAcnt = TxData.RewardAcnt ShortHash MockDSIGN
 
@@ -52,81 +53,85 @@ type KeyPairs = LedgerState.KeyPairs MockDSIGN
 
 type VKeyGenesis = Keys.VKeyGenesis MockDSIGN
 
-type EpochState = LedgerState.EpochState ShortHash MockDSIGN
+type EpochState = LedgerState.EpochState ShortHash MockDSIGN FakeVRF
 
-type NEWEPOCH = STS.NewEpoch.NEWEPOCH ShortHash MockDSIGN
+type NEWEPOCH = STS.NewEpoch.NEWEPOCH ShortHash MockDSIGN FakeVRF
 
-type LedgerState = LedgerState.LedgerState ShortHash MockDSIGN
+type LedgerState = LedgerState.LedgerState ShortHash MockDSIGN FakeVRF
 
-type LedgerValidation = LedgerState.LedgerValidation ShortHash MockDSIGN
+type LedgerValidation = LedgerState.LedgerValidation ShortHash MockDSIGN FakeVRF
 
-type UTxOState = LedgerState.UTxOState ShortHash MockDSIGN
+type UTxOState = LedgerState.UTxOState ShortHash MockDSIGN FakeVRF
 
 type DState = LedgerState.DState ShortHash MockDSIGN
 
-type PState = LedgerState.PState ShortHash MockDSIGN
+type PState = LedgerState.PState ShortHash MockDSIGN FakeVRF
 
-type DPState = LedgerState.DPState ShortHash MockDSIGN
+type DPState = LedgerState.DPState ShortHash MockDSIGN FakeVRF
 
 type Addr = TxData.Addr ShortHash MockDSIGN
 
-type Tx = Tx.Tx ShortHash MockDSIGN
+type Tx = Tx.Tx ShortHash MockDSIGN FakeVRF
 
-type TxBody = Tx.TxBody ShortHash MockDSIGN
+type TxBody = Tx.TxBody ShortHash MockDSIGN FakeVRF
 
-type TxIn = Tx.TxIn ShortHash MockDSIGN
+type TxIn = Tx.TxIn ShortHash MockDSIGN FakeVRF
 
 type TxOut = Tx.TxOut ShortHash MockDSIGN
 
-type TxId = TxData.TxId ShortHash MockDSIGN
+type TxId = TxData.TxId ShortHash MockDSIGN FakeVRF
 
-type UTxO = UTxO.UTxO ShortHash MockDSIGN
+type UTxO = UTxO.UTxO ShortHash MockDSIGN FakeVRF
 
-type Block = BlockChain.Block ShortHash MockDSIGN MockKES
+type Block = BlockChain.Block ShortHash MockDSIGN MockKES FakeVRF
 
-type BHBody = BlockChain.BHBody ShortHash MockDSIGN MockKES
+type BHBody = BlockChain.BHBody ShortHash MockDSIGN MockKES FakeVRF
 
 type SKeyES = Keys.SKeyES MockKES
 
 type VKeyES = Keys.VKeyES MockKES
 
+type SignKeyVRF = Keys.SignKeyVRF FakeVRF
+
+type VerKeyVRF = Keys.VerKeyVRF FakeVRF
+
+type CertifiedVRF = Keys.CertifiedVRF FakeVRF
+
 type KESig = Keys.KESig MockKES BHBody
 
 type Sig a = Keys.Sig MockDSIGN a
-
-type Proof a = BlockChain.Proof MockDSIGN
 
 type BHeader = BlockChain.BHeader ShortHash MockDSIGN MockKES
 
 type OCert = OCert.OCert MockDSIGN MockKES
 
-type HashHeader = BlockChain.HashHeader ShortHash MockDSIGN MockKES
+type HashHeader = BlockChain.HashHeader ShortHash MockDSIGN MockKES FakeVRF
 
 type NewEpochState = LedgerState.NewEpochState ShortHash MockDSIGN
 
 type RewardUpdate = LedgerState.RewardUpdate ShortHash MockDSIGN
 
-type ChainState = STS.Chain.ChainState ShortHash MockDSIGN MockKES
+type ChainState = STS.Chain.ChainState ShortHash MockDSIGN MockKES FakeVRF
 
-type CHAIN = STS.Chain.CHAIN ShortHash MockDSIGN MockKES
+type CHAIN = STS.Chain.CHAIN ShortHash MockDSIGN MockKES FakeVRF
 
-type UTXOW = STS.Utxow.UTXOW ShortHash MockDSIGN
+type UTXOW = STS.Utxow.UTXOW ShortHash MockDSIGN FakeVRF
 
-type UTXO = STS.Utxo.UTXO ShortHash MockDSIGN
+type UTXO = STS.Utxo.UTXO ShortHash MockDSIGN FakeVRF
 
 type UtxoEnv = STS.Utxo.UtxoEnv ShortHash MockDSIGN
 
-type DELEG = STS.Deleg.DELEG ShortHash MockDSIGN
+type DELEG = STS.Deleg.DELEG ShortHash MockDSIGN FakeVRF
 
-type LEDGER = STS.Ledger.LEDGER ShortHash MockDSIGN
+type LEDGER = STS.Ledger.LEDGER ShortHash MockDSIGN FakeVRF
 
 type LedgerEnv = STS.Ledger.LedgerEnv
 
-type DELEGS = STS.Delegs.DELEGS ShortHash MockDSIGN
+type DELEGS = STS.Delegs.DELEGS ShortHash MockDSIGN FakeVRF
 
-type POOL = STS.Pool.POOL ShortHash MockDSIGN
+type POOL = STS.Pool.POOL ShortHash MockDSIGN FakeVRF
 
-type POOLREAP = STS.PoolReap.POOLREAP ShortHash MockDSIGN
+type POOLREAP = STS.PoolReap.POOLREAP ShortHash MockDSIGN FakeVRF
 
 type Credential = TxData.Credential ShortHash MockDSIGN
 
@@ -141,7 +146,7 @@ type WitVKey = TxData.WitVKey ShortHash MockDSIGN
 
 type Wdrl = TxData.Wdrl ShortHash MockDSIGN
 
-type SnapShots = EpochBoundary.SnapShots ShortHash MockDSIGN
+type SnapShots = EpochBoundary.SnapShots ShortHash MockDSIGN FakeVRF
 
 type Stake = EpochBoundary.Stake ShortHash MockDSIGN
 

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -15,7 +15,7 @@ import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
 
-import           BaseTypes (Seed (..), (⭒))
+import           BaseTypes ((⭒), mkNonce)
 import           Control.State.Transition (TRC (..), applySTS)
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import           Slot (Slot (..))
@@ -34,9 +34,9 @@ import           TxData (pattern RewardAcnt, pattern ScriptHashObj)
 testUPNEarly :: Assertion
 testUPNEarly =
   let
-    st = applySTS @UPDN (TRC (Nonce 1, UpdnState (Nonce 2) (Nonce 3), Slot.Slot 5))
+    st = applySTS @UPDN (TRC (mkNonce 1, UpdnState (mkNonce 2) (mkNonce 3), Slot.Slot 5))
   in
-    st @?= Right (UpdnState (Nonce 2 ⭒ Nonce 1) (Nonce 2 ⭒ Nonce 1))
+    st @?= Right (UpdnState (mkNonce 2 ⭒ mkNonce 1) (mkNonce 2 ⭒ mkNonce 1))
 
 -- | The UPDN transition should update only the evolving nonce
 -- in the last thirds of the epoch.
@@ -44,9 +44,9 @@ testUPNEarly =
 testUPNLate :: Assertion
 testUPNLate =
   let
-    st = applySTS @UPDN (TRC (Nonce 1, UpdnState (Nonce 2) (Nonce 3), Slot.Slot 85))
+    st = applySTS @UPDN (TRC (mkNonce 1, UpdnState (mkNonce 2) (mkNonce 3), Slot.Slot 85))
   in
-    st @?= Right (UpdnState (SeedOp (Nonce 2) (Nonce 1)) (Nonce 3))
+    st @?= Right (UpdnState ((mkNonce 2) <> (mkNonce 1)) (mkNonce 3))
 
 testCHAINExample :: CHAINExample -> Assertion
 testCHAINExample (CHAINExample slotNow initSt block expectedSt) = do

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -46,7 +46,7 @@ testUPNLate =
   let
     st = applySTS @UPDN (TRC (mkNonce 1, UpdnState (mkNonce 2) (mkNonce 3), Slot.Slot 85))
   in
-    st @?= Right (UpdnState ((mkNonce 2) <> (mkNonce 1)) (mkNonce 3))
+    st @?= Right (UpdnState ((mkNonce 2) ⭒ (mkNonce 1)) (mkNonce 3))
 
 testCHAINExample :: CHAINExample -> Assertion
 testCHAINExample (CHAINExample slotNow initSt block expectedSt) = do

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -17,6 +17,7 @@ import           Test.Tasty.HUnit
 
 import           Address
 import           BaseTypes
+import qualified Cardano.Crypto.VRF.Fake as FakeVRF
 import           Coin
 import           Delegation.Certificates (pattern Delegate, pattern RegKey, pattern RegPool,
                      pattern RetirePool, StakeKeys (..), StakePools (..))
@@ -24,7 +25,7 @@ import           TxData (pattern AddrBase, Credential (..), Delegation (..), pat
                      pattern Ptr, pattern RewardAcnt, _poolCost, _poolMargin, _poolOwners,
                      _poolPledge, _poolPubKey, _poolRAcnt, _poolVrf)
 
-import           Keys (pattern Dms, pattern KeyPair, hashKey, vKey)
+import           Keys (pattern Dms, pattern KeyPair, hashKey, hashKeyVRF, vKey)
 import           LedgerState (pattern LedgerState, pattern UTxOState, ValidationError (..),
                      asStateTransition, cCounters, delegationState, delegations, dstate,
                      emptyDelegation, genesisId, genesisCoins, genesisState, minfee, pParams, pstate, ptrs,
@@ -84,8 +85,8 @@ changeReward ls acnt c = ls & delegationState . dstate . rewards .~ newAccounts
 stakePoolKey1 :: KeyPair
 stakePoolKey1 = KeyPair 5 5
 
-stakePoolVRFKey1 :: KeyPair
-stakePoolVRFKey1 = KeyPair 15 15
+stakePoolVRFKey1 :: VerKeyVRF
+stakePoolVRFKey1 = FakeVRF.VerKeyFakeVRF 15
 
 
 ledgerState :: [Tx] -> Either [ValidationError] LedgerState
@@ -331,7 +332,7 @@ stakePool :: PoolParams
 stakePool = PoolParams
             {
               _poolPubKey = hashKey $ vKey stakePoolKey1
-            , _poolVrf = hashKey $ vKey stakePoolVRFKey1
+            , _poolVrf = hashKeyVRF stakePoolVRFKey1
             , _poolPledge  = Coin 0
             , _poolCost = Coin 0      -- TODO: what is a sensible value?
             , _poolMargin = interval0     --          or here?
@@ -347,7 +348,7 @@ stakePoolUpdate :: PoolParams
 stakePoolUpdate = PoolParams
                    {
                      _poolPubKey = hashKey $ vKey stakePoolKey1
-                   , _poolVrf = hashKey $ vKey stakePoolVRFKey1
+                   , _poolVrf = hashKeyVRF stakePoolVRFKey1
                    , _poolPledge  = Coin 0
                    , _poolCost = Coin 100      -- TODO: what is a sensible value?
                    , _poolMargin = halfInterval     --          or here?

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/96e8dcb29dc3c29eee99c0d020152fad6071af6d/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/b9bf62f2bab90539809bee13620fe7d29b35928d/snapshot.yaml
 
 packages:
 - shelley/chain-and-ledger/executable-spec
@@ -14,10 +14,10 @@ extra-deps:
 - bimap-0.4.0
 
 - git: https://github.com/input-output-hk/cardano-prelude
-  commit: 96e8dcb29dc3c29eee99c0d020152fad6071af6d
+  commit: b9bf62f2bab90539809bee13620fe7d29b35928d
 
 - git: https://github.com/input-output-hk/cardano-base
-  commit: ccbc085f1ebdde706feb7955fdebb33260dc5e32
+  commit: bb262f466d659d94ed6e5500c2dc101f7c2c6b1e
   subdirs:
     - binary
     - cardano-crypto-class


### PR DESCRIPTION
This PR adds abstraction over VRF throughout the executable spec. It addresses issue #797 through splitting `Seed` into distinct `Nonce` and `Seed` values - the `Nonce` is updated regularly, the `Seed` is what feeds into the VRF calculation.