### PR TITLE
Define `lastSignal` and `traceInit`, which are needed for issue 787

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Chain.hs
@@ -167,6 +167,10 @@ instance Embed DELEG CHAIN where
 instance Embed UTXOWS CHAIN where
   wrapFailed = LedgerUTxOFailure
 
+isHeaderSizeTooBigFailure :: PredicateFailure CHAIN -> Bool
+isHeaderSizeTooBigFailure (HeaderSizeTooBig _ _ _) = True
+isHeaderSizeTooBigFailure _ = False
+
 
 headerIsValid :: UPIState -> BlockHeader -> Rule CHAIN 'Transition ()
 headerIsValid us bh = do

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Generator.hs
@@ -31,6 +31,7 @@ module Control.State.Transition.Generator
   , traceWithProfile
   , traceOfLength
   , traceSuchThat
+  , ofLengthAtLeast
   , suchThatLastState
   , nonTrivialTrace
   , HasSizeInfo
@@ -353,6 +354,12 @@ traceSuchThat
   -> (Trace s -> Bool)
   -> Gen (Trace s)
 traceSuchThat n cond = Gen.filter cond (trace @s n)
+
+
+ofLengthAtLeast :: Gen (Trace s) -> Int -> Gen (Trace s)
+ofLengthAtLeast traceGen minLength =
+  Gen.filter ((minLength <=) . traceLength) traceGen
+
 
 suchThatLastState
   :: forall s


### PR DESCRIPTION
- Define `lastSignal` and `traceInit`, which are needed for #787
- Use `ofLengthAtLeast` in the Shelley delegation tests.
- Add `isHeaderSizeTooBigFailure` function.

