### PR TITLE
Propertyies for `UTXO` STS rule

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -96,6 +96,7 @@ test-suite delegation-test
                          Rules.TestDeleg
                          Rules.TestPool
                          Rules.TestPoolreap
+                         Rules.TestUtxo
                          Rules.TestUtxow
     hs-source-dirs:      test
     ghc-options:

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module STS.Utxo
   ( UTXO
@@ -30,8 +31,11 @@ import           Updates
 import           UTxO
 
 import           Control.State.Transition
+import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
 import           STS.Up
+
+import           Hedgehog (Gen)
 
 data UTXO hashAlgo dsignAlgo
 
@@ -123,3 +127,8 @@ instance
   => Embed (UP hashAlgo dsignAlgo) (UTXO hashAlgo dsignAlgo)
  where
   wrapFailed = UpdateFailure
+
+instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, Signable dsignAlgo (TxBody hashAlgo dsignAlgo))
+  => HasTrace (UTXO hashAlgo dsignAlgo) where
+  envGen _ = undefined :: Gen (UtxoEnv hashAlgo dsignAlgo)
+  sigGen _ _ = undefined :: Gen (Tx hashAlgo dsignAlgo)

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -107,6 +107,8 @@ type CHAIN = STS.Chain.CHAIN ShortHash MockDSIGN MockKES
 
 type UTXOW = STS.Utxow.UTXOW ShortHash MockDSIGN
 
+type UTXO = STS.Utxo.UTXO ShortHash MockDSIGN
+
 type UtxoEnv = STS.Utxo.UtxoEnv ShortHash MockDSIGN
 
 type DELEG = STS.Deleg.DELEG ShortHash MockDSIGN

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxo.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+module Rules.TestUtxo where
+
+import           Data.Word (Word64)
+
+import           Hedgehog (Property, forAll, property, withTests)
+
+import           Control.State.Transition.Generator (ofLengthAtLeast, trace)
+import           Control.State.Transition.Trace (pattern SourceSignalTarget, source,
+                     sourceSignalTargets, target)
+
+import           LedgerState (pattern UTxOState)
+import           MockTypes (UTXO)
+
+import           Test.Utils (assertAll)
+
+------------------------------
+-- Constants for Properties --
+------------------------------
+
+numberOfTests :: Word64
+numberOfTests = 300
+
+traceLen :: Word64
+traceLen = 100
+
+--------------------------
+-- Properties for UTXOW --
+--------------------------
+
+-- | Property that checks that the fees are non-decreasing
+feesNonDecreasing :: Property
+feesNonDecreasing = withTests (fromIntegral numberOfTests) . property $ do
+  tr <- fmap sourceSignalTargets $ forAll (trace @UTXO traceLen `ofLengthAtLeast` 1)
+
+  assertAll feesDoNotIncrease tr
+
+  where feesDoNotIncrease (SourceSignalTarget
+                            { source = UTxOState _ _ fees _
+                            , target = UTxOState _ _ fees' _}) =
+          fees <= fees'


### PR DESCRIPTION
Adds properties from the `Properties.md` file

 - the fees are non-decreasing
 - the sum of the pots circulation / deposits / fees increases with the sum of the withdrawals