### PR TITLE
Add property to check for rewards balance invariant in `DELEG`

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestDeleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestDeleg.hs
@@ -8,6 +8,7 @@ module Rules.TestDeleg
   ( credentialMappingAfterDelegation
   , credentialRemovedAfterDereg
   , rewardZeroAfterReg
+  , rewardsSumInvariant
   )
 where
 
@@ -24,7 +25,7 @@ import           BaseTypes ((==>))
 
 import           Control.State.Transition.Generator (ofLengthAtLeast, trace)
 import           Control.State.Transition.Trace (SourceSignalTarget, pattern SourceSignalTarget,
-                     signal, sourceSignalTargets, target)
+                     signal, source, sourceSignalTargets, target)
 import           Generator.LedgerTrace ()
 import           Ledger.Core (dom, range, (∈), (∉), (◁))
 

--- a/shelley/chain-and-ledger/formal-spec/Properties.md
+++ b/shelley/chain-and-ledger/formal-spec/Properties.md
@@ -46,6 +46,10 @@ Pots in scope: Rewards
 **Property** The rewards to do not change (both as an aggregated value
 and as individual balances).
 
+*Note:* here we consider elements that are not present to have a value of 0. On
+the implementation there is a difference between an element which is not present
+in the rewards map and an element with a 0 rewards balance.
+
 ### DELEGS
 
 Pots in scope: Rewards


### PR DESCRIPTION
```
### DELEG, POOL, DELPL

Pots in scope: Rewards

**Property** The rewards to do not change (both as an aggregated value
and as individual balances).
```
in addition, elements added or dropped (via RegKey or DeregKey) have a zero reward balance