### PR TITLE
Change hash type to Maybe Int

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Block.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Block.hs
@@ -159,7 +159,7 @@ mkBlock
 -- | Dummy genesis hash.
 genesisHash :: Hash
 -- Not sure we need a concrete hash in the specs ...
-genesisHash = Hash $ H.hash ("" :: ByteString)
+genesisHash = Hash $ Just $ H.hash ("" :: ByteString)
 
 
 -- | Protocol version endorsment
@@ -203,7 +203,7 @@ bHeaderSize = fromIntegral . abstractSize costs
 
 -- | Computes the hash of a header.
 hashHeader :: BlockHeader -> Hash
-hashHeader bh = Hash $ H.hash (bh ^. bhPrevHash, bh ^. bhSlot, bh ^. bhIssuer)
+hashHeader bh = Hash $ Just $ H.hash (bh ^. bhPrevHash, bh ^. bhSlot, bh ^. bhIssuer)
 
 -- | Computes the hash of the header.
 bhToSign :: BlockHeader -> Hash

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -88,8 +88,8 @@ signersListIsBoundedByK =  withTests 300 $ property $ do
 
 
 relevantCasesAreCovered :: Property
-relevantCasesAreCovered = withTests 400 $ property $ do
-  tr <- forAll $ traceSigGen (Desired 250) (sigGenChain GenDelegation NoGenUTxO NoGenUpdate)
+relevantCasesAreCovered = withTests 200 $ property $ do
+  tr <- forAll $ traceSigGen (Desired 200) (sigGenChain GenDelegation NoGenUTxO NoGenUpdate)
   let certs = traceDCerts tr
 
   -- for at least 1% of traces...
@@ -191,3 +191,12 @@ traceDCertsByBlock tr = _bDCerts . _bBody <$> traceSignals OldestFirst tr
 -- | Flattended list of DCerts for the given Trace
 traceDCerts :: Trace CHAIN -> [DCert]
 traceDCerts = concat . traceDCertsByBlock
+
+invalidSignalsAreGenerated :: Property
+invalidSignalsAreGenerated =
+  withTests 100
+    $ TransitionGenerator.invalidSignalsAreGenerated
+        @CHAIN
+        [(1, invalidProofsBlockGen)]
+        50
+        (coverInvalidBlockProofs 20)

--- a/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
+++ b/byron/chain/executable-spec/test/Cardano/Spec/Chain/STS/Properties.hs
@@ -16,7 +16,7 @@ import           Hedgehog (MonadTest, Property, assert, cover, failure, forAll, 
 import           Control.State.Transition
 import           Control.State.Transition.Generator (TraceLength (Desired, Maximum),
                      classifyTraceLength, traceSigGen)
-import qualified Control.State.Transition.Generator as TransitionGenerator
+import qualified Control.State.Transition.Generator as Transition.Generator
 import           Control.State.Transition.Trace
 
 import           Ledger.Core (BlockCount (BlockCount), Epoch, Slot (unSlot))
@@ -66,7 +66,7 @@ blockIssuersAreDelegates =
 
 onlyValidSignalsAreGenerated :: Property
 onlyValidSignalsAreGenerated =
-  withTests 200 $ TransitionGenerator.onlyValidSignalsAreGenerated @CHAIN 100
+  withTests 200 $ Transition.Generator.onlyValidSignalsAreGenerated @CHAIN 100
 
 signersListIsBoundedByK :: Property
 signersListIsBoundedByK =  withTests 300 $ property $ do
@@ -195,7 +195,7 @@ traceDCerts = concat . traceDCertsByBlock
 invalidSignalsAreGenerated :: Property
 invalidSignalsAreGenerated =
   withTests 100
-    $ TransitionGenerator.invalidSignalsAreGenerated
+    $ Transition.Generator.invalidSignalsAreGenerated
         @CHAIN
         [(1, invalidProofsBlockGen)]
         50

--- a/byron/chain/executable-spec/test/Main.hs
+++ b/byron/chain/executable-spec/test/Main.hs
@@ -20,5 +20,6 @@ main = defaultMain tests
       , testProperty "Only valid signals are generated" CHAIN.onlyValidSignalsAreGenerated
       , testProperty "Signers list is bounded by k " CHAIN.signersListIsBoundedByK
       , testProperty "We are generating reasonable Chain Traces" CHAIN.relevantCasesAreCovered
+      , testProperty "Invalid signals are generated when requested" CHAIN.invalidSignalsAreGenerated
       ]
     ]

--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -28,6 +28,7 @@ library
                      , Ledger.Core.Generators
                      , Ledger.Core.Omniscient
                      , Ledger.Delegation
+                     , Ledger.Delegation.Test
                      , Ledger.GlobalParams
                      , Ledger.Update
                      , Ledger.Update.Generators

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -152,7 +152,7 @@ data DCert = DCert
 instance HasTypeReps DCert
 
 instance HasHash [DCert] where
-  hash = Hash . H.hash
+  hash = Hash . Just . H.hash
 
 mkDCert
   :: VKeyGenesis

--- a/byron/ledger/executable-spec/src/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation.hs
@@ -798,6 +798,9 @@ mkGoblinGens
   ]
 
 tamperedDcerts :: DIEnv -> DIState -> Gen [DCert]
-tamperedDcerts env st = do
-  sg <- Gen.element goblinGensDELEG
-  sg env st
+tamperedDcerts env st =
+  Gen.choice [ Gen.list (Range.constant 0 10) (randomDCertGen env)
+             , do
+                 sg <- Gen.element goblinGensDELEG
+                 sg env st
+             ]

--- a/byron/ledger/executable-spec/src/Ledger/Delegation/Test.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Delegation/Test.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Ledger.Delegation.Test (coverDelegFailures) where
+
+import qualified Control.State.Transition.Generator as Generator
+import           Data.Data (Data)
+import           GHC.Stack (HasCallStack)
+import           Hedgehog (MonadTest)
+import           Hedgehog.Internal.Property (CoverPercentage)
+
+import           Ledger.Delegation (PredicateFailure (DoesNotVerify, EpochInThePast, EpochPastNextEpoch, HasAlreadyDelegated, IsAlreadyScheduled, IsNotGenesisKey))
+
+
+coverDelegFailures
+  :: forall m a
+   .  ( MonadTest m
+      , HasCallStack
+      , Data a
+      )
+  => CoverPercentage
+  -> a
+  -> m ()
+coverDelegFailures coverPercentage =
+  Generator.coverFailures
+    coverPercentage
+    [ EpochInThePast undefined
+    , EpochPastNextEpoch undefined
+    , IsAlreadyScheduled
+    , IsNotGenesisKey
+    , HasAlreadyDelegated
+    , DoesNotVerify
+    ]

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -195,17 +195,6 @@ instance GeneOps g => Goblin g Tx where
     outputs <- replicateM listLenO conjure
     pure (Tx inputs outputs)
 
--- instance GeneOps g => Goblin g TxId where
---   tinker gen
---     = tinkerRummagedOrConjureOrSave
---         (TxId
---            <$$> tinker ((\(TxId h) -> h) <$> gen))
---     -- = tinkerRummagedOrConjureOrSave
---     --     ((TxId . Hash . Just . (`mod` 30))
---     --        <$$> tinker ((\(TxId (Hash x)) -> x) <$> gen))
---   conjure = saveInBagOfTricks =<< (TxId <$> conjure)
-
-
 --------------------------------------------------------------------------------
 -- AddShrinks instances
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -97,7 +97,7 @@ balance (UTxO utxo) = Map.foldl' addValues mempty utxo
   where addValues b (TxOut _ a) = b <> a
 
 instance Ledger.Core.HasHash Tx where
-  hash = Hash . H.hash
+  hash = Hash . Just . H.hash
 
 ---------------------------------------------------------------------------------
 -- UTxO transitions
@@ -131,7 +131,7 @@ data TxWits = TxWits
   } deriving (Show, Eq, Generic, Hashable, HasTypeReps, Data, Typeable)
 
 instance HasHash [TxWits] where
-  hash = Hash . H.hash
+  hash = Hash . Just . H.hash
 
 -- |Create a witness for transaction
 makeWitness :: KeyPair -> Tx -> Wit
@@ -162,6 +162,7 @@ deriveGoblin ''TxIn
 deriveGoblin ''TxOut
 deriveGoblin ''TxWits
 deriveGoblin ''Wit
+deriveGoblin ''TxId
 
 instance GeneOps g => Goblin g Tx where
   tinker gen = do
@@ -194,12 +195,15 @@ instance GeneOps g => Goblin g Tx where
     outputs <- replicateM listLenO conjure
     pure (Tx inputs outputs)
 
-instance GeneOps g => Goblin g TxId where
-  tinker gen
-    = tinkerRummagedOrConjureOrSave
-        ((TxId . Hash . (`mod` 30))
-           <$$> tinker ((\(TxId (Hash x)) -> x) <$> gen))
-  conjure = saveInBagOfTricks =<< (TxId . Hash . (`mod` 30) <$> conjure)
+-- instance GeneOps g => Goblin g TxId where
+--   tinker gen
+--     = tinkerRummagedOrConjureOrSave
+--         (TxId
+--            <$$> tinker ((\(TxId h) -> h) <$> gen))
+--     -- = tinkerRummagedOrConjureOrSave
+--     --     ((TxId . Hash . Just . (`mod` 30))
+--     --        <$$> tinker ((\(TxId (Hash x)) -> x) <$> gen))
+--   conjure = saveInBagOfTricks =<< (TxId <$> conjure)
 
 
 --------------------------------------------------------------------------------

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -248,7 +248,6 @@ mkUProp aUpId issuer pv pps sv stags mdt = uprop
 instance HasTypeReps (ProtVer, PParams, SwVer, Set STag, Metadata)
 instance HasTypeReps Metadata
 instance HasTypeReps UProp
-instance HasTypeReps (Maybe UProp)
 
 
 -- | Test if a pair is present in a map.
@@ -562,7 +561,7 @@ mkVote caster proposalId
   }
 
 instance HasHash (Maybe Ledger.Update.UProp, [Ledger.Update.Vote]) where
-  hash = Core.Hash . H.hash
+  hash = Core.Hash . Just . H.hash
 
 
 data ADDVOTE deriving (Generic, Data, Typeable)

--- a/byron/ledger/executable-spec/src/Ledger/Update/Test.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Test.hs
@@ -66,13 +66,12 @@ coverUpivoteFailures
   => CoverPercentage
   -> a
   -> m ()
-coverUpivoteFailures coverPercentage someData =
+coverUpivoteFailures coverPercentage =
   Generator.coverFailures
     coverPercentage
     [ AVSigDoesNotVerify
     , NoUpdateProposal (UpId 0) -- We need to pass a dummy update id here.
     ]
-    someData
 
 
 coverDelegFailures
@@ -84,7 +83,7 @@ coverDelegFailures
   => CoverPercentage
   -> a
   -> m ()
-coverDelegFailures coverPercentage someData =
+coverDelegFailures coverPercentage =
   Generator.coverFailures
     coverPercentage
     [ EpochInThePast undefined
@@ -92,4 +91,3 @@ coverDelegFailures coverPercentage someData =
     , IsAlreadyScheduled
     , IsNotGenesisKey
     ]
-    someData

--- a/byron/ledger/executable-spec/src/Ledger/Update/Test.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Test.hs
@@ -4,7 +4,6 @@
 module Ledger.Update.Test
   ( coverUpiregFailures
   , coverUpivoteFailures
-  , coverDelegFailures
   )
 where
 
@@ -14,9 +13,9 @@ import           GHC.Stack (HasCallStack)
 import           Hedgehog (MonadTest)
 import           Hedgehog.Internal.Property (CoverPercentage)
 
-import           Ledger.Delegation (PredicateFailure (EpochInThePast, EpochPastNextEpoch, IsAlreadyScheduled, IsNotGenesisKey))
 import           Ledger.Update (PredicateFailure (AVSigDoesNotVerify, AlreadyProposedPv, AlreadyProposedSv, CannotFollowPv, CannotFollowSv, CannotUpdatePv, DoesNotVerify, InvalidApplicationName, InvalidSystemTags, NoUpdateProposal, NotGenesisDelegate))
 import           Ledger.Update (UpId (UpId))
+
 
 -- | Check that all the relevant predicate failures are covered.
 coverUpiregFailures
@@ -71,23 +70,4 @@ coverUpivoteFailures coverPercentage =
     coverPercentage
     [ AVSigDoesNotVerify
     , NoUpdateProposal (UpId 0) -- We need to pass a dummy update id here.
-    ]
-
-
-coverDelegFailures
-  :: forall m a
-   .  ( MonadTest m
-      , HasCallStack
-      , Data a
-      )
-  => CoverPercentage
-  -> a
-  -> m ()
-coverDelegFailures coverPercentage =
-  Generator.coverFailures
-    coverPercentage
-    [ EpochInThePast undefined
-    , EpochPastNextEpoch undefined
-    , IsAlreadyScheduled
-    , IsNotGenesisKey
     ]

--- a/byron/ledger/executable-spec/test/Ledger/AbstractSize/Properties.hs
+++ b/byron/ledger/executable-spec/test/Ledger/AbstractSize/Properties.hs
@@ -45,6 +45,7 @@ exampleTypeRepsTxIn =
   in typeReps txIn @?= typeOf (undefined::TxIn)
                          <| typeOf (undefined::TxId)
                          <| typeOf (undefined::Hash)
+                         <| typeOf (undefined::Maybe Int)
                          <| typeOf (undefined::Int)
                          <| typeOf (undefined::Natural)
                          <| empty

--- a/byron/semantics/executable-spec/src/Data/AbstractSize.hs
+++ b/byron/semantics/executable-spec/src/Data/AbstractSize.hs
@@ -141,6 +141,9 @@ instance (HasTypeReps a) => GHasTypeReps (K1 i a) where
 -- HasTypeReps instances
 --------------------------------------------------------------------------------
 
+instance (Typeable a, HasTypeReps a) => HasTypeReps (Maybe a) where
+  typeReps x = typeOf x <| maybe [] typeReps x
+
 instance (Typeable a, HasTypeReps a) => HasTypeReps [a] where
   typeReps xs = typeOf xs <| foldMap typeReps xs
 

--- a/cabal.project
+++ b/cabal.project
@@ -29,4 +29,4 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/goblins
-  tag: 545448938bf620bb2a25212e1686916cfa3acee9
+  tag: 26d35ad52fe9ade3391532dbfeb2f416f07650bc

--- a/nix/.stack.nix/goblins.nix
+++ b/nix/.stack.nix/goblins.nix
@@ -50,7 +50,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/goblins";
-      rev = "545448938bf620bb2a25212e1686916cfa3acee9";
-      sha256 = "1b9whagxvspzmll7b63ilxvbdq2ha3fkcfmgjnlpn4b939fgpclm";
+      rev = "26d35ad52fe9ade3391532dbfeb2f416f07650bc";
+      sha256 = "17p5x0hj6c67jkdqx0cysqlwq2zs2l87azihn1alzajy9ak6ii0b";
       });
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,7 +23,7 @@ extra-deps:
     - cardano-crypto-class
 
 - git: https://github.com/input-output-hk/goblins
-  commit: 545448938bf620bb2a25212e1686916cfa3acee9
+  commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
 - moo-1.2
 - gray-code-0.3.1
 


### PR DESCRIPTION
In this way we can signal to elaborators that they should produce an invalid (concrete) hash.


Part of #787 