### PR TITLE
renaming variables

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -2,7 +2,7 @@
 module Delegation.Certificates
   (
     DCert(..)
-  , StakeKeys(..)
+  , StakeCreds(..)
   , StakePools(..)
   , PoolDistr(..)
   , cwitness
@@ -24,7 +24,7 @@ import           Keys (Hash, KeyHash, VRFAlgorithm (VerKeyVRF))
 import           PParams (PParams (..), keyDecayRate, keyDeposit, keyMinRefund, poolDecayRate,
                      poolDeposit, poolMinRefund)
 import           Slot (Duration (..))
-import           TxData (Credential (..), DCert (..), StakeCredential, StakeKeys (..),
+import           TxData (Credential (..), DCert (..), StakeCredential, StakeCreds (..),
                      StakePools (..), delegator, poolPubKey)
 
 import           BaseTypes (FixedPoint, UnitInterval, fpEpsilon, intervalValue)

--- a/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/EpochBoundary.hs
@@ -33,7 +33,7 @@ module EpochBoundary
   ) where
 
 import           Coin (Coin (..))
-import           Delegation.Certificates (StakeKeys (..), StakePools (..), decayKey, decayPool,
+import           Delegation.Certificates (StakeCreds (..), StakePools (..), decayKey, decayPool,
                      refund)
 import           Keys (KeyHash)
 import           PParams (PParams (..))
@@ -151,11 +151,11 @@ poolRefunds pp retirees cslot =
 -- | Calculate total possible refunds.
 obligation
   :: PParams
-  -> StakeKeys hashAlgo dsignAlgo
+  -> StakeCreds hashAlgo dsignAlgo
   -> StakePools hashAlgo dsignAlgo
   -> Slot
   -> Coin
-obligation pc (StakeKeys stakeKeys) (StakePools stakePools) cslot =
+obligation pc (StakeCreds stakeKeys) (StakePools stakePools) cslot =
   sum (map (\s -> refund dval dmin lambdad (cslot -* s)) $ Map.elems stakeKeys) +
   sum (map (\s -> refund pval pmin lambdap (cslot -* s)) $ Map.elems stakePools)
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -37,7 +37,7 @@ module Keys
   , verify
 
   , GKeys(..)
-  , Dms(..)
+  , GenDelegs(..)
 
   , KESAlgorithm
   , KESignable
@@ -208,8 +208,8 @@ verifyKES (VKeyES vKeyES) vd (KESig sigKES) n =
   either (const False) (const True)
     $ verifySignedKES vKeyES n vd sigKES
 
-newtype Dms hashAlgo dsignAlgo =
-  Dms (Map (GenKeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo))
+newtype GenDelegs hashAlgo dsignAlgo =
+  GenDelegs (Map (GenKeyHash hashAlgo dsignAlgo) (KeyHash hashAlgo dsignAlgo))
   deriving (Show, Eq, NoUnexpectedThunks)
 
 newtype GKeys dsignAlgo = GKeys (Set (VKeyGenesis dsignAlgo))

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
@@ -30,7 +30,7 @@ data AVUPState hashAlgo dsignAlgo
       (Applications hashAlgo)
 
 data AVUPEnv hashAlgo dsignAlgo
-  = AVUPEnv Slot (Dms hashAlgo dsignAlgo)
+  = AVUPEnv Slot (GenDelegs hashAlgo dsignAlgo)
 
 instance STS (AVUP hashAlgo dsignAlgo) where
   type State (AVUP hashAlgo dsignAlgo)
@@ -62,12 +62,12 @@ avUpdateEmpty = do
 
 avUpdateNoConsensus :: TransitionRule (AVUP hashAlgo dsignAlgo)
 avUpdateNoConsensus = do
-  TRC (AVUPEnv _slot (Dms _dms), AVUPState (AVUpdate aupS) favs avs, AVUpdate _aup) <-
+  TRC (AVUPEnv _slot (GenDelegs _genDelegs), AVUPState (AVUpdate aupS) favs avs, AVUpdate _aup) <-
     judgmentContext
 
   not (Map.null _aup) ?! EmptyAVUP
 
-  dom _aup ⊆ dom _dms ?! NonGenesisUpdateAVUP
+  dom _aup ⊆ dom _genDelegs ?! NonGenesisUpdateAVUP
 
   all allApNamesValid (range _aup) ?! InvalidName
 
@@ -84,12 +84,12 @@ avUpdateNoConsensus = do
 
 avUpdateConsensus :: TransitionRule (AVUP hashAlgo dsignAlgo)
 avUpdateConsensus = do
-  TRC (AVUPEnv _slot (Dms _dms), AVUPState (AVUpdate aupS) favs avs, AVUpdate _aup) <-
+  TRC (AVUPEnv _slot (GenDelegs _genDelegs), AVUPState (AVUpdate aupS) favs avs, AVUpdate _aup) <-
     judgmentContext
 
   not (Map.null _aup) ?! EmptyAVUP
 
-  dom _aup ⊆ dom _dms ?! NonGenesisUpdateAVUP
+  dom _aup ⊆ dom _genDelegs ?! NonGenesisUpdateAVUP
 
   all allApNamesValid (range _aup) ?! InvalidName
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
@@ -95,10 +95,12 @@ chainTransition = do
 
   let NewEpochState _ eta0 _ bcur es _ _pd osched = nes'
   let EpochState (AccountState _ _reserves) _ ls pp                         = es
-  let LedgerState _ (DPState (DState _ _ _ _ _ _dms _) (PState _ _ _ cs)) _ = ls
+  let LedgerState _ (DPState (DState _ _ _ _ _ _genDelegs _) (PState _ _ _ cs)) _ = ls
 
   PrtclState cs' h' sL' etaV' etaC' <- trans @(PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo)
-    $ TRC (PrtclEnv (OverlayEnv pp osched eta0 _pd _dms) sNow, PrtclState cs h sL etaV etaC, bh)
+    $ TRC ( PrtclEnv (OverlayEnv pp osched eta0 _pd _genDelegs) sNow
+          , PrtclState cs h sL etaV etaC
+          , bh)
 
   let ls' = setIssueNumbers ls cs'
   BbodyState ls'' bcur' <- trans @(BBODY hashAlgo dsignAlgo kesAlgo vrfAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -60,41 +60,41 @@ delegationTransition = do
 
   case c of
     RegKey key -> do
-      key ∉ dom (_stKeys ds) ?! StakeKeyAlreadyRegisteredDELEG
+      key ∉ dom (_stkCreds ds) ?! StakeKeyAlreadyRegisteredDELEG
 
       pure $ ds
-        { _stKeys  = _stKeys ds  ∪ singleton key slot_
+        { _stkCreds  = _stkCreds ds  ∪ singleton key slot_
         , _rewards = _rewards ds ∪ Map.singleton (RewardAcnt key) (Coin 0)
         , _ptrs    = _ptrs ds    ∪ Map.singleton ptr_ key
         }
 
     DeRegKey key -> do
-      key ∈ dom (_stKeys ds) ?! StakeKeyNotRegisteredDELEG
+      key ∈ dom (_stkCreds ds) ?! StakeKeyNotRegisteredDELEG
 
       let rewardCoin = Map.lookup (RewardAcnt key) (_rewards ds)
       rewardCoin == Just 0 ?! StakeKeyNonZeroAccountBalanceDELEG
 
       pure $ ds
-        { _stKeys      = Set.singleton key              ⋪ _stKeys ds
+        { _stkCreds      = Set.singleton key              ⋪ _stkCreds ds
         , _rewards     = Set.singleton (RewardAcnt key) ⋪ _rewards ds
         , _delegations = Set.singleton key              ⋪ _delegations ds
         , _ptrs        = _ptrs ds                       ⋫ Set.singleton key
         }
 
     Delegate (Delegation delegator_ delegatee_) -> do
-      delegator_ ∈ dom (_stKeys ds) ?! StakeDelegationImpossibleDELEG
+      delegator_ ∈ dom (_stkCreds ds) ?! StakeDelegationImpossibleDELEG
 
       pure $ ds
         { _delegations = _delegations ds ⨃ [(delegator_, delegatee_)] }
 
     GenesisDelegate (gkey, vk) -> do
       let s' = slot_ +* slotsPrior
-          (Dms dms_) = _dms ds
+          (GenDelegs genDelegs_) = _genDelegs ds
 
-      gkey ∈ dom dms_ ?! GenesisKeyNotInpMappingDELEG
-      vk ∉ range dms_ ?! DuplicateGenesisDelegateDELEG
+      gkey ∈ dom genDelegs_ ?! GenesisKeyNotInpMappingDELEG
+      vk ∉ range genDelegs_ ?! DuplicateGenesisDelegateDELEG
       pure $ ds
-        { _fdms = _fdms ds ⨃ [((s', gkey), vk)]}
+        { _fGenDelegs = _fGenDelegs ds ⨃ [((s', gkey), vk)]}
 
     InstantaneousRewards credCoinMap -> do
       let combinedMap = Map.union credCoinMap (_irwd ds)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
@@ -67,7 +67,7 @@ ledgerTransition
 ledgerTransition = do
   TRC (LedgerEnv slot ix pp _reserves, (u, d), tx) <- judgmentContext
   utxo' <- trans @(UTXOW hashAlgo dsignAlgo vrfAlgo) $ TRC
-    ( UtxoEnv slot pp (d ^. dstate . stKeys) (d ^. pstate . stPools) (d ^. dstate . dms)
+    ( UtxoEnv slot pp (d ^. dstate . stkCreds) (d ^. pstate . stPools) (d ^. dstate . genDelegs)
     , u
     , tx
     )

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
@@ -84,21 +84,21 @@ ledgersTransition = do
 
   let ds = _dstate dw''
       ps = _pstate dw''
-      fdms_    = _fdms ds
-      Dms dms_ = _dms ds
-      (curr, fdms') = Map.partitionWithKey (\(s, _) _ -> s <= slot) fdms_
+      fGenDelegs_    = _fGenDelegs ds
+      GenDelegs genDelegs_ = _genDelegs ds
+      (curr, fGenDelegs') = Map.partitionWithKey (\(s, _) _ -> s <= slot) fGenDelegs_
   let maxSlot = maximum . Set.map fst . Map.keysSet
   let latestPerGKey gk =
         ( (maxSlot . Map.filterWithKey (\(_, c) _ -> c == gk)) curr
         , gk)
-  let dmsKeys = Set.map
+  let genDelegsKeys = Set.map
                   latestPerGKey
                   (Set.map snd (Map.keysSet curr))
-  let dms' = Map.mapKeys snd $ dmsKeys ◁ curr
-  let oldGenDelegs = range (dom dms' ◁ dms_)
-  let cs' = (oldGenDelegs ⋪ _cCounters ps) ⨃ fmap (\x -> (x, 0)) (Map.elems dms')
-  let dw''' = dw'' { _dstate = ds { _fdms = fdms'
-                                  , _dms = Dms $ dms_ ⨃ Map.toList dms'}
+  let genDelegs' = Map.mapKeys snd $ genDelegsKeys ◁ curr
+  let oldGenDelegs = range (dom genDelegs' ◁ genDelegs_)
+  let cs' = (oldGenDelegs ⋪ _cCounters ps) ⨃ fmap (\x -> (x, 0)) (Map.elems genDelegs')
+  let dw''' = dw'' { _dstate = ds { _fGenDelegs = fGenDelegs'
+                                  , _genDelegs = GenDelegs $ genDelegs_ ⨃ Map.toList genDelegs'}
                    , _pstate = ps { _cCounters = cs' }
                    }
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
@@ -17,7 +17,7 @@ import           Lens.Micro ((^.))
 import           Coin
 import           EpochBoundary
 import           LedgerState (AccountState, DState, PState, UTxOState, pattern UTxOState, clearPpup,
-                     emptyAccount, stKeys, stPools, _deposited, _irwd, _reserves)
+                     emptyAccount, stkCreds, stPools, _deposited, _irwd, _reserves)
 import           PParams
 import           Slot
 import           Updates
@@ -57,8 +57,8 @@ newPpTransition = do
   case ppNew of
     Just ppNew' -> do
       let slot_ = firstSlot e
-          Coin oblgCurr = obligation pp (ds ^. stKeys) (ps ^. stPools) slot_
-          Coin oblgNew = obligation ppNew' (ds ^. stKeys) (ps ^. stPools) slot_
+          Coin oblgCurr = obligation pp (ds ^. stkCreds) (ps ^. stPools) slot_
+          Coin oblgNew = obligation ppNew' (ds ^. stkCreds) (ps ^. stPools) slot_
           diff = oblgCurr - oblgNew
           Coin reserves = _reserves acnt
           Coin requiredInstantaneousRewards = foldl (+) (Coin 0) $ _irwd ds

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Overlay.hs
@@ -40,7 +40,7 @@ data OverlayEnv hashAlgo dsignAlgo kesAlgo vrfAlgo
       (Map Slot (Maybe (GenKeyHash hashAlgo dsignAlgo)))
       Nonce
       (PoolDistr hashAlgo dsignAlgo vrfAlgo)
-      (Dms hashAlgo dsignAlgo)
+      (GenDelegs hashAlgo dsignAlgo)
   deriving Generic
 
 instance NoUnexpectedThunks (OverlayEnv hashAlgo dsignAlgo kesAlgo vrfAlgo)
@@ -88,7 +88,7 @@ overlayTransition
      )
   => TransitionRule (OVERLAY hashAlgo dsignAlgo kesAlgo vrfAlgo)
 overlayTransition = do
-  TRC ( OverlayEnv pp osched eta0 pd (Dms dms)
+  TRC ( OverlayEnv pp osched eta0 pd (GenDelegs genDelegs)
       , cs
       , bh@(BHeader bhb _)) <- judgmentContext
   let vk = bvkcold bhb
@@ -100,11 +100,11 @@ overlayTransition = do
     Just Nothing ->
       failBecause NotActiveSlotOVERLAY
     Just (Just gkey) ->
-      case Map.lookup gkey dms of
+      case Map.lookup gkey genDelegs of
         Nothing ->
           failBecause NoGenesisStakingOVERLAY
-        Just dmsKey ->
-          vkh == dmsKey ?! WrongGenesisColdKeyOVERLAY vkh dmsKey
+        Just genDelegsKey ->
+          vkh == genDelegsKey ?! WrongGenesisColdKeyOVERLAY vkh genDelegsKey
 
   trans @(OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo) $ TRC ((), cs, bh)
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -26,7 +26,7 @@ import           Numeric.Natural (Natural)
 data PPUP hashAlgo dsignAlgo
 
 data PPUPEnv hashAlgo dsignAlgo
-  = PPUPEnv Slot PParams (Dms hashAlgo dsignAlgo)
+  = PPUPEnv Slot PParams (GenDelegs hashAlgo dsignAlgo)
 
 instance STS (PPUP hashAlgo dsignAlgo) where
   type State (PPUP hashAlgo dsignAlgo) = PPUpdate hashAlgo dsignAlgo
@@ -62,13 +62,13 @@ ppupTransitionEmpty = do
 
 ppupTransitionNonEmpty :: TransitionRule (PPUP hashAlgo dsignAlgo)
 ppupTransitionNonEmpty = do
-  TRC (PPUPEnv s pp (Dms _dms), pupS, pup@(PPUpdate pup')) <- judgmentContext
+  TRC (PPUPEnv s pp (GenDelegs _genDelegs), pupS, pup@(PPUpdate pup')) <- judgmentContext
 
   pup' /= Map.empty ?! PPUpdateEmpty
 
   all (all (pvCanFollow (_protocolVersion pp))) pup' ?! PVCannotFollowPPUP
 
-  (dom pup' ⊆ dom _dms) ?! NonGenesisUpdatePPUP (dom pup') (dom _dms)
+  (dom pup' ⊆ dom _genDelegs) ?! NonGenesisUpdatePPUP (dom pup') (dom _genDelegs)
 
   let Epoch slotEpoch = epochFromSlot (Slot 1)
   s

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
@@ -52,7 +52,7 @@ snapTransition = do
   TRC (SnapEnv pparams d p, SnapState s u, eNew) <- judgmentContext
   let pooledStake = stakeDistr (u ^. utxo) d p
   let _slot = firstSlot eNew
-  let oblg = obligation pparams (d ^. stKeys) (p ^. stPools) _slot
+  let oblg = obligation pparams (d ^. stkCreds) (p ^. stPools) _slot
   let decayed = (u ^. deposited) - oblg
   pure $ SnapState
     s { _pstakeMark = pooledStake

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
@@ -23,7 +23,7 @@ import           STS.Ppup
 data UP hashAlgo dsignAlgo
 
 data UpdateEnv hashAlgo dsignAlgo
-  = UpdateEnv Slot PParams (Dms hashAlgo dsignAlgo)
+  = UpdateEnv Slot PParams (GenDelegs hashAlgo dsignAlgo)
 
 instance DSIGNAlgorithm dsignAlgo => STS (UP hashAlgo dsignAlgo) where
   type State (UP hashAlgo dsignAlgo) = UpdateState hashAlgo dsignAlgo
@@ -43,11 +43,13 @@ upTransition
    . DSIGNAlgorithm dsignAlgo
   => TransitionRule (UP hashAlgo dsignAlgo)
 upTransition = do
-  TRC (UpdateEnv _slot pp _dms, UpdateState pupS aupS favs avs, Update pup _aup) <- judgmentContext
+  TRC ( UpdateEnv _slot pp _genDelegs
+      , UpdateState pupS aupS favs avs
+      , Update pup _aup) <- judgmentContext
 
-  pup' <- trans @(PPUP hashAlgo dsignAlgo) $ TRC (PPUPEnv _slot pp _dms, pupS, pup)
+  pup' <- trans @(PPUP hashAlgo dsignAlgo) $ TRC (PPUPEnv _slot pp _genDelegs, pupS, pup)
   AVUPState aup' favs' avs' <-
-    trans @(AVUP hashAlgo dsignAlgo) $ TRC (AVUPEnv _slot _dms, AVUPState aupS favs avs, _aup)
+    trans @(AVUP hashAlgo dsignAlgo) $ TRC (AVUPEnv _slot _genDelegs, AVUPState aupS favs avs, _aup)
 
   pure $ UpdateState pup' aup' favs' avs'
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -43,9 +43,9 @@ data UtxoEnv hashAlgo dsignAlgo
   = UtxoEnv
       Slot
       PParams
-      (StakeKeys hashAlgo dsignAlgo)
+      (StakeCreds hashAlgo dsignAlgo)
       (StakePools hashAlgo dsignAlgo)
-      (Dms hashAlgo dsignAlgo)
+      (GenDelegs hashAlgo dsignAlgo)
       deriving(Show)
 
 instance
@@ -82,7 +82,7 @@ utxoInductive
    . (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, VRFAlgorithm vrfAlgo)
   => TransitionRule (UTXO hashAlgo dsignAlgo vrfAlgo)
 utxoInductive = do
-  TRC (UtxoEnv slot_ pp stakeKeys stakePools dms_, u, tx) <- judgmentContext
+  TRC (UtxoEnv slot_ pp stakeKeys stakePools genDelegs_, u, tx) <- judgmentContext
   let txBody = _body tx
 
   _ttl txBody >= slot_ ?! ExpiredUTxO (_ttl txBody) slot_
@@ -100,7 +100,7 @@ utxoInductive = do
   consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
 
   -- process Update Proposals
-  ups' <- trans @(UP hashAlgo dsignAlgo) $ TRC (UpdateEnv slot_ pp dms_, u ^. ups, txup tx)
+  ups' <- trans @(UP hashAlgo dsignAlgo) $ TRC (UpdateEnv slot_ pp genDelegs_, u ^. ups, txup tx)
 
   let outputCoins = [c | (TxOut _ c) <- Set.toList (range (txouts txBody))]
   all (0 <=) outputCoins ?! NegativeOutputsUTxO

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -224,8 +224,8 @@ data Tx hashAlgo dsignAlgo vrfAlgo
 instance (DSIGNAlgorithm dsignAlgo)
   => NoUnexpectedThunks (Tx hashAlgo dsignAlgo vrfAlgo)
 
-newtype StakeKeys hashAlgo dsignAlgo =
-  StakeKeys (Map (StakeCredential hashAlgo dsignAlgo) Slot)
+newtype StakeCreds hashAlgo dsignAlgo =
+  StakeCreds (Map (StakeCredential hashAlgo dsignAlgo) Slot)
   deriving (Show, Eq, NoUnexpectedThunks)
 
 newtype StakePools hashAlgo dsignAlgo =
@@ -435,35 +435,35 @@ instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
     encodeListLen 1
       <> toCBOR (getRwdCred rwdAcnt)
 
-instance Relation (StakeKeys hashAlgo dsignAlgo) where
-  type Domain (StakeKeys hashAlgo dsignAlgo) = StakeCredential hashAlgo dsignAlgo
-  type Range (StakeKeys hashAlgo dsignAlgo)  = Slot
+instance Relation (StakeCreds hashAlgo dsignAlgo) where
+  type Domain (StakeCreds hashAlgo dsignAlgo) = StakeCredential hashAlgo dsignAlgo
+  type Range (StakeCreds hashAlgo dsignAlgo)  = Slot
 
-  singleton k v = StakeKeys $ Map.singleton k v
+  singleton k v = StakeCreds $ Map.singleton k v
 
-  dom (StakeKeys stKeys) = dom stKeys
+  dom (StakeCreds stkCreds) = dom stkCreds
 
-  range (StakeKeys stKeys) = range stKeys
+  range (StakeCreds stkCreds) = range stkCreds
 
-  s ◁ (StakeKeys stKeys) = StakeKeys $ s ◁ stKeys
+  s ◁ (StakeCreds stkCreds) = StakeCreds $ s ◁ stkCreds
 
-  s ⋪ (StakeKeys stKeys) = StakeKeys $ s ⋪ stKeys
+  s ⋪ (StakeCreds stkCreds) = StakeCreds $ s ⋪ stkCreds
 
-  (StakeKeys stKeys) ▷ s = StakeKeys $ stKeys ▷ s
+  (StakeCreds stkCreds) ▷ s = StakeCreds $ stkCreds ▷ s
 
-  (StakeKeys stKeys) ⋫ s = StakeKeys $ stKeys ⋫ s
+  (StakeCreds stkCreds) ⋫ s = StakeCreds $ stkCreds ⋫ s
 
-  (StakeKeys a) ∪ (StakeKeys b) = StakeKeys $ a ∪ b
+  (StakeCreds a) ∪ (StakeCreds b) = StakeCreds $ a ∪ b
 
-  (StakeKeys a) ⨃ b = StakeKeys $ a ⨃ b
+  (StakeCreds a) ⨃ b = StakeCreds $ a ⨃ b
 
-  vmax <=◁ (StakeKeys stKeys) = StakeKeys $ vmax <=◁ stKeys
+  vmax <=◁ (StakeCreds stkCreds) = StakeCreds $ vmax <=◁ stkCreds
 
-  (StakeKeys stKeys) ▷<= vmax = StakeKeys $ stKeys ▷<= vmax
+  (StakeCreds stkCreds) ▷<= vmax = StakeCreds $ stkCreds ▷<= vmax
 
-  (StakeKeys stKeys) ▷>= vmin = StakeKeys $ stKeys ▷>= vmin
+  (StakeCreds stkCreds) ▷>= vmin = StakeCreds $ stkCreds ▷>= vmin
 
-  size (StakeKeys stKeys) = size stKeys
+  size (StakeCreds stkCreds) = size stkCreds
 
 -- Lenses
 

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -46,7 +46,7 @@ import           Cardano.Prelude (NoUnexpectedThunks(..))
 
 import           BaseTypes (Nonce, UnitInterval)
 import           Coin (Coin)
-import           Keys (DSIGNAlgorithm, Dms, GenKeyHash)
+import           Keys (DSIGNAlgorithm, GenDelegs, GenKeyHash)
 import           PParams (PParams (..))
 import           Slot (Epoch, Slot)
 
@@ -90,7 +90,7 @@ instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo) => ToCBOR (Update ha
 
 data PPUpdateEnv hashAlgo dsignAlgo = PPUpdateEnv {
     slot :: Slot
-  , dms  :: Dms hashAlgo dsignAlgo
+  , genDelegs  :: GenDelegs hashAlgo dsignAlgo
   } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (PPUpdateEnv hashAlgo dsignAlgo)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation.hs
@@ -22,7 +22,7 @@ import           Delegation.Certificates (pattern DeRegKey, pattern RegKey, deca
 import           Examples (unsafeMkUnitInterval)
 import           Generator.Core (toCred)
 import           Ledger.Core (dom, (∈), (∉))
-import           LedgerState (dstate, keyRefund, stKeys, _dstate, _pstate, _stKeys, _stPools)
+import           LedgerState (dstate, keyRefund, stkCreds, _dstate, _pstate, _stkCreds, _stPools)
 import           MockTypes (DCert, DPState, DState, KeyPair, KeyPairs)
 import           PParams (PParams (..), emptyPParams)
 import           Slot (Epoch (Epoch), Slot)
@@ -80,7 +80,7 @@ genDCerts keys pparams dpState slotWithTTL = do
              in keyRefund dval
                           dmin
                           lambda
-                          (dpState ^. dstate . stKeys)
+                          (dpState ^. dstate . stkCreds)
                           slotWithTTL
                           crt
           refunds_ = sum (rewardForCred <$> deRegStakeCreds)
@@ -115,7 +115,7 @@ genRegKeyCert keys delegSt =
            (_payKey, stakeKey) <- Gen.element availableKeys
            pure $ Just $ (RegKey (toCred stakeKey), stakeKey)
   where
-    notRegistered k = k ∉ dom (_stKeys delegSt)
+    notRegistered k = k ∉ dom (_stkCreds delegSt)
     availableKeys = filter (notRegistered . toCred . snd) keys
 
 -- | Generate a DeRegKey certificate along with the stake key, which is needed
@@ -131,5 +131,5 @@ genDeRegKeyCert keys delegSt =
            (_payKey, stakeKey) <- Gen.element availableKeys
            pure $ Just (DeRegKey (toCred stakeKey), stakeKey)
   where
-    registered k = k ∈ dom (_stKeys delegSt)
+    registered k = k ∈ dom (_stkCreds delegSt)
     availableKeys = filter (registered . toCred . snd) keys

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -136,7 +136,8 @@ type POOLREAP = STS.PoolReap.POOLREAP ShortHash MockDSIGN FakeVRF
 type Credential = TxData.Credential ShortHash MockDSIGN
 
 type StakeCredential = TxData.StakeCredential ShortHash MockDSIGN
-type StakeKeys = TxData.StakeKeys ShortHash MockDSIGN
+
+type StakeCreds = TxData.StakeCreds ShortHash MockDSIGN
 
 type MultiSig = TxData.MultiSig ShortHash MockDSIGN
 

--- a/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MultiSigExamples.hs
@@ -21,7 +21,7 @@ import qualified Data.Set as Set (fromList)
 
 import           Coin
 import           Control.State.Transition (PredicateFailure, TRC (..), applySTS)
-import           Keys (pattern Dms, undiscriminateKeyHash)
+import           Keys (pattern GenDelegs, undiscriminateKeyHash)
 import           LedgerState (genesisId, genesisCoins, genesisState, _utxoState)
 import           MockTypes (Addr, KeyPair, LedgerState, MultiSig, ScriptHash, Tx, TxBody, TxId,
                      TxIn, UTXOW, UTxOState, Wdrl)
@@ -31,7 +31,7 @@ import           STS.Utxo (UtxoEnv (..))
 import           Tx (hashScript)
 import           TxData (pattern AddrBase, pattern KeyHashObj, pattern RequireAllOf,
                      pattern RequireAnyOf, pattern RequireMOf, pattern RequireSignature,
-                     pattern ScriptHashObj, pattern StakeKeys, pattern StakePools, pattern Tx,
+                     pattern ScriptHashObj, pattern StakeCreds, pattern StakePools, pattern Tx,
                      pattern TxBody, pattern TxIn, pattern TxOut, _body)
 import           Updates (emptyUpdate)
 import           UTxO (makeWitnessesVKey, txid)
@@ -131,9 +131,9 @@ initialUTxOState aliceKeep msigs =
   (txid $ _body tx, applySTS @UTXOW (TRC( UtxoEnv
                                            (Slot 0)
                                            initPParams
-                                           (StakeKeys Map.empty)
+                                           (StakeCreds Map.empty)
                                            (StakePools Map.empty)
-                                           (Dms Map.empty)
+                                           (GenDelegs Map.empty)
                                          , _utxoState genesis
                                          , tx)))
 
@@ -168,8 +168,8 @@ applyTxWithScript lockScripts unlockScripts wdrl aliceKeep signers = utxoSt'
         utxoSt' = applySTS @UTXOW (TRC( UtxoEnv
                                           (Slot 0)
                                           initPParams
-                                          (StakeKeys Map.empty)
+                                          (StakeCreds Map.empty)
                                           (StakePools Map.empty)
-                                          (Dms Map.empty)
+                                          (GenDelegs Map.empty)
                                       , utxoSt
                                       , tx))

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestDeleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestDeleg.hs
@@ -30,7 +30,7 @@ import           Generator.LedgerTrace ()
 import           Ledger.Core (dom, range, (∈), (∉), (◁))
 
 import           Coin (Coin, pattern Coin)
-import           LedgerState (_delegations, _rewards, _stKeys)
+import           LedgerState (_delegations, _rewards, _stkCreds)
 import           MockTypes (DELEG, DState, KeyHash, RewardAcnt, StakeCredential)
 import           Test.Utils (assertAll)
 import           TxData (pattern DeRegKey, pattern Delegate, pattern Delegation, pattern RegKey)
@@ -40,7 +40,7 @@ import           TxData (pattern DeRegKey, pattern Delegate, pattern Delegation,
 -------------------------------
 
 getStDelegs :: DState -> Set StakeCredential
-getStDelegs = dom . _stKeys
+getStDelegs = dom . _stkCreds
 
 getRewards :: DState -> Map RewardAcnt Coin
 getRewards = _rewards

--- a/shelley/chain-and-ledger/formal-spec/Properties.md
+++ b/shelley/chain-and-ledger/formal-spec/Properties.md
@@ -197,8 +197,8 @@ application version or protocol parameters.
 
 **Property**
 The keys (of type Slot) of the following two mappings are always past the current slot:
-the future application versions (favs) and the future genesis delegation mapping (fdms).
-The favs slots can appear in any current or future epoch, but the fdms slots
+the future application versions (favs) and the future genesis delegation mapping (fGenDelegs).
+The favs slots can appear in any current or future epoch, but the fGenDelegs slots
 can be at most one epoch into the future.
 
 **Property**
@@ -243,23 +243,23 @@ The sum of stake in the stake snapshots is always at most forty-five billion ADA
 
 **Property**
 The following delegation mappings always has the same size:
-`stdelegs`, `rewards`, and `ptrs`.
-Moreover, the key set of `stdelegs` is the same
+`stkCreds`, `rewards`, and `ptrs`.
+Moreover, the key set of `stkCreds` is the same
 as the range of `ptrs`, which also corresponds one-one with the reward addresses
-in `rewards`. Finally, the key set of `delegations` is a subset of that of `stdelegs`.
+in `rewards`. Finally, the key set of `delegations` is a subset of that of `stkCreds`.
 
 **Property**
 If all stake keys and pools deregister, then, assuming that no one registers anything,
 by epoch `e+1`, where `e` is the max epoch in the stake pool retirement mapping,
 the delegation state will be nearly empty. More precisely,
-the mappings `stDelegs`, `rewards`, `delegations`, `ptrs`, `stpools`, `poolParams`,
+the mappings `stkCreds`, `rewards`, `delegations`, `ptrs`, `stpools`, `poolParams`,
 and `retiring` are all the empty map.
 (The map `cs` will have size seven, for the genesis keys.)
 
 # Genesis Node Property
 
 **Property**
-The size of the genesis delegation mapping `dms` is always num-genesis.
+The size of the genesis delegation mapping `genDelegs` is always num-genesis.
 Note that the value num-genesis can be given as the size of the
 mapping inherited from Byron.
 

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -911,7 +911,7 @@ The environments for this transition are:
     responsible for producing the block.
   \item The epoch nonce $\eta_0$.
   \item The stake pool stake distribution $\var{pd}$.
-  \item The mapping $\var{dms}$ of genesis keys to their cold keys.
+  \item The mapping $\var{genDelegs}$ of genesis keys to their cold keys.
 \end{itemize}
 
 The states for this transition consist only of the mapping of certificate issue numbers.
@@ -946,7 +946,7 @@ it is worth examining the interaction in Equation~\ref{eq:decentralized} closely
         \var{osched} & \Slot\mapsto\KeyHashGen^? & \text{OBFT overlay schedule} \\
         \eta_0 & \Seed & \text{epoch nonce} \\
         \var{pd} & \PoolDistr & \text{pool stake distribution} \\
-        \var{dms} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
+        \var{genDelegs} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
       \end{array}
     \right)
   \end{equation*}
@@ -973,7 +973,7 @@ it is worth examining the interaction in Equation~\ref{eq:decentralized} closely
       \\
       \bslot bhb \mapsto \var{gkh}\in\var{osched}
       &
-      \var{gkh}\mapsto\var{vkh}\in\var{dms}
+      \var{gkh}\mapsto\var{vkh}\in\var{genDelegs}
       \\~\\
       {
         \vdash\var{cs}\trans{\hyperref[fig:rules:ocert]{ocert}}{\var{bh}}\var{cs'}
@@ -985,7 +985,7 @@ it is worth examining the interaction in Equation~\ref{eq:decentralized} closely
          \var{osched} \\
          \eta_0 \\
          \var{pd} \\
-         \var{dms} \\
+         \var{genDelegs} \\
        \end{array}}
       \vdash
       \var{cs}
@@ -1015,7 +1015,7 @@ it is worth examining the interaction in Equation~\ref{eq:decentralized} closely
          \var{osched} \\
          \eta_0 \\
          \var{pd} \\
-         \var{dms} \\
+         \var{genDelegs} \\
        \end{array}}
       \vdash
       \var{cs}
@@ -1362,7 +1362,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
   \emph{Chain Transition Helper Functions}
   \begin{align*}
       & \fun{getGKeys} \in \NewEpochState \to \powerset{\KeyHashGen} \\
-      & \fun{getGKeys}~\var{nes} = \dom{dms} \\
+      & \fun{getGKeys}~\var{nes} = \dom{genDelegs} \\
       &
       \begin{array}{lr@{~=~}l}
         \where
@@ -1372,7 +1372,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
           & (\wcard,~\wcard,~\var{ls},~\wcard)
           & \var{es}
           \\
-          & (\wcard,~((\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{dms}),~\wcard))
+          & (\wcard,~((\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{genDelegs}),~\wcard))
           & \var{ls}
       \end{array}
   \end{align*}
@@ -1423,7 +1423,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
         \leteq\var{nes'} \\
         (\var{acnt},~\wcard,\var{ls},~\var{pp})\leteq\var{es}\\
         ( \wcard,
-          ( (\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{dms}),~
+          ( (\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{genDelegs}),~
           (\wcard,~\wcard,~\wcard,~\var{cs})))\leteq\var{ls}\\
           (\wcard, reserves) \leteq \var{acnt}\\
       {
@@ -1433,7 +1433,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
              \var{osched} \\
              \eta_0 \\
              \var{pd} \\
-             \var{dms} \\
+             \var{genDelegs} \\
            \end{array}\\
            \var{s_{now}} \\
          \end{array}}

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -54,7 +54,7 @@ Here we introduce the following primitive datatypes used in delegation:
 \end{itemize}
 The following derived types are introduced:
 \begin{itemize}
-\item $\type{StakeDelegs}$ represents registered stake delegations and is
+\item $\type{StakeCreds}$ represents registered stake delegations and is
   represented by a finite map from stake credentials to slot when it was
   registered.
 \item$\type{StakePools}$ represents registered stake pools
@@ -121,7 +121,7 @@ It does the following:
   \emph{Derived types}
   \begin{equation*}
     \begin{array}{l@{\qquad=\qquad}lr}
-      \StakeDelegs
+      \StakeCreds
       & \Credential \mapsto \Slot
       & \text{registered stake credential} \\
       %
@@ -139,7 +139,7 @@ It does the following:
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \cwitness{} & \DCert\setminus\DCertMir \to \StakeDelegs & \text{certificate witness} \\
+      \cwitness{} & \DCert\setminus\DCertMir \to \StakeCreds & \text{certificate witness} \\
       \fun{dpool} & \DCertDeleg \to \KeyHash
                                             & \text{pool being delegated to}
       \\
@@ -149,7 +149,7 @@ It does the following:
       \fun{retire} & \DCertRetirePool \to \Epoch
                                             & \text{epoch of pool retirement}
       \\
-      \fun{genDel} & \DCertGen \to (\VKeyGen,~\VKey)
+      \fun{genesisDeleg} & \DCertGen \to (\VKeyGen,~\VKey)
                                             & \text{genesis delegation}
       \\
       \fun{moveRewards} & \DCertMir \to (\KeyHash \mapsto \Coin)
@@ -198,7 +198,7 @@ state transition types. We define two separate parts of the ledger state.
 \begin{itemize}
   \item $\DState$ keeps track of the delegation state, consisting of:
     \begin{itemize}
-    \item $\var{stdelegs}$ tracks the registered stake credentials. It consists
+    \item $\var{stkCreds}$ tracks the registered stake credentials. It consists
       of a finite mapping from hashkeys to the slot of the registration.
     \item $\var{rewards}$ stores the rewards accumulated by stake credentials.
       These are represented by a finite map from reward addresses to the
@@ -208,11 +208,11 @@ state transition types. We define two separate parts of the ledger state.
     \item $\var{ptrs}$ maps stake credentials to the position of the
       registration certificate in the blockchain. This is needed to lookup the
       stake hashkey of a pointer address.
-      \item $\var{fdms}$ are the future genesis keys delegations. This variable
+      \item $\var{fGenDelegs}$ are the future genesis keys delegations. This variable
       is needed because genesis keys can only update their delegation with a
       delay of $\SlotsPrior$ slots after submitting the certificate (this is
       necessary for header validation, see Section \ref{sec:chain})
-      \item $\var{dms}$ maps genesis key hashes to hashes of the cold key
+      \item $\var{genDelegs}$ maps genesis key hashes to hashes of the cold key
         delegates.
       \item $\var{i_{rwd}}$ stored the map of stake credentials to $\Coin$
         values for moving instantaneous rewards at the epoch boundary.
@@ -252,7 +252,7 @@ and the protocol parameters.
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
       \var{stakeCred} & \StakeCredential & (\KeyHash_{stake} \uniondistinct
                                        \HashScr) \\
-      \var{stakeDelegator} & \StakeDelegs & \StakeCredential \mapsto \Slot \\
+      \var{stakeDelegator} & \StakeCreds & \StakeCredential \mapsto \Slot \\
     \end{array}
   \end{equation*}
   %
@@ -262,12 +262,12 @@ and the protocol parameters.
     \begin{array}{l}
     \DState =
     \left(\begin{array}{r@{~\in~}lr}
-            \var{stDelegs} & \StakeDelegs & \text{registered stake delegators}\\
+            \var{stkCreds} & \StakeCreds & \text{registered stake delegators}\\
             \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
             \var{delegations} & \StakeCredential \mapsto \KeyHash_{pool} & \text{delegations}\\
             \var{ptrs} & \Ptr \mapsto \KeyHash & \text{pointer to hashkey}\\
-            \var{fdms} & (\Slot\times\KeyHashGen) \mapsto \KeyHash & \text{future genesis key delegations}\\
-            \var{dms} & \KeyHashGen \mapsto \KeyHash & \text{genesis key delegations}\\
+            \var{fGenDelegs} & (\Slot\times\KeyHashGen) \mapsto \KeyHash & \text{future genesis key delegations}\\
+            \var{genDelegs} & \KeyHashGen \mapsto \KeyHash & \text{genesis key delegations}\\
             \var{i_{rwd}} & \KeyHash \mapsto \Coin & \text{instantaneous rewards}\\
           \end{array}
       \right)
@@ -372,7 +372,7 @@ concerns are independent of the ledger rules.
     \end{itemize}
 
   \item Genesis key delegation is handled by \cref{eq:deleg-gen}.
-    There is a precondition that the genesis key is already in the mapping $\var{dms}$.
+    There is a precondition that the genesis key is already in the mapping $\var{genDelegs}$.
     Genesis delegation causes the following state transformation:
     \begin{itemize}
       \item The future genesis delegation relation is updated with the new delegate
@@ -395,7 +395,7 @@ concerns are independent of the ledger rules.
   \begin{equation}\label{eq:deleg-reg}
     \inference[Deleg-Reg]
     {
-    \var{c}\in\DCertRegKey & hk \leteq \cwitness{c} & hk \notin \dom \var{stdelegs}
+    \var{c}\in\DCertRegKey & hk \leteq \cwitness{c} & hk \notin \dom \var{stkCreds}
     }
     {
       \begin{array}{r}
@@ -406,24 +406,24 @@ concerns are independent of the ledger rules.
       \vdash
       \left(
         \begin{array}{r}
-        \var{stdelegs} \\
+        \var{stkCreds} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
-        \var{fdms} \\
-        \var{dms} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
         \var{i_{rwd}}
       \end{array}
       \right)
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \varUpdate{\var{stdelegs}} & \varUpdate{\union} & \varUpdate{\{\var{hk} \mapsto slot\}} \\
+        \varUpdate{\var{stkCreds}} & \varUpdate{\union} & \varUpdate{\{\var{hk} \mapsto slot\}} \\
         \varUpdate{\var{rewards}} & \varUpdate{\union} & \varUpdate{\{\addrRw \var{hk} \mapsto 0\}}\\
         \var{delegations} \\
         \varUpdate{\var{ptrs}} & \varUpdate{\union} & \varUpdate{\{ptr \mapsto \var{hk}\}} \\
-        \var{fdms} \\
-        \var{dms} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
         \var{i_{rwd}}
       \end{array}
       \right)
@@ -434,7 +434,7 @@ concerns are independent of the ledger rules.
     \inference[Deleg-Dereg]
     {
       \var{c}\in \DCertDeRegKey  & hk \leteq \cwitness{c} \\
-    hk \in \dom \var{stdelegs} & \addrRw \var{hk} \mapsto 0 \in \var{rewards}
+    hk \in \dom \var{stkCreds} & \addrRw \var{hk} \mapsto 0 \in \var{rewards}
     }
     {
       \begin{array}{r}
@@ -445,24 +445,24 @@ concerns are independent of the ledger rules.
       \vdash
       \left(
       \begin{array}{r}
-        \var{stdelegs} \\
+        \var{stkCreds} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
-        \var{fdms} \\
-        \var{dms} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
         \var{i_{rwd}}
       \end{array}
       \right)
       \trans{deleg}{\var{c}}
       \left(
       \begin{array}{rcl}
-        \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{stdelegs}} \\
+        \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{stkCreds}} \\
         \varUpdate{\{\addrRw \var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{rewards}} \\
         \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{delegations}} \\
         \varUpdate{\var{ptrs}} & \varUpdate{\subtractrange} & \varUpdate{\{\var{hk}\}} \\
-        \var{fdms} \\
-        \var{dms} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
         \var{i_{rwd}}
       \end{array}
       \right)
@@ -472,7 +472,7 @@ concerns are independent of the ledger rules.
   \begin{equation}\label{eq:deleg-deleg}
     \inference[Deleg-Deleg]
     {
-      \var{c}\in \DCertDeleg & hk \leteq \cwitness{c} & hk \in \dom \var{stdelegs}
+      \var{c}\in \DCertDeleg & hk \leteq \cwitness{c} & hk \in \dom \var{stkCreds}
     }
     {
       \begin{array}{r}
@@ -483,25 +483,25 @@ concerns are independent of the ledger rules.
       \vdash
       \left(
       \begin{array}{r}
-        \var{stdelegs} \\
+        \var{stkCreds} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
-        \var{fdms} \\
-        \var{dms} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
         \var{i_{rwd}}
       \end{array}
       \right)
       \trans{deleg}{c}
       \left(
       \begin{array}{rcl}
-        \var{stdelegs} \\
+        \var{stkCreds} \\
         \var{rewards} \\
         \varUpdate{\var{delegations}} & \varUpdate{\unionoverrideRight}
                                       & \varUpdate{\{\var{hk} \mapsto \dpool c\}} \\
         \var{ptrs} \\
-        \var{fdms} \\
-        \var{dms} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
         \var{i_{rwd}}
       \end{array}
       \right)
@@ -512,14 +512,14 @@ concerns are independent of the ledger rules.
     \inference[Deleg-Gen]
     {
       \var{c}\in \DCertGen
-      & (\var{gkey},~\var{vk})\leteq\fun{genDel}~{c}
+      & (\var{gkey},~\var{vk})\leteq\fun{genesisDeleg}~{c}
       \\
       \var{gkh} \leteq \hashKey{gkey}
       & \var{vkh} \leteq \hashKey{vk}
       \\
       s'\leteq\var{slot}+\SlotsPrior
-      & \var{gkh}\in\dom{dms}
-      & \var{vk}\notin\range{dms}
+      & \var{gkh}\in\dom{genDelegs}
+      & \var{vk}\notin\range{genDelegs}
     }
     {
       \begin{array}{r}
@@ -530,25 +530,25 @@ concerns are independent of the ledger rules.
       \vdash
       \left(
       \begin{array}{r}
-        \var{stdelegs} \\
+        \var{stkCreds} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
-        \var{fdms} \\
-        \var{dms} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
         \var{i_{rwd}}
       \end{array}
       \right)
       \trans{deleg}{c}
       \left(
       \begin{array}{rcl}
-        \var{stdelegs} \\
+        \var{stkCreds} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
-        \varUpdate{\var{fdms}} & \varUpdate{\unionoverrideRight}
+        \varUpdate{\var{fGenDelegs}} & \varUpdate{\unionoverrideRight}
                                & \varUpdate{\{(\var{s'},~\var{gkh}) \mapsto \var{vkh}\}} \\
-        \var{dms} \\
+        \var{genDelegs} \\
         \var{i_{rwd}}
       \end{array}
       \right)
@@ -578,24 +578,24 @@ concerns are independent of the ledger rules.
       \vdash
       \left(
       \begin{array}{r}
-        \var{stdelegs} \\
+        \var{stkCreds} \\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
-        \var{fdms} \\
-        \var{dms} \\
+        \var{fGenDelegs} \\
+        \var{genDelegs} \\
         \var{i_{rwd}}
       \end{array}
       \right)
       \trans{deleg}{c}
       \left(
       \begin{array}{rcl}
-        \var{stdelegs}\\
+        \var{stkCreds}\\
         \var{rewards} \\
         \var{delegations} \\
         \var{ptrs} \\
-        \var{fdms}\\
-        \var{dms} \\
+        \var{fGenDelegs}\\
+        \var{genDelegs} \\
         \varUpdate{\var{i_{rwd}}} & \varUpdate{\unionoverrideRight}
         & \varUpdate{\fun{moveRewards}~\var{c}}
       \end{array}
@@ -865,7 +865,7 @@ will be successful, since the pool certificates are disjoint from the delegation
   \emph{Delegation and Pool Combined Rules}
   \begin{equation}
     \label{eq:delpl-d}
-    \inference[Delpl-Del]
+    \inference[Delpl-Deleg]
     {
       &
       {
@@ -1023,12 +1023,12 @@ will be invalid.
       \begin{array}{c}
         \left(
         \begin{array}{r}
-          \var{stdelegs} \\
+          \var{stkCreds} \\
           \var{rewards} \\
           \var{delegations} \\
           \var{ptrs} \\
-          \var{fdms} \\
-          \var{dms} \\
+          \var{fGenDelegs} \\
+          \var{genDelegs} \\
           \var{i_{rwd}}
         \end{array}
         \right) \\~\\
@@ -1047,12 +1047,12 @@ will be invalid.
       \begin{array}{c}
         \left(
         \begin{array}{c}
-          \var{stdelegs} \\
+          \var{stkCreds} \\
           \varUpdate{\var{rewards'}} \\
           \var{delegations} \\
           \var{ptrs} \\
-          \var{fdms} \\
-          \var{dms} \\
+          \var{fGenDelegs} \\
+          \var{genDelegs} \\
           \var{i_{rwd}}
         \end{array}
         \right) \\~\\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -136,9 +136,9 @@ throughout the rest of the section.
 \begin{figure}[htb]
   \emph{Total possible refunds}
   \begin{align*}
-    & \fun{obligation} \in \PParams \to \StakeDelegs \to \StakePools \to \Slot \to \Coin \\
-    & \obligation{pp}{stdelegs}{stpools}{cslot} =\\
-    & \sum\limits_{(\_ \mapsto s) \in \var{stdelegs}}
+    & \fun{obligation} \in \PParams \to \StakeCreds \to \StakePools \to \Slot \to \Coin \\
+    & \obligation{pp}{stkCreds}{stpools}{cslot} =\\
+    & \sum\limits_{(\_ \mapsto s) \in \var{stkCreds}}
       \refund{d_{\mathsf{val}}}{d_{\min}}{\lambda_d}{(\slotminus{cslot}{s})}
       + \sum\limits_{(\_ \mapsto s) \in \var{stpools}}
       \refund{p_{\mathsf{val}}}{p_{\min}}{\lambda_p}{(\slotminus{cslot}{s})} \\
@@ -282,7 +282,7 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
       & \fun{stakeDistr}~{utxo}~{dstate}~{pstate} =
       (\dom{\var{activeDelegs}})\restrictdom\left(\fun{aggregate_{+}}~\var{stakeRelation}\right)\\
       & \where \\
-      & ~~~~ (\var{stdelegs},~\var{rewards},~\var{delegations},~\var{ptrs},~\wcard,~\wcard)
+      & ~~~~ (\var{stkCreds},~\var{rewards},~\var{delegations},~\var{ptrs},~\wcard,~\wcard)
         = \var{dstate} \\
       & ~~~~ (\var{stpools},~\wcard,~\wcard,~\wcard,~\wcard) = \var{pstate} \\
       & ~~~~ \var{stakeRelation} = \left(
@@ -291,7 +291,7 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
         \right)
         \cup \left(\fun{stakeCred_r}^{-1}\circ\var{rewards}\right) \\
       & ~~~~ \var{activeDelegs} =
-               (\dom{stdelegs}) \restrictdom \var{delegations} \restrictrange (\dom{stpools}) \\
+               (\dom{stkCreds}) \restrictdom \var{delegations} \restrictrange (\dom{stpools}) \\
   \end{align*}
 
   \caption{Stake Distribution Function}
@@ -396,11 +396,11 @@ This transition has no preconditions and results in the following state change:
       {
       \begin{array}{r@{~\leteq~}l}
         (\var{utxo},~\var{deposits},~\var{fees},~\wcard) & \var{utxoSt}\\
-        (\var{stdelegs},~\wcard,~\var{delegations},~\wcard,~\wcard,~\wcard) & \var{dstate}\\
+        (\var{stkCreds},~\wcard,~\var{delegations},~\wcard,~\wcard,~\wcard) & \var{dstate}\\
         (\var{stpools},~\var{poolParams},~\wcard,~\wcard) & \var{pstate}\\
         \var{stake} & \stakeDistr{utxo}{dstate}{pstate} \\
         \var{slot} & \firstSlot{e} \\
-        \var{oblg} & \obligation{pp}{stdelegs}{stpools}{slot} \\
+        \var{oblg} & \obligation{pp}{stkCreds}{stpools}{slot} \\
         \var{decayed} & \var{deposits} - \var{oblg} \\
       \end{array}
       }
@@ -541,11 +541,11 @@ This transition has no preconditions and results in the following state change:
           \var{treasury} \\
           \var{reserves} \\
           ~ \\
-          \var{stdelegs} \\
+          \var{stkCreds} \\
           \var{rewards} \\
           \var{delegations} \\
           \var{ptrs} \\
-          \var{dms} \\
+          \var{genDelegs} \\
           ~ \\
           \var{stpools} \\
           \var{poolParams} \\
@@ -566,11 +566,11 @@ This transition has no preconditions and results in the following state change:
           \varUpdate{\var{treasury}} & \varUpdate{+} & \varUpdate{\var{unclaimed}} \\
           \var{reserves} \\
           ~ \\
-          \var{stdelegs} \\
+          \var{stkCreds} \\
           \varUpdate{\var{rewards}} & \varUpdate{\unionoverridePlus} & \varUpdate{\var{refunds}} \\
           \varUpdate{\var{delegations}} & \varUpdate{\subtractrange} & \varUpdate{\var{retired}} \\
           \var{ptrs} \\
-          \var{dms} \\
+          \var{genDelegs} \\
           ~ \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{stpools}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{poolParams}} \\
@@ -679,8 +679,8 @@ for ease of reading.
       \var{pp_{new}}\neq\Nothing \\~\\
       {\begin{array}{rcl}
          \var{slot} & \leteq & \firstSlot{e} \\
-         \var{oblg_{cur}} & \leteq & \obligation{pp}{stdelegs}{stpools}{slot} \\
-         \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stdelegs}{stpools}{slot} \\
+         \var{oblg_{cur}} & \leteq & \obligation{pp}{stkCreds}{stpools}{slot} \\
+         \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stkCreds}{stpools}{slot} \\
          \var{(\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{i_{rwd}})} &
                                                                                       \leteq
                               & \var{dstate}\\
@@ -759,8 +759,8 @@ for ease of reading.
       \\~\\~\\
       {\begin{array}{rcl}
           \var{slot} & \leteq & \firstSlot{e} \\
-          \var{oblg_{cur}} & \leteq & \obligation{pp}{stdelegs}{stpools}{slot} \\
-          \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stdelegs}{stpools}{slot} \\
+          \var{oblg_{cur}} & \leteq & \obligation{pp}{stkCreds}{stpools}{slot} \\
+          \var{oblg_{new}} & \leteq & \obligation{pp_{new}}{stkCreds}{stpools}{slot} \\
          \var{(\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{i_{rwd}})} &
                                                                                  \leteq
                               & \var{dstate}\\
@@ -1351,7 +1351,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
     & ~~~~~~~\left(
       \wcard,~
       \left(
-      \left(\var{stDelegs},~\var{rewards},~\wcard,~\wcard,~\wcard,~\wcard,~\var{i_{rwd}}\right)~
+      \left(\var{stkCreds},~\var{rewards},~\wcard,~\wcard,~\wcard,~\wcard,~\var{i_{rwd}}\right)~
       \wcard
       \right)
       \right) = \var{ls} \\
@@ -1414,11 +1414,11 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
           \var{treasury} \\
           \var{reserves} \\
           ~ \\
-          \var{stdelegs} \\
+          \var{stkCreds} \\
           \var{rewards} \\
           \var{delegations} \\
           \var{ptrs} \\
-          \var{dms} \\
+          \var{genDelegs} \\
           \var{i_{rwd}}
           \\~ \\
           \var{stpools} \\
@@ -1438,11 +1438,11 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
           \varUpdate{\var{treasury} + \Delta t}\\
           \varUpdate{\var{reserves} + \Delta r}\\
           ~ \\
-          \varUpdate{\var{stdelegs}\unionoverrideLeft \var{update_{delegs}}} \\
+          \varUpdate{\var{stkCreds}\unionoverrideLeft \var{update_{delegs}}} \\
           \varUpdate{(\var{rewards}\unionoverridePlus\var{rs})\unionoverridePlus\var{update_{rwd}}} \\
           \var{delegations} \\
           \var{ptrs} \\
-          \var{dms} \\
+          \var{genDelegs} \\
           \varUpdate{\emptyset}
           \\~ \\
           \var{stpools} \\

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -57,7 +57,7 @@
 \newcommand{\SlotsStabilityParam}{\fun{k}}
 \newcommand{\Duration}{\type{Duration}}
 \newcommand{\StakePools}{\type{StakePools}}
-\newcommand{\StakeDeleg}{\type{StakeDeleg}}
+\newcommand{\StakeCreds}{\type{StakeCreds}}
 \newcommand{\Seed}{\type{Seed}}
 \newcommand{\seedOp}{\star}
 \newcommand{\Ppm}{\type{Ppm}}
@@ -107,7 +107,6 @@
 
 % multi-signature
 \newcommand{\StakeCredential}{\type{Credential}_{stake}}
-\newcommand{\StakeDelegs}{\type{StakeDelegs}}
 
 \newcommand{\txwitsVKey}[1]{\fun{txwitsVKey}~\var{#1}}
 \newcommand{\txwitsScript}[1]{\fun{txwitsScript}~\var{#1}}

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -76,16 +76,16 @@ then calls the $\mathsf{DELEGS}$ transition.
                      \fun{txcerts}~\var{tx}} dpstate'
       \\~\\
       (\var{dstate}, \var{pstate}) \leteq \var{dpstate} \\
-      (\var{stdelegs}, \_, \_, \_, \_, \var{dms}) \leteq \var{dstate} \\
+      (\var{stkCreds}, \_, \_, \_, \_, \var{genDelegs}) \leteq \var{dstate} \\
       (\var{stpools}, \_, \_, \_) \leteq \var{pstate} \\
       \\~\\
       {
         \begin{array}{c}
         \var{slot} \\
         \var{pp} \\
-        \var{stdelegs} \\
+        \var{stkCreds} \\
         \var{stpools} \\
-        \var{dms} \\
+        \var{genDelegs} \\
         \end{array}
       }
       \vdash \var{utxoSt} \trans{\hyperref[fig:rules:utxow-shelley]{utxow}}{tx} \var{utxoSt'}
@@ -126,7 +126,7 @@ and cleans up the future application versions mapping.
 Note that it is better to handle this logic here than in the $\mathsf{AVUP}$ transiton,
 because here it will happen even if the block contains no transactions.
 Similarly, the genesis key delegation mapping is updated according to the future delegation
-mapping. For each genesis key, we adopt the most recent delegation in $\var{fdms}$
+mapping. For each genesis key, we adopt the most recent delegation in $\var{fGenDelegs}$
 that is past the current slot, and any future genesis key delegations past the current
 slot is removed.
 
@@ -152,7 +152,7 @@ slot is removed.
       \\
       (\var{pup},~\var{aup},~\var{favs},~\var{avs}) \leteq\var{us}
       \\
-      (\var{stkeys},~\var{rewards},~\var{delegations}, ~\var{ptrs},~\var{fdms},~\var{dms})
+      (\var{stkeys},~\var{rewards},~\var{delegations}, ~\var{ptrs},~\var{fGenDelegs},~\var{genDelegs})
       \leteq\var{ds}
       \\
       (\var{stpools},~\var{poolParams},~\var{retiring},~\var{cs})\leteq\var{ps}
@@ -166,11 +166,11 @@ slot is removed.
       \\~\\
       \var{curr}\leteq
       \{
-        (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{fdms}
+        (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{fGenDelegs}
         ~\mid~
         \var{s}\leq\var{slot}
       \}\\
-      \var{dms'}\leteq
+      \var{genDelegs'}\leteq
       \left\{
         \var{gkh}\mapsto\var{vkh}
         ~\mathrel{\Bigg|}~
@@ -186,12 +186,12 @@ slot is removed.
       \\
       \var{ds'}\leteq
       (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},
-      ~\var{fdms}\setminus\var{curr},~\var{dms}\unionoverrideRight\var{dms'})
+      ~\var{fGenDelegs}\setminus\var{curr},~\var{genDelegs}\unionoverrideRight\var{genDelegs'})
       \\
-      \var{oldGenDelegs}\leteq\range((\dom\var{dms'})\restrictdom\var{dms})
+      \var{oldGenDelegs}\leteq\range((\dom\var{genDelegs'})\restrictdom\var{genDelegs})
       \\
       \var{cs'}\leteq(\var{oldGenDelegs}\subtractdom\var{oldGenDelegs})\unionoverrideRight
-      \{\var{hk}\mapsto 0~\mid~\var{hk}\in\range{dms'}\}
+      \{\var{hk}\mapsto 0~\mid~\var{hk}\in\range{genDelegs'}\}
       \\
       \var{ps'}\leteq(\var{stpools},~\var{poolParams},~\var{retiring},~\var{cs'})
       \\

--- a/shelley/chain-and-ledger/formal-spec/multi-sig.tex
+++ b/shelley/chain-and-ledger/formal-spec/multi-sig.tex
@@ -80,7 +80,7 @@
 \newcommand{\SlotsPerKESPeriod}{\mathsf{SlotsPerKESPeriod}}
 \newcommand{\Duration}{\type{Duration}}
 \newcommand{\StakePools}{\type{StakePools}}
-\newcommand{\StakeDelegs}{\type{StakeDelegs}}
+\newcommand{\StakeCreds}{\type{StakeCreds}}
 \newcommand{\StakeObject}{\type{StakeCredential}}
 
 \newcommand{\DCert}{\type{DCert}}
@@ -521,7 +521,7 @@ multi-signature scripts.
 
 Staking using multiple signatures requires a change to the type of staking reference from
 just a hashed key to either a hashed key or a hashed script. This is
-reflected in the type of $\StakeDelegs$ (which replaces the previous
+reflected in the type of $\StakeCreds$ (which replaces the previous
 $\type{StakeKeys}$ type) and the new $\StakeObject$ type, % (which describes either a key or a script used for staking),
 as shown in
 Figure~\ref{fig:delegation-state-type}.
@@ -532,7 +532,7 @@ Figure~\ref{fig:delegation-state-type}.
       \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
         \var{stakeCred} & \StakeObject & (\KeyHash_{stake} \uniondistinct
                                             \HashScr) \\
-        \var{stakeDelegator} & \StakeDelegs & \StakeObject \mapsto \Slot \\
+        \var{regCreds} & \StakeCreds & \StakeObject \mapsto \Slot \\
       \end{array}
     \end{equation*}
     %
@@ -542,12 +542,12 @@ Figure~\ref{fig:delegation-state-type}.
     \begin{array}{l}
     \DState =
     \left(\begin{array}{r@{~\in~}lr}
-      \var{stDelegs} & \StakeDelegs & \text{registered stake delegators}\\
+      \var{stkCreds} & \StakeCreds & \text{registered stake delegators}\\
       \var{rewards} & \AddrRWD \mapsto \Coin & \text{rewards}\\
       \var{delegations} & \StakeObject \mapsto \KeyHash_{pool} & \text{delegations}\\
       \var{ptrs} & \Ptr \mapsto \StakeObject & \text{pointer to staking reference}\\
-      \var{fdms} & (\Slot\times\VKeyGen) \mapsto \VKey & \text{future genesis key delegations}\\
-      \var{dms} & \VKeyGen \mapsto \VKey & \text{genesis key delegations}\\
+      \var{fGenDelegs} & (\Slot\times\VKeyGen) \mapsto \VKey & \text{future genesis key delegations}\\
+      \var{genDelegs} & \VKeyGen \mapsto \VKey & \text{genesis key delegations}\\
           \end{array}\right)
     \end{array}
   \end{equation*}
@@ -556,7 +556,7 @@ Figure~\ref{fig:delegation-state-type}.
   %
   \begin{equation*}
   \begin{array}{r@{~\in~}lr}
-    \cwitness{} & \DCert \to \StakeDelegs & \text{certificate witness}
+    \cwitness{} & \DCert \to \StakeCreds & \text{certificate witness}
   \end{array}
   \end{equation*}
   \caption{Delegation State type}

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -77,7 +77,7 @@ state.
     \forall \var{l}, \var{l'} \in \LState: \applyFun{validLedgerstate}{l},
     l=(u,\wcard,\wcard,\wcard), l' = (u',\wcard,\wcard,\wcard)\\
     \implies \forall \var{tx} \in \Tx, lenv \in\LEnv, lenv \vdash\var{u} \trans{utxow}{tx} \var{u'} \\
-    \implies \applyFun{destroyed}{pc~utxo~stDelegs~rewards~tx} =
+    \implies \applyFun{destroyed}{pc~utxo~stkCreds~rewards~tx} =
     \applyFun{created}{pc~stPools~tx}
   \end{multline*}
   \label{prop:ledger-properties-1}
@@ -198,8 +198,8 @@ each output of a transition is spent at most once.
   \begin{align*}
     \fun{getStDelegs} & \in & \DState \to \powerset \Credential \\
     \fun{getStDelegs} & \coloneqq &
-                                    ((\var{stDelegs}, \wcard,
-                                    \wcard,\wcard,\wcard,\wcard) \to \var{stDelegs} \\
+                                    ((\var{stkCreds}, \wcard,
+                                    \wcard,\wcard,\wcard,\wcard) \to \var{stkCreds} \\
                       &&\\
     \fun{getRewards} & \in & \DState \to (\AddrRWD \mapsto \Coin) \\
     \fun{getRewards} & \coloneqq & (\wcard, \var{rewards},
@@ -287,7 +287,7 @@ delegation certificate in $l'$.
   \begin{multline*}
     \forall \var{l}, \var{l'} \in \LState: \applyFun{validLedgerstate}{l},\\
     \implies \forall \Gamma \in \seqof{\Tx}, env \in (\Slot \times \PParams), \\
-    env \vdash\var{l} \trans{ledgers}{\Gamma} \var{l'} \implies |dms| = 7
+    env \vdash\var{l} \trans{ledgers}{\Gamma} \var{l'} \implies |genDelegs| = 7
   \end{multline*}
 \end{property}
 

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -19,7 +19,7 @@ for a transaction, see \ref{sec:witnesses-shelley}.
 
 \textbf{Genesis Key Delegations.} The environment for both protocol parameter
 and application version updates contains
-the value $\var{dms}$, which is a finite map indexed by genesis key hashes.
+the value $\var{genDelegs}$, which is a finite map indexed by genesis key hashes.
 This is the genesis key delegations. During the Byron era, they are all
 already delegated to some $\KeyHash$, and these delegations are inherited
 through the Byron-Shelley transition (see \ref{sec:byron-to-shelley}).
@@ -63,7 +63,7 @@ This rule has the following predicate failures:
   $\fun{firstSlot}~((\fun{epoch}~\var{slot}) + 1) - \fun{SlotsPrior}$, there is
   a \emph{PPUpdateTooEarly} failure.
 \item In the case of \var{pup} being non-empty, if the check $\dom pup \subseteq
-  \dom dms$ fails, there is a \emph{NonGenesisUpdate} failure as only genesis keys
+  \dom genDelegs$ fails, there is a \emph{NonGenesisUpdate} failure as only genesis keys
   can be used in the protocol parameter update.
 \item If a protocol parameter update in \var{pup} cannot follow the current
   protocol parameter, there is a \emph{PVCannotFollow} failure.
@@ -88,7 +88,7 @@ and will be rejected otherwise.
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
-        \var{dms} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
+        \var{genDelegs} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
       \end{array}
     \right)
   \end{equation*}
@@ -114,7 +114,7 @@ and will be rejected otherwise.
       \begin{array}{r}
         \var{slot}\\
         \var{pp}\\
-        \var{dms}\\
+        \var{genDelegs}\\
       \end{array}
       \vdash \var{pup_s}\trans{ppup}{pup}\var{pup_s}
     }
@@ -127,7 +127,7 @@ and will be rejected otherwise.
     {
       \var{pup}\neq\emptyset
       &
-      \dom{pup}\subseteq\dom{dms}
+      \dom{pup}\subseteq\dom{genDelegs}
       \\
       \forall\var{ps}\in\range{pup},~
         \var{pv}\mapsto\var{v}\in\var{ps}\implies\fun{pvCanFollow}~(\fun{pv}~\var{pp})~\var{v}
@@ -138,7 +138,7 @@ and will be rejected otherwise.
       \begin{array}{r}
         \var{slot}\\
         \var{pp}\\
-        \var{dms}\\
+        \var{genDelegs}\\
       \end{array}
       \vdash
       \var{pup_s}
@@ -277,7 +277,7 @@ All other update proposals are scrapped.
 The AVUP rule has three predicate failures:
 \begin{itemize}
 \item In the case of \var{aup} being non-empty, if the check $\dom aup \subseteq
-  \dom dms$ fails, there is a \emph{NonGenesisUpdate} failure as only genesis keys
+  \dom genDelegs$ fails, there is a \emph{NonGenesisUpdate} failure as only genesis keys
   can be used in the application version update.
 \item In the case of \var{aup} being non-empty, if any of the application names
   in the proposal are invalid, there is a \emph{InvalidName} failure.
@@ -296,7 +296,7 @@ The AVUP rule has three predicate failures:
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
-        \var{dms} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
+        \var{genDelegs} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
       \end{array}
     \right)
   \end{equation*}
@@ -333,7 +333,7 @@ The AVUP rule has three predicate failures:
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{dms}\\
+        \var{genDelegs}\\
       \end{array}
       \vdash
       \left(
@@ -361,7 +361,7 @@ The AVUP rule has three predicate failures:
     {
       \var{aup}\neq\emptyset
       &
-      \dom{\var{aup}}\subseteq\dom{\var{dms}}
+      \dom{\var{aup}}\subseteq\dom{\var{genDelegs}}
       \\
       \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\in\dom{vote},~
         \fun{apNameValid}~\var{v}
@@ -381,7 +381,7 @@ The AVUP rule has three predicate failures:
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{dms}\\
+        \var{genDelegs}\\
       \end{array}
       \vdash
       \left(
@@ -409,7 +409,7 @@ The AVUP rule has three predicate failures:
     {
       \var{aup}\neq\emptyset
       &
-      \dom{\var{aup}}\subseteq\dom{\var{dms}}
+      \dom{\var{aup}}\subseteq\dom{\var{genDelegs}}
       \\
       \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\in\dom{vote},~
         \fun{apNameValid}~\var{v}
@@ -431,7 +431,7 @@ The AVUP rule has three predicate failures:
     {
       \begin{array}{l}
         \var{slot}\\
-        \var{dms}\\
+        \var{genDelegs}\\
       \end{array}
       \vdash
       \left(
@@ -472,7 +472,7 @@ update rules for each.
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
-        \var{dms} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
+        \var{genDelegs} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
       \end{array}
     \right)
   \end{equation*}
@@ -511,7 +511,7 @@ update rules for each.
         \begin{array}{r}
           \var{slot} \\
           \var{pp} \\
-          \var{dms} \\
+          \var{genDelegs} \\
         \end{array}
       }
       \vdash
@@ -522,7 +522,7 @@ update rules for each.
       {
         \begin{array}{r}
           \var{slot} \\
-          \var{dms} \\
+          \var{genDelegs} \\
         \end{array}
       }
       \vdash
@@ -550,7 +550,7 @@ update rules for each.
       \begin{array}{r}
         \var{slot}\\
         \var{pp} \\
-        \var{dms}\\
+        \var{genDelegs}\\
       \end{array}
       \vdash
       \left(

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -59,7 +59,7 @@ Figure~\ref{fig:functions:utxo} defines functions needed for the UTxO transition
     withdrawals and stake credential deposit refunds. Some of the definitions
     used in this function will be defined in Section~\ref{sec:deps-refunds}. In
     particular, $\fun{keyRefunds}$ is defined in
-    Figure~\ref{fig:functions:deposits-refunds} and $\StakeDelegs$ is defined in
+    Figure~\ref{fig:functions:deposits-refunds} and $\StakeCreds$ is defined in
     Figure~\ref{fig:delegation-defs}.
 
   \item The calculation $\fun{produced}$ gives the value produced by the transaction $\var{tx}$
@@ -101,12 +101,12 @@ Registration will be discussed more in Section~\ref{sec:delegation-shelley}.
     & \text{withdrawal balance} \\
     & \fun{wbalance} ~ ws = \sum_{(\wcard\mapsto c)\in\var{ws}} c
     \nextdef
-    & \fun{consumed} \in \PParams \to \UTxO \to \StakeDelegs \to \Wdrl \to \Tx \to \Coin
+    & \fun{consumed} \in \PParams \to \UTxO \to \StakeCreds \to \Wdrl \to \Tx \to \Coin
     & \text{value consumed} \\
-    & \consumed{pp}{utxo}{stdelegs}{rewards}~{tx} = \\
+    & \consumed{pp}{utxo}{stkCreds}{rewards}~{tx} = \\
     & ~~\ubalance{(\txins{tx} \restrictdom \var{utxo})} +
         \fun{wbalance}~(\fun{txwdrls}~{tx}) \\
-    & ~~ + \keyRefunds{pp}{stdelegs}{tx} \\
+    & ~~ + \keyRefunds{pp}{stkCreds}{tx} \\
     \nextdef
     & \fun{produced} \in \PParams \to \StakePools \to \Tx \to \Coin
     & \text{value produced} \\
@@ -155,9 +155,9 @@ The signal for the UTxO transition is a transaction.
       \begin{array}{r@{~\in~}lr}
         \var{slot} & \Slot & \text{current slot}\\
         \var{pp} & \PParams & \text{protocol parameters}\\
-        \var{stdelegs} & \StakeDeleg & \text{stake credential}\\
+        \var{stkCreds} & \StakeCreds & \text{stake credential}\\
         \var{stpools} & \StakePools & \text{stake pool}\\
-        \var{dms} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
+        \var{genDelegs} & \KeyHashGen\mapsto\KeyHash & \text{genesis key delegations} \\
       \end{array}
     \right)
   \end{equation*}
@@ -293,7 +293,7 @@ requests).
       & \minfee{pp}{tx} \leq \txfee{tx}
       & \txins{tx} \subseteq \dom \var{utxo}
       \\
-      \consumed{pp}{utxo}{stdelegs}{rewards}~{tx} = \produced{pp}{stpools}~{tx}
+      \consumed{pp}{utxo}{stkCreds}{rewards}~{tx} = \produced{pp}{stpools}~{tx}
       \\
       ~
       \\
@@ -301,7 +301,7 @@ requests).
         \begin{array}{r}
           \var{slot} \\
           \var{pp} \\
-          \var{dms} \\
+          \var{genDelegs} \\
         \end{array}
       }
       \vdash \var{ups} \trans{\hyperref[fig:rules:update]{up}}{\fun{txup}~\var{tx}} \var{ups'}
@@ -314,9 +314,9 @@ requests).
       \\
       ~
       \\
-      \var{refunded} \leteq \keyRefunds{pp}{stdelegs}~{tx}
+      \var{refunded} \leteq \keyRefunds{pp}{stkCreds}~{tx}
       \\
-      \var{decayed} \leteq \decayedTx{pp}{stdelegs}~{tx}
+      \var{decayed} \leteq \decayedTx{pp}{stkCreds}~{tx}
       \\
       \var{depositChange} \leteq
         (\deposits{pp}~{stpools}~{\txcerts{tx}}) - (\var{refunded} + \var{decayed})
@@ -325,9 +325,9 @@ requests).
       \begin{array}{r}
         \var{slot}\\
         \var{pp}\\
-        \var{stdelegs}\\
+        \var{stkCreds}\\
         \var{stpools}\\
-        \var{dms}\\
+        \var{genDelegs}\\
       \end{array}
       \vdash
       \left(
@@ -391,7 +391,7 @@ and refund functions.
   \item The function $\fun{keyRefund}$, calculates the refund for an individual
     stake credential registration deposit, based on the slot when it was created
     and the slot passed to the function. The creation slot should always exist
-    in the map $\var{stdelegs}$ passed to the function and this would be a good
+    in the map $\var{stkCreds}$ passed to the function and this would be a good
     property to prove about the transition system.
   \item The function $\fun{keyRefunds}$, in turn, uses $\fun{keyRefund}$ to calculate
     the total value to be refunded to all individual key deregistration certificate authors
@@ -470,25 +470,25 @@ Section~\ref{sec:epoch}.
             \left(d_{\min}+(1-d_{\min})\cdot e^{-\lambda\cdot\delta}\right)}
       \nextdef
       & \fun{keyRefund} \in \Coin \to \unitInterval \to \posReals \to \\
-      & ~~~~~\StakeDelegs \to \Slot \to \DCertDeRegKey \to \Coin
+      & ~~~~~\StakeCreds \to \Slot \to \DCertDeRegKey \to \Coin
       & \text{key refund for a certificate} \\
-      & \keyRefund{\dval}{d_{\min}}{\lambda}{stdelegs}{slot}{c} =\\
+      & \keyRefund{\dval}{d_{\min}}{\lambda}{stkCreds}{slot}{c} =\\
       & ~~~~~\begin{cases}
-            0 & \text{if}~\cwitness c \notin \dom stdelegs \\
+            0 & \text{if}~\cwitness c \notin \dom stkCreds \\
             \refund{\dval}{d_{\min}}{\lambda}{\delta}
             & \text{otherwise}
         \end{cases}\\
       &
       \begin{array}{lr@{~=~}l}
         \where
-        &\delta & \slotminus{slot}{(stdelegs~(\cwitness c))}\\
+        &\delta & \slotminus{slot}{(stkCreds~(\cwitness c))}\\
       \end{array}\\
       \nextdef
-      & \fun{keyRefunds} \in \PParams \to \StakeDelegs \to \Tx \to \Coin
+      & \fun{keyRefunds} \in \PParams \to \StakeCreds \to \Tx \to \Coin
       & \text{key refunds for a transaction} \\
-      & \keyRefunds{pp}{stdelegs}{tx} =\\
+      & \keyRefunds{pp}{stkCreds}{tx} =\\
       & ~~~~~ \sum\limits_{\substack{c \in (\txcerts{tx} \\ \cap \DCertDeRegKey)}}
-              \keyRefund{\dval}{d_{\min}}{\lambda}{stdelegs}{(\txttl{tx})}{c}\\
+              \keyRefund{\dval}{d_{\min}}{\lambda}{stkCreds}{(\txttl{tx})}{c}\\
       &
       \begin{array}{lr@{~=~}l}
         \where \\
@@ -504,31 +504,31 @@ Section~\ref{sec:epoch}.
 \begin{figure}[htb]
   \begin{align*}
       & \fun{decayedKey} \in
-      \PParams \to \StakeDelegs \to \Slot \to \DCertDeRegKey \to \Coin
+      \PParams \to \StakeCreds \to \Slot \to \DCertDeRegKey \to \Coin
       & \text{decayed since epoch} \\
-      & \decayedKey{pp}{stdelegs}{cslot}{c} =\\
+      & \decayedKey{pp}{stkCreds}{cslot}{c} =\\
       & \begin{cases}
-            0 & \text{if}~\cwitness c \notin \dom stdelegs\\
+            0 & \text{if}~\cwitness c \notin \dom stkCreds\\
             \var{epochRefund} - \var{currentRefund}
             & \text{otherwise}
         \end{cases}\\
       &
       \begin{array}{lr@{~=~}l}
         \where
-          & \var{created} & \var{stdelegs}~(\cwitness~\var{c}) \\
+          & \var{created} & \var{stkCreds}~(\cwitness~\var{c}) \\
           & \var{start} & \mathsf{max}~(\firstSlot{\epoch{cslot}})~created \\
-          & \var{epochRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stdelegs}{start}{c} \\
-          & \var{currentRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stdelegs}{cslot}{c} \\
+          & \var{epochRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkCreds}{start}{c} \\
+          & \var{currentRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkCreds}{cslot}{c} \\
           & \dval & \fun{keyDeposit}~\var{pp}\\
           & d_{\min} & \fun{keyMinRefund}~\var{pp}\\
           & \lambda & \fun{keyDecayRate}~\var{pp}\\
       \end{array}\\
       \nextdef
-      & \fun{decayedTx} \in \PParams \to \StakeDelegs \to \Tx \to \Coin
+      & \fun{decayedTx} \in \PParams \to \StakeCreds \to \Tx \to \Coin
       & \text{decayed deposit portions} \\
-      & \decayedTx{pp}{stdelegs}{tx} =\\
+      & \decayedTx{pp}{stkCreds}{tx} =\\
       &   \sum\limits_{\substack{c \in (\txcerts{tx} \\ \cap \DCertDeRegKey)}}
-          \decayedKey{pp}{stdelegs}{(\txttl{tx})}{c}\\
+          \decayedKey{pp}{stkCreds}{(\txttl{tx})}{c}\\
   \end{align*}
   \caption{Functions used in Deposits - Decay}
   \label{fig:functions:deposits-decay}
@@ -569,12 +569,12 @@ This consists of:
   \begin{align*}
     & \fun{propWits} \in \Update \to (\KeyHashGen\mapsto\VKey) \to \powerset{\KeyHash}
     & \text{hashkeys for proposals} \\
-    & \fun{propWits}~(\var{pup},~\var{aup})~\var{dms} = \\
+    & \fun{propWits}~(\var{pup},~\var{aup})~\var{genDelegs} = \\
     & ~~\left\{
       \hashKey{vkey}
       \mid
       \var{gkey}\mapsto\var{vkey}\in
-      \left(\left(\dom{\var{pup}}\cup\dom{\var{aup}}\right)\restrictdom\var{dms}\right)
+      \left(\left(\dom{\var{pup}}\cup\dom{\var{aup}}\right)\restrictdom\var{genDelegs}\right)
       \right\}
   \end{align*}
 
@@ -582,13 +582,13 @@ This consists of:
     & \hspace{-0.8cm}\fun{witsVKeyNeeded} \in \UTxO \to \Tx \to (\KeyHashGen\mapsto\VKey) \to
       \powerset{\KeyHash}
     & \text{required key hashes} \\
-    &  \hspace{-0.8cm}\fun{witsVKeyNeeded}~\var{utxo}~\var{tx}~\var{dms} = \\
+    &  \hspace{-0.8cm}\fun{witsVKeyNeeded}~\var{utxo}~\var{tx}~\var{genDelegs} = \\
     & ~~\{ \fun{paymentHK}~a \mid i \mapsto (a, \wcard) \in \var{utxo},~i\in\fun{txinsVKey}~{tx} \} \\
     \cup & ~~
            \{\fun{stakeCred_r}~a\mid a\mapsto \wcard \in \AddrRWDVKey
       \restrictdom \txwdrls{tx}\}\\
     \cup & ~~\{\cwitness{c} \mid c \in \txcerts{tx} \setminus \DCertMir\}~\cup \\
-    \cup & ~~\fun{propWits}~(\fun{txup}~\var{tx})~\var{dms} \\
+    \cup & ~~\fun{propWits}~(\fun{txup}~\var{tx})~\var{genDelegs} \\
     \cup & ~~\bigcup_{\substack{c \in \txcerts{tx} \\ ~c \in\DCertRegPool}} \fun{poolOwners}~{c}
   \end{align*}
   \begin{align*}
@@ -643,12 +643,12 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
       \\~\\
       \forall \var{vk} \mapsto \sigma \in \txwitsVKey{tx},
       \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma} \\
-      \fun{witsVKeyNeeded}~{utxo}~{tx}~{dms} \subseteq \{ \hashKey \var{vk} \mid
+      \fun{witsVKeyNeeded}~{utxo}~{tx}~{genDelegs} \subseteq \{ \hashKey \var{vk} \mid
       \var{vk}\in\dom{(\txwitsVKey{tx})} \}
       \\~\\
       genSig \leteq
       \left\{
-        \fun{hashKey}~vk \vert gkey\mapsto vk \in\var{dms}
+        \fun{hashKey}~vk \vert gkey\mapsto vk \in\var{genDelegs}
       \right\}
       \cap
       \left\{
@@ -664,9 +664,9 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
         \begin{array}{r}
           \var{slot}\\
           \var{pp}\\
-          \var{stdelegs}\\
+          \var{stkCreds}\\
           \var{stpools}\\
-          \var{dms}\\
+          \var{genDelegs}\\
         \end{array}
       }
       \vdash \var{utxoSt} \trans{\hyperref[fig:rules:utxo-shelley]{utxo}}{tx}
@@ -676,9 +676,9 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
       \begin{array}{r}
         \var{slot}\\
         \var{pp}\\
-        \var{stdelegs}\\
+        \var{stkCreds}\\
         \var{stpools}\\
-        \var{dms}\\
+        \var{genDelegs}\\
       \end{array}
       \vdash \var{utxoSt} \trans{utxow}{tx} \varUpdate{\var{utxoSt'}}
     }


### PR DESCRIPTION
I've renamed some variables in both the latex spec and exec model

`stkeys` -> `stkCreds`
`dms` -> `genDelegs`
`fdms` -> `fGenDelegs`

and two more in the formal spec that are not in the exec model:
the function `genDel` is now `genesisDeleg` (is just a pattern match in the exec model)
the rule `Delpl-Del` is now `Delpl-Deleg`.

closes #831 