### PR TITLE
several small edits

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1505,7 +1505,7 @@ The Byron ledger state $\CEState$ is defined in \cite{byron_chain_spec}.
 Figure~\ref{fig:functions:to-shelley} defines a function $\fun{toShelley}$
 which takes the Byron ledger state and creates the Shelley ledger state.
 Note that we use the hash of the final Byron header as the first evolving and
-canditate nonces for Shelley.
+candidate nonces for Shelley.
 
 %%
 %% Figure - Byron to Shelley State Transition

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -4,7 +4,6 @@
 \newcommand{\Proof}{\type{Proof}}
 \newcommand{\Seedl}{\mathsf{Seed}_\ell}
 \newcommand{\Seede}{\mathsf{Seed}_\eta}
-\newcommand{\StartRewards}{\ensuremath{\mathsf{StartRewards}}}
 \newcommand{\activeSlotCoeff}[1]{\fun{activeSlotCoeff}~ \var{#1}}
 \newcommand{\slotToSeed}[1]{\fun{slotToSeed}~ \var{#1}}
 
@@ -107,8 +106,6 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
     & 0_{seed} \in \Seed & \text{neutral seed element} \\
     & \Seedl \in \Seed & \text{leader seed constant} \\
     & \Seede \in \Seed & \text{nonce seed constant}\\
-    & \SlotsPrior \in \Duration & \tau\text{ in \cite{ouroboros_praos}}\\
-    & \StartRewards \in \Duration & \text{duration to start reward calculations}\\
   \end{align*}
 
   \caption{VRF definitions}
@@ -640,7 +637,7 @@ execution of the transition role is as follows:
 \subsection{Block Header Transition}
 \label{sec:block-header-trans}
 
-The Block Header Transition checks a couple sizes and performs some chain level upkeep.
+The Block Header Transition checks a couple of sizes and performs some chain level upkeep.
 The environment consists of a candidate nonce and a set of genesis keys, and the state is the
 epoch specific state necessary for the $\mathsf{NEWEPOCH}$ transition.
 
@@ -779,8 +776,8 @@ transition which are the following:
 
 \begin{itemize}
 \item The KES period start \var{c_0} is greater than or equal to the KES period of
-  the slot of the block header body and less than 90 KES periods after \var{c_0}.
-  The value of 90 KES periods is the agreed-upon lifetime of an operational certificate,
+  the slot of the block header body and less than $\MaxKESEvo$-many KES periods after \var{c_0}.
+  The value of $\MaxKESEvo$ is the agreed-upon lifetime of an operational certificate,
   see \cite{delegation_design}.
 \item \var{hk} exists as key in the mapping of certificate issues numbers to a KES
   period \var{m} and that period is less than or equal to \var{n}.
@@ -808,7 +805,7 @@ of the key \var{hk} with the KES period \var{n}.
       &
       t \leteq \kesPeriod{s} - c_0
       \\~\\
-      c_0 \leq \kesPeriod{s} < c_0 + 90
+      c_0 \leq \kesPeriod{s} < c_0 + \MaxKESEvo
       \\
       \var{hk}\mapsto m\in\var{cs}
       &
@@ -1507,6 +1504,8 @@ This section describes how to transition the state held by the Byron ledger to t
 The Byron ledger state $\CEState$ is defined in \cite{byron_chain_spec}.
 Figure~\ref{fig:functions:to-shelley} defines a function $\fun{toShelley}$
 which takes the Byron ledger state and creates the Shelley ledger state.
+Note that we use the hash of the final Byron header as the first evolving and
+canditate nonces for Shelley.
 
 %%
 %% Figure - Byron to Shelley State Transition

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -830,7 +830,7 @@ The OCERT rule has six predicate failures:
 \item If the KES period is less than the KES period start in the certificate,
   there is a \emph{KESBeforeStart} failure.
 \item If the KES period is greater than or equal to the KES period end (start +
-  90) in the certificate, there is a \emph{KESAfterEnd} failure.
+  $\MaxKESEvo$) in the certificate, there is a \emph{KESAfterEnd} failure.
 \item If the period counter in the original key hash counter mapping is larger
   than the period number in the certificate, there is a \emph{KESPeriodWrong}
   failure.

--- a/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
+++ b/shelley/chain-and-ledger/formal-spec/crypto-primitives.tex
@@ -17,10 +17,6 @@ multi-signature scripts. The constraint we introduce states that a signature of
 some data signed with a (private) key is only correct whenever we can verify it
 using the corresponding public key.
 
-Besides basic cryptographic abstractions, we also make use of some abstract
-data storage properties in this document in order to build necessary definitions
-and make judgement calls about them.
-
 Abstract data types in this paper are essentially placeholders with names
 indicating the data types they are meant to represent in an implementation.
 Derived types are made up of data structures (i.e.~products, lists, finite
@@ -97,8 +93,8 @@ In KES, the public verification key stays constant, but the
 corresponding private key evolves incrementally. For this reason, KES
 verification keys are indexed by integers representing the step in the key's
 evolution. This evolution step parameter is also an additional parameter needed
-for the signing (denoted by $\signEv$) and verification
-(denoted by $\verifyEv$) functions.
+for the signing (denoted by $\fun{signEv}$) and verification
+(denoted by $\fun{verifyEv}$) functions.
 
 Since the private key evolves incrementally in a KES scheme, the ledger rules
 require the pool operators to evolve their keys once per KES period-slots.

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -120,18 +120,22 @@ It does the following:
   %
   \emph{Derived types}
   \begin{equation*}
-    \begin{array}{l@{\qquad=\qquad}lr}
+    \begin{array}{lclr}
       \StakeCreds
+      & ~=~
       & \Credential \mapsto \Slot
       & \text{registered stake credential} \\
       %
       \StakePools
+      & ~=~
       & \KeyHash \mapsto \Slot
       & \text{registered stake pools} \\
       %
       \PoolParam
-      & \powerset{\KeyHash} \times \Coin \times \unitInterval \times \Coin \times \AddrRWD
+      & ~=~
+      & \powerset{\KeyHash} \times \Coin \times \unitInterval \times \Coin
       & \text{stake pool parameters} \\
+      & & \qquad \times \AddrRWD \times \KeyHash_{vrf}
     \end{array}
   \end{equation*}
   %

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -36,7 +36,7 @@
 \newcommand{\Nothing}{\ensuremath{\Diamond}}
 \newcommand{\N}{\ensuremath{\mathbb{N}}}
 \newcommand{\Bool}{\type{Bool}}
-\newcommand{\Npos}{\ensuremath{\mathbb{N}^{+}}}
+\newcommand{\Npos}{\ensuremath{\mathbb{N}^{>0}}}
 \newcommand{\Z}{\ensuremath{\mathbb{Z}}}
 \newcommand{\R}{\ensuremath{\mathbb{R}}}
 \newcommand{\Rnn}{\ensuremath{\mathbb{R}^{\geq 0}}}
@@ -54,7 +54,9 @@
 \newcommand{\SlotsPrior}{\ensuremath{\mathsf{SlotsPrior}}}
 \newcommand{\SlotsPerEpoch}{\mathsf{SlotsPerEpoch}}
 \newcommand{\SlotsPerKESPeriod}{\mathsf{SlotsPerKESPeriod}}
-\newcommand{\SlotsStabilityParam}{\fun{k}}
+\newcommand{\StartRewards}{\ensuremath{\mathsf{StartRewards}}}
+\newcommand{\MaxKESEvo}{\ensuremath{\mathsf{MaxKESEvo}}}
+\newcommand{\Quorum}{\ensuremath{\mathsf{Quorum}}}
 \newcommand{\Duration}{\type{Duration}}
 \newcommand{\StakePools}{\type{StakePools}}
 \newcommand{\StakeCreds}{\type{StakeCreds}}

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -190,7 +190,7 @@ slot is removed.
       \\
       \var{oldGenDelegs}\leteq\range((\dom\var{genDelegs'})\restrictdom\var{genDelegs})
       \\
-      \var{cs'}\leteq(\var{oldGenDelegs}\subtractdom\var{oldGenDelegs})\unionoverrideRight
+      \var{cs'}\leteq(\var{oldGenDelegs}\subtractdom\var{cs})\unionoverrideRight
       \{\var{hk}\mapsto 0~\mid~\var{hk}\in\range{genDelegs'}\}
       \\
       \var{ps'}\leteq(\var{stpools},~\var{poolParams},~\var{retiring},~\var{cs'})

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -12,11 +12,17 @@ The type $\Coin$ is defined as an alias for the integers.
 Negative values will not be allowed in UTxO outputs or reward accounts,
 and $\Z$ is only chosen over $\N$ for its additive inverses.
 
-Two global constants are defined, $\SlotsPerEpoch$ and $\SlotsPerKESPeriod$,
-representing the number of slots in an epoch/KES period (for a brief explanation
+Six global constants are defined.
+As global constants, these values can only be changed by updating the software.
+The constants $\SlotsPerEpoch$ and $\SlotsPerKESPeriod$
+represent the number of slots in an epoch/KES period (for a brief explanation
 of a KES period, see Section \ref{sec:crypto-primitives-shelley}).
-As global constants, these values can only be
-changed by updating the software.
+The constants $\SlotsPrior$ and $\StartRewards$ concern the chain stability.
+The maximum number of time a KES key can be evolved before a pool operator
+must create a new operational certificate is given by $\MaxKESEvo$.
+Finally, $\Quorum$ determines the quorum amount needed for votes on the
+protocol parameter updates and the application version updates.
+
 
 Some helper functions are defined in Figure~\ref{fig:defs:protocol-parameters-helpers}.
 The $\fun{minfee}$ function calculates the minimum fee that must be paid by a transaction.
@@ -127,7 +133,10 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
     \begin{array}{r@{~\in~}lr}
       \SlotsPerEpoch & \N & \text{slots per epoch} \\
       \SlotsPerKESPeriod & \N & \text{slots per KES period} \\
-      \SlotsStabilityParam & \N & \text{stability parameter}
+      \SlotsPrior & \Duration & \tau\text{ in \cite{ouroboros_praos}}\\
+      \StartRewards & \Duration & \text{duration to start reward calculations}\\
+      \MaxKESEvo & \N & \text{duration to start reward calculations}\\
+      \Quorum & \N & \text{quorum for update system votes}\\
     \end{array}
   \end{equation*}
   %
@@ -141,12 +150,12 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
   \begin{align*}
     \fun{minfee} & \in \PParams \to \Tx \to \Coin & \text{minimum fee}\\
     \fun{minfee} & ~\var{pp}~\var{tx} =
-    (\fun{a}~\var{pp}) * \fun{txSize}~\var{tx} + (\fun{b}~\var{pp})
+    (\fun{a}~\var{pp}) \cdot \fun{txSize}~\var{tx} + (\fun{b}~\var{pp})
     \\
     \\
     \fun{epoch} & \in ~ \Slot \to \Epoch & \text{epoch of a slot}
     \\
-    \fun{epoch} & ~\var{slot} = \var{slot}~\mathsf{div}~\SlotsPerEpoch
+    \fun{epoch} & ~\var{slot} = \var{slot}~/~\SlotsPerEpoch
     \\
     \\
     \fun{firstSlot} & \in ~ \Epoch \to \Slot
@@ -157,7 +166,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
     \\
     \fun{kesPeriod} & \in ~ \Slot \to \KESPeriod & \text{KES period of a slot}
     \\
-    \fun{kesPeriod} & ~\var{slot} = \var{slot}~\mathsf{div}~\SlotsPerKESPeriod
+    \fun{kesPeriod} & ~\var{slot} = \var{slot}~/~\SlotsPerKESPeriod
   \end{align*}
   %
   \caption{Helper functions for the Protocol Parameters}

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -20,6 +20,9 @@ of a KES period, see Section \ref{sec:crypto-primitives-shelley}).
 The constants $\SlotsPrior$ and $\StartRewards$ concern the chain stability.
 The maximum number of time a KES key can be evolved before a pool operator
 must create a new operational certificate is given by $\MaxKESEvo$.
+\textbf{Note that if } $\MaxKESEvo$
+\textbf{is changed, the KES signature format may have to change as well.}
+
 Finally, $\Quorum$ determines the quorum amount needed for votes on the
 protocol parameter updates and the application version updates.
 
@@ -135,7 +138,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
       \SlotsPerKESPeriod & \N & \text{slots per KES period} \\
       \SlotsPrior & \Duration & \tau\text{ in \cite{ouroboros_praos}}\\
       \StartRewards & \Duration & \text{duration to start reward calculations}\\
-      \MaxKESEvo & \N & \text{duration to start reward calculations}\\
+      \MaxKESEvo & \N & \text{maximum KES key evolutions}\\
       \Quorum & \N & \text{quorum for update system votes}\\
     \end{array}
   \end{equation*}

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -197,6 +197,6 @@ Figure~\ref{fig:defs:functions-txins} shows the helper functions
 $\fun{txinsVKey}$ and $\fun{txinsScript}$ which partition the set of transaction
 inputs of the transaction into those that are locked with a private key and
 those that are locked via a script.
-It also defines $\fun{txinsScript}$, which validates the multisignature scripts.
+It also defines $\fun{validateScript}$, which validates the multisignature scripts.
 
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -22,55 +22,20 @@ A transaction body, $\TxBody$, is made up of seven pieces:
     For reward calculation rules, see Section \ref{sec:reward-overview},
     and for the rule for collecting rewards, see Section \ref{sec:utxo-trans}.
   \item Update proposals for protocol parameters and software.
+    The update system will be explained in Section \ref{sec:update}.
+  \item $\PPUpdate$, the protocol parameter upates.
+  \item $\AVUpdate$, the updates to Shelley software (applications).
 \end{itemize}
-
-In the derived types, $\Metadata$ and $\Applications$ are values
-that contain versions of current and next versions of applications.
-The $\ApName$ uniquely identifies a specific kind of application (e.g.
-the wallet), and the associated $\ApVer$ is the specific version of that
-application. The associated $\Metadata$ value gives the \textit{next possible}
-versions of the given application. It is a mapping of system tags to hashes of
-installer binaries, and is needed for the update mechanism.
-The update proposal type $\Update$ is a pair of
-
-\begin{itemize}
-  \item $\PPUpdate$, the protocol parameter upates
-  \item $\AVUpdate$, the updates to Shelley software (applications)
-\end{itemize}
-
-The $\PPUpdate$ has to do with changing rules and constants of the ledger
-protocol. The relationship between the rule update procedure and updating the
-node software that implements these rules is outlined in the next section
-(see Section \ref{sec:update}).
-
-Note that both of these finite maps are indexed by the hashes of the keys of
-entities proposing the given
-updates, $\KeyHashGen$.
-We use the abstract type $\KeyHashGen$ to represent hashes of genesis
-(public verification) keys, which have type $\VKeyGen$.
-Genesis keys are the keys belonging to the federated
-nodes running the Cardano system currently (also referred to as core nodes).
-The the regular user verification keys are of a type $\VKey$, distinct from the
-genesis key type, $\VKeyGen$. Similarly, the type hashes of these
-are distinct, $\KeyHash$ and $\KeyHashGen$ respectively.
-
-Currently, updates
-can only be proposed and voted on by the owners of the genesis keys.
-The process of decentralization will result in the core nodes gradually giving up
-some of their priviledges and responsibilities to the other system nodes.
-The aim is for these nodes to eventually give them \textit{all} up.
-The intent is that in the future, the update proposal mechanism will
-be decentralized as well, and allow all nodes to participate (but likely
-not as a feature in the Shelley release).
-For more on the decentralization process,
-see \ref{sec:new-epoch-trans}.
 
 A transaction, $\Tx$, consists of:
 
 \begin{itemize}
   \item The transaction body.
-  \item A collection of witnesses, represented as a finite map from payment verification keys
-    to signatures.
+  \item A pair of:
+    \begin{itemize}
+      \item A finite map from payment verification keys to signatures.
+      \item A finite map from script hashes to scripts.
+    \end{itemize}
 \end{itemize}
 
 Additionally, the $\UTxO$ type will be used by the ledger state to store all the
@@ -116,7 +81,12 @@ This function must produce a unique id for each unique transaction.
       & \Wdrl
       & \AddrRWD \mapsto \Coin
       & \text{reward withdrawal}
-      \\
+    \end{array}
+  \end{equation*}
+  \emph{Derived types (update system)}
+  %
+  \begin{equation*}
+    \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
       \var{pup}
       & \PPUpdate
       & \KeyHashGen \mapsto \Ppm \mapsto \Seed
@@ -210,7 +180,7 @@ This function must produce a unique id for each unique transaction.
   \begin{align*}
     \fun{validateScript} & \in\Script\to\Tx\to\Bool & \text{validate
                                                       script} \\
-    \fun{validateScript} & \var{msig}~\var{tx}=
+    \fun{validateScript} & ~\var{msig}~\var{tx}=
                            \begin{cases}
                              \fun{evalMultiSigScript}~msig~vhks & \text{if}~msig \in\MSig \\
                              \mathsf{False} & \text{otherwise}
@@ -227,5 +197,6 @@ Figure~\ref{fig:defs:functions-txins} shows the helper functions
 $\fun{txinsVKey}$ and $\fun{txinsScript}$ which partition the set of transaction
 inputs of the transaction into those that are locked with a private key and
 those that are locked via a script.
+It also defines $\fun{txinsScript}$, which validates the multisignature scripts.
 
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -7,7 +7,7 @@ The governance process includes a mechanism for core nodes to propose and vote o
 updates. In this chapter we
 outline rules for genesis keys \textit{proposing} both protocol parameter
 and application version updates, as well as voting on whether a particular
-software update is an acceptable future option (again, only genesis keys vote on this).
+software update is an acceptable future option.
 For rules regarding the \textit{adoption} of protocol
 parameter updates, see \ref{sec:pparam-update}. For rules regarding
 adoption of new software versions see \ref{sec:software-updates}.
@@ -36,6 +36,38 @@ For transparency in both voting mechanisms, the votes and proposals for updates
 are stored
 on the ledger in addition to the currently accepted protocol parameters and
 application versions.
+
+\subsection{Descriptions of the Data}
+\label{sec:update-types}
+
+The types were defined in Figure~\ref{fig:defs:utxo-shelley}.
+In the derived types, $\Metadata$ and $\Applications$ are values
+that contain versions of current and next versions of applications.
+The $\ApName$ uniquely identifies a specific kind of application (e.g.
+the wallet), and the associated $\ApVer$ is the specific version of that
+application. The associated $\Metadata$ value gives the \textit{next possible}
+versions of the given application. It is a mapping of system tags to hashes of
+installer binaries, and is needed for the update mechanism.
+The update proposal type $\Update$ is a pair of $\PPUpdate$ and $\AVUpdate$.
+$\PPUpdate$ allows for changing protocol parameters,
+and $\AVUpdate$ allows for updating the software versions.
+
+Note that both of these finite maps are indexed by the hashes of the keys of
+entities proposing the given updates, $\KeyHashGen$.
+We use the abstract type $\KeyHashGen$ to represent hashes of genesis
+(public verification) keys, which have type $\VKeyGen$.
+Genesis keys are the keys belonging to the federated
+nodes running the Cardano system currently (also referred to as core nodes).
+The the regular user verification keys are of a type $\VKey$, distinct from the
+genesis key type, $\VKeyGen$. Similarly, the type hashes of these
+are distinct, $\KeyHash$ and $\KeyHashGen$ respectively.
+
+Currently, updates can only be proposed and voted on by the owners of the genesis keys.
+The process of decentralization will result in the core nodes gradually giving up
+some of their priviledges and responsibilities to the network,
+eventually give them \textit{all} up.
+The update proposal mechanism will not be decentralization in the Shelley era, however.
+For more on the decentralization process, see \ref{sec:new-epoch-trans}.
 
 \subsection{Protocol Parameter Update Proposals}
 \label{sec:pp-proposals}
@@ -174,6 +206,10 @@ The function $\fun{newAVs}$ adds the most recent valid application
 versions to a finite map of applications using right override.
 This helper function will be used in the ledger update.
 
+\textbf{Note that} $\fun{votedValue}$
+\textbf{is only well-defined if } $\Quorum$
+\textbf{is greater than half the number of core nodes, i.e.}
+$\Quorum > |\var{genDelegs}|/2$ \textbf{.}
 %%
 %% Figure - Helper Function for Consensus of Update Proposals
 %%
@@ -182,7 +218,7 @@ This helper function will be used in the ledger update.
       & \fun{votedValue_T} \in (\KeyHashGen\mapsto\type{T}) \to \type{T}^?\\
       & \fun{votedValue_T}~\var{vs} =
         \begin{cases}
-          t & \exists t\in\range{vs}~(|vs\restrictrange t|\geq 5) \\
+          t & \exists t\in\range{vs}~(|vs\restrictrange t|\geq \Quorum) \\
           \Nothing & \text{otherwise} \\
         \end{cases}
   \end{align*}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -38,6 +38,7 @@ that a transaction failed to be processed.
 \label{sec:utxo-trans}
 
 Figure~\ref{fig:functions:utxo} defines functions needed for the UTxO transition system.
+See Figure~\ref{fig:defs:utxo-shelley} for most of the definitions used in the transition system.
 
 \begin{itemize}
 
@@ -144,6 +145,7 @@ The state needed for the UTxO transition $\UTxOState$, consists of:
   \item The current UTxO.
   \item The deposit pot.
   \item The fee pot.
+  \item The update state (see Figure~\ref{fig:ts-types:update}).
 \end{itemize}
 The signal for the UTxO transition is a transaction.
 

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -659,7 +659,7 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
       \\
       \left\{
         c\in\txcerts{tx}~\cap\DCertMir
-      \right\} \neq\emptyset \implies \vert genSig\vert \geq 5 \wedge
+      \right\} \neq\emptyset \implies \vert genSig\vert \geq \Quorum \wedge
       \fun{d}~\var{pp} > 0
       \\~\\
       {


### PR DESCRIPTION
This PR combines several small edits.

* I removed the `SlotsStabilityParam`.
* I added new global constants, `MaxKESEvo ` and `Quorum`, and put all constants in the protocol parameter section (so I moved `SlotsPrior` and `StartRewards`.
* few white-space edits
* changed N^+ to N^{>0}
* consistent multiplication and division symbols.
* moved update system explanations in the transaction section to the update section.
* added a few extra prose descriptions.
* fixed the typo @nc6 found today, we now have `oldGenDelegs </| cs`.

closes #827
closes #830
closes #833 (this one looks to have been completed by an earlier PR, but I checked)