### PR TITLE
Add MIR examples

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -121,6 +121,7 @@ module LedgerState
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Control.Monad (foldM)
 import           Data.Foldable (toList)
+import           Delegation.Certificates (isInstantaneousRewards)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe, mapMaybe)
@@ -622,8 +623,9 @@ witsVKeyNeeded utxo' tx@(Tx txbody _ _) _genDelegs =
       Set.fromList $ extractKeyHash $ map getRwdCred (Map.keys (txbody ^. wdrls))
     owners = foldl Set.union Set.empty
                [pool ^. poolOwners . to (Set.map undiscriminateKeyHash) | RegPool pool <- toList $ txbody ^. certs]
-    certAuthors = Set.fromList $ extractKeyHash (fmap getCertHK (toList $ txbody ^. certs))
+    certAuthors = Set.fromList $ extractKeyHash (fmap getCertHK certificates)
     getCertHK = cwitness
+    certificates = filter (not . isInstantaneousRewards) (toList $ txbody ^. certs)
     updateKeys = undiscriminateKeyHash `Set.map` propWits (txup tx) _genDelegs
 
 -- |Given a ledger state, determine if the UTxO witnesses in a given

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -1201,12 +1201,12 @@ createRUpd b@(BlocksMade b') (EpochState acnt ss ls pp) =
         newIrwd = Map.union registered newlyRegister'
 
         -- reserves and rewards change
-        deltaR' =
+        deltaRl =
             (floor $ min 1 eta * intervalValue (_rho pp) * fromIntegral reserves'')
-          + Coin rewardsMIR
+        deltaR' = deltaRl + Coin rewardsMIR
         eta = fromIntegral blocksMade / expectedBlocks
 
-        Coin rewardPot = _feeSS ss + deltaR'
+        Coin rewardPot = _feeSS ss + deltaRl
         deltaT1 = floor $ intervalValue (_tau pp) * fromIntegral rewardPot
         r@(Coin r') = Coin $ rewardPot - deltaT1
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Bbody.hs
@@ -10,6 +10,7 @@ module STS.Bbody
   ( BBODY
   , BbodyState (..)
   , BbodyEnv (..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
@@ -9,6 +9,7 @@
 module STS.Chain
   ( CHAIN
   , ChainState (..)
+  , PredicateFailure(..)
   , totalAda
   )
 where

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
@@ -39,11 +39,12 @@ data CHAIN hashAlgo dsignAlgo kesAlgo vrfAlgo
 
 data ChainState hashAlgo dsignAlgo kesAlgo vrfAlgo
   = ChainState
-      (NewEpochState hashAlgo dsignAlgo vrfAlgo)
-      Nonce
-      Nonce
-      (HashHeader hashAlgo dsignAlgo kesAlgo vrfAlgo)
-      Slot
+    { chainNes            :: NewEpochState hashAlgo dsignAlgo vrfAlgo
+    , chainEvolvingNonce  :: Nonce
+    , chainCandidateNonce :: Nonce
+    , chainHashHeader     :: HashHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
+    , chainSlot           :: Slot
+    }
   deriving (Show, Eq)
 
 instance

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -4,6 +4,7 @@
 module STS.Deleg
   ( DELEG
   , DelegEnv (..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delegs.hs
@@ -7,6 +7,7 @@
 module STS.Delegs
   ( DELEGS
   , DelegsEnv (..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
@@ -7,6 +7,7 @@
 module STS.Delpl
   ( DELPL
   , DelplEnv (..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
@@ -9,6 +9,7 @@
 module STS.Ledger
   ( LEDGER
   , LedgerEnv (..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledgers.hs
@@ -9,6 +9,7 @@
 module STS.Ledgers
   ( LEDGERS
   , LedgersEnv (..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
@@ -19,7 +19,7 @@ import qualified Data.Set as Set
 import           BaseTypes (intervalValue, (==>))
 import           Delegation.Certificates (isInstantaneousRewards)
 import           Keys
-import           Ledger.Core (range, (∩))
+import           Ledger.Core (dom, (∩))
 import           LedgerState hiding (genDelegs)
 import           PParams (_d)
 import           STS.Utxo
@@ -98,10 +98,9 @@ utxoWitnessed = do
   -- check genesis keys signatures for instantaneous rewards certificates
   let mirCerts = Seq.filter isInstantaneousRewards $ _certs txbody
       GenDelegs genMapping = _genDelegs
-      genSig = (Set.map undiscriminateKeyHash $ range genMapping) ∩ Set.map witKeyHash wits
+      genSig = (Set.map undiscriminateKeyHash $ dom genMapping) ∩ Set.map witKeyHash wits
   (    (not $ null mirCerts)
-   ==> (0 < intervalValue (_d pp) && Set.size genSig >= 0))
-   -- TODO why is >= 5 failing?
+   ==> (0 < intervalValue (_d pp) && Set.size genSig >= 5))
     ?! MIRInsufficientGenesisSigsUTXOW
 
   trans @(UTXO hashAlgo dsignAlgo vrfAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
@@ -100,7 +100,8 @@ utxoWitnessed = do
       GenDelegs genMapping = _genDelegs
       genSig = (Set.map undiscriminateKeyHash $ range genMapping) ∩ Set.map witKeyHash wits
   (    (not $ null mirCerts)
-   ==> (0 < intervalValue (_d pp) && Set.size genSig >= 5))
+   ==> (0 < intervalValue (_d pp) && Set.size genSig >= 0))
+   -- TODO why is >= 5 failing?
     ?! MIRInsufficientGenesisSigsUTXOW
 
   trans @(UTXO hashAlgo dsignAlgo vrfAlgo)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
@@ -52,6 +52,7 @@ instance
     | ScriptWitnessNotValidatingUTXOW
     | UtxoFailure (PredicateFailure (UTXO hashAlgo dsignAlgo vrfAlgo))
     | MIRInsufficientGenesisSigsUTXOW
+    | MIRImpossibleInDecentralizedNetUTXOW
     deriving (Eq, Show)
 
   transitionRules = [utxoWitnessed]
@@ -100,8 +101,11 @@ utxoWitnessed = do
       GenDelegs genMapping = _genDelegs
       genSig = (Set.map undiscriminateKeyHash $ dom genMapping) ∩ Set.map witKeyHash wits
   (    (not $ null mirCerts)
-   ==> (0 < intervalValue (_d pp) && Set.size genSig >= 5))
-    ?! MIRInsufficientGenesisSigsUTXOW
+   ==> Set.size genSig >= 5)
+      ?! MIRInsufficientGenesisSigsUTXOW
+  (    (not $ null mirCerts)
+   ==> (0 < intervalValue (_d pp)))
+    ?! MIRImpossibleInDecentralizedNetUTXOW
 
   trans @(UTXO hashAlgo dsignAlgo vrfAlgo)
     $ TRC (UtxoEnv slot pp stakeKeys stakePools _genDelegs, u, tx)

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -56,7 +56,7 @@ import           TxData (Addr (..), Credential (..), ScriptHash, StakeCredential
                      inputs, outputs, poolPubKey, txUpdate)
 import           Updates (Update)
 
-import           Delegation.Certificates (DCert (..), StakePools (..), cwitness, dvalue)
+import           Delegation.Certificates (DCert (..), StakePools (..), cwitness, dvalue, isInstantaneousRewards)
 
 -- |The unspent transaction outputs.
 newtype UTxO hashAlgo dsignAlgo vrfAlgo
@@ -221,7 +221,7 @@ scriptsNeeded u tx =
   `Set.union`
   Set.fromList (Maybe.mapMaybe (scriptStakeCred . getRwdCred) $ Map.keys withdrawals)
   `Set.union`
-  Set.fromList (Maybe.mapMaybe (scriptStakeCred . cwitness) certificates)
+  Set.fromList (Maybe.mapMaybe (scriptStakeCred . cwitness) (filter (not . isInstantaneousRewards) certificates))
   where unTxOut (TxOut a _) = a
         withdrawals = _wdrls $ _body tx
         UTxO u'' = txinsScript (txins $ _body tx) u <| u

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -31,6 +31,7 @@ module Examples
   , ex6A
   , ex6B
   , ex6C
+  , ex6D
   , maxLovelaceSupply
   -- key pairs and example addresses
   , alicePay
@@ -2155,3 +2156,15 @@ ex6C =
    (initStEx2A { chainNes = initNesEx2A { nesEs = esEx2A { esPp = ppsEx1 { _d = unsafeMkUnitInterval 0 }}}})
    blockEx6A
    (Left [[expectedStEx6C]])
+
+
+-- | Example 6C - Instantaneous rewards in decentralized era and not enough core
+-- signatures
+
+ex6D :: CHAINExample
+ex6D =
+  CHAINExample
+   (Slot 10)
+   (initStEx2A { chainNes = initNesEx2A { nesEs = esEx2A { esPp = ppsEx1 { _d = unsafeMkUnitInterval 0 }}}})
+   blockEx6B
+   (Left [[expectedStEx6C, expectedStEx6B]])

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -109,7 +109,7 @@ type OCert = OCert.OCert MockDSIGN MockKES
 
 type HashHeader = BlockChain.HashHeader ShortHash MockDSIGN MockKES FakeVRF
 
-type NewEpochState = LedgerState.NewEpochState ShortHash MockDSIGN
+type NewEpochState = LedgerState.NewEpochState ShortHash MockDSIGN FakeVRF
 
 type RewardUpdate = LedgerState.RewardUpdate ShortHash MockDSIGN
 

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -10,7 +10,7 @@ import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
-                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, maxLovelaceSupply)
+                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, ex6A, maxLovelaceSupply)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -84,6 +84,7 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 4C - adopt a future app version" $ testCHAINExample ex4C
   , testCase "CHAIN example 5A - stage genesis key delegation" $ testCHAINExample ex5A
   , testCase "CHAIN example 5B - adopt genesis key delegation" $ testCHAINExample ex5B
+  , testCase "CHAIN example 6A - create MIR cert" $ testCHAINExample ex6A
   , testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda ex1
   , testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda ex2A
   , testCase "CHAIN example 2B - Preservation of ADA" $ testPreservationOfAda ex2B

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -11,7 +11,7 @@ import           Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCas
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
                      ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, ex6A, ex6B, ex6C,
-                     ex6D, maxLovelaceSupply)
+                     ex6D, ex6E, maxLovelaceSupply)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -95,6 +95,7 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 6B - FAIL: insufficient core node signatures" $ testCHAINExample ex6B
   , testCase "CHAIN example 6C - FAIL: MIR impossible in decentralized network" $ testCHAINExample ex6C
   , testCase "CHAIN example 6D - FAIL: MIR impossible (decentralized and insufficient sigs)" $ testCHAINExample ex6D
+  , testCase "CHAIN example 6E - FAIL: MIR insufficient reserves" $ testCHAINExample ex6E
   , testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda ex1
   , testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda ex2A
   , testCase "CHAIN example 2B - Preservation of ADA" $ testPreservationOfAda ex2B

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -10,7 +10,7 @@ import           Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCas
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
-                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, ex6A, ex6B,
+                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, ex6A, ex6B, ex6C,
                      maxLovelaceSupply)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
@@ -92,7 +92,8 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 5A - stage genesis key delegation" $ testCHAINExample ex5A
   , testCase "CHAIN example 5B - adopt genesis key delegation" $ testCHAINExample ex5B
   , testCase "CHAIN example 6A - create MIR cert" $ testCHAINExample ex6A
-  , testCase "CHAIN example 6B - insufficient core node signatures" $ testCHAINExample ex6B
+  , testCase "CHAIN example 6B - FAIL: insufficient core node signatures" $ testCHAINExample ex6B
+  , testCase "CHAIN example 6C - FAIL: MIR impossible in decentralized network" $ testCHAINExample ex6C
   , testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda ex1
   , testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda ex2A
   , testCase "CHAIN example 2B - Preservation of ADA" $ testPreservationOfAda ex2B

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -11,7 +11,7 @@ import           Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCas
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
                      ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, ex6A, ex6B, ex6C,
-                     maxLovelaceSupply)
+                     ex6D, maxLovelaceSupply)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
@@ -94,6 +94,7 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 6A - create MIR cert" $ testCHAINExample ex6A
   , testCase "CHAIN example 6B - FAIL: insufficient core node signatures" $ testCHAINExample ex6B
   , testCase "CHAIN example 6C - FAIL: MIR impossible in decentralized network" $ testCHAINExample ex6C
+  , testCase "CHAIN example 6D - FAIL: MIR impossible (decentralized and insufficient sigs)" $ testCHAINExample ex6D
   , testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda ex1
   , testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda ex2A
   , testCase "CHAIN example 2B - Preservation of ADA" $ testPreservationOfAda ex2B

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -6,16 +6,17 @@ module STSTests (stsTests) where
 import           Data.Either (isRight)
 import qualified Data.Map.Strict as Map (empty, singleton)
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
+import           Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCase, (@?=))
 
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
-                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, ex6A, maxLovelaceSupply)
+                     ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, ex6A, ex6B,
+                     maxLovelaceSupply)
 import           MockTypes (CHAIN)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
 
-import           BaseTypes ((⭒), mkNonce)
+import           BaseTypes (mkNonce, (⭒))
 import           Control.State.Transition (TRC (..), applySTS)
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import           Slot (Slot (..))
@@ -49,12 +50,18 @@ testUPNLate =
     st @?= Right (UpdnState ((mkNonce 2) ⭒ (mkNonce 1)) (mkNonce 3))
 
 testCHAINExample :: CHAINExample -> Assertion
-testCHAINExample (CHAINExample slotNow initSt block expectedSt) = do
+testCHAINExample (CHAINExample slotNow initSt block (Right expectedSt)) = do
   checkTrace @CHAIN slotNow $ pure initSt .- block .-> expectedSt
+testCHAINExample (CHAINExample slotNow initSt block predicateFailure@(Left _)) = do
+  let
+    st = applySTS @CHAIN (TRC (slotNow, initSt, block))
+  st @?= predicateFailure
 
 testPreservationOfAda :: CHAINExample -> Assertion
-testPreservationOfAda (CHAINExample _ _ _ expectedSt) =
+testPreservationOfAda (CHAINExample _ _ _ (Right expectedSt)) =
   totalAda expectedSt @?= maxLovelaceSupply
+testPreservationOfAda (CHAINExample _ _ _ (Left predicateFailure)) =
+  assertFailure $ "Ada not preserved " ++ show predicateFailure
 
 stsTests :: TestTree
 stsTests = testGroup "STS Tests"
@@ -85,6 +92,7 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 5A - stage genesis key delegation" $ testCHAINExample ex5A
   , testCase "CHAIN example 5B - adopt genesis key delegation" $ testCHAINExample ex5B
   , testCase "CHAIN example 6A - create MIR cert" $ testCHAINExample ex6A
+  , testCase "CHAIN example 6B - insufficient core node signatures" $ testCHAINExample ex6B
   , testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda ex1
   , testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda ex2A
   , testCase "CHAIN example 2B - Preservation of ADA" $ testPreservationOfAda ex2B

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -1375,11 +1375,12 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
       \in newlyRegister
       \right\}\\
     & ~~~~~~~\Delta d = \vert newlyRegister \vert\cdot\fun{keydeposit}~\var{pp} \\
-    & ~~~~~~~\Delta r = \floor*{\min(1,\eta) \cdot (\fun{rho}~{pp}) \cdot
-      \var{reserves'}} + rewards_{mir}
+    & ~~~~~~~\Delta r_{l} = \floor*{\min(1,\eta) \cdot (\fun{rho}~{pp}) \cdot
+      \var{reserves'}}
     \\
+    & ~~~~~~~\Delta r = \Delta r_{l} + rewards_{mir}\\
     & ~~~~~~~\eta = \frac{blocksMade}{\SlotsPerEpoch \cdot \fun{activeSlotCoeff}~{pp}} \\
-    & ~~~~~~~\var{rewardPot} = \var{feeSS} + \Delta r \\
+    & ~~~~~~~\var{rewardPot} = \var{feeSS} + \Delta r_{l} \\
     & ~~~~~~~\Delta t_1 = \floor*{(\fun{tau}~{pp}) \cdot \var{rewardPot}} \\
     & ~~~~~~~\var{R} = \var{rewardPot} - \Delta t_1 \\
     & ~~~~~~~\var{rs}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -637,25 +637,24 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
     \label{eq:utxo-witness-inductive-shelley}
     \inference[UTxO-wit]
     {
-      (utxo, \wcard, \wcard) \leteq \var{utxoSt} \\~\\
-            \forall \var{hs} \mapsto \var{validator} \in \fun{txwitsScript}~{tx},\\
+      (utxo, \wcard, \wcard) \leteq \var{utxoSt} \\
+      \var{witsKeyHashes} \leteq \{\fun{hashKey}~\var{vk} \vert \var{vk} \in
+      \dom (\txwitsVKey{tx}) \}\\~\\
+      \forall \var{hs} \mapsto \var{validator} \in \fun{txwitsScript}~{tx},\\
       \fun{hashScript}~\var{validator} = \var{hs} \wedge
       \fun{validateScript}~\var{validator}~\var{tx}\\~\\
       \fun{scriptsNeeded}~\var{utxo}~\var{tx} = \dom (\fun{txwitsScript}~{tx})
       \\~\\
       \forall \var{vk} \mapsto \sigma \in \txwitsVKey{tx},
       \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma} \\
-      \fun{witsVKeyNeeded}~{utxo}~{tx}~{genDelegs} \subseteq \{ \hashKey \var{vk} \mid
-      \var{vk}\in\dom{(\txwitsVKey{tx})} \}
+      \fun{witsVKeyNeeded}~{utxo}~{tx}~{genDelegs} \subseteq witsKeyHashes
       \\~\\
       genSig \leteq
       \left\{
-        \fun{hashKey}~vk \vert gkey\mapsto vk \in\var{genDelegs}
+        \fun{hashKey}~gkey \vert gkey \in\dom{genDelegs}
       \right\}
       \cap
-      \left\{
-        \fun{hashKey}~\var{vk} \vert \var{vk}\in\dom{(\txwitsVKey{tx})}
-      \right\}
+      \var{witsKeyHashes}
       \\
       \left\{
         c\in\txcerts{tx}~\cap\DCertMir


### PR DESCRIPTION
Adds different examples for MIR
 - creating instantaneous rewards
 - rejecting MIR because of insufficient core node signatures
 - rejecting MIR because of `d = 0`
 - rejecting MIR because of both of the above
 - rejecting MIR because of insufficient reserves