### PR TITLE
Typo: missing comma

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -855,7 +855,7 @@ in sequence.
   \begin{equation}\label{eq:epoch}
     \inference[Epoch]
     {
-      (\var{utxoSt},~(\var{dstate}~\var{pstate}))\leteq\var{ls} \\
+      (\var{utxoSt},~(\var{dstate},~\var{pstate}))\leteq\var{ls} \\
       {
         \begin{array}{l}
           \var{pp}\\


### PR DESCRIPTION
In Epoch Inference Rule SNAP:
![typo](https://user-images.githubusercontent.com/3624828/67791114-2fb5b300-fa77-11e9-98cc-7fdf72dccca2.jpg)
