### PR TITLE
Renamed Hedgehog.Gen.Aux to Hedgehog.Gen.Double

### DIFF
--- a/byron/ledger/executable-spec/cs-ledger.cabal
+++ b/byron/ledger/executable-spec/cs-ledger.cabal
@@ -23,7 +23,7 @@ flag development
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Hedgehog.Gen.Aux
+  exposed-modules:     Hedgehog.Gen.Double
                      , Ledger.Core
                      , Ledger.Core.Generators
                      , Ledger.Core.Omniscient

--- a/byron/ledger/executable-spec/src/Hedgehog/Gen/Double.hs
+++ b/byron/ledger/executable-spec/src/Hedgehog/Gen/Double.hs
@@ -1,6 +1,6 @@
 -- | Generally useful generators not present in the upstream release
 -- of Hedgehog
-module Hedgehog.Gen.Aux (doubleInc) where
+module Hedgehog.Gen.Double (doubleInc) where
 
 import           Data.Bits (shiftL)
 import           Data.Word (Word64)

--- a/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update/Generators.hs
@@ -9,7 +9,7 @@ where
 import           Data.Word (Word64)
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
-import           Hedgehog.Gen.Aux (doubleInc)
+import           Hedgehog.Gen.Double (doubleInc)
 import qualified Hedgehog.Range as Range
 import           Ledger.Core (BlockCount (BlockCount), SlotCount (SlotCount), unBlockCount,
                      unSlotCount)


### PR DESCRIPTION
AUX is a reserved file name on Windows.

resolve #961 