### PR TITLE
Add `RegPool` re-reg properties

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestPool.hs
@@ -132,14 +132,14 @@ registeredPoolIsAdded env ssts =
     check :: PoolParams -> m ()
     check poolParams = do
       let hk = poolParams ^. poolPubKey
-          pSt = target sst
+          tSt = target sst
       -- PoolParams are registered in pParams map
-      M.lookup hk (pSt ^. pParams) === Just poolParams
+      M.lookup hk (tSt ^. pParams) === Just poolParams
       -- Hashkey is registered in stPools map
-      M.lookup hk (pSt ^. stPools . to (\(StakePools x) -> x))
+      M.lookup hk (tSt ^. stPools . to (\(StakePools x) -> x))
         === Just (ledgerSlot env)
       -- Hashkey is registered in cCounters map
-      assert (hk ∈ M.keys (pSt ^. cCounters))
+      assert (hk ∈ M.keys (tSt ^. cCounters))
 
 -- | Assert that PState maps are in sync with each other after each `Signal
 -- POOL` transition.


### PR DESCRIPTION
In #870 I added a check for adding new pools. In this PR I add a small additional check for re-registering pools once they've been `DeReg`ed, and thus added to the `retiring` set.