### PR TITLE
sync POOLREAP with formal spec

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -520,8 +520,8 @@ This transition has no preconditions and results in the following state change:
                       \right\} \\
         \var{refunds} & \dom{rewards}\restrictdom\var{rewardAcnts'} \\
         \var{mRefunds} & \dom{rewards}\subtractdom\var{rewardAcnts'} \\
-        \var{refunded} & \sum\limits_{c\in\range{\var{refunds}}} c \\
-        \var{unclaimed} & \sum\limits_{c\in\range{\var{mRefunds}}} c \\
+        \var{refunded} & \sum\limits_{\wcard\mapsto c\in\var{refunds}} c \\
+        \var{unclaimed} & \sum\limits_{\wcard\mapsto c\in\var{mRefunds}} c \\
       \end{array}
       }
     }


### PR DESCRIPTION
This PR syncs the changes to the POOLREAP transition with the changes recently made in the formal spec: #976 

It now looks like this:

![poolreap](https://user-images.githubusercontent.com/943479/68048970-15b6e300-fcb8-11e9-82ba-9609c65e26d0.png)
