### PR TITLE
Design doc: Do not require witness for stake key registration.

### DIFF
--- a/shelley/design-spec/delegation_design_spec.tex
+++ b/shelley/design-spec/delegation_design_spec.tex
@@ -4188,13 +4188,10 @@ system implicitly issues a transaction/state-change to pay out rewards
 to each staking key reward account. These rewards accumulate if they are
 not withdrawn.
 
-It is to be decided if value held in a reward account contributes to
-stake that is delegated to a stake pool and hence itself attracts
-rewards. Doing so would reduce the incentive to withdraw early and would
-mean the stake corresponding to the reward is not effectively offline.
-It should be possible to do so since the value in the reward account is
-identified with the staking key, and the delegation of the staking key is
-known.
+Value held in a reward account contributes to stake that is delegated to a stake
+pool and hence itself attracts rewards. This reduces the incentive to withdraw
+early and means the stake corresponding to the reward is not effectively
+offline.
 
 Withdrawal of rewards is done similarly to the withdrawal transaction from the
 Chimeric Ledgers paper. This uses the staking key as the witness, which reveals

--- a/shelley/design-spec/delegation_design_spec.tex
+++ b/shelley/design-spec/delegation_design_spec.tex
@@ -1128,7 +1128,9 @@ This certificate contains:
   the public staking key \(vks\)
 \end{itemize}
 
-The certificate witness must contain a signature by \(sks\).
+We do not require a witness to register a stake key (besides, of course,
+any witnesses needed for the transaction that is used to post the
+certificate).
 \item[Stake key de-registration certificate]
 This certificate contains:
 


### PR DESCRIPTION
As discussed yesterday, we do not want to require a witness from the private stake key for registering the key. The only reason we had for requiring one was to prevent people from registering a key they do not own (and they can still end up in the same situation if they lose the key after registration). Not requiring a witness makes the reward transfer from the incentivised testnet easier.

Also, I fixed the appendix (which was out of data, and still said it was to be decided whether stake in reward accounts was considered active).