### PR TITLE
Fix errata: firstSlot misplaced parens (formal spec)

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -512,7 +512,7 @@ near the end of the epoch is not discarded).
   \begin{equation}\label{eq:update-both}
     \inference[Update-Both]
     {
-      s < \firstSlot{((\epoch{s}) + 1) - \SlotsPrior}
+      s < \fun{firstSlot}~((\epoch{s}) + 1) - \SlotsPrior
     }
     {
       {\begin{array}{c}
@@ -540,7 +540,7 @@ near the end of the epoch is not discarded).
   \begin{equation}\label{eq:only-evolve}
     \inference[Only-Evolve]
     {
-      s \geq \firstSlot{((\epoch{s}) + 1) - \SlotsPrior}
+      s \geq \fun{firstSlot}~((\epoch{s}) + 1) - \SlotsPrior
     }
     {
       {\begin{array}{c}
@@ -619,7 +619,7 @@ execution of the transition role is as follows:
   \begin{equation}\label{eq:reward-update}
     \inference[Create-Reward-Update]
     {
-      s > (\firstSlot{\epoch{s}}) + \StartRewards
+      s > \fun{firstSlot}~(\epoch{s}) + \StartRewards
       &
       ru = \Nothing
       \\~\\
@@ -659,7 +659,7 @@ execution of the transition role is as follows:
     {
       ru = \Nothing
       \\
-      s \leq (\firstSlot{\epoch{s}}) + \StartRewards
+      s \leq \fun{firstSlot}~(\epoch{s}) + \StartRewards
     }
     {
       {\begin{array}{c}

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -566,7 +566,7 @@ concerns are independent of the ledger rules.
     \inference[Deleg-Mir]
     {
       \var{c}\in \DCertMir\\
-      slot < \fun{firstSlot}((\fun{epoch}~\var{s} + 1)) - \fun{SlotsPrior}\\
+      slot < \fun{firstSlot}~((\epoch{slot}) + 1) - \fun{SlotsPrior}\\
       \left(
         \sum\limits_{\wcard\mapsto\var{val}\in(\var{i_{rwd}}\unionoverrideRight\var{i_{rwd}})} val      \right)\leq\var{reserves}
     }

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -406,7 +406,7 @@ and will always be large enough to meet all of its obligations.
   These stronger invariants will require a few additional definitions.
 %
   Given a slot $s$, let $\ell(s)$ be the first slot of the epoch that $s$ occurs in,
-  that is $\ell = \firstSlot{}\circ\epoch{}$.
+  that is $\ell = \fun{firstSlot}\circ\fun{epoch}$.
   Given a mapping $m\in\mathsf{T}\to\Slot$ and a slot $s\in\Slot$,
   let $\fun{sep}$ be the function that separates $m$ into two maps,
   those whose value is strictly less than $s$ and those whose value is at least $s$.

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -92,7 +92,7 @@ This rule has the following predicate failures:
 
 \begin{enumerate}
 \item In the case of \var{slot} being smaller than
-  $\fun{firstSlot}~((\fun{epoch}~\var{slot}) + 1) - \fun{SlotsPrior}$, there is
+  $\fun{firstSlot}~((\epoch{slot}) + 1) - \fun{SlotsPrior}$, there is
   a \emph{PPUpdateTooEarly} failure.
 \item In the case of \var{pup} being non-empty, if the check $\dom pup \subseteq
   \dom genDelegs$ fails, there is a \emph{NonGenesisUpdate} failure as only genesis keys
@@ -164,7 +164,7 @@ and will be rejected otherwise.
       \forall\var{ps}\in\range{pup},~
         \var{pv}\mapsto\var{v}\in\var{ps}\implies\fun{pvCanFollow}~(\fun{pv}~\var{pp})~\var{v}
       \\
-      \var{slot} < \firstSlot{((\epoch{slot}) + 1) - \SlotsPrior}
+      \var{slot} < \fun{firstSlot}~((\epoch{slot}) + 1) - \SlotsPrior
     }
     {
       \begin{array}{r}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -518,7 +518,7 @@ Section~\ref{sec:epoch}.
       \begin{array}{lr@{~=~}l}
         \where
           & \var{created} & \var{stkCreds}~(\cwitness~\var{c}) \\
-          & \var{start} & \mathsf{max}~(\firstSlot{\epoch{cslot}})~created \\
+          & \var{start} & \mathsf{max}~(\fun{firstSlot}~(\epoch{cslot}))~created \\
           & \var{epochRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkCreds}{start}{c} \\
           & \var{currentRefund} & \keyRefund{\dval}{d_{\min}}{\lambda}{stkCreds}{cslot}{c} \\
           & \dval & \fun{keyDeposit}~\var{pp}\\


### PR DESCRIPTION
Fig. 22: 
![fig22](https://user-images.githubusercontent.com/3624828/68487371-3b596480-0243-11ea-9a29-c93a2cb81f3d.jpg)

Fig. 29: `s` should be `slot`
![fig29](https://user-images.githubusercontent.com/3624828/68487383-43190900-0243-11ea-8314-c1fa05c4aace.jpg)

Fig. 65: 
![fig65](https://user-images.githubusercontent.com/3624828/68487401-4c09da80-0243-11ea-832f-a40f388d0506.jpg)

Some numbers `1` are in italics because expressions are passed as parameters (I think): 
![fig](https://user-images.githubusercontent.com/3624828/68487890-3ba62f80-0244-11ea-9aee-3faf8093010d.jpg)


