### PR TITLE
Parametrise everything over a single crypto class.

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -57,6 +57,8 @@ library
                      STS.Updn
                      STS.Utxo
                      STS.Utxow
+
+                     Cardano.Ledger.Shelley.Crypto
   hs-source-dirs: src
   ghc-options:
     -Wall

--- a/shelley/chain-and-ledger/executable-spec/src/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Address.hs
@@ -8,35 +8,32 @@ module Address
   )
 where
 
-import           Cardano.Crypto.Hash (HashAlgorithm)
-
-import           Keys (DSIGNAlgorithm, KeyDiscriminator (..), KeyPair, hashKey, vKey)
+import           Cardano.Ledger.Shelley.Crypto
+import           Keys (KeyDiscriminator (..), KeyPair, hashKey, vKey)
 import           TxData (Addr (..), Credential (..), RewardAcnt (..))
 
 mkVKeyRwdAcnt
-  :: ( HashAlgorithm hashAlgo
-     , DSIGNAlgorithm dsignAlgo
-     )
-  => KeyPair 'Regular dsignAlgo
-  -> RewardAcnt hashAlgo dsignAlgo
+  :: Crypto crypto
+  => KeyPair 'Regular crypto
+  -> RewardAcnt crypto
 mkVKeyRwdAcnt keys = RewardAcnt $ KeyHashObj (hashKey $ vKey keys)
 
 mkRwdAcnt
-  :: Credential hashAlgo dsignAlgo
-  -> RewardAcnt hashAlgo dsignAlgo
+  :: Credential crypto
+  -> RewardAcnt crypto
 mkRwdAcnt script@(ScriptHashObj _) = RewardAcnt script
 mkRwdAcnt key@(KeyHashObj _) = RewardAcnt key
 mkRwdAcnt (GenesisHashObj _) =
   error "cannot construct reward account with genesis key"
 
 toAddr
-  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => (KeyPair 'Regular dsignAlgo, KeyPair 'Regular dsignAlgo)
-  -> Addr hashAlgo dsignAlgo
+  :: Crypto crypto
+  => (KeyPair 'Regular crypto, KeyPair 'Regular crypto)
+  -> Addr crypto
 toAddr (payKey, stakeKey) = AddrBase (toCred payKey) (toCred stakeKey)
 
 toCred
-  :: (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => KeyPair 'Regular dsignAlgo
-  -> Credential hashAlgo dsignAlgo
+  :: Crypto crypto
+  => KeyPair 'Regular crypto
+  -> Credential crypto
 toCred k = KeyHashObj . hashKey $ vKey k

--- a/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Crypto.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Cardano/Ledger/Shelley/Crypto.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Package all the crypto constraints into one place.
+module Cardano.Ledger.Shelley.Crypto where
+
+import Cardano.Crypto.DSIGN
+import Cardano.Crypto.Hash
+import Cardano.Crypto.KES
+import Cardano.Crypto.VRF
+import Data.Kind (Type)
+import Data.Typeable (Typeable)
+
+class
+  ( HashAlgorithm (HASH c),
+    DSIGNAlgorithm (DSIGN c),
+    KESAlgorithm (KES c),
+    VRFAlgorithm (VRF c),
+    Typeable c
+  ) =>
+  Crypto c where
+
+  type HASH c :: Type
+
+  type DSIGN c :: Type
+
+  type KES c :: Type
+
+  type VRF c :: Type

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -34,7 +34,7 @@ import           PParams (PParams (..), keyDecayRate, keyDeposit, keyMinRefund, 
 import           Slot (Duration (..))
 import           TxData (Credential (..), DCert (..), StakeCredential, StakeCreds (..),
                      StakePools (..), delegator, poolPubKey)
-
+import           Cardano.Ledger.Shelley.Crypto
 import           BaseTypes (FixedPoint, UnitInterval, fpEpsilon, intervalValue)
 import           NonIntegral (exp')
 
@@ -45,7 +45,7 @@ import           Data.Ratio (approxRational)
 import           Lens.Micro ((^.))
 
 -- |Determine the certificate author
-cwitness :: DCert hashAlgo dsignAlgo vrfAlgo -> StakeCredential hashAlgo dsignAlgo
+cwitness :: DCert crypto-> StakeCredential crypto
 cwitness (RegKey _)                = error "no witness in key registration certificate"
 cwitness (DeRegKey hk)             = hk
 cwitness (RegPool pool)            = KeyHashObj $ pool ^. poolPubKey
@@ -55,7 +55,7 @@ cwitness (GenesisDelegate (gk, _)) = GenesisHashObj gk
 cwitness (InstantaneousRewards _)  = error "no witness in MIR certificate"
 
 -- |Retrieve the deposit amount for a certificate
-dvalue :: DCert hashAlgo dsignAlgo vrfAlgo -> PParams -> Coin
+dvalue :: DCert crypto-> PParams -> Coin
 dvalue (RegKey _)  = flip (^.) keyDeposit
 dvalue (RegPool _) = flip (^.) poolDeposit
 dvalue _ = const $ Coin 0
@@ -71,36 +71,36 @@ refund (Coin dval) dmin lambda delta = floor refund'
 
 -- | Check whether certificate is of releasing type, i.e., key deregistration or
 -- pool retirement.
-releasing :: DCert hashAlgo dsignAlgo vrfAlgo -> Bool
+releasing :: DCert crypto-> Bool
 releasing c = dderegister c || dretire c
 
-dderegister :: DCert hashAlgo dsignAlgo vrfAlgo -> Bool
+dderegister :: DCert crypto-> Bool
 dderegister (DeRegKey _) = True
 dderegister _            = False
 
-dretire :: DCert hashAlgo dsignAlgo vrfAlgo -> Bool
+dretire :: DCert crypto-> Bool
 dretire (RetirePool _ _) = True
 dretire _                = False
 
 -- | Check whether certificate is of allocating type, i.e, key or pool
 -- registration.
-allocating :: DCert hashAlgo dsignAlgo vrfAlgo -> Bool
+allocating :: DCert crypto-> Bool
 allocating (RegKey _)  = True
 allocating (RegPool _) = True
 allocating _           = False
 
 -- | Check for `RegKey` constructor
-isRegKey :: DCert hashAlgo dsignAlgo vrfAlgo -> Bool
+isRegKey :: DCert crypto-> Bool
 isRegKey (RegKey _) = True
 isRegKey _ = False
 
 -- | Check for `DeRegKey` constructor
-isDeRegKey :: DCert hashAlgo dsignAlgo vrfAlgo -> Bool
+isDeRegKey :: DCert crypto-> Bool
 isDeRegKey (DeRegKey _) = True
 isDeRegKey _ = False
 
 -- | Check for `RegPool` constructor
-isRegPool :: DCert hashAlgo dsignAlgo vrfAlgo -> Bool
+isRegPool :: DCert crypto-> Bool
 isRegPool (RegPool _) = True
 isRegPool _ = False
 
@@ -116,18 +116,18 @@ decayPool pc = (pval, pmin, lambdap)
           pmin    = pc ^. poolMinRefund
           lambdap = pc ^. poolDecayRate
 
-newtype PoolDistr hashAlgo dsignAlgo vrfAlgo =
-  PoolDistr (Map (KeyHash hashAlgo dsignAlgo) (Rational, Hash hashAlgo (VerKeyVRF vrfAlgo)))
+newtype PoolDistr crypto=
+  PoolDistr (Map (KeyHash crypto) (Rational, Hash (HASH crypto) (VerKeyVRF (VRF crypto))))
   deriving (Show, Eq, NoUnexpectedThunks, Relation)
 
-isInstantaneousRewards :: DCert hashAlgo dsignAlgo vrfAlgo -> Bool
+isInstantaneousRewards :: DCert crypto-> Bool
 isInstantaneousRewards (InstantaneousRewards _) = True
 isInstantaneousRewards _                        = False
 
 -- | Returns True for delegation certificates that require at least
 -- one witness, and False otherwise. It is mainly used to ensure
 -- that calling `cwitness` is safe.
-requiresVKeyWitness :: DCert hashAlgo dsignAlgo vrfAlgo -> Bool
+requiresVKeyWitness :: DCert crypto-> Bool
 requiresVKeyWitness (InstantaneousRewards _) = False
 requiresVKeyWitness (RegKey _) = False
 requiresVKeyWitness _ = True

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/PoolParams.hs
@@ -8,5 +8,5 @@ import           BaseTypes (UnitInterval)
 import           Coin (Coin)
 import           TxData (PoolParams, poolCost, poolMargin, poolPledge)
 
-poolSpec :: PoolParams hashAlgo dsignAlgo vrfAlgo -> (Coin, UnitInterval, Coin)
+poolSpec :: PoolParams crypto -> (Coin, UnitInterval, Coin)
 poolSpec pool = (pool ^. poolCost, pool ^. poolMargin, pool ^. poolPledge)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -20,12 +20,13 @@ import           LedgerState
 import           Slot
 import           TxData
 
+import           Cardano.Ledger.Shelley.Crypto
 import           Control.State.Transition
 import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
 import           Hedgehog (Gen)
 
-data DELEG hashAlgo dsignAlgo vrfAlgo
+data DELEG crypto
 
 data DelegEnv
   = DelegEnv
@@ -35,12 +36,12 @@ data DelegEnv
   }
   deriving (Show, Eq)
 
-instance STS (DELEG hashAlgo dsignAlgo vrfAlgo)
+instance STS (DELEG crypto)
  where
-  type State (DELEG hashAlgo dsignAlgo vrfAlgo) = DState hashAlgo dsignAlgo
-  type Signal (DELEG hashAlgo dsignAlgo vrfAlgo) = DCert hashAlgo dsignAlgo vrfAlgo
-  type Environment (DELEG hashAlgo dsignAlgo vrfAlgo) = DelegEnv
-  data PredicateFailure (DELEG hashAlgo dsignAlgo vrfAlgo)
+  type State (DELEG crypto) = DState crypto
+  type Signal (DELEG crypto) = DCert crypto
+  type Environment (DELEG crypto) = DelegEnv
+  data PredicateFailure (DELEG crypto)
     = StakeKeyAlreadyRegisteredDELEG
     | StakeKeyNotRegisteredDELEG
     | StakeKeyNonZeroAccountBalanceDELEG
@@ -56,7 +57,7 @@ instance STS (DELEG hashAlgo dsignAlgo vrfAlgo)
   transitionRules = [delegationTransition]
 
 delegationTransition
-  :: TransitionRule (DELEG hashAlgo dsignAlgo vrfAlgo)
+  :: TransitionRule (DELEG crypto)
 delegationTransition = do
   TRC (DelegEnv slot_ ptr_ reserves_, ds, c) <- judgmentContext
 
@@ -113,7 +114,7 @@ delegationTransition = do
       pure ds
 
 
-instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => HasTrace (DELEG hashAlgo dsignAlgo vrfAlgo) where
+instance Crypto crypto
+  => HasTrace (DELEG crypto) where
   envGen _ = undefined :: Gen DelegEnv
-  sigGen _ _ = undefined :: Gen (DCert hashAlgo dsignAlgo vrfAlgo)
+  sigGen _ _ = undefined :: Gen (DCert crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
@@ -25,8 +25,9 @@ import           STS.Delegs
 import           STS.Utxo (UtxoEnv (..))
 import           STS.Utxow
 import           Tx
+import           Cardano.Ledger.Shelley.Crypto
 
-data LEDGER hashAlgo dsignAlgo vrfAlgo
+data LEDGER crypto
 
 data LedgerEnv
   = LedgerEnv
@@ -38,61 +39,53 @@ data LedgerEnv
   deriving (Show)
 
 instance
-  ( HashAlgorithm hashAlgo
-  , DSIGNAlgorithm dsignAlgo
-  , Signable dsignAlgo (TxBody hashAlgo dsignAlgo vrfAlgo)
-  , VRFAlgorithm vrfAlgo
+  ( Crypto crypto
+  , Signable (DSIGN crypto) (TxBody crypto)
   )
-  => STS (LEDGER hashAlgo dsignAlgo vrfAlgo)
+  => STS (LEDGER crypto)
  where
-  type State (LEDGER hashAlgo dsignAlgo vrfAlgo)
-    = (UTxOState hashAlgo dsignAlgo vrfAlgo, DPState hashAlgo dsignAlgo vrfAlgo)
-  type Signal (LEDGER hashAlgo dsignAlgo vrfAlgo) = Tx hashAlgo dsignAlgo vrfAlgo
-  type Environment (LEDGER hashAlgo dsignAlgo vrfAlgo) = LedgerEnv
-  data PredicateFailure (LEDGER hashAlgo dsignAlgo vrfAlgo)
-    = UtxowFailure (PredicateFailure (UTXOW hashAlgo dsignAlgo vrfAlgo))
-    | DelegsFailure (PredicateFailure (DELEGS hashAlgo dsignAlgo vrfAlgo))
+  type State (LEDGER crypto)
+    = (UTxOState crypto, DPState crypto)
+  type Signal (LEDGER crypto) = Tx crypto
+  type Environment (LEDGER crypto) = LedgerEnv
+  data PredicateFailure (LEDGER crypto)
+    = UtxowFailure (PredicateFailure (UTXOW crypto))
+    | DelegsFailure (PredicateFailure (DELEGS crypto))
     deriving (Show, Eq)
 
   initialRules = []
   transitionRules = [ledgerTransition]
 
 ledgerTransition
-  :: forall hashAlgo dsignAlgo vrfAlgo
-   . ( HashAlgorithm hashAlgo
-     , DSIGNAlgorithm dsignAlgo
-     , Signable dsignAlgo (TxBody hashAlgo dsignAlgo vrfAlgo)
-     , VRFAlgorithm vrfAlgo
+  :: forall crypto
+   . ( Crypto crypto
+     , Signable (DSIGN crypto) (TxBody crypto)
      )
-  => TransitionRule (LEDGER hashAlgo dsignAlgo vrfAlgo)
+  => TransitionRule (LEDGER crypto)
 ledgerTransition = do
   TRC (LedgerEnv slot ix pp _reserves, (u, d), tx) <- judgmentContext
-  utxo' <- trans @(UTXOW hashAlgo dsignAlgo vrfAlgo) $ TRC
+  utxo' <- trans @(UTXOW crypto) $ TRC
     ( UtxoEnv slot pp (d ^. dstate . stkCreds) (d ^. pstate . stPools) (d ^. dstate . genDelegs)
     , u
     , tx
     )
   deleg' <-
-    trans @(DELEGS hashAlgo dsignAlgo vrfAlgo)
+    trans @(DELEGS crypto)
       $ TRC (DelegsEnv slot ix pp tx _reserves, d, tx ^. body . certs)
   pure (utxo', deleg')
 
 instance
-  ( HashAlgorithm hashAlgo
-  , DSIGNAlgorithm dsignAlgo
-  , Signable dsignAlgo (TxBody hashAlgo dsignAlgo vrfAlgo)
-  , VRFAlgorithm vrfAlgo
+  ( Crypto crypto
+  , Signable (DSIGN crypto) (TxBody crypto)
   )
-  => Embed (DELEGS hashAlgo dsignAlgo vrfAlgo) (LEDGER hashAlgo dsignAlgo vrfAlgo)
+  => Embed (DELEGS crypto) (LEDGER crypto)
  where
   wrapFailed = DelegsFailure
 
 instance
-  ( HashAlgorithm hashAlgo
-  , DSIGNAlgorithm dsignAlgo
-  , Signable dsignAlgo (TxBody hashAlgo dsignAlgo vrfAlgo)
-  , VRFAlgorithm vrfAlgo
+  ( Crypto crypto
+  , Signable (DSIGN crypto) (TxBody crypto)
   )
-  => Embed (UTXOW hashAlgo dsignAlgo vrfAlgo) (LEDGER hashAlgo dsignAlgo vrfAlgo)
+  => Embed (UTXOW crypto) (LEDGER crypto)
  where
   wrapFailed = UtxowFailure

--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -15,7 +15,6 @@ import           Data.Maybe (catMaybes)
 
 import           Coin
 import           EpochBoundary
-import           Keys (DSIGNAlgorithm, HashAlgorithm, VRFAlgorithm)
 import           LedgerState
 import           Slot
 import           TxData
@@ -24,20 +23,21 @@ import           STS.Epoch
 
 import           Delegation.Certificates
 
+import           Cardano.Ledger.Shelley.Crypto
 import           Control.State.Transition
 import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
 import           Hedgehog (Gen)
 
-data NEWEPOCH hashAlgo dsignAlgo vrfAlgo
+data NEWEPOCH crypto
 
-instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, VRFAlgorithm vrfAlgo)
-    => STS (NEWEPOCH hashAlgo dsignAlgo vrfAlgo) where
-  type State (NEWEPOCH hashAlgo dsignAlgo vrfAlgo) = NewEpochState hashAlgo dsignAlgo vrfAlgo
-  type Signal (NEWEPOCH hashAlgo dsignAlgo vrfAlgo) = Epoch
-  type Environment (NEWEPOCH hashAlgo dsignAlgo vrfAlgo) = NewEpochEnv hashAlgo dsignAlgo
-  data PredicateFailure (NEWEPOCH hashAlgo dsignAlgo vrfAlgo)
-    = EpochFailure (PredicateFailure (EPOCH hashAlgo dsignAlgo vrfAlgo))
+instance Crypto crypto
+    => STS (NEWEPOCH crypto) where
+  type State (NEWEPOCH crypto) = NewEpochState crypto
+  type Signal (NEWEPOCH crypto) = Epoch
+  type Environment (NEWEPOCH crypto) = NewEpochEnv crypto
+  data PredicateFailure (NEWEPOCH crypto)
+    = EpochFailure (PredicateFailure (EPOCH crypto))
     deriving (Show, Eq)
 
   initialRules =
@@ -52,9 +52,9 @@ instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, VRFAlgorithm vrfAlgo
         Map.empty]
   transitionRules = [newEpochTransition]
 
-newEpochTransition :: forall hashAlgo dsignAlgo vrfAlgo
-  .  (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, VRFAlgorithm vrfAlgo)
-  => TransitionRule (NEWEPOCH hashAlgo dsignAlgo vrfAlgo)
+newEpochTransition :: forall crypto
+  .  Crypto crypto
+  => TransitionRule (NEWEPOCH crypto)
 newEpochTransition = do
   TRC ( NewEpochEnv _s gkeys
       , src@(NewEpochState (Epoch eL) _ bcur es ru _pd _osched)
@@ -65,7 +65,7 @@ newEpochTransition = do
       let es_ = case ru of
             Nothing  -> es
             Just ru' -> applyRUpd ru' es
-      es' <- trans @(EPOCH hashAlgo dsignAlgo vrfAlgo) $ TRC ((), es_, e)
+      es' <- trans @(EPOCH crypto) $ TRC ((), es_, e)
       let EpochState _acnt ss _ls pp = es'
 
           (Stake stake, delegs) = _pstakeSet ss
@@ -90,15 +90,11 @@ newEpochTransition = do
      where
        aggregatePlus = Map.fromListWith (+)
 
-instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo, VRFAlgorithm vrfAlgo)
-    => Embed (EPOCH hashAlgo dsignAlgo vrfAlgo) (NEWEPOCH hashAlgo dsignAlgo vrfAlgo) where
+instance Crypto crypto
+    => Embed (EPOCH crypto) (NEWEPOCH crypto) where
   wrapFailed = EpochFailure
 
-instance
-  ( HashAlgorithm hashAlgo
-  , DSIGNAlgorithm dsignAlgo
-  , VRFAlgorithm vrfAlgo
-  )
-  => HasTrace (NEWEPOCH hashAlgo dsignAlgo vrfAlgo) where
-  envGen _ = undefined :: Gen (NewEpochEnv hashAlgo dsignAlgo)
+instance Crypto crypto
+  => HasTrace (NEWEPOCH crypto) where
+  envGen _ = undefined :: Gen (NewEpochEnv crypto)
   sigGen _ _ = undefined :: Gen Epoch

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
@@ -25,32 +25,32 @@ import           UTxO
 
 import           Control.State.Transition
 
-data NEWPP hashAlgo dsignAlgo vrfAlgo
+data NEWPP crypto
 
-data NewppState hashAlgo dsignAlgo vrfAlgo
-  = NewppState (UTxOState hashAlgo dsignAlgo vrfAlgo) AccountState PParams
+data NewppState crypto
+  = NewppState (UTxOState crypto) AccountState PParams
 
-data NewppEnv hashAlgo dsignAlgo vrfAlgo
-  = NewppEnv (Maybe PParams) (DState hashAlgo dsignAlgo) (PState hashAlgo dsignAlgo vrfAlgo)
+data NewppEnv crypto
+  = NewppEnv (Maybe PParams) (DState crypto) (PState crypto)
 
-instance STS (NEWPP hashAlgo dsignAlgo vrfAlgo) where
-  type State (NEWPP hashAlgo dsignAlgo vrfAlgo) = NewppState hashAlgo dsignAlgo vrfAlgo
-  type Signal (NEWPP hashAlgo dsignAlgo vrfAlgo) = Epoch
-  type Environment (NEWPP hashAlgo dsignAlgo vrfAlgo) = NewppEnv hashAlgo dsignAlgo vrfAlgo
-  data PredicateFailure (NEWPP hashAlgo dsignAlgo vrfAlgo)
+instance STS (NEWPP crypto) where
+  type State (NEWPP crypto) = NewppState crypto
+  type Signal (NEWPP crypto) = Epoch
+  type Environment (NEWPP crypto) = NewppEnv crypto
+  data PredicateFailure (NEWPP crypto)
     = FailureNEWPP
     deriving (Show, Eq)
 
   initialRules = [initialNewPp]
   transitionRules = [newPpTransition]
 
-initialNewPp :: InitialRule (NEWPP hashAlgo dsignAlgo vrfAlgo)
+initialNewPp :: InitialRule (NEWPP crypto)
 initialNewPp = pure $ NewppState
   (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState)
   emptyAccount
   emptyPParams
 
-newPpTransition :: TransitionRule (NEWPP hashAlgo dsignAlgo vrfAlgo)
+newPpTransition :: TransitionRule (NEWPP crypto)
 newPpTransition = do
   TRC (NewppEnv ppNew ds ps, NewppState utxoSt acnt pp, e) <- judgmentContext
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ocert.hs
@@ -17,25 +17,24 @@ import           Keys
 import           Ledger.Core ((⨃))
 import           OCert
 
+import           Cardano.Ledger.Shelley.Crypto
 import           Control.State.Transition
 
-data OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo
+data OCERT crypto
 
 instance
-  ( HashAlgorithm hashAlgo
-  , DSIGNAlgorithm dsignAlgo
-  , Signable dsignAlgo (VKeyES kesAlgo, Natural, KESPeriod)
-  , KESAlgorithm kesAlgo
-  , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  ( Crypto crypto
+  , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
+  , KESignable crypto (BHBody crypto)
   )
-  => STS (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  => STS (OCERT crypto)
  where
-  type State (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
-    = Map (KeyHash hashAlgo dsignAlgo) Natural
-  type Signal (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
-    = BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
-  type Environment (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo) = OCertEnv hashAlgo dsignAlgo
-  data PredicateFailure (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  type State (OCERT crypto)
+    = Map (KeyHash crypto) Natural
+  type Signal (OCERT crypto)
+    = BHeader crypto
+  type Environment (OCERT crypto) = OCertEnv crypto
+  data PredicateFailure (OCERT crypto)
     = KESBeforeStartOCERT
     | KESAfterEndOCERT
     | KESPeriodWrongOCERT
@@ -48,13 +47,11 @@ instance
   transitionRules = [ocertTransition]
 
 ocertTransition
-  :: ( HashAlgorithm hashAlgo
-     , DSIGNAlgorithm dsignAlgo
-     , Signable dsignAlgo (VKeyES kesAlgo, Natural, KESPeriod)
-     , KESAlgorithm kesAlgo
-     , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  :: ( Crypto crypto
+     , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
+     , KESignable crypto (BHBody crypto)
      )
-  => TransitionRule (OCERT hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  => TransitionRule (OCERT crypto)
 ocertTransition = do
   TRC (env, cs, BHeader bhb sigma) <- judgmentContext
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -19,23 +19,24 @@ import           PParams
 import           Slot
 import           TxData
 
+import           Cardano.Ledger.Shelley.Crypto
 import           Control.State.Transition
 import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
 import           Hedgehog (Gen)
 
-data POOL hashAlgo dsignAlgo vrfAlgo
+data POOL crypto
 
 data PoolEnv =
   PoolEnv Slot PParams
   deriving (Show, Eq)
 
-instance STS (POOL hashAlgo dsignAlgo vrfAlgo)
+instance STS (POOL crypto)
  where
-  type State (POOL hashAlgo dsignAlgo vrfAlgo) = PState hashAlgo dsignAlgo vrfAlgo
-  type Signal (POOL hashAlgo dsignAlgo vrfAlgo) = DCert hashAlgo dsignAlgo vrfAlgo
-  type Environment (POOL hashAlgo dsignAlgo vrfAlgo) = PoolEnv
-  data PredicateFailure (POOL hashAlgo dsignAlgo vrfAlgo)
+  type State (POOL crypto) = PState crypto
+  type Signal (POOL crypto) = DCert crypto
+  type Environment (POOL crypto) = PoolEnv
+  data PredicateFailure (POOL crypto)
     = StakePoolNotRegisteredOnKeyPOOL
     | StakePoolRetirementWrongEpochPOOL
     | WrongCertificateTypePOOL
@@ -44,7 +45,7 @@ instance STS (POOL hashAlgo dsignAlgo vrfAlgo)
   initialRules = [pure emptyPState]
   transitionRules = [poolDelegationTransition]
 
-poolDelegationTransition :: TransitionRule (POOL hashAlgo dsignAlgo vrfAlgo)
+poolDelegationTransition :: TransitionRule (POOL crypto)
 poolDelegationTransition = do
   TRC (PoolEnv slot pp, ps, c) <- judgmentContext
   let StakePools stPools_ = _stPools ps
@@ -79,17 +80,17 @@ poolDelegationTransition = do
 -- would require an Ord instance for PParams, which we don't need otherwise.
 -- Instead, we just define these operators here.
 
-(⨃) :: Map (KeyHash hashAlgo dsignAlgo) a
-    -> (KeyHash hashAlgo dsignAlgo, a)
-    -> Map (KeyHash hashAlgo dsignAlgo) a
+(⨃) :: Map (KeyHash crypto) a
+    -> (KeyHash crypto, a)
+    -> Map (KeyHash crypto) a
 m ⨃ (k,v) = Map.union (Map.singleton k v) m
 
-(∪) :: Map (KeyHash hashAlgo dsignAlgo) a
-    -> (KeyHash hashAlgo dsignAlgo, a)
-    -> Map (KeyHash hashAlgo dsignAlgo) a
+(∪) :: Map (KeyHash crypto) a
+    -> (KeyHash crypto, a)
+    -> Map (KeyHash crypto) a
 m ∪ (k,v) = Map.union m (Map.singleton k v)
 
-instance (HashAlgorithm hashAlgo, DSIGNAlgorithm dsignAlgo)
-  => HasTrace (POOL hashAlgo dsignAlgo vrfAlgo) where
+instance Crypto crypto
+  => HasTrace (POOL crypto) where
   envGen _ = undefined :: Gen PoolEnv
-  sigGen _ _ = undefined :: Gen (DCert hashAlgo dsignAlgo vrfAlgo)
+  sigGen _ _ = undefined :: Gen (DCert crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/PoolReap.hs
@@ -25,27 +25,27 @@ import           Hedgehog (Gen)
 
 import           Ledger.Core (dom, (∈), (∪+), (⋪), (⋫), (▷), (◁))
 
-data POOLREAP hashAlgo dsignAlgo vrfAlgo
+data POOLREAP crypto
 
-data PoolreapState hashAlgo dsignAlgo vrfAlgo = PoolreapState
-  { prUTxOSt :: UTxOState hashAlgo dsignAlgo vrfAlgo
+data PoolreapState crypto = PoolreapState
+  { prUTxOSt :: UTxOState crypto
   , prAcnt   :: AccountState
-  , prDState :: DState hashAlgo dsignAlgo
-  , prPState :: PState hashAlgo dsignAlgo vrfAlgo
+  , prDState :: DState crypto
+  , prPState :: PState crypto
   }
   deriving (Show, Eq)
 
-instance STS (POOLREAP hashAlgo dsignAlgo vrfAlgo) where
-  type State (POOLREAP hashAlgo dsignAlgo vrfAlgo) = PoolreapState hashAlgo dsignAlgo vrfAlgo
-  type Signal (POOLREAP hashAlgo dsignAlgo vrfAlgo) = Epoch
-  type Environment (POOLREAP hashAlgo dsignAlgo vrfAlgo) = PParams
-  data PredicateFailure (POOLREAP hashAlgo dsignAlgo vrfAlgo)
+instance STS (POOLREAP crypto) where
+  type State (POOLREAP crypto) = PoolreapState crypto
+  type Signal (POOLREAP crypto) = Epoch
+  type Environment (POOLREAP crypto) = PParams
+  data PredicateFailure (POOLREAP crypto)
     = FailurePOOLREAP
     deriving (Show, Eq)
   initialRules = [pure $ PoolreapState emptyUTxOState emptyAccount emptyDState emptyPState]
   transitionRules = [poolReapTransition]
 
-poolReapTransition :: TransitionRule (POOLREAP hashAlgo dsignAlgo vrfAlgo)
+poolReapTransition :: TransitionRule (POOLREAP crypto)
 poolReapTransition = do
   TRC (pp, PoolreapState us a ds ps, e) <- judgmentContext
 
@@ -72,6 +72,6 @@ poolReapTransition = do
        , _retiring = retired ⋪ _retiring ps
        }
 
-instance HasTrace (POOLREAP hashAlgo dsignAlgo vrfAlgo) where
+instance HasTrace (POOLREAP crypto) where
   envGen _ = undefined :: Gen PParams
   sigGen _ _ = undefined :: Gen Epoch

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -23,17 +23,17 @@ import           Control.State.Transition
 import           Data.Ix (inRange)
 import           Numeric.Natural (Natural)
 
-data PPUP hashAlgo dsignAlgo
+data PPUP crypto
 
-data PPUPEnv hashAlgo dsignAlgo
-  = PPUPEnv Slot PParams (GenDelegs hashAlgo dsignAlgo)
+data PPUPEnv crypto
+  = PPUPEnv Slot PParams (GenDelegs crypto)
 
-instance STS (PPUP hashAlgo dsignAlgo) where
-  type State (PPUP hashAlgo dsignAlgo) = PPUpdate hashAlgo dsignAlgo
-  type Signal (PPUP hashAlgo dsignAlgo) = PPUpdate hashAlgo dsignAlgo
-  type Environment (PPUP hashAlgo dsignAlgo) = PPUPEnv hashAlgo dsignAlgo
-  data PredicateFailure (PPUP hashAlgo dsignAlgo)
-    = NonGenesisUpdatePPUP (Set (GenKeyHash hashAlgo dsignAlgo)) (Set (GenKeyHash hashAlgo dsignAlgo))
+instance STS (PPUP crypto) where
+  type State (PPUP crypto) = PPUpdate crypto
+  type Signal (PPUP crypto) = PPUpdate crypto
+  type Environment (PPUP crypto) = PPUPEnv crypto
+  data PredicateFailure (PPUP crypto)
+    = NonGenesisUpdatePPUP (Set (GenKeyHash crypto)) (Set (GenKeyHash crypto))
     | PPUpdateTooEarlyPPUP
     | PPUpdateEmpty
     | PPUpdateNonEmpty
@@ -52,7 +52,7 @@ pvCanFollow (mjp, mip, ap) (ProtocolVersion (mjn, mn, an))
   && ((mjp + 1 == mjn) ==> (mn == 0))
 pvCanFollow _ _ = True
 
-ppupTransitionEmpty :: TransitionRule (PPUP hashAlgo dsignAlgo)
+ppupTransitionEmpty :: TransitionRule (PPUP crypto)
 ppupTransitionEmpty = do
   TRC (_, pupS, PPUpdate pup') <- judgmentContext
 
@@ -60,7 +60,7 @@ ppupTransitionEmpty = do
 
   pure pupS
 
-ppupTransitionNonEmpty :: TransitionRule (PPUP hashAlgo dsignAlgo)
+ppupTransitionNonEmpty :: TransitionRule (PPUP crypto)
 ppupTransitionNonEmpty = do
   TRC (PPUPEnv s pp (GenDelegs _genDelegs), pupS, pup@(PPUpdate pup')) <- judgmentContext
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Prtcl.hs
@@ -34,57 +34,55 @@ import           STS.Updn
 import qualified Cardano.Crypto.VRF as VRF
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Control.State.Transition
+import           Cardano.Ledger.Shelley.Crypto
 
-data PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo
+data PRTCL crypto
 
-data PrtclState hashAlgo dsignAlgo kesAlgo vrfAlgo
+data PrtclState crypto
   = PrtclState
-      (Map (KeyHash hashAlgo dsignAlgo) Natural)
-      (HashHeader hashAlgo dsignAlgo kesAlgo vrfAlgo)
+      (Map (KeyHash crypto) Natural)
+      (HashHeader crypto)
       Slot
       Nonce -- ^ Current epoch nonce
       Nonce -- ^ Evolving nonce
       Nonce -- ^ Candidate nonce
   deriving (Generic, Show)
 
-instance NoUnexpectedThunks (PrtclState hashAlgo dsignAlgo kesAlgo vrfAlgo)
+instance NoUnexpectedThunks (PrtclState crypto)
 
-data PrtclEnv hashAlgo dsignAlgo kesAlgo vrfAlgo
+data PrtclEnv crypto
   = PrtclEnv
       PParams
-      (Map Slot (Maybe (GenKeyHash hashAlgo dsignAlgo)))
-      (PoolDistr hashAlgo dsignAlgo vrfAlgo)
-      (GenDelegs hashAlgo dsignAlgo)
+      (Map Slot (Maybe (GenKeyHash crypto)))
+      (PoolDistr crypto)
+      (GenDelegs crypto)
       Slot
       Bool -- ^ New epoch marker
   deriving (Generic)
 
-instance NoUnexpectedThunks (PrtclEnv hashAlgo dsignAlgo kesAlgo vrfAlgo)
+instance NoUnexpectedThunks (PrtclEnv crypto)
 
 instance
-  ( HashAlgorithm hashAlgo
-  , DSIGNAlgorithm dsignAlgo
-  , Signable dsignAlgo (VKeyES kesAlgo, Natural, KESPeriod)
-  , KESAlgorithm kesAlgo
-  , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
-  , VRFAlgorithm vrfAlgo
-  , VRF.Signable vrfAlgo Seed
+  ( Crypto crypto
+  , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
+  , KESignable crypto (BHBody crypto)
+  , VRF.Signable (VRF crypto) Seed
   )
-  => STS (PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  => STS (PRTCL crypto)
  where
-  type State (PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo)
-    = PrtclState hashAlgo dsignAlgo kesAlgo vrfAlgo
+  type State (PRTCL crypto)
+    = PrtclState crypto
 
-  type Signal (PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo)
-    = BHeader hashAlgo dsignAlgo kesAlgo vrfAlgo
+  type Signal (PRTCL crypto)
+    = BHeader crypto
 
-  type Environment (PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo)
-    = PrtclEnv hashAlgo dsignAlgo kesAlgo vrfAlgo
+  type Environment (PRTCL crypto)
+    = PrtclEnv crypto
 
-  data PredicateFailure (PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  data PredicateFailure (PRTCL crypto)
     = WrongSlotIntervalPRTCL
     | WrongBlockSequencePRTCL
-    | OverlayFailure (PredicateFailure (OVERLAY hashAlgo dsignAlgo kesAlgo vrfAlgo))
+    | OverlayFailure (PredicateFailure (OVERLAY crypto))
     | UpdnFailure (PredicateFailure UPDN)
     deriving (Show, Eq)
 
@@ -93,16 +91,13 @@ instance
   transitionRules = [prtclTransition]
 
 prtclTransition
-  :: forall hashAlgo dsignAlgo kesAlgo vrfAlgo
-   . ( HashAlgorithm hashAlgo
-     , DSIGNAlgorithm dsignAlgo
-     , Signable dsignAlgo (VKeyES kesAlgo, Natural, KESPeriod)
-     , KESAlgorithm kesAlgo
-     , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
-     , VRFAlgorithm vrfAlgo
-     , VRF.Signable vrfAlgo Seed
+  :: forall crypto
+   . ( Crypto crypto
+     , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
+     , KESignable crypto (BHBody crypto)
+     , VRF.Signable (VRF crypto) Seed
      )
-  => TransitionRule (PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  => TransitionRule (PRTCL crypto)
 prtclTransition = do
   TRC ( PrtclEnv pp osched pd dms sNow ne
       , PrtclState cs h sL eta0 etaV etaC
@@ -116,33 +111,27 @@ prtclTransition = do
   UpdnState eta0' etaV' etaC'
     <- trans @UPDN $ TRC (UpdnEnv eta pp ne, UpdnState eta0 etaV etaC, slot)
   cs'
-    <- trans @(OVERLAY hashAlgo dsignAlgo kesAlgo vrfAlgo)
+    <- trans @(OVERLAY crypto)
         $ TRC (OverlayEnv pp osched eta0' pd dms, cs, bh)
 
   pure $ PrtclState cs' (bhHash bh) slot eta0' etaV' etaC'
 
 instance
-  ( HashAlgorithm hashAlgo
-  , DSIGNAlgorithm dsignAlgo
-  , Signable dsignAlgo (VKeyES kesAlgo, Natural, KESPeriod)
-  , KESAlgorithm kesAlgo
-  , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
-  , VRFAlgorithm vrfAlgo
-  , VRF.Signable vrfAlgo Seed
+  ( Crypto crypto
+  , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
+  , KESignable crypto (BHBody crypto)
+  , VRF.Signable (VRF crypto) Seed
   )
-  => Embed (OVERLAY hashAlgo dsignAlgo kesAlgo vrfAlgo) (PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  => Embed (OVERLAY crypto) (PRTCL crypto)
  where
   wrapFailed = OverlayFailure
 
 instance
-  ( HashAlgorithm hashAlgo
-  , DSIGNAlgorithm dsignAlgo
-  , Signable dsignAlgo (VKeyES kesAlgo, Natural, KESPeriod)
-  , KESAlgorithm kesAlgo
-  , KESignable kesAlgo (BHBody hashAlgo dsignAlgo kesAlgo vrfAlgo)
-  , VRFAlgorithm vrfAlgo
-  , VRF.Signable vrfAlgo Seed
+  ( Crypto crypto
+  , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
+  , KESignable crypto (BHBody crypto)
+  , VRF.Signable (VRF crypto) Seed
   )
-  => Embed UPDN (PRTCL hashAlgo dsignAlgo kesAlgo vrfAlgo)
+  => Embed UPDN (PRTCL crypto)
  where
   wrapFailed = UpdnFailure

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Rupd.hs
@@ -14,23 +14,23 @@ import           Slot
 
 import           Control.State.Transition
 
-data RUPD hashAlgo dsignAlgo vrfAlgo
+data RUPD crypto
 
-data RupdEnv hashAlgo dsignAlgo vrfAlgo
-  = RupdEnv (BlocksMade hashAlgo dsignAlgo) (EpochState hashAlgo dsignAlgo vrfAlgo)
+data RupdEnv crypto
+  = RupdEnv (BlocksMade crypto) (EpochState crypto)
 
-instance STS (RUPD hashAlgo dsignAlgo vrfAlgo) where
-  type State (RUPD hashAlgo dsignAlgo vrfAlgo) = Maybe (RewardUpdate hashAlgo dsignAlgo)
-  type Signal (RUPD hashAlgo dsignAlgo vrfAlgo) = Slot.Slot
-  type Environment (RUPD hashAlgo dsignAlgo vrfAlgo) = RupdEnv hashAlgo dsignAlgo vrfAlgo
-  data PredicateFailure (RUPD hashAlgo dsignAlgo vrfAlgo)
+instance STS (RUPD crypto) where
+  type State (RUPD crypto) = Maybe (RewardUpdate crypto)
+  type Signal (RUPD crypto) = Slot.Slot
+  type Environment (RUPD crypto) = RupdEnv crypto
+  data PredicateFailure (RUPD crypto)
     = FailureRUPD
     deriving (Show, Eq)
 
   initialRules = [pure Nothing]
   transitionRules = [rupdTransition]
 
-rupdTransition :: TransitionRule (RUPD hashAlgo dsignAlgo vrfAlgo)
+rupdTransition :: TransitionRule (RUPD crypto)
 rupdTransition = do
   TRC (RupdEnv b es, ru, s) <- judgmentContext
   let slot = firstSlot (epochFromSlot s) +* startRewards

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Snap.hs
@@ -22,24 +22,24 @@ import           UTxO
 
 import           Control.State.Transition
 
-data SNAP hashAlgo dsignAlgo vrfAlgo
+data SNAP crypto
 
-data SnapState hashAlgo dsignAlgo vrfAlgo
+data SnapState crypto
   = SnapState
-      (SnapShots hashAlgo dsignAlgo vrfAlgo)
-      (UTxOState hashAlgo dsignAlgo vrfAlgo)
+      (SnapShots crypto)
+      (UTxOState crypto)
 
-data SnapEnv hashAlgo dsignAlgo vrfAlgo
+data SnapEnv crypto
   = SnapEnv
       PParams
-      (DState hashAlgo dsignAlgo)
-      (PState hashAlgo dsignAlgo vrfAlgo)
+      (DState crypto)
+      (PState crypto)
 
-instance STS (SNAP hashAlgo dsignAlgo vrfAlgo) where
-  type State (SNAP hashAlgo dsignAlgo vrfAlgo) = SnapState hashAlgo dsignAlgo vrfAlgo
-  type Signal (SNAP hashAlgo dsignAlgo vrfAlgo) = Epoch
-  type Environment (SNAP hashAlgo dsignAlgo vrfAlgo) = SnapEnv hashAlgo dsignAlgo vrfAlgo
-  data PredicateFailure (SNAP hashAlgo dsignAlgo vrfAlgo)
+instance STS (SNAP crypto) where
+  type State (SNAP crypto) = SnapState crypto
+  type Signal (SNAP crypto) = Epoch
+  type Environment (SNAP crypto) = SnapEnv crypto
+  data PredicateFailure (SNAP crypto)
     = FailureSNAP
     deriving (Show, Eq)
 
@@ -47,7 +47,7 @@ instance STS (SNAP hashAlgo dsignAlgo vrfAlgo) where
     [pure $ SnapState emptySnapShots (UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyUpdateState)]
   transitionRules = [snapTransition]
 
-snapTransition :: TransitionRule (SNAP hashAlgo dsignAlgo vrfAlgo)
+snapTransition :: TransitionRule (SNAP crypto)
 snapTransition = do
   TRC (SnapEnv pparams d p, SnapState s u, eNew) <- judgmentContext
   let pooledStake = stakeDistr (u ^. utxo) d p

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
@@ -17,44 +17,45 @@ import           Updates
 
 import           Control.State.Transition
 
+import           Cardano.Ledger.Shelley.Crypto
 import           STS.Avup
 import           STS.Ppup
 
-data UP hashAlgo dsignAlgo
+data UP crypto
 
-data UpdateEnv hashAlgo dsignAlgo
-  = UpdateEnv Slot PParams (GenDelegs hashAlgo dsignAlgo)
+data UpdateEnv crypto
+  = UpdateEnv Slot PParams (GenDelegs crypto)
 
-instance DSIGNAlgorithm dsignAlgo => STS (UP hashAlgo dsignAlgo) where
-  type State (UP hashAlgo dsignAlgo) = UpdateState hashAlgo dsignAlgo
-  type Signal (UP hashAlgo dsignAlgo) = Update hashAlgo dsignAlgo
-  type Environment (UP hashAlgo dsignAlgo) = UpdateEnv hashAlgo dsignAlgo
-  data PredicateFailure (UP hashAlgo dsignAlgo)
+instance Crypto crypto => STS (UP crypto) where
+  type State (UP crypto) = UpdateState crypto
+  type Signal (UP crypto) = Update crypto
+  type Environment (UP crypto) = UpdateEnv crypto
+  data PredicateFailure (UP crypto)
     = NonGenesisUpdateUP
-    | AvupFailure (PredicateFailure (AVUP hashAlgo dsignAlgo))
-    | PpupFailure (PredicateFailure (PPUP hashAlgo dsignAlgo))
+    | AvupFailure (PredicateFailure (AVUP crypto))
+    | PpupFailure (PredicateFailure (PPUP crypto))
     deriving (Show, Eq)
 
   initialRules = []
   transitionRules = [upTransition]
 
 upTransition
-  :: forall hashAlgo dsignAlgo
-   . DSIGNAlgorithm dsignAlgo
-  => TransitionRule (UP hashAlgo dsignAlgo)
+  :: forall crypto
+   . Crypto crypto
+  => TransitionRule (UP crypto)
 upTransition = do
   TRC ( UpdateEnv _slot pp _genDelegs
       , UpdateState pupS aupS favs avs
       , Update pup _aup) <- judgmentContext
 
-  pup' <- trans @(PPUP hashAlgo dsignAlgo) $ TRC (PPUPEnv _slot pp _genDelegs, pupS, pup)
+  pup' <- trans @(PPUP crypto) $ TRC (PPUPEnv _slot pp _genDelegs, pupS, pup)
   AVUPState aup' favs' avs' <-
-    trans @(AVUP hashAlgo dsignAlgo) $ TRC (AVUPEnv _slot _genDelegs, AVUPState aupS favs avs, _aup)
+    trans @(AVUP crypto) $ TRC (AVUPEnv _slot _genDelegs, AVUPState aupS favs avs, _aup)
 
   pure $ UpdateState pup' aup' favs' avs'
 
-instance DSIGNAlgorithm dsignAlgo => Embed (AVUP hashAlgo dsignAlgo) (UP hashAlgo dsignAlgo) where
+instance Crypto crypto => Embed (AVUP crypto) (UP crypto) where
   wrapFailed = AvupFailure
 
-instance DSIGNAlgorithm dsignAlgo => Embed (PPUP hashAlgo dsignAlgo) (UP hashAlgo dsignAlgo) where
+instance Crypto crypto => Embed (PPUP crypto) (UP crypto) where
   wrapFailed = PpupFailure

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -80,7 +80,7 @@ import           MockTypes (AVUpdate, Addr, Applications, Block, CHAIN, Certifie
                      Credential, DState, EpochState, GenKeyHash, HashHeader, KeyHash, KeyPair,
                      LedgerState, Mdt, NewEpochState, PPUpdate, PState, PoolDistr, PoolParams,
                      RewardAcnt, SKey, SKeyES, SignKeyVRF, SnapShots, Stake, Tx, TxBody, UTxO,
-                     UTxOState, Update, UpdateState, VKey, VKeyES, VKeyGenesis, VerKeyVRF)
+                     UTxOState, Update, UpdateState, VKey, VKeyES, VKeyGenesis, VerKeyVRF, hashKeyVRF)
 import           Numeric.Natural (Natural)
 import           Unsafe.Coerce (unsafeCoerce)
 
@@ -96,7 +96,7 @@ import           Delegation.Certificates (pattern DeRegKey, pattern Delegate,
 import           EpochBoundary (BlocksMade (..), pattern SnapShots, pattern Stake, emptySnapShots,
                      _feeSS, _poolsSS, _pstakeGo, _pstakeMark, _pstakeSet)
 import           Keys (pattern GenDelegs, Hash, pattern KeyPair, pattern SKey, pattern SKeyES,
-                     pattern VKey, pattern VKeyES, pattern VKeyGenesis, hash, hashKey, hashKeyVRF,
+                     pattern VKey, pattern VKeyES, pattern VKeyGenesis, hash, hashKey,
                      sKey, sign, signKES, vKey)
 import           LedgerState (AccountState (..), pattern DPState, pattern EpochState,
                      pattern LedgerState, pattern NewEpochState, pattern RewardUpdate,

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -24,11 +25,11 @@ import           Delegation.Certificates (pattern DeRegKey, pattern RegKey, patt
                      decayKey, isDeRegKey)
 import           Examples (unsafeMkUnitInterval)
 import           Generator.Core (genInteger, genNatural, toCred)
-import           Keys (hashKey, hashKeyVRF, vKey)
+import           Keys (hashKey, vKey)
 import           Ledger.Core (dom, (∈), (∉))
 import           LedgerState (dstate, keyRefund, pParams, pstate, stkCreds, _pstate, _stPools,
                      _stkCreds)
-import           MockTypes (DCert, DPState, DState, KeyPair, KeyPairs, PoolParams, VrfKeyPairs)
+import           MockTypes (DCert, DPState, DState, KeyPair, KeyPairs, PoolParams, VrfKeyPairs, hashKeyVRF)
 import           Mutator (getAnyStakeKey)
 import           PParams (PParams (..))
 import           Slot (Slot)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
@@ -10,10 +10,7 @@
 
 module Generator.LedgerTrace where
 
-import           Cardano.Crypto.DSIGN.Mock (MockDSIGN)
-import           Cardano.Crypto.Hash (ShortHash)
-import           Cardano.Crypto.VRF.Fake (FakeVRF)
-
+import           MockTypes (MockCrypto)
 import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 import           Generator.Core (genCoin, traceKeyPairs, traceVRFKeyPairs)
 import           Generator.Update (genPParams)
@@ -23,7 +20,7 @@ import           STS.Ledger (LEDGER, LedgerEnv (..))
 
 -- The LEDGER STS combines utxo and delegation rules and allows for generating transactions
 -- with meaningful delegation certificates.
-instance HasTrace (LEDGER ShortHash MockDSIGN FakeVRF)
+instance HasTrace (LEDGER MockCrypto)
   where
     envGen _ =
       LedgerEnv <$> pure (Slot 0)

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module MockTypes where
 
@@ -26,141 +29,155 @@ import qualified Tx
 import qualified TxData
 import qualified Updates
 import qualified UTxO
+import           Cardano.Ledger.Shelley.Crypto
 
-type DCert = Delegation.Certificates.DCert ShortHash MockDSIGN FakeVRF
+data MockCrypto
 
-type PoolDistr = Delegation.Certificates.PoolDistr ShortHash MockDSIGN FakeVRF
+instance Crypto MockCrypto where
+  type HASH MockCrypto = ShortHash
+  type DSIGN MockCrypto = MockDSIGN
+  type KES MockCrypto = MockKES
+  type VRF MockCrypto = FakeVRF
 
-type Delegation = TxData.Delegation ShortHash MockDSIGN
+type DCert = Delegation.Certificates.DCert MockCrypto
 
-type PoolParams = TxData.PoolParams ShortHash MockDSIGN FakeVRF
+type PoolDistr = Delegation.Certificates.PoolDistr MockCrypto
 
-type RewardAcnt = TxData.RewardAcnt ShortHash MockDSIGN
+type Delegation = TxData.Delegation MockCrypto
 
-type StakePools = TxData.StakePools ShortHash MockDSIGN
+type PoolParams = TxData.PoolParams MockCrypto
 
-type KeyHash = Keys.KeyHash ShortHash MockDSIGN
+type RewardAcnt = TxData.RewardAcnt MockCrypto
 
-type GenKeyHash = Keys.GenKeyHash ShortHash MockDSIGN
+type StakePools = TxData.StakePools MockCrypto
 
-type KeyPair = Keys.KeyPair 'Keys.Regular MockDSIGN
+type KeyHash = Keys.KeyHash MockCrypto
 
-type VKey = Keys.VKey MockDSIGN
+type GenKeyHash = Keys.GenKeyHash MockCrypto
 
-type SKey = Keys.SKey MockDSIGN
+type KeyPair = Keys.KeyPair 'Keys.Regular MockCrypto
 
-type KeyPairs = LedgerState.KeyPairs MockDSIGN
+type VKey = Keys.VKey MockCrypto
 
-type VKeyGenesis = Keys.VKeyGenesis MockDSIGN
+type SKey = Keys.SKey MockCrypto
 
-type EpochState = LedgerState.EpochState ShortHash MockDSIGN FakeVRF
+type KeyPairs = LedgerState.KeyPairs MockCrypto
 
-type NEWEPOCH = STS.NewEpoch.NEWEPOCH ShortHash MockDSIGN FakeVRF
+type VKeyGenesis = Keys.VKeyGenesis MockCrypto
 
-type LedgerState = LedgerState.LedgerState ShortHash MockDSIGN FakeVRF
+type EpochState = LedgerState.EpochState MockCrypto
 
-type LedgerValidation = LedgerState.LedgerValidation ShortHash MockDSIGN FakeVRF
+type NEWEPOCH = STS.NewEpoch.NEWEPOCH MockCrypto
 
-type UTxOState = LedgerState.UTxOState ShortHash MockDSIGN FakeVRF
+type LedgerState = LedgerState.LedgerState MockCrypto
 
-type DState = LedgerState.DState ShortHash MockDSIGN
+type LedgerValidation = LedgerState.LedgerValidation MockCrypto
 
-type PState = LedgerState.PState ShortHash MockDSIGN FakeVRF
+type UTxOState = LedgerState.UTxOState MockCrypto
 
-type DPState = LedgerState.DPState ShortHash MockDSIGN FakeVRF
+type DState = LedgerState.DState MockCrypto
 
-type Addr = TxData.Addr ShortHash MockDSIGN
+type PState = LedgerState.PState MockCrypto
 
-type Tx = Tx.Tx ShortHash MockDSIGN FakeVRF
+type DPState = LedgerState.DPState MockCrypto
 
-type TxBody = Tx.TxBody ShortHash MockDSIGN FakeVRF
+type Addr = TxData.Addr MockCrypto
 
-type TxIn = Tx.TxIn ShortHash MockDSIGN FakeVRF
+type Tx = Tx.Tx MockCrypto
 
-type TxOut = Tx.TxOut ShortHash MockDSIGN
+type TxBody = Tx.TxBody MockCrypto
 
-type TxId = TxData.TxId ShortHash MockDSIGN FakeVRF
+type TxIn = Tx.TxIn MockCrypto
 
-type UTxO = UTxO.UTxO ShortHash MockDSIGN FakeVRF
+type TxOut = Tx.TxOut MockCrypto
 
-type Block = BlockChain.Block ShortHash MockDSIGN MockKES FakeVRF
+type TxId = TxData.TxId MockCrypto
 
-type BHBody = BlockChain.BHBody ShortHash MockDSIGN MockKES FakeVRF
+type UTxO = UTxO.UTxO MockCrypto
 
-type SKeyES = Keys.SKeyES MockKES
+type Block = BlockChain.Block MockCrypto
 
-type VKeyES = Keys.VKeyES MockKES
+type BHBody = BlockChain.BHBody MockCrypto
 
-type SignKeyVRF = Keys.SignKeyVRF FakeVRF
+type SKeyES = Keys.SKeyES MockCrypto
 
-type VerKeyVRF = Keys.VerKeyVRF FakeVRF
+type VKeyES = Keys.VKeyES MockCrypto
+
+type SignKeyVRF = Keys.SignKeyVRF (VRF MockCrypto)
+
+type VerKeyVRF = Keys.VerKeyVRF (VRF MockCrypto)
 
 type VrfKeyPairs = [(SignKeyVRF, VerKeyVRF)]
 
-type CertifiedVRF = Keys.CertifiedVRF FakeVRF
+type CertifiedVRF = Keys.CertifiedVRF (VRF MockCrypto)
 
-type KESig = Keys.KESig MockKES BHBody
+type KESig = Keys.KESig MockCrypto BHBody
 
-type Sig a = Keys.Sig MockDSIGN a
+type Sig a = Keys.Sig MockCrypto a
 
-type BHeader = BlockChain.BHeader ShortHash MockDSIGN MockKES
+type BHeader = BlockChain.BHeader MockCrypto
 
-type OCert = OCert.OCert MockDSIGN MockKES
+type OCert = OCert.OCert MockCrypto
 
-type HashHeader = BlockChain.HashHeader ShortHash MockDSIGN MockKES FakeVRF
+type HashHeader = BlockChain.HashHeader MockCrypto
 
-type NewEpochState = LedgerState.NewEpochState ShortHash MockDSIGN FakeVRF
+type NewEpochState = LedgerState.NewEpochState MockCrypto
 
-type RewardUpdate = LedgerState.RewardUpdate ShortHash MockDSIGN
+type RewardUpdate = LedgerState.RewardUpdate MockCrypto
 
-type ChainState = STS.Chain.ChainState ShortHash MockDSIGN MockKES FakeVRF
+type ChainState = STS.Chain.ChainState MockCrypto
 
-type CHAIN = STS.Chain.CHAIN ShortHash MockDSIGN MockKES FakeVRF
+type CHAIN = STS.Chain.CHAIN MockCrypto
 
-type UTXOW = STS.Utxow.UTXOW ShortHash MockDSIGN FakeVRF
+type UTXOW = STS.Utxow.UTXOW MockCrypto
 
-type UTXO = STS.Utxo.UTXO ShortHash MockDSIGN FakeVRF
+type UTXO = STS.Utxo.UTXO MockCrypto
 
-type UtxoEnv = STS.Utxo.UtxoEnv ShortHash MockDSIGN
+type UtxoEnv = STS.Utxo.UtxoEnv MockCrypto
 
-type DELEG = STS.Deleg.DELEG ShortHash MockDSIGN FakeVRF
+type DELEG = STS.Deleg.DELEG MockCrypto
 
-type LEDGER = STS.Ledger.LEDGER ShortHash MockDSIGN FakeVRF
+type LEDGER = STS.Ledger.LEDGER MockCrypto
 
 type LedgerEnv = STS.Ledger.LedgerEnv
 
-type DELEGS = STS.Delegs.DELEGS ShortHash MockDSIGN FakeVRF
+type DELEGS = STS.Delegs.DELEGS MockCrypto
 
-type POOL = STS.Pool.POOL ShortHash MockDSIGN FakeVRF
+type POOL = STS.Pool.POOL MockCrypto
 
-type POOLREAP = STS.PoolReap.POOLREAP ShortHash MockDSIGN FakeVRF
+type POOLREAP = STS.PoolReap.POOLREAP MockCrypto
 
-type Credential = TxData.Credential ShortHash MockDSIGN
+type Credential = TxData.Credential MockCrypto
 
-type StakeCredential = TxData.StakeCredential ShortHash MockDSIGN
+type StakeCredential = TxData.StakeCredential MockCrypto
 
-type StakeCreds = TxData.StakeCreds ShortHash MockDSIGN
+type StakeCreds = TxData.StakeCreds MockCrypto
 
-type MultiSig = TxData.MultiSig ShortHash MockDSIGN
+type MultiSig = TxData.MultiSig MockCrypto
 
-type ScriptHash = TxData.ScriptHash ShortHash MockDSIGN
+type ScriptHash = TxData.ScriptHash MockCrypto
 
-type WitVKey = TxData.WitVKey ShortHash MockDSIGN
+type WitVKey = TxData.WitVKey MockCrypto
 
-type Wdrl = TxData.Wdrl ShortHash MockDSIGN
+type Wdrl = TxData.Wdrl MockCrypto
 
-type SnapShots = EpochBoundary.SnapShots ShortHash MockDSIGN FakeVRF
+type SnapShots = EpochBoundary.SnapShots MockCrypto
 
-type Stake = EpochBoundary.Stake ShortHash MockDSIGN
+type Stake = EpochBoundary.Stake MockCrypto
 
-type Mdt = Updates.Mdt ShortHash
+type Mdt = Updates.Mdt MockCrypto
 
-type Applications = Updates.Applications ShortHash
+type Applications = Updates.Applications MockCrypto
 
-type Update = Updates.Update ShortHash MockDSIGN
+type Update = Updates.Update MockCrypto
 
-type UpdateState = Updates.UpdateState ShortHash MockDSIGN
+type UpdateState = Updates.UpdateState MockCrypto
 
-type PPUpdate = Updates.PPUpdate ShortHash MockDSIGN
+type PPUpdate = Updates.PPUpdate MockCrypto
 
-type AVUpdate = Updates.AVUpdate ShortHash MockDSIGN
+type AVUpdate = Updates.AVUpdate MockCrypto
+
+hashKeyVRF
+  :: Keys.VerKeyVRF FakeVRF
+  -> Keys.Hash ShortHash (Keys.VerKeyVRF FakeVRF)
+hashKeyVRF = Keys.hashKeyVRF @MockCrypto

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -25,7 +25,7 @@ import           TxData (pattern AddrBase, Credential (..), Delegation (..), pat
                      pattern Ptr, pattern RewardAcnt, _poolCost, _poolMargin, _poolOwners,
                      _poolPledge, _poolPubKey, _poolRAcnt, _poolVrf)
 
-import           Keys (pattern GenDelegs, pattern KeyPair, hashKey, hashKeyVRF, vKey)
+import           Keys (pattern GenDelegs, pattern KeyPair, hashKey, vKey)
 import           LedgerState (pattern LedgerState, pattern UTxOState, ValidationError (..),
                      asStateTransition, delegationState, delegations, dstate,
                      emptyDelegation, genesisId, genesisCoins, genesisState, minfee, pParams, pstate, ptrs,


### PR DESCRIPTION
Should have bitten this bullet earlier, but got fed up of all the
parameters and decided to do it now. We now talk only in terms of a
single `Crypto` class throughout the code.