### PR TITLE
[926] Test invalid trace profile for LEDGER STS - Invalid RegKey certs

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Coin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -8,11 +9,12 @@ module Coin
     ) where
 
 import           Cardano.Binary (ToCBOR)
-import           Cardano.Prelude (NoUnexpectedThunks(..))
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+import           Data.Data (Data)
 
 -- |The amount of value held by a transaction output.
 newtype Coin = Coin Integer
-  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks, ToCBOR)
+  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks, ToCBOR, Data)
 
 splitCoin :: Coin -> Integer -> (Coin, Coin)
 splitCoin (Coin n) 0 = (Coin 0, Coin n)

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -120,6 +121,7 @@ import           Cardano.Ledger.Shelley.Crypto
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Coin (Coin (..))
 import           Control.Monad (foldM)
+import           Data.Data (Data)
 import           Data.Foldable (toList)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -199,7 +201,7 @@ data ValidationError =
   | StakeDelegationImpossible
   -- | Stake pool not registered for key, cannot be retired.
   | StakePoolNotRegisteredOnKey
-    deriving (Show, Eq, Generic)
+    deriving (Show, Eq, Generic, Data)
 
 instance NoUnexpectedThunks ValidationError
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -9,6 +10,7 @@ module STS.Avup
   )
 where
 
+import           Data.Data (Data)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 
@@ -22,6 +24,7 @@ import           Data.Maybe
 import           Ledger.Core (dom, range, (⊆), (⨃))
 
 data AVUP crypto
+  deriving Data
 
 data AVUPState crypto
   = AVUPState
@@ -46,7 +49,7 @@ instance STS (AVUP crypto) where
     | CannotFollow
     | InvalidName
     | InvalidSystemTags
-    deriving (Show, Eq)
+    deriving (Show, Eq, Data)
 
   initialRules = []
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -8,6 +9,7 @@ module STS.Deleg
   )
 where
 
+import           Data.Data (Data)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 
@@ -27,6 +29,7 @@ import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 import           Hedgehog (Gen)
 
 data DELEG crypto
+  deriving Data
 
 data DelegEnv
   = DelegEnv
@@ -51,7 +54,7 @@ instance STS (DELEG crypto)
     | DuplicateGenesisDelegateDELEG
     | InsufficientForInstantaneousRewardsDELEG
     | MIRCertificateTooLateinEpochDELEG
-    deriving (Show, Eq)
+    deriving (Show, Eq, Data)
 
   initialRules = [pure emptyDState]
   transitionRules = [delegationTransition]

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delegs.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -11,9 +12,9 @@ module STS.Delegs
   )
 where
 
-import qualified Data.Set as Set
-
+import           Data.Data (Data)
 import           Data.Sequence (Seq (..))
+import qualified Data.Set as Set
 
 import           Coin (Coin)
 import           Delegation.Certificates
@@ -34,6 +35,7 @@ import           Ledger.Core (dom, (∈), (⊆), (⨃))
 import           Hedgehog (Gen)
 
 data DELEGS crypto
+  deriving Data
 
 data DelegsEnv crypto
   = DelegsEnv
@@ -56,7 +58,7 @@ instance
     = DelegateeNotRegisteredDELEG
     | WithrawalsNotInRewardsDELEGS
     | DelplFailure (PredicateFailure (DELPL crypto))
-    deriving (Show, Eq)
+    deriving (Show, Eq, Data)
 
   initialRules    = [ pure emptyDelegation ]
   transitionRules = [ delegsTransition     ]

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -10,6 +11,8 @@ module STS.Delpl
   , PredicateFailure(..)
   )
 where
+
+import           Data.Data (Data)
 
 import           Coin (Coin)
 import           Delegation.Certificates
@@ -25,6 +28,7 @@ import           STS.Deleg
 import           STS.Pool
 
 data DELPL crypto
+  deriving Data
 
 data DelplEnv
   = DelplEnv
@@ -47,7 +51,7 @@ instance
     | ScriptNotInWitnessDELPL
     | ScriptHashNotMatchDELPL
     | ScriptDoesNotValidateDELPL
-    deriving (Show, Eq)
+    deriving (Show, Eq, Data)
 
   initialRules    = [ pure emptyDelegation ]
   transitionRules = [ delplTransition      ]

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ledger.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -13,8 +14,10 @@ module STS.Ledger
   )
 where
 
+import           Data.Data (Data)
 import           Lens.Micro ((^.))
 
+import           Cardano.Ledger.Shelley.Crypto
 import           Coin (Coin)
 import           Control.State.Transition
 import           Keys
@@ -25,9 +28,9 @@ import           STS.Delegs
 import           STS.Utxo (UtxoEnv (..))
 import           STS.Utxow
 import           Tx
-import           Cardano.Ledger.Shelley.Crypto
 
 data LEDGER crypto
+  deriving Data
 
 data LedgerEnv
   = LedgerEnv
@@ -51,7 +54,7 @@ instance
   data PredicateFailure (LEDGER crypto)
     = UtxowFailure (PredicateFailure (UTXOW crypto))
     | DelegsFailure (PredicateFailure (DELEGS crypto))
-    deriving (Show, Eq)
+    deriving (Show, Eq, Data)
 
   initialRules = []
   transitionRules = [ledgerTransition]

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -6,7 +7,7 @@ module STS.Pool
   , PoolEnv (..)
   )
 where
-
+import           Data.Data (Data)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -26,6 +27,7 @@ import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 import           Hedgehog (Gen)
 
 data POOL crypto
+  deriving Data
 
 data PoolEnv =
   PoolEnv Slot PParams
@@ -40,7 +42,7 @@ instance STS (POOL crypto)
     = StakePoolNotRegisteredOnKeyPOOL
     | StakePoolRetirementWrongEpochPOOL
     | WrongCertificateTypePOOL
-    deriving (Show, Eq)
+    deriving (Show, Eq, Data)
 
   initialRules = [pure emptyPState]
   transitionRules = [poolDelegationTransition]

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -9,6 +10,8 @@ module STS.Up
   , UpdateEnv(..)
   )
 where
+
+import           Data.Data (Data)
 
 import           Keys
 import           PParams
@@ -22,6 +25,7 @@ import           STS.Avup
 import           STS.Ppup
 
 data UP crypto
+  deriving Data
 
 data UpdateEnv crypto
   = UpdateEnv Slot PParams (GenDelegs crypto)
@@ -34,7 +38,7 @@ instance Crypto crypto => STS (UP crypto) where
     = NonGenesisUpdateUP
     | AvupFailure (PredicateFailure (AVUP crypto))
     | PpupFailure (PredicateFailure (PPUP crypto))
-    deriving (Show, Eq)
+    deriving (Show, Eq, Data)
 
   initialRules = []
   transitionRules = [upTransition]

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -12,11 +13,15 @@ module STS.Utxo
   )
 where
 
+import           Data.Data (Data)
 import           Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-
+import           Hedgehog (Gen)
 import           Lens.Micro ((^.))
+
+import           Control.State.Transition
+import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 
 import           Coin
 import           Delegation.Certificates
@@ -25,20 +30,15 @@ import           Ledger.Core (dom, range, (∪), (⊆), (⋪))
 import           LedgerState
 import           PParams
 import           Slot
+import           STS.Up
 import           Tx
-
 import           Updates
 import           UTxO
 
 import           Cardano.Ledger.Shelley.Crypto
-import           Control.State.Transition
-import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
-
-import           STS.Up
-
-import           Hedgehog (Gen)
 
 data UTXO crypto
+  deriving Data
 
 data UtxoEnv crypto
   = UtxoEnv
@@ -69,7 +69,8 @@ instance
                                               -- failures?
     | UnexpectedSuccessUTXO
     | UpdateFailure (PredicateFailure (UP crypto))
-    deriving (Eq, Show)
+    deriving (Eq, Show, Data)
+
   transitionRules = [utxoInductive]
   initialRules = [initialLedgerState]
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxow.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -12,6 +13,7 @@ module STS.Utxow
   )
 where
 
+import           Data.Data (Data)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq (filter)
 import qualified Data.Set as Set
@@ -34,6 +36,7 @@ import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
 import           Hedgehog (Gen)
 
 data UTXOW crypto
+  deriving Data
 
 instance
   ( Crypto crypto
@@ -52,7 +55,7 @@ instance
     | UtxoFailure (PredicateFailure (UTXO crypto))
     | MIRInsufficientGenesisSigsUTXOW
     | MIRImpossibleInDecentralizedNetUTXOW
-    deriving (Eq, Show)
+    deriving (Eq, Show, Data)
 
   transitionRules = [utxoWitnessed]
   initialRules = [initialLedgerStateUTXOW]

--- a/shelley/chain-and-ledger/executable-spec/src/Slot.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Slot.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -23,18 +24,19 @@ module Slot
   )
 where
 
-import           Data.Word                      ( Word64 )
-import           Numeric.Natural                ( Natural )
-import           GHC.Generics                   ( Generic )
-import           Cardano.Binary                 ( ToCBOR )
-import           Cardano.Prelude                ( NoUnexpectedThunks(..) )
+import           Data.Data (Data)
+import           Numeric.Natural (Natural)
+import           Data.Word ( Word64 )
+import           GHC.Generics ( Generic )
 
-import qualified Ledger.Core                   as Byron
-                                                ( Slot(..) )
+import           Cardano.Binary (ToCBOR)
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+
+import qualified Ledger.Core as Byron (Slot (..))
 
 -- |A Slot
 newtype Slot = Slot Natural
-  deriving (Show, Eq, Ord, NoUnexpectedThunks, Num, ToCBOR)
+  deriving (Show, Eq, Ord, NoUnexpectedThunks, Num, ToCBOR, Data)
 
 instance Semigroup Slot where
   (Slot x) <> (Slot y) = Slot $ x + y

--- a/shelley/chain-and-ledger/executable-spec/test/Cardano/Crypto/VRF/Fake.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Cardano/Crypto/VRF/Fake.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
@@ -22,11 +23,13 @@ import Cardano.Crypto.Hash
 import Cardano.Crypto.Util (nonNegIntR)
 import Cardano.Crypto.VRF.Class
 import Cardano.Prelude (NoUnexpectedThunks, UseIsNormalForm(..))
+import Data.Data (Data)
 import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
 
 data FakeVRF
+  deriving Data
 
 -- | A class for seeds which sneakily contain the certified natural we wish to
 -- "randomly" derive from them.

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
@@ -3,7 +3,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Generator.Core
-  ( findPayKeyPair
+  ( GenValidity (..)
+  , findPayKeyPair
   , genBool
   , genCoin
   , genInteger
@@ -38,6 +39,9 @@ import           MockTypes (Addr, DPState, KeyPair, KeyPairs, LedgerEnv, SignKey
 import           Numeric.Natural (Natural)
 import           Tx (pattern TxOut)
 import           TxData (pattern AddrBase, pattern KeyHashObj)
+
+-- | Switch between generating Valid or Invalid values
+data GenValidity = GenValid | GenInvalid
 
 genBool :: Gen Bool
 genBool = Gen.enumBounded

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
@@ -12,7 +12,7 @@ module Generator.LedgerTrace where
 
 import           MockTypes (MockCrypto)
 import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
-import           Generator.Core (genCoin, traceKeyPairs, traceVRFKeyPairs)
+import           Generator.Core (GenValidity (..), genCoin, traceKeyPairs, traceVRFKeyPairs)
 import           Generator.Update (genPParams)
 import           Generator.Utxo (genTx)
 import           Slot (Slot (..))
@@ -29,4 +29,4 @@ instance HasTrace (LEDGER MockCrypto)
                 <*> genCoin 0 1000
 
     sigGen ledgerEnv ledgerSt =
-      genTx ledgerEnv ledgerSt traceKeyPairs traceVRFKeyPairs
+      genTx ledgerEnv ledgerSt traceKeyPairs traceVRFKeyPairs GenValid

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo.hs
@@ -20,7 +20,7 @@ import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
 import           Coin (Coin (..), splitCoin)
-import           Generator.Core (findPayKeyPair, toAddr)
+import           Generator.Core (GenValidity, findPayKeyPair, toAddr)
 import           Generator.Delegation (genDCerts)
 import           LedgerState (pattern UTxOState)
 import           MockTypes (Addr, DCert, DPState, KeyPair, KeyPairs, Tx, TxBody, TxIn, TxOut, UTxO,
@@ -39,8 +39,9 @@ genTx :: LedgerEnv
       -> (UTxOState, DPState)
       -> KeyPairs
       -> VrfKeyPairs
+      -> GenValidity
       -> Gen Tx
-genTx (LedgerEnv slot _ pparams _) (UTxOState utxo _ _ _, dpState) keys vrfKeys = do
+genTx (LedgerEnv slot _ pparams _) (UTxOState utxo _ _ _, dpState) keys vrfKeys validity = do
   keys' <- Gen.shuffle keys
 
   -- inputs
@@ -55,7 +56,7 @@ genTx (LedgerEnv slot _ pparams _) (UTxOState utxo _ _ _, dpState) keys vrfKeys 
 
   -- certificates
   (certs, certWitnesses, deposits_, refunds_)
-    <- genDCerts keys' vrfKeys pparams dpState slotWithTTL
+    <- genDCerts keys' vrfKeys pparams dpState slotWithTTL validity
 
   -- attempt to make provision for certificate deposits (otherwise discard this generator)
   when (spendingBalance < deposits_) Gen.discard

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -12,20 +12,19 @@ import qualified Data.Set as Set
 
 import           Lens.Micro ((%~), (&), (.~), (^.))
 
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
 import           Hedgehog.Internal.Property (LabelName (..))
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
-
-import           Hedgehog
-import qualified Hedgehog.Gen as Gen
 
 import           Coin
 import           Ledger.Core ((<|))
 import           LedgerState hiding (genDelegs)
 import           PParams
 import           Rules.ClassifyTraces (onlyValidLedgerSignalsAreGenerated, relevantCasesAreCovered)
-import           Rules.TestLedger (credentialRemovedAfterDereg, pStateIsInternallyConsistent,
-                     registeredPoolIsAdded, rewardZeroAfterReg)
+import           Rules.TestLedger (credentialRemovedAfterDereg, invalidDelegSignalsAreGenerated,
+                     pStateIsInternallyConsistent, registeredPoolIsAdded, rewardZeroAfterReg)
 import           Slot
 import           Tx (pattern TxIn, pattern TxOut, body, certs, inputs, outputs, witnessVKeySet,
                      _body, _witnessVKeySet)
@@ -211,9 +210,12 @@ propertyTests = testGroup "Property-Based Testing"
                     classifyInvalidDoubleSpend
                   ]
                 , testGroup "Properties of Trace generators"
-                  [testProperty
-                   "Only valid LEDGER STS signals are generated"
-                   onlyValidLedgerSignalsAreGenerated
+                  [ testProperty
+                    "Only valid LEDGER STS signals are generated"
+                    onlyValidLedgerSignalsAreGenerated
+                  , testProperty
+                    "Invalid LEDGER STS signals are generated when required"
+                    invalidDelegSignalsAreGenerated
                   ]
                 ]
 

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestLedger.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestLedger.hs
@@ -1,40 +1,65 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
+
+-- Enable standalone Data instances for ShortHash and MockDSIGN (in cardano-base)
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Rules.TestLedger
   ( rewardZeroAfterReg
   , credentialRemovedAfterDereg
   , consumedEqualsProduced
+  , invalidDelegSignalsAreGenerated
   , registeredPoolIsAdded
   , pStateIsInternallyConsistent
   )
 where
 
+import           Data.Data (Data)
 import           Data.Foldable (toList)
 import           Data.Word (Word64)
+import           GHC.Stack (HasCallStack)
 import           Lens.Micro ((^.))
 
-import           Hedgehog (Property, forAll, property, withTests)
+import           Hedgehog (MonadTest, Property, forAll, property, withTests)
+import           Hedgehog.Internal.Property (CoverPercentage)
 
-import           Control.State.Transition.Generator (ofLengthAtLeast, trace,
-                     traceOfLengthWithInitState)
+import           Control.State.Transition (PredicateFailure)
+import           Control.State.Transition.Generator (SignalGenerator, TraceProfile (TraceProfile),
+                     coverFailures, failures, invalidSignalsAreGeneratedForTrace, ofLengthAtLeast,
+                     proportionOfValidSignals, trace, traceOfLengthWithInitState)
 import           Control.State.Transition.Trace (SourceSignalTarget (..), source,
                      sourceSignalTargets, target, traceEnv)
-import           Generator.Core (mkGenesisLedgerState)
+import           Generator.Core (GenValidity (..), mkGenesisLedgerState, traceKeyPairs,
+                     traceVRFKeyPairs)
 import           Generator.LedgerTrace ()
+import           Generator.Utxo (genTx)
 
+import           Cardano.Crypto.DSIGN (MockDSIGN)
+import           Cardano.Crypto.Hash.Short (ShortHash)
 import           Coin (pattern Coin)
 import           LedgerState (pattern DPState, pattern DState, pattern UTxOState, _deposited,
                      _dstate, _fees, _rewards, _utxo)
-import           MockTypes (DELEG, LEDGER, POOL)
+import           MockTypes (DELEG, LEDGER, MockCrypto, POOL)
 import qualified Rules.TestDeleg as TestDeleg
 import qualified Rules.TestPool as TestPool
+import           STS.Deleg
+                     (PredicateFailure (StakeKeyAlreadyRegisteredDELEG, StakeKeyNotRegisteredDELEG))
+import           STS.Ledger (pattern DelegsFailure, PredicateFailure (..))
 import           TxData (body, certs)
 import           UTxO (balance)
 
 import           Test.Utils (assertAll)
+
+-- We need Data instances for these types in `cardano-base`
+deriving instance Data ShortHash
+deriving instance Data MockDSIGN
+deriving instance Data MockCrypto
 
 ------------------------------
 -- Constants for Properties --
@@ -54,9 +79,7 @@ traceLen = 100
 rewardZeroAfterReg :: Property
 rewardZeroAfterReg = withTests (fromIntegral numberOfTests) . property $ do
   t <- forAll
-       (traceOfLengthWithInitState @LEDGER
-                                   (fromIntegral traceLen)
-                                   mkGenesisLedgerState
+       (traceOfLengthWithInitState @LEDGER (fromIntegral traceLen) mkGenesisLedgerState
         `ofLengthAtLeast` 1)
 
   TestDeleg.rewardZeroAfterReg
@@ -68,9 +91,7 @@ credentialRemovedAfterDereg =
   withTests (fromIntegral numberOfTests) . property $ do
     tr <- fmap sourceSignalTargets
           $ forAll
-          $ traceOfLengthWithInitState @LEDGER
-                                     (fromIntegral traceLen)
-                                     mkGenesisLedgerState
+          $ traceOfLengthWithInitState @LEDGER (fromIntegral traceLen) mkGenesisLedgerState
             `ofLengthAtLeast` 1
     TestDeleg.credentialRemovedAfterDereg
       (concatMap ledgerToDelegSsts tr)
@@ -113,9 +134,7 @@ registeredPoolIsAdded :: Property
 registeredPoolIsAdded = do
   withTests (fromIntegral numberOfTests) . property $ do
     tr <- forAll
-          $ traceOfLengthWithInitState @LEDGER
-                                     (fromIntegral traceLen)
-                                     mkGenesisLedgerState
+          $ traceOfLengthWithInitState @LEDGER (fromIntegral traceLen) mkGenesisLedgerState
             `ofLengthAtLeast` 1
     TestPool.registeredPoolIsAdded
       (tr ^. traceEnv)
@@ -126,9 +145,7 @@ pStateIsInternallyConsistent :: Property
 pStateIsInternallyConsistent = do
   withTests (fromIntegral numberOfTests) . property $ do
     tr <- forAll
-          $ traceOfLengthWithInitState @LEDGER
-                                     (fromIntegral traceLen)
-                                     mkGenesisLedgerState
+          $ traceOfLengthWithInitState @LEDGER (fromIntegral traceLen) mkGenesisLedgerState
             `ofLengthAtLeast` 1
     TestPool.pStateIsInternallyConsistent
       (concatMap ledgerToPoolSsts (sourceSignalTargets tr))
@@ -148,3 +165,44 @@ ledgerToPoolSsts
   -> [SourceSignalTarget POOL]
 ledgerToPoolSsts (SourceSignalTarget (_, DPState _ p) (_, DPState _ p') tx) =
   [SourceSignalTarget p p' cert | cert <- toList (tx ^. body . certs)]
+
+
+profile :: TraceProfile LEDGER
+profile
+  = TraceProfile
+      { proportionOfValidSignals = 95
+      , failures = [(5, tamperTx)]
+      }
+  where
+    tamperTx :: SignalGenerator LEDGER
+    tamperTx env st
+      = genTx env st traceKeyPairs traceVRFKeyPairs GenInvalid
+
+-- | The signal generator generates invalid signals with high probability when
+-- invalid signals are requested.
+invalidDelegSignalsAreGenerated :: Property
+invalidDelegSignalsAreGenerated =
+  withTests 100
+    $ invalidSignalsAreGeneratedForTrace
+        (traceOfLengthWithInitState @LEDGER (fromIntegral traceLen) mkGenesisLedgerState)
+        (failures profile)
+        (coverLedgerFailures 2)
+        10 -- coverage percentage of LEDGER Predicate failures
+
+coverLedgerFailures
+  :: forall m a
+   .  ( MonadTest m
+      , HasCallStack
+      , Data a
+      )
+  => CoverPercentage
+  -- ^ Minimum percentage that each failure must occur.
+  -> a
+  -- ^ Structure containing the failures
+  -> m ()
+coverLedgerFailures coverPercentage =
+  coverFailures
+    coverPercentage
+    ([ DelegsFailure (DelplFailure (DelegFailure StakeKeyAlreadyRegisteredDELEG))
+     , DelegsFailure (DelplFailure (DelegFailure StakeKeyNotRegisteredDELEG)) ]
+       :: [PredicateFailure LEDGER])


### PR DESCRIPTION
Closes #926 

* this PR does Invalid Trace Profile testing for the LEDGER STS (with signal `Tx`), focusing on generating invalid `RegKey` certs (as part of a Tx).
* in Byron, we used the Goblins approach to breed tampered generators that target STS Predicate Failures
* here, we don't breed Goblins or even tamper with valid generators. Instead, we pass a Validity switch (Valid/Invalid) into generators and generate Invalid values in the same context as Valid generation (e.g. see 'genRegKeyCert`)
* this allows us to generate invalid values in situ, with the advantages:
  - we can precisely target predicate failures that might arise from the particular generator/STS
  - we can generate invalid values in the context of their containers (e.g. if we tampered with a particular Cert in a Tx, we'd have to recompute the witnesses for the Cert to keep all things equal; if not, we'd fail on "bad witnesses" and not reach whatever predicate failure we want to target)

