### PR TITLE
Fix: misplaced parens in deposits function (formal spec)

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -624,7 +624,7 @@ may either be from the current epoch or an earlier one, so we split them using $
   \end{equation*}
   Looking at the $\mathsf{UTXO}$ transition in Figure~\ref{fig:rules:utxo-shelley},
   \begin{equation*}
-    \var{deposits}' = \var{deposits} + (\deposits{pp}~{stpools}~{\txcerts{tx}})
+    \var{deposits}' = \var{deposits} + \deposits{pp}~{stpools}~{(\txcerts{tx})}
     - (\var{refunded} + \var{decayed})
   \end{equation*}
   The function $\fun{deposits}$ is defined in Figure~\ref{fig:functions:deposits-refunds}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -321,7 +321,7 @@ requests).
       \var{decayed} \leteq \decayedTx{pp}{stkCreds}~{tx}
       \\
       \var{depositChange} \leteq
-        (\deposits{pp}~{stpools}~{\txcerts{tx}}) - (\var{refunded} + \var{decayed})
+        \deposits{pp}~{stpools}~{(\txcerts{tx})} - (\var{refunded} + \var{decayed})
     }
     {
       \begin{array}{r}


### PR DESCRIPTION
replaces #1021 in order to get a buildkite build