### PR TITLE
Fix: predicate of PPUpdateTooLatePPUP (exec spec)

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -64,15 +64,13 @@ ppupTransitionNonEmpty :: TransitionRule (PPUP crypto)
 ppupTransitionNonEmpty = do
   TRC (PPUPEnv s pp (GenDelegs _genDelegs), pupS, pup@(PPUpdate pup')) <- judgmentContext
 
-  pup' /= Map.empty ?! PPUpdateEmpty
+  not (Map.null pup') ?! PPUpdateEmpty
 
   all (all (pvCanFollow (_protocolVersion pp))) pup' ?! PVCannotFollowPPUP
 
   (dom pup' ⊆ dom _genDelegs) ?! NonGenesisUpdatePPUP (dom pup') (dom _genDelegs)
 
-  let Epoch slotEpoch = epochFromSlot (Slot 1)
-  s
-    <  (firstSlot (Epoch $ slotEpoch + 1) *- slotsPrior)
-    ?! PPUpdateTooLatePPUP
+  let Epoch e = epochFromSlot s
+  s < firstSlot (Epoch $ e + 1) *- slotsPrior ?! PPUpdateTooLatePPUP
 
   pure $ updatePPup pupS pup

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -14,7 +14,7 @@ import           Data.Set (Set)
 import           BaseTypes
 import           BlockChain
 import           Keys
-import           Ledger.Core (dom, (⊆))
+import           Ledger.Core (dom, (⊆), (⨃))
 import           PParams
 import           Slot
 import           Updates
@@ -62,15 +62,15 @@ ppupTransitionEmpty = do
 
 ppupTransitionNonEmpty :: TransitionRule (PPUP crypto)
 ppupTransitionNonEmpty = do
-  TRC (PPUPEnv s pp (GenDelegs _genDelegs), pupS, pup@(PPUpdate pup')) <- judgmentContext
+  TRC (PPUPEnv s pp (GenDelegs _genDelegs), PPUpdate pupS, PPUpdate pup) <- judgmentContext
 
-  not (Map.null pup') ?! PPUpdateEmpty
+  not (Map.null pup) ?! PPUpdateEmpty
 
-  all (all (pvCanFollow (_protocolVersion pp))) pup' ?! PVCannotFollowPPUP
+  all (all (pvCanFollow (_protocolVersion pp))) pup ?! PVCannotFollowPPUP
 
-  (dom pup' ⊆ dom _genDelegs) ?! NonGenesisUpdatePPUP (dom pup') (dom _genDelegs)
+  (dom pup ⊆ dom _genDelegs) ?! NonGenesisUpdatePPUP (dom pup) (dom _genDelegs)
 
   let Epoch e = epochFromSlot s
   s < firstSlot (Epoch $ e + 1) *- slotsPrior ?! PPUpdateTooLatePPUP
 
-  pure $ updatePPup pupS pup
+  pure $ PPUpdate (pupS ⨃  Map.toList pup)

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -7,7 +7,6 @@ module Updates
   ( Ppm(..)
   , PPUpdateEnv(..)
   , PPUpdate(..)
-  , updatePPup
   , ApName(..)
   , ApVer(..)
   , Mdt(..)
@@ -30,6 +29,10 @@ module Updates
   )
 where
 
+import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
+import           Cardano.Crypto.Hash (Hash)
+import           Cardano.Ledger.Shelley.Crypto
+import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Data.ByteString (ByteString)
 import           Data.ByteString.Char8 (unpack)
 import           Data.Char (isAscii)
@@ -40,10 +43,6 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word (Word8)
 import           GHC.Generics (Generic)
-import           Cardano.Ledger.Shelley.Crypto
-import           Cardano.Binary (ToCBOR (toCBOR), encodeListLen)
-import           Cardano.Crypto.Hash (Hash)
-import           Cardano.Prelude (NoUnexpectedThunks(..))
 
 import           BaseTypes (Nonce, UnitInterval)
 import           Coin (Coin)
@@ -53,7 +52,7 @@ import           Slot (Epoch, Slot)
 
 import           Numeric.Natural (Natural)
 
-import           Ledger.Core (dom, range, (∪), (◁))
+import           Ledger.Core (dom, range, (◁))
 
 newtype ApVer = ApVer Natural
   deriving (Show, Ord, Eq, NoUnexpectedThunks, ToCBOR)
@@ -177,14 +176,6 @@ instance ToCBOR Ppm where
 newtype PPUpdate crypto
   = PPUpdate (Map (GenKeyHash crypto) (Set Ppm))
   deriving (Show, Eq, ToCBOR, NoUnexpectedThunks)
-
--- | Update Protocol Parameter update with new values, prefer value from `pup1`
--- in case of already existing value in `pup0`
-updatePPup
-  :: PPUpdate crypto
-  -> PPUpdate crypto
-  -> PPUpdate crypto
-updatePPup (PPUpdate pup0') (PPUpdate pup1') = PPUpdate (pup1' ∪ pup0')
 
 -- | This is just an example and not neccessarily how we will actually validate names
 apNameValid :: ApName -> Bool

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -80,7 +80,8 @@ import           MockTypes (AVUpdate, Addr, Applications, Block, CHAIN, Certifie
                      Credential, DState, EpochState, GenKeyHash, HashHeader, KeyHash, KeyPair,
                      LedgerState, Mdt, NewEpochState, PPUpdate, PState, PoolDistr, PoolParams,
                      RewardAcnt, SKey, SKeyES, SignKeyVRF, SnapShots, Stake, Tx, TxBody, UTxO,
-                     UTxOState, Update, UpdateState, VKey, VKeyES, VKeyGenesis, VerKeyVRF, hashKeyVRF)
+                     UTxOState, Update, UpdateState, VKey, VKeyES, VKeyGenesis, VerKeyVRF,
+                     hashKeyVRF)
 import           Numeric.Natural (Natural)
 import           Unsafe.Coerce (unsafeCoerce)
 
@@ -96,8 +97,8 @@ import           Delegation.Certificates (pattern DeRegKey, pattern Delegate,
 import           EpochBoundary (BlocksMade (..), pattern SnapShots, pattern Stake, emptySnapShots,
                      _feeSS, _poolsSS, _pstakeGo, _pstakeMark, _pstakeSet)
 import           Keys (pattern GenDelegs, Hash, pattern KeyPair, pattern SKey, pattern SKeyES,
-                     pattern VKey, pattern VKeyES, pattern VKeyGenesis, hash, hashKey,
-                     sKey, sign, signKES, vKey)
+                     pattern VKey, pattern VKeyES, pattern VKeyGenesis, hash, hashKey, sKey, sign,
+                     signKES, vKey)
 import           LedgerState (AccountState (..), pattern DPState, pattern EpochState,
                      pattern LedgerState, pattern NewEpochState, pattern RewardUpdate,
                      pattern UTxOState, deltaF, deltaR, deltaT, emptyDState, emptyPState,
@@ -124,8 +125,7 @@ import           TxData (pattern AddrBase, pattern AddrPtr, pattern Delegation, 
                      _poolPubKey, _poolRAcnt, _poolVrf)
 import           Updates (pattern AVUpdate, ApName (..), ApVer (..), pattern Applications,
                      InstallerHash (..), pattern Mdt, pattern PPUpdate, Ppm (..), SystemTag (..),
-                     pattern Update, pattern UpdateState, emptyUpdate, emptyUpdateState,
-                     updatePPup)
+                     pattern Update, pattern UpdateState, emptyUpdate, emptyUpdateState)
 import           UTxO (pattern UTxO, balance, makeGenWitnessesVKey, makeWitnessesVKey, txid)
 
 import           Control.State.Transition (PredicateFailure, TRC (..), applySTS)
@@ -1641,7 +1641,8 @@ blockEx3B = mkBlock
 
 updateStEx3B :: UpdateState
 updateStEx3B = UpdateState
-  (ppupEx3A `updatePPup` ppupEx3B)
+  (PPUpdate $ Map.fromList $ fmap (\n -> (hashKey $ coreNodeVKG n, ppVote3A))
+    [0, 1, 3, 4, 5])
   (AVUpdate Map.empty)
   Map.empty
   byronApps


### PR DESCRIPTION
replaces #1028 in order to get a buildkite build

additionally addresses a point of confusion mentioned in #1028, namely the use of union instead of union override. the function `updatePPup` was calling union with the order of the parameter swapped, so it was in fact correct, but perhaps confusing. I've removed `updatePPup` entirely and just use union override directly in the STS rule.