### PR TITLE
CBOR serialization adjustments of Shelley txns

### DIFF
--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -79,6 +79,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           depends = [
             (hsPkgs."base" or (buildDepError "base"))
             (hsPkgs."bytestring" or (buildDepError "bytestring"))
+            (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))
+            (hsPkgs."cborg" or (buildDepError "cborg"))
             (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
             (hsPkgs."tasty" or (buildDepError "tasty"))
             (hsPkgs."tasty-hunit" or (buildDepError "tasty-hunit"))

--- a/shelley/chain-and-ledger/cddl-spec/shelley.cddl
+++ b/shelley/chain-and-ledger/cddl-spec/shelley.cddl
@@ -17,7 +17,7 @@ header =
   , slot             : uint
   , nonce            : uint
   , nonce_proof      : $vrf_proof
-  , leader_value     : ~rational
+  , leader_value     : ~unit_interval
   , leader_proof     : $vrf_proof
   , size             : uint
   , block_body_hash  : $hash            ; merkle pair root
@@ -88,14 +88,14 @@ credential =
   // 2, genesishash
   )
 
-coin = uint
+coin = int
 
 epoch = uint
 
 keyhash = $hash
 scripthash = $hash
 
-pool_params = [[* keyhash], coin, rational, coin, credential, $vrf_keyhash]
+pool_params = [[* keyhash], coin, unit_interval, coin, credential, $vrf_keyhash]
 
 withdrawal = (reward_acct : credential, amount : uint)
 
@@ -130,7 +130,7 @@ $kes_signature /= bytes
 
 ; Numeric Types
 
-rational =
+unit_interval =
   [ numerator   : uint
   , denominator : uint
   ]

--- a/shelley/chain-and-ledger/cddl-spec/shelley.cddl
+++ b/shelley/chain-and-ledger/cddl-spec/shelley.cddl
@@ -1,0 +1,136 @@
+; Shelley Types
+
+; When you have something that is always length 2, why do you need the header?
+; Would using a map here make it cheaper?
+block =
+  [ header                     : header
+  , transaction_bodies         : [* transaction_body]
+  , transaction_witness_sets   : [* transaction_witness_set]
+  ]
+
+; TODO: Replace direct inlining with unwrap operator (~) for closer correspondence to Haskell types
+; Inlining the header body here to save word, but this would mean no valid CBOR instance for header body...
+header =
+  [ prev_hash        : $hash
+  , issuer_vkey      : $vkey
+  , vrf_vkey         : $vrf_vkey
+  , slot             : uint
+  , nonce            : uint
+  , nonce_proof      : $vrf_proof
+  , leader_value     : ~rational
+  , leader_proof     : $vrf_proof
+  , size             : uint
+  , block_body_hash  : $hash            ; merkle pair root
+  , operational_cert : operational_cert
+  , protocol_version : protocol_version
+  , body_signature   : $kes_signature
+  ]
+
+operational_cert =
+  [ hot_vkey        : $kes_vkey
+  , cold_vkey       : $vkey
+  , sequence_number : uint
+  , kes_period      : uint
+  , sigma           : $signature
+  ]
+
+protocol_version = [uint, uint, uint]
+
+; Do we want to use a Map here? Is it actually cheaper?
+; Do we want to add extension points here?
+transaction_body =
+  { 0 : #6.258([* transaction_input]) ; x
+  , 1 : [* transaction_output]        ; x
+  , 2 : [* delegation_certificate]
+  , 3 : [* withdrawal]
+  , 4 : coin ; fee                    ; x
+  , 5 : uint ; ttl                    ; x
+  , 6 : update
+  }
+
+; Is it okay to have this as a group? Is it valid CBOR?! Does it need to be?
+transaction_input = (transaction_id : $hash, index : uint)
+
+transaction_output = (address : address, amount : uint)
+
+address =
+ (  0, keyhash, keyhash       ; base address
+ // 1, keyhash, scripthash    ; base address
+ // 2, scripthash, keyhash    ; base address
+ // 3, scripthash, scripthash ; base address
+ // 4, keyhash, pointer       ; pointer address
+ // 5, scripthash, pointer    ; pointer address
+ // 6, keyhash                ; enterprise address (null staking reference)
+ // 7, scripthash             ; enterprise address (null staking reference)
+ // 8, keyhash                ; bootstrap address
+ )
+
+delegation_certificate =
+  (  0, keyhash         ; stake key registration
+  // 1, keyhash         ; stake key de-registration
+  // 2                  ; stake key delegation
+      , keyhash         ; delegating key
+      , keyhash         ; key delegated to
+  // 3, keyhash, pool_params  ; stake pool registration
+  // 4, keyhash, epoch  ; stake pool retirement
+  // 5 ; genesis key delegation
+      , keyhash ; delegating key
+      , key     ; key delegated to
+  // 6, [* move_instantaneous_reward] ; move instantaneous rewards
+  )
+
+move_instantaneous_reward = ( keyhash, coin )
+pointer = (uint, uint, uint)
+
+credential =
+  (  0, keyhash
+  // 1, scripthash
+  // 2, genesishash
+  )
+
+coin = uint
+
+epoch = uint
+
+keyhash = $hash
+scripthash = $hash
+
+pool_params = [[* keyhash], coin, rational, coin, credential, $vrf_keyhash]
+
+withdrawal = (reward_acct : credential, amount : uint)
+
+update = [* update_part]
+
+transaction_witness_set =
+  (  0, vkeywitness
+  // 1, scriptwitness
+  // 2, [* vkeywitness]
+  // 3, [* scriptwitness]
+  // 4, [* vkeywitness],[* scriptwitness]
+  )
+
+vkeywitness = [vkey, signature]
+scriptwitness = script
+
+; Crypto Types will be defined for mock and real crypto in separate files using this syntax
+
+$hash /= bytes
+
+$vkey /= bytes
+
+$signature /= bytes
+
+$vrf_keyhash /= bytes
+
+$vrf_proof /= bytes
+
+$kes_vkey /= bytes
+
+$kes_signature /= bytes
+
+; Numeric Types
+
+rational =
+  [ numerator   : uint
+  , denominator : uint
+  ]

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -27,6 +27,7 @@ library
                      PParams
                      EpochBoundary
                      LedgerState
+                     Serialization
                      Delegation.PoolParams
                      Delegation.Certificates
                      OCert
@@ -118,6 +119,8 @@ test-suite delegation-test
                          Rules.TestPoolreap
                          Rules.TestUtxo
                          Rules.TestUtxow
+                         Test.Serialization
+                         Test.Utils
     hs-source-dirs:      test
     ghc-options:
       -threaded
@@ -140,6 +143,8 @@ test-suite delegation-test
     build-depends:
       base,
       bytestring,
+      cardano-binary,
+      cborg,
       cryptonite,
       tasty,
       tasty-hunit,

--- a/shelley/chain-and-ledger/executable-spec/src/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Coin.hs
@@ -7,12 +7,16 @@ module Coin
     , splitCoin
     ) where
 
-import           Cardano.Binary (ToCBOR)
+import           Cardano.Binary (ToCBOR (toCBOR))
+import           Data.Word (Word64)
 import           Cardano.Prelude (NoUnexpectedThunks(..))
 
 -- |The amount of value held by a transaction output.
 newtype Coin = Coin Integer
-  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks, ToCBOR)
+  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks)
+
+instance ToCBOR Coin where
+  toCBOR (Coin c) = toCBOR (fromInteger c :: Word64)
 
 splitCoin :: Coin -> Integer -> (Coin, Coin)
 splitCoin (Coin n) 0 = (Coin 0, Coin n)

--- a/shelley/chain-and-ledger/executable-spec/src/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Serialization.hs
@@ -1,0 +1,15 @@
+
+module Serialization where
+
+import Cardano.Binary (ToCBOR (..), encodeListLen, Encoding)
+import Data.Typeable
+
+class Typeable a => ToCBORGroup a where
+  toCBORGroup :: a -> Encoding
+  listLen     :: a -> Word
+
+newtype CBORGroup a = CBORGroup a
+
+instance ToCBORGroup a => ToCBOR (CBORGroup a) where
+  toCBOR (CBORGroup x) = encodeListLen (listLen x) <> toCBORGroup x
+

--- a/shelley/chain-and-ledger/executable-spec/src/Slot.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Slot.hs
@@ -26,7 +26,7 @@ where
 import           Data.Word                      ( Word64 )
 import           Numeric.Natural                ( Natural )
 import           GHC.Generics                   ( Generic )
-import           Cardano.Binary                 ( ToCBOR )
+import           Cardano.Binary                 (ToCBOR(..))
 import           Cardano.Prelude                ( NoUnexpectedThunks(..) )
 
 import qualified Ledger.Core                   as Byron
@@ -34,7 +34,10 @@ import qualified Ledger.Core                   as Byron
 
 -- |A Slot
 newtype Slot = Slot Natural
-  deriving (Show, Eq, Ord, NoUnexpectedThunks, Num, ToCBOR)
+  deriving (Show, Eq, Ord, NoUnexpectedThunks, Num)
+
+instance ToCBOR Slot where
+  toCBOR (Slot s) = toCBOR (fromInteger (toInteger s) :: Word64)
 
 instance Semigroup Slot where
   (Slot x) <> (Slot y) = Slot $ x + y

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -23,6 +23,7 @@ module Updates
   , votedValue
   , emptyUpdateState
   , emptyUpdate
+  , updateNull
   , updatePParams
   , svCanFollow
   , sTagsValid
@@ -87,6 +88,9 @@ newtype AVUpdate crypto = AVUpdate {
 data Update crypto
   = Update (PPUpdate crypto) (AVUpdate crypto)
   deriving (Show, Eq, Generic)
+
+updateNull :: Update crypto -> Bool
+updateNull (Update (PPUpdate ppup) (AVUpdate avup)) = null ppup && null avup
 
 instance NoUnexpectedThunks (Update crypto)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
@@ -30,12 +30,12 @@ import qualified Hedgehog.Range as Range
 
 import           Address (toAddr, toCred)
 import           Coin (Coin (..))
-import           Examples (mkKeyPair)
 import           Keys (pattern KeyPair, hashKey, vKey)
 import           LedgerState (pattern LedgerState, genesisCoins, genesisState)
 import           MockTypes (Addr, DPState, KeyPair, KeyPairs, LedgerEnv, SignKeyVRF, TxOut, UTxO,
                      UTxOState, VKey, VerKeyVRF)
 import           Numeric.Natural (Natural)
+import           Test.Utils (mkKeyPair)
 import           Tx (pattern TxOut)
 import           TxData (pattern AddrBase, pattern KeyHashObj)
 

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -169,6 +169,8 @@ type Mdt = Updates.Mdt MockCrypto
 
 type Applications = Updates.Applications MockCrypto
 
+type InstallerHash = Updates.InstallerHash MockCrypto
+
 type Update = Updates.Update MockCrypto
 
 type UpdateState = Updates.UpdateState MockCrypto

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
@@ -116,21 +116,6 @@ getRawInstallerHash (InstallerHash hsh) = getHash hsh
 testScript :: MultiSig
 testScript = RequireSignature $ undiscriminateKeyHash testKeyHash1
 
---data ToTokens where
---  T :: Encoding -> ToTokens
---  S :: ToCBOR a => a -> ToTokens
---  Plus :: ToTokens -> ToTokens -> ToTokens
-
---tokens :: ToTokens -> Encoding
---tokens (T xs) = xs
---tokens (S s) = tokens s
---tokens (Plus a b) = tokens a <> tokens b
-
---instance Monoid ToTokens where
---  mappend = Plus
---  mempty =
-
-
 serializationTests :: TestTree
 serializationTests = testGroup "Serialization Tests" $ checkEncoding <$>
   [ Coin 30 #> Encoding (TkWord64 30)
@@ -180,34 +165,6 @@ serializationTests = testGroup "Serialization Tests" $ checkEncoding <$>
           . TkWord64 500
       )
   , Tx -- minimal transaction
-      (TxBody
-        (Set.fromList [TxIn genesisId 1])
-        [TxOut testAddrE (Coin 2)]
-        Seq.empty
-        Map.empty
-        (Coin 9)
-        (Slot 500)
-        emptyUpdate)
-      Set.empty
-      Map.empty #>
-
-      Encoding (TkListLen 3
-        . TkMapLen 6 -- Transaction
-          . TkWord 0 -- Tx Ins
-            . TkTag 258 . TkListLen 1 -- one input
-              . TkListLen 2 . TkBytes (getRawTxId genesisId) . TkInteger 1
-          . TkWord 1 -- Tx Outs
-            . TkListBegin
-              . TkListLen 2 . TkWord 6 . TkBytes (getRawKeyHash testKeyHash1) . TkWord64 2
-            . TkBreak
-          . TkWord 2 -- Tx Fee
-            . TkWord64 9
-          . TkWord 3 -- Tx TTL
-            . TkWord64 500
-        . TkTag 258 . TkListLen 0 -- no key witnesses
-        . TkMapLen 0 -- no scripts
-      )
-  , Tx -- minimal transaction with witnesses
       (TxBody
         (Set.fromList [TxIn genesisId 1])
         [TxOut testAddrE (Coin 2)]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
@@ -3,9 +3,6 @@
 
 module Test.Serialization where
 
---import Cardano.Prelude
---import Test.Cardano.Prelude
-
 import           Cardano.Binary (ToCBOR, toCBOR)
 import           Cardano.Crypto.DSIGN (DSIGNAlgorithm (encodeVerKeyDSIGN), encodeSignedDSIGN)
 import           Cardano.Crypto.Hash (getHash)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
@@ -1,0 +1,311 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+module Test.Serialization where
+
+--import Cardano.Prelude
+--import Test.Cardano.Prelude
+
+import           Cardano.Binary (ToCBOR, toCBOR)
+import           Cardano.Crypto.DSIGN (DSIGNAlgorithm (encodeVerKeyDSIGN), encodeSignedDSIGN)
+import           Cardano.Crypto.Hash (getHash)
+import           Codec.CBOR.Encoding (Encoding (..), Tokens (..))
+import           Data.ByteString (ByteString)
+import           Data.ByteString.Char8 (pack)
+
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit (assertEqual, testCase)
+
+
+import           BaseTypes (UnitInterval (..))
+import           Coin (Coin (..))
+import           Data.Ratio ((%))
+import           Delegation.Certificates (pattern RegKey)
+import           Keys (DiscVKey (..), pattern GenKeyHash, pattern KeyHash, pattern KeyPair,
+                     pattern UnsafeSig, hash, hashKey, sKey, sign, undiscriminateKeyHash, vKey)
+import           LedgerState (genesisId)
+import           Slot (Slot (..))
+import           Test.Utils
+import           Tx (hashScript)
+import           TxData (pattern AddrBase, pattern AddrEnterprise, pattern AddrPtr, Credential (..),
+                     Ptr (..), pattern RequireSignature, pattern RewardAcnt, pattern ScriptHash,
+                     pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut, _TxId)
+import           Updates (pattern AVUpdate, ApName (..), ApVer (..), pattern Applications,
+                     pattern InstallerHash, pattern Mdt, pattern PPUpdate, Ppm (..),
+                     SystemTag (..), pattern Update, emptyUpdate)
+
+import           MockTypes (Addr, GenKeyHash, InstallerHash, KeyHash, KeyPair, MultiSig, ScriptHash,
+                     Sig, TxBody, TxId, TxIn, TxOut, VKey, WitVKey)
+import           UTxO (makeWitnessVKey)
+
+import qualified Data.Map.Strict as Map
+import qualified Data.Sequence as Seq
+import qualified Data.Set as Set
+import           Data.Typeable (Typeable, typeOf)
+
+
+
+data EncodingPair where
+  EncodePair :: (Typeable a, ToCBOR a) => a -> Encoding -> EncodingPair
+
+(#>) :: (ToCBOR a) => a -> Encoding -> EncodingPair
+(#>) = EncodePair
+
+checkEncoding :: EncodingPair -> TestTree
+checkEncoding (EncodePair x t) = testCase testName $
+  assertEqual typeName (fromEncoding t) (fromEncoding $ toCBOR x)
+  where
+   typeName = show (typeOf x)
+   testName = "prop_serialize_" <> map (\c -> if c == ' ' then '-' else c) typeName
+
+fromEncoding :: Encoding -> Tokens
+fromEncoding (Encoding e) = e TkEnd
+
+getRawKeyHash :: KeyHash -> ByteString
+getRawKeyHash (KeyHash hsh) = getHash hsh
+
+getRawGenKeyHash :: GenKeyHash -> ByteString
+getRawGenKeyHash (GenKeyHash hsh) = getHash hsh
+
+getRawScriptHash :: ScriptHash -> ByteString
+getRawScriptHash (ScriptHash hsh) = getHash hsh
+
+getRawTxId :: TxId -> ByteString
+getRawTxId = getHash . _TxId
+
+testGKeyHash :: GenKeyHash
+testGKeyHash = (hashKey . snd . mkGenKeys) (0, 0, 0, 0, 0)
+
+testTxb :: TxBody
+testTxb = TxBody Set.empty [] Seq.empty Map.empty (Coin 0) (Slot 0) emptyUpdate
+
+testKey1 :: KeyPair
+testKey1 = KeyPair vk sk
+  where (sk, vk) = mkKeyPair (0, 0, 0, 0, 1)
+
+testKeyWit1 :: WitVKey
+testKeyWit1 = makeWitnessVKey testTxb testKey1
+
+testKey1Token :: Tokens -> Tokens
+testKey1Token = e
+  where
+    (DiscVKey vk) = vKey testKey1 :: VKey
+    Encoding e = encodeVerKeyDSIGN vk
+
+testKey1SigToken :: Tokens -> Tokens
+testKey1SigToken = e
+  where
+    (UnsafeSig s) = sign (sKey testKey1) testTxb :: Sig TxBody
+    Encoding e = encodeSignedDSIGN s
+
+testKeyHash1 :: KeyHash
+testKeyHash1 = (hashKey . snd . mkKeyPair) (0, 0, 0, 0, 1)
+
+testKeyHash2 :: KeyHash
+testKeyHash2 = (hashKey . snd . mkKeyPair) (0, 0, 0, 0, 2)
+
+testAddrE :: Addr
+testAddrE = AddrEnterprise (KeyHashObj testKeyHash1)
+
+testInstallerHash :: InstallerHash
+testInstallerHash = (InstallerHash . hash . pack) "ABC"
+
+getRawInstallerHash :: InstallerHash -> ByteString
+getRawInstallerHash (InstallerHash hsh) = getHash hsh
+
+testScript :: MultiSig
+testScript = RequireSignature $ undiscriminateKeyHash testKeyHash1
+
+--data ToTokens where
+--  T :: Encoding -> ToTokens
+--  S :: ToCBOR a => a -> ToTokens
+--  Plus :: ToTokens -> ToTokens -> ToTokens
+
+--tokens :: ToTokens -> Encoding
+--tokens (T xs) = xs
+--tokens (S s) = tokens s
+--tokens (Plus a b) = tokens a <> tokens b
+
+--instance Monoid ToTokens where
+--  mappend = Plus
+--  mempty =
+
+
+serializationTests :: TestTree
+serializationTests = testGroup "Serialization Tests" $ checkEncoding <$>
+  [ Coin 30 #> Encoding (TkWord64 30)
+  , UnsafeUnitInterval (1 % 2) #> Encoding (TkWord64 1 . TkWord64 2)
+  , Slot 7 #> Encoding (TkWord64 7)
+  , testKeyHash1 #> Encoding (TkBytes (getRawKeyHash testKeyHash1))
+  , KeyHashObj testKeyHash1 #>
+      Encoding (TkListLen 2 . TkWord 0 . TkBytes (getRawKeyHash testKeyHash1))
+  , AddrBase (KeyHashObj testKeyHash1) (KeyHashObj testKeyHash2) #>
+      Encoding (TkWord 0
+        . TkBytes (getRawKeyHash testKeyHash1)
+        . TkBytes (getRawKeyHash testKeyHash2))
+  , AddrPtr (KeyHashObj testKeyHash1) (Ptr (Slot 12) 0 3) #>
+      Encoding (TkWord 4
+        . TkBytes (getRawKeyHash testKeyHash1)
+        . TkWord64 12 . TkWord 0 . TkWord 3)
+  , AddrEnterprise (KeyHashObj testKeyHash1) #>
+      Encoding (TkWord 6
+        . TkBytes (getRawKeyHash testKeyHash1))
+  , (TxIn genesisId 0 :: TxIn) #>
+      Encoding (TkListLen 2 . TkBytes (getRawTxId genesisId) . TkInteger 0)
+  , (TxOut (AddrEnterprise (KeyHashObj testKeyHash1)) (Coin 2) :: TxOut) #>
+      Encoding (TkListLen 2 . TkWord 6
+        . TkBytes (getRawKeyHash testKeyHash1) . TkWord64  2)
+  , (Map.fromList [(10, 1), (20, 2), (30, 3)] :: (Map.Map Int Int)) #>
+      Encoding (TkMapLen 3 . TkInt 10 . TkInt 1 . TkInt 20 . TkInt 2 . TkInt 30 . TkInt 3)
+  , TxBody -- minimal transaction body
+      (Set.fromList [TxIn genesisId 1])
+      [TxOut testAddrE (Coin 2)]
+      Seq.empty
+      Map.empty
+      (Coin 9)
+      (Slot 500)
+      emptyUpdate #>
+
+      Encoding (TkMapLen 6
+        . TkWord 0 -- Tx Ins
+          . TkTag 258 . TkListLen 1 -- one input
+            . TkListLen 2 . TkBytes (getRawTxId genesisId) . TkInteger 1
+        . TkWord 1 -- Tx Outs
+          . TkListBegin
+            . TkListLen 2 . TkWord 6 . TkBytes (getRawKeyHash testKeyHash1) . TkWord64 2
+          . TkBreak
+        . TkWord 2 -- Tx Fee
+          . TkWord64 9
+        . TkWord 3 -- Tx TTL
+          . TkWord64 500
+      )
+  , Tx -- minimal transaction
+      (TxBody
+        (Set.fromList [TxIn genesisId 1])
+        [TxOut testAddrE (Coin 2)]
+        Seq.empty
+        Map.empty
+        (Coin 9)
+        (Slot 500)
+        emptyUpdate)
+      Set.empty
+      Map.empty #>
+
+      Encoding (TkListLen 3
+        . TkMapLen 6 -- Transaction
+          . TkWord 0 -- Tx Ins
+            . TkTag 258 . TkListLen 1 -- one input
+              . TkListLen 2 . TkBytes (getRawTxId genesisId) . TkInteger 1
+          . TkWord 1 -- Tx Outs
+            . TkListBegin
+              . TkListLen 2 . TkWord 6 . TkBytes (getRawKeyHash testKeyHash1) . TkWord64 2
+            . TkBreak
+          . TkWord 2 -- Tx Fee
+            . TkWord64 9
+          . TkWord 3 -- Tx TTL
+            . TkWord64 500
+        . TkTag 258 . TkListLen 0 -- no key witnesses
+        . TkMapLen 0 -- no scripts
+      )
+  , Tx -- minimal transaction with witnesses
+      (TxBody
+        (Set.fromList [TxIn genesisId 1])
+        [TxOut testAddrE (Coin 2)]
+        Seq.empty
+        Map.empty
+        (Coin 9)
+        (Slot 500)
+        emptyUpdate)
+      Set.empty
+      Map.empty #>
+
+      Encoding (TkListLen 3
+        . TkMapLen 6 -- Transaction
+          . TkWord 0 -- Tx Ins
+            . TkTag 258 . TkListLen 1 -- one input
+              . TkListLen 2 . TkBytes (getRawTxId genesisId) . TkInteger 1
+          . TkWord 1 -- Tx Outs
+            . TkListBegin
+              . TkListLen 2 . TkWord 6 . TkBytes (getRawKeyHash testKeyHash1) . TkWord64 2
+            . TkBreak
+          . TkWord 2 -- Tx Fee
+            . TkWord64 9
+          . TkWord 3 -- Tx TTL
+            . TkWord64 500
+        . TkTag 258 . TkListLen 0 -- no key witnesses
+        . TkMapLen 0 -- no scripts
+      )
+  , Set.singleton testKeyWit1 #> -- Transaction _witnessVKeySet
+      Encoding (TkTag 258  . TkListLen 1 -- one vkey witness
+        . TkListLen 2
+        . testKey1Token -- vkey
+        . testKey1SigToken -- signature
+      )
+  , Map.singleton (hashScript testScript :: ScriptHash) testScript #> -- Transaction _witnessMSigMap
+      Encoding (TkMapLen 1
+        . TkBytes (getRawScriptHash $ hashScript testScript)
+        . TkListLen 2 . TkWord 0 . TkBytes (getRawKeyHash testKeyHash1)
+      )
+  , TxBody -- transaction body with all components
+      (Set.fromList [TxIn genesisId 1])
+      [TxOut testAddrE (Coin 2)]
+      (Seq.fromList [ RegKey (KeyHashObj testKeyHash1) ])
+      (Map.singleton (RewardAcnt (KeyHashObj testKeyHash2)) (Coin 123))
+      (Coin 9)
+      (Slot 500)
+      (Update
+        (PPUpdate (Map.singleton
+                     testGKeyHash
+                     (Set.singleton (Nopt 100))))
+        (AVUpdate (Map.singleton
+                     testGKeyHash
+                     (Applications (Map.singleton
+                            (ApName $ pack "Daedalus")
+                            (ApVer 17
+                            , Mdt $ Map.singleton
+                                (SystemTag $ pack "DOS")
+                                testInstallerHash
+                            )))))
+      ) #>
+
+      Encoding (TkMapLen 6
+        . TkWord 0 -- Tx Ins
+          . TkTag 258 . TkListLen 1 -- one input
+            . TkListLen 2 . TkBytes (getRawTxId genesisId) . TkInteger 1
+        . TkWord 1 -- Tx Outs
+          . TkListBegin
+            . TkListLen 2 . TkWord 6 . TkBytes (getRawKeyHash testKeyHash1) . TkWord64 2
+          . TkBreak
+        . TkWord 2 -- Tx Fee
+          . TkWord64 9
+        . TkWord 3 -- Tx TTL
+          . TkWord64 500
+        . TkWord 4 -- Tx Certs
+          . TkListBegin
+            -- A stake key registration certificate
+            . TkListLen 2
+              . TkWord 0 -- Reg Cert
+              . TkListLen 2 . TkWord 0 . TkBytes (getRawKeyHash testKeyHash1)
+          . TkBreak
+        . TkWord 5 -- Tx Reward Withdrawals
+          . TkMapLen 1 -- one withdrawal
+            . TkListLen 2 . TkWord 0 . TkBytes (getRawKeyHash testKeyHash2)
+            . TkWord64 123
+        . TkWord 6 -- Tx Reward Withdrawals
+          . TkListLen 2
+            . TkMapLen 1 -- one protocol parameter update
+              . TkBytes (getRawGenKeyHash testGKeyHash)
+              . TkTag 258 . TkListLen 1 -- one paratemer change
+                . TkListLen 2 . TkWord 11 . TkInteger 100 -- set nopt (word 11) to 100
+            . TkMapLen 1 -- one software version update
+              . TkBytes (getRawGenKeyHash testGKeyHash) -- genesis key hash
+              . TkMapLen 1 -- one application
+                . TkBytes (pack "Daedalus")
+                . TkListLen 2
+                  . TkInteger 17 -- version 17
+                  . TkMapLen 1 -- metadata
+                    . TkBytes (pack "DOS") -- system tag
+                    . TkBytes (getRawInstallerHash testInstallerHash)
+      )
+  ]
+

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Utils.hs
@@ -1,8 +1,45 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Test.Utils
   ( assertAll
+  , mkGenKeys
+  , mkKeyPair
+  , mkAddr
+  , unsafeMkUnitInterval
   ) where
+
+import           BaseTypes (UnitInterval, mkUnitInterval)
+import           Cardano.Crypto.DSIGN (deriveVerKeyDSIGN, genKeyDSIGN)
+import           Crypto.Random (drgNewTest, withDRG)
+import           Data.Maybe (fromMaybe)
+import           Data.Word (Word64)
+import           Keys (pattern SKey, pattern VKey, pattern VKeyGenesis, hashKey, vKey)
+import           MockTypes (Addr, KeyPair, SKey, VKey, VKeyGenesis)
+import           TxData (pattern AddrBase, pattern KeyHashObj)
 
 import           Hedgehog (MonadTest, (===))
 
+
 assertAll :: (MonadTest m, Show a, Eq a) => (a -> Bool) -> [a] -> m ()
 assertAll p xs = [] === filter (not . p) xs
+
+mkGenKeys :: (Word64, Word64, Word64, Word64, Word64) -> (SKey, VKeyGenesis)
+mkGenKeys seed = fst . withDRG (drgNewTest seed) $ do
+  sk <- genKeyDSIGN
+  return (SKey sk, VKeyGenesis $ deriveVerKeyDSIGN sk)
+
+
+mkKeyPair :: (Word64, Word64, Word64, Word64, Word64) -> (SKey, VKey)
+mkKeyPair seed = fst . withDRG (drgNewTest seed) $ do
+  sk <- genKeyDSIGN
+  return (SKey sk, VKey $ deriveVerKeyDSIGN sk)
+
+mkAddr :: (KeyPair, KeyPair) -> Addr
+mkAddr (payKey, stakeKey) =
+  AddrBase (KeyHashObj . hashKey $ vKey payKey)
+           (KeyHashObj . hashKey $ vKey stakeKey)
+
+-- | You vouch that argument is in [0; 1].
+unsafeMkUnitInterval :: Rational -> UnitInterval
+unsafeMkUnitInterval r =
+  fromMaybe (error "could not construct unit interval") $ mkUnitInterval r

--- a/shelley/chain-and-ledger/executable-spec/test/Tests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Tests.hs
@@ -3,9 +3,10 @@ import           Test.Tasty
 import           PropertyTests (propertyTests)
 import           STSTests (stsTests)
 import           UnitTests (unitTests)
+import           Test.Serialization(serializationTests)
 
 tests :: TestTree
-tests = testGroup "Ledger with Delegation" [unitTests, propertyTests, stsTests]
+tests = testGroup "Ledger with Delegation" [unitTests, propertyTests, stsTests, serializationTests]
 
 -- main entry point
 main :: IO ()


### PR DESCRIPTION
This PR makes some adjustments to how we serialize the Shelley transactions, and includes several tests that can be used to see exactly what CBOR tokens are generated in the various situations. The new tests are found in `shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs`.

Additionally, this PR adds a cddl file, which is still a work in progress, but that I think is worth including as a roadmap.

closes  #1015 