### PR TITLE
[872] Generate Delegation Certificates

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -21,6 +21,7 @@ module Delegation.Certificates
   , decayPool
   , isRegKey
   , isDeRegKey
+  , isDelegation
   , isRegPool
   , isRetirePool
   , isInstantaneousRewards
@@ -99,6 +100,11 @@ isRegKey _ = False
 isDeRegKey :: DCert crypto-> Bool
 isDeRegKey (DeRegKey _) = True
 isDeRegKey _ = False
+
+-- | Check for `Delegation` constructor
+isDelegation :: DCert crypto-> Bool
+isDelegation (Delegate _) = True
+isDelegation _ = False
 
 -- | Check for `RegPool` constructor
 isRegPool :: DCert crypto-> Bool

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -109,6 +109,12 @@ genUtxo0 lower upper = do
   outs <- genTxOut (fmap toAddr genesisKeys)
   return (genesisCoins outs)
 
+-- | Generate initial state for the LEDGER STS using the STS environment.
+--
+-- Note: this function must be usable in place of 'applySTS' and needs to align
+-- with the signature 'RuleContext sts -> Gen (Either [[PredicateFailure sts]] (State sts))'.
+-- To achieve this we (1) use 'IRC LEDGER' (the "initial rule context") instead of simply 'LedgerEnv'
+-- and (2) always return Right (since this function does not raise predicate failures).
 mkGenesisLedgerState
   :: IRC LEDGER
   -> Gen (Either a (UTxOState, DPState))

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -31,9 +31,10 @@ import qualified Test.QuickCheck as QC
 
 import           Address (toAddr, toCred)
 import           Coin (Coin (..))
+import           Control.State.Transition (IRC)
 import           Keys (pattern KeyPair, hashKey, vKey)
 import           LedgerState (pattern LedgerState, genesisCoins, genesisState)
-import           MockTypes (Addr, DPState, KeyPair, KeyPairs, LedgerEnv, SignKeyVRF, TxOut, UTxO,
+import           MockTypes (Addr, DPState, KeyPair, KeyPairs, LEDGER, SignKeyVRF, TxOut, UTxO,
                      UTxOState, VKey, VerKeyVRF)
 import           Numeric.Natural (Natural)
 import           Test.Utils (mkKeyPair)
@@ -109,12 +110,12 @@ genUtxo0 lower upper = do
   return (genesisCoins outs)
 
 mkGenesisLedgerState
-  :: LedgerEnv
-  -> Gen (UTxOState, DPState)
+  :: IRC LEDGER
+  -> Gen (Either a (UTxOState, DPState))
 mkGenesisLedgerState _ = do
   utxo0 <- genUtxo0 5 10
   let (LedgerState utxoSt dpSt _) = genesisState utxo0
-  pure (utxoSt, dpSt)
+  pure $ Right (utxoSt, dpSt)
 
 -- | Generate values the given distribution in 90% of the cases, and values at
 -- the bounds of the range in 10% of the cases.

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -158,7 +158,7 @@ classifyInvalidDoubleSpend = withTests 1000 $ property $ do
 propertyTests :: TestTree
 propertyTests = testGroup "Property-Based Testing"
                 [ testGroup "Classify Traces"
-                  [testProperty "Ledger trace covers the relevant cases" relevantCasesAreCovered]
+                  [TQC.testProperty "Ledger trace covers the relevant cases" relevantCasesAreCovered]
                 , testGroup "STS Rules - Delegation Properties"
                   [ testProperty "newly registered key has a reward of 0" rewardZeroAfterReg
                   , testProperty "deregistered key's credential is removed"
@@ -217,9 +217,9 @@ propertyTests = testGroup "Property-Based Testing"
                     classifyInvalidDoubleSpend
                   ]
                 , testGroup "Properties of Trace generators"
-                  [testProperty
-                   "Only valid LEDGER STS signals are generated"
-                   onlyValidLedgerSignalsAreGenerated
+                  [TQC.testProperty
+                      "Only valid LEDGER STS signals are generated"
+                      onlyValidLedgerSignalsAreGenerated
                   ]
                 ]
 


### PR DESCRIPTION
Closes #872 
Closes  #1039 

This PR
* generates Delegate certs (using QuickCheck)
* classify the trace to ensure that Delegate certs are being produced
* switch the LEDGER Trace Classifier to QuickCheck from Hedgehog (HH was still being used here due to #1039 which is resolved by this PR) 

@mhuesch #1039 had to do with the fact that the LEDGER STS needs an initial state but does not have an Initial Rule to produce that state, so we have to provide an Initial State generator. I amended the STS machinery to allow for this. 
(hence the error "applySTSIndifferently was called with an empty set of rules", which is trying to produce the initial state from an initial rule)