### PR TITLE
adding the last hash in prev epoch to nonce

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -17,6 +17,7 @@ module BlockChain
   , TxSeq(..)
   , bhHash
   , bhbHash
+  , hashHeaderToNonce
   , bHeaderSize
   , bBodySize
   , slotToNonce
@@ -101,6 +102,10 @@ bhbHash
   => TxSeq crypto
   -> HashBBody crypto
 bhbHash = HashBBody . hash
+
+-- |HashHeader to Nonce
+hashHeaderToNonce :: HashHeader crypto -> Nonce
+hashHeaderToNonce = Nonce . coerce
 
 data BHeader crypto
   = BHeader

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -80,8 +80,8 @@ import           Unsafe.Coerce (unsafeCoerce)
 import           Address (mkRwdAcnt)
 import           BaseTypes (Nonce (..), UnitInterval, intervalValue, mkNonce, (⭒))
 import           BlockChain (pattern BHBody, pattern BHeader, pattern Block, pattern HashHeader,
-                     ProtVer (..), TxSeq (..), bBodySize, bhHash, bhbHash, bheader, mkSeed,
-                     seedEta, seedL, startRewards)
+                     ProtVer (..), TxSeq (..), bBodySize, bhHash, bhbHash, bheader,
+                     hashHeaderToNonce, mkSeed, seedEta, seedL, startRewards)
 import           Coin (Coin (..))
 import           Delegation.Certificates (pattern DeRegKey, pattern Delegate,
                      pattern GenesisDelegate, pattern InstantaneousRewards, pattern PoolDistr,
@@ -403,6 +403,7 @@ initStEx1 = ChainState
   (mkNonce 0)
   (mkNonce 0)
   (mkNonce 0)
+  NeutralNonce
   lastByronHeaderHash
   (Slot 0)
 
@@ -438,6 +439,7 @@ expectedStEx1 = ChainState
   (mkNonce 0)
   (mkNonce 0 ⭒ mkNonce 1)
   (mkNonce 0 ⭒ mkNonce 1)
+  NeutralNonce
   (bhHash (bheader blockEx1))
   (Slot 1)
 
@@ -550,6 +552,7 @@ initStEx2A = ChainState
   (mkNonce 0)
   (mkNonce 0)
   (mkNonce 0)
+  NeutralNonce
   lastByronHeaderHash
   (Slot 0)
 
@@ -628,6 +631,7 @@ expectedStEx2A = ChainState
   (mkNonce 0)
   (mkNonce 0 ⭒ mkNonce 1)
   (mkNonce 0 ⭒ mkNonce 1)
+  NeutralNonce
   blockEx2AHash
   (Slot 10)
 
@@ -726,6 +730,7 @@ expectedStEx2Bgeneric pp = ChainState
   (mkNonce 0)
   (mkNonce 0 ⭒ mkNonce 1 ⭒ mkNonce 2) -- ^ Evolving nonce
   (mkNonce 0 ⭒ mkNonce 1)             -- ^ Candidate nonce
+  NeutralNonce
   blockEx2BHash                       -- ^ Hash header of the chain
   (Slot 90)                           -- ^ Current slot
 
@@ -842,6 +847,7 @@ expectedStEx2Cgeneric ss ls pp = ChainState
   (mkNonce 0 ⭒ mkNonce 1)
   (mkSeqNonce 3)
   (mkSeqNonce 3)
+  (hashHeaderToNonce blockEx2BHash)
   blockEx2CHash
   (Slot 110)
 
@@ -917,6 +923,7 @@ expectedStEx2D = ChainState
   (mkNonce 0 ⭒ mkNonce 1)
   (mkSeqNonce 4)
   (mkSeqNonce 3)
+  (hashHeaderToNonce blockEx2BHash)
   blockEx2DHash
   (Slot 190)
 
@@ -935,7 +942,7 @@ blockEx2E = mkBlock
              []
              (Slot 220)
              (BlockNo 2)
-             (mkSeqNonce 3)
+             ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
              (NatNonce 5)
              zero
              2
@@ -991,9 +998,10 @@ expectedStEx2E = ChainState
           (1, hashKeyVRF (snd $ vrf alicePool))))
      epoch1OSchedEx2E)
   oCertIssueNosEx1
-  (mkSeqNonce 3)
+  ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
   (mkSeqNonce 5)
   (mkSeqNonce 5)
+  (hashHeaderToNonce blockEx2DHash)
   blockEx2EHash
   (Slot 220)
 
@@ -1013,7 +1021,7 @@ blockEx2F = mkBlock
              []
              (Slot 295) -- odd slots open for decentralization in epoch1OSchedEx2E
              (BlockNo 2)
-             (mkSeqNonce 3)
+             ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
              (NatNonce 6)
              zero
              3
@@ -1040,9 +1048,10 @@ expectedStEx2F = ChainState
      pdEx2F
      epoch1OSchedEx2E)
   oCertIssueNosEx2F
-  (mkSeqNonce 3)
+  ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
   (mkSeqNonce 6)
   (mkSeqNonce 5)
+  (hashHeaderToNonce blockEx2DHash)
   blockEx2FHash
   (Slot 295)
 
@@ -1105,9 +1114,10 @@ expectedStEx2G = ChainState
      pdEx2F
      epoch1OSchedEx2G)
   oCertIssueNosEx2F
-  (mkSeqNonce 5)
+  ((mkSeqNonce 5) ⭒ (hashHeaderToNonce blockEx2DHash))
   (mkSeqNonce 7)
   (mkSeqNonce 7)
+  (hashHeaderToNonce blockEx2FHash)
   blockEx2GHash
   (Slot 310)
 
@@ -1159,9 +1169,10 @@ expectedStEx2H = ChainState
      pdEx2F
      epoch1OSchedEx2G)
   oCertIssueNosEx2F
-  (mkSeqNonce 5)
+  ((mkSeqNonce 5) ⭒ (hashHeaderToNonce blockEx2DHash))
   (mkSeqNonce 8)
   (mkSeqNonce 7)
+  (hashHeaderToNonce blockEx2FHash)
   blockEx2HHash
   (Slot 390)
 
@@ -1235,9 +1246,10 @@ expectedStEx2I = ChainState
      pdEx2F
      epoch1OSchedEx2I)
   oCertIssueNosEx2F
-  (mkSeqNonce 7)
+  ((mkSeqNonce 7) ⭒ (hashHeaderToNonce blockEx2FHash))
   (mkSeqNonce 9)
   (mkSeqNonce 9)
+  (hashHeaderToNonce blockEx2HHash)
   blockEx2IHash
   (Slot 410)
 
@@ -1321,9 +1333,10 @@ expectedStEx2J = ChainState
      pdEx2F
      epoch1OSchedEx2I)
   oCertIssueNosEx2F
-  (mkSeqNonce 7)
+  ((mkSeqNonce 7) ⭒ (hashHeaderToNonce blockEx2FHash))
   (mkSeqNonce 10)
   (mkSeqNonce 10)
+  (hashHeaderToNonce blockEx2HHash)
   blockEx2JHash
   (Slot 420)
 
@@ -1402,9 +1415,10 @@ expectedStEx2K = ChainState
      pdEx2F
      epoch1OSchedEx2I)
   oCertIssueNosEx2F
-  (mkSeqNonce 7)
+  ((mkSeqNonce 7) ⭒ (hashHeaderToNonce blockEx2FHash))
   (mkSeqNonce 11)
   (mkSeqNonce 10)
+  (hashHeaderToNonce blockEx2HHash)
   blockEx2KHash
   (Slot 490)
 
@@ -1475,9 +1489,10 @@ expectedStEx2L = ChainState
      pdEx2F
      (overlaySchedule (Epoch 5) (Map.keysSet genDelegs) ppsEx1))
   oCertIssueNosEx2F
-  (mkSeqNonce 10)
+  ((mkSeqNonce 10) ⭒ (hashHeaderToNonce blockEx2HHash))
   (mkSeqNonce 12)
   (mkSeqNonce 12)
+  (hashHeaderToNonce blockEx2KHash)
   blockEx2LHash
   (Slot 510)
 
@@ -1572,6 +1587,7 @@ expectedStEx3A = ChainState
   (mkNonce 0)
   (mkNonce 0 ⭒ mkNonce 1)
   (mkNonce 0 ⭒ mkNonce 1)
+  NeutralNonce
   blockEx3AHash
   (Slot 10)
 
@@ -1664,6 +1680,7 @@ expectedStEx3B = ChainState
   (mkNonce 0)
   (mkSeqNonce 2)
   (mkSeqNonce 2)
+  NeutralNonce
   blockEx3BHash
   (Slot 20)
 
@@ -1725,6 +1742,7 @@ expectedStEx3C = ChainState
   (mkSeqNonce 2 ⭒ mkNonce 123)
   (mkSeqNonce 3)
   (mkSeqNonce 3)
+  (hashHeaderToNonce blockEx3BHash)
   blockEx3CHash
   (Slot 110)
 
@@ -1826,6 +1844,7 @@ expectedStEx4A = ChainState
   (mkNonce 0)
   (mkNonce 0 ⭒ mkNonce 1)
   (mkNonce 0 ⭒ mkNonce 1)
+  NeutralNonce
   blockEx4AHash
   (Slot 10)
 
@@ -1916,6 +1935,7 @@ expectedStEx4B = ChainState
   (mkNonce 0)
   (mkSeqNonce 2)
   (mkSeqNonce 2)
+  NeutralNonce
   blockEx4BHash
   (Slot 20)
 
@@ -1980,6 +2000,7 @@ expectedStEx4C = ChainState
   (mkNonce 0)
   (mkSeqNonce 3)
   (mkSeqNonce 3)
+  NeutralNonce
   blockEx4CHash
   (Slot 60)
 
@@ -2063,6 +2084,7 @@ expectedStEx5A = ChainState
   (mkNonce 0)
   (mkNonce 0 ⭒ mkNonce 1)
   (mkNonce 0 ⭒ mkNonce 1)
+  NeutralNonce
   blockEx5AHash
   (Slot 10)
 
@@ -2123,6 +2145,7 @@ expectedStEx5B = ChainState
   (mkNonce 0)
   (mkSeqNonce 2)
   (mkSeqNonce 2)
+  NeutralNonce
   blockEx5BHash
   (Slot 50)
 
@@ -2206,6 +2229,7 @@ expectedStEx6A = ChainState
   (mkNonce 0)
   (mkNonce 0 ⭒ mkNonce 1)
   (mkNonce 0 ⭒ mkNonce 1)
+  NeutralNonce
   blockEx6AHash
   (Slot 10)
 

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -6,6 +6,7 @@
 \newcommand{\Seede}{\mathsf{Seed}_\eta}
 \newcommand{\activeSlotCoeff}[1]{\fun{activeSlotCoeff}~ \var{#1}}
 \newcommand{\slotToSeed}[1]{\fun{slotToSeed}~ \var{#1}}
+\newcommand{\hashToSeed}[1]{\fun{hashToSeed}~ \var{#1}}
 
 \newcommand{\T}{\type{T}}
 \newcommand{\vrf}[3]{\fun{vrf}_{#1} ~ #2 ~ #3}
@@ -45,6 +46,7 @@
 \newcommand{\NewEpochEnv}{\type{NewEpochEnv}}
 \newcommand{\NewEpochState}{\type{NewEpochState}}
 \newcommand{\UpdateNonceState}{\type{UpdateNonceState}}
+\newcommand{\UpdateNonceEnv}{\type{UpdateNonceEnv}}
 \newcommand{\PoolDistr}{\type{PoolDistr}}
 \newcommand{\BBodyEnv}{\type{BBodyEnv}}
 \newcommand{\BBodyState}{\type{BBodyState}}
@@ -191,6 +193,8 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
                    & \text{size of a block body} \\
       \slotToSeed{} & \Slot \to \Seed
                     & \text{convert a slot to a seed} \\
+      \hashToSeed{} & \HashHeader \to \Seed
+                    & \text{convert a header hash to a seed} \\
     \end{array}
   \end{equation*}
   %
@@ -436,12 +440,25 @@ In the second case, the new epoch state is updated as follows:
 
 The Update Nonce Transition updates the nonces until the randomness gets fixed.
 The environment is shown in Figure~\ref{fig:ts-types:updnonce} and consists of
-the block nonce $\eta$, the protocol parameters $\var{pp}$ and a marker
-$\var{ne}$ determining whether we are in a new epoch. The update nonce state is
-shown in Figure~\ref{fig:rules:update-nonce} and consists of the epoch nonce
-$\eta_0$, the candidate nonce $\eta_c$ and the evolving nonce $\eta_v$.
+the block nonce $\eta$, the protocol parameters $\var{pp}$, the current previous hash $h_c$,
+and a marker $\var{ne}$ determining whether we are in a new epoch.
+The update nonce state is shown in Figure~\ref{fig:ts-types:updnonce} and consists of
+the epoch nonce $\eta_0$, the candidate nonce $\eta_c$ and the evolving nonce $\eta_v$.
 
 \begin{figure}
+  \emph{Update Nonce environments}
+  \begin{equation*}
+    \UpdateNonceEnv =
+    \left(
+      \begin{array}{r@{~\in~}lr}
+        \eta & \Seed & \text{new nonce} \\
+        \var{pp} & \PParams & \text{protocol parameters} \\
+        h_c & \HashHeader & \text{current previous hash} \\
+        b & \Bool & \text{is new epoch} \\
+      \end{array}
+    \right)
+  \end{equation*}
+  %
   \emph{Update Nonce states}
   \begin{equation*}
     \UpdateNonceState =
@@ -450,6 +467,7 @@ $\eta_0$, the candidate nonce $\eta_c$ and the evolving nonce $\eta_v$.
         \eta_0 & \Seed & \text{epoch nonce} \\
         \eta_c & \Seed & \text{candidate nonce} \\
         \eta_v & \Seed & \text{evolving nonce} \\
+        \eta_h & \Seed & \text{seed generated from hash of previous epoch} \\
       \end{array}
     \right)
   \end{equation*}
@@ -457,7 +475,7 @@ $\eta_0$, the candidate nonce $\eta_c$ and the evolving nonce $\eta_v$.
   \emph{Update Nonce Transitions}
   \begin{equation*}
     \_ \vdash \var{\_} \trans{updn}{\_} \var{\_} \subseteq
-    \powerset ((\Seed \times \PParams \times \Bool)
+    \powerset (\UpdateNonceEnv
                \times \UpdateNonceState
                \times \Slot
                \times \UpdateNonceState
@@ -485,11 +503,15 @@ near the end of the epoch is not discarded).
 \begin{figure}[ht]
    \begin{equation}\label{eq:update-all}
     \inference[Update-All]
-    { }
+    { \eta_e \leteq \fun{extraEntropy}~\var{pp}
+      &
+      \eta_p \leteq \hashToSeed h_c
+    }
     {
       {\begin{array}{c}
          \eta \\
          \var{pp} \\
+         h_c \\
          \mathsf{True}
        \end{array}}
       \vdash
@@ -497,12 +519,14 @@ near the end of the epoch is not discarded).
             \eta_0 \\
             \eta_v \\
             \eta_c \\
+            \eta_h \\
       \end{array}\right)}
       \trans{updn}{\var{s}}
       {\left(\begin{array}{c}
-            \varUpdate{\eta_c \seedOp \fun{extraEntropy}~\var{pp}} \\
+            \varUpdate{\eta_c \seedOp \eta_h \seedOp \eta_e} \\
             \varUpdate{\eta_v\seedOp\eta} \\
             \varUpdate{\eta_v\seedOp\eta} \\
+            \varUpdate{\eta_p} \\
       \end{array}\right)}
     }
   \end{equation}
@@ -518,6 +542,7 @@ near the end of the epoch is not discarded).
       {\begin{array}{c}
          \eta \\
          \var{pp} \\
+         h_c \\
          \mathsf{False}
        \end{array}}
       \vdash
@@ -525,12 +550,14 @@ near the end of the epoch is not discarded).
             \eta_0 \\
             \eta_v \\
             \eta_c \\
+            \eta_h \\
       \end{array}\right)}
       \trans{updn}{\var{s}}
       {\left(\begin{array}{c}
             \eta_0 \\
             \varUpdate{\eta_v\seedOp\eta} \\
             \varUpdate{\eta_v\seedOp\eta} \\
+            \eta_h \\
       \end{array}\right)}
     }
   \end{equation}
@@ -546,6 +573,7 @@ near the end of the epoch is not discarded).
       {\begin{array}{c}
          \eta \\
          \var{pp} \\
+         h_c \\
          \mathsf{False}
        \end{array}}
       \vdash
@@ -553,12 +581,14 @@ near the end of the epoch is not discarded).
             \eta_0 \\
             \eta_v \\
             \eta_c \\
+            \eta_h \\
       \end{array}\right)}
       \trans{updn}{\var{s}}
       {\left(\begin{array}{c}
             \eta_0 \\
             \varUpdate{\eta_v\seedOp\eta} \\
             \eta_c \\
+            \eta_h \\
       \end{array}\right)}
     }
   \end{equation}
@@ -1112,6 +1142,7 @@ followed by the transition to update the evolving and candidate nonces.
         \eta_0 & \Seed & \text{current epoch nonce} \\
         \eta_v & \Seed & \text{evolving nonce} \\
         \eta_c & \Seed & \text{candidate nonce} \\
+        \eta_h & \Seed & \text{seed generated from hash of previous epoch} \\
       \end{array}
     \right)
   \end{equation*}
@@ -1148,6 +1179,7 @@ The states for this transition consists of:
   \item The current epoch nonce.
   \item The evolving nonce.
   \item The canditate nonce for the next epoch.
+  \item The nonce for hash of the last epoch.
 \end{itemize}
 
 \begin{figure}[ht]
@@ -1168,19 +1200,22 @@ The states for this transition consists of:
         {\left(\begin{array}{c}
         \eta \\
         \var{pp} \\
-        \var{ne}
+        h \\
+        \var{ne} \\
         \end{array}\right)}
         \vdash
         {\left(\begin{array}{c}
         \eta_0 \\
         \eta_v \\
         \eta_c \\
+        \eta_h \\
         \end{array}\right)}
         \trans{\hyperref[fig:rules:update-nonce]{updn}}{\var{slot}}
         {\left(\begin{array}{c}
         \eta_0' \\
         \eta_v' \\
         \eta_c' \\
+        \eta_h' \\
         \end{array}\right)}
       }\\~\\
       {
@@ -1213,6 +1248,7 @@ The states for this transition consists of:
             \eta_0 \\
             \eta_v \\
             \eta_c \\
+            \eta_h \\
       \end{array}\right)}
       \trans{prtcl}{\var{bh}}
       {\left(\begin{array}{c}
@@ -1222,6 +1258,7 @@ The states for this transition consists of:
             \varUpdate{\eta_0'} \\
             \varUpdate{\eta_v'} \\
             \varUpdate{\eta_c'} \\
+            \varUpdate{\eta_h'} \\
       \end{array}\right)}
     }
   \end{equation}
@@ -1405,6 +1442,7 @@ following:
   \item The epoch nonce $\eta_0$.
   \item The evolving nonce $\eta_v$.
   \item The candidate nonce $\eta_c$.
+  \item The previous epoch hash nonce $\eta_h$.
   \item The last header hash \var{h}.
   \item The last slot \var{s_\ell}.
 \end{itemize}
@@ -1420,6 +1458,7 @@ following:
         ~\eta_0 & \Seed & \text{epoch nonce} \\
         ~\eta_v & \Seed & \text{evolving nonce} \\
         ~\eta_c & \Seed & \text{candidate nonce} \\
+        ~\eta_h & \Seed & \text{seed generated from hash of previous epoch} \\
         \var{h} & \HashHeader & \text{latest header hash} \\
         \var{s_\ell} & \Slot & \text{last slot} \\
       \end{array}
@@ -1531,6 +1570,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
               \eta_0 \\
               \eta_v \\
               \eta_c \\
+              \eta_h \\
         \end{array}\right)}
         \trans{\hyperref[fig:rules:prtcl]{prtcl}}{\var{bh}}
         {\left(\begin{array}{c}
@@ -1540,6 +1580,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
               \eta_0' \\
               \eta_v' \\
               \eta_c' \\
+              \eta_h' \\
         \end{array}\right)}
       } \\~\\~\\
       {
@@ -1570,6 +1611,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
             \eta_0 \\
             \eta_v \\
             \eta_c \\
+            \eta_h \\
             \var{h} \\
             \var{s_\ell} \\
       \end{array}\right)}
@@ -1580,6 +1622,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
             \varUpdate{\eta_0'} \\
             \varUpdate{\eta_v'} \\
             \varUpdate{\eta_c'} \\
+            \varUpdate{\eta_h'} \\
             \varUpdate{\var{h}'} \\
             \varUpdate{\var{s_\ell}'} \\
       \end{array}\right)}
@@ -1705,8 +1748,9 @@ candidate nonces for Shelley.
               \emptyset \\
             \end{array}
           \right) \\
-          \fun{hash}~{h} \\
-          \fun{hash}~{h} \\
+          \hashToSeed(\fun{hash}~{h}) \\
+          \hashToSeed(\fun{hash}~{h}) \\
+          0_{seed} \\
           \var{h} \\
           \var{s_{last}} \\
         \end{array}


### PR DESCRIPTION
The `UPDN` transition now stores the hash of the last block header of the previous epoch so that it can combine this with the next epoch nonce created.

closes #1058 