### PR TITLE
Generate MIR certs

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
@@ -13,7 +13,6 @@ module Generator.Core
   , genCoinList
   , increasingProbabilityAt
   , mkGenesisLedgerState
-  , traceCoreKeyPairs
   , traceKeyPairs
   , traceVRFKeyPairs
   , someKeyPairs
@@ -140,10 +139,3 @@ traceVRFKeyPairs = [body (0,0,0,0,i) | i <- [1 .. 50]]
   body seed = fst . withDRG (drgNewTest seed) $ do
     sk <- genKeyVRF
     return (sk, deriveVerKeyVRF sk)
-
--- | A pre-populated space of core node keys
-traceCoreKeyPairs :: [CoreKeyPair]
-traceCoreKeyPairs = mkGenKeys <$> [1..7]
-
-mkGenKeys :: Word64 -> CoreKeyPair
-mkGenKeys n = (uncurry KeyPair . swap) (mkGenKey (n, n , n, n, n))

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
@@ -91,7 +91,7 @@ pickStakeKey keys = vKey . snd <$> Gen.element keys
 -- to include certificates that require deposits.
 genTxOut :: [Addr] -> Gen [TxOut]
 genTxOut addrs = do
-  ys <- genCoinList 1000 10000 (length addrs) (length addrs)
+  ys <- genCoinList 10000 100000 (length addrs) (length addrs)
   return (uncurry TxOut <$> zip addrs ys)
 
 -- | Generates a list of 'Coin' values of length between 'lower' and 'upper'

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core.hs
@@ -34,10 +34,10 @@ import           Address (toAddr, toCred)
 import           Coin (Coin (..))
 import           Keys (pattern KeyPair, hashKey, vKey)
 import           LedgerState (pattern LedgerState, genesisCoins, genesisState)
-import           MockTypes (Addr, CoreKeyPair, DPState, KeyPair, KeyPairs, LedgerEnv, SignKeyVRF,
-                     TxOut, UTxO, UTxOState, VKey, VerKeyVRF)
+import           MockTypes (Addr, DPState, KeyPair, KeyPairs, LedgerEnv, SignKeyVRF, TxOut, UTxO,
+                     UTxOState, VKey, VerKeyVRF)
 import           Numeric.Natural (Natural)
-import           Test.Utils (mkGenKey, mkKeyPair)
+import           Test.Utils (mkKeyPair)
 import           Tx (pattern TxOut)
 import           TxData (pattern AddrBase, pattern KeyHashObj)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -13,8 +13,8 @@ module Generator.Core.QuickCheck
   , genUtxo0
   , increasingProbabilityAt
   , mkGenesisLedgerState
+  , numCoreNodes
   , coreKeyPairs
-  , traceCoreKeyPairs
   , traceKeyPairs
   , traceVRFKeyPairs
   , someKeyPairs
@@ -180,10 +180,3 @@ traceVRFKeyPairs = [body (0,0,0,0,i) | i <- [1 .. 50]]
   body seed = fst . withDRG (drgNewTest seed) $ do
     sk <- genKeyVRF
     return (sk, deriveVerKeyVRF sk)
-
--- | A pre-populated space of core node keys
-traceCoreKeyPairs :: [CoreKeyPair]
-traceCoreKeyPairs = mkGenKeys <$> [1..7]
-
-mkGenKeys :: Word64 -> CoreKeyPair
-mkGenKeys n = (uncurry KeyPair . swap) (mkGenKey (n, n , n, n, n))

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -115,7 +115,7 @@ pickStakeKey keys = vKey . snd <$> QC.elements keys
 -- to include certificates that require deposits.
 genTxOut :: [Addr] -> Gen [TxOut]
 genTxOut addrs = do
-  ys <- genCoinList 1000 10000 (length addrs) (length addrs)
+  ys <- genCoinList 10000 100000 (length addrs) (length addrs)
   return (uncurry TxOut <$> zip addrs ys)
 
 -- | Generates a list of 'Coin' values of length between 'lower' and 'upper'

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -115,7 +115,7 @@ pickStakeKey keys = vKey . snd <$> QC.elements keys
 -- to include certificates that require deposits.
 genTxOut :: [Addr] -> Gen [TxOut]
 genTxOut addrs = do
-  ys <- genCoinList 10000 100000 (length addrs) (length addrs)
+  ys <- genCoinList 1000 10000 (length addrs) (length addrs)
   return (uncurry TxOut <$> zip addrs ys)
 
 -- | Generates a list of 'Coin' values of length between 'lower' and 'upper'

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation.hs
@@ -147,8 +147,9 @@ genInstantaneousRewards _ coreKeys delegSt = do
                       <*> Gen.shuffle (Map.keys credentials)
   coins <- genCoinList 1 1000 (length winnerCreds) (length winnerCreds)
 
-  coreSigners <- take <$> Gen.integral (Range.linear 0 $ length coreKeys)
-                      <*> Gen.shuffle coreKeys
+  coreSigners <-
+    take <$> Gen.integral (Range.linear (div (length coreKeys) 2) $ length coreKeys)
+         <*> Gen.shuffle coreKeys
 
   pure $ Just ( InstantaneousRewards (Map.fromList $ zip winnerCreds coins)
               , Right coreSigners)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
@@ -26,8 +26,7 @@ import           Delegation.Certificates (pattern DeRegKey, pattern Delegate,
                      pattern GenesisDelegate, pattern InstantaneousRewards, pattern RegKey,
                      pattern RegPool, pattern RetirePool, pattern StakeCreds, decayKey, isDeRegKey)
 import           Examples (unsafeMkUnitInterval)
-import           Generator.Core.QuickCheck (genCoinList, genInteger, genNatural, numCoreNodes,
-                     toCred)
+import           Generator.Core.QuickCheck (genCoinList, genInteger, genNatural, toCred)
 import           Keys (GenDelegs (..), hashKey, vKey)
 import           Ledger.Core (dom, range, (∈), (∉))
 import           LedgerState (dstate, keyRefund, pParams, pstate, stPools, stkCreds, _dstate,

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
@@ -26,7 +26,8 @@ import           Delegation.Certificates (pattern DeRegKey, pattern Delegate,
                      pattern GenesisDelegate, pattern InstantaneousRewards, pattern RegKey,
                      pattern RegPool, pattern RetirePool, pattern StakeCreds, decayKey, isDeRegKey)
 import           Examples (unsafeMkUnitInterval)
-import           Generator.Core.QuickCheck (genCoinList, genInteger, genNatural, toCred)
+import           Generator.Core.QuickCheck (genCoinList, genInteger, genNatural, numCoreNodes,
+                     toCred)
 import           Keys (GenDelegs (..), hashKey, vKey)
 import           Ledger.Core (dom, range, (∈), (∉))
 import           LedgerState (dstate, keyRefund, pParams, pstate, stPools, stkCreds, _dstate,
@@ -298,7 +299,7 @@ genInstantaneousRewards coreKeys delegSt = do
                       <*> QC.shuffle (Map.keys credentials)
   coins <- genCoinList 1 1000 (length winnerCreds) (length winnerCreds)
 
-  coreSigners <- take <$> QC.elements [0.. (max 0 $ (length coreKeys) - 1)]
+  coreSigners <- take <$> QC.elements [5 .. (max 0 $ (length coreKeys) - 1)]
                       <*> QC.shuffle coreKeys
 
   let credCoinMap = Map.fromList $ zip winnerCreds coins

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
@@ -111,7 +111,7 @@ genDCert keys coreKeys vrfKeys pparams dpState slot =
                -- TODO mgudemann
                -- needs to sign transaction with `coreKeys`
                -- tends to generate Txs without input which leads to error
-               , (0, genInstantaneousRewards coreKeys dState)
+               , (1, genInstantaneousRewards coreKeys dState)
                ]
  where
   dState = dpState ^. dstate

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace.hs
@@ -11,7 +11,7 @@
 module Generator.LedgerTrace where
 
 import           Control.State.Transition.Generator (HasTrace, envGen, sigGen)
-import           Generator.Core (genCoin, traceCoreKeyPairs, traceKeyPairs, traceVRFKeyPairs)
+import           Generator.Core (genCoin, traceKeyPairs, traceVRFKeyPairs)
 import           Generator.Update (genPParams)
 import           Generator.Utxo (genTx)
 import           MockTypes (MockCrypto)
@@ -29,4 +29,4 @@ instance HasTrace (LEDGER MockCrypto)
                 <*> genCoin 0 1000
 
     sigGen ledgerEnv ledgerSt =
-      genTx ledgerEnv ledgerSt traceKeyPairs traceCoreKeyPairs traceVRFKeyPairs
+      genTx ledgerEnv ledgerSt traceKeyPairs [] traceVRFKeyPairs

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace/QuickCheck.hs
@@ -30,7 +30,7 @@ instance TQC.HasTrace LEDGER Word64 where
     LedgerEnv <$> pure (Slot 0)
               <*> pure 0
               <*> genPParams
-              <*> genCoin 0 1000
+              <*> genCoin 1000000 10000000
 
   sigGen _ ledgerEnv ledgerSt =
     genTx ledgerEnv ledgerSt traceKeyPairs coreKeyPairs traceVRFKeyPairs

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -73,7 +73,8 @@ genPParams = mkPParams <$> pure 0 -- _minfeeA
                              (genIntervalInThousands 0 1000)
                              (unsafeMkUnitInterval 0, unsafeMkUnitInterval 1)
                        -- decentralisation param: 0,0.1,0.2..1
-                       <*> (unsafeMkUnitInterval <$> QC.elements [0, 0.1 .. 1])
+                             -- TODO: mgudemann, allow 0 despite MIR cert generation
+                       <*> (unsafeMkUnitInterval <$> QC.elements [0.1,0.2 .. 1])
                        <*> genExtraEntropy
                        -- protocolVersion
                        <*> ((,,) <$> genNatural 1 10 <*> genNatural 1 50 <*> genNatural 1 100)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
@@ -13,23 +13,19 @@ module Generator.Utxo.QuickCheck
 import           Control.Monad (when)
 import qualified Data.Map.Strict as Map
 import           Data.Sequence (Seq)
-import qualified Data.Sequence as Seq (filter)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 
 import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
 
-import           BaseTypes (interval0)
 import           Coin (Coin (..), splitCoin)
-import           Delegation.Certificates (isInstantaneousRewards)
 import           Generator.Core (findPayKeyPair, toAddr)
 import           Generator.Core.QuickCheck (genNatural)
 import           Generator.Delegation.QuickCheck (genDCerts)
 import           LedgerState (pattern UTxOState)
 import           MockTypes (Addr, CoreKeyPair, DCert, DPState, KeyPair, KeyPairs, Tx, TxBody, TxIn,
                      TxOut, UTxO, UTxOState, VrfKeyPairs)
-import           PParams (_d)
 import           Slot (Slot (..))
 import           STS.Ledger (LedgerEnv (..))
 import           Tx (pattern Tx, pattern TxBody, pattern TxOut)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
@@ -13,19 +13,23 @@ module Generator.Utxo.QuickCheck
 import           Control.Monad (when)
 import qualified Data.Map.Strict as Map
 import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq (filter)
 import           Data.Set (Set)
 import qualified Data.Set as Set
 
 import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
 
+import           BaseTypes (interval0)
 import           Coin (Coin (..), splitCoin)
+import           Delegation.Certificates (isInstantaneousRewards)
 import           Generator.Core (findPayKeyPair, toAddr)
 import           Generator.Core.QuickCheck (genNatural)
 import           Generator.Delegation.QuickCheck (genDCerts)
 import           LedgerState (pattern UTxOState)
 import           MockTypes (Addr, CoreKeyPair, DCert, DPState, KeyPair, KeyPairs, Tx, TxBody, TxIn,
                      TxOut, UTxO, UTxOState, VrfKeyPairs)
+import           PParams (_d)
 import           Slot (Slot (..))
 import           STS.Ledger (LedgerEnv (..))
 import           Tx (pattern Tx, pattern TxBody, pattern TxOut)

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
@@ -15,8 +15,8 @@ import           Control.State.Transition.Trace (TraceOrder (OldestFirst), trace
                      traceSignals)
 import           Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState,
                      onlyValidSignalsAreGeneratedFromInitState)
-import           Delegation.Certificates (isDeRegKey, isDelegation, isGenesisDelegation, isRegKey,
-                     isRegPool, isRetirePool)
+import           Delegation.Certificates (isDeRegKey, isDelegation, isGenesisDelegation,
+                     isInstantaneousRewards, isRegKey, isRegPool, isRetirePool)
 import           Generator.Core.QuickCheck (mkGenesisLedgerState)
 import           Generator.LedgerTrace.QuickCheck ()
 import           MockTypes (DCert, LEDGER, Tx)
@@ -31,33 +31,37 @@ relevantCasesAreCovered = withMaxSuccess 500 . property $ do
         certs_ = allCerts txs
 
     checkCoverage $ conjoin [
-       cover_ 75
+       cover_ 60
              (traceLength tr <= 5 * length certs_)
              "there is at least 1 certificate for every 5 transactions"
 
-     , cover_ 75
+     , cover_ 60
               (traceLength tr <= 20 * length (filter isRegKey certs_))
               "there is at least 1 RegKey certificate for every 10 transactions"
 
-     , cover_ 75
+     , cover_ 60
               (traceLength tr <= 20 * length (filter isDeRegKey certs_))
               "there is at least 1 DeRegKey certificate for every 20 transactions"
 
-     , cover_ 75
+     , cover_ 60
               (traceLength tr <= 20 * length (filter isDelegation certs_))
               "there is at least 1 Delegation certificate for every 10 transactions"
 
-     , cover_ 75
+     , cover_ 60
               (traceLength tr <= 40 * length (filter isGenesisDelegation certs_))
               "there is at least 1 Genesis Delegation certificate for every 40 transactions"
 
-     , cover_ 75
+     , cover_ 60
               (traceLength tr <= 20 * length (filter isRegPool certs_))
               "there is at least 1 RegPool certificate for every 10 transactions"
 
-     , cover_ 75
+     , cover_ 60
               (traceLength tr <= 20 * length (filter isRetirePool certs_))
               "there is at least 1 RetirePool certificate for every 20 transactions"
+
+     , cover_ 60
+              (traceLength tr <= 20 * length (filter isInstantaneousRewards certs_))
+              "there is at least 1 MIR certificate for every 20 transactions"
 
      , cover_ 25
               (0.75 >= noCertsRatio (certsByTx txs))

--- a/shelley/chain-and-ledger/executable-spec/test/Tests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Tests.hs
@@ -2,11 +2,11 @@ import           Test.Tasty
 
 import           PropertyTests (propertyTests)
 import           STSTests (stsTests)
+import           Test.Serialization (serializationTests)
 import           UnitTests (unitTests)
-import           Test.Serialization(serializationTests)
 
 tests :: TestTree
-tests = testGroup "Ledger with Delegation" [unitTests, propertyTests, stsTests, serializationTests]
+tests = testGroup "Ledger with Delegation" [unitTests, propertyTests, stsTests, serializationTests ]
 
 -- main entry point
 main :: IO ()


### PR DESCRIPTION
This activates generation of MIR certificates in the tests. Valid signals require full signature and non-zero `d`