### PR TITLE
FromCBOR instances and tests

### DIFF
--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -69,6 +69,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
           (hsPkgs."mtl" or (buildDepError "mtl"))
           (hsPkgs."non-integer" or (buildDepError "non-integer"))
           (hsPkgs."stm" or (buildDepError "stm"))
+          (hsPkgs."text" or (buildDepError "text"))
           (hsPkgs."transformers" or (buildDepError "transformers"))
           (hsPkgs."cs-ledger" or (buildDepError "cs-ledger"))
           (hsPkgs."cardano-binary" or (buildDepError "cardano-binary"))

--- a/shelley/chain-and-ledger/executable-spec/Makefile
+++ b/shelley/chain-and-ledger/executable-spec/Makefile
@@ -7,7 +7,7 @@ ghcid: ## Run ghcid
 ghcid-test: ## Have ghcid run the test suite
 # Note, to run just tests matching the pattern "foo", run "TASTY_PATTERN=foo make ghcid-test"
 	ghcid \
-          --command "stack ghci delegation:lib delegation:test:delegation-test --ghci-options=-fobject-code" \
+          --command "stack ghci delegation:lib delegation:test:delegation-test --ghci-options='-fobject-code -w'" \
           --test "main"
 
 .PHONY: ghcid ghcid-test help

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -89,6 +89,7 @@ library
     mtl,
     non-integer,
     stm,
+    text,
     transformers,
     cs-ledger,
     cardano-binary,

--- a/shelley/chain-and-ledger/executable-spec/src/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Coin.hs
@@ -7,13 +7,13 @@ module Coin
     , splitCoin
     ) where
 
-import           Cardano.Binary (ToCBOR (toCBOR))
+import           Cardano.Binary (FromCBOR, ToCBOR (toCBOR))
+import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Data.Word (Word64)
-import           Cardano.Prelude (NoUnexpectedThunks(..))
 
 -- |The amount of value held by a transaction output.
 newtype Coin = Coin Integer
-  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks)
+  deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks, FromCBOR)
 
 instance ToCBOR Coin where
   toCBOR (Coin c) = toCBOR (fromInteger c :: Word64)

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -78,7 +78,7 @@ import qualified Cardano.Crypto.DSIGN as DSIGN
 import           Cardano.Crypto.Hash (Hash, HashAlgorithm, hash, hashWithSerialiser)
 import           Cardano.Crypto.KES
                      (KESAlgorithm (SignKeyKES, VerKeyKES, encodeSigKES, encodeVerKeyKES),
-                     SignedKES (SignedKES), signedKES, verifySignedKES)
+                     SignedKES (SignedKES), decodeSignedKES, signedKES, verifySignedKES)
 import qualified Cardano.Crypto.KES as KES
 import           Cardano.Crypto.VRF (VRFAlgorithm (VerKeyVRF))
 import qualified Cardano.Crypto.VRF as VRF
@@ -183,6 +183,8 @@ deriving instance (Crypto crypto) => NoUnexpectedThunks (KESig crypto a)
 
 instance (Crypto crypto, Typeable a) => ToCBOR (KESig crypto a) where
   toCBOR (KESig (SignedKES sigKES)) = encodeSigKES sigKES
+instance (Crypto crypto, Typeable a) => FromCBOR (KESig crypto a) where
+  fromCBOR = KESig <$> decodeSignedKES
 
 
 -- |Produce a key evolving signature
@@ -229,6 +231,7 @@ newtype DiscKeyHash (discriminator :: KeyDiscriminator) crypto =
   deriving (Show, Eq, Ord, NoUnexpectedThunks)
 
 deriving instance (Crypto crypto, Typeable disc) => ToCBOR (DiscKeyHash disc crypto)
+deriving instance (Crypto crypto, Typeable disc) => FromCBOR (DiscKeyHash disc crypto)
 
 type KeyHash crypto = DiscKeyHash 'Regular crypto
 {-# COMPLETE KeyHash #-}

--- a/shelley/chain-and-ledger/executable-spec/src/OCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/OCert.hs
@@ -13,23 +13,22 @@ module OCert
   , kesPeriod)
 where
 
-import           Cardano.Binary (FromCBOR(..), ToCBOR
-                                , enforceSize, toCBOR)
-import           Cardano.Prelude (NoUnexpectedThunks(..))
-import           Data.Set (Set)
-import qualified Data.Set as Set
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           GHC.Generics (Generic)
-import           Cardano.Ledger.Shelley.Crypto
-import           Keys (KeyHash, Sig, VKey, VKeyES)
-import           Slot (SlotNo (..))
 import           BaseTypes
-import           Numeric.Natural (Natural)
+import           Cardano.Binary (FromCBOR (..), ToCBOR, toCBOR)
+import           Cardano.Ledger.Shelley.Crypto
+import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Control.Monad.Trans.Reader (asks)
 import           Data.Functor ((<&>))
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           GHC.Generics (Generic)
+import           Keys (KeyHash, Sig, VKey, VKeyES)
+import           Numeric.Natural (Natural)
+import           Slot (SlotNo (..))
 
-import           Serialization (ToCBORGroup (..), CBORGroup (..))
+import           Serialization (CBORGroup (..), FromCBORGroup (..), ToCBORGroup (..))
 
 data OCertEnv crypto = OCertEnv
   { ocertEnvStPools :: Set (KeyHash crypto)
@@ -80,9 +79,9 @@ instance
 
 instance
   (Crypto crypto)
-  => FromCBOR (OCert crypto)
+  => FromCBORGroup (OCert crypto)
  where
-  fromCBOR = enforceSize "OCert should have 5 fields" 5 >>
+  fromCBORGroup =
     OCert
       <$> fromCBOR
       <*> fromCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Serialization.hs
@@ -1,8 +1,8 @@
 
 module Serialization where
 
-import Cardano.Binary (ToCBOR (..), encodeListLen, Encoding)
-import Data.Typeable
+import           Cardano.Binary (Decoder, Encoding, ToCBOR (..), encodeListLen)
+import           Data.Typeable
 
 class Typeable a => ToCBORGroup a where
   toCBORGroup :: a -> Encoding
@@ -13,3 +13,5 @@ newtype CBORGroup a = CBORGroup a
 instance ToCBORGroup a => ToCBOR (CBORGroup a) where
   toCBOR (CBORGroup x) = encodeListLen (listLen x) <> toCBORGroup x
 
+class Typeable a => FromCBORGroup a where
+  fromCBORGroup :: Decoder s a

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -30,6 +30,7 @@ module UTxO
   , deposits
   , makeWitnessVKey
   , makeWitnessesVKey
+  , makeGenWitnessVKey
   , makeGenWitnessesVKey
   , verifyWitVKey
   , scriptsNeeded
@@ -48,8 +49,7 @@ import qualified Data.Set as Set
 
 import           Cardano.Ledger.Shelley.Crypto
 import           Coin (Coin (..))
-import           Keys (KeyDiscriminator (..), KeyPair, Signable,
-                     hash, sKey, sign, vKey, verify)
+import           Keys (KeyDiscriminator (..), KeyPair, Signable, hash, sKey, sign, vKey, verify)
 import           Ledger.Core (Relation (..))
 import           PParams (PParams (..))
 import           TxData (Addr (..), Credential (..), ScriptHash, StakeCredential, Tx (..),

--- a/shelley/chain-and-ledger/executable-spec/test/Tests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Tests.hs
@@ -6,7 +6,12 @@ import           Test.Serialization (serializationTests)
 import           UnitTests (unitTests)
 
 tests :: TestTree
-tests = testGroup "Ledger with Delegation" [unitTests, propertyTests, stsTests, serializationTests ]
+tests = testGroup "Ledger with Delegation"
+  [ unitTests
+  , propertyTests
+  , stsTests
+  , serializationTests
+  ]
 
 -- main entry point
 main :: IO ()


### PR DESCRIPTION
This PR adds `FromCBOR` instances to match all our recent `ToCBOR` instances. The `checkEncoding` tests now also check that the serialization round trips correctly, in the sense that `fromCBOR . toCBOR` is the identity (we can soon turn these into property tests as well).