### PR TITLE
Restructure certificates

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Address.hs
@@ -23,8 +23,6 @@ mkRwdAcnt
   -> RewardAcnt crypto
 mkRwdAcnt script@(ScriptHashObj _) = RewardAcnt script
 mkRwdAcnt key@(KeyHashObj _) = RewardAcnt key
-mkRwdAcnt (GenesisHashObj _) =
-  error "cannot construct reward account with genesis key"
 
 toAddr
   :: Crypto crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -44,8 +44,8 @@ import           PParams (PParams (..), keyDecayRate, keyDeposit, keyMinRefund, 
                      poolDeposit, poolMinRefund)
 import           Slot (Duration (..))
 import           TxData (Credential (..), DCert (..), DelegCert (..), GenesisDelegate (..),
-                     MIRCert (..), PoolCert (..), StakeCredential, StakeCreds (..),
-                     StakePools (..), delegator, poolPubKey)
+                     MIRCert (..), PoolCert (..), StakeCreds (..), StakePools (..), delegator,
+                     poolPubKey)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Data.Map.Strict (Map)
@@ -54,7 +54,7 @@ import           Data.Ratio (approxRational)
 import           Lens.Micro ((^.))
 
 -- |Determine the certificate author
-delegCWitness :: DelegCert crypto-> StakeCredential crypto
+delegCWitness :: DelegCert crypto-> Credential crypto
 delegCWitness (RegKey _)            = error "no witness in key registration certificate"
 delegCWitness (DeRegKey hk)         = hk
 delegCWitness (Delegate delegation) = delegation ^. delegator

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -5,12 +5,13 @@
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Delegation.Certificates
-  (
-    DCert(..)
+  ( DCert(..)
   , StakeCreds(..)
   , StakePools(..)
   , PoolDistr(..)
-  , cwitness
+  , delegCWitness
+  , poolCWitness
+  , genesisCWitness
   , dvalue
   , refund
   , releasing
@@ -32,13 +33,14 @@ module Delegation.Certificates
 import           BaseTypes (FixedPoint, UnitInterval, fpEpsilon, intervalValue)
 import           Cardano.Ledger.Shelley.Crypto
 import           Coin (Coin (..))
-import           Keys (Hash, KeyHash, VRFAlgorithm (VerKeyVRF))
+import           Keys (GenKeyHash, Hash, KeyHash, VRFAlgorithm (VerKeyVRF))
 import           Ledger.Core (Relation (..))
 import           NonIntegral (exp')
 import           PParams (PParams (..), keyDecayRate, keyDeposit, keyMinRefund, poolDecayRate,
                      poolDeposit, poolMinRefund)
 import           Slot (Duration (..))
-import           TxData (Credential (..), DCert (..), StakeCredential, StakeCreds (..),
+import           TxData (Credential (..), DCert (..), DelegCert (..), GenesisDelegate (..),
+                     MIRCert (..), PoolCert (..), StakeCredential, StakeCreds (..),
                      StakePools (..), delegator, poolPubKey)
 
 import           Cardano.Prelude (NoUnexpectedThunks (..))
@@ -48,19 +50,22 @@ import           Data.Ratio (approxRational)
 import           Lens.Micro ((^.))
 
 -- |Determine the certificate author
-cwitness :: DCert crypto-> StakeCredential crypto
-cwitness (RegKey _)                = error "no witness in key registration certificate"
-cwitness (DeRegKey hk)             = hk
-cwitness (RegPool pool)            = KeyHashObj $ pool ^. poolPubKey
-cwitness (RetirePool k _)          = KeyHashObj k
-cwitness (Delegate delegation)     = delegation ^. delegator
-cwitness (GenesisDelegate (gk, _)) = GenesisHashObj gk
-cwitness (InstantaneousRewards _)  = error "no witness in MIR certificate"
+delegCWitness :: DelegCert crypto-> StakeCredential crypto
+delegCWitness (RegKey _)            = error "no witness in key registration certificate"
+delegCWitness (DeRegKey hk)         = hk
+delegCWitness (Delegate delegation) = delegation ^. delegator
+
+poolCWitness :: PoolCert crypto -> Credential crypto
+poolCWitness (RegPool pool)            = KeyHashObj $ pool ^. poolPubKey
+poolCWitness (RetirePool k _)          = KeyHashObj k
+
+genesisCWitness :: GenesisDelegate crypto -> GenKeyHash crypto
+genesisCWitness (GenesisDelegate (gk, _)) = gk
 
 -- |Retrieve the deposit amount for a certificate
 dvalue :: DCert crypto-> PParams -> Coin
-dvalue (RegKey _)  = flip (^.) keyDeposit
-dvalue (RegPool _) = flip (^.) poolDeposit
+dvalue (DCertDeleg (RegKey _))  = flip (^.) keyDeposit
+dvalue (DCertPool (RegPool _)) = flip (^.) poolDeposit
 dvalue _ = const $ Coin 0
 
 -- |Compute a refund on a deposit
@@ -78,48 +83,48 @@ releasing :: DCert crypto-> Bool
 releasing c = dderegister c || dretire c
 
 dderegister :: DCert crypto-> Bool
-dderegister (DeRegKey _) = True
+dderegister (DCertDeleg (DeRegKey _)) = True
 dderegister _            = False
 
 dretire :: DCert crypto-> Bool
-dretire (RetirePool _ _) = True
+dretire (DCertPool (RetirePool _ _)) = True
 dretire _                = False
 
 -- | Check whether certificate is of allocating type, i.e, key or pool
 -- registration.
 allocating :: DCert crypto-> Bool
-allocating (RegKey _)  = True
-allocating (RegPool _) = True
+allocating (DCertDeleg _)  = True
+allocating (DCertPool _) = True
 allocating _           = False
 
 -- | Check for `RegKey` constructor
 isRegKey :: DCert crypto-> Bool
-isRegKey (RegKey _) = True
+isRegKey (DCertDeleg (RegKey _)) = True
 isRegKey _ = False
 
 -- | Check for `DeRegKey` constructor
 isDeRegKey :: DCert crypto-> Bool
-isDeRegKey (DeRegKey _) = True
+isDeRegKey (DCertDeleg (DeRegKey _)) = True
 isDeRegKey _ = False
 
 -- | Check for `Delegation` constructor
 isDelegation :: DCert crypto-> Bool
-isDelegation (Delegate _) = True
+isDelegation (DCertDeleg (Delegate _)) = True
 isDelegation _ = False
 
 -- | Check for `GenesisDelegate` constructor
 isGenesisDelegation :: DCert crypto-> Bool
-isGenesisDelegation (GenesisDelegate _) = True
+isGenesisDelegation (DCertGenesis (GenesisDelegate _)) = True
 isGenesisDelegation _ = False
 
 -- | Check for `RegPool` constructor
 isRegPool :: DCert crypto-> Bool
-isRegPool (RegPool _) = True
+isRegPool (DCertPool (RegPool _)) = True
 isRegPool _ = False
 
 -- | Check for `RetirePool` constructor
 isRetirePool :: DCert crypto -> Bool
-isRetirePool (RetirePool _ _) = True
+isRetirePool (DCertPool (RetirePool _ _)) = True
 isRetirePool _ = False
 
 decayKey :: PParams -> (Coin, UnitInterval, Rational)
@@ -139,13 +144,13 @@ newtype PoolDistr crypto=
   deriving (Show, Eq, NoUnexpectedThunks, Relation)
 
 isInstantaneousRewards :: DCert crypto-> Bool
-isInstantaneousRewards (InstantaneousRewards _) = True
-isInstantaneousRewards _                        = False
+isInstantaneousRewards (DCertMir _) = True
+isInstantaneousRewards _       = False
 
 -- | Returns True for delegation certificates that require at least
 -- one witness, and False otherwise. It is mainly used to ensure
--- that calling `cwitness` is safe.
+-- that calling a variant of `cwitness` is safe.
 requiresVKeyWitness :: DCert crypto-> Bool
-requiresVKeyWitness (InstantaneousRewards _) = False
-requiresVKeyWitness (RegKey _) = False
+requiresVKeyWitness (DCertMir (MIRCert _)) = False
+requiresVKeyWitness (DCertDeleg (RegKey _)) = False
 requiresVKeyWitness _ = True

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -6,6 +6,10 @@
 
 module Delegation.Certificates
   ( DCert(..)
+  , DelegCert(..)
+  , PoolCert(..)
+  , GenesisDelegate(..)
+  , MIRCert(..)
   , StakeCreds(..)
   , StakePools(..)
   , PoolDistr(..)

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -125,9 +125,9 @@ import           Slot (Duration (..), EpochNo (..), SlotNo (..), epochInfoEpoch,
                      epochInfoSize, (+*), (-*))
 import           Tx (extractGenKeyHash, extractKeyHash)
 import           TxData (Addr (..), Credential (..), DelegCert (..), Ix, PoolCert (..), PoolParams,
-                     Ptr (..), RewardAcnt (..), StakeCredential, Tx (..), TxBody (..), TxId (..),
-                     TxIn (..), TxOut (..), body, certs, getRwdCred, inputs, poolOwners,
-                     poolPledge, poolRAcnt, ttl, txfee, wdrls, witKeyHash)
+                     Ptr (..), RewardAcnt (..), Tx (..), TxBody (..), TxId (..), TxIn (..),
+                     TxOut (..), body, certs, getRwdCred, inputs, poolOwners, poolPledge,
+                     poolRAcnt, ttl, txfee, wdrls, witKeyHash)
 import           Updates (AVUpdate (..), PPUpdate (..), Update (..), UpdateState (..), emptyUpdate,
                      emptyUpdateState)
 import           UTxO (UTxO (..), balance, deposits, txinLookup, txins, txouts, txup, verifyWitVKey)
@@ -166,9 +166,9 @@ data DState crypto = DState
       -- |The active reward accounts.
     ,  _rewards    :: RewardAccounts       crypto
       -- |The current delegations.
-    , _delegations :: Map (StakeCredential crypto) (KeyHash crypto)
+    , _delegations :: Map (Credential crypto) (KeyHash crypto)
       -- |The pointed to hash keys.
-    , _ptrs        :: Map Ptr (StakeCredential crypto)
+    , _ptrs        :: Map Ptr (Credential crypto)
       -- | future genesis key delegations
     , _fGenDelegs  :: Map (SlotNo, GenKeyHash crypto) (KeyHash crypto)
       -- |Genesis key delegations
@@ -761,7 +761,7 @@ rewardOnePool
   -> Coin
   -> Natural
   -> Natural
-  -> StakeCredential crypto
+  -> Credential crypto
   -> PoolParams crypto
   -> Stake crypto
   -> Coin
@@ -800,7 +800,7 @@ reward
   -> Set (RewardAcnt crypto)
   -> Map (KeyHash crypto) (PoolParams crypto)
   -> Stake crypto
-  -> Map (StakeCredential crypto) (KeyHash crypto)
+  -> Map (Credential crypto) (KeyHash crypto)
   -> Map (RewardAcnt crypto) Coin
 reward pp (BlocksMade b) r addrsRew poolParams stake@(Stake stake') delegs =
   rewards'
@@ -829,7 +829,7 @@ stakeDistr
   -> DState crypto
   -> PState crypto
   -> ( Stake crypto
-     , Map (StakeCredential crypto) (KeyHash crypto)
+     , Map (Credential crypto) (KeyHash crypto)
      )
 stakeDistr u ds ps = ( Stake $ dom activeDelegs ◁ aggregatePlus stakeRelation
                      , delegs)
@@ -838,7 +838,7 @@ stakeDistr u ds ps = ( Stake $ dom activeDelegs ◁ aggregatePlus stakeRelation
       PState (StakePools stpools) _ _                          = ps
       outs = aggregateOuts u
 
-      stakeRelation :: [(StakeCredential crypto, Coin)]
+      stakeRelation :: [(Credential crypto, Coin)]
       stakeRelation = baseStake outs ∪ ptrStake outs ptrs' ∪ rewardStake rewards'
 
       activeDelegs = dom stkcreds ◁ delegs ▷ dom stpools

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delegs.hs
@@ -91,7 +91,7 @@ delegsTransition = do
       let ptr = Ptr _slot txIx (fromIntegral $ length certs_)
 
           isDelegationRegistered = case cert of
-            Delegate deleg ->
+            DCertDeleg (Delegate deleg) ->
               let StakePools stPools_ = _stPools $ _pstate dpstate' in
               _delegatee deleg ∈ dom stPools_
             _ -> True

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
@@ -65,35 +65,35 @@ delplTransition
 delplTransition = do
   TRC (DelplEnv slotIx _ptr pp _reserves, d, c) <- judgmentContext
   case c of
-    RegPool _ -> do
+    DCertPool (RegPool _) -> do
       ps <-
         trans @(POOL crypto) $ TRC (PoolEnv slotIx pp, _pstate d, c)
       pure $ d { _pstate = ps }
-    RetirePool _ _ -> do
+    DCertPool (RetirePool _ _) -> do
       ps <-
         trans @(POOL crypto) $ TRC (PoolEnv slotIx pp, _pstate d, c)
       pure $ d { _pstate = ps }
-    GenesisDelegate _ -> do
+    DCertGenesis (GenesisDelegate _) -> do
       ds <-
         trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves, _dstate d, c)
       pure $ d { _dstate = ds }
 
-    RegKey _ -> do
+    DCertDeleg (RegKey _) -> do
       ds <-
         trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves, _dstate d, c)
       pure $ d { _dstate = ds }
 
-    DeRegKey _ -> do
+    DCertDeleg (DeRegKey _) -> do
       ds <-
         trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves, _dstate d, c)
       pure $ d { _dstate = ds }
 
-    Delegate _ -> do
+    DCertDeleg (Delegate _) -> do
       ds <-
         trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves , _dstate d, c)
       pure $ d { _dstate = ds }
 
-    InstantaneousRewards _ -> do
+    DCertMir _ -> do
       ds <- trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves , _dstate d, c)
       pure $ d { _dstate = ds }
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -63,7 +63,7 @@ poolDelegationTransition = do
   TRC (PoolEnv slot pp, ps, c) <- judgmentContext
   let StakePools stPools_ = _stPools ps
   case c of
-    RegPool poolParam -> do
+    DCertPool (RegPool poolParam) -> do
       let hk = poolParam ^. poolPubKey
       if hk ∉ dom stPools_
         then-- register new
@@ -80,7 +80,7 @@ poolDelegationTransition = do
               { _pParams = _pParams ps ⨃ (hk, poolParam),
                 _retiring = Set.singleton hk ⋪ _retiring ps
               }
-    RetirePool hk (EpochNo e) -> do
+    DCertPool (RetirePool hk (EpochNo e)) -> do
       EpochNo cepoch <- liftSTS $ do
         ei <- asks epochInfo
         epochInfoEpoch ei slot

--- a/shelley/chain-and-ledger/executable-spec/src/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Tx.hs
@@ -44,10 +44,9 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           Data.Word (Word8)
 
-import           TxData (Credential (..), MultiSig (..), ScriptHash (..), StakeCredential, Tx (..),
-                     TxBody (..), TxId (..), TxIn (..), TxOut (..), WitVKey (..), body, certs,
-                     inputs, outputs, ttl, txUpdate, txfee, wdrls, witKeyHash, witnessMSigMap,
-                     witnessVKeySet)
+import           TxData (Credential (..), MultiSig (..), ScriptHash (..), Tx (..), TxBody (..),
+                     TxId (..), TxIn (..), TxOut (..), WitVKey (..), body, certs, inputs, outputs,
+                     ttl, txUpdate, txfee, wdrls, witKeyHash, witnessMSigMap, witnessVKeySet)
 
 -- | Typeclass for multis-signature script data types. Allows for script
 -- validation and hashing.
@@ -109,7 +108,7 @@ txwitsScript
 txwitsScript = _witnessMSigMap
 
 extractKeyHash
-  :: [StakeCredential crypto]
+  :: [Credential crypto]
   -> [AnyKeyHash crypto]
 extractKeyHash =
   mapMaybe (\case
@@ -117,7 +116,7 @@ extractKeyHash =
                 _ -> Nothing)
 
 extractScriptHash
-  :: [StakeCredential crypto]
+  :: [Credential crypto]
   -> [ScriptHash crypto]
 extractScriptHash =
   mapMaybe (\case

--- a/shelley/chain-and-ledger/executable-spec/src/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Tx.hs
@@ -28,11 +28,12 @@ module Tx
   , txwitsScript
   , extractKeyHash
   , extractScriptHash
+  , extractGenKeyHash
   )
 where
 
 
-import           Keys (AnyKeyHash, undiscriminateKeyHash)
+import           Keys (AnyKeyHash, GenKeyHash, undiscriminateKeyHash)
 
 import           Cardano.Binary (ToCBOR (toCBOR), encodeWord8)
 import           Cardano.Crypto.Hash (hashWithSerialiser)
@@ -122,3 +123,8 @@ extractScriptHash =
   mapMaybe (\case
                 ScriptHashObj hk -> Just hk
                 _ -> Nothing)
+
+extractGenKeyHash
+  :: [GenKeyHash crypto]
+  -> [AnyKeyHash crypto]
+extractGenKeyHash = map undiscriminateKeyHash

--- a/shelley/chain-and-ledger/executable-spec/src/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Tx.hs
@@ -37,11 +37,11 @@ import           Keys (AnyKeyHash, undiscriminateKeyHash)
 import           Cardano.Binary (ToCBOR (toCBOR), encodeWord8)
 import           Cardano.Crypto.Hash (hashWithSerialiser)
 import           Cardano.Ledger.Shelley.Crypto
-import           Data.Word (Word8)
 import           Data.Map.Strict (Map)
 import           Data.Maybe (mapMaybe)
 import           Data.Set (Set)
 import qualified Data.Set as Set
+import           Data.Word (Word8)
 
 import           TxData (Credential (..), MultiSig (..), ScriptHash (..), StakeCredential, Tx (..),
                      TxBody (..), TxId (..), TxIn (..), TxOut (..), WitVKey (..), body, certs,
@@ -113,7 +113,6 @@ extractKeyHash
 extractKeyHash =
   mapMaybe (\case
                 KeyHashObj hk -> Just $ undiscriminateKeyHash hk
-                GenesisHashObj hk -> Just $ undiscriminateKeyHash hk
                 _ -> Nothing)
 
 extractScriptHash

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -73,7 +73,7 @@ instance NoUnexpectedThunks (PoolParams crypto)
 
 -- |An account based address for rewards
 newtype RewardAcnt crypto = RewardAcnt
-  { getRwdCred :: StakeCredential crypto
+  { getRwdCred :: Credential crypto
   } deriving (Show, Eq, NoUnexpectedThunks, Ord, FromCBOR, ToCBOR)
 
 -- | Script hash or key hash for a payment or a staking object.
@@ -177,13 +177,11 @@ data TxOut crypto
 
 instance NoUnexpectedThunks (TxOut crypto)
 
-type StakeCredential crypto = Credential crypto
-
 data DelegCert crypto =
     -- | A stake key registration certificate.
-    RegKey (StakeCredential crypto)
+    RegKey (Credential crypto)
     -- | A stake key deregistration certificate.
-  | DeRegKey (StakeCredential crypto)
+  | DeRegKey (Credential crypto)
     -- | A stake delegation certificate.
   | Delegate (Delegation crypto)
   deriving (Show, Generic, Eq)
@@ -263,10 +261,10 @@ data Tx crypto
 instance Crypto crypto => NoUnexpectedThunks (Tx crypto)
 
 newtype StakeCreds crypto =
-  StakeCreds (Map (StakeCredential crypto) SlotNo)
+  StakeCreds (Map (Credential crypto) SlotNo)
   deriving (Show, Eq, NoUnexpectedThunks)
 
-addStakeCreds :: (StakeCredential crypto) -> SlotNo -> (StakeCreds crypto) -> StakeCreds crypto
+addStakeCreds :: (Credential crypto) -> SlotNo -> (StakeCreds crypto) -> StakeCreds crypto
 addStakeCreds newCred s (StakeCreds creds) = StakeCreds $ Map.insert newCred s creds
 
 newtype StakePools crypto =
@@ -713,7 +711,7 @@ instance
             }
 
 instance Relation (StakeCreds crypto) where
-  type Domain (StakeCreds crypto) = StakeCredential crypto
+  type Domain (StakeCreds crypto) = Credential crypto
   type Range (StakeCreds crypto)  = SlotNo
 
   singleton k v = StakeCreds $ Map.singleton k v

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -276,86 +276,62 @@ newtype StakePools crypto =
 
 -- CBOR
 
-instance (Crypto crypto)
-  => ToCBOR (DelegCert crypto)
- where toCBOR = \case
-         RegKey (KeyHashObj h) ->
-           encodeListLen 2
-           <> toCBOR (0 :: Word8)
-           <> toCBOR h
-         RegKey (ScriptHashObj h) ->
-           encodeListLen 2
-           <> toCBOR (1 :: Word8)
-           <> toCBOR h
-         DeRegKey (KeyHashObj h) ->
-           encodeListLen 2
-           <> toCBOR (2 :: Word8)
-           <> toCBOR h
-         DeRegKey (ScriptHashObj h) ->
-           encodeListLen 2
-           <> toCBOR (3 :: Word8)
-           <> toCBOR h
-         Delegate (Delegation (KeyHashObj h) poolkh) ->
-           encodeListLen 3
-           <> toCBOR (4 :: Word8)
-           <> toCBOR h
-           <> toCBOR poolkh
-         Delegate (Delegation (ScriptHashObj h) poolkh) ->
-           encodeListLen 3
-           <> toCBOR (5 :: Word8)
-           <> toCBOR h
-           <> toCBOR poolkh
-
-instance (Crypto crypto)
-  => ToCBOR (PoolCert crypto)
- where toCBOR = \case
-         RegPool poolParams ->
-           encodeListLen (1 + listLen poolParams)
-           <> toCBOR (0 :: Word8)
-           <> toCBORGroup poolParams
-         RetirePool vk epoch ->
-           encodeListLen 3
-           <> toCBOR (1 :: Word8)
-           <> toCBOR vk
-           <> toCBOR epoch
-
-instance (Crypto crypto)
-  => ToCBOR (GenesisDelegate crypto)
-  where toCBOR (GenesisDelegate (gk, kh)) =
-         encodeListLen 2
-         <> toCBOR gk
-         <> toCBOR kh
-
-instance (Crypto crypto)
-  => ToCBOR (MIRCert crypto)
-  where toCBOR (MIRCert credCoinMap) =
-          toCBOR credCoinMap
-
-
 instance
   (Crypto crypto)
   => ToCBOR (DCert crypto)
  where
    toCBOR = \case
-     DCertDeleg dcert ->
-       encodeListLen 2
-       <> toCBOR (0 :: Word8)
-       <> toCBOR dcert
+           -- DCertDeleg
+     DCertDeleg (RegKey (KeyHashObj h)) ->
+           encodeListLen 2
+           <> toCBOR (0 :: Word8)
+           <> toCBOR h
+     DCertDeleg (RegKey (ScriptHashObj h)) ->
+           encodeListLen 2
+           <> toCBOR (1 :: Word8)
+           <> toCBOR h
+     DCertDeleg (DeRegKey (KeyHashObj h)) ->
+           encodeListLen 2
+           <> toCBOR (2 :: Word8)
+           <> toCBOR h
+     DCertDeleg (DeRegKey (ScriptHashObj h)) ->
+           encodeListLen 2
+           <> toCBOR (3 :: Word8)
+           <> toCBOR h
+     DCertDeleg (Delegate (Delegation (KeyHashObj h) poolkh)) ->
+           encodeListLen 3
+           <> toCBOR (4 :: Word8)
+           <> toCBOR h
+           <> toCBOR poolkh
+     DCertDeleg (Delegate (Delegation (ScriptHashObj h) poolkh)) ->
+           encodeListLen 3
+           <> toCBOR (5 :: Word8)
+           <> toCBOR h
+           <> toCBOR poolkh
 
-     DCertPool pcert ->
-       encodeListLen 2
-       <> toCBOR (1 :: Word8)
-       <> toCBOR pcert
+           -- DCertPool
+     DCertPool (RegPool poolParams) ->
+           encodeListLen (1 + listLen poolParams)
+           <> toCBOR (6 :: Word8)
+           <> toCBORGroup poolParams
+     DCertPool (RetirePool vk epoch) ->
+           encodeListLen 3
+           <> toCBOR (7 :: Word8)
+           <> toCBOR vk
+           <> toCBOR epoch
 
-     DCertGenesis gcert ->
-       encodeListLen 2
-       <> toCBOR (2 :: Word8)
-       <> toCBOR gcert
+           -- DCertGenesis
+     DCertGenesis (GenesisDelegate (gk, kh)) ->
+           encodeListLen 3
+           <> toCBOR (8 :: Word8)
+           <> toCBOR gk
+           <> toCBOR kh
 
-     DCertMir mcert ->
-       encodeListLen 2
-       <> toCBOR (3 :: Word8)
-       <> toCBOR mcert
+           -- DCertMIR
+     DCertMir (MIRCert credCoinMap) ->
+           encodeListLen 2
+           <> toCBOR (9 :: Word8)
+           <> toCBOR credCoinMap
 
 instance
   (Crypto crypto)
@@ -392,7 +368,7 @@ instance
         a <- fromCBOR
         b <- fromCBOR
         pure $ DCertGenesis $ GenesisDelegate (a, b)
-      9 -> matchSize "InstantaneousRewards" 2 n >> (DCertMir . MIRCert) <$> fromCBOR
+      9 -> matchSize "MIRCert" 2 n >> (DCertMir . MIRCert) <$> fromCBOR
       k -> invalidKey k
 
 instance

--- a/shelley/chain-and-ledger/executable-spec/test/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator.hs
@@ -255,7 +255,7 @@ repeatCollectTx' n keyPairs fees ls txs validationErrors
     repeatCollectTx' (n - 1) keyPairs (txfee' + fees) ls' (tx:txs) (validationErrors ++ errors')
 
 -- | Find first matching key pair for stake key in 'AddrTxin'.
-findStakeKeyPair :: StakeCredential -> KeyPairs -> KeyPair
+findStakeKeyPair :: Credential -> KeyPairs -> KeyPair
 findStakeKeyPair (KeyHashObj hk) keyList =
     snd $ head $ filter (\(_, stake) -> hk == hashKey (vKey stake)) keyList
 findStakeKeyPair _ _ = undefined -- TODO treat script case

--- a/shelley/chain-and-ledger/executable-spec/test/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator.hs
@@ -57,13 +57,14 @@ import           STS.Utxo (pattern BadInputsUTxO, pattern ExpiredUTxO, pattern F
                      pattern InputSetEmptyUTxO, pattern ValueNotConservedUTxO)
 import           STS.Utxow (pattern InvalidWitnessesUTXOW, pattern MissingScriptWitnessesUTXOW,
                      pattern MissingVKeyWitnessesUTXOW, PredicateFailure (..))
+import           Test.Utils
 import           Tx (pattern Tx, pattern TxBody, pattern TxOut, body)
-import           TxData (pattern AddrBase, pattern DeRegKey, pattern Delegate, pattern Delegation,
-                     pattern KeyHashObj, pattern RegKey, pattern RetirePool, StakeCreds (..))
+import           TxData (pattern AddrBase, pattern DCertDeleg, pattern DCertPool, pattern DeRegKey,
+                     pattern Delegate, pattern Delegation, pattern KeyHashObj, pattern RegKey,
+                     pattern RetirePool, StakeCreds (..))
 import           Updates
 import           UTxO (pattern UTxO, balance, makeWitnessVKey)
 import           Validation (ValidationError (..), Validity (..))
-import           Test.Utils
 
 import           MockTypes
 import           Mutator
@@ -318,16 +319,16 @@ genDelegationData keys epoch =
 
 genDCertRegKey :: KeyPairs -> Gen DCert
 genDCertRegKey keys =
-  RegKey . KeyHashObj . hashKey <$> getAnyStakeKey keys
+  DCertDeleg . RegKey . KeyHashObj . hashKey <$> getAnyStakeKey keys
 
 genDCertDeRegKey :: KeyPairs -> Gen DCert
 genDCertDeRegKey keys =
-    DeRegKey . KeyHashObj . hashKey <$> getAnyStakeKey keys
+    DCertDeleg . DeRegKey . KeyHashObj . hashKey <$> getAnyStakeKey keys
 
 genDCertRetirePool :: KeyPairs -> EpochNo -> Gen DCert
 genDCertRetirePool keys epoch = do
   key <- getAnyStakeKey keys
-  pure $ RetirePool (hashKey key) epoch
+  pure $ DCertPool $ RetirePool (hashKey key) epoch
 
 genDelegation :: KeyPairs -> DPState -> Gen Delegation
 genDelegation keys d = do
@@ -337,7 +338,7 @@ genDelegation keys d = do
        where (StakeCreds stkCreds') = d ^. dstate . stkCreds
 
 genDCertDelegate :: KeyPairs -> DPState -> Gen DCert
-genDCertDelegate keys ds = Delegate <$> genDelegation keys ds
+genDCertDelegate keys ds = (DCertDeleg . Delegate) <$> genDelegation keys ds
 
 -- |In the case where a transaction is valid for a given ledger state,
 -- apply the transaction as a state transition function on the ledger state.

--- a/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/MockTypes.hs
@@ -151,8 +151,6 @@ type POOLREAP = STS.PoolReap.POOLREAP MockCrypto
 
 type Credential = TxData.Credential MockCrypto
 
-type StakeCredential = TxData.StakeCredential MockCrypto
-
 type StakeCreds = TxData.StakeCreds MockCrypto
 
 type MultiSig = TxData.MultiSig MockCrypto

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestDeleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestDeleg.hs
@@ -31,7 +31,7 @@ import           Ledger.Core (dom, range, (∈), (∉), (◁))
 
 import           Coin (Coin, pattern Coin)
 import           LedgerState (_delegations, _irwd, _rewards, _stkCreds)
-import           MockTypes (DELEG, DState, KeyHash, RewardAcnt, StakeCredential)
+import           MockTypes (Credential, DELEG, DState, KeyHash, RewardAcnt)
 import           TxData (pattern DCertDeleg, pattern DCertMir, pattern DeRegKey, pattern Delegate,
                      pattern Delegation, pattern MIRCert, pattern RegKey)
 
@@ -39,13 +39,13 @@ import           TxData (pattern DCertDeleg, pattern DCertMir, pattern DeRegKey,
 -- helper accessor functions --
 -------------------------------
 
-getStDelegs :: DState -> Set StakeCredential
+getStDelegs :: DState -> Set Credential
 getStDelegs = dom . _stkCreds
 
 getRewards :: DState -> Map RewardAcnt Coin
 getRewards = _rewards
 
-getDelegations :: DState -> Map StakeCredential KeyHash
+getDelegations :: DState -> Map Credential KeyHash
 getDelegations = _delegations
 
 --------------------------


### PR DESCRIPTION
This restructures certificates a bit, grouping into Deleg / Pool / Genesis and Mir in order to have cleaner functions, e.g., `cwitness`. This should help with generators as genesis and mir certs are conceptually different from the others.