### PR TITLE
[1083] Allow full decentralisation in generators

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -28,15 +28,15 @@ import           Cardano.Ledger.Shelley.Crypto (HASH)
 import           Coin (Coin (..))
 import           Examples (unsafeMkUnitInterval)
 import           Generator.Core.QuickCheck (genInteger, genNatural, genWord64,
-                                            increasingProbabilityAt)
+                     increasingProbabilityAt)
 import           Keys (hash)
 import           Keys (GenKeyHash)
 import           Numeric.Natural (Natural)
 import           PParams (PParams (..))
 import           Slot (EpochNo (EpochNo))
 import           Updates (AVUpdate (..), ApName (..), ApVer (..), Applications (..),
-                          InstallerHash (..), Mdt (..), PPUpdate (..), PParamsUpdate (..), Ppm (..),
-                          SystemTag (..), Update (..))
+                     InstallerHash (..), Mdt (..), PPUpdate (..), PParamsUpdate (..), Ppm (..),
+                     SystemTag (..), Update (..))
 
 genRationalInThousands :: Integer -> Integer -> Gen Rational
 genRationalInThousands lower upper =
@@ -159,10 +159,8 @@ genActiveSlotCoeff  = increasingProbabilityAt
                         (unsafeMkUnitInterval   0,
                          unsafeMkUnitInterval   1)
 
--- | decentralisation param: 0,0.1,0.2..1
--- TODO: mgudemann, allow 0 despite MIR cert generation
 genDecentralisationParam :: Gen UnitInterval
-genDecentralisationParam = unsafeMkUnitInterval <$> QC.elements [0.1,0.2 .. 1]
+genDecentralisationParam = unsafeMkUnitInterval <$> QC.elements [0,0.1 .. 1]
 
 -- | protocolVersion is a triple of numbers
 genProtocolVersion :: Gen (Natural, Natural, Natural)

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
@@ -60,9 +60,9 @@ relevantCasesAreCovered = withMaxSuccess 500 . property $ do
               (traceLength tr <= 20 * length (filter isRetirePool certs_))
               "there is at least 1 RetirePool certificate for every 20 transactions"
 
-     , cover_ 60
-              (traceLength tr <= 20 * length (filter isInstantaneousRewards certs_))
-              "there is at least 1 MIR certificate for every 20 transactions"
+     , cover_ 40
+              (traceLength tr <= 50 * length (filter isInstantaneousRewards certs_))
+              "there is at least 1 MIR certificate for every 50 transactions"
 
      , cover_ 25
               (0.75 >= noCertsRatio (certsByTx txs))

--- a/shelley/chain-and-ledger/executable-spec/test/Shrinkers.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Shrinkers.hs
@@ -1,7 +1,5 @@
 module Shrinkers where
 
-import           Cardano.Ledger.Shelley.Crypto
-
 import           Data.Foldable (toList)
 import           Data.Map (Map)
 import qualified Data.Map as M
@@ -18,13 +16,14 @@ import           TxData
 import           Updates
 
 shrinkTx
-  :: Crypto crypto
-  => Tx crypto
+  :: Tx crypto
   -> [Tx crypto]
-shrinkTx (Tx b ws wm) =
+shrinkTx (Tx _b _ws _wm) = []
+  {- TODO @uroboros write shrinker that shrinks to valid transactions
   [ Tx b' ws wm | b' <- shrinkTxBody b ] ++
   [ Tx b ws' wm | ws' <- shrinkSet shrinkWitVKey ws ] ++
   [ Tx b ws wm' | wm' <- shrinkMap shrinkScriptHash shrinkMultiSig wm ]
+  -}
 
 shrinkTxBody :: TxBody crypto -> [TxBody crypto]
 shrinkTxBody (TxBody is os cs ws tf tl tu) =


### PR DESCRIPTION
Closes #1083 

* `genInstantaneousRewards` was producing empty certificates (`InstantaneousReward {}`) when no stake credentials are available, in this PR we discard such certs
* `genInstantaneousRewards` now discards generated certs when d=0 (full decentralisation mode)
* with that in place I could generate PParams with d=0 again

