### PR TITLE
Minor edits to the Shelley ledger formal spec

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -70,15 +70,17 @@ delegationTransition = do
 
   case c of
     DCertDeleg (RegKey key) -> do
+      -- note that pattern match is used instead of regCred, as in the spec
       key ∉ dom (_stkCreds ds) ?! StakeKeyAlreadyRegisteredDELEG
 
       pure $ ds
         { _stkCreds  = _stkCreds ds  ∪ singleton key slot_
-        , _rewards = _rewards ds ∪ Map.singleton (RewardAcnt key) (Coin 0)
+        , _rewards = _rewards ds ∪ Map.singleton (RewardAcnt key) (Coin 0) -- ∪ is override left
         , _ptrs    = _ptrs ds    ∪ Map.singleton ptr_ key
         }
 
     DCertDeleg (DeRegKey key) -> do
+      -- note that pattern match is used instead of cwitness, as in the spec
       key ∈ dom (_stkCreds ds) ?! StakeKeyNotRegisteredDELEG
 
       let rewardCoin = Map.lookup (RewardAcnt key) (_rewards ds)
@@ -92,12 +94,14 @@ delegationTransition = do
         }
 
     DCertDeleg (Delegate (Delegation delegator_ delegatee_)) -> do
+      -- note that pattern match is used instead of cwitness, as in the spec
       delegator_ ∈ dom (_stkCreds ds) ?! StakeDelegationImpossibleDELEG
 
       pure $ ds
         { _delegations = _delegations ds ⨃ [(delegator_, delegatee_)] }
 
     DCertGenesis (GenesisDelegate (gkey, vk)) -> do
+      -- note that pattern match is used instead of genesisDeleg, as in the spec
       let s' = slot_ +* slotsPrior
           (GenDelegs genDelegs_) = _genDelegs ds
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Pool.hs
@@ -64,6 +64,7 @@ poolDelegationTransition = do
   let StakePools stPools_ = _stPools ps
   case c of
     DCertPool (RegPool poolParam) -> do
+      -- note that pattern match is used instead of cwitness, as in the spec
       let hk = poolParam ^. poolPubKey
       if hk ∉ dom stPools_
         then-- register new
@@ -81,6 +82,7 @@ poolDelegationTransition = do
                 _retiring = Set.singleton hk ⋪ _retiring ps
               }
     DCertPool (RetirePool hk (EpochNo e)) -> do
+      -- note that pattern match is used instead of cwitness, as in the spec
       EpochNo cepoch <- liftSTS $ do
         ei <- asks epochInfo
         epochInfoEpoch ei slot

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -143,8 +143,8 @@ It does the following:
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \cwitness{} & \DCert\setminus(\DCertRegKey\cup\DCertMir) \to \powerset{\Credential} & \text{certificate witness} \\
-      \fun{regCred} & \DCertRegPool \to \Credential & \text{registered credential} \\
+      \cwitness{} & \DCert\setminus(\DCertRegKey\cup\DCertMir) \to \Credential & \text{certificate witness} \\
+      \fun{regCred} & \DCertRegKey \to \Credential & \text{registered credential} \\
       \fun{dpool} & \DCertDeleg \to \KeyHash
                                             & \text{pool being delegated to}
       \\
@@ -348,6 +348,12 @@ concerns are independent of the ledger rules.
     \begin{itemize}
     \item The key is added to the set of registered stake credentials.
       \item A reward account is created for this key, with a starting balance of zero.
+        Note that \cref{eq:deleg-reg} uses a union override left to add
+        a zero balance reward account.
+        We could have used a normal union, since the system as a whole enjoys the property that
+        $\var{hk}\in\dom{\var{stkCreds}}\iff \addrRw \var{hk}\in\dom{\var{rewards}}$.
+        The union override left, however, gives us a \textit{local}
+        preservation of value property. See \cref{sec:preservation-of-value}.
       \item The certificate pointer is mapped to the new stake credential.
     \end{itemize}
 
@@ -420,7 +426,7 @@ concerns are independent of the ledger rules.
       \left(
       \begin{array}{rcl}
         \varUpdate{\var{stkCreds}} & \varUpdate{\union} & \varUpdate{\{\var{hk} \mapsto slot\}} \\
-        \varUpdate{\var{rewards}} & \varUpdate{\union} & \varUpdate{\{\addrRw \var{hk} \mapsto 0\}}\\
+        \varUpdate{\var{rewards}} & \varUpdate{\unionoverrideLeft} & \varUpdate{\{\addrRw \var{hk} \mapsto 0\}}\\
         \var{delegations} \\
         \varUpdate{\var{ptrs}} & \varUpdate{\union} & \varUpdate{\{ptr \mapsto \var{hk}\}} \\
         \var{fGenDelegs} \\

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -84,7 +84,6 @@
 \newcommand{\Seed}{\type{Seed}}
 \newcommand{\seedOp}{\star}
 \newcommand{\Ppm}{\type{Ppm}}
-\newcommand{\Value}{\type{Value}}
 \newcommand{\ProtVer}{\ensuremath{\type{ProtVer}}}
 \newcommand{\ApName}{\ensuremath{\type{ApName}}}
 \newcommand{\ApVer}{\ensuremath{\type{ApVer}}}

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -154,8 +154,9 @@ If we let:
     \Val(\txins{t} \restrictdom{\var{utxo}}) + \Val(\txins{t} \subtractdom{\var{utxo}}) + w
     = \Val(\outs{t}) + f + d - k + \Val(\txins{t} \subtractdom{\var{utxo}})
   \end{equation*}
-  Note that $d-k-c$ is non-negative since the deposits will always be large enough to cover
-  the current obligation (see Theorem~\ref{thm:non-neg-deposits}).
+  (Though not needed for the proof at hand,
+  note that $d-k-c$ is non-negative since the deposits will always be large enough to cover
+  the current obligation. See Theorem~\ref{thm:non-neg-deposits}.)
 %
   It then follows that:
   \begin{equation*}

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -2,7 +2,9 @@
 \label{sec:protocol-parameters}
 
 The rules for the ledger depend on several parameters contained in the $\PParams$ type,
-defined in \cite{byron_ledger_spec}.
+defined in the same way as in the Byron ledger specification \cite{byron_ledger_spec}.
+The type $\Ppm$ represents the names of the protocol parameters,
+and $\mathsf{T_{ppm}}$ represents the dependent type of a given protocol parameter.
 The parameters are listed in Figure~\ref{fig:defs:protocol-parameters},
 the first ten of which below are common to the Byron era.
 We will explain the significance of each parameter as it comes up in
@@ -42,6 +44,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
+      \var{p} & \Ppm & \text{protocol parameter}\\
       \var{dur} & \Duration & \text{difference between slots}\\
       \var{epoch} & \Epoch & \text{epoch} \\
       \var{kesPeriod} & \KESPeriod & \text{KES period} \\
@@ -54,7 +57,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}lr}
       \var{pp}
       & \PParams
-      & \Ppm \mapsto \Value
+      & \Ppm \mapsto \mathsf{T_{ppm}}
       & \text{protocol parameter map}
       \\
       \var{coin}


### PR DESCRIPTION
@javierdiaz72 's recent work to formalize the "preservation of ada" property of the Shelley ledger spec (ie section 15.1) has revealed some improvements, which this PR adds:

* The protocol parameters are now fully defined in the Shelley spec (instead of just referencing the Byron spec)
* The hand proof of "preservation of ada" in section 15.1 makes it clear that the "non-negative deposits" comment is not needed for the proof (but is just nice to note)
* In the exec model, in the places where a pattern match is used instead of a named accessor function used in the spec, a comment is added.
* The domain of the `regCred` function was fixed (regkey instead of regpool).
* The range of the `cwitness` is fixed (not a powerset anymore).
* New reward accounts are now created with union override left instead of a plain union, which provides a nice _local_ preservation of ada property for the `Deleg` transition.