### PR TITLE
syncing formal and exec specs

### DIFF
--- a/byron/ledger/executable-spec/src/Ledger/Core.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core.hs
@@ -288,7 +288,7 @@ class Relation m where
   -- | Union
   (∪) :: (Ord (Domain m), Ord (Range m)) => m -> m -> m
 
-  -- | Union Override
+  -- | Union Override Right
   (⨃) :: (Ord (Domain m), Ord (Range m), Foldable f) => m -> f (Domain m, Range m) -> m
 
   -- | Restrict domain to values less or equal than the given value.

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -244,7 +244,6 @@ emptyLedgerState =
   LedgerState
   emptyUTxOState
   emptyDelegation
-  0
 
 emptyAccount :: AccountState
 emptyAccount = AccountState (Coin 0) (Coin 0)
@@ -301,7 +300,7 @@ getGKeys
 getGKeys nes = Map.keysSet genDelegs
   where NewEpochState _ _ _ es _ _ _ = nes
         EpochState _ _ ls _ = es
-        LedgerState _ (DPState (DState _ _ _ _ _ (GenDelegs genDelegs) _) _) _ = ls
+        LedgerState _ (DPState (DState _ _ _ _ _ (GenDelegs genDelegs) _) _) = ls
 
 data NewEpochEnv crypto=
   NewEpochEnv {
@@ -318,8 +317,6 @@ data LedgerState crypto=
     _utxoState         :: !(UTxOState crypto)
     -- |The current delegation state
   , _delegationState   :: !(DPState crypto)
-    -- |The current transaction index in the current slot.
-  , _txSlotIx          :: Ix
   } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (LedgerState crypto)
@@ -367,7 +364,6 @@ genesisState genDelegs0 utxo0 = LedgerState
     (Coin 0)
     emptyUpdateState)
   (DPState dState emptyPState)
-  0
   where
     dState = emptyDState {_genDelegs = GenDelegs genDelegs0}
 
@@ -687,7 +683,6 @@ applyTxBody ls pp tx =
        & utxoState . deposited .~ depositPoolChange ls pp tx
        & utxoState . fees .~ (tx ^. txfee) + (ls ^. utxoState . fees)
        & delegationState . dstate . rewards .~ newAccounts
-       & txSlotIx  %~ (+) 1
   where
     newAccounts = reapRewards (ls ^. delegationState . dstate. rewards) (tx ^. wdrls)
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
@@ -77,11 +77,11 @@ avUpdateNoConsensus = do
 
   all allApNamesValid (range _aup) ?! InvalidName
 
-  all (allSvCanFollow_ avs favs) (range _aup) ?! CannotFollow
+  all (allSvCanFollow avs favs) (range _aup) ?! CannotFollow
 
   all allTagsValid (range _aup) ?! InvalidSystemTags
 
-  let aup' = _aup ⨃ Map.toList aupS
+  let aup' = aupS ⨃ Map.toList _aup
   let fav  = votedValue aup'
 
   fav == Nothing ?! AVConsensus
@@ -90,7 +90,7 @@ avUpdateNoConsensus = do
 
 avUpdateConsensus :: TransitionRule (AVUP crypto)
 avUpdateConsensus = do
-  TRC (AVUPEnv _slot (GenDelegs _genDelegs), AVUPState (AVUpdate aupS) favs avs, AVUpdate _aup) <-
+  TRC (AVUPEnv slot (GenDelegs _genDelegs), AVUPState (AVUpdate aupS) favs avs, AVUpdate _aup) <-
     judgmentContext
 
   not (Map.null _aup) ?! EmptyAVUP
@@ -99,17 +99,17 @@ avUpdateConsensus = do
 
   all allApNamesValid (range _aup) ?! InvalidName
 
-  all (allSvCanFollow_ avs favs) (range _aup) ?! CannotFollow
+  all (allSvCanFollow avs favs) (range _aup) ?! CannotFollow
 
   all allTagsValid (range _aup) ?! InvalidSystemTags
 
-  let aup' = _aup ⨃ Map.toList aupS
+  let aup' = aupS ⨃ Map.toList _aup
   let fav  = votedValue aup'
 
   fav /= Nothing ?! NoAVConsensus
   let fav' = fromMaybe (Applications Map.empty) fav
 
-  let s = _slot +* slotsPrior
+  let s = slot +* slotsPrior
 
   pure $ AVUPState
     (AVUpdate Map.empty)
@@ -119,8 +119,8 @@ avUpdateConsensus = do
 allApNamesValid :: Applications crypto -> Bool
 allApNamesValid = all apNameValid . dom . apps
 
-allSvCanFollow_ :: Applications crypto -> Favs crypto -> Applications crypto -> Bool
-allSvCanFollow_ avs favs = all (svCanFollow avs favs) . Map.toList . apps
+allSvCanFollow :: Applications crypto -> Favs crypto -> Applications crypto -> Bool
+allSvCanFollow avs favs = all (svCanFollow avs favs) . Map.toList . apps
 
 allTagsValid :: Applications crypto -> Bool
 allTagsValid = all sTagsValid . range . range . apps

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Chain.hs
@@ -105,7 +105,7 @@ chainTransition = do
   let NewEpochState e1 _ _ _ _ _ _ = nes
       NewEpochState e2 _ bcur es _ _pd osched = nes'
   let EpochState (AccountState _ _reserves) _ ls pp'                         = es
-  let LedgerState _ (DPState (DState _ _ _ _ _ _genDelegs _) (PState _ _ _)) _ = ls
+  let LedgerState _ (DPState (DState _ _ _ _ _ _genDelegs _) (PState _ _ _)) = ls
 
   PrtclState cs' h' sL' eta0' etaV' etaC' etaH' <- trans @(PRTCL crypto)
     $ TRC ( PrtclEnv pp' osched _pd _genDelegs sNow (e1 /= e2)

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Deleg.hs
@@ -26,7 +26,8 @@ import           GHC.Generics (Generic)
 import           Hedgehog (Gen)
 import           Keys
 import           Ledger.Core (dom, range, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
-import           LedgerState
+import           LedgerState (DState, emptyDState, _delegations, _fGenDelegs, _genDelegs, _irwd,
+                     _ptrs, _rewards, _stkCreds)
 import           Slot
 import           TxData
 
@@ -34,9 +35,9 @@ data DELEG crypto
 
 data DelegEnv
   = DelegEnv
-  { slot     :: SlotNo
-  , ptr      :: Ptr
-  , reserves :: Coin
+  { slotNo    :: SlotNo
+  , ptr_      :: Ptr
+  , reserves_ :: Coin
   }
   deriving (Show, Eq)
 
@@ -66,60 +67,61 @@ instance NoUnexpectedThunks (PredicateFailure (DELEG crypto))
 delegationTransition
   :: TransitionRule (DELEG crypto)
 delegationTransition = do
-  TRC (DelegEnv slot_ ptr_ reserves_, ds, c) <- judgmentContext
+  TRC (DelegEnv slot ptr reserves, ds, c) <- judgmentContext
 
   case c of
-    DCertDeleg (RegKey key) -> do
+    DCertDeleg (RegKey hk) -> do
       -- note that pattern match is used instead of regCred, as in the spec
-      key ∉ dom (_stkCreds ds) ?! StakeKeyAlreadyRegisteredDELEG
+      hk ∉ dom (_stkCreds ds) ?! StakeKeyAlreadyRegisteredDELEG
 
       pure $ ds
-        { _stkCreds  = _stkCreds ds  ∪ singleton key slot_
-        , _rewards = _rewards ds ∪ Map.singleton (RewardAcnt key) (Coin 0) -- ∪ is override left
-        , _ptrs    = _ptrs ds    ∪ Map.singleton ptr_ key
+        { _stkCreds  = _stkCreds ds  ∪ singleton hk slot
+        , _rewards = _rewards ds ∪ Map.singleton (RewardAcnt hk) (Coin 0) -- ∪ is override left
+        , _ptrs    = _ptrs ds    ∪ Map.singleton ptr hk
         }
 
-    DCertDeleg (DeRegKey key) -> do
+    DCertDeleg (DeRegKey hk) -> do
       -- note that pattern match is used instead of cwitness, as in the spec
-      key ∈ dom (_stkCreds ds) ?! StakeKeyNotRegisteredDELEG
+      hk ∈ dom (_stkCreds ds) ?! StakeKeyNotRegisteredDELEG
 
-      let rewardCoin = Map.lookup (RewardAcnt key) (_rewards ds)
+      let rewardCoin = Map.lookup (RewardAcnt hk) (_rewards ds)
       rewardCoin == Just 0 ?! StakeKeyNonZeroAccountBalanceDELEG
 
       pure $ ds
-        { _stkCreds      = Set.singleton key              ⋪ _stkCreds ds
-        , _rewards     = Set.singleton (RewardAcnt key) ⋪ _rewards ds
-        , _delegations = Set.singleton key              ⋪ _delegations ds
-        , _ptrs        = _ptrs ds                       ⋫ Set.singleton key
+        { _stkCreds    = Set.singleton hk              ⋪ _stkCreds ds
+        , _rewards     = Set.singleton (RewardAcnt hk) ⋪ _rewards ds
+        , _delegations = Set.singleton hk              ⋪ _delegations ds
+        , _ptrs        = _ptrs ds                      ⋫ Set.singleton hk
         }
 
-    DCertDeleg (Delegate (Delegation delegator_ delegatee_)) -> do
-      -- note that pattern match is used instead of cwitness, as in the spec
-      delegator_ ∈ dom (_stkCreds ds) ?! StakeDelegationImpossibleDELEG
+    DCertDeleg (Delegate (Delegation hk dpool)) -> do
+      -- note that pattern match is used instead of cwitness and dpool, as in the spec
+      hk ∈ dom (_stkCreds ds) ?! StakeDelegationImpossibleDELEG
 
       pure $ ds
-        { _delegations = _delegations ds ⨃ [(delegator_, delegatee_)] }
+        { _delegations = _delegations ds ⨃ [(hk, dpool)] }
 
-    DCertGenesis (GenesisDelegate (gkey, vk)) -> do
+    DCertGenesis (GenesisDelegate (gkh, vkh)) -> do
       -- note that pattern match is used instead of genesisDeleg, as in the spec
-      let s' = slot_ +* slotsPrior
-          (GenDelegs genDelegs_) = _genDelegs ds
+      let s' = slot +* slotsPrior
+          (GenDelegs genDelegs) = _genDelegs ds
 
-      gkey ∈ dom genDelegs_ ?! GenesisKeyNotInpMappingDELEG
-      vk ∉ range genDelegs_ ?! DuplicateGenesisDelegateDELEG
+      gkh ∈ dom genDelegs ?! GenesisKeyNotInpMappingDELEG
+      vkh ∉ range genDelegs ?! DuplicateGenesisDelegateDELEG
       pure $ ds
-        { _fGenDelegs = _fGenDelegs ds ⨃ [((s', gkey), vk)]}
+        { _fGenDelegs = _fGenDelegs ds ⨃ [((s', gkh), vkh)]}
 
     DCertMir (MIRCert credCoinMap) -> do
-      let combinedMap = Map.union credCoinMap (_irwd ds)
-          requiredForRewards = foldl (+) (Coin 0) (range combinedMap)
       firstSlot <- liftSTS $ do
         ei <- asks epochInfo
-        EpochNo currEpoch <- epochInfoEpoch ei slot_
+        EpochNo currEpoch <- epochInfoEpoch ei slot
         epochInfoFirst ei $ EpochNo (currEpoch + 1)
-      slot_ < firstSlot *- slotsPrior
+      slot < firstSlot *- slotsPrior
         ?! MIRCertificateTooLateinEpochDELEG
-      requiredForRewards <= reserves_ ?! InsufficientForInstantaneousRewardsDELEG
+
+      let combinedMap = Map.union credCoinMap (_irwd ds)
+          requiredForRewards = foldl (+) (Coin 0) (range combinedMap)
+      requiredForRewards <= reserves ?! InsufficientForInstantaneousRewardsDELEG
 
       pure $ ds { _irwd = combinedMap }
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Delpl.hs
@@ -20,10 +20,10 @@ import           Coin (Coin)
 import           Control.State.Transition
 import           Delegation.Certificates
 import           GHC.Generics (Generic)
-import           LedgerState
+import           LedgerState (DPState, emptyDelegation, _dstate, _pstate)
 import           PParams hiding (d)
 import           Slot
-import           STS.Deleg
+import           STS.Deleg (DELEG, DelegEnv (..))
 import           STS.Pool
 import           TxData
 
@@ -63,38 +63,38 @@ delplTransition
    . Crypto crypto
   => TransitionRule (DELPL crypto)
 delplTransition = do
-  TRC (DelplEnv slotIx _ptr pp _reserves, d, c) <- judgmentContext
+  TRC (DelplEnv slot ptr pp reserves, d, c) <- judgmentContext
   case c of
     DCertPool (RegPool _) -> do
       ps <-
-        trans @(POOL crypto) $ TRC (PoolEnv slotIx pp, _pstate d, c)
+        trans @(POOL crypto) $ TRC (PoolEnv slot pp, _pstate d, c)
       pure $ d { _pstate = ps }
     DCertPool (RetirePool _ _) -> do
       ps <-
-        trans @(POOL crypto) $ TRC (PoolEnv slotIx pp, _pstate d, c)
+        trans @(POOL crypto) $ TRC (PoolEnv slot pp, _pstate d, c)
       pure $ d { _pstate = ps }
     DCertGenesis (GenesisDelegate _) -> do
       ds <-
-        trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves, _dstate d, c)
+        trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
       pure $ d { _dstate = ds }
 
     DCertDeleg (RegKey _) -> do
       ds <-
-        trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves, _dstate d, c)
+        trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
       pure $ d { _dstate = ds }
 
     DCertDeleg (DeRegKey _) -> do
       ds <-
-        trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves, _dstate d, c)
+        trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
       pure $ d { _dstate = ds }
 
     DCertDeleg (Delegate _) -> do
       ds <-
-        trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves , _dstate d, c)
+        trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves , _dstate d, c)
       pure $ d { _dstate = ds }
 
     DCertMir _ -> do
-      ds <- trans @(DELEG crypto) $ TRC (DelegEnv slotIx _ptr _reserves , _dstate d, c)
+      ds <- trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves , _dstate d, c)
       pure $ d { _dstate = ds }
 
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
@@ -22,7 +22,7 @@ import           PParams
 import           Slot
 import           STS.Avup
 import           STS.Ppup
-import           Updates
+import           Updates (Update (..), UpdateState (..))
 
 data UP crypto
 
@@ -50,13 +50,13 @@ upTransition
    . Crypto crypto
   => TransitionRule (UP crypto)
 upTransition = do
-  TRC ( UpdateEnv _slot pp _genDelegs
-      , UpdateState pupS aupS favs avs
-      , Update pup _aup) <- judgmentContext
+  TRC ( UpdateEnv slot pp _genDelegs
+      , UpdateState pup aup favs avs
+      , Update pupU aupU) <- judgmentContext
 
-  pup' <- trans @(PPUP crypto) $ TRC (PPUPEnv _slot pp _genDelegs, pupS, pup)
+  pup' <- trans @(PPUP crypto) $ TRC (PPUPEnv slot pp _genDelegs, pup, pupU)
   AVUPState aup' favs' avs' <-
-    trans @(AVUP crypto) $ TRC (AVUPEnv _slot _genDelegs, AVUPState aupS favs avs, _aup)
+    trans @(AVUP crypto) $ TRC (AVUPEnv slot _genDelegs, AVUPState aup favs avs, aupU)
 
   pure $ UpdateState pup' aup' favs' avs'
 

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -112,7 +112,7 @@ instance Crypto crypto => FromCBOR (Update crypto) where
       <*> fromCBOR
 
 data PPUpdateEnv crypto = PPUpdateEnv {
-    slot :: SlotNo
+    slotNo :: SlotNo
   , genDelegs  :: GenDelegs crypto
   } deriving (Show, Eq, Generic)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -334,7 +334,7 @@ psEx1 = emptyPState
 
 -- | Ledger state
 lsEx1 :: LedgerState
-lsEx1 = LedgerState utxostEx1 (DPState dsEx1 psEx1) 0
+lsEx1 = LedgerState utxostEx1 (DPState dsEx1 psEx1)
 
 ppsEx1 :: PParams
 ppsEx1 = emptyPParams { _maxBBSize       =       50000
@@ -515,7 +515,7 @@ utxostEx2A :: UTxOState
 utxostEx2A = UTxOState utxoEx2A (Coin 0) (Coin 0) usEx2A
 
 lsEx2A :: LedgerState
-lsEx2A = LedgerState utxostEx2A (DPState dsEx1 psEx1) 0
+lsEx2A = LedgerState utxostEx2A (DPState dsEx1 psEx1)
 
 maxLovelaceSupply :: Coin
 maxLovelaceSupply = Coin 45*1000*1000*1000*1000*1000
@@ -609,7 +609,6 @@ expectedLSEx2A = LedgerState
                  (Coin 3)
                  updateStEx2A)
                (DPState dsEx2A psEx2A)
-               0
 
 blockEx2AHash :: HashHeader
 blockEx2AHash = bhHash (bheader blockEx2A)
@@ -709,7 +708,6 @@ expectedLSEx2B = LedgerState
                  (Coin 7)
                  updateStEx2A)
                (DPState dsEx2B psEx2A)
-               0
 
 expectedStEx2Bgeneric :: PParams -> ChainState
 expectedStEx2Bgeneric pp = ChainState
@@ -818,7 +816,6 @@ expectedLSEx2Cgeneric lsDeposits lsFees =
            , _rewards  = Map.insert (mkRwdAcnt carlSHK) 110 $ _rewards dsEx2B
            }
     psEx2A)
-  0
 
 expectedLSEx2C :: LedgerState
 expectedLSEx2C = expectedLSEx2Cgeneric 257 21
@@ -975,7 +972,6 @@ expectedLSEx2E = LedgerState
                        , _rewards = Map.insert (mkRwdAcnt carlSHK) 110 $ _rewards dsEx2B
                        }
                  psEx2A)
-               0
 
 blockEx2EHash :: HashHeader
 blockEx2EHash = bhHash (bheader blockEx2E)
@@ -1103,7 +1099,6 @@ expectedLSEx2G = LedgerState
                         , _rewards = Map.insert (mkRwdAcnt carlSHK) 110 $ _rewards dsEx2B
                         }
                  psEx2A)
-               0
 
 expectedStEx2G :: ChainState
 expectedStEx2G = ChainState
@@ -1226,7 +1221,6 @@ expectedLSEx2I = LedgerState
                  (Coin 9)
                  usEx2A)
                (DPState dsEx2I psEx2A)
-               0
 
 snapsEx2I :: SnapShots
 snapsEx2I = snapsEx2G { _pstakeMark =
@@ -1322,7 +1316,6 @@ expectedLSEx2J = LedgerState
                  (Coin 18)
                  usEx2A)
                (DPState dsEx2J psEx2A)
-               0
 
 expectedStEx2J :: ChainState
 expectedStEx2J = ChainState
@@ -1398,8 +1391,6 @@ expectedLSEx2K = LedgerState
                  (Coin 20)
                  usEx2A)
                (DPState dsEx2J psEx2K)
-               0
-
 
 expectedStEx2K :: ChainState
 expectedStEx2K = ChainState
@@ -1478,7 +1469,6 @@ expectedLSEx2L = LedgerState
                  (Coin 22)
                  usEx2A)
                (DPState dsEx2L psEx1) -- Note the stake pool is reaped
-               0
 
 expectedStEx2L :: ChainState
 expectedStEx2L = ChainState
@@ -1570,7 +1560,6 @@ expectedLSEx3A = LedgerState
                  (Coin 1)
                  updateStEx3A)
                (DPState dsEx1 psEx1)
-               0
 
 blockEx3AHash :: HashHeader
 blockEx3AHash = bhHash (bheader blockEx3A)
@@ -1663,7 +1652,6 @@ expectedLSEx3B = LedgerState
                  (Coin 2)
                  updateStEx3B)
                (DPState dsEx1 psEx1)
-               0
 
 blockEx3BHash :: HashHeader
 blockEx3BHash = bhHash (bheader blockEx3B)
@@ -1725,7 +1713,6 @@ expectedLSEx3C = LedgerState
                  (Coin 2)
                  usEx2A)
                (DPState dsEx1 psEx1)
-               0
 
 ppsEx3C :: PParams
 ppsEx3C = ppsEx1 { _poolDeposit = Coin 200, _extraEntropy = mkNonce 123 }
@@ -1827,7 +1814,6 @@ expectedLSEx4A = LedgerState
                  (Coin 1)
                  updateStEx4A)
                (DPState dsEx1 psEx1)
-               0
 
 blockEx4AHash :: HashHeader
 blockEx4AHash = bhHash (bheader blockEx4A)
@@ -1918,7 +1904,6 @@ expectedLSEx4B = LedgerState
                  (Coin 2)
                  updateStEx4B)
                (DPState dsEx1 psEx1)
-               0
 
 blockEx4BHash :: HashHeader
 blockEx4BHash = bhHash (bheader blockEx4B)
@@ -1978,7 +1963,6 @@ expectedLSEx4C = LedgerState
                  (Coin 2)
                  updateStEx4C)
                (DPState dsEx1 psEx1)
-               0
 
 blockEx4CHash :: HashHeader
 blockEx4CHash = bhHash (bheader blockEx4C)
@@ -2070,7 +2054,6 @@ expectedLSEx5A = LedgerState
                  (Coin 1)
                  (UpdateState (PPUpdate Map.empty) (AVUpdate Map.empty) Map.empty byronApps))
                (DPState dsEx5A psEx1)
-               0
 
 expectedStEx5A :: ChainState
 expectedStEx5A = ChainState
@@ -2126,7 +2109,6 @@ expectedLSEx5B = LedgerState
                  (Coin 1)
                  (UpdateState (PPUpdate Map.empty) (AVUpdate Map.empty) Map.empty byronApps))
                (DPState dsEx5B psEx1)
-               0
 
 expectedStEx5B :: ChainState
 expectedStEx5B = ChainState
@@ -2215,7 +2197,6 @@ expectedLSEx6A = LedgerState
                  (Coin 1)
                  (UpdateState (PPUpdate Map.empty) (AVUpdate Map.empty) Map.empty byronApps))
                (DPState dsEx6A psEx1)
-               0
 
 expectedStEx6A :: ChainState
 expectedStEx6A = ChainState

--- a/shelley/chain-and-ledger/executable-spec/test/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator.hs
@@ -47,7 +47,7 @@ import           Control.State.Transition.Extended (TRC (..), applySTS)
 import           Keys (pattern KeyPair, hashKey, vKey)
 import           LedgerState (pattern LedgerValidation, applyTxBody, dstate, genesisCoins,
                      genesisState, stkCreds, utxo, utxoState, validTx, _delegationState, _dstate,
-                     _genDelegs, _txSlotIx, _utxoState)
+                     _genDelegs, _utxoState)
 import           PParams (PParams (..), emptyPParams)
 import           Slot
 import           STS.Delegs (pattern DelegateeNotRegisteredDELEG, PredicateFailure (..),
@@ -352,7 +352,7 @@ asStateTransition
   -> Either [ValidationError] LedgerState
 asStateTransition _slot pp ls tx res =
   let next = runShelleyBase $ applySTS @LEDGER
-              (TRC ((LedgerEnv _slot (_txSlotIx ls) pp res)
+              (TRC ((LedgerEnv _slot 0 pp res)
               , (_utxoState ls, _delegationState ls)
               , tx))
   in
@@ -360,7 +360,6 @@ asStateTransition _slot pp ls tx res =
     Left pfs -> Left $ convertPredicateFailuresToValidationErrors pfs
     Right (u, d)  -> Right $ ls { _utxoState = u
                                 , _delegationState = d
-                                , _txSlotIx = 1 + _txSlotIx ls
                                 }
 
 -- | Apply transition independent of validity, collect validation errors on the

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -160,7 +160,7 @@ mkGenesisLedgerState
   -> Gen (Either a (UTxOState, DPState))
 mkGenesisLedgerState _ = do
   utxo0 <- genUtxo0 5 10
-  let (LedgerState utxoSt dpSt _) = genesisState genesisDelegs0 utxo0
+  let (LedgerState utxoSt dpSt) = genesisState genesisDelegs0 utxo0
   pure $ Right (utxoSt, dpSt)
 
 -- | Generate values the given distribution in 90% of the cases, and values at

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -102,7 +102,7 @@ testLedgerValidTransactions ls utxoState' =
     ls @?= Right (LedgerState
                      utxoState'
                      LedgerState.emptyDelegation
-                     1)
+                     )
 
 testValidStakeKeyRegistration ::
   Tx -> UTxOState -> DPState -> Assertion
@@ -112,7 +112,7 @@ testValidStakeKeyRegistration tx utxoState' stakeKeyRegistration =
   in ls2 @?= Right (LedgerState
                      utxoState'
                      stakeKeyRegistration
-                     1)
+                     )
 
 testValidDelegation ::
   [Tx] -> UTxOState -> DPState -> PoolParams -> Assertion
@@ -128,7 +128,7 @@ testValidDelegation txs utxoState' stakeKeyRegistration pool =
                 Map.fromList [(KeyHashObj $ hashKey $ vKey aliceStake, poolhk)]
            & pstate . stPools .~ (StakePools $ Map.fromList [(poolhk, SlotNo 0)])
            & pstate . pParams .~ Map.fromList [(poolhk, pool)])
-          (fromIntegral $ length txs))
+          )
 
 testValidRetirement ::
   [Tx] -> UTxOState -> DPState -> EpochNo -> PoolParams -> Assertion
@@ -145,7 +145,7 @@ testValidRetirement txs utxoState' stakeKeyRegistration e pool =
            & pstate . stPools .~  (StakePools $ Map.fromList [(poolhk, SlotNo 0)])
            & pstate . pParams .~ Map.fromList [(poolhk, pool)]
            & pstate . retiring .~ Map.fromList [(poolhk, e)])
-          3)
+          )
 
 bobWithdrawal :: Map RewardAcnt Coin
 bobWithdrawal = Map.singleton (mkVKeyRwdAcnt bobStake) (Coin 10)
@@ -176,7 +176,7 @@ testValidWithdrawal =
   in ls @?= Right (LedgerState
                      (UTxOState (UTxO utxo') (Coin 0) (Coin 1000) emptyUpdateState)
                      expectedDS
-                     1)
+                     )
 
 testInvalidWintess :: Assertion
 testInvalidWintess =

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -154,7 +154,7 @@ It does the following:
       \fun{retire} & \DCertRetirePool \to \Epoch
                                             & \text{epoch of pool retirement}
       \\
-      \fun{genesisDeleg} & \DCertGen \to (\VKeyGen,~\VKey)
+      \fun{genesisDeleg} & \DCertGen \to (\KeyHashGen,~\KeyHash)
                                             & \text{genesis delegation}
       \\
       \fun{moveRewards} & \DCertMir \to (\StakeCredential \mapsto \Coin)
@@ -519,10 +519,7 @@ concerns are independent of the ledger rules.
     \inference[Deleg-Gen]
     {
       \var{c}\in \DCertGen
-      & (\var{gkey},~\var{vk})\leteq\fun{genesisDeleg}~{c}
-      \\
-      \var{gkh} \leteq \hashKey{gkey}
-      & \var{vkh} \leteq \hashKey{vk}
+      & (\var{gkh},~\var{vkh})\leteq\fun{genesisDeleg}~{c}
       \\
       s'\leteq\var{slot}+\SlotsPrior
       & \var{gkh}\in\dom{genDelegs}
@@ -1003,7 +1000,7 @@ will be invalid.
     \label{eq:delegs-base}
     \inference[Seq-delg-base]
     {
-      \var{wdrls} \leteq \txwdrls{tx}
+      \var{wdrls} \leteq \txwdrls{(\txbody{tx})}
       &
       \var{wdrls} \subseteq \var{rewards}
       \\
@@ -1072,8 +1069,6 @@ will be invalid.
     \label{eq:delegs-induct}
     \inference[Seq-delg-ind]
     {
-      \var{c}\in\DCertDeleg \Rightarrow \fun{dpool}~{c} \in \dom \var{stpools} \\
-      ptr \leteq (\var{slot},~\var{txIx},~\mathsf{len}~\Gamma) \\~\\
         {
           \begin{array}{c}
             \var{slot}\\
@@ -1088,6 +1083,8 @@ will be invalid.
       \trans{delegs}{\Gamma}
       \var{dpstate'}
     \\~\\~\\
+      \var{c}\in\DCertDeleg \Rightarrow \fun{dpool}~{c} \in \dom \var{stpools} \\
+      ptr \leteq (\var{slot},~\var{txIx},~\mathsf{len}~\Gamma) \\~\\
     {
       \begin{array}{c}
         \var{slot}\\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -395,7 +395,6 @@ This transition has no preconditions and results in the following state change:
     {
       {
       \begin{array}{r@{~\leteq~}l}
-        (\var{utxo},~\var{deposits},~\var{fees},~\wcard) & \var{utxoSt}\\
         (\var{stkCreds},~\wcard,~\var{delegations},~\wcard,~\wcard,~\wcard) & \var{dstate}\\
         (\var{stpools},~\var{poolParams},~\wcard,~\wcard) & \var{pstate}\\
         \var{stake} & \stakeDistr{utxo}{dstate}{pstate} \\
@@ -548,7 +547,6 @@ This transition has no preconditions and results in the following state change:
           \var{stpools} \\
           \var{poolParams} \\
           \var{retiring} \\
-          \var{cs} \\
         \end{array}
       \right)
       \trans{poolreap}{e}
@@ -574,7 +572,6 @@ This transition has no preconditions and results in the following state change:
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{stpools}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{poolParams}} \\
           \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
-          \varUpdate{\var{retired}} & \varUpdate{\subtractdom} & \varUpdate{\var{cs}} \\
         \end{array}
       \right)
     }
@@ -896,6 +893,7 @@ in sequence.
       \left(
         {
           \begin{array}{r}
+            \var{utxoSt'} \\
             \var{acnt} \\
             \var{dstate} \\
             \var{pstate} \\
@@ -906,6 +904,7 @@ in sequence.
       \left(
       {
         \begin{array}{rcl}
+            \var{utxoSt''} \\
             \var{acnt'} \\
             \var{dstate'} \\
             \var{pstate'} \\
@@ -913,8 +912,9 @@ in sequence.
       }
       \right)
       \\~\\~\\
-      \var{(\wcard,~\wcard,~\wcard,~(\var{pup},~\wcard,~\wcard,~\wcard))}\leteq\var{utxoSt'}\\
-      \var{pp_{new}}\leteq\fun{votedValue_{PParams}}~\var{pup}\\
+      \var{(\wcard,~\wcard,~\wcard,~(\var{ppup},~\wcard,~\wcard,~\wcard))}\leteq\var{utxoSt'}\\
+      \var{pp_{new}}\leteq\var{pp}\unionoverrideRight
+      \fun{votedValue_{(\Ppm\to\mathsf{T_{ppm}})}}~\var{ppup}\\
       {
         \begin{array}{r}
           \var{pp_{new}}\\
@@ -926,7 +926,7 @@ in sequence.
       \left(
         {
           \begin{array}{r}
-            \var{utxoSt'} \\
+            \var{utxoSt''} \\
             \var{acnt'} \\
             \var{pp}\\
           \end{array}
@@ -936,14 +936,14 @@ in sequence.
       \left(
       {
         \begin{array}{rcl}
-            \var{utxoSt''} \\
+            \var{utxoSt'''} \\
             \var{acnt''} \\
             \var{pp'}\\
         \end{array}
       }
       \right)
       \\~\\~\\
-      \var{ls}' \leteq (\var{utxoSt}'',~(\var{dstate}',~\var{pstate}'))
+      \var{ls}' \leteq (\var{utxoSt}''',~(\var{dstate}',~\var{pstate}'))
     }
     {
       \vdash

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -73,11 +73,11 @@ then calls the $\mathsf{DELEGS}$ transition.
       }
       \vdash
       dpstate \trans{\hyperref[fig:rules:delegation-sequence]{delegs}}{
-                     \fun{txcerts}~\var{tx}} dpstate'
+        \fun{txcerts}~\var{(\txbody{tx})}} dpstate'
       \\~\\
       (\var{dstate}, \var{pstate}) \leteq \var{dpstate} \\
-      (\var{stkCreds}, \_, \_, \_, \_, \var{genDelegs}) \leteq \var{dstate} \\
-      (\var{stpools}, \_, \_, \_) \leteq \var{pstate} \\
+      (\var{stkCreds}, \_, \_, \_, \_, \var{genDelegs}, \_) \leteq \var{dstate} \\
+      (\var{stpools}, \_, \_) \leteq \var{pstate} \\
       \\~\\
       {
         \begin{array}{c}
@@ -152,7 +152,8 @@ slot is removed.
       \\
       (\var{pup},~\var{aup},~\var{favs},~\var{avs}) \leteq\var{us}
       \\
-      (\var{stkeys},~\var{rewards},~\var{delegations}, ~\var{ptrs},~\var{fGenDelegs},~\var{genDelegs})
+      (\var{stkeys},~\var{rewards},~\var{delegations}, ~\var{ptrs},
+      ~\var{fGenDelegs},~\var{genDelegs},~\var{i_{rwd}})
       \leteq\var{ds}
       \\~\\
       {\begin{array}{r@{~\leteq~}l}
@@ -162,12 +163,18 @@ slot is removed.
         & \var{avs}\unionoverrideRight\fun{newAVs}~\var{avs}~(\var{favs}\setminus\var{favs'})
       \end{array}}
       \\~\\
-      \var{curr}\leteq
-      \{
-        (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{fGenDelegs}
-        ~\mid~
-        \var{s}\leq\var{slot}
-      \}\\
+      {\begin{array}{r@{~\leteq~}l}
+          \var{curr}
+          &
+          \{
+            (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{fGenDelegs}
+            ~\mid~
+            \var{s}\leq\var{slot}
+          \}\\
+          \var{fGenDelegs'}
+          &
+          \var{fGenDelegs}\setminus\var{curr}\\
+      \end{array}}\\
       \var{genDelegs'}\leteq
       \left\{
         \var{gkh}\mapsto\var{vkh}
@@ -184,7 +191,7 @@ slot is removed.
       \\
       \var{ds'}\leteq
       (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},
-      ~\var{fGenDelegs}\setminus\var{curr},~\var{genDelegs}\unionoverrideRight\var{genDelegs'})
+      ~\var{fGenDelegs'},~\var{genDelegs}\unionoverrideRight\var{genDelegs'},~\var{i_{rwd}})
       \\
       \var{ls'}\leteq((\var{utxo},~\var{deposits},~\var{fees},~\var{us'}),~(\var{ds'}, \var{ps}))
     }
@@ -226,7 +233,7 @@ slot is removed.
       }
       \vdash
         \var{ls'}
-        \trans{\hyperref[fig:rules:ledger]{ledger}}{c}
+        \trans{\hyperref[fig:rules:ledger]{ledger}}{\var{tx}}
         \var{ls''}
     }
     {
@@ -237,7 +244,7 @@ slot is removed.
       \end{array}
     \vdash
       \var{ls}
-      \trans{ledgers}{\Gamma; c}
+      \trans{ledgers}{\Gamma;~\var{tx}}
       \varUpdate{\var{ls''}}
     }
   \end{equation}

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -154,7 +154,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
   \emph{Helper Functions}
   %
   \begin{align*}
-    \fun{minfee} & \in \PParams \to \Tx \to \Coin & \text{minimum fee}\\
+    \fun{minfee} & \in \PParams \to \TxBody \to \Coin & \text{minimum fee}\\
     \fun{minfee} & ~\var{pp}~\var{tx} =
     (\fun{a}~\var{pp}) \cdot \fun{txSize}~\var{tx} + (\fun{b}~\var{pp})
     \\

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -85,7 +85,7 @@ Registration will be discussed more in Section~\ref{sec:delegation-shelley}.
 
 \begin{figure}[htb]
   \begin{align*}
-    & \fun{outs} \in \Tx \to \UTxO
+    & \fun{outs} \in \TxBody \to \UTxO
     & \text{tx outputs as UTxO} \\
     & \fun{outs} ~ \var{tx} =
         \left\{
@@ -102,14 +102,14 @@ Registration will be discussed more in Section~\ref{sec:delegation-shelley}.
     & \text{withdrawal balance} \\
     & \fun{wbalance} ~ ws = \sum_{(\wcard\mapsto c)\in\var{ws}} c
     \nextdef
-    & \fun{consumed} \in \PParams \to \UTxO \to \StakeCreds \to \Tx \to \Coin
+    & \fun{consumed} \in \PParams \to \UTxO \to \StakeCreds \to \TxBody \to \Coin
     & \text{value consumed} \\
     & \consumed{pp}{utxo}{stkCreds}{tx} = \\
     & ~~\ubalance{(\txins{tx} \restrictdom \var{utxo})} +
         \fun{wbalance}~(\fun{txwdrls}~{tx}) \\
     & ~~ + \keyRefunds{pp}{stkCreds}{tx} \\
     \nextdef
-    & \fun{produced} \in \PParams \to \StakePools \to \Tx \to \Coin
+    & \fun{produced} \in \PParams \to \StakePools \to \TxBody \to \Coin
     & \text{value produced} \\
     & \fun{produced}~\var{pp}~\var{stpools}~\var{tx} = \\
     &~~\ubalance{(\outs{tx})}
@@ -290,12 +290,13 @@ requests).
 \begin{figure}[htb]
   \begin{equation}\label{eq:utxo-inductive-shelley}
     \inference[UTxO-inductive]
-    { \txttl tx \geq \var{slot}
-      & \txins{tx} \neq \emptyset
-      & \minfee{pp}{tx} \leq \txfee{tx}
-      & \txins{tx} \subseteq \dom \var{utxo}
+    { \var{txb}\leteq\txbody{tx}
+      & \txttl txb \geq \var{slot}
+      \\ \txins{txb} \neq \emptyset
+      & \minfee{pp}{txb} \leq \txfee{txb}
+      & \txins{txb} \subseteq \dom \var{utxo}
       \\
-      \consumed{pp}{utxo}{stkCreds}{rewards}~{tx} = \produced{pp}{stpools}~{tx}
+      \consumed{pp}{utxo}{stkCreds}{rewards}~{txb} = \produced{pp}{stpools}~{txb}
       \\
       ~
       \\
@@ -310,18 +311,18 @@ requests).
       \\
       ~
       \\
-      \forall (\_\mapsto (\_, c)) \in \txouts{tx}, c \geq 0
+      \forall (\_\mapsto (\_, c)) \in \txouts{txb}, c \geq 0
       \\
-      \fun{txsize}~{tx}\leq\fun{maxTxSize}~\var{pp}
+      \fun{txsize}~{txb}\leq\fun{maxTxSize}~\var{pp}
       \\
       ~
       \\
-      \var{refunded} \leteq \keyRefunds{pp}{stkCreds}~{tx}
+      \var{refunded} \leteq \keyRefunds{pp}{stkCreds}~{txb}
       \\
-      \var{decayed} \leteq \decayedTx{pp}{stkCreds}~{tx}
+      \var{decayed} \leteq \decayedTx{pp}{stkCreds}~{txb}
       \\
       \var{depositChange} \leteq
-        \deposits{pp}~{stpools}~{(\txcerts{tx})} - (\var{refunded} + \var{decayed})
+        \deposits{pp}~{stpools}~{(\txcerts{txb})} - (\var{refunded} + \var{decayed})
     }
     {
       \begin{array}{r}
@@ -343,9 +344,9 @@ requests).
       \trans{utxo}{tx}
       \left(
       \begin{array}{r}
-        \varUpdate{(\txins{tx} \subtractdom \var{utxo}) \cup \outs{tx}}  \\
+        \varUpdate{(\txins{txb} \subtractdom \var{utxo}) \cup \outs{txb}}  \\
         \varUpdate{\var{deposits} + \var{depositChange}} \\
-        \varUpdate{\var{fees} + \txfee{tx} + \var{decayed}} \\
+        \varUpdate{\var{fees} + \txfee{txb} + \var{decayed}} \\
         \varUpdate{ups'}\\
       \end{array}
       \right)
@@ -486,7 +487,7 @@ Section~\ref{sec:epoch}.
         &\delta & \slotminus{slot}{(stkCreds~(\cwitness c))}\\
       \end{array}\\
       \nextdef
-      & \fun{keyRefunds} \in \PParams \to \StakeCreds \to \Tx \to \Coin
+      & \fun{keyRefunds} \in \PParams \to \StakeCreds \to \TxBody \to \Coin
       & \text{key refunds for a transaction} \\
       & \keyRefunds{pp}{stkCreds}{tx} =\\
       & ~~~~~ \sum\limits_{\substack{c \in (\txcerts{tx} \\ \cap \DCertDeRegKey)}}
@@ -526,7 +527,7 @@ Section~\ref{sec:epoch}.
           & \lambda & \fun{keyDecayRate}~\var{pp}\\
       \end{array}\\
       \nextdef
-      & \fun{decayedTx} \in \PParams \to \StakeCreds \to \Tx \to \Coin
+      & \fun{decayedTx} \in \PParams \to \StakeCreds \to \TxBody \to \Coin
       & \text{decayed deposit portions} \\
       & \decayedTx{pp}{stkCreds}{tx} =\\
       &   \sum\limits_{\substack{c \in (\txcerts{tx} \\ \cap \DCertDeRegKey)}}
@@ -643,7 +644,7 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
     \label{eq:utxo-witness-inductive-shelley}
     \inference[UTxO-wit]
     {
-      (utxo, \wcard, \wcard) \leteq \var{utxoSt} \\
+      (utxo, \wcard, \wcard, \wcard) \leteq \var{utxoSt} \\
       \var{witsKeyHashes} \leteq \{\fun{hashKey}~\var{vk} \vert \var{vk} \in
       \dom (\txwitsVKey{tx}) \}\\~\\
       \forall \var{hs} \mapsto \var{validator} \in \fun{txwitsScript}~{tx},\\


### PR DESCRIPTION
I went through the formal and exec specs today, line by line, comparing them.  In order of the formal spec, I made it through the end of the `EPOCH` rule. This PR is comprised mostly of trivial changes to get the two specs in sync.

The majority of the changes are 1) renaming variables, and 2) reordering the order in which things are defined and predicates checked.  In order to have the same variable names between the specs, I made a lot of use of relative imports in the haskell code (LedgerState.hs was the biggest culprit).

Other notable changes:

* the `AVUP` rule was using union override right, but in the wrong order.
* the ledger state does not need to store the index of the transaction being processed. this is a artifact from the `asStateTransation` method still  being using in the unit tests, instead of the actual STS framework.
* I removed lenses wherever I saw them (I have no issue with them personally, but we decided as a group not to use them).
* The spec was incorrectly using full keys (instead of key hashes) for the genesis delegation certificates (both the gen key and the cold key).
* The spec was incorrectly using a `Tx` instead of a `TxBody` in several places surrounding the `UTXO` transition and helper functions.
* The voting on the new protocol parameters was incorrectly assuming that a partial update of fields was the whole parameter set.
