### PR TITLE
[1084] Fixed and improved trace shrinker

### DIFF
--- a/byron/semantics/executable-spec/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
@@ -38,7 +38,7 @@ import           Data.Functor.Identity (Identity(..))
 import           Data.Kind (Type)
 import           Data.Maybe (fromMaybe)
 import           Data.Word (Word64)
-import Data.List (sortBy)
+import Data.List (sortOn)
 
 import qualified Test.QuickCheck as QuickCheck
 
@@ -189,7 +189,12 @@ forAllTrace
 forAllTrace baseEnv maxTraceLength traceGenEnv =
   forAllTraceFromInitState baseEnv maxTraceLength traceGenEnv Nothing
 
--- | See 'Test.QuickCheck.shrink'.
+-- | Shrink a trace by shrinking the list of signals and reconstructing traces from these
+-- shrunk lists of signals. 
+--
+-- When shrinking a trace that is failing some property (often stated in terms of a signal in the trace)
+-- then the most recent signal is likely crucial to the failure of the property and must be preserved
+-- in the shrunk traces.
 shrinkTrace
   :: forall sts traceGenEnv
    . (HasTrace sts traceGenEnv
@@ -205,9 +210,13 @@ shrinkTrace baseEnv tr =
     st0 = Trace._traceInitState tr
     signals = Trace.traceSignals Trace.NewestFirst tr
 
-    compareLen a b = compare (length a) (length b) -- ascending sort 
-    shrunk = sortBy compareLen (shrinkSignals signals)
+    shrunk = sortOn length (shrinkSignals signals)
 
+    -- Shrink a list of signals such that we preserve the most recent signal in the shrunk lists.
+    -- This shrinker
+    --   - recursively omits all but the most recent signal
+    --   - builds up lists of signals starting with the most recent signal and
+    --     building up a list excluding the first (oldest) signal
     shrinkSignals (sn:_last:[]) =
       [[sn]]
     shrinkSignals (sn:sm:sigs) =

--- a/byron/semantics/executable-spec/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
+++ b/byron/semantics/executable-spec/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
@@ -38,6 +38,7 @@ import           Data.Functor.Identity (Identity(..))
 import           Data.Kind (Type)
 import           Data.Maybe (fromMaybe)
 import           Data.Word (Word64)
+import Data.List (sortBy)
 
 import qualified Test.QuickCheck as QuickCheck
 
@@ -196,14 +197,27 @@ shrinkTrace
   => BaseEnv sts
   -> Trace sts
   -> [Trace sts]
-shrinkTrace baseEnv tr = interpretSTS @sts @traceGenEnv baseEnv
-    $ Trace.closure env st0 `traverse` traceSignalsShrinks
+shrinkTrace baseEnv tr =
+    interpretSTS @sts @traceGenEnv baseEnv
+    $ Trace.closure env st0 `traverse` shrunk
   where
     env = Trace._traceEnv tr
     st0 = Trace._traceInitState tr
-    signals = Trace.traceSignals Trace.OldestFirst tr
-    traceSignalsShrinks =
-      QuickCheck.shrinkList (shrinkSignal @sts @traceGenEnv) signals
+    signals = Trace.traceSignals Trace.NewestFirst tr
+
+    compareLen a b = compare (length a) (length b) -- ascending sort 
+    shrunk = sortBy compareLen (shrinkSignals signals)
+
+    shrinkSignals (sn:_last:[]) =
+      [[sn]]
+    shrinkSignals (sn:sm:sigs) =
+      [[sn]] -- a trace with only the most recent signal
+      ++ [sn:sigs] -- discard the second most recent signal
+      ++ ((sn:) <$> shrinkSignals (sm:sigs)) -- shrink the tail
+
+    -- shrink to [] if there is one or no signals
+    shrinkSignals _  = []
+
 
 -- | Property that asserts that only valid signals are generated.
 onlyValidSignalsAreGenerated


### PR DESCRIPTION
Closes #1084 

This PR 

* fixes a bug in the trace shrinker (signals were passed in OldestFirst order to `Trace.closure` which expects NewestFirst)
* write a custom shrinker signal shrinker (replaces shrinkList) that preserves the leading signal during trace shrinking

This PR was intended to close #1084 which was about improving the Tx shrinker. On closer inspection the next bottleneck was _trace_ shrinking - since at this stage we're only producing Txs with single certificates and outputs, the options for shrinking are very limited. 

The remaining Tx shrinking work should be done as part of #868 and #877 (when we add multiple certs we can shrink them in a Tx, same with outputs)