### PR TITLE
change function name deposits to totalDeposits

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -130,7 +130,8 @@ import           TxData (Addr (..), Credential (..), DelegCert (..), Ix, PoolCer
                      poolRAcnt, ttl, txfee, wdrls, witKeyHash)
 import           Updates (AVUpdate (..), PPUpdate (..), Update (..), UpdateState (..), emptyUpdate,
                      emptyUpdateState)
-import           UTxO (UTxO (..), balance, deposits, txinLookup, txins, txouts, txup, verifyWitVKey)
+import           UTxO (UTxO (..), balance, totalDeposits, txinLookup, txins, txouts, txup,
+                     verifyWitVKey)
 import           Validation
 
 import           Delegation.Certificates (DCert (..), PoolDistr (..), StakeCreds (..),
@@ -418,7 +419,7 @@ produced
   -> TxBody crypto
   -> Coin
 produced pp stakePools tx =
-    balance (txouts tx) + tx ^. txfee + deposits pp stakePools (toList $ tx ^. certs)
+    balance (txouts tx) + tx ^. txfee + totalDeposits pp stakePools (toList $ tx ^. certs)
 
 -- |Compute the key deregistration refunds in a transaction
 keyRefunds
@@ -668,7 +669,7 @@ depositPoolChange ls pp tx = (currentPool + txDeposits) - txRefunds
   where
     currentPool = ls ^. utxoState . deposited
     txDeposits =
-      deposits pp (ls ^. delegationState . pstate . stPools) (toList $ tx ^. certs)
+      totalDeposits pp (ls ^. delegationState . pstate . stPools) (toList $ tx ^. certs)
     txRefunds = keyRefunds pp (ls ^. delegationState . dstate . stkCreds) tx
 
 -- |Apply a transaction body as a state transition function on the ledger state.

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -116,13 +116,11 @@ utxoInductive = do
   let refunded = keyRefunds pp stakeCreds txb
   decayed <- liftSTS $ decayedTx pp stakeCreds txb
   let txCerts = toList $ txb ^. certs
-  let depositChange = deposits pp stakepools txCerts - (refunded + decayed)
+  let depositChange = totalDeposits pp stakepools txCerts - (refunded + decayed)
 
   pure UTxOState
         { _utxo      = (txins txb ⋪ utxo) ∪ txouts txb
         , _deposited = deposits' + depositChange
-          -- TODO change variable "deposits" to "deposited" in formal and exec spec,
-          -- in order to not clash with the function of the same name
         , _fees      = fees + (_txfee txb) + decayed
         , _ups       = ups'
         }

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -28,7 +28,7 @@ module UTxO
   , txUpdate
   , txup
   , balance
-  , deposits
+  , totalDeposits
   , makeWitnessVKey
   , makeWitnessesVKey
   , makeGenWitnessVKey
@@ -200,12 +200,12 @@ balance (UTxO utxo) = foldr addCoins 0 utxo
   where addCoins (TxOut _ a) b = a + b
 
 -- |Determine the total deposit amount needed
-deposits
+totalDeposits
   :: PParams
   -> StakePools crypto
   -> [DCert crypto]
   -> Coin
-deposits pc (StakePools stpools) cs = foldl f (Coin 0) cs'
+totalDeposits pc (StakePools stpools) cs = foldl f (Coin 0) cs'
   where
     f coin cert = coin + dvalue cert pc
     notRegisteredPool (DCertPool (RegPool pool)) =

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
@@ -40,7 +40,7 @@ import           Slot (EpochNo (EpochNo), SlotNo (SlotNo))
 import           TxData (Credential (KeyHashObj), pattern DCertDeleg, pattern DCertGenesis,
                      pattern DCertPool, pattern Delegation, pattern PoolParams, RewardAcnt (..),
                      StakePools (StakePools), _poolPubKey, _poolVrf)
-import           UTxO (deposits)
+import           UTxO (totalDeposits)
 
 -- | Generate certificates and also return the associated witnesses and
 -- deposits and refunds required.
@@ -65,7 +65,7 @@ genDCerts keys coreKeys vrfKeys pparams dpState slot ttl = do
       return (Seq.empty, [], [], Coin 0, Coin 0)
     Just (cert_, witnessOrCoreKeys) -> do
       let certs = [cert_]
-          deposits_ = deposits pparams (_stPools (_pstate dpState)) certs
+          deposits_ = totalDeposits pparams (_stPools (_pstate dpState)) certs
 
           deRegStakeCreds = filter isDeRegKey certs
           slotWithTTL = slot + SlotNo (fromIntegral ttl)

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -36,7 +36,7 @@ import           Rules.TestLedger (consumedEqualsProduced, credentialMappingAfte
 import           Slot
 import           Tx (pattern TxIn, pattern TxOut, body, certs, inputs, outputs, witnessVKeySet,
                      _body, _witnessVKeySet)
-import           UTxO (balance, deposits, makeWitnessVKey, txid, txins, txouts, verifyWitVKey)
+import           UTxO (balance, makeWitnessVKey, totalDeposits, txid, txins, txouts, verifyWitVKey)
 import           Validation (ValidationError (..))
 
 import           Generator
@@ -333,5 +333,5 @@ propPreserveBalance = property $ do
   let created =
            balance (l' ^. utxoState . utxo)
         + fee
-        + (deposits emptyPParams (l' ^. delegationState . pstate . stPools) $ toList $ tx ^.body . certs)
+        + (totalDeposits emptyPParams (l' ^. delegationState . pstate . stPools) $ toList $ tx ^.body . certs)
   destroyed === created

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxow.hs
@@ -26,7 +26,7 @@ import           LedgerState (pattern UTxOState, keyRefunds)
 import           MockTypes (StakeCreds, StakePools, Tx, UTXO, UTXOW)
 import           PParams (PParams)
 import           TxData (pattern TxIn, _body, _certs, _inputs, _txfee)
-import           UTxO (pattern UTxO, balance, deposits, txins, txouts)
+import           UTxO (pattern UTxO, balance, totalDeposits, txins, txouts)
 
 --------------------------
 -- Properties for UTXOW --
@@ -51,7 +51,7 @@ preserveBalance pp tr =
     created u stp_ tx =
         balance u
       + _txfee (_body tx)
-      + deposits pp stp_ (toList $ _certs $ _body tx)
+      + totalDeposits pp stp_ (toList $ _certs $ _body tx)
 
     consumed u stk_ tx =
         balance u
@@ -80,7 +80,7 @@ preserveBalanceRestricted pp tr =
       + depositChange stk_ stp_ (toList $ _certs tx) tx
 
     depositChange stk_ stp_ certs txb =
-        deposits pp stp_ certs
+        totalDeposits pp stp_ certs
       - (keyRefunds pp stk_ txb)
 
 -- | Preserve outputs of Txs

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -195,7 +195,7 @@
 \newcommand{\ubalance}[1]{\fun{ubalance}~ \var{#1}}
 \newcommand{\txttl}[1]{\fun{txttl}~ \var{#1}}
 \newcommand{\firstSlot}[1]{\fun{firstSlot}~ \var{#1}}
-\newcommand{\deposits}[2]{\fun{deposits}~ \var{#1} ~ \var{#2}}
+\newcommand{\totalDeposits}[3]{\fun{totalDeposits}~ \var{#1} ~ \var{#2} ~ \var{#3}}
 \newcommand{\decayedKey}[4]{\fun{decayedKey}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
 \newcommand{\decayedTx}[3]{\fun{decayedTx}~ \var{#1}~ \var{#2}~ \var{#3}}
 \newcommand{\keyRefund}[6]{\fun{keyRefund}~ {#1}~{#2}~{#3}~\var{#4}~\var{#5}~\var{#6}}

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -140,7 +140,7 @@ If we let:
     \begin{array}{r@{~=~}l}
       k & \keyRefunds{pp}{stkCreds}{tx} \\
       f & \txfee{tx} \\
-      d & \deposits{pp}{stpools}~{(\txcerts{tx})} \\
+      d & \totalDeposits{pp}{stpools}{(\txcerts{tx})} \\
       c & \decayedTx{pp}{stkCreds}~{tx} \\
     \end{array}
   \end{equation*}
@@ -625,10 +625,10 @@ may either be from the current epoch or an earlier one, so we split them using $
   \end{equation*}
   Looking at the $\mathsf{UTXO}$ transition in Figure~\ref{fig:rules:utxo-shelley},
   \begin{equation*}
-    \var{deposits}' = \var{deposits} + \deposits{pp}~{stpools}~{(\txcerts{tx})}
+    \var{deposits}' = \var{deposits} + \totalDeposits{pp}{stpools}{(\txcerts{tx})}
     - (\var{refunded} + \var{decayed})
   \end{equation*}
-  The function $\fun{deposits}$ is defined in Figure~\ref{fig:functions:deposits-refunds}
+  The function $\fun{totalDeposits}$ is defined in Figure~\ref{fig:functions:deposits-refunds}
   and it is clear that here it is equal to
   $$|A_s|\cdot d_{val} + |P_c|\cdot p_{val.}$$
   Recall that

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -69,7 +69,7 @@ See Figure~\ref{fig:defs:utxo-shelley} for most of the definitions used in the t
     the transaction fee and all needed deposits.
     Some of the definitions used in this function will be defined in
     Section~\ref{sec:deps-refunds}.
-    In particular, $\fun{deposits}$ is defined in Figure~\ref{fig:functions:deposits-refunds}
+    In particular, $\fun{totalDeposits}$ is defined in Figure~\ref{fig:functions:deposits-refunds}
     and $\StakePools$ is defined in Figure~\ref{fig:delegation-defs}.
 \end{itemize}
 
@@ -113,7 +113,7 @@ Registration will be discussed more in Section~\ref{sec:delegation-shelley}.
     & \text{value produced} \\
     & \fun{produced}~\var{pp}~\var{stpools}~\var{tx} = \\
     &~~\ubalance{(\outs{tx})}
-    + \txfee{tx} + \deposits{pp}{stpools}~{(\txcerts{tx})}\\
+    + \txfee{tx} + \totalDeposits{pp}{stpools}{(\txcerts{tx})}\\
   \end{align*}
 
   \caption{Functions used in UTxO rules}
@@ -322,7 +322,7 @@ requests).
       \var{decayed} \leteq \decayedTx{pp}{stkCreds}~{txb}
       \\
       \var{depositChange} \leteq
-        \deposits{pp}~{stpools}~{(\txcerts{txb})} - (\var{refunded} + \var{decayed})
+        \totalDeposits{pp}{stpools}{(\txcerts{txb})} - (\var{refunded} + \var{decayed})
     }
     {
       \begin{array}{r}
@@ -384,7 +384,7 @@ $\cwitness{}$, which gets the certificate witness from a certificate, will be
 defined later.  Figure~\ref{fig:functions:deposits-refunds} defines the deposit
 and refund functions.
 \begin{itemize}
-\item The function $\fun{deposits}$ returns the total deposits that have to be
+\item The function $\fun{totalDeposits}$ returns the total deposits that have to be
   made by a transaction.  This calculation is based on the protocol parameters.
   Specifically, for a given transaction, it sums up the values of the stake
   credential deposits and the stake pool deposits. Those certificates which are
@@ -457,9 +457,9 @@ Section~\ref{sec:epoch}.
 
 \begin{figure}[htb]
   \begin{align*}
-    & \fun{deposits} \in \PParams \to \StakePools \to \seqof{\DCert} \to \Coin
+    & \fun{totalDeposits} \in \PParams \to \StakePools \to \seqof{\DCert} \to \Coin
     & \text{total deposits for transaction} \\
-    & \fun{deposits}~{pp}~{stpools}~{certs} = \\
+    & \totalDeposits{pp}{stpools}{certs} = \\
     &  \sum\limits_{c\in\var{certs} \cap \DCertRegKey}(\fun{keyDeposit}~pp)
     +  \sum\limits_{\substack{
          c\in\var{certs}\cap\DCertRegPool \\ (\cwitness{c})\notin \var{stpools}}}


### PR DESCRIPTION
There was a state variable and a function both named `deposits`. I have renamed the function to `totalDeposits`in both the formal spec and the exec model.

I think this is the only such remaining variable name like this. closes #980 