### PR TITLE
Removes some redundant / unused functions, correction of predicate

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -18,10 +18,6 @@ module Delegation.Certificates
   , genesisCWitness
   , dvalue
   , refund
-  , releasing
-  , allocating
-  , dretire
-  , dderegister
   , decayKey
   , decayPool
   , isRegKey
@@ -80,26 +76,6 @@ refund (Coin dval) dmin lambda delta = floor refund'
     refund' = fromIntegral dval * (dmin' + (1 - dmin') * dCay)
     dmin'   = intervalValue dmin
     dCay    = approxRational (exp' pow) fpEpsilon
-
--- | Check whether certificate is of releasing type, i.e., key deregistration or
--- pool retirement.
-releasing :: DCert crypto-> Bool
-releasing c = dderegister c || dretire c
-
-dderegister :: DCert crypto-> Bool
-dderegister (DCertDeleg (DeRegKey _)) = True
-dderegister _            = False
-
-dretire :: DCert crypto-> Bool
-dretire (DCertPool (RetirePool _ _)) = True
-dretire _                = False
-
--- | Check whether certificate is of allocating type, i.e, key or pool
--- registration.
-allocating :: DCert crypto-> Bool
-allocating (DCertDeleg _)  = True
-allocating (DCertPool _) = True
-allocating _           = False
 
 -- | Check for `RegKey` constructor
 isRegKey :: DCert crypto-> Bool

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
@@ -71,7 +71,7 @@ relevantCasesAreCovered = withMaxSuccess 500 . property $ do
               (0.75 >= noCertsRatio (certsByTx txs))
               "at most 75% of transactions have no certificates"
      , cover_ 25
-              (0.25 >= txScriptOutputsRatio (map (_outputs . _body) txs))
+              (0.25 <= txScriptOutputsRatio (map (_outputs . _body) txs))
               "at least 25% of transactions have script TxOuts"
      , cover_ 10
               (0.25 <= scriptCredentialCertsRatio certs_)


### PR DESCRIPTION
Some functions in `Delegation.Certificates` were redundant or unused.
A comparion in a coverage test was flipped.