### PR TITLE
cbor instances for NewEpochState

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,19 +12,19 @@ constraints:
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 53d773907edea2fdcf65cebeb81ab5e47eeab805
+  tag: 0fcb3a306e96ce36fca75d62792c55ab1de871ea
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 53d773907edea2fdcf65cebeb81ab5e47eeab805
+  tag: 0fcb3a306e96ce36fca75d62792c55ab1de871ea
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 0fc0af253df8be5ca6bf60c92bcd2e514b40a47c
+  tag: 0fcb3a306e96ce36fca75d62792c55ab1de871ea
   subdir: slotting
 
 source-repository-package

--- a/nix/.stack.nix/cardano-binary.nix
+++ b/nix/.stack.nix/cardano-binary.nix
@@ -101,8 +101,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "9e41a682fcffc696f599f83d8372c40c9c609578";
-      sha256 = "1x3jacfggim9ynnw8rzaswhbvmhk13hid44k91a8137fv0jg6l14";
+      rev = "0fcb3a306e96ce36fca75d62792c55ab1de871ea";
+      sha256 = "0fbcf3iim4fh8m647ilw02ybbxiqna3zpny0w7rlqjgd4skfqvjr";
       });
     postUnpack = "sourceRoot+=/binary; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-crypto-class.nix
+++ b/nix/.stack.nix/cardano-crypto-class.nix
@@ -90,8 +90,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "9e41a682fcffc696f599f83d8372c40c9c609578";
-      sha256 = "1x3jacfggim9ynnw8rzaswhbvmhk13hid44k91a8137fv0jg6l14";
+      rev = "0fcb3a306e96ce36fca75d62792c55ab1de871ea";
+      sha256 = "0fbcf3iim4fh8m647ilw02ybbxiqna3zpny0w7rlqjgd4skfqvjr";
       });
     postUnpack = "sourceRoot+=/cardano-crypto-class; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-slotting.nix
+++ b/nix/.stack.nix/cardano-slotting.nix
@@ -73,8 +73,8 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-base";
-      rev = "9e41a682fcffc696f599f83d8372c40c9c609578";
-      sha256 = "1x3jacfggim9ynnw8rzaswhbvmhk13hid44k91a8137fv0jg6l14";
+      rev = "0fcb3a306e96ce36fca75d62792c55ab1de871ea";
+      sha256 = "0fbcf3iim4fh8m647ilw02ybbxiqna3zpny0w7rlqjgd4skfqvjr";
       });
     postUnpack = "sourceRoot+=/slotting; echo source root reset to \$sourceRoot";
     }

--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -31,6 +31,7 @@ module Delegation.Certificates
   ) where
 
 import           BaseTypes (FixedPoint, UnitInterval, fpEpsilon, intervalValue)
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           Cardano.Ledger.Shelley.Crypto
 import           Coin (Coin (..))
 import           Keys (GenKeyHash, Hash, KeyHash, VRFAlgorithm (VerKeyVRF))
@@ -121,7 +122,7 @@ decayPool pc = (pval, pmin, lambdap)
 
 newtype PoolDistr crypto=
   PoolDistr (Map (KeyHash crypto) (Rational, Hash (HASH crypto) (VerKeyVRF (VRF crypto))))
-  deriving (Show, Eq, NoUnexpectedThunks, Relation)
+  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks, Relation)
 
 isInstantaneousRewards :: DCert crypto-> Bool
 isInstantaneousRewards (DCertMir _) = True

--- a/shelley/chain-and-ledger/executable-spec/src/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Keys.hs
@@ -216,7 +216,7 @@ verifyKES (VKeyES vKeyES) vd (KESig sigKES) n =
 
 newtype GenDelegs crypto =
   GenDelegs (Map (GenKeyHash crypto) (KeyHash crypto))
-  deriving (Show, Eq, NoUnexpectedThunks)
+  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
 newtype GKeys crypto = GKeys (Set (VKeyGenesis crypto))
   deriving (Show, Eq, NoUnexpectedThunks)

--- a/shelley/chain-and-ledger/executable-spec/src/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/PParams.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
+
 -- | This module contains just the type of protocol parameters.
 module PParams
   ( PParams(..)
@@ -27,6 +29,7 @@ module PParams
   , protocolVersion
   ) where
 
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
@@ -82,6 +85,99 @@ data PParams = PParams
   } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks PParams
+
+instance ToCBOR PParams
+ where
+  toCBOR (PParams
+    { _minfeeA         = minfeeA'
+    , _minfeeB         = minfeeB'
+    , _maxBBSize       = maxBBSize'
+    , _maxTxSize       = maxTxSize'
+    , _maxBHSize       = maxBHSize'
+    , _keyDeposit      = keyDeposit'
+    , _keyMinRefund    = keyMinRefund'
+    , _keyDecayRate    = keyDecayRate'
+    , _poolDeposit     = poolDeposit'
+    , _poolMinRefund   = poolMinRefund'
+    , _poolDecayRate   = poolDecayRate'
+    , _eMax            = eMax'
+    , _nOpt            = nOpt'
+    , _a0              = a0'
+    , _rho             = rho'
+    , _tau             = tau'
+    , _activeSlotCoeff = activeSlotCoeff'
+    , _d               = d'
+    , _extraEntropy    = extraEntropy'
+    , _protocolVersion = protocolVersion'
+    }) =
+      encodeListLen 20
+        <> toCBOR minfeeA'
+        <> toCBOR minfeeB'
+        <> toCBOR maxBBSize'
+        <> toCBOR maxTxSize'
+        <> toCBOR maxBHSize'
+        <> toCBOR keyDeposit'
+        <> toCBOR keyMinRefund'
+        <> toCBOR keyDecayRate'
+        <> toCBOR poolDeposit'
+        <> toCBOR poolMinRefund'
+        <> toCBOR poolDecayRate'
+        <> toCBOR eMax'
+        <> toCBOR nOpt'
+        <> toCBOR a0'
+        <> toCBOR rho'
+        <> toCBOR tau'
+        <> toCBOR activeSlotCoeff'
+        <> toCBOR d'
+        <> toCBOR extraEntropy'
+        <> toCBOR protocolVersion'
+
+instance FromCBOR PParams
+ where
+  fromCBOR = do
+    enforceSize "PParams" 20
+    minfeeA' <- fromCBOR
+    minfeeB' <- fromCBOR
+    maxBBSize' <- fromCBOR
+    maxTxSize' <- fromCBOR
+    maxBHSize' <- fromCBOR
+    keyDeposit' <- fromCBOR
+    keyMinRefund' <- fromCBOR
+    keyDecayRate' <- fromCBOR
+    poolDeposit' <- fromCBOR
+    poolMinRefund' <- fromCBOR
+    poolDecayRate' <- fromCBOR
+    eMax' <- fromCBOR
+    nOpt' <- fromCBOR
+    a0' <- fromCBOR
+    rho' <- fromCBOR
+    tau' <- fromCBOR
+    activeSlotCoeff' <- fromCBOR
+    d' <- fromCBOR
+    extraEntropy' <- fromCBOR
+    protocolVersion' <- fromCBOR
+    pure $ PParams
+      { _minfeeA         = minfeeA'
+      , _minfeeB         = minfeeB'
+      , _maxBBSize       = maxBBSize'
+      , _maxTxSize       = maxTxSize'
+      , _maxBHSize       = maxBHSize'
+      , _keyDeposit      = keyDeposit'
+      , _keyMinRefund    = keyMinRefund'
+      , _keyDecayRate    = keyDecayRate'
+      , _poolDeposit     = poolDeposit'
+      , _poolMinRefund   = poolMinRefund'
+      , _poolDecayRate   = poolDecayRate'
+      , _eMax            = eMax'
+      , _nOpt            = nOpt'
+      , _a0              = a0'
+      , _rho             = rho'
+      , _tau             = tau'
+      , _activeSlotCoeff = activeSlotCoeff'
+      , _d               = d'
+      , _extraEntropy    = extraEntropy'
+      , _protocolVersion = protocolVersion'
+      }
 
 makeLenses ''PParams
 

--- a/shelley/chain-and-ledger/executable-spec/src/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Serialization.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE OverloadedStrings #-}
 
 module Serialization where
 
-import           Cardano.Binary (Decoder, Encoding, ToCBOR (..), encodeListLen)
+import           Cardano.Binary (Decoder, Encoding, FromCBOR (..), ToCBOR (..), decodeListLen,
+                     encodeListLen, matchSize)
 import           Data.Typeable
 
 class Typeable a => ToCBORGroup a where
@@ -15,3 +17,10 @@ instance ToCBORGroup a => ToCBOR (CBORGroup a) where
 
 class Typeable a => FromCBORGroup a where
   fromCBORGroup :: Decoder s a
+
+instance (FromCBORGroup a, ToCBORGroup a) => FromCBOR (CBORGroup a) where
+  fromCBOR = do
+    n <- decodeListLen
+    x <- fromCBORGroup
+    matchSize "CBORGroup" ((fromIntegral . toInteger . listLen) x) n
+    pure $ CBORGroup x

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -66,6 +66,7 @@ data PoolParams crypto =
     , _poolOwners  :: Set (KeyHash crypto)
     } deriving (Show, Generic, Eq)
       deriving ToCBOR via CBORGroup (PoolParams crypto)
+      deriving FromCBOR via CBORGroup (PoolParams crypto)
 
 instance NoUnexpectedThunks (PoolParams crypto)
 
@@ -109,6 +110,8 @@ type Ix  = Natural
 data Ptr
   = Ptr SlotNo Ix Ix
   deriving (Show, Eq, Ord, Generic)
+  deriving ToCBOR via CBORGroup Ptr
+  deriving FromCBOR via CBORGroup Ptr
 
 instance NoUnexpectedThunks Ptr
 
@@ -260,14 +263,14 @@ instance Crypto crypto => NoUnexpectedThunks (Tx crypto)
 
 newtype StakeCreds crypto =
   StakeCreds (Map (Credential crypto) SlotNo)
-  deriving (Show, Eq, NoUnexpectedThunks)
+  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
 addStakeCreds :: (Credential crypto) -> SlotNo -> (StakeCreds crypto) -> StakeCreds crypto
 addStakeCreds newCred s (StakeCreds creds) = StakeCreds $ Map.insert newCred s creds
 
 newtype StakePools crypto =
   StakePools (Map (KeyHash crypto) SlotNo)
-  deriving (Show, Eq, NoUnexpectedThunks)
+  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
 
 -- CBOR
@@ -650,6 +653,8 @@ instance ToCBORGroup Ptr where
       <> toCBOR (fromInteger (toInteger certIx) :: Word)
   listLen _ = 3
 
+instance FromCBORGroup Ptr where
+  fromCBORGroup = Ptr <$> fromCBOR <*> fromCBOR <*> fromCBOR
 
 instance
   (Crypto crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -41,6 +41,7 @@ module UTxO
 
 import           Lens.Micro ((^.))
 
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Data.Foldable (toList)
 import           Data.Map.Strict (Map)
@@ -66,7 +67,7 @@ import           Delegation.Certificates (DCert (..), StakePools (..), dvalue, r
 -- |The unspent transaction outputs.
 newtype UTxO crypto
   = UTxO (Map (TxIn crypto) (TxOut crypto))
-  deriving (Show, Eq, Ord, NoUnexpectedThunks)
+  deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
 instance Relation (UTxO crypto) where
   type Domain (UTxO crypto) = TxIn crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -301,3 +301,18 @@ data UpdateState crypto
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (UpdateState crypto)
+
+instance Crypto crypto => ToCBOR (UpdateState crypto)
+ where
+  toCBOR (UpdateState a b c d) =
+    encodeListLen 4 <> toCBOR a <> toCBOR b <> toCBOR c <> toCBOR d
+
+instance Crypto crypto => FromCBOR (UpdateState crypto)
+ where
+  fromCBOR = do
+    enforceSize "UpdateState" 4
+    a <- fromCBOR
+    b <- fromCBOR
+    c <- fromCBOR
+    d <- fromCBOR
+    pure $ UpdateState a b c d

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@ extra-deps:
   commit: cb54482c7e3d45f6c1aac490dc937ed835de0333
 
 - git: https://github.com/input-output-hk/cardano-base
-  commit: 9e41a682fcffc696f599f83d8372c40c9c609578
+  commit: 0fcb3a306e96ce36fca75d62792c55ab1de871ea
   subdirs:
     - binary
     - cardano-crypto-class


### PR DESCRIPTION
This PR adds all the necessary `ToCBOR` and `FromCBOR` instances needed to be able to serialize `NewEpochState`.

We do not intend to send this data over the wire, these instances are needed for local storage.

The work was mostly manual and straightforward, but there are a few things worth mentioning:
* I added a `FromCBOR` instance for the `CBORGroup` class.
* I put in some TODOs for reconsidering how we serialize `Coin`. We currently do not ever want anyone to send a negitive value on the wire. Therefore we are using `Word`. This will change, however, with Plutus (eg, forging negative amounts of currency). Moreover, there are two places in the ledger state where the coin values are _always_ non-positive (both in the reward updates, where we record how to reduce the reward pot and the fee pot).
* I did not add as many tests as I would like. Since most of the instances are extremely straightforward, the tests I would still like to add would be to catch issues when things move around in the future.

closes #1144 