### PR TITLE
abstract transaction size function

### DIFF
--- a/shelley/chain-and-ledger/cddl-spec/shelley.cddl
+++ b/shelley/chain-and-ledger/cddl-spec/shelley.cddl
@@ -43,7 +43,7 @@ transaction_body =
   { 0 : #6.258([* transaction_input])
   , 1 : [* transaction_output]
   , ? 2 : [* delegation_certificate]
-  , ? 3 : [* withdrawal]
+  , ? 3 : withdrawals
   , 4 : coin ; fee
   , 5 : uint ; ttl
   , ? 6 : full_update
@@ -82,10 +82,10 @@ delegation_certificate =
   // 8                                ; genesis key delegation
       , genesishash                   ; delegating key
       , keyhash                       ; key delegated to
-  // 9, [* move_instantaneous_reward] ; move instantaneous rewards
+  // 9, move_instantaneous_reward ; move instantaneous rewards
  ) ]
 
-move_instantaneous_reward = ( keyhash, coin )
+move_instantaneous_reward = { * keyhash => coin }
 pointer = (uint, uint, uint)
 
 credential =
@@ -100,10 +100,10 @@ pool_params = ( #6.258([* keyhash]) ; pool owners
               , coin                ; pledge
               , keyhash             ; operator
               , $vrf_keyhash        ; vrf keyhash
-              , [credential]        ; reward_account
+              , credential          ; reward account
               )
 
-withdrawal = [credential, amount : uint]
+withdrawals = { * credential => coin }
 
 full_update = [ protocol_param_update_votes, application_version_update_votes ]
 
@@ -139,8 +139,8 @@ application_version_update = { * application_name =>  [uint, application_metadat
 
 application_metadata = { * system_tag => installerhash }
 
-application_name = tstr
-system_tag = tstr
+application_name = tstr .size 12
+system_tag = tstr .size 10
 
 transaction_witness_set =
   (  0, vkeywitness

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -438,11 +438,28 @@ txsize (TxBody ins outs cs ws _ _ (Update (PPUpdate ppup) (AVUpdate avup))) =
     cSize = sum $ fmap certSize cs
     wSize = label + mapPrefix + (toInteger $ length ws) * (uint + credential)
 
-    params = uint + uint + uint + uint + uint + uint
-               + unitInterval + unitInterval + uint + unitInterval
-               + unitInterval + uint + uint + unitInterval
-               + unitInterval + unitInterval + unitInterval + unitInterval
-               + uint + (arrayPrefix + uint + uint + uint)
+    protoVersion = (smallArray + uint + uint + uint)
+    params = mapPrefix
+               + label + uint         -- minfee A
+               + label + uint         -- minfee B
+               + label + uint         -- max block body size
+               + label + uint         -- max transaction size
+               + label + uint         -- max block header size
+               + label + uint         -- key deposit
+               + label + unitInterval -- key deposit min refund
+               + label + unitInterval -- key deposit decay rate
+               + label + uint         -- pool deposit
+               + label + unitInterval -- pool deposit min refund
+               + label + unitInterval -- pool deposit decay rate
+               + label + uint         -- maximum epoch
+               + label + uint         -- n_optimal. desired number of stake pools
+               + label + unitInterval -- pool pledge influence
+               + label + unitInterval -- expansion rate
+               + label + unitInterval -- treasury growth rate
+               + label + unitInterval -- active slot coefficient
+               + label + unitInterval -- d. decentralization constant
+               + label + uint         -- extra entropy
+               + label + protoVersion -- protocol version
     ppupSize = mapPrefix + (toInteger $ length ppup) * (hashObj + params)
     avupSize = mapPrefix + (sum $ fmap appsSize avup)
     appsSize as = hashObj + mapPrefix + (sum $ fmap mdSize (apps as))

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -24,7 +24,9 @@ import           Coin
 import           Ledger.Core ((<|))
 import           LedgerState hiding (genDelegs)
 import           PParams
-import           Rules.ClassifyTraces (onlyValidLedgerSignalsAreGenerated, relevantCasesAreCovered)
+import           Rules.ClassifyTraces (onlyValidLedgerSignalsAreGenerated,
+                     propAbstractSizeBoundsBytes, propAbstractSizeNotTooBig,
+                     relevantCasesAreCovered)
 import           Rules.TestLedger (consumedEqualsProduced, credentialMappingAfterDelegation,
                      credentialRemovedAfterDereg, eliminateTxInputs, feesNonDecreasing,
                      newEntriesAndUniqueTxIns, noDoubleSpend, pStateIsInternallyConsistent,
@@ -238,6 +240,12 @@ propertyTests = testGroup "Property-Based Testing"
                   , testProperty
                     "Correctly preserve balance"
                     propPreserveBalance
+                  , TQC.testProperty
+                    "abstract tx size bounds bytes"
+                    propAbstractSizeBoundsBytes
+                  , TQC.testProperty
+                    "abstract tx size not too big"
+                    propAbstractSizeNotTooBig
                   ]
                 , testGroup "Property tests with mutated transactions"
                   [testProperty


### PR DESCRIPTION
This PR adds a realistic abstract size function for transactions based on our cddl file. The purpose of the function is to be a reasonable bound on the number of bytes.

There are still a few remaining details to iron out regarding incorporating the non-body components of the transaction into the fee. This will be incorporated with the resolution of #812 

closes #298 