### PR TITLE
Don't generate `k` equal to zero

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
@@ -7,6 +7,7 @@ module Cardano.Spec.Chain.STS.Rule.Epoch where
 
 import           Control.State.Transition
 import           Data.Data (Data, Typeable)
+import           GHC.Stack (HasCallStack)
 import           Ledger.Core
 import           Ledger.GlobalParams (slotsPerEpoch)
 import           Ledger.Update
@@ -14,7 +15,8 @@ import           Ledger.Update
 
 -- | Compute the epoch for the given _absolute_ slot and chain stability parameter.
 sEpoch
-  :: Slot
+  :: HasCallStack
+  => Slot
   -> BlockCount
   -> Epoch
 sEpoch (Slot s) k = if k' > 0

--- a/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Core/Generators.hs
@@ -77,8 +77,8 @@ k chainLength maxNumberOfEpochs =
 -- So the resulting @k@ value will be directly proportional to the @chainLength@ and inversely
 -- proportional to the chosen @numberOfEpochs@.
 --
--- When the number of epochs is greater or equal than the @chainLength@ the resulting @k@ parameter
--- will be 0.
+-- The minimum value for @k@ will be 1. In particular, this will be the value
+-- returned when the number of epochs is greater or equal than @chainLength@.
 kForNumberOfEpochs
   :: Word64
   -- ^ Chain length
@@ -86,7 +86,7 @@ kForNumberOfEpochs
   -- ^ Desired number of epochs
   -> BlockCount
 kForNumberOfEpochs chainLength numberOfEpochs =
-  slotsPerEpochToK slotsPerEpoch
+  max 1 (slotsPerEpochToK slotsPerEpoch)
   where
     slotsPerEpoch :: Word64
     slotsPerEpoch = round $ fromIntegral chainLength / (fromIntegral numberOfEpochs :: Double)


### PR DESCRIPTION
The generator for `k` in `Ledger.Core.Generators` sometimes generated `k = 0`. This was documented behaviour, but unfortunately some of the the other generators in the ledger spec could not deal with this. Two examples:

```haskell
-- | Compute the epoch for the given _absolute_ slot and chain stability parameter.
sEpoch
  :: HasCallStack
  => Slot
  -> BlockCount
  -> Epoch
sEpoch (Slot s) k = if k' > 0
                       then Epoch $ s `div` k'
                       else error ("sEpoch: bad `k` provided: " <> show k)
  where k' = slotsPerEpoch k
```

and the computation of the PBFT threshold

```haskell
sigCntT :: BlockCount -> Word8 -> Gen Double
sigCntT (BlockCount k) ngk =
  Gen.double (Range.constant lower upper)
  where
    lower = 1 / (fromIntegral ngk * 0.7) + 1 / fromIntegral k
    upper = 1 / (fromIntegral ngk * 0.5) + 1 / fromIntegral k
```

which would return infinity.

More insidiously, when the generator picked `k = 0`, the `HasTrace` instance for `CHAIN` might often loop indefinitely. I've not debugged this in great detail, so I don't know where that loop is coming from, but I _have_ confirmed that after this PR, I can run the generator 100,000,000 times without it looping.

I do wonder if this is related to the test non-termination problems that the ledger folks were having.