### PR TITLE
Include witnesses in transaction size calculation

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -552,8 +552,16 @@ txsize (Tx (TxBody ins outs cs ws _ _ (Update (PPUpdate ppup) (AVUpdate avup))) 
     scriptNodes = Map.foldl (+) 0 (Map.map countMSigNodes msigScripts)
 
     -- TODO witness size is currently
-    --  (#vkeywitness + #all msigNodes + #msigscripts) * size(hash)
-    witnessSize = hl * fromIntegral (signatures + Map.size msigScripts + scriptNodes)
+    --  (5 * #vkeywitness + 2 * #all msigNodes + 5 * #msigscripts) * size(hash)
+    --
+    -- while hashes have a specific bytecount, the DSIGNAlgorithm class does not
+    -- provide a similar function. Also, vkeys for mock are potentiall unbounded
+    -- in length. Therefore the above constants have been chosen to give an
+    -- abstract size estimation in terms of the size of hash.
+    witnessSize = hl * fromIntegral (
+      5 * signatures +
+      2 * Map.size msigScripts +
+      5 * scriptNodes)
 
     -- hash
     hl = toInteger $ byteCount (Proxy :: Proxy (HASH crypto))

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Utxo.hs
@@ -154,7 +154,7 @@ utxoInductive = do
 
   txins txb /= Set.empty ?! InputSetEmptyUTxO
 
-  let minFee = minfee pp txb
+  let minFee = minfee pp tx
       txFee  = _txfee txb
   minFee <= txFee ?! FeeTooSmallUTxO minFee txFee
 
@@ -171,7 +171,7 @@ utxoInductive = do
   all (0 <=) outputCoins ?! NegativeOutputsUTxO
 
   let maxTxSize_ = fromIntegral (_maxTxSize pp)
-      txSize_ = txsize txb
+      txSize_ = txsize tx
   txSize_ <= maxTxSize_ ?! MaxTxSizeUTxO txSize_ maxTxSize_
 
   let refunded = keyRefunds pp stakeCreds txb

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -153,6 +153,13 @@ newtype ScriptHash crypto =
 deriving instance Crypto crypto => ToCBOR (ScriptHash crypto)
 deriving instance Crypto crypto => FromCBOR (ScriptHash crypto)
 
+-- | Count nodes and leaves of multi signature script
+countMSigNodes :: MultiSig crypto -> Int
+countMSigNodes (RequireSignature _) = 1
+countMSigNodes (RequireAllOf msigs) = 1 + sum (map countMSigNodes msigs)
+countMSigNodes (RequireAnyOf msigs) = 1 + sum (map countMSigNodes msigs)
+countMSigNodes (RequireMOf _ msigs) = 1 + sum (map countMSigNodes msigs)
+
 type Wdrl crypto = Map (RewardAcnt crypto) Coin
 
 -- |A unique ID of a transaction, which is computable from the transaction.

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
@@ -152,7 +152,7 @@ propAbstractSizeBoundsBytes = property $ do
   forAllTraceFromInitState @LEDGER testGlobals tl tl (Just mkGenesisLedgerState) $ \tr -> do
     let txs :: [Tx]
         txs = traceSignals OldestFirst tr
-    all (\txb -> txsize txb >= numBytes txb) (fmap _body txs)
+    all (\tx -> txsize tx >= numBytes tx) txs
 
 -- | Check that the abstract transaction size function
 -- is not off by an acceptable order of magnitude.
@@ -170,7 +170,7 @@ propAbstractSizeNotTooBig = property $ do
   forAllTraceFromInitState @LEDGER testGlobals tl tl (Just mkGenesisLedgerState) $ \tr -> do
     let txs :: [Tx]
         txs = traceSignals OldestFirst tr
-    all notTooBig (fmap _body txs)
+    all notTooBig txs
 
 onlyValidChainSignalsAreGenerated :: Property
 onlyValidChainSignalsAreGenerated = withMaxSuccess 20 $

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -517,7 +517,7 @@ testFeeTooSmall =
            (SlotNo 100)
            [alicePay]
   in ledgerState [tx] @?=
-       Left [ FeeTooSmall (minfee testPCs $ tx ^. body) (Coin 1) ]
+       Left [ FeeTooSmall (minfee testPCs tx) (Coin 1) ]
 
 testExpiredTx :: Assertion
 testExpiredTx =

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -154,7 +154,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
   \emph{Helper Functions}
   %
   \begin{align*}
-    \fun{minfee} & \in \PParams \to \TxBody \to \Coin & \text{minimum fee}\\
+    \fun{minfee} & \in \PParams \to \Tx \to \Coin & \text{minimum fee}\\
     \fun{minfee} & ~\var{pp}~\var{tx} =
     (\fun{a}~\var{pp}) \cdot \fun{txSize}~\var{tx} + (\fun{b}~\var{pp})
     \\

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -293,7 +293,7 @@ requests).
     { \var{txb}\leteq\txbody{tx}
       & \txttl txb \geq \var{slot}
       \\ \txins{txb} \neq \emptyset
-      & \minfee{pp}{txb} \leq \txfee{txb}
+      & \minfee{pp}{tx} \leq \txfee{txb}
       & \txins{txb} \subseteq \dom \var{utxo}
       \\
       \consumed{pp}{utxo}{stkCreds}{rewards}~{txb} = \produced{pp}{stpools}~{txb}
@@ -313,7 +313,7 @@ requests).
       \\
       \forall (\_\mapsto (\_, c)) \in \txouts{txb}, c \geq 0
       \\
-      \fun{txsize}~{txb}\leq\fun{maxTxSize}~\var{pp}
+      \fun{txsize}~{tx}\leq\fun{maxTxSize}~\var{pp}
       \\
       ~
       \\


### PR DESCRIPTION
Since adding the multi-sig scripts, there can be more signatures than required by the vkey witnesses. Ti Disincentivize addinging redundant signatures, we include the witnesses and multi-signature scripts in the transaction size calculation.