### PR TITLE
small shelley ledger spec edits from isabelle review #3

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Newpp.hs
@@ -42,6 +42,7 @@ instance STS (NEWPP crypto) where
   type BaseM (NEWPP crypto) = ShelleyBase
   data PredicateFailure (NEWPP crypto)
     = FailureNEWPP
+    | UnexpectedDepositPot
     deriving (Show, Eq, Generic)
 
   initialRules = [initialNewPp]
@@ -69,6 +70,8 @@ newPpTransition = do
           diff = oblgCurr - oblgNew
           Coin reserves = _reserves acnt
           Coin requiredInstantaneousRewards = foldl (+) (Coin 0) $ _irwd dstate
+
+      (Coin oblgCurr) == (_deposited utxoSt) ?! UnexpectedDepositPot
 
       if reserves + diff >= requiredInstantaneousRewards
          && (_maxTxSize ppNew' + _maxBHSize ppNew') <  _maxBBSize ppNew'

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -195,6 +195,7 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
                     & \text{convert a slot to a seed} \\
       \hashHeaderToNonce{} & \HashHeader \to \Seed
                     & \text{convert a header hash to a seed} \\
+      \fun{bbodyhash} & \seqof{\Tx} \to \HashBBody \\
     \end{array}
   \end{equation*}
   %
@@ -214,7 +215,7 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
       \fun{bleader} & \BHBody \to \unitInterval\\
       \fun{\bprfl{}} & \BHBody \to \Proof\\
       \fun{hBbsize} & \BHBody \to \N \\
-      \fun{bbodyhash} & \seqof{\Tx} \to \HashBBody \\
+      \fun{bhash} & \BHBody \to \HashBBody \\
       \fun{bocert} & \BHBody \to \OCert \\
     \end{array}
   \end{equation*}
@@ -342,7 +343,7 @@ In the second case, the new epoch state is updated as follows:
       \\~\\
       {
         \vdash
-        (\fun{applyRUpd}~\var{ru}~\var{e}~\var{es})
+        (\fun{applyRUpd}~\var{ru}~\var{es})
           \trans{\hyperref[fig:rules:epoch]{epoch}}{\var{e}}\var{es'}
       }
       \\~\\
@@ -752,25 +753,28 @@ Three transitions are done:
         \var{nes}'
       }
       \\~\\
-      (\wcard,~\wcard,~\var{b_{prev}},~\wcard,~\var{es},~\wcard,~\wcard,~\wcard)\leteq\var{nes} \\
+      (\wcard,~\var{b_{prev}},~\wcard,~\var{es},~\wcard,~\wcard,~\wcard)\leteq\var{nes} \\
       \\
-      (\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{ru},~\wcard,~\wcard)\leteq\var{nes'} \\
+      (\var{e_\ell'},~\var{b_{prev}'},~\var{b_{cur}'},~\var{es'},~\var{ru'},~\var{pd'},\var{osched'})
+      \leteq\var{nes'}
       \\~\\
       {
         {\begin{array}{c}
            \var{b_{prev}} \\
            \var{es} \\
          \end{array}}
-        \vdash \var{ru}\trans{\hyperref[fig:rules:reward-update]{rupd}}{\var{s}} \var{ru}'
+        \vdash \var{ru'}\trans{\hyperref[fig:rules:reward-update]{rupd}}{\var{s}} \var{ru''}
       }
       \\~\\
-      \var{nes}''\leteq\var{nes'}\unionoverrideRight\{\var{ru'}\}
+      \var{nes''}\leteq
+      (\var{e_\ell'},~\var{b_{prev}'},~\var{b_{cur}'},~\var{es'},~\var{ru''},~\var{pd'},\var{osched'})
+      \\~\\
     }
     {
       {\begin{array}{c}
          \var{gkeys} \\
        \end{array}}
-      \vdash\var{nes}\trans{tick}{\var{bh}}\varUpdate{\var{nes''}}
+      \vdash\var{nes}\trans{tick}{\var{s}}\varUpdate{\var{nes''}}
     }
   \end{equation}
   \caption{Tick rules}
@@ -1364,13 +1368,13 @@ current slot is not an overlay slot.
     {
       \var{txs} \leteq \bbody{block}
       &
-      \var{bhb} \leteq \bhbody\bheader{block}
+      \var{bhb} \leteq \bhbody{(\bheader{block})}
       &
-      \var{hk} \leteq \hashKey\bvkcold{bhb}
+      \var{hk} \leteq \hashKey{(\bvkcold{bhb})}
       \\~\\
       \bBodySize{txs} = \hBbsize{bhb}
       &
-      \fun{hash}~{txs} = \bbodyhash{bhb}
+      \fun{bbodyhash}~{txs} = \bhash{bhb}
       \\~\\
       {
         {\begin{array}{c}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -284,7 +284,7 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
       & \where \\
       & ~~~~ (\var{stkCreds},~\var{rewards},~\var{delegations},~\var{ptrs},~\wcard,~\wcard)
         = \var{dstate} \\
-      & ~~~~ (\var{stpools},~\wcard,~\wcard,~\wcard,~\wcard) = \var{pstate} \\
+      & ~~~~ (\var{stpools},~\wcard,~\wcard) = \var{pstate} \\
       & ~~~~ \var{stakeRelation} = \left(
         \left(\fun{stakeCred_b}^{-1}\cup\left(\fun{addrPtr}\circ\var{ptr}\right)^{-1}\right)
         \circ\left(\range{\var{utxo}}\right)
@@ -396,7 +396,7 @@ This transition has no preconditions and results in the following state change:
       {
       \begin{array}{r@{~\leteq~}l}
         (\var{stkCreds},~\wcard,~\var{delegations},~\wcard,~\wcard,~\wcard) & \var{dstate}\\
-        (\var{stpools},~\var{poolParams},~\wcard,~\wcard) & \var{pstate}\\
+        (\var{stpools},~\var{poolParams},~\wcard) & \var{pstate}\\
         \var{stake} & \stakeDistr{utxo}{dstate}{pstate} \\
         \var{slot} & \firstSlot{e} \\
         \var{oblg} & \obligation{pp}{stkCreds}{stpools}{slot} \\
@@ -680,39 +680,22 @@ for ease of reading.
          \var{(\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\var{i_{rwd}})} &
                                                                                       \leteq
                               & \var{dstate}\\
-         \var{diff} & \leteq & \var{oblg_{cur}} - \var{oblg_{new}}
+         \var{diff} & \leteq & \var{oblg_{cur}} - \var{oblg_{new}}\\
+         (\var{utxo},~\var{deposits},~\var{fees},~\var{ups}) & \leteq & \var{utxoSt} \\
+         (\var{pup},~\var{aup},~\var{favs},~\var{avs}) & \leteq & \var{ups} \\
       \end{array}}
       \\~\\~\\
+      \var{oblg_{cur}} = \var{deposits} \\
       \var{reserves} + \var{diff} \geq \sum\limits_{\wcard\mapsto\var{val}\in\var{i_{rwd}}} val \\
       \fun{maxTxSize}~\var{pp_{new}} + \fun{maxHeaderSize}~\var{pp_{new}} <
         \fun{maxBlockSize}~\var{pp_{new}}
       \\~\\
-      \var{utxoSt'} \leteq
-      \left(
-        {
-          \begin{array}{r}
-            \var{utxo} \\
-            \varUpdate{oblg_{new}} \\
-            \var{fees} \\
-            \left(\begin{array}{r}
-              \varUpdate{\emptyset} \\
-              \var{aup} \\
-              \var{favs} \\
-              \var{avs} \\
-          \end{array}\right)
-          \end{array}
-        }
-      \right)
-      &
-      \var{acnt'} \leteq
-      \left(
-        {
-          \begin{array}{r}
-            \var{treasury} \\
-            \varUpdate{reserves + diff} \\
-          \end{array}
-        }
-      \right)
+        \var{utxoSt'} \leteq
+        \left(\var{utxo},~\varUpdate{oblg_{new}},~\var{fees}
+        \left(\varUpdate{\emptyset},~\var{aup},~\var{favs},~\var{avs}\right)\right)
+      \\~\\
+      (\var{treasury},~\var{reserves})\leteq \var{acnt} \\
+      \var{acnt'} \leteq (\var{treasury},~\varUpdate{reserves + diff}) \\
     }
     {
       \begin{array}{l}
@@ -763,22 +746,12 @@ for ease of reading.
          \var{diff} & \leteq & \var{oblg_{cur}} - \var{oblg_{new}}
       \end{array}}
       \\~\\~\\
-      \var{utxoSt'} \leteq
-      \left(
-        {
-          \begin{array}{r}
-            \var{utxo} \\
-            \var{deposits} \\
-            \var{fees} \\
-            \left(\begin{array}{r}
-              \varUpdate{\emptyset} \\
-              \var{aup} \\
-              \var{favs} \\
-              \var{avs} \\
-          \end{array}\right)
-          \end{array}
-        }
-      \right)
+      \left(\var{utxo},~\var{oblg},~\var{fees}
+        \left(\var{pup},~\var{aup},~\var{favs},~\var{avs}\right)\right)
+        \leteq \var{utxoSt} \\
+        \var{utxoSt'} \leteq
+        \left(\var{utxo},~\var{oblg},~\var{fees}
+        \left(\varUpdate{\emptyset},~\var{aup},~\var{favs},~\var{avs}\right)\right)
     }
     {
       \begin{array}{l}
@@ -850,6 +823,13 @@ protocol parameters.
 
 The epoch transition rule calls $\mathsf{SNAP}$, $\mathsf{POOLREAP}$ and $\mathsf{NEWPP}$
 in sequence.
+The ordering of these rules is important.
+The stake pools which will be reaped during the $\mathsf{POOLREAP}$ transition must still be a
+part of the new snapshot, and so $\mathsf{SNAP}$ must occur before $\mathsf{POOLREAP}$.
+Moreover, $\mathsf{SNAP}$ sets the deposit pot equal to current obligation,
+which is a property that is preserved by $\mathsf{POOLREAP}$ and which
+is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ transation.
+
 %%
 %% Figure - Epoch Rule
 %%

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -828,7 +828,7 @@ The stake pools which will be reaped during the $\mathsf{POOLREAP}$ transition m
 part of the new snapshot, and so $\mathsf{SNAP}$ must occur before $\mathsf{POOLREAP}$.
 Moreover, $\mathsf{SNAP}$ sets the deposit pot equal to current obligation,
 which is a property that is preserved by $\mathsf{POOLREAP}$ and which
-is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ transation.
+is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ transition.
 
 %%
 %% Figure - Epoch Rule

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -65,7 +65,7 @@ represented in the state to zero.
 For example, given $\var{utxoSt}\in\UTxOState$,
 \begin{equation*}
   \Val(\var{utxoSt}) =
-  \left(\sum_{\wcard\mapsto v\in\var{utxo}}v\right) + \var{deposits} + \var{fees}
+  \left(\sum_{\wcard\mapsto(\wcard,~v)\in\var{utxo}}v\right) + \var{deposits} + \var{fees}
 \end{equation*}
 
 \noindent


### PR DESCRIPTION
This PR addresses several issues that arose from the Isabelle formalization (the third installment :) ). The main issue to be resolved was #1146, but in the process we learned more than was mentioned in the issue on github. In fact, all that was needed was the extra predicate `deposits == obligation` in the `NEWPP` rule. (The explanation is: The stake pools which will be reaped during the `POOLREAP` transition must still be a part of the new snapshot, and so `SNAP` must occur before `POOLREAP`. Moreover, `SNAP` sets the deposit pot equal to current obligation, which is a property that is preserved by `POOLREAP` and which is necessary for the preservation of Ada property in the `NEWPP` transation.)

Several small issues/typos were fixed:
* remove some abusive notation, which was using union overrides and colored let bindings in place of setting variables in big state objects properly.
* `applyRUpd` was used with an extra/rogue `e` parameter.
* the definition of value `Val(utxo)` in section 15.1 (preservation of Ada) was wrong. since the value in the map is a pair containing a coin, not a coin itself.
* wrong signal in main `TICK` transition (should be `s` not `bh`).
* some missing parenthesis in the `BBODY` transition.
* misnamed hash functions in `BBODY` (there was confusion in what was actually hashing transactions and what was getting the supposed hash from the block header).

closes #1146 