### PR TITLE
Fix brittle tests in small-steps

### DIFF
--- a/byron/semantics/executable-spec/test/Control/State/Transition/Examples/CommitReveal.hs
+++ b/byron/semantics/executable-spec/test/Control/State/Transition/Examples/CommitReveal.hs
@@ -162,7 +162,7 @@ instance
     where
       genCommit = do
         id <- Id <$> QC.arbitrary
-        n <- QC.choose (-10, 10)
+        n <- QC.choose (-2, 2)
         let newData = Data (id, n)
         pure $! Commit (hash newData) newData
       genReveal = do
@@ -203,8 +203,8 @@ prop_qc_UniqueData =
 -- where it shouldn't be possible to shrink @d0@ any further.
 --
 prop_qc_OnlyValidSignals :: QC.Property
-prop_qc_OnlyValidSignals = QC.withMaxSuccess 1000 -- We need to test a large
+prop_qc_OnlyValidSignals = QC.withMaxSuccess 5000 -- We need to test a large
                                                   -- number of times to make sure
                                                   -- we get a collision in the
                                                   -- generated data
-  $ STS.Gen.onlyValidSignalsAreGenerated @(CR ShortHash Map Data) @() () 100 ()
+  $ STS.Gen.onlyValidSignalsAreGenerated @(CR ShortHash Map Data) @() () 150 ()

--- a/byron/semantics/executable-spec/test/examples/Main.hs
+++ b/byron/semantics/executable-spec/test/examples/Main.hs
@@ -7,8 +7,8 @@ import           Test.Tasty.Hedgehog (testProperty)
 import qualified Test.Tasty.QuickCheck as Tasty.QuickCheck
 
 import qualified Control.State.Transition.Examples.CommitReveal as CommitReveal
-import qualified Control.State.Transition.Examples.Sum as Sum
 import qualified Control.State.Transition.Examples.GlobalSum as GSum
+import qualified Control.State.Transition.Examples.Sum as Sum
 
 main :: IO ()
 main = do
@@ -43,7 +43,7 @@ main = do
               "Unique Data (QuickCheck)"
               CommitReveal.prop_qc_UniqueData
         , expectFailBecause
-            "we're inspecting generated counterexamples"
+            "a counterexample of an invalid signal should be found"
           $ Tasty.QuickCheck.testProperty
               "Only valid signals are generated (QuickCheck)"
               CommitReveal.prop_qc_OnlyValidSignals


### PR DESCRIPTION
- Increase the number of tests to run in `prop_qc_OnlyValidSignals`
- Increase the length of the trace (this will increase the chance of finding a
  duplicated submission)
- Reduce the test space (id's are taken from the interval `[-2, 2]` instead of
  `[-10, 10]`).