### PR TITLE
simplify createRUpd (both formal spec and exec spec)

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -21,6 +21,7 @@ import           Control.State.Transition
 import           Control.State.Transition.Generator
 import           Data.Functor.Identity (runIdentity)
 import qualified Data.Map.Strict as Map
+import           Data.Map.Strict (Map)
 import           Data.Maybe (catMaybes)
 import           Delegation.Certificates
 import           EpochBoundary
@@ -48,6 +49,7 @@ instance
 
   data PredicateFailure (NEWEPOCH crypto)
     = EpochFailure (PredicateFailure (EPOCH crypto))
+    | CorruptIRWDs (Map (Credential crypto) Coin) (Map (Credential crypto) Coin)
     deriving (Show, Generic, Eq)
 
   initialRules =
@@ -80,11 +82,16 @@ newEpochTransition = do
   if e_ /= eL + 1
     then pure src
     else do
-      let es_ = case ru of
-            Nothing  -> es
-            Just ru' -> applyRUpd ru' es
-      es' <- trans @(EPOCH crypto) $ TRC ((), es_, e)
-      let EpochState _acnt ss _ls pp = es'
+      es' <- case ru of
+               Nothing  -> pure es
+               Just ru' -> do
+                 let irwd' = updateIRwd ru'
+                 let irwd_ = getIR es
+                 irwd' == irwd_ ?! CorruptIRWDs irwd' irwd_
+                 pure $ applyRUpd ru' es
+
+      es'' <- trans @(EPOCH crypto) $ TRC ((), es', e)
+      let EpochState _acnt ss _ls pp = es''
           (Stake stake, delegs) = _pstakeSet ss
           Coin total = Map.foldl (+) (Coin 0) stake
           sd =
@@ -100,7 +107,7 @@ newEpochTransition = do
           e
           bcur
           (BlocksMade Map.empty)
-          es'
+          es''
           Nothing
           (PoolDistr pd')
           osched'

--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -86,7 +86,7 @@ newEpochTransition = do
                Nothing  -> pure es
                Just ru' -> do
                  let irwd' = updateIRwd ru'
-                 let irwd_ = getIR es
+                     irwd_ = getIR es
                  irwd' == irwd_ ?! CorruptIRWDs irwd' irwd_
                  pure $ applyRUpd ru' es
 

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -644,10 +644,11 @@ expectedStEx2Bgeneric pp = ChainState
      (EpochState acntEx2A emptySnapShots expectedLSEx2B pp)
                             -- ^ Previous epoch state
      (Just RewardUpdate { deltaT        = Coin 0
-                        , deltaR        = Coin (-110)
+                        , deltaR        = Coin (-209)
                         , rs            = Map.empty
                         , deltaF        = Coin 0
-                        , updateIRwd    = Map.fromList [(carlSHK, 110)]
+                        , updateIRwd    = Map.fromList [ (carlSHK, Coin 110)
+                                                       , (dariaSHK, Coin 99)]
                         })  -- ^ Update reward
      (PoolDistr Map.empty)
      overlayEx2A)
@@ -2335,7 +2336,7 @@ ex6F' = do
 test6F :: Assertion
 test6F = do
   case ex6F' of
-    Left _ -> assertFailure "encountered error state"
+    Left e -> assertFailure (show e)
     Right ex6FState -> do
       let getDState = _dstate . _delegationState . esLState . nesEs . chainNes
           ds = getDState ex6FState

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
@@ -35,8 +35,7 @@ import           Keys (DiscVKey (..), pattern GenKeyHash, Hash, pattern KeyHash,
                      pattern UnsafeSig, hash, hashKey, sKey, sign, signKES, undiscriminateKeyHash,
                      vKey)
 import           LedgerState (AccountState (..), EpochState (..), NewEpochState (..),
-                     pattern RewardUpdate, deltaF, deltaR, deltaT, emptyLedgerState, genesisId, rs,
-                     updateIRwd)
+                     pattern RewardUpdate, deltaF, deltaR, deltaT, emptyLedgerState, genesisId, rs, updateIRwd)
 import           Numeric.Natural (Natural)
 import           PParams (emptyPParams)
 import           Serialization (FromCBORGroup (..), ToCBORGroup (..))

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -347,7 +347,7 @@ In the first case, the new epoch state is updated as follows:
       &
       \var{ru} \neq \Nothing
       \\
-      (\wcard,~\wcard,~\wcard,~\wcard,~,\var{irwd'})\leteq\var{ru}
+      (\wcard,~\wcard,~\wcard,~\wcard,~\var{irwd'})\leteq\var{ru}
       &
       \var{irwd'} = \getIR{es}
       \\

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -310,13 +310,19 @@ of which are active.
   \label{fig:ts-types:newepoch}
 \end{figure}
 
-Figure~\ref{fig:rules:new-epoch} defines the new epoch state transition. It has two rules.
+Figure~\ref{fig:rules:new-epoch} defines the new epoch state transition. It has three rules.
 The first rule describes the change in the case of $e$ being equal to the next epoch
-$e_\ell+ 1$. It also calls the $\mathsf{EPOCH}$ rule.
-The second one deals with the case when the epoch signal $e$ is not one greater than the
+$e_\ell+ 1$. It also calls the $\mathsf{EPOCH}$ rule and checks that the
+instantaneous rewards stored in the reward update is the same as the instantaneous rewards 
+stored in the current epoch state.
+This should always hold and is present only for extra assurance and for help in proving
+that Ada is preserved by reward updates.
+The second rule deals with the case when the epoch signal $e$ is not one greater than the
 current epoch \var{e_\ell}. This rule does not change the state.
+The third one deals with the case when the reward update is equal to $\Nothing$.
+This rule also does not change the state.
 
-In the second case, the new epoch state is updated as follows:
+In the first case, the new epoch state is updated as follows:
 
 \begin{itemize}
 \item The epoch is set to the new epoch $e$.
@@ -340,15 +346,21 @@ In the second case, the new epoch state is updated as follows:
       e = e_\ell + 1
       &
       \var{ru} \neq \Nothing
-      \\~\\
+      \\
+      (\wcard,~\wcard,~\wcard,~\wcard,~,\var{irwd'})\leteq\var{ru}
+      &
+      \var{irwd'} = \getIR{es}
+      \\
+      \var{es'}\leteq\fun{applyRUpd}~\var{ru}~\var{es}
+      &
       {
         \vdash
-        (\fun{applyRUpd}~\var{ru}~\var{es})
-          \trans{\hyperref[fig:rules:epoch]{epoch}}{\var{e}}\var{es'}
+        \var{es'}
+          \trans{\hyperref[fig:rules:epoch]{epoch}}{\var{e}}\var{es''}
       }
       \\~\\
       {\begin{array}{r@{~\leteq~}l}
-          (\var{acnt},~\var{ss},~\var{ls}, \var{pp}) & \var{es'} \\
+          (\var{acnt},~\var{ss},~\var{ls}, \var{pp}) & \var{es''} \\
          (\wcard,~\var{pstake_{set}},~\wcard,~\var{pools},~\wcard) & \var{ss} \\
          (\var{stake}, \var{delegs}) & \var{pstake_{set}} \\
          total & \sum_{\_ \mapsto c\in\var{stake}} c \\
@@ -390,7 +402,7 @@ In the second case, the new epoch state is updated as follows:
             \varUpdate{\var{e}} \\
             \varUpdate{\var{b_{cur}}} \\
             \varUpdate{\emptyset} \\
-            \varUpdate{\var{es}'} \\
+            \varUpdate{\var{es''}} \\
             \varUpdate{\Nothing} \\
             \varUpdate{\var{pd}'} \\
             \varUpdate{\var{osched}'} \\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -28,6 +28,7 @@
 \newcommand{\mReward}[4]{\fun{r_{member}}~ \var{#1}~ \var{#2}~ \var{#3}~ {#4}}
 \newcommand{\poolReward}[5]{\fun{poolReward}~\var{#1}~{#2}~\var{#3}~\var{#4}~\var{#5}}
 \newcommand{\createRUpd}[2]{\fun{createRUpd}~\var{#1}~\var{#2}}
+\newcommand{\getIR}[1]{\fun{getIR}~\var{#1}}
 
 This chapter introduces the epoch boundary transition system and the related reward calculation.
 
@@ -816,6 +817,14 @@ protocol parameters.
     \subseteq \powerset (\EpochState \times \Epoch \times \EpochState)
   \end{equation*}
   %
+  \emph{Accessor Functions}
+  \begin{equation*}
+    \begin{array}{r@{~\in~}lr}
+      \fun{getIR} & \EpochState \to (\StakeCredential \mapsto \Coin)
+                  & \text{get instantaneous rewards} \\
+    \end{array}
+  \end{equation*}
+  %
   \caption{Epoch transition-system types}
   \label{fig:ts-types:epoch}
 \end{figure}
@@ -1292,6 +1301,9 @@ The $\fun{createRUpd}$ function does the following:
     performance.  The difference between the maximal amount and the actual amount received is
     added to the amount moved to the treasury.
   \item The fee pot will be reduced by $\var{feeSS}$.
+  \item The instantaneous rewards $\var{i_{rwd}}$ are stored. This is not neccessary,
+    but ensuring that they will not have changed when the reward update is applied
+    makes for better local properties.
 \end{itemize}
 
 Note that fees are not explicitly removed from any account:
@@ -1322,7 +1334,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
   \begin{align*}
     & \fun{createRUpd} \in \BlocksMade \to \EpochState \to \RewardUpdate \\
     & \createRUpd{b}{es} = \left(
-      \Delta t_1+\Delta t_2,-~\Delta r,~\var{rs},~-\var{feeSS},~\var{registered}\right) \\
+      \Delta t_1+\Delta t_2,-~\Delta r,~\var{rs},~-\var{feeSS},~\var{i_{rwd}}\right) \\
     & ~~~\where \\
     & ~~~~~~~(\var{acnt},~\var{ss},~\var{ls},~\var{pp}) = \var{es} \\
     & ~~~~~~~(\wcard,~\wcard,~\var{pstake_{go}},~\var{poolsSS},~\var{feeSS}) = \var{ss}\\
@@ -1331,14 +1343,12 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
     & ~~~~~~~\left(
       \wcard,~
       \left(
-      \left(\var{stkCreds},~\var{rewards},~\wcard,~\wcard,~\wcard,~\wcard,~\var{i_{rwd}}\right)~
+      \left(\wcard,~\var{rewards},~\wcard,~\wcard,~\wcard,~\wcard,~\var{i_{rwd}}\right)~
       \wcard
       \right)
       \right) = \var{ls} \\
-    & ~~~~~~~unregistered = \dom{i_{rwd}} \setminus \dom{stkCreds}\\
-    & ~~~~~~~\var{registered} = \var{unregistered}\subtractdom i_{rwd} \\
     & ~~~~~~~\var{rewards_{mir}} =
-      \sum\limits_{\wcard\mapsto\var{val}\in\var{registered}}\var{val} \\
+      \sum\limits_{\wcard\mapsto\var{val}\in\var{i_{rwd}}}\var{val} \\
     & ~~~~~~~\var{reserves'} = \var{reserves} - \var{rewards_{mir}}\\
     & ~~~~~~~\Delta r_{l} = \floor*{\min(1,\eta) \cdot (\fun{rho}~{pp}) \cdot
       \var{reserves'}}
@@ -1370,7 +1380,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
           \Delta r \\
           \var{rs} \\
           \Delta f \\
-          \var{rew_{mir}}
+          \var{i_{rwd}'} \\
         \end{array}
     \right)
       \left(
@@ -1388,7 +1398,6 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
           \var{stpools} \\
           \var{poolParams} \\
           \var{retiring} \\
-          \var{cs} \\
           ~ \\
           \var{utxo} \\
           \var{deposits} \\
@@ -1412,7 +1421,6 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
           \var{stpools} \\
           \var{poolParams} \\
           \var{retiring} \\
-          \var{cs} \\
           ~ \\
           \var{utxo} \\
           \var{deposits} \\
@@ -1421,8 +1429,8 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
         \end{array}
     \right)\\
       & ~~~\where \\
-      & ~~~~~~~\var{rew_{mir}'} =  \dom{\var{stkCreds}}\restrictdom\var{rew_{mir}} \\
-      & ~~~~~~~\var{unregistered} = \dom{\var{stkCreds}}\subtractdom\var{rew_{mir}}
+      & ~~~~~~~\var{rew_{mir}'} =  \dom{\var{stkCreds}}\restrictdom\var{i_{rwd}'} \\
+      & ~~~~~~~\var{unregistered} = \dom{\var{stkCreds}}\subtractdom\var{i_{rwd}'}
     \\
       & ~~~~~~~\var{nonDistributed} = \sum\limits_{\wcard\mapsto \var{val} \in
                                       unregistered} \var{val}  \\

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -274,9 +274,9 @@ If we let:
 
 \begin{lemma}
   \label{lemma:ru-pres-of-value}
-  For all mappings $b$ of blocks made, epochs $\epsilon$, and epoch states $s$,
+  For all mappings $b$ of blocks made, and epoch states $s_1$ and $s_2$,
   \begin{equation*}
-    \Val(s) = \Val(\fun{applyRUpd}~(\fun{createRUpd}~b~s)~s)
+    \Val(s_2) = \Val(\fun{applyRUpd}~(\fun{createRUpd}~b~s_1)~s_2)
   \end{equation*}
 \end{lemma}
 
@@ -286,32 +286,34 @@ If we let:
   \begin{equation*}
     \Delta t + \Delta r + \Val(rs) + \Val(\var{update_{rwd}}) + \var{nonDistributed} + \Delta f = 0
   \end{equation*}
+  Note that only $\var{nonDistributed}$ and $\var{update_{rwd}}$ depend on $s_2$,
+  as all the other values are pure computations based on $s_1$.
+
   In the definition of $\fun{createRUpd}$ in Figure~\ref{fig:functions:reward-update-creation},
+  using only variable names for values in $s_1$,
   we see that:
   \begin{equation*}
     \begin{array}{r@{~=~}l}
       \var{rewardPot} & \var{feeSS} + \Delta r_l \\
       \var{R} & \var{rewardPot} - \Delta t_1 \\
       \Delta t_2 & R - \Val(\var{rs})\\
-      \Delta r & - (\Delta r_l+\Val(registered)) \\
+      \Delta r & - (\Delta r_l+\Val(i_{rwd})) \\
     \end{array}
   \end{equation*}
   Therefore
   \begin{equation*}
     \begin{array}{c}
-      (\var{feeSS} + \Delta r_l) = \var{rewardPot} = R + \Delta t_1 = \Delta t_2 + \Val(rs) + \Delta r_l  \\
+      (\var{feeSS} + \Delta r_l) = \var{rewardPot} = R + \Delta t_1 = \Delta t_2 + \Val(rs) + \Delta t_1  \\
       0 = (\Delta t_1 + \Delta t_2 ) - \Delta r_l + \Val(rs)- \var{feeSS} \\
     \end{array}
   \end{equation*}
-  So it suffices to show that:
+  It then suffices to show that:
   \begin{equation*}
-    -\Val(registered) + \Val(\var{update_{rwd}}) + \var{nonDistributed} = 0
+    -\Val(i_{rwd}) + \Val(\var{update_{rwd}}) + \var{nonDistributed} = 0
   \end{equation*}
-  Notice that $\var{rew}_{\var{mir}} = \var{registered}$
-    (the name is different between $\fun{applyRUpd}$ and $\fun{createRUpd}$)
-    and that $\var{rew}_{\var{mir}}$ is the disjoint union of
-    $\var{rew'}_{\var{mir}}$ and $\var{unregistered}$.
-    Therefore
+  Notice that $\var{i}_{rwd}$ (from $s_1$) is the disjoint union of
+  $\var{rew'}_{\var{mir}}$ and $\var{unregistered}$.
+  Therefore
   \begin{equation*}
     \begin{array}{r@{~=~}l}
       \Val(\var{registered}) & \Val(\var{rew}_{\var{mir}}) \\


### PR DESCRIPTION
This PR simplifies the `createRUpd` function. This makes the function both easier to understand and easier to prove things about.

Prior to these changes, `createRUpd` was filtering out the instantaneous rewards for all those stake keys that were not registered, and saving this filtered mapping in the reward update. The `applyRUpd` function would then further filter the map, since between the time the reward update was created and when it was applied, stake keys could have been deregistered. We now skip the filtering of unregistered keys in the creation of the reward update. We do, however, still store the instantaneous rewards in the reward update. Though we do _not_ expect the instantaneous rewards mapping to change (as it is frozen during the end of an epoch), using the stored mapping from the reward update instead of the current available state at the time of calling `applyRUpd` allows for better local properties and makes the proof that ada is preserved by an reward update much easier.

The only semantic change is that now a stake key does not need to be registered at the time a MIR cert is processed in order to get rewards, it must just be registered before the end of the next epoch in which the MIR happened.

I have added a check that the instantaneous rewards in the reward update are indeed the same as that in the epoch state at the time the rewards are applied.

I also took the opportunity to make the formal spec and the exec spec look more alike each other.

I also had to adapt the proof of lemma 15.9 accordingly (and fixed a couple typos).