### PR TITLE
updates can now specify target epoch

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -542,7 +542,7 @@ validInputs tx u =
 
 -- |Implementation of abstract transaction size
 txsize :: forall crypto . (Crypto crypto) => Tx crypto-> Integer
-txsize (Tx (TxBody ins outs cs ws _ _ (Update (PPUpdate ppup) (AVUpdate avup))) vKeySigs msigScripts) =
+txsize (Tx (TxBody ins outs cs ws _ _ (Update (PPUpdate ppup) (AVUpdate avup) _)) vKeySigs msigScripts) =
   iSize + oSize + cSize + wSize + feeSize + ttlSize + uSize + witnessSize
   where
     -- vkey signatures
@@ -630,7 +630,7 @@ txsize (Tx (TxBody ins outs cs ws _ _ (Update (PPUpdate ppup) (AVUpdate avup))) 
     sysTagSize = 10
     mdSize (_av, (Mdt m)) = nameSize + arrayPrefix + uint + mapPrefix
                              + (toInteger $ length m) * (sysTagSize + hashObj)
-    uSize = arrayPrefix + ppupSize + avupSize
+    uSize = arrayPrefix + ppupSize + avupSize + smallArray + uint
 
 -- |Minimum fee calculation
 minfee :: forall crypto . (Crypto crypto) => PParams -> Tx crypto-> Coin
@@ -866,7 +866,7 @@ propWits
   :: Update crypto
   -> GenDelegs crypto
   -> Set (KeyHash crypto)
-propWits (Update (PPUpdate pup) (AVUpdate aup')) (GenDelegs _genDelegs) =
+propWits (Update (PPUpdate pup) (AVUpdate aup') _) (GenDelegs _genDelegs) =
   Set.fromList $ Map.elems updateKeys
   where updateKeys = (Map.keysSet pup `Set.union` Map.keysSet aup') ◁ _genDelegs
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Up.hs
@@ -87,9 +87,9 @@ upTransition
 upTransition = do
   TRC ( UpdateEnv slot pp _genDelegs
       , UpdateState pup aup favs avs
-      , Update pupU aupU) <- judgmentContext
+      , Update pupU aupU e) <- judgmentContext
 
-  pup' <- trans @(PPUP crypto) $ TRC (PPUPEnv slot pp _genDelegs, pup, pupU)
+  pup' <- trans @(PPUP crypto) $ TRC (PPUPEnv slot pp _genDelegs, pup, (pupU, e))
   AVUPState aup' favs' avs' <-
     trans @(AVUP crypto) $ TRC (AVUPEnv slot _genDelegs, AVUPState aup favs avs, aupU)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -395,7 +395,7 @@ ppupEx2A = PPUpdate $ Map.singleton
 -- | Update proposal that just changes protocol parameters,
 --   and does not change applications.
 updateEx2A :: Update
-updateEx2A = Update ppupEx2A (AVUpdate Map.empty)
+updateEx2A = Update ppupEx2A (AVUpdate Map.empty) (Just $ EpochNo 0)
 
 -- | Transaction body to be processed.
 txbodyEx2A :: TxBody
@@ -1431,7 +1431,7 @@ ppupEx3A = PPUpdate $ Map.fromList [ (hashKey $ coreNodeVKG 0, ppVote3A)
                                    ]
 
 updateEx3A :: Update
-updateEx3A = Update ppupEx3A (AVUpdate Map.empty)
+updateEx3A = Update ppupEx3A (AVUpdate Map.empty) (Just $ EpochNo 0)
 
 txbodyEx3A :: TxBody
 txbodyEx3A = TxBody
@@ -1520,7 +1520,7 @@ ppupEx3B = PPUpdate $ Map.fromList [ (hashKey $ coreNodeVKG 1, ppVote3A)
                                    ]
 
 updateEx3B :: Update
-updateEx3B = Update ppupEx3B (AVUpdate Map.empty)
+updateEx3B = Update ppupEx3B (AVUpdate Map.empty) (Just $ EpochNo 0)
 
 txbodyEx3B :: TxBody
 txbodyEx3B = TxBody
@@ -1685,7 +1685,7 @@ avupEx4A = AVUpdate $ Map.fromList [ (hashKey $ coreNodeVKG 0, appsEx4A)
                                    ]
 
 updateEx4A :: Update
-updateEx4A = Update (PPUpdate Map.empty) avupEx4A
+updateEx4A = Update (PPUpdate Map.empty) avupEx4A Nothing
 
 txbodyEx4A :: TxBody
 txbodyEx4A = TxBody
@@ -1773,7 +1773,7 @@ avupEx4B = AVUpdate $ Map.fromList [ (hashKey $ coreNodeVKG 1, appsEx4A)
                                    ]
 
 updateEx4B :: Update
-updateEx4B = Update (PPUpdate Map.empty) avupEx4B
+updateEx4B = Update (PPUpdate Map.empty) avupEx4B Nothing
 
 txbodyEx4B :: TxBody
 txbodyEx4B = TxBody

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -255,7 +255,9 @@ genApplications =
 
 -- | Generate entire @Update of protocol parameters
 genUpdate :: HashAlgorithm (HASH crypto)
-          => [GenKeyHash         crypto]
+          => EpochNo -- to be valid, this must be the current epoch
+          -> [GenKeyHash         crypto]
           ->  Gen (Update        crypto)
-genUpdate genesisKeys = Update <$> genPPUpdate genesisKeys
-                               <*> genAVUpdate genesisKeys
+genUpdate e genesisKeys = Update <$> genPPUpdate genesisKeys
+                                 <*> genAVUpdate genesisKeys
+                                 <*> pure (Just e)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
@@ -584,11 +584,13 @@ serializationTests = testGroup "Serialization Tests"
                              (SystemTag $ pack "DOS")
                              testInstallerHash
                          ))))
+      e = Just $ EpochNo 0
     in checkEncodingCBOR "full_update"
-    (Update ppup avup)
-    ( (T $ TkListLen 2)
+    (Update ppup avup e)
+    ( (T $ TkListLen 3)
       <> S ppup
       <> S avup
+      <> S e
     )
 
   -- checkEncodingCBOR "minimal_txn"
@@ -635,6 +637,7 @@ serializationTests = testGroup "Serialization Tests"
                                     (SystemTag $ pack "DOS")
                                     testInstallerHash
                                 )))))
+             (Just $ EpochNo 0)
     in checkEncodingCBOR "txbody_partial"
     ( TxBody -- transaction body with some optional components
         tin
@@ -680,6 +683,7 @@ serializationTests = testGroup "Serialization Tests"
                                     (SystemTag $ pack "DOS")
                                     testInstallerHash
                                 )))))
+             (Just $ EpochNo 0)
     in checkEncodingCBOR "txbody_full"
     ( TxBody -- transaction body with all components
         tin

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -114,7 +114,7 @@ This function must produce a unique id for each unique transaction.
       \\
       \var{up}
       & \Update
-      & \PPUpdate \times \AVUpdate
+      & \PPUpdate \times \AVUpdate \times \Epoch^?
       & \text{update proposal}
     \end{array}
   \end{equation*}

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -75,8 +75,10 @@ For more on the decentralization process, see \ref{sec:new-epoch-trans}.
 The transition type $\mathsf{PPUP}$ is for proposing updates to protocol
 parameters, see Figure \ref{fig:ts-types:pp-update} (for the corresponding rules,
 see Figure \ref{fig:rules:pp-update}).
-The signal for this transition is a finite map of proposed updates (indexed by
-genesis keys). The purpose of the $\Seed$ type in the $\PPUpdate$ derived type is explained
+The signal for this transition is a pair consisting of a finite map of
+proposed updates (indexed by genesis keys) and an optional epoch
+(the epoch must be specified if the mapping is nonempty).
+The purpose of the $\Seed$ type in the $\PPUpdate$ derived type is explained
 in the protocol parameter adoption rules.
 
 \begin{itemize}
@@ -94,6 +96,8 @@ This rule has the following predicate failures:
 \item In the case of \var{slot} being greater than or equal to
   $\fun{firstSlot}~((\epoch{slot}) + 1) - \fun{SlotsPrior}$, there is
   a \emph{PPUpdateTooLate} failure.
+\item In the case that the epoch number in the signal is not the current epoch,
+  there is a \emph{PPUpdateNoEpoch} failure.
 \item In the case of \var{pup} being non-empty, if the check $\dom pup \subseteq
   \dom genDelegs$ fails, there is a \emph{NonGenesisUpdate} failure as only genesis keys
   can be used in the protocol parameter update.
@@ -129,7 +133,8 @@ and will be rejected otherwise.
   \begin{equation*}
     \_ \vdash
     \var{\_} \trans{ppup}{\_} \var{\_}
-    \subseteq \powerset (\PPUpdateEnv \times \PPUpdate \times \PPUpdate \times \PPUpdate)
+    \subseteq \powerset (
+    \PPUpdateEnv \times \PPUpdate \times (\PPUpdate\times\Epoch^?) \times \PPUpdate)
   \end{equation*}
   %
   \caption{Protocol Parameter Update Transition System Types}
@@ -148,7 +153,7 @@ and will be rejected otherwise.
         \var{pp}\\
         \var{genDelegs}\\
       \end{array}
-      \vdash \var{pup_s}\trans{ppup}{pup}\var{pup_s}
+      \vdash \var{pup_s}\trans{ppup}{(pup,~e)}\var{pup_s}
     }
   \end{equation}
 
@@ -165,6 +170,8 @@ and will be rejected otherwise.
         \var{pv}\mapsto\var{v}\in\var{ps}\implies\fun{pvCanFollow}~(\fun{pv}~\var{pp})~\var{v}
       \\
       \var{slot} < \fun{firstSlot}~((\epoch{slot}) + 1) - \SlotsPrior
+      \\
+      \epoch{slot} = e
     }
     {
       \begin{array}{r}
@@ -174,7 +181,7 @@ and will be rejected otherwise.
       \end{array}
       \vdash
       \var{pup_s}
-      \trans{ppup}{pup}
+      \trans{ppup}{(pup,~e)}
       \varUpdate{pup_s\unionoverrideRight pup}
     }
   \end{equation}
@@ -541,7 +548,7 @@ update rules for each.
   \begin{equation}\label{eq:update}
     \inference[Update]
     {
-      (\var{pup_{u}},~\var{aup_{u}})\leteq\var{up}
+      (\var{pup_{u}},~\var{aup_{u}},~e)\leteq\var{up}
       \\~\\
       {
         \begin{array}{r}
@@ -552,7 +559,7 @@ update rules for each.
       }
       \vdash
       \left(\var{pup}\right)
-      \trans{\hyperref[fig:rules:pp-update]{ppup}}{\var{pup_{u}}}
+      \trans{\hyperref[fig:rules:pp-update]{ppup}}{(\var{pup_{u}},~e)}
       \left(\var{pup'}\right)
       &
       {


### PR DESCRIPTION
In order to avoid the situation where a transaction can go from being invalid to valid while sitting in the mempool, we now require that nonempty protocol parameter updates specify the epoch in which to process them.

The `Update` type now includes an optional epoch number. The signal for the `PPUP` rule is now a pair of a `ppup` and an optional epoch number. In `PPUP`' if the mapping `ppup` is non-empty, then we check that the epoch number in the signal is equal to the current epoch.

Originally I tried putting the optional epoch number in the protocol parameter update type itself, but this turned out to be more disruptive.

closes #1111 