### PR TITLE
[1113] Generate OCerts and valid blocks (for short traces)

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Block.hs
@@ -7,15 +7,19 @@ module Generator.Block
   where
 
 import           Data.Foldable (toList)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map (lookup)
 import           Data.Word (Word64)
 import           Test.QuickCheck (Gen, choose)
 
-import           ConcreteCryptoTypes (Block, ChainState, CoreKeyPair, LEDGERS)
+import           ConcreteCryptoTypes (Block, ChainState, CoreKeyPair, KeyHash, KeyPair, LEDGERS)
 import           Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
-import           Generator.Core.QuickCheck (AllPoolKeys (..), NatNonce (..), genNatural,
-                     mkBlock, zero)
+import           Generator.Core.QuickCheck (AllPoolKeys (..), NatNonce (..), genNatural, mkBlock,
+                     zero)
 import           Generator.LedgerTrace.QuickCheck ()
-import           LedgerState (esAccountState, esLState, esPp, nesEs, _reserves)
+import           Keys (GenDelegs (..), hashKey, vKey)
+import           LedgerState (esAccountState, esLState, esPp, nesEs, nesOsched, _delegationState,
+                     _dstate, _genDelegs, _reserves)
 import           Slot (BlockNo (..), SlotNo (..))
 import           STS.Chain (chainEpochNonce, chainHashHeader, chainNes, chainSlotNo)
 import           STS.Ledgers (LedgersEnv (..))
@@ -24,21 +28,45 @@ genBlock
   :: SlotNo
   -> ChainState
   -> [(CoreKeyPair, AllPoolKeys)] -- core node keys
+  -> Map KeyHash KeyPair -- indexed keys By StakeHash
   -> Gen Block
-genBlock _slotNo chainSt coreNodeKeys =
+genBlock _slotNo chainSt coreNodeKeys keysByStakeHash = do
+  nextSlot <- genNextSlot
   mkBlock
     <$> pure (chainHashHeader chainSt)
     <*> pure issuerKeys
-    <*> toList <$> genTxs
-    <*> genNextSlot
+    <*> toList <$> genTxs nextSlot
+    <*> pure nextSlot
     <*> pure chainDifficulty
     <*> pure (chainEpochNonce chainSt)
     <*> genBlockNonce
     <*> genPraosLeader
     <*> pure kesPeriod
   where
+    ledgerSt = (esLState . nesEs . chainNes) chainSt
+    osched = (nesOsched . chainNes) chainSt
+    (GenDelegs genesisDelegs) = (_genDelegs . _dstate . _delegationState) ledgerSt
+
     -- TODO @uroboros pick the first core node each time for now
-    issuerKeys = snd (coreNodeKeys !! 0)
+    origIssuerKeys = snd (coreNodeKeys !! 0)
+    issuerKeys = case Map.lookup (chainSlotNo chainSt) osched of
+      Nothing ->
+        error "TODO @uroboros make Praos block"
+      Just Nothing ->
+        error "TODO @uroboros don't make a block in a NonActive Slot"
+      Just (Just gkey) ->
+        case Map.lookup gkey genesisDelegs of
+          Nothing ->
+            error "genBlock: NoGenesisStakingOVERLAY"
+          Just gKeyHash ->
+            -- if GenesisDelegate certs changed a delegation to a new key
+            case Map.lookup gKeyHash keysByStakeHash of
+              Nothing ->
+                -- then we use the original keys (which have not been changed by a genesis delegation)
+                origIssuerKeys
+              Just updatedCold ->
+                -- if we find the pre-hashed key in keysByStakeHash, we use it instead of the original cold key
+                origIssuerKeys {cold = updatedCold, hk = (hashKey . vKey) updatedCold}
 
     -- TODO @uroboros "90 days of slots" (constant)
     kesPeriod = 0
@@ -49,15 +77,14 @@ genBlock _slotNo chainSt coreNodeKeys =
     chainDifficulty = BlockNo 1 -- used only in consensus
 
     -- we assume small gaps in slot numbers
-    genNextSlot = SlotNo . (unSlotNo (chainSlotNo chainSt) +) <$> choose (1, 10)
+    genNextSlot = SlotNo . (unSlotNo (chainSlotNo chainSt) +) <$> choose (1, 5)
 
     genBlockNonce = NatNonce <$> genNatural 1 100
 
-    genTxs = do
-      let ledgerSt = (esLState . nesEs . chainNes) chainSt
-          pParams = (esPp . nesEs . chainNes) chainSt
+    genTxs s = do
+      let pParams = (esPp . nesEs . chainNes) chainSt
           reserves = (_reserves . esAccountState . nesEs . chainNes) chainSt
-          ledgerEnv = LedgersEnv (chainSlotNo chainSt) pParams reserves
+          ledgerEnv = LedgersEnv s pParams reserves
 
       n <- choose (1, 10)
       sigGen @LEDGERS (n :: Word64) ledgerEnv ledgerSt

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -116,7 +116,7 @@ genExtraEntropy  = QC.frequency [ (1, pure NeutralNonce)
 -- Note: we keep the lower bound high enough so that we can more likely
 -- generate valid transactions and blocks
 low, hi :: Natural
-low = 10000
+low = 20000
 hi = 200000
 
 -- keyMinRefund: 0.1-0.5

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -24,9 +24,8 @@ import           Coin
 import           Ledger.Core ((<|))
 import           LedgerState hiding (genDelegs)
 import           PParams
-import           Rules.ClassifyTraces (onlyValidLedgerSignalsAreGenerated,
-                     propAbstractSizeBoundsBytes, propAbstractSizeNotTooBig,
-                     relevantCasesAreCovered)
+import           Rules.ClassifyTraces (onlyValidChainSignalsAreGenerated,
+                     onlyValidLedgerSignalsAreGenerated, relevantCasesAreCovered)
 import           Rules.TestLedger (consumedEqualsProduced, credentialMappingAfterDelegation,
                      credentialRemovedAfterDereg, eliminateTxInputs, feesNonDecreasing,
                      newEntriesAndUniqueTxIns, noDoubleSpend, pStateIsInternallyConsistent,
@@ -240,12 +239,6 @@ propertyTests = testGroup "Property-Based Testing"
                   , testProperty
                     "Correctly preserve balance"
                     propPreserveBalance
-                  , TQC.testProperty
-                    "abstract tx size bounds bytes"
-                    propAbstractSizeBoundsBytes
-                  , TQC.testProperty
-                    "abstract tx size not too big"
-                    propAbstractSizeNotTooBig
                   ]
                 , testGroup "Property tests with mutated transactions"
                   [testProperty
@@ -259,6 +252,9 @@ propertyTests = testGroup "Property-Based Testing"
                   [ TQC.testProperty
                        "Only valid LEDGER STS signals are generated"
                        onlyValidLedgerSignalsAreGenerated
+                  , TQC.testProperty
+                       "Only valid CHAIN STS signals are generated"
+                       onlyValidChainSignalsAreGenerated
                   ]
                 ]
 

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
@@ -173,5 +173,5 @@ propAbstractSizeNotTooBig = property $ do
     all notTooBig txs
 
 onlyValidChainSignalsAreGenerated :: Property
-onlyValidChainSignalsAreGenerated = withMaxSuccess 20 $
+onlyValidChainSignalsAreGenerated = withMaxSuccess 300 $
   onlyValidSignalsAreGeneratedFromInitState @CHAIN testGlobals 10 (10::Word64) (Just mkGenesisChainState)


### PR DESCRIPTION
Closes #1113 

Generate OCerts as part of block headers. Also adds a property test to validate the blocks we are creating as signals of the CHAIN trace. 

As it stands the block validation fails for traces that are longer than 10-20 blocks, due to InvliadKESSignature predicate failures - see new issue  #1173 

Other issues addressed by this PR: 

* when generating MIR certs, we suppress generation when it is too late in the epoch for valid MIR certs
* BUG fixed: `genTx` was using the previous chain slot and leading to ValueNotConserved  predicate failures
* `mkGenesisChainState` now uses `initialShelleyState`
