### PR TITLE
Make sure CHAIN generator produces transactions

### DIFF
--- a/byron/ledger/executable-spec/src/Ledger/UTxO.hs
+++ b/byron/ledger/executable-spec/src/Ledger/UTxO.hs
@@ -60,6 +60,13 @@ newtype UTxO = UTxO
   } deriving stock (Show, Data, Typeable)
     deriving newtype (Eq, Relation, Semigroup, Monoid)
 
+-- | Apply function uniformly across all outputs
+mapUTxOValues :: (Lovelace -> Lovelace) -> UTxO -> UTxO
+mapUTxOValues f (UTxO utxo) = UTxO (f' <$> utxo)
+  where
+    f' :: TxOut -> TxOut
+    f' (TxOut addr value) = TxOut addr (f value)
+
 addValue :: TxOut -> Lovelace -> TxOut
 addValue tx@TxOut{ value } d = tx { value = value + d }
 


### PR DESCRIPTION
See https://github.com/input-output-hk/cardano-ledger/issues/698#issuecomment-578726113 for a detailed description of the bug this fixes. 

Before the fix, no regular transactions were being generated at all. After the fix, in 7% of test runs the average number of txs per block is still 0, but  in in 29% of test runs the average number of txs per block is 1, and in 59% of test runs the average is more than 1. 

Note that the situation for other kinds of transactions (delegation certificates, update proposals and update votes) already looks good and does not seem to require a similar kind of fix. 

```
trace length: empty       3% ▌···················

avg # tx == 0            97% ███████████████████▍
min # tx == 0            97% ███████████████████▍
max # tx == 0            97% ███████████████████▍

avg # dcert == 0         90% ██████████████████··
avg # dcert == 1          7% █▍··················
max # dcert == 0          7% █▍··················
max # dcert == 1         49% █████████▋··········
max # dcert >  1         41% ████████▎···········
min # dcert == 0         95% ███████████████████·
min # dcert == 1          2% ▍···················

avg # prop == 0          93% ██████████████████▌·
avg # prop == 1           5% ▉···················
min # prop == 0          93% ██████████████████▌·
min # prop == 1           5% ▉···················
max # prop == 1          97% ███████████████████▍

avg # votes == 0         83% ████████████████▌···
avg # votes == 1         14% ██▊·················
avg # votes >  1          1% ▏···················
min # votes == 0         96% ███████████████████▏
min # votes == 1          1% ▎···················
max # votes == 0          8% █▌··················
max # votes == 1         21% ████▏···············
max # votes >  1         69% █████████████▋······
```
          
After the fix

```
trace length: empty       6% █▏··················

avg # tx == 0             7% █▎··················
avg # tx == 1            29% █████▋··············
avg # tx >  1            59% ███████████▋········
min # tx == 0            66% █████████████▏······
min # tx == 1            21% ████▎···············
min # tx >  1             7% █▎··················
max # tx == 0             1% ▏···················
max # tx == 1             5% ▉···················
max # tx >  1            89% █████████████████▋··

avg # dcert == 0         87% █████████████████▍··
avg # dcert >  1          1% ▏···················
avg # dcert == 1          6% █▏··················
min # dcert == 0         93% ██████████████████▋·
min # dcert == 1          1% ▏···················
max # dcert == 0          9% █▋··················
max # dcert == 1         47% █████████▍··········
max # dcert >  1         38% ███████▌············

avg # prop == 0          89% █████████████████▊··
avg # prop == 1           5% ▉···················
min # prop == 0          89% █████████████████▊··
min # prop == 1           5% ▉···················
max # prop == 1          94% ██████████████████▊·

avg # votes == 0         79% ███████████████▋····
avg # votes == 1         15% ███·················
max # votes == 0          5% █···················
max # votes == 1         24% ████▊···············
max # votes >  1         65% ████████████▉·······
min # votes == 0         93% ██████████████████▋·
min # votes == 1          1% ▏···················
```

These stats are generated by a version of `cardano-ledger` I have in a local PR, that depends on this one. Will submit separate PR for that.