### PR TITLE
[1137] Wire up PoolReap and NewEpoch properties to CHAIN trace generator

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -120,6 +120,7 @@ test-suite delegation-test
                          Examples
                          Rules.ClassifyTraces
                          Cardano.Crypto.VRF.Fake
+                         Rules.TestChain
                          Rules.TestDeleg
                          Rules.TestLedger
                          Rules.TestNewEpoch

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -26,9 +26,8 @@ import           LedgerState hiding (genDelegs)
 import           PParams
 import           Rules.ClassifyTraces (onlyValidChainSignalsAreGenerated,
                      onlyValidLedgerSignalsAreGenerated, relevantCasesAreCovered)
-import           Rules.TestChain (circulationDepositsInvariant, constantSumPots,
-                     nonNegativeDeposits, removedAfterPoolreap,
-                     rewardDecreaseEqualsTreasuryRewardPot)
+import           Rules.TestChain (constantSumPots, nonNegativeDeposits, preservationOfAda,
+                     removedAfterPoolreap)
 import           Rules.TestLedger (consumedEqualsProduced, credentialMappingAfterDelegation,
                      credentialRemovedAfterDereg, eliminateTxInputs, feesNonDecreasing,
                      newEntriesAndUniqueTxIns, noDoubleSpend, pStateIsInternallyConsistent,
@@ -211,10 +210,8 @@ propertyTests = testGroup "Property-Based Testing"
                                      removedAfterPoolreap
                   ]
                 , testGroup "STS Rules - NewEpoch Properties"
-                  [ TQC.testProperty "circulation and deposits do not change in NEWEPOCH transition"
-                                     circulationDepositsInvariant
-                  , TQC.testProperty "rewards decrease by the increase of treasury and rewards"
-                                     rewardDecreaseEqualsTreasuryRewardPot
+                  [ TQC.testProperty "total amount of Ada is preserved"
+                                     preservationOfAda
                   ]
                 , testGroup "STS Rules - MIR certificates"
                   [ TQC.testProperty "entries of MIR certificate are added to\

--- a/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/PropertyTests.hs
@@ -26,6 +26,9 @@ import           LedgerState hiding (genDelegs)
 import           PParams
 import           Rules.ClassifyTraces (onlyValidChainSignalsAreGenerated,
                      onlyValidLedgerSignalsAreGenerated, relevantCasesAreCovered)
+import           Rules.TestChain (circulationDepositsInvariant, constantSumPots,
+                     nonNegativeDeposits, removedAfterPoolreap,
+                     rewardDecreaseEqualsTreasuryRewardPot)
 import           Rules.TestLedger (consumedEqualsProduced, credentialMappingAfterDelegation,
                      credentialRemovedAfterDereg, eliminateTxInputs, feesNonDecreasing,
                      newEntriesAndUniqueTxIns, noDoubleSpend, pStateIsInternallyConsistent,
@@ -198,6 +201,20 @@ propertyTests = testGroup "Property-Based Testing"
                                      pStateIsInternallyConsistent
                   , TQC.testProperty "executing a pool retirement certificate adds to 'retiring'"
                                      poolRetireInEpoch
+                  ]
+                , testGroup "STS Rules - Poolreap Properties"
+                  [ TQC.testProperty "circulation+deposits+fees+treasury+rewards+reserves is constant."
+                                     constantSumPots
+                  , TQC.testProperty "deposits are always non-negative"
+                                     nonNegativeDeposits
+                  , TQC.testProperty "pool is removed from stake pool and retiring maps"
+                                     removedAfterPoolreap
+                  ]
+                , testGroup "STS Rules - NewEpoch Properties"
+                  [ TQC.testProperty "circulation and deposits do not change in NEWEPOCH transition"
+                                     circulationDepositsInvariant
+                  , TQC.testProperty "rewards decrease by the increase of treasury and rewards"
+                                     rewardDecreaseEqualsTreasuryRewardPot
                   ]
                 , testGroup "STS Rules - MIR certificates"
                   [ TQC.testProperty "entries of MIR certificate are added to\

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestChain.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+module Rules.TestChain
+  ( -- TestPoolReap
+    constantSumPots
+  , nonNegativeDeposits
+  , removedAfterPoolreap
+    -- TestNewEpoch
+  , circulationDepositsInvariant
+  , rewardDecreaseEqualsTreasuryRewardPot)
+where
+
+import           Control.Monad.Trans.Reader (asks)
+import           Data.Word (Word64)
+import           Test.QuickCheck (Property, Testable, property, withMaxSuccess)
+
+import           BaseTypes (epochInfo)
+import           BlockChain (Block (..), bhbody, bheaderSlotNo)
+import           ConcreteCryptoTypes (CHAIN, NEWEPOCH, POOLREAP)
+import           Control.State.Transition.Trace (SourceSignalTarget (..), Trace,
+                     sourceSignalTargets)
+import           Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState)
+import           Generator.ChainTrace (mkGenesisChainState)
+import           LedgerState (pattern DPState, esAccountState, esLState, nesEs, _delegationState,
+                     _utxoState)
+import qualified Rules.TestNewEpoch as TestNewEpoch
+import qualified Rules.TestPoolreap as TestPoolreap
+import           Slot (EpochNo, SlotNo, epochInfoEpoch)
+import           STS.Chain (ChainState (..))
+import           STS.PoolReap (PoolreapState (..))
+
+import           Test.Utils (runShelleyBase, testGlobals)
+
+
+------------------------------
+-- Constants for Properties --
+------------------------------
+
+numberOfTests :: Word64
+numberOfTests = 300
+
+traceLen :: Word64
+traceLen = 10 -- TODO @uroboros use short traces while we implement proper KES block signatures
+
+----------------------------------------------------------------------
+-- Properties for PoolReap (using the CHAIN Trace) --
+----------------------------------------------------------------------
+
+constantSumPots :: Property
+constantSumPots =
+  forAllChainTrace $ \tr ->
+    let sst = map chainToPoolreapSst (sourceSignalTargets tr)
+    in TestPoolreap.constantSumPots sst
+
+nonNegativeDeposits :: Property
+nonNegativeDeposits =
+  forAllChainTrace $ \tr ->
+    let sst = map chainToPoolreapSst (sourceSignalTargets tr)
+    in TestPoolreap.nonNegativeDeposits sst
+
+removedAfterPoolreap :: Property
+removedAfterPoolreap =
+  forAllChainTrace $ \tr ->
+    let sst = map chainToPoolreapSst (sourceSignalTargets tr)
+    in TestPoolreap.removedAfterPoolreap sst
+
+----------------------------------------------------------------------
+-- Properties for NewEpoch (using the CHAIN Trace) --
+----------------------------------------------------------------------
+
+rewardDecreaseEqualsTreasuryRewardPot :: Property
+rewardDecreaseEqualsTreasuryRewardPot =
+  forAllChainTrace $ \tr ->
+    let sst = map chainToNewEpochSst (sourceSignalTargets tr)
+    in TestNewEpoch.rewardDecreaseEqualsTreasuryRewardPot sst
+
+circulationDepositsInvariant :: Property
+circulationDepositsInvariant =
+  forAllChainTrace $ \tr ->
+    let sst = map chainToNewEpochSst (sourceSignalTargets tr)
+    in TestNewEpoch.rewardDecreaseEqualsTreasuryRewardPot sst
+
+---------------------------
+-- Utils --
+---------------------------
+
+forAllChainTrace
+  :: (Testable prop)
+  => (Trace CHAIN -> prop)
+  -> Property
+forAllChainTrace prop =
+  withMaxSuccess (fromIntegral numberOfTests) . property $
+    forAllTraceFromInitState testGlobals traceLen traceLen (Just mkGenesisChainState) prop
+
+epochFromSlot :: SlotNo -> EpochNo
+epochFromSlot s =
+  runShelleyBase $ do
+    ei <- asks epochInfo
+    epochInfoEpoch ei s
+
+-- | Transform CHAIN `sourceSignalTargets`s to POOLREAP ones.
+chainToPoolreapSst
+  :: SourceSignalTarget CHAIN
+  -> SourceSignalTarget POOLREAP
+chainToPoolreapSst (SourceSignalTarget ChainState {chainNes = nes}
+                                       ChainState  {chainNes = nes'}
+                                       (Block bh _)) =
+  SourceSignalTarget (PoolreapState (utxoSt nes)
+                                    (accountSt nes)
+                                    dstate
+                                    pstate)
+                     (PoolreapState (utxoSt nes')
+                                    (accountSt nes')
+                                    dstate'
+                                    pstate')
+                     (epochFromSlot s)
+  where
+    s = (bheaderSlotNo . bhbody) bh
+
+    DPState dstate pstate = (_delegationState . esLState . nesEs) nes
+    DPState dstate' pstate' = (_delegationState . esLState . nesEs) nes'
+
+    utxoSt = _utxoState . esLState . nesEs
+    accountSt = esAccountState . nesEs
+
+-- | Transform CHAIN `sourceSignalTargets`s to NEWEPOCH ones.
+chainToNewEpochSst
+  :: SourceSignalTarget CHAIN
+  -> SourceSignalTarget NEWEPOCH
+chainToNewEpochSst (SourceSignalTarget ChainState {chainNes = nes}
+                                       ChainState {chainNes = nes'}
+                                       (Block bh _)) =
+  SourceSignalTarget nes nes' (epochFromSlot s)
+  where
+    s = (bheaderSlotNo . bhbody) bh
+

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestChain.hs
@@ -7,7 +7,7 @@ module Rules.TestChain
   , removedAfterPoolreap
     -- TestNewEpoch
   , circulationDepositsInvariant
-  , rewardDecreaseEqualsTreasuryRewardPot)
+  , preservationOfAda)
 where
 
 import           Control.Monad.Trans.Reader (asks)
@@ -68,17 +68,17 @@ removedAfterPoolreap =
 -- Properties for NewEpoch (using the CHAIN Trace) --
 ----------------------------------------------------------------------
 
-rewardDecreaseEqualsTreasuryRewardPot :: Property
-rewardDecreaseEqualsTreasuryRewardPot =
+preservationOfAda :: Property
+preservationOfAda =
   forAllChainTrace $ \tr ->
     let sst = map chainToNewEpochSst (sourceSignalTargets tr)
-    in TestNewEpoch.rewardDecreaseEqualsTreasuryRewardPot sst
+    in TestNewEpoch.preservationOfAda sst
 
 circulationDepositsInvariant :: Property
 circulationDepositsInvariant =
   forAllChainTrace $ \tr ->
     let sst = map chainToNewEpochSst (sourceSignalTargets tr)
-    in TestNewEpoch.rewardDecreaseEqualsTreasuryRewardPot sst
+    in TestNewEpoch.circulationDepositsInvariant sst
 
 ---------------------------
 -- Utils --
@@ -133,4 +133,3 @@ chainToNewEpochSst (SourceSignalTarget ChainState {chainNes = nes}
   SourceSignalTarget nes nes' (epochFromSlot s)
   where
     s = (bheaderSlotNo . bhbody) bh
-

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestNewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestNewEpoch.hs
@@ -18,7 +18,7 @@ import           ConcreteCryptoTypes (NEWEPOCH)
 import           LedgerState (pattern AccountState, pattern DPState, pattern DState,
                      pattern EpochState, pattern LedgerState, pattern NewEpochState,
                      pattern UTxOState, esAccountState, esLState, nesEs, _delegationState,
-                     _deposited, _dstate, _fees, _reserves, _rewards, _treasury, _utxo, _utxoState)
+                     _deposited, _dstate, _reserves, _rewards, _treasury, _utxo, _utxoState)
 import           UTxO (balance)
 
 -----------------------------
@@ -34,7 +34,9 @@ rewardDecreaseEqualsTreasuryRewardPot tr =
   conjoin $
     map rewardsDecreaseBalanced tr
 
-  where rewardsDecreaseBalanced
+  where sum_ = foldl (+) (Coin 0)
+
+        rewardsDecreaseBalanced
           (SourceSignalTarget
             {
               source = NewEpochState
@@ -47,11 +49,10 @@ rewardDecreaseEqualsTreasuryRewardPot tr =
                                    }
                 , esLState = LedgerState
                              {
-                               _utxoState = UTxOState { _fees = fees }
-                             , _delegationState = DPState
-                                                  { _dstate = DState
-                                                              { _rewards = rewards }
-                                                  }
+                             _delegationState = DPState
+                                                { _dstate = DState
+                                                            { _rewards = rewards }
+                                                }
                              }
                 }
               }
@@ -65,19 +66,16 @@ rewardDecreaseEqualsTreasuryRewardPot tr =
                                    }
                 , esLState = LedgerState
                              {
-                               _utxoState = UTxOState { _fees = fees' }
-                             , _delegationState = DPState
-                                                  { _dstate = DState
-                                                              { _rewards = rewards' }
-                                                  }
+                             _delegationState = DPState
+                                                { _dstate = DState
+                                                            { _rewards = rewards' }
+                                                }
                              }
                 }
               }
             }
           ) =
-          (reserves  + fees  + treasury  + foldl (+) (Coin 0) rewards) ==
-          (reserves' + fees' + treasury' + foldl (+) (Coin 0) rewards')
-
+          reserves + treasury + sum_ rewards == reserves' + treasury' + sum_ rewards'
 
 -- | Check that the circulation and deposits do not change in a NEWEPOCH
 -- transition.

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestPoolreap.hs
@@ -4,10 +4,13 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
-module Rules.TestPoolreap where
+module Rules.TestPoolreap
+  ( constantSumPots
+  , nonNegativeDeposits
+  , removedAfterPoolreap)
+where
 
 import qualified Data.Set as Set (intersection, isSubsetOf, null, singleton)
-import           Data.Word (Word64)
 
 import           Test.QuickCheck (Property, conjoin)
 
@@ -24,16 +27,6 @@ import           UTxO (balance)
 
 import           Ledger.Core (dom, (▷))
 import           Rules.TestPool (getRetiring, getStPools)
-
-------------------------------
--- Constants for Properties --
-------------------------------
-
-numberOfTests :: Word64
-numberOfTests = 300
-
-traceLen :: Word64
-traceLen = 100
 
 -----------------------------
 -- Properties for POOLREAP --
@@ -57,8 +50,8 @@ removedAfterPoolreap tr =
               retiring        = getRetiring p
               retiring'       = getRetiring p'
               retire          = dom $ retiring ▷ Set.singleton e in
-             (not . null) retire
-          && (retire `Set.isSubsetOf` dom stp)
+
+          (retire `Set.isSubsetOf` dom stp)
           && Set.null (retire `Set.intersection` dom stp')
           && Set.null (retire `Set.intersection` dom retiring')
 


### PR DESCRIPTION
Closes #1134 
Closes #1136 
Closes #1137 
Closes #878  

When wiring up these properties,the following 2 failed: 

* POOLREAP.removedAfterPoolReap - removed a clause that required an empty retired set ` (not . null) retire`
* NEWEPOCH.rewardDecreaseEqualsTreasuryRewardPot - added deposits and utxo balance to the invariant - this was neccessary due to the fact that the pre/post states we're testing the NEWEPOCH STS with is derived from the pre/post states of the CHAIN STS and because of that includes effects from other STSs, not just NEWEPOCH in this case