### PR TITLE
Vary parameters d and f in chain trace generation

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Delegation/Certificates.hs
@@ -120,9 +120,9 @@ decayPool pc = (pval, pmin, lambdap)
           pmin    = pc ^. poolMinRefund
           lambdap = pc ^. poolDecayRate
 
-newtype PoolDistr crypto=
-  PoolDistr (Map (KeyHash crypto) (Rational, Hash (HASH crypto) (VerKeyVRF (VRF crypto))))
-  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks, Relation)
+newtype PoolDistr crypto = PoolDistr
+  { unPoolDistr :: (Map (KeyHash crypto) (Rational, Hash (HASH crypto) (VerKeyVRF (VRF crypto))))
+  } deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks, Relation)
 
 isInstantaneousRewards :: DCert crypto-> Bool
 isInstantaneousRewards (DCertMir _) = True

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -1163,9 +1163,9 @@ overlaySchedule e gkeys pp = do
         toRelativeSlotNo x = (Duration . floor) (dInv * fromInteger x)
         toSlotNo x = firstSlotNo +* toRelativeSlotNo x
 
-        genesisSlots = [ toSlotNo x | x <-[0..(floor numActive)] ]
+        genesisSlots = [ toSlotNo x | x <-[0..(floor numActive - 1)] ]
 
-        numInactivePerActive = floor ((1 - asc) * fromRational numActive) - 1
+        numInactivePerActive = floor (1 / asc) - 1
         activitySchedule = cycle (True:replicate numInactivePerActive False)
         unassignedSched = zip activitySchedule genesisSlots
 

--- a/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/NewEpoch.hs
@@ -20,7 +20,6 @@ import           Control.Monad.Trans.Reader (runReaderT)
 import           Control.State.Transition
 import           Control.State.Transition.Generator
 import           Data.Functor.Identity (runIdentity)
-import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (catMaybes)
 import           Delegation.Certificates
@@ -49,7 +48,6 @@ instance
 
   data PredicateFailure (NEWEPOCH crypto)
     = EpochFailure (PredicateFailure (EPOCH crypto))
-    | CorruptIRWDs (Map (Credential crypto) Coin) (Map (Credential crypto) Coin)
     deriving (Show, Generic, Eq)
 
   initialRules =
@@ -85,9 +83,6 @@ newEpochTransition = do
       es' <- case ru of
                Nothing  -> pure es
                Just ru' -> do
-                 let irwd' = updateIRwd ru'
-                     irwd_ = getIR es
-                 irwd' == irwd_ ?! CorruptIRWDs irwd' irwd_
                  pure $ applyRUpd ru' es
 
       es'' <- trans @(EPOCH crypto) $ TRC ((), es', e)

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -486,7 +486,7 @@ initStEx2A = initialShelleyState
 blockEx2A :: Block
 blockEx2A = mkBlock
              lastByronHeaderHash
-             (coreNodeKeys 6)
+             (coreNodeKeys 2)
              [txEx2A]
              (SlotNo 10)
              (BlockNo 10)
@@ -594,7 +594,7 @@ txEx2B = Tx
 blockEx2B :: Block
 blockEx2B = mkBlock
              blockEx2AHash    -- ^ Hash of previous block
-             (coreNodeKeys 3) -- ^ Third genesis node
+             (coreNodeKeys 5)
              [txEx2B]         -- ^ Single transaction to record
              (SlotNo 90)        -- ^ Current slot
              (BlockNo 2)
@@ -687,7 +687,7 @@ ex2B = CHAINExample (SlotNo 90) expectedStEx2A blockEx2B (Right expectedStEx2B)
 blockEx2C :: Block
 blockEx2C = mkBlock
              blockEx2BHash    -- ^ Hash of previous block
-             (coreNodeKeys 6) -- ^ Sixth genesis node
+             (coreNodeKeys 2)
              []               -- ^ No transactions at all (empty block)
              (SlotNo 110)       -- ^ Current slot
              (BlockNo 2)      -- ^ Second block within the epoch
@@ -817,7 +817,7 @@ ex2Cquater =
 blockEx2D :: Block
 blockEx2D = mkBlock
              blockEx2CHash
-             (coreNodeKeys 3)
+             (coreNodeKeys 5)
              []
              (SlotNo 190)
              (BlockNo 2)
@@ -863,7 +863,7 @@ ex2D = CHAINExample (SlotNo 190) expectedStEx2C blockEx2D (Right expectedStEx2D)
 blockEx2E :: Block
 blockEx2E = mkBlock
              blockEx2DHash
-             (coreNodeKeys 3)
+             (coreNodeKeys 5)
              []
              (SlotNo 220)
              (BlockNo 2)
@@ -990,7 +990,7 @@ ex2F = CHAINExample (SlotNo 295) expectedStEx2E blockEx2F (Right expectedStEx2F)
 blockEx2G :: Block
 blockEx2G = mkBlock
              blockEx2FHash
-             (coreNodeKeys 6)
+             (coreNodeKeys 2)
              []
              (SlotNo 310)
              (BlockNo 2)
@@ -1054,7 +1054,7 @@ ex2G = CHAINExample (SlotNo 310) expectedStEx2F blockEx2G (Right expectedStEx2G)
 blockEx2H :: Block
 blockEx2H = mkBlock
              blockEx2GHash
-             (coreNodeKeys 3)
+             (coreNodeKeys 5)
              []
              (SlotNo 390)
              (BlockNo 2)
@@ -1109,7 +1109,7 @@ ex2H = CHAINExample (SlotNo 390) expectedStEx2G blockEx2H (Right expectedStEx2H)
 blockEx2I :: Block
 blockEx2I = mkBlock
               blockEx2HHash
-              (coreNodeKeys 6)
+              (coreNodeKeys 2)
               []
               (SlotNo 410)
               (BlockNo 2)
@@ -1206,7 +1206,7 @@ txEx2J = Tx
 blockEx2J :: Block
 blockEx2J = mkBlock
               blockEx2IHash
-              (coreNodeKeys 3)
+              (coreNodeKeys 5)
               [txEx2J]
               (SlotNo 420)
               (BlockNo 2)
@@ -1287,7 +1287,7 @@ txEx2K = Tx
 blockEx2K :: Block
 blockEx2K = mkBlock
               blockEx2JHash
-              (coreNodeKeys 3)
+              (coreNodeKeys 5)
               [txEx2K]
               (SlotNo 490)
               (BlockNo 2)
@@ -1351,7 +1351,7 @@ ex2K = CHAINExample (SlotNo 490) expectedStEx2J blockEx2K (Right expectedStEx2K)
 blockEx2L :: Block
 blockEx2L = mkBlock
               blockEx2KHash
-              (coreNodeKeys 6)
+              (coreNodeKeys 2)
               []
               (SlotNo 510)
               (BlockNo 2)
@@ -1459,7 +1459,7 @@ txEx3A = Tx
 blockEx3A :: Block
 blockEx3A = mkBlock
              lastByronHeaderHash
-             (coreNodeKeys 6)
+             (coreNodeKeys 2)
              [txEx3A]
              (SlotNo 10)
              (BlockNo 2)
@@ -1547,7 +1547,7 @@ txEx3B = Tx
 blockEx3B :: Block
 blockEx3B = mkBlock
              blockEx3AHash
-             (coreNodeKeys 3)
+             (coreNodeKeys 5)
              [txEx3B]
              (SlotNo 20)
              (BlockNo 2)
@@ -1610,7 +1610,7 @@ ex3B = CHAINExample (SlotNo 20) expectedStEx3A blockEx3B (Right expectedStEx3B)
 blockEx3C :: Block
 blockEx3C = mkBlock
              blockEx3BHash
-             (coreNodeKeys 6)
+             (coreNodeKeys 2)
              []
              (SlotNo 110)
              (BlockNo 2)
@@ -1713,7 +1713,7 @@ txEx4A = Tx
 blockEx4A :: Block
 blockEx4A = mkBlock
              lastByronHeaderHash
-             (coreNodeKeys 6)
+             (coreNodeKeys 2)
              [txEx4A]
              (SlotNo 10)
              (BlockNo 2)
@@ -1800,7 +1800,7 @@ txEx4B = Tx
 blockEx4B :: Block
 blockEx4B = mkBlock
              blockEx4AHash
-             (coreNodeKeys 3)
+             (coreNodeKeys 5)
              [txEx4B]
              (SlotNo 20)
              (BlockNo 2)
@@ -1862,7 +1862,7 @@ ex4B = CHAINExample (SlotNo 20) expectedStEx4A blockEx4B (Right expectedStEx4B)
 blockEx4C :: Block
 blockEx4C = mkBlock
              blockEx4BHash
-             (coreNodeKeys 0)
+             (coreNodeKeys 3)
              []
              (SlotNo 60)
              (BlockNo 2)
@@ -1949,7 +1949,7 @@ txEx5A = Tx
 blockEx5A :: Block
 blockEx5A = mkBlock
               lastByronHeaderHash
-              (coreNodeKeys 6)
+              (coreNodeKeys 2)
               [txEx5A]
               (SlotNo 10)
               (BlockNo 2)
@@ -2008,7 +2008,7 @@ ex5A = CHAINExample (SlotNo 10) initStEx2A blockEx5A (Right expectedStEx5A)
 blockEx5B :: Block
 blockEx5B = mkBlock
              blockEx5AHash
-             (coreNodeKeys 2)
+             (coreNodeKeys 1)
              []
              (SlotNo 50)
              (BlockNo 2)
@@ -2094,7 +2094,7 @@ txEx6A = Tx
 blockEx6A :: Block
 blockEx6A = mkBlock
               lastByronHeaderHash
-              (coreNodeKeys 6)
+              (coreNodeKeys 2)
               [txEx6A]
               (SlotNo 10)
               (BlockNo 1)
@@ -2162,7 +2162,7 @@ txEx6B = Tx
 blockEx6B :: Block
 blockEx6B = mkBlock
               lastByronHeaderHash
-              (coreNodeKeys 6)
+              (coreNodeKeys 2)
               [txEx6B]
               (SlotNo 10)
               (BlockNo 1)
@@ -2247,7 +2247,7 @@ txEx6F = Tx txbodyEx6F
 blockEx6F :: Block
 blockEx6F = mkBlock
               lastByronHeaderHash
-              (coreNodeKeys 6)
+              (coreNodeKeys 2)
               [txEx6F]
               (SlotNo 10)
               (BlockNo 1)
@@ -2277,7 +2277,7 @@ txEx6F' = Tx txbodyEx6F' (makeWitnessesVKey txbodyEx6F' [ alicePay ]) Map.empty
 blockEx6F' :: Block
 blockEx6F' = mkBlock
               (bhHash (bheader blockEx6F))
-              (coreNodeKeys 1)
+              (coreNodeKeys 0)
               [txEx6F']
               ((slotFromEpoch $ EpochNo 1)
                 +* Duration (startRewards testGlobals) + SlotNo 7)
@@ -2307,7 +2307,7 @@ txEx6F'' = Tx txbodyEx6F'' (makeWitnessesVKey txbodyEx6F'' [ alicePay ]) Map.emp
 blockEx6F'' :: Block
 blockEx6F'' = mkBlock
                (bhHash (bheader blockEx6F'))
-               (coreNodeKeys 6)
+               (coreNodeKeys 2)
                [txEx6F'']
                ((slotFromEpoch $ EpochNo 2) + SlotNo 10)
                (BlockNo 1)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -31,6 +31,7 @@ module Generator.Core.QuickCheck
   , traceKeyPairsByStakeHash
   , traceKeyHashMap
   , traceVRFKeyPairs
+  , traceVRFKeyPairsByHash
   , traceMSigScripts
   , traceMSigCombinations
   , someKeyPairs
@@ -66,7 +67,8 @@ import           BlockChain (pattern BHBody, pattern BHeader, pattern Block, Pro
 import           Coin (Coin (..))
 import           ConcreteCryptoTypes (Addr, AnyKeyHash, Block, CoreKeyPair, Credential, GenKeyHash,
                      HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig, MultiSigPairs, SKeyES,
-                     SignKeyVRF, Tx, TxOut, UTxO, VKey, VKeyES, VKeyGenesis, VerKeyVRF)
+                     SignKeyVRF, Tx, TxOut, UTxO, VKey, VKeyES, VKeyGenesis, VRFKeyHash, VerKeyVRF,
+                     hashKeyVRF)
 import           Generator.Core.Constants (maxGenesisOutputVal, maxNumKeyPairs, minGenesisOutputVal,
                      numBaseScripts)
 import           Keys (pattern KeyPair, hashAnyKey, hashKey, sKey, sign, signKES,
@@ -343,6 +345,9 @@ traceVRFKeyPairs = [body (0,0,0,0,i) | i <- [1 .. 50]]
   body seed = fst . withDRG (drgNewTest seed) $ do
     sk <- genKeyVRF
     return (sk, deriveVerKeyVRF sk)
+
+traceVRFKeyPairsByHash :: Map VRFKeyHash (SignKeyVRF, VerKeyVRF)
+traceVRFKeyPairsByHash = Map.fromList $ fmap (\p -> (hashKeyVRF (snd p), p)) traceVRFKeyPairs
 
 zero :: UnitInterval
 zero = unsafeMkUnitInterval 0

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -152,15 +152,18 @@ genRho = genIntervalInThousands 1 9
 genTau :: Gen UnitInterval
 genTau = genIntervalInThousands 100 300
 
--- | activeSlotCoeff: 0-1
+-- | activeSlotCoeff: 0.1-1
 genActiveSlotCoeff :: Gen UnitInterval
-genActiveSlotCoeff  = increasingProbabilityAt
-                        (genIntervalInThousands 0 1000)
-                        (unsafeMkUnitInterval   0,
-                         unsafeMkUnitInterval   1)
+genActiveSlotCoeff = unsafeMkUnitInterval <$> QC.elements [0.025, 0.05, 0.075, 0.1, 0.2, 0.5]
+-- ^^ This is a somewhat arbitrary group of values.
+-- In the real system, we will probably be using a value near 1/10,
+-- and we know that we would not ever choose values too small (say below 1/40)
+-- or greater than a 1/2.
 
 genDecentralisationParam :: Gen UnitInterval
-genDecentralisationParam = unsafeMkUnitInterval <$> QC.elements [0,0.1 .. 1]
+genDecentralisationParam = unsafeMkUnitInterval <$> QC.elements [0.1, 0.2 .. 1]
+-- ^^ TODO jc - generating d=0 takes some care, if there are no registered
+-- stake pools then d=0 deadlocks the system.
 
 -- | protocolVersion is a triple of numbers
 genProtocolVersion :: Gen (Natural, Natural, Natural)

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -92,7 +92,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
         \var{a_0} \mapsto \posReals & \PParams & \text{pool influence}\\
         \tau \mapsto \unitInterval & \PParams & \text{treasury expansion}\\
         \rho \mapsto \unitInterval & \PParams & \text{monetary expansion}\\
-        \var{activeSlotCoeff} \mapsto \unitInterval & \PParams & f\text{ in \cite{ouroboros_praos}}\\
+        \var{activeSlotCoeff} \mapsto (0, 1] & \PParams & f\text{ in \cite{ouroboros_praos}}\\
         \var{d} \mapsto \{0,~0.1,~0.2,~\ldots,~1\} & \PParams & \text{decentralization parameter}\\
         \var{extraEntropy} \mapsto \Seed & \PParams & \text{extra entropy}\\
         \var{pv} \mapsto \ProtVer & \PParams & \text{protocol version}\\


### PR DESCRIPTION
This PR removes the restriction that `d=1` and `f=1` during the chain trace generation. We still do not allow `d=0` and `f=0`. The case when `d=0` requires ensuring that there are active stake pools (otherwise the chain deadlocks). The case when `f=0` is problematic if there is an overlay schedule (and is degenerate anyway, since this means no one can ever win leader election).

In order to validate chain traces while varying `d` and `f`, we use the overlay schedule to guide the selection of the next slots used for the blocks.

A couple of problems were found with the overlay schedule creation function. They have been fixed.

This work also uncovered a problem with the creation of reward updates, see #1187. The `CorruptIRWDs` error/check has been removed (in the exec model, not the formal spec).

Even though we are now generating slots during the decentralized/Praos slots, the hot/KES key selection still needs work (there is a TODO for this).