### PR TITLE
new feature - transaction metadata

### DIFF
--- a/nix/.stack.nix/delegation.nix
+++ b/nix/.stack.nix/delegation.nix
@@ -59,6 +59,7 @@ in { system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
         depends = [
           (hsPkgs."base" or (buildDepError "base"))
           (hsPkgs."bytestring" or (buildDepError "bytestring"))
+          (hsPkgs."cborg" or (buildDepError "cborg"))
           (hsPkgs."containers" or (buildDepError "containers"))
           (hsPkgs."cryptonite" or (buildDepError "cryptonite"))
           (hsPkgs."hedgehog" or (buildDepError "hedgehog"))

--- a/shelley/chain-and-ledger/cddl-spec/shelley.cddl
+++ b/shelley/chain-and-ledger/cddl-spec/shelley.cddl
@@ -4,7 +4,7 @@ block =
   [ header
   , transaction_bodies         : [* transaction_body]
   , transaction_witness_sets   : [* transaction_witness_set]
-  , transaction_metadata_set   : { * uint => transaction_metadata }
+  , transaction_metadata_set   : { * uint => [transaction_metadata] }
   ]
 
 header =
@@ -102,10 +102,10 @@ pool_params = ( #6.258([* keyhash]) ; pool owners
               , coin                ; pledge
               , keyhash             ; operator
               , $vrf_keyhash        ; vrf keyhash
-              , credential          ; reward account
+              , [credential]        ; reward account
               )
 
-withdrawals = { * credential => coin }
+withdrawals = { * [credential] => coin }
 
 full_update = [ protocol_param_update_votes, application_version_update_votes ]
 
@@ -153,12 +153,11 @@ transaction_witness_set =
   )
 
 transaction_metadata =
-  (  { *transaction_metadata => transaction_metadata }
-  // [* transaction_metadata ]
-  // int
-  // bytes
-  // string
-  )
+    { * transaction_metadata => transaction_metadata }
+  / [ * transaction_metadata ]
+  / int
+  / bytes
+  / text
 
 vkeywitness = [$vkey, $signature]
 
@@ -179,6 +178,8 @@ scripthash = $hash
 genesishash = $hash
 
 installerhash = $hash
+
+metadata_hash = $hash
 
 $hash /= bytes
 

--- a/shelley/chain-and-ledger/cddl-spec/shelley.cddl
+++ b/shelley/chain-and-ledger/cddl-spec/shelley.cddl
@@ -4,6 +4,7 @@ block =
   [ header
   , transaction_bodies         : [* transaction_body]
   , transaction_witness_sets   : [* transaction_witness_set]
+  , transaction_metadata_set   : { * uint => transaction_metadata }
   ]
 
 header =
@@ -47,6 +48,7 @@ transaction_body =
   , 4 : coin ; fee
   , 5 : uint ; ttl
   , ? 6 : full_update
+  , ? 7 : metadata_hash
   }
 
 ; Is it okay to have this as a group? Is it valid CBOR?! Does it need to be?
@@ -148,6 +150,14 @@ transaction_witness_set =
   // 2, [* vkeywitness]
   // 3, [* $script]
   // 4, [* vkeywitness],[* $script]
+  )
+
+transaction_metadata =
+  (  { *transaction_metadata => transaction_metadata }
+  // [* transaction_metadata ]
+  // int
+  // bytes
+  // string
   )
 
 vkeywitness = [$vkey, $signature]

--- a/shelley/chain-and-ledger/cddl-spec/shelley.cddl
+++ b/shelley/chain-and-ledger/cddl-spec/shelley.cddl
@@ -4,7 +4,7 @@ block =
   [ header
   , transaction_bodies         : [* transaction_body]
   , transaction_witness_sets   : [* transaction_witness_set]
-  , transaction_metadata_set   : { * uint => [transaction_metadata] }
+  , transaction_metadata_set   : { * uint => transaction_metadata }
   ]
 
 header =

--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -27,6 +27,7 @@ library
                      PParams
                      EpochBoundary
                      LedgerState
+                     MetaData
                      Serialization
                      Delegation.PoolParams
                      Delegation.Certificates
@@ -80,6 +81,7 @@ library
   build-depends:
     base >= 4.7 && < 5,
     bytestring,
+    cborg,
     containers,
     cryptonite,
     hedgehog,

--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -46,7 +46,6 @@ import           Data.Coerce (coerce)
 import           Data.Foldable (toList)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Proxy (Proxy (..))
 import           Data.Ratio (denominator, numerator)
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
@@ -56,7 +55,6 @@ import           Data.Word (Word8)
 import           GHC.Generics (Generic)
 import           MetaData (MetaData)
 import           Numeric.Natural (Natural)
-import           Unsafe.Coerce (unsafeCoerce)
 
 import           BaseTypes (CborSeq (..), Nonce (..), Seed (..), UnitInterval, intervalValue,
                      invalidKey, mkNonce)

--- a/shelley/chain-and-ledger/executable-spec/src/MetaData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/MetaData.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ViewPatterns       #-}
+
+module MetaData
+  ( MetaDatum (..)
+  , MetaData
+  , MetaDataHash (..)
+  , hashMetaData
+) where
+
+import           Cardano.Binary (DecoderError (..), FromCBOR (fromCBOR), ToCBOR (toCBOR))
+import           Cardano.Crypto.Hash (Hash, hash)
+import           Cardano.Ledger.Shelley.Crypto (Crypto, HASH)
+import           Cardano.Prelude (NoUnexpectedThunks (..), Word64, cborError)
+import           Data.Bifunctor (bimap)
+import           Data.Bitraversable (bitraverse)
+import           Data.ByteString as B
+import           Data.ByteString.Lazy as BL
+import           Data.Map.Strict (Map)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import qualified Codec.CBOR.Term as CBOR
+
+import           GHC.Generics
+
+-- | A generic metadatum type.
+data MetaDatum
+    = Map [(MetaDatum, MetaDatum)]
+    | List [MetaDatum]
+    | I Integer
+    | B B.ByteString
+    | S T.Text
+    deriving stock (Show, Eq, Ord, Generic)
+
+instance NoUnexpectedThunks MetaDatum
+
+type MetaData = Map Word64 MetaDatum
+
+type CBORToDataError = String
+
+{- Note [Permissive decoding]
+We're using a canonical representation of lists, maps, bytes, and integers. However,
+the CBOR library does not guarantee that a TInteger gets encoded as a big integer,
+so we can't rely on getting back our canonical version when we decode (see
+https://github.com/well-typed/cborg/issues/222). So we need to be permissive
+when we decode.
+-}
+
+viewList :: CBOR.Term -> Maybe [CBOR.Term]
+viewList (CBOR.TList l)  = Just l
+viewList (CBOR.TListI l) = Just l
+viewList _               = Nothing
+
+viewMap :: CBOR.Term -> Maybe [(CBOR.Term, CBOR.Term)]
+viewMap (CBOR.TMap m)  = Just m
+viewMap (CBOR.TMapI m) = Just m
+viewMap _              = Nothing
+
+viewBytes :: CBOR.Term -> Maybe B.ByteString
+viewBytes (CBOR.TBytes b)  = Just b
+viewBytes (CBOR.TBytesI b) = Just (BL.toStrict b)
+viewBytes _                = Nothing
+
+viewInteger :: CBOR.Term -> Maybe Integer
+viewInteger (CBOR.TInt i)     = Just (fromIntegral i)
+viewInteger (CBOR.TInteger i) = Just i
+viewInteger _                 = Nothing
+
+viewString :: CBOR.Term -> Maybe T.Text
+viewString (CBOR.TString  s)  = Just s
+viewString (CBOR.TStringI s)  = Just (TL.toStrict s)
+viewString _                  = Nothing
+
+fromTerm :: CBOR.Term -> Either CBORToDataError MetaDatum
+fromTerm = \case
+    -- See Note [Permissive decoding]
+    (viewInteger -> Just i) -> pure $ I i
+    (viewBytes -> Just b) -> pure $ B b
+    (viewString -> Just s) -> pure $ S s
+    (viewMap -> Just entries) -> Map <$> traverse (bitraverse fromTerm fromTerm) entries
+    (viewList -> Just ts) -> List <$> traverse fromTerm ts
+    t -> Left $ "Unsupported CBOR term: " ++ show t
+
+toTerm :: MetaDatum -> CBOR.Term
+toTerm = \case
+    I i -> CBOR.TInteger i
+    B b -> CBOR.TBytes b
+    S s -> CBOR.TString s
+    Map entries -> CBOR.TMap (fmap (bimap toTerm toTerm) entries)
+    List ts -> CBOR.TList (fmap toTerm ts)
+
+instance ToCBOR MetaDatum
+ where
+   toCBOR = CBOR.encodeTerm . toTerm
+
+instance FromCBOR MetaDatum
+ where
+   fromCBOR = do
+     t <- CBOR.decodeTerm
+     case fromTerm t of
+       Right d -> pure d
+       Left e   -> (cborError . DecoderErrorCustom "metadata" . T.pack) e
+
+newtype MetaDataHash crypto
+  = MetaDataHash { unsafeMetaDataHash :: Hash (HASH crypto) MetaData }
+  deriving (Show, Eq, Ord, NoUnexpectedThunks)
+
+deriving instance Crypto crypto => ToCBOR (MetaDataHash crypto)
+deriving instance Crypto crypto => FromCBOR (MetaDataHash crypto)
+
+hashMetaData
+  :: Crypto crypto
+  => MetaData
+  -> MetaDataHash crypto
+hashMetaData = MetaDataHash . hash

--- a/shelley/chain-and-ledger/executable-spec/src/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/TxData.hs
@@ -40,6 +40,7 @@ import           Coin (Coin (..))
 import           Keys (AnyKeyHash, pattern AnyKeyHash, GenKeyHash, Hash, KeyHash, pattern KeyHash,
                      Sig, VKey, VKeyGenesis, VerKeyVRF, hashAnyKey)
 import           Ledger.Core (Relation (..))
+import           MetaData
 import           Slot (EpochNo (..), SlotNo (..))
 import           Updates (Update, emptyUpdate, updateNull)
 
@@ -232,6 +233,7 @@ data TxBody crypto
       , _txfee    :: Coin
       , _ttl      :: SlotNo
       , _txUpdate :: Update crypto
+      , _mdHash   :: Maybe (MetaDataHash crypto)
       } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (TxBody crypto)
@@ -263,6 +265,7 @@ data Tx crypto
       , _witnessVKeySet :: !(Set (WitVKey crypto))
       , _witnessMSigMap ::
           Map (ScriptHash crypto) (MultiSig crypto)
+      , _metadata       :: Maybe MetaData
       } deriving (Show, Eq, Generic)
 
 instance Crypto crypto => NoUnexpectedThunks (Tx crypto)
@@ -446,14 +449,15 @@ instance
   => ToCBOR (Tx crypto)
  where
   toCBOR tx =
-    encodeListLen 3
+    encodeListLen 4
       <> toCBOR (_body tx)
       <> toCBOR (_witnessVKeySet tx)
       <> toCBOR (_witnessMSigMap tx)
+      <> toCBOR (_metadata tx)
 
 instance Crypto crypto => FromCBOR (Tx crypto) where
-  fromCBOR = decodeListLenOf 3 >>
-    Tx <$> fromCBOR <*> fromCBOR <*> fromCBOR
+  fromCBOR = decodeListLenOf 4 >>
+    Tx <$> fromCBOR <*> fromCBOR <*> fromCBOR <*> fromCBOR
 
 instance
   (Crypto crypto)
@@ -468,15 +472,18 @@ instance
             . (if null cs then none else single (encodeWord 4 <> toCBOR (CborSeq cs)))
             . (if null ws then none else single (encodeWord 5 <> toCBOR ws))
             . (if updateNull us then none else single (encodeWord 6 <> toCBOR us))
+            . (encodeMDH $ _mdHash txbody)
         toList xs = xs []
-        single x = (x:)
-        none = id
         n = fromIntegral $ length l
     in encodeMapLen n <> foldr (<>) mempty l
     where
       cs = _certs txbody
       ws = _wdrls txbody
       us = _txUpdate txbody
+      single x = (x:)
+      none = id
+      encodeMDH Nothing   = none
+      encodeMDH (Just md) = single $ encodeWord 7 <> toCBOR md
 
 mapHelper :: Decoder s b -> Decoder s [b]
 mapHelper decodePart = decodeMapLenOrIndef >>= \case
@@ -502,6 +509,7 @@ instance
          4 -> (unwrapCborSeq <$> fromCBOR) >>= \x -> pure (4, \t -> t { _certs    = x })
          5 -> fromCBOR                     >>= \x -> pure (5, \t -> t { _wdrls    = x })
          6 -> fromCBOR                     >>= \x -> pure (6, \t -> t { _txUpdate = x })
+         7 -> fromCBOR                     >>= \x -> pure (7, \t -> t { _mdHash   = Just x })
          k -> invalidKey k
      let requiredFields :: Map Int String
          requiredFields = Map.fromList $
@@ -524,6 +532,7 @@ instance
           , _certs    = Seq.empty
           , _wdrls    = Map.empty
           , _txUpdate = emptyUpdate
+          , _mdHash   = Nothing
           }
 
 instance (Crypto crypto) =>

--- a/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/UTxO.hs
@@ -213,7 +213,7 @@ totalDeposits pc (StakePools stpools) cs = foldl f (Coin 0) cs'
     cs' = filter notRegisteredPool cs
 
 txup :: Tx crypto -> Update crypto
-txup (Tx txbody _ _) = _txUpdate txbody
+txup (Tx txbody _ _ _) = _txUpdate txbody
 
 -- | Extract script hash from value address with script.
 getScriptHash :: Addr crypto -> Maybe (ScriptHash crypto)

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -412,6 +412,7 @@ txbodyEx2A = TxBody
            (Coin 3)
            (SlotNo 10)
            updateEx2A
+           Nothing
 
 txEx2A :: Tx
 txEx2A = Tx
@@ -430,6 +431,7 @@ txEx2A = Tx
              , KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
              ])
           Map.empty
+          Nothing
 
 -- | Pointer address to address of Alice address.
 alicePtrAddr :: Addr
@@ -582,6 +584,7 @@ txbodyEx2B = TxBody
       , TxData._txfee    = Coin 4
       , TxData._ttl      = SlotNo 90
       , TxData._txUpdate = emptyUpdate
+      , TxData._mdHash   = Nothing
       }
 
 txEx2B :: Tx
@@ -590,6 +593,7 @@ txEx2B = Tx
           (makeWitnessesVKey txbodyEx2B [alicePay, aliceStake, bobStake, cold $ coreNodeKeys 0])
                      -- ^ Witness verification key set
           Map.empty  -- ^ Witness signature map
+          Nothing
 
 blockEx2B :: Block
 blockEx2B = mkBlock
@@ -1191,12 +1195,14 @@ txbodyEx2J = TxBody
            (Coin 9)
            (SlotNo 500)
            emptyUpdate
+           Nothing
 
 txEx2J :: Tx
 txEx2J = Tx
           txbodyEx2J
           (makeWitnessesVKey txbodyEx2J [bobPay, bobStake])
           Map.empty
+          Nothing
 
 blockEx2J :: Block
 blockEx2J = mkBlock
@@ -1272,12 +1278,14 @@ txbodyEx2K = TxBody
            (Coin 2)
            (SlotNo 500)
            emptyUpdate
+           Nothing
 
 txEx2K :: Tx
 txEx2K = Tx
           txbodyEx2K
           (makeWitnessesVKey txbodyEx2K [cold alicePool, alicePay])
           Map.empty
+          Nothing
 
 blockEx2K :: Block
 blockEx2K = mkBlock
@@ -1437,6 +1445,7 @@ txbodyEx3A = TxBody
            (Coin 1)
            (SlotNo 10)
            updateEx3A
+           Nothing
 
 txEx3A :: Tx
 txEx3A = Tx
@@ -1449,6 +1458,7 @@ txEx3A = Tx
             , cold $ coreNodeKeys 4
             ])
           Map.empty
+          Nothing
 
 blockEx3A :: Block
 blockEx3A = mkBlock
@@ -1526,6 +1536,7 @@ txbodyEx3B = TxBody
            (Coin 1)
            (SlotNo 31)
            updateEx3B
+           Nothing
 
 txEx3B :: Tx
 txEx3B = Tx
@@ -1537,6 +1548,7 @@ txEx3B = Tx
             , cold $ coreNodeKeys 5
             ])
           Map.empty
+          Nothing
 
 blockEx3B :: Block
 blockEx3B = mkBlock
@@ -1691,6 +1703,7 @@ txbodyEx4A = TxBody
            (Coin 1)
            (SlotNo 10)
            updateEx4A
+           Nothing
 
 txEx4A :: Tx
 txEx4A = Tx
@@ -1703,6 +1716,7 @@ txEx4A = Tx
             , cold $ coreNodeKeys 4
             ])
           Map.empty
+          Nothing
 
 blockEx4A :: Block
 blockEx4A = mkBlock
@@ -1779,6 +1793,7 @@ txbodyEx4B = TxBody
            (Coin 1)
            (SlotNo 31)
            updateEx4B
+           Nothing
 
 txEx4B :: Tx
 txEx4B = Tx
@@ -1790,6 +1805,7 @@ txEx4B = Tx
             , cold $ coreNodeKeys 5
             ])
           Map.empty
+          Nothing
 
 blockEx4B :: Block
 blockEx4B = mkBlock
@@ -1932,12 +1948,14 @@ txbodyEx5A = TxBody
               (Coin 1)
               (SlotNo 10)
               emptyUpdate
+              Nothing
 
 txEx5A :: Tx
 txEx5A = Tx
            txbodyEx5A
            (makeWitnessesVKey txbodyEx5A [ alicePay ] `Set.union` makeGenWitnessesVKey txbodyEx5A [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0) ])
            Map.empty
+           Nothing
 
 blockEx5A :: Block
 blockEx5A = mkBlock
@@ -2070,6 +2088,7 @@ txbodyEx6A = TxBody
               (Coin 1)
               (SlotNo 10)
               emptyUpdate
+              Nothing
 
 txEx6A :: Tx
 txEx6A = Tx
@@ -2082,6 +2101,7 @@ txEx6A = Tx
              , KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
            ])
            Map.empty
+           Nothing
 
 blockEx6A :: Block
 blockEx6A = mkBlock
@@ -2150,6 +2170,7 @@ txEx6B = Tx
              , KeyPair (coreNodeVKG 3) (coreNodeSKG 3)
            ])
            Map.empty
+           Nothing
 
 blockEx6B :: Block
 blockEx6B = mkBlock
@@ -2224,6 +2245,7 @@ txbodyEx6F = TxBody
               (Coin 1)
               (SlotNo 99)
               emptyUpdate
+              Nothing
 
 txEx6F :: Tx
 txEx6F = Tx txbodyEx6F
@@ -2235,6 +2257,7 @@ txEx6F = Tx txbodyEx6F
              , KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
              ])
             Map.empty
+            Nothing
 
 blockEx6F :: Block
 blockEx6F = mkBlock
@@ -2262,9 +2285,10 @@ txbodyEx6F' = TxBody
                ((slotFromEpoch $ EpochNo 1)
                 +* Duration (startRewards testGlobals) + SlotNo 7)
                emptyUpdate
+               Nothing
 
 txEx6F' :: Tx
-txEx6F' = Tx txbodyEx6F' (makeWitnessesVKey txbodyEx6F' [ alicePay ]) Map.empty
+txEx6F' = Tx txbodyEx6F' (makeWitnessesVKey txbodyEx6F' [ alicePay ]) Map.empty Nothing
 
 blockEx6F' :: Block
 blockEx6F' = mkBlock
@@ -2292,9 +2316,10 @@ txbodyEx6F'' = TxBody
                 (Coin 1)
                 ((slotFromEpoch $ EpochNo 2) + SlotNo 10)
                 emptyUpdate
+                Nothing
 
 txEx6F'' :: Tx
-txEx6F'' = Tx txbodyEx6F'' (makeWitnessesVKey txbodyEx6F'' [ alicePay ]) Map.empty
+txEx6F'' = Tx txbodyEx6F'' (makeWitnessesVKey txbodyEx6F'' [ alicePay ]) Map.empty Nothing
 
 blockEx6F'' :: Block
 blockEx6F'' = mkBlock

--- a/shelley/chain-and-ledger/executable-spec/test/Generator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator.hs
@@ -178,8 +178,9 @@ genTx keyList (UTxO m) cslot = do
            txfee'
            (cslot + SlotNo txttl)
            emptyUpdate
+           Nothing
   let !txwit = makeWitnessVKey txbody selectedKeyPair
-  pure (txfee', Tx txbody (Set.fromList [txwit]) Map.empty)
+  pure (txfee', Tx txbody (Set.fromList [txwit]) Map.empty Nothing)
             where utxoInputs = Map.keys m
                   addr inp   = getTxOutAddr $ m Map.! inp
 

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
@@ -128,8 +128,9 @@ genTx (LedgerEnv slot _ pparams _) (UTxOState utxo _ _ _, dpState) keys keyHashM
                 `Set.union` makeGenWitnessesVKey txBody genesisWitnesses
                 `Set.union` makeWitnessesFromScriptKeys txBody keyHashMap msigSignatures
 
+    let metadata = Nothing -- TODO generate metadata
     -- discard if balance is negative, i.e., deposits exceed spending balance
-    pure (Tx txBody wits multiSig)
+    pure (Tx txBody wits multiSig metadata)
 
 -- | Generate a transaction body with the given inputs/outputs and certificates
 genTxBody
@@ -149,6 +150,7 @@ genTxBody inputs outputs certs wdrls fee slotWithTTL = do
              fee
              slotWithTTL
              emptyUpdate -- TODO @uroboros generate updates
+             Nothing -- TODO generate metadata
 
 -- | Calculate the fee and distribute the remainder of the balance
 -- to the given addresses (as transaction outputs)

--- a/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
@@ -86,7 +86,7 @@ mutateCoin lower upper (Coin val) = Coin <$> mutateInteger lower upper val
 mutateTx :: Tx -> Gen Tx
 mutateTx txwits = do
   body' <- mutateTxBody $ _body txwits
-  pure $ Tx body' (_witnessVKeySet txwits) (_witnessMSigMap txwits)
+  pure $ Tx body' (_witnessVKeySet txwits) (_witnessMSigMap txwits) Nothing
 
 -- | Mutator for Transaction which mutates the set of inputs and the set of
 -- unspent outputs.
@@ -101,6 +101,7 @@ mutateTxBody tx = do
     (_txfee tx)
     (_ttl tx)
     emptyUpdate
+    Nothing
 
 -- | Mutator for a list of 'TxIn'.
 mutateInputs :: [TxIn] -> Gen [TxIn]

--- a/shelley/chain-and-ledger/executable-spec/test/Shrinkers.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Shrinkers.hs
@@ -9,8 +9,8 @@ import           Data.Set (Set)
 import qualified Data.Set as S
 import           Test.QuickCheck (shrinkIntegral, shrinkList)
 
-import           ConcreteCryptoTypes (Block)
 import           Coin
+import           ConcreteCryptoTypes (Block)
 import           Slot
 import           Tx
 import           TxData
@@ -24,21 +24,21 @@ shrinkBlock _ = []
 shrinkTx
   :: Tx crypto
   -> [Tx crypto]
-shrinkTx (Tx _b _ws _wm) =
-  [ Tx b' _ws _wm | b' <- shrinkTxBody _b ]
+shrinkTx (Tx _b _ws _wm _md) =
+  [ Tx b' _ws _wm _md | b' <- shrinkTxBody _b ]
   {- TODO @uroboros write shrinker that shrinks to valid transactions
   [ Tx b ws' wm | ws' <- shrinkSet shrinkWitVKey ws ] ++
   [ Tx b ws wm' | wm' <- shrinkMap shrinkScriptHash shrinkMultiSig wm ]
   -}
 
 shrinkTxBody :: TxBody crypto -> [TxBody crypto]
-shrinkTxBody (TxBody is os cs ws tf tl tu) =
+shrinkTxBody (TxBody is os cs ws tf tl tu md) =
   -- shrinking inputs is probably not very beneficial
   -- [ TxBody is' os cs ws tf tl tu | is' <- shrinkSet shrinkTxIn is ] ++
 
   -- Shrink outputs, add the differing balance of the original and new outputs
   -- to the fees in order to preserve the invariant
-  [ TxBody is os' cs ws (tf + (outBalance - outputBalance os')) tl tu |
+  [ TxBody is os' cs ws (tf + (outBalance - outputBalance os')) tl tu md |
     os' <- shrinkList shrinkTxOut os ]
 
   -- [ TxBody is os cs' ws tf tl tu | cs' <- shrinkSeq shrinkDCert cs ] ++

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -89,6 +89,9 @@
 \newcommand{\ApVer}{\ensuremath{\type{ApVer}}}
 \newcommand{\SystemTag}{\ensuremath{\type{SystemTag}}}
 \newcommand{\InstallerHash}{\ensuremath{\type{InstallerHash}}}
+\newcommand{\MetaDatum}{\ensuremath{\type{MetaDatum}}}
+\newcommand{\MetaData}{\ensuremath{\type{MetaData}}}
+\newcommand{\MetaDataHash}{\ensuremath{\type{MetaDataHash}}}
 \newcommand{\Metadata}{\ensuremath{\type{Mdt}}}
 \newcommand{\PPUpdate}{\type{PPUpdate}}
 \newcommand{\Applications}{\type{Applications}}

--- a/shelley/chain-and-ledger/formal-spec/transactions.tex
+++ b/shelley/chain-and-ledger/formal-spec/transactions.tex
@@ -2,7 +2,7 @@
 \label{sec:transactions}
 
 Transactions are defined in Figure~\ref{fig:defs:utxo-shelley}.
-A transaction body, $\TxBody$, is made up of seven pieces:
+A transaction body, $\TxBody$, is made up of eight pieces:
 
 \begin{itemize}
   \item A set of transaction inputs.
@@ -23,18 +23,18 @@ A transaction body, $\TxBody$, is made up of seven pieces:
     and for the rule for collecting rewards, see Section \ref{sec:utxo-trans}.
   \item Update proposals for protocol parameters and software.
     The update system will be explained in Section \ref{sec:update}.
-  \item $\PPUpdate$, the protocol parameter upates.
-  \item $\AVUpdate$, the updates to Shelley software (applications).
+  \item An optional metadata hash.
 \end{itemize}
 
 A transaction, $\Tx$, consists of:
 
 \begin{itemize}
   \item The transaction body.
-  \item A pair of:
+  \item A triple of:
     \begin{itemize}
       \item A finite map from payment verification keys to signatures.
       \item A finite map from script hashes to scripts.
+      \item Optional metadata.
     \end{itemize}
 \end{itemize}
 
@@ -56,6 +56,8 @@ This function must produce a unique id for each unique transaction.
       \var{an} & \ApName & \text{application name}\\
       \var{st} & \SystemTag & \text{system tag}\\
       \var{ih} & \InstallerHash & \text{update data}\\
+      \var{m} & \MetaDatum & \text{metadatum}\\
+      \var{mdh} & \MetaDataHash & \text{hash of transaction metadata}\\
     \end{array}
   \end{equation*}
   \emph{Derived types}
@@ -81,6 +83,11 @@ This function must produce a unique id for each unique transaction.
       & \Wdrl
       & \AddrRWD \mapsto \Coin
       & \text{reward withdrawal}
+      \\
+      \var{md}
+      & \MetaData
+      & \N \mapsto \MetaDatum
+      & \text{metadata}
     \end{array}
   \end{equation*}
   \emph{Derived types (update system)}
@@ -125,14 +132,17 @@ This function must produce a unique id for each unique transaction.
     \begin{array}{r@{~\in~}l@{\qquad=\qquad}l}
       \var{txbody}
       & \TxBody
-      & \powerset{\TxIn} \times (\Ix \mapsto \TxOut) \times \seqof{\DCert}
-        \times \Coin \times \Slot \times \Wdrl \times \Update
+      & \begin{array}{l}
+        \powerset{\TxIn} \times (\Ix \mapsto \TxOut) \times \seqof{\DCert}
+        \times \Coin \times \Slot \times \Wdrl
+        \\ ~~~~\times \Update \times \MetaDataHash^?
+        \end{array}
       \\
       \var{wit} & \TxWitness & (\VKey \mapsto \Sig, \HashScr \mapsto \Script)
       \\
       \var{tx}
       & \Tx
-      & \TxBody \times \TxWitness
+      & \TxBody \times \TxWitness \times \MetaData^?
     \end{array}
   \end{equation*}
   %
@@ -148,7 +158,9 @@ This function must produce a unique id for each unique transaction.
       \fun{txbody} & \Tx \to \TxBody & \text{transaction body}\\
       \fun{txwitsVKey} & \Tx \to (\VKey \mapsto \Sig) & \text{VKey witnesses} \\
       \fun{txwitsScript} & \Tx \to (\HashScr \mapsto \Script) & \text{script witnesses}\\
-      \fun{txup} & \Tx \to \Update & \text{protocol parameter update}
+      \fun{txup} & \Tx \to \Update & \text{protocol parameter update}\\
+      \fun{txMD} & \Tx \to \MetaData & \text{metadata}\\
+      \fun{txMDhash} & \Tx \to \MetaDataHash & \text{metadata hash}\\
     \end{array}
   \end{equation*}
   %
@@ -156,7 +168,8 @@ This function must produce a unique id for each unique transaction.
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \txid{} & \Tx \to \TxId & \text{compute transaction id}\\
-      \fun{validateScript} & \Script \to \Tx \to \Bool & \text{script interpreter}
+      \fun{validateScript} & \Script \to \Tx \to \Bool & \text{script interpreter}\\
+      \fun{hashMD} & \MetaData \to \MetaDataHash & \text{hash the metadata}\\
     \end{array}
   \end{equation*}
   \caption{Definitions used in the UTxO transition system}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -631,11 +631,18 @@ Figure~\ref{fig:ts-types:utxow-shelley} defines the type for this transition.
 \end{figure}
 
 Figure~\ref{fig:rules:utxow-shelley} defines UTxOW transition.
-It has two predicates:
+It has six predicates:
 \begin{itemize}
   \item Every signature in the transaction is a valid signature of the transaction body.
-  \item The set of (hashes of) verification keys given by the transaction is exactly
+  \item The set of (hashes of) verification keys given by the transaction is a subset of
     the set of needed (hashes of) verification keys.
+  \item Every multisignature script is valid.
+  \item The set of scripts given by the transaction is equal to the set of required scripts.
+  \item Any instantaneous reward certificates have quorum agreement from the genesis nodes.
+  \item No instantaneous reward certificates are allowed when
+    the decentralization parameter is equal to zero.
+  \item Either the transaction metadata hash and the transaction metadata are both absent,
+    or the hash present in the body is actually equal to the hash of the metadata.
 \end{itemize}
 If the predicates are satisfied, the state is transitioned by the UTxO transition rule.
 
@@ -668,6 +675,14 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
       \right\} \neq\emptyset \implies \vert genSig\vert \geq \Quorum \wedge
       \fun{d}~\var{pp} > 0
       \\~\\
+      \var{mdh}\leteq\fun{txMDhash}~\var{tx}
+      &
+      \var{md}\leteq\fun{txMD}~\var{tx}
+      \\
+      (\var{mdh}=\Nothing \land \var{md}=\Nothing)
+      \lor
+      (\var{mdh}=\fun{hashMD}~\var{md})
+      \\~\\
       {
         \begin{array}{r}
           \var{slot}\\
@@ -695,12 +710,24 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
   \label{fig:rules:utxow-shelley}
 \end{figure}
 
-The UTXOW rule has two predicate failures:
+The UTXOW rule has eight predicate failures:
 \begin{itemize}                 %TODO: add multi-sig script failure predicates
-\item In the case of an incorrect witness, there is a \emph{InvalidWitnesses}
-  failure.
-\item In the case of a missing witness, there is a \emph{MissingVKeyWitnesses}
-  failure.
+\item In the case of an incorrect witness,
+  there is a \emph{InvalidWitnesses} failure.
+\item In the case of a missing witness,
+  there is a \emph{MissingVKeyWitnesses} failure.
+\item In the case of missing scripts,
+  there is a \emph{MissingScriptWitnesses} failure.
+\item In the case of an invalid script,
+  there is a \emph{ScriptWitnessNotValidating} failure.
+\item In the case that the $\mathsf{}$ rule fails,
+  there is a \emph{UtxoFailure} failure.
+\item In the case of a lack of quorum on an instantaneous reward certificate,
+  there is a \emph{MIRInsufficientGenesisSigs} failure.
+\item In the case of an instantaneous reward certificate after decentralization,
+  there is a \emph{MIRImpossibleInDecentralizedNet} failure.
+\item In the case of inconsist metadata hashes,
+  there is a \emph{BadMetaDataHash} failure.
 \end{itemize}
 
 \clearpage


### PR DESCRIPTION
This PR introduces transaction metadata to the shelley ledger.

The metadata type itself was mostly taken from the plutus repo:  https://github.com/input-output-hk/plutus/blob/master/plutus-tx/src/Language/PlutusTx/Data.hs

We will not supporting the `Constr Integer [Data]` constructor for the first release of Shelley, though. In Shelley we call the `Data` type `MetaDatum`. And there is a `MetaData` type for a mapping of `Word64` to `MetaDatum`. Please let me know if there are better names.

The transaction body now contains an optional field for the hash of metadata.  The transaction itself now contains a new third component, optional metadata. The `UTXOW` STS rule now requires that: either both the metadata hash and the metadata are absent, or the hash of the later is equal to the former.

We handle the serialization of the metadata similarly to the transaction witnesses, in a segwit-style. Unlike the witnesses, though, since we expect metadata to usually be missing, it is serialized not as a list in the block but instead as a mapping from transaction index to metadata.

There is still a bit of work to be done. There is currently no enforcement of 64 bytes on the leaves of the metadatum, and the cddl has not been tested. And the metadatum format itself is not documented in any of the formal specs / pdfs.

@michaelpj - regarding #1069, after talking with @dcoutts , we've decided not to implement some mechanism for letting folks bypass the 64 byte restriction on the leaves of the metadata (via some extra fee, etc). The argument is that 64 bytes is pretty big for things like counters, but small enough to disallow bad uses. Of course, folks can still write sufficiently bad contracts that would get themselves into trouble, but we are deciding that preventing that is not worth the added complexity.