### PR TITLE
Block Number checks

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -331,6 +331,7 @@ esEx1 = EpochState acntEx1 emptySnapShots lsEx1 ppsEx1
 initStEx1 :: ChainState
 initStEx1 = initialShelleyState
   (SlotNo 0)
+  (BlockNo 0)
   (EpochNo 0)
   lastByronHeaderHash
   (UTxO Map.empty)
@@ -374,6 +375,7 @@ expectedStEx1 = ChainState
   NeutralNonce
   (bhHash (bheader blockEx1))
   (SlotNo 1)
+  (BlockNo 1)
 
 -- | Wraps example all together.
 ex1 :: CHAINExample
@@ -480,6 +482,7 @@ initNesEx2A = NewEpochState
 initStEx2A :: ChainState
 initStEx2A = initialShelleyState
   (SlotNo 0)
+  (BlockNo 0)
   (EpochNo 0)
   lastByronHeaderHash
   utxoEx2A
@@ -495,7 +498,7 @@ blockEx2A = mkBlock
              (coreNodeKeys 2)
              [txEx2A]
              (SlotNo 10)
-             (BlockNo 10)
+             (BlockNo 1)
              (mkNonce 0)
              (NatNonce 1)
              zero
@@ -568,6 +571,7 @@ expectedStEx2A = ChainState
   NeutralNonce
   blockEx2AHash
   (SlotNo 10)
+  (BlockNo 1)
 
 ex2A :: CHAINExample
 ex2A = CHAINExample (SlotNo 10) initStEx2A blockEx2A (Right expectedStEx2A)
@@ -667,8 +671,9 @@ expectedStEx2Bgeneric pp = ChainState
   (nonce0 ⭒ mkNonce 1 ⭒ mkNonce 2) -- ^ Evolving nonce
   (nonce0 ⭒ mkNonce 1)             -- ^ Candidate nonce
   NeutralNonce
-  blockEx2BHash                       -- ^ Hash header of the chain
-  (SlotNo 90)                           -- ^ Current slot
+  blockEx2BHash                    -- ^ Hash header of the chain
+  (SlotNo 90)                      -- ^ Current slot
+  (BlockNo 2)                      -- ^ Current block no
 
 -- | Expected state after transition
 expectedStEx2B :: ChainState
@@ -700,7 +705,7 @@ blockEx2C = mkBlock
              (coreNodeKeys 2)
              []               -- ^ No transactions at all (empty block)
              (SlotNo 110)       -- ^ Current slot
-             (BlockNo 2)      -- ^ Second block within the epoch
+             (BlockNo 3)      -- ^ Second block within the epoch
              (mkNonce 0)      -- ^ Epoch nonce
              (NatNonce 3)     -- ^ Block nonce
              zero             -- ^ Praos leader value
@@ -787,6 +792,7 @@ expectedStEx2Cgeneric ss ls pp = ChainState
   (hashHeaderToNonce blockEx2BHash)
   blockEx2CHash
   (SlotNo 110)
+  (BlockNo 3)
 
 -- ** Expected chain state after STS
 expectedStEx2C :: ChainState
@@ -832,7 +838,7 @@ blockEx2D = mkBlock
              (coreNodeKeys 5)
              []
              (SlotNo 190)
-             (BlockNo 2)
+             (BlockNo 4)
              (mkNonce 0 ⭒ mkNonce 1)
              (NatNonce 4)
              zero
@@ -864,6 +870,7 @@ expectedStEx2D = ChainState
   (hashHeaderToNonce blockEx2BHash)
   blockEx2DHash
   (SlotNo 190)
+  (BlockNo 4)
 
 ex2D :: CHAINExample
 ex2D = CHAINExample (SlotNo 190) expectedStEx2C blockEx2D (Right expectedStEx2D)
@@ -879,7 +886,7 @@ blockEx2E = mkBlock
              (coreNodeKeys 5)
              []
              (SlotNo 220)
-             (BlockNo 2)
+             (BlockNo 5)
              ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
              (NatNonce 5)
              zero
@@ -947,6 +954,7 @@ expectedStEx2E = ChainState
   (hashHeaderToNonce blockEx2DHash)
   blockEx2EHash
   (SlotNo 220)
+  (BlockNo 5)
 
 ex2E :: CHAINExample
 ex2E = CHAINExample (SlotNo 220) expectedStEx2D blockEx2E (Right expectedStEx2E)
@@ -963,7 +971,7 @@ blockEx2F = mkBlock
              alicePool
              []
              (SlotNo 295) -- odd slots open for decentralization in epoch1OSchedEx2E
-             (BlockNo 2)
+             (BlockNo 6)
              ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
              (NatNonce 6)
              zero
@@ -998,6 +1006,7 @@ expectedStEx2F = ChainState
   (hashHeaderToNonce blockEx2DHash)
   blockEx2FHash
   (SlotNo 295)
+  (BlockNo 6)
 
 ex2F :: CHAINExample
 ex2F = CHAINExample (SlotNo 295) expectedStEx2E blockEx2F (Right expectedStEx2F)
@@ -1013,7 +1022,7 @@ blockEx2G = mkBlock
              (coreNodeKeys 2)
              []
              (SlotNo 310)
-             (BlockNo 2)
+             (BlockNo 7)
              (mkSeqNonce 5)
              (NatNonce 7)
              zero
@@ -1069,6 +1078,7 @@ expectedStEx2G = ChainState
   (hashHeaderToNonce blockEx2FHash)
   blockEx2GHash
   (SlotNo 310)
+  (BlockNo 7)
 
 ex2G :: CHAINExample
 ex2G = CHAINExample (SlotNo 310) expectedStEx2F blockEx2G (Right expectedStEx2G)
@@ -1083,7 +1093,7 @@ blockEx2H = mkBlock
              (coreNodeKeys 5)
              []
              (SlotNo 390)
-             (BlockNo 2)
+             (BlockNo 8)
              (mkSeqNonce 5)
              (NatNonce 8)
              zero
@@ -1129,6 +1139,7 @@ expectedStEx2H = ChainState
   (hashHeaderToNonce blockEx2FHash)
   blockEx2HHash
   (SlotNo 390)
+  (BlockNo 8)
 
 ex2H :: CHAINExample
 ex2H = CHAINExample (SlotNo 390) expectedStEx2G blockEx2H (Right expectedStEx2H)
@@ -1143,7 +1154,7 @@ blockEx2I = mkBlock
               (coreNodeKeys 2)
               []
               (SlotNo 410)
-              (BlockNo 2)
+              (BlockNo 9)
               (mkSeqNonce 7)
               (NatNonce 9)
               zero
@@ -1211,6 +1222,7 @@ expectedStEx2I = ChainState
   (hashHeaderToNonce blockEx2HHash)
   blockEx2IHash
   (SlotNo 410)
+  (BlockNo 9)
 
 ex2I :: CHAINExample
 ex2I = CHAINExample (SlotNo 410) expectedStEx2H blockEx2I (Right expectedStEx2I)
@@ -1248,7 +1260,7 @@ blockEx2J = mkBlock
               (coreNodeKeys 5)
               [txEx2J]
               (SlotNo 420)
-              (BlockNo 2)
+              (BlockNo 10)
               (mkSeqNonce 7)
               (NatNonce 10)
               zero
@@ -1305,6 +1317,7 @@ expectedStEx2J = ChainState
   (hashHeaderToNonce blockEx2HHash)
   blockEx2JHash
   (SlotNo 420)
+  (BlockNo 10)
 
 ex2J :: CHAINExample
 ex2J = CHAINExample (SlotNo 420) expectedStEx2I blockEx2J (Right expectedStEx2J)
@@ -1337,7 +1350,7 @@ blockEx2K = mkBlock
               (coreNodeKeys 5)
               [txEx2K]
               (SlotNo 490)
-              (BlockNo 2)
+              (BlockNo 11)
               (mkSeqNonce 7)
               (NatNonce 11)
               zero
@@ -1388,6 +1401,7 @@ expectedStEx2K = ChainState
   (hashHeaderToNonce blockEx2HHash)
   blockEx2KHash
   (SlotNo 490)
+  (BlockNo 11)
 
 ex2K :: CHAINExample
 ex2K = CHAINExample (SlotNo 490) expectedStEx2J blockEx2K (Right expectedStEx2K)
@@ -1402,7 +1416,7 @@ blockEx2L = mkBlock
               (coreNodeKeys 2)
               []
               (SlotNo 510)
-              (BlockNo 2)
+              (BlockNo 12)
               (mkSeqNonce 10)
               (NatNonce 12)
               zero
@@ -1468,6 +1482,7 @@ expectedStEx2L = ChainState
   (hashHeaderToNonce blockEx2KHash)
   blockEx2LHash
   (SlotNo 510)
+  (BlockNo 12)
 
 ex2L :: CHAINExample
 ex2L = CHAINExample (SlotNo 510) expectedStEx2K blockEx2L (Right expectedStEx2L)
@@ -1519,7 +1534,7 @@ blockEx3A = mkBlock
              (coreNodeKeys 2)
              [txEx3A]
              (SlotNo 10)
-             (BlockNo 2)
+             (BlockNo 1)
              (mkNonce 0)
              (NatNonce 1)
              zero
@@ -1566,6 +1581,7 @@ expectedStEx3A = ChainState
   NeutralNonce
   blockEx3AHash
   (SlotNo 10)
+  (BlockNo 1)
 
 ex3A :: CHAINExample
 ex3A = CHAINExample (SlotNo 10) initStEx2A blockEx3A (Right expectedStEx3A)
@@ -1662,6 +1678,7 @@ expectedStEx3B = ChainState
   NeutralNonce
   blockEx3BHash
   (SlotNo 20)
+  (BlockNo 2)
 
 ex3B :: CHAINExample
 ex3B = CHAINExample (SlotNo 20) expectedStEx3A blockEx3B (Right expectedStEx3B)
@@ -1676,7 +1693,7 @@ blockEx3C = mkBlock
              (coreNodeKeys 2)
              []
              (SlotNo 110)
-             (BlockNo 2)
+             (BlockNo 3)
              (mkSeqNonce 2)
              (NatNonce 3)
              zero
@@ -1725,6 +1742,7 @@ expectedStEx3C = ChainState
   (hashHeaderToNonce blockEx3BHash)
   blockEx3CHash
   (SlotNo 110)
+  (BlockNo 3)
 
 ex3C :: CHAINExample
 ex3C = CHAINExample (SlotNo 110) expectedStEx3B blockEx3C (Right expectedStEx3C)
@@ -1783,7 +1801,7 @@ blockEx4A = mkBlock
              (coreNodeKeys 2)
              [txEx4A]
              (SlotNo 10)
-             (BlockNo 2)
+             (BlockNo 1)
              (mkNonce 0)
              (NatNonce 1)
              zero
@@ -1830,6 +1848,7 @@ expectedStEx4A = ChainState
   NeutralNonce
   blockEx4AHash
   (SlotNo 10)
+  (BlockNo 1)
 
 ex4A :: CHAINExample
 ex4A = CHAINExample (SlotNo 10) initStEx2A blockEx4A (Right expectedStEx4A)
@@ -1924,6 +1943,7 @@ expectedStEx4B = ChainState
   NeutralNonce
   blockEx4BHash
   (SlotNo 20)
+  (BlockNo 2)
 
 ex4B :: CHAINExample
 ex4B = CHAINExample (SlotNo 20) expectedStEx4A blockEx4B (Right expectedStEx4B)
@@ -1938,7 +1958,7 @@ blockEx4C = mkBlock
              (coreNodeKeys 3)
              []
              (SlotNo 60)
-             (BlockNo 2)
+             (BlockNo 3)
              (mkNonce 0)
              (NatNonce 3)
              zero
@@ -1989,6 +2009,7 @@ expectedStEx4C = ChainState
   NeutralNonce
   blockEx4CHash
   (SlotNo 60)
+  (BlockNo 3)
 
 
 ex4C :: CHAINExample
@@ -2028,7 +2049,7 @@ blockEx5A = mkBlock
               (coreNodeKeys 2)
               [txEx5A]
               (SlotNo 10)
-              (BlockNo 2)
+              (BlockNo 1)
               (mkNonce 0)
               (NatNonce 1)
               zero
@@ -2076,6 +2097,7 @@ expectedStEx5A = ChainState
   NeutralNonce
   blockEx5AHash
   (SlotNo 10)
+  (BlockNo 1)
 
 ex5A :: CHAINExample
 ex5A = CHAINExample (SlotNo 10) initStEx2A blockEx5A (Right expectedStEx5A)
@@ -2137,6 +2159,7 @@ expectedStEx5B = ChainState
   NeutralNonce
   blockEx5BHash
   (SlotNo 50)
+  (BlockNo 2)
 
 ex5B :: CHAINExample
 ex5B = CHAINExample (SlotNo 50) expectedStEx5A blockEx5B (Right expectedStEx5B)
@@ -2224,6 +2247,7 @@ expectedStEx6A = ChainState
   NeutralNonce
   blockEx6AHash
   (SlotNo 10)
+  (BlockNo 1)
 
 ex6A :: CHAINExample
 ex6A = CHAINExample (SlotNo 10) initStEx2A blockEx6A (Right expectedStEx6A)
@@ -2372,7 +2396,7 @@ blockEx6F' = mkBlock
               [txEx6F']
               ((slotFromEpoch $ EpochNo 1)
                 +* Duration (startRewards testGlobals) + SlotNo 7)
-              (BlockNo 1)
+              (BlockNo 2)
               (mkNonce 0)
               (NatNonce 1)
               zero
@@ -2404,7 +2428,7 @@ blockEx6F'' = mkBlock
                (coreNodeKeys 2)
                [txEx6F'']
                ((slotFromEpoch $ EpochNo 2) + SlotNo 10)
-               (BlockNo 1)
+               (BlockNo 3)
                (mkNonce 0)
                (NatNonce 1)
                zero

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Block.hs
@@ -27,9 +27,9 @@ import           LedgerState (esAccountState, esLState, esPp, nesEL, nesEs, nesO
                      overlaySchedule, _delegationState, _dstate, _genDelegs, _pParams, _pstate,
                      _reserves)
 import           OCert (KESPeriod (..), currentIssueNo, kesPeriod)
-import           Slot (BlockNo (..), EpochNo (..), SlotNo (..))
-import           STS.Chain (chainEpochNonce, chainHashHeader, chainNes, chainOCertIssue,
-                     chainSlotNo)
+import           Slot (EpochNo (..), SlotNo (..))
+import           STS.Chain (chainBlockNo, chainEpochNonce, chainHashHeader, chainNes,
+                     chainOCertIssue, chainSlotNo)
 import           STS.Ledgers (LedgersEnv (..))
 import           STS.Ocert (pattern OCertEnv)
 import           Test.Utils (maxKESIterations, runShelleyBase)
@@ -142,7 +142,7 @@ genBlock sNow chainSt coreNodeKeys keysByStakeHash = do
       <*> pure keys'
       <*> toList <$> genTxs nextOSlot
       <*> pure nextOSlot
-      <*> pure chainDifficulty
+      <*> pure (chainBlockNo chainSt + 1)
       <*> pure (chainEpochNonce chainSt)
       <*> genBlockNonce
       <*> genPraosLeader
@@ -172,8 +172,6 @@ genBlock sNow chainSt coreNodeKeys keysByStakeHash = do
 
     -- TODO @uroboros
     genPraosLeader = pure zero
-
-    chainDifficulty = BlockNo 1 -- used only in consensus
 
     -- we assume small gaps in slot numbers
     genSlotIncrease = SlotNo . (lastSlotNo +) <$> QC.choose (1, 5)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
@@ -40,7 +40,7 @@ import           Generator.Update.QuickCheck (genPParams)
 import           Keys (pattern GenDelegs, Hash, hash)
 import           LedgerState (overlaySchedule)
 import           Shrinkers (shrinkBlock)
-import           Slot (EpochNo (..), SlotNo (..))
+import           Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import           STS.Chain (initialShelleyState)
 import           Test.Utils (runShelleyBase)
 import           Updates (ApName (..), ApVer (..), pattern Applications, pattern Mdt)
@@ -96,6 +96,7 @@ mkGenesisChainState (IRC _slotNo) = do
 
   pure . Right $ initialShelleyState
     (SlotNo 0)
+    (BlockNo 0)
     epoch0
     lastByronHeaderHash
     utxo0

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -128,6 +128,7 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
     \begin{array}{r@{~\in~}lr}
       \var{h} & \HashHeader & \text{hash of a block header}\\
       \var{hb} & \HashBBody & \text{hash of a block body}\\
+      \var{bn} & \BlockNo & \text{block number}\\
     \end{array}
   \end{equation*}
   %
@@ -201,21 +202,22 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
   %
   \emph{Accessor Functions}
   \begin{equation*}
-    \begin{array}{r@{~\in~}lr}
-      \fun{bheader} & \Block \to \BHeader \\
+    \begin{array}{r@{~\in~}l@{~~~~~~~~~~}r@{~\in~}lr}
+      \fun{bheader} & \Block \to \BHeader &
       \fun{bhbody} & \BHeader \to \BHBody \\
-      \fun{hsig} & \BHeader \to \Sig\\
+      \fun{hsig} & \BHeader \to \Sig &
       \fun{bbody} & \Block \to \seqof{\Tx} \\
-      \fun{bvkcold} & \BHBody \to \VKey\\
-      \fun{bvkvrf} & \BHBody \to \VKey\\
-      \fun{bprev} & \BHBody \to \HashHeader\\
-      \fun{bslot} & \BHBody \to \Slot\\
-      \fun{bnonce} & \BHBody \to \Seed\\
-      \fun{\bprfn{}} & \BHBody \to \Proof\\
-      \fun{bleader} & \BHBody \to \unitInterval\\
-      \fun{\bprfl{}} & \BHBody \to \Proof\\
+      \fun{bvkcold} & \BHBody \to \VKey &
+      \fun{bvkvrf} & \BHBody \to \VKey \\
+      \fun{bprev} & \BHBody \to \HashHeader &
+      \fun{bslot} & \BHBody \to \Slot \\
+      \fun{bblockno} & \BHBody \to \BlockNo &
+      \fun{bnonce} & \BHBody \to \Seed \\
+      \fun{\bprfn{}} & \BHBody \to \Proof &
+      \fun{bleader} & \BHBody \to \unitInterval \\
+      \fun{\bprfl{}} & \BHBody \to \Proof &
       \fun{hBbsize} & \BHBody \to \N \\
-      \fun{bhash} & \BHBody \to \HashBBody \\
+      \fun{bhash} & \BHBody \to \HashBBody &
       \fun{bocert} & \BHBody \to \OCert \\
     \end{array}
   \end{equation*}
@@ -1270,6 +1272,7 @@ followed by the transition to update the evolving and candidate nonces.
         \var{cs} & \KeyHash_{pool} \mapsto \N & \text{operational certificate issues numbers} \\
         \var{h} & \HashHeader & \text{latest header hash} \\
         \var{s_\ell} & \Slot & \text{last slot} \\
+        \var{b_\ell} & \BlockNo & \text{last block number} \\
         \eta_0 & \Seed & \text{current epoch nonce} \\
         \eta_v & \Seed & \text{evolving nonce} \\
         \eta_c & \Seed & \text{candidate nonce} \\
@@ -1306,6 +1309,7 @@ The states for this transition consists of:
 \begin{itemize}
   \item The operational certificate issue number mapping.
   \item The slot of the last block header.
+  \item The last block number.
   \item The hash of last block header.
   \item The current epoch nonce.
   \item The evolving nonce.
@@ -1321,11 +1325,13 @@ The states for this transition consists of:
       &
       \var{slot} \leteq \bslot{bhb}
       &
-      \eta\leteq\fun{bnonce}~{bhb}
+      \eta\leteq\fun{bnonce}~\var{bhb}
       \\
       \var{s_\ell} < \var{slot} \leq \var{s_{now}}
       &
       \var{h} = \bprev{bhb}
+      &
+      \var{b_\ell} + 1 = \fun{bblockno}~\var{bhb}
       \\~\\
       {
         {\left(\begin{array}{c}
@@ -1376,6 +1382,7 @@ The states for this transition consists of:
             \var{cs} \\
             \var{h} \\
             \var{s_\ell} \\
+            \var{b_\ell} \\
             \eta_0 \\
             \eta_v \\
             \eta_c \\
@@ -1386,6 +1393,7 @@ The states for this transition consists of:
             \varUpdate{cs'} \\
             \varUpdate{\bhHash{bh}} \\
             \varUpdate{slot} \\
+            \varUpdate{b_\ell + 1} \\
             \varUpdate{\eta_0'} \\
             \varUpdate{\eta_v'} \\
             \varUpdate{\eta_c'} \\
@@ -1397,13 +1405,15 @@ The states for this transition consists of:
   \label{fig:rules:prtcl}
 \end{figure}
 
-The PRTCL rule has two predicate failures:
+The PRTCL rule has three predicate failures:
 \begin{itemize}
 \item If the slot of the block header body is not larger than the last slot or
   greater than the current slot, there is a \emph{WrongSlotInterval} failure.
 \item If the hash of the previous header of the block header body is not equal
   to the hash given in the environment, there is a \emph{WrongBlockSequence}
   failure.
+\item If the block number does not increase by exactly one,
+  there is a \emph{WrongBlockNo} failure.
 \end{itemize}
 
 \clearpage
@@ -1576,6 +1586,7 @@ following:
   \item The previous epoch hash nonce $\eta_h$.
   \item The last header hash \var{h}.
   \item The last slot \var{s_\ell}.
+  \item The last block number \var{b_\ell}.
 \end{itemize}
 
 \begin{figure}
@@ -1592,6 +1603,7 @@ following:
         ~\eta_h & \Seed & \text{seed generated from hash of previous epoch} \\
         \var{h} & \HashHeader & \text{latest header hash} \\
         \var{s_\ell} & \Slot & \text{last slot} \\
+        \var{b_\ell} & \Slot & \text{last block number} \\
       \end{array}
     \right)
   \end{equation*}
@@ -1698,6 +1710,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
               \var{cs} \\
               \var{h} \\
               \var{s_\ell} \\
+              \var{b_\ell} \\
               \eta_0 \\
               \eta_v \\
               \eta_c \\
@@ -1708,6 +1721,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
               \var{cs'} \\
               \var{h'} \\
               \var{s_\ell'} \\
+              \var{b_\ell'} \\
               \eta_0' \\
               \eta_v' \\
               \eta_c' \\
@@ -1745,6 +1759,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
             \eta_h \\
             \var{h} \\
             \var{s_\ell} \\
+            \var{b_\ell} \\
       \end{array}\right)}
       \trans{chain}{\var{block}}
       {\left(\begin{array}{c}
@@ -1756,6 +1771,7 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
             \varUpdate{\eta_h'} \\
             \varUpdate{\var{h}'} \\
             \varUpdate{\var{s_\ell}'} \\
+            \varUpdate{\var{b_\ell}'} \\
       \end{array}\right)}
     }
   \end{equation}
@@ -1792,13 +1808,14 @@ candidate nonces for Shelley.
   \emph{Shelley Initial States}
   %
   \begin{align*}
-      & \fun{initialShelleyState} \in \Slot \to \Epoch \to\HashHeader \to \UTxO
-        \to \Coin \to (\KeyHashGen \mapsto \KeyHash) \\
-      & ~~~\to (\Slot\mapsto\KeyHashGen^?) \to \Applications \to  \PParams \to \ChainState \\
+      & \fun{initialShelleyState} \in \Slot \to \BlockNo \to \Epoch \to\HashHeader \to \UTxO
+        \to \Coin \\
+      & ~~~ \to (\KeyHashGen \mapsto \KeyHash) \to (\Slot\mapsto\KeyHashGen^?) \to \Applications \to  \PParams \to \ChainState \\
       & \fun{initialShelleyState}~
       \left(
         \begin{array}{c}
           \var{s} \\
+          \var{bn} \\
           \var{e} \\
           \var{h} \\
           \var{utxo} \\
@@ -1891,6 +1908,7 @@ candidate nonces for Shelley.
           0_{seed} \\
           \var{h} \\
           \var{s} \\
+          \var{bn} \\
         \end{array}
       \right) \\
       & ~~~~\where cs = \{\var{hk}\mapsto 0~\mid~\var{hk}\in\range{genDelegs}\} \\
@@ -1924,6 +1942,7 @@ candidate nonces for Shelley.
       \left(
         \begin{array}{c}
           \var{s_{last}} \\
+          \var{bn} \\
           e \\
           \fun{hash}~{h} \\
           \var{utxo} \\
@@ -1936,6 +1955,7 @@ candidate nonces for Shelley.
       \right) \\
       & ~~~~\where \\
       & ~~~~~~~~~e = \epoch{s_{last}} \\
+      & ~~~~~~~~~bn = \mathsf{TODO} \\
       & ~~~~~~~~~gd = \fun{dms}~\var{ds} \\
       & ~~~~~~~~~pp = \pps{us} \\
   \end{align*}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -75,6 +75,7 @@
 \newcommand{\SlotsPrior}{\ensuremath{\mathsf{SlotsPrior}}}
 \newcommand{\SlotsPerEpoch}{\mathsf{SlotsPerEpoch}}
 \newcommand{\SlotsPerKESPeriod}{\mathsf{SlotsPerKESPeriod}}
+\newcommand{\BlockNo}{\type{BlockNo}}
 \newcommand{\StartRewards}{\ensuremath{\mathsf{StartRewards}}}
 \newcommand{\MaxKESEvo}{\ensuremath{\mathsf{MaxKESEvo}}}
 \newcommand{\Quorum}{\ensuremath{\mathsf{Quorum}}}


### PR DESCRIPTION
This PR adds support for block numbers in the block header. It was previously included in the exec spec, as a part of the block header body, though it was not used by the ledger. We now include the block numbers in the formal spec and use it for a new check.

In particular:
* the `BlockNo` value is now apart of the state for the `PRTCL` and `CHAIN` transitions. This represents the last seen block number.
* `PRTCL` now checks that the block header being processed is exactly one greater than the last block number.

I added a TODO to the formal spec for figuring out how to get the last block number from the byron chain state. (See Figure 82, "Byron to Shelley State Transition".)