### PR TITLE
Generate blocks in Praos slots

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
@@ -35,7 +35,7 @@ import           Generator.Block (genBlock)
 import           Generator.Core.Constants (maxGenesisUTxOouts, maxSlotTrace, minGenesisUTxOouts,
                      minSlotTrace)
 import           Generator.Core.QuickCheck (coreNodeKeys, genUtxo0, genesisDelegs0,
-                     maxLovelaceSupply, traceKeyPairsByStakeHash)
+                     maxLovelaceSupply, tracePoolKeysMap)
 import           Generator.Update.QuickCheck (genPParams)
 import           Keys (pattern GenDelegs, Hash, hash)
 import           LedgerState (overlaySchedule)
@@ -58,7 +58,7 @@ instance HasTrace CHAIN Word64 where
       env
       st
       coreNodeKeys
-      traceKeyPairsByStakeHash
+      tracePoolKeysMap
 
   shrinkSignal = shrinkBlock
 

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
@@ -127,3 +127,6 @@ minSlotTrace = 1000
 -- | Maximal slot for CHAIN trace generation.
 maxSlotTrace :: Int
 maxSlotTrace = 5000
+
+maxPoolKeys :: Word64
+maxPoolKeys = 50

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -28,7 +28,8 @@ module Generator.Core.QuickCheck
   , coreKeyPairs
   , coreNodeKeys
   , traceKeyPairs
-  , traceKeyPairsByStakeHash
+  , tracePoolKeys
+  , tracePoolKeysMap
   , traceKeyHashMap
   , traceVRFKeyPairs
   , traceVRFKeyPairsByHash
@@ -71,8 +72,8 @@ import           ConcreteCryptoTypes (Addr, AnyKeyHash, Block, CoreKeyPair, Cred
                      HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig, MultiSigPairs, OCert,
                      SKeyES, SignKeyVRF, Tx, TxOut, UTxO, VKey, VKeyES, VKeyGenesis, VRFKeyHash,
                      VerKeyVRF, hashKeyVRF)
-import           Generator.Core.Constants (maxGenesisOutputVal, maxNumKeyPairs, maxSlotTrace,
-                     minGenesisOutputVal, numBaseScripts)
+import           Generator.Core.Constants (maxGenesisOutputVal, maxNumKeyPairs, maxPoolKeys,
+                     maxSlotTrace, minGenesisOutputVal, numBaseScripts)
 import           Keys (pattern KeyPair, hashAnyKey, hashKey, sKey, sign, signKES,
                      undiscriminateKeyHash, vKey)
 import           LedgerState (AccountState (..), genesisCoins)
@@ -115,12 +116,13 @@ mkKeyPairs n
 traceKeyPairs :: KeyPairs
 traceKeyPairs = mkKeyPairs <$> [1 .. maxNumKeyPairs]
 
-traceKeyPairsByStakeHash
-  :: Map KeyHash KeyPair
-traceKeyPairsByStakeHash =
-  Map.fromList (f <$> traceKeyPairs)
-  where
-    f (_payK, stakeK) = ((hashKey . vKey) stakeK, stakeK)
+-- | Constant list of keys intended to be used as pool keys in the generators.
+tracePoolKeys :: [KeyPair]
+tracePoolKeys = (fst . mkKeyPairs) <$> ((maxNumKeyPairs +) <$> [1 .. maxPoolKeys])
+
+tracePoolKeysMap :: Map KeyHash KeyPair
+tracePoolKeysMap =
+  Map.fromList ((\k -> ((hashKey . vKey) k, k)) <$> tracePoolKeys)
 
 -- | Mapping from key hash to key pair
 traceKeyHashMap :: Map AnyKeyHash KeyPair

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace/QuickCheck.hs
@@ -27,7 +27,7 @@ import           Data.Word (Word64)
 import           Generator.Core.Constants (maxGenesisUTxOouts, minGenesisUTxOouts, numBaseScripts)
 import           Generator.Core.QuickCheck (coreKeyPairs, genCoin, genUtxo0, genesisDelegs0,
                      traceKeyHashMap, traceKeyPairs, traceMSigCombinations, traceMSigScripts,
-                     traceVRFKeyPairs)
+                     tracePoolKeys, traceVRFKeyPairs)
 import           Generator.Update.QuickCheck (genPParams)
 import           Generator.Utxo.QuickCheck (genTx)
 import           LedgerState (pattern LedgerState, genesisState)
@@ -52,6 +52,7 @@ instance TQC.HasTrace LEDGER Word64 where
      ledgerSt
      traceKeyPairs
      traceKeyHashMap
+     tracePoolKeys
      (traceMSigCombinations $ take numBaseScripts traceMSigScripts)
      coreKeyPairs
      traceVRFKeyPairs

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
@@ -55,11 +55,12 @@ genTx :: LedgerEnv
       -> (UTxOState, DPState)
       -> KeyPairs
       -> Map AnyKeyHash KeyPair
+      -> [KeyPair]
       -> MultiSigPairs
       -> [CoreKeyPair]
       -> VrfKeyPairs
       -> Gen Tx
-genTx (LedgerEnv slot _ pparams _) (UTxOState utxo _ _ _, dpState) keys keyHashMap scripts coreKeys vrfKeys = do
+genTx (LedgerEnv slot _ pparams _) (UTxOState utxo _ _ _, dpState) keys keyHashMap poolKeys scripts coreKeys vrfKeys = do
   keys' <- QC.shuffle keys
   scripts' <- QC.shuffle scripts
 
@@ -89,7 +90,7 @@ genTx (LedgerEnv slot _ pparams _) (UTxOState utxo _ _ _, dpState) keys keyHashM
 
   -- certificates
   (certs, certCreds, deposits_, refunds_)
-    <- genDCerts keys' keyHashMap scripts' coreKeys vrfKeys pparams dpState slot ttl
+    <- genDCerts keys' keyHashMap scripts' poolKeys coreKeys vrfKeys pparams dpState slot ttl
 
   if spendingBalance < deposits_
     then D.trace ("discarded") QC.discard

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -522,7 +522,7 @@ concerns are independent of the ledger rules.
       \\
       s'\leteq\var{slot}+\SlotsPrior
       & \var{gkh}\in\dom{genDelegs}
-      & \var{vk}\notin\range{genDelegs}
+      & \var{vkh}\notin\range{genDelegs}
     }
     {
       \begin{array}{r}


### PR DESCRIPTION
This activates block generation in the tests for Praos slots. The essential
change is to filter the pool distributions for non-emptiness, else we allowed
block creation for pools without delegated stake.

cf. #1198 