### PR TITLE
Revert change to add explicit pool keys in generators

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Block.hs
@@ -24,8 +24,7 @@ import           Generator.LedgerTrace.QuickCheck ()
 import           Keys (GenDelegs (..), hashKey, vKey)
 import           Ledger.Core (dom, range)
 import           LedgerState (esAccountState, esLState, esPp, nesEL, nesEs, nesOsched, nesPd,
-                     overlaySchedule, _delegationState, _dstate, _genDelegs, _pParams, _pstate,
-                     _reserves)
+                     overlaySchedule, _delegationState, _dstate, _genDelegs, _reserves)
 import           OCert (KESPeriod (..), currentIssueNo, kesPeriod)
 import           Slot (EpochNo (..), SlotNo (..))
 import           STS.Chain (chainBlockNo, chainEpochNonce, chainHashHeader, chainNes,

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Block.hs
@@ -117,14 +117,11 @@ genBlock sNow chainSt coreNodeKeys keysByStakeHash = do
     let kp@(KESPeriod kesPeriod_) = runShelleyBase (kesPeriod $ nextSlot)
         cs = chainOCertIssue chainSt
 
-        -- poolParams in SNAP (_, poolParams, _) in pstate
-        poolKeys = dom $ (_pParams . _pstate) dpstate
-
         -- ran genDelegs
         genDelegationKeys = range cores
 
         n' = currentIssueNo
-             (OCertEnv poolKeys genDelegationKeys)
+             (OCertEnv (dom poolParams) genDelegationKeys)
              cs
              ((hashKey . vKey . cold) keys)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
@@ -35,7 +35,7 @@ import           Generator.Block (genBlock)
 import           Generator.Core.Constants (maxGenesisUTxOouts, maxSlotTrace, minGenesisUTxOouts,
                      minSlotTrace)
 import           Generator.Core.QuickCheck (coreNodeKeys, genUtxo0, genesisDelegs0,
-                     maxLovelaceSupply, tracePoolKeysMap)
+                     maxLovelaceSupply, traceKeyPairsByStakeHash)
 import           Generator.Update.QuickCheck (genPParams)
 import           Keys (pattern GenDelegs, Hash, hash)
 import           LedgerState (overlaySchedule)
@@ -58,7 +58,7 @@ instance HasTrace CHAIN Word64 where
       env
       st
       coreNodeKeys
-      tracePoolKeysMap
+      traceKeyPairsByStakeHash
 
   shrinkSignal = shrinkBlock
 

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
@@ -132,9 +132,6 @@ minSlotTrace = 1000
 maxSlotTrace :: Int
 maxSlotTrace = 5000
 
-maxPoolKeys :: Word64
-maxPoolKeys = 50
-
 -- | Lower bound of the MaxEpoch protocol parameter
 frequencyLowMaxEpoch :: Word64
 frequencyLowMaxEpoch = 6

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -28,8 +28,7 @@ module Generator.Core.QuickCheck
   , coreKeyPairs
   , coreNodeKeys
   , traceKeyPairs
-  , tracePoolKeys
-  , tracePoolKeysMap
+  , traceKeyPairsByStakeHash
   , traceKeyHashMap
   , traceVRFKeyPairs
   , traceVRFKeyPairsByHash
@@ -74,8 +73,8 @@ import           ConcreteCryptoTypes (Addr, AnyKeyHash, Block, CoreKeyPair, Cred
                      HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig, MultiSigPairs, OCert,
                      SKeyES, SignKeyVRF, Tx, TxOut, UTxO, VKey, VKeyES, VKeyGenesis, VRFKeyHash,
                      VerKeyVRF, hashKeyVRF)
-import           Generator.Core.Constants (maxGenesisOutputVal, maxNumKeyPairs, maxPoolKeys,
-                     maxSlotTrace, minGenesisOutputVal, numBaseScripts)
+import           Generator.Core.Constants (maxGenesisOutputVal, maxNumKeyPairs, maxSlotTrace,
+                     minGenesisOutputVal, numBaseScripts)
 import           Keys (pattern KeyPair, hashAnyKey, hashKey, sKey, sign, signKES,
                      undiscriminateKeyHash, vKey)
 import           LedgerState (AccountState (..), genesisCoins)
@@ -120,13 +119,12 @@ mkKeyPairs n
 traceKeyPairs :: KeyPairs
 traceKeyPairs = mkKeyPairs <$> [1 .. maxNumKeyPairs]
 
--- | Constant list of keys intended to be used as pool keys in the generators.
-tracePoolKeys :: [KeyPair]
-tracePoolKeys = (fst . mkKeyPairs) <$> ((maxNumKeyPairs +) <$> [1 .. maxPoolKeys])
-
-tracePoolKeysMap :: Map KeyHash KeyPair
-tracePoolKeysMap =
-  Map.fromList ((\k -> ((hashKey . vKey) k, k)) <$> tracePoolKeys)
+traceKeyPairsByStakeHash
+  :: Map KeyHash KeyPair
+traceKeyPairsByStakeHash =
+  Map.fromList (f <$> traceKeyPairs)
+  where
+    f (_payK, stakeK) = ((hashKey . vKey) stakeK, stakeK)
 
 -- | Mapping from key hash to key pair
 traceKeyHashMap :: Map AnyKeyHash KeyPair

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/LedgerTrace/QuickCheck.hs
@@ -27,8 +27,8 @@ import           Data.Word (Word64)
 
 import           Generator.Core.Constants (maxGenesisUTxOouts, minGenesisUTxOouts, numBaseScripts)
 import           Generator.Core.QuickCheck (coreNodeKeys, genCoin, genUtxo0, genesisDelegs0,
-                     traceKeyHashMap, traceKeyPairs, traceMSigCombinations, traceMSigScripts,
-                     tracePoolKeys, tracePoolKeysMap, traceVRFKeyPairs)
+                     traceKeyHashMap, traceKeyPairs, traceKeyPairsByStakeHash,
+                     traceMSigCombinations, traceMSigScripts, traceVRFKeyPairs)
 import           Generator.Update.QuickCheck (genPParams)
 import           Generator.Utxo.QuickCheck (genTx)
 import           LedgerState (pattern LedgerState, genesisState)
@@ -53,10 +53,9 @@ instance TQC.HasTrace LEDGER Word64 where
      ledgerSt
      traceKeyPairs
      traceKeyHashMap
-     tracePoolKeys
      (traceMSigCombinations $ take numBaseScripts traceMSigScripts)
      coreNodeKeys
-     tracePoolKeysMap
+     traceKeyPairsByStakeHash
      traceVRFKeyPairs
 
   shrinkSignal = shrinkTx

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
@@ -55,13 +55,12 @@ genTx :: LedgerEnv
       -> (UTxOState, DPState)
       -> KeyPairs
       -> Map AnyKeyHash KeyPair
-      -> [KeyPair]
       -> MultiSigPairs
       -> [(CoreKeyPair, AllPoolKeys)]
       -> Map KeyHash KeyPair -- indexed keys By StakeHash
       -> VrfKeyPairs
       -> Gen Tx
-genTx (LedgerEnv slot _ pparams _) (utxoSt@(UTxOState utxo _ _ _), dpState) keys keyHashMap poolKeys scripts coreKeys keysByStakeHash vrfKeys = do
+genTx (LedgerEnv slot _ pparams _) (utxoSt@(UTxOState utxo _ _ _), dpState) keys keyHashMap scripts coreKeys keysByStakeHash vrfKeys = do
   keys' <- QC.shuffle keys
   scripts' <- QC.shuffle scripts
 
@@ -91,7 +90,7 @@ genTx (LedgerEnv slot _ pparams _) (utxoSt@(UTxOState utxo _ _ _), dpState) keys
 
   -- certificates
   (certs, certCreds, deposits_, refunds_)
-    <- genDCerts keys' keyHashMap scripts' poolKeys (fst <$> coreKeys) vrfKeys keysByStakeHash pparams dpState slot ttl
+    <- genDCerts keys' keyHashMap scripts' (fst <$> coreKeys) vrfKeys keysByStakeHash pparams dpState slot ttl
 
   if spendingBalance < deposits_
     then D.trace ("discarded") QC.discard


### PR DESCRIPTION
This turned out to be unnecessary and added unneeded complexity.