### PR TITLE
Pass TICK changes in pParams and account state to LEDGER siggen

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -200,12 +200,11 @@ genSetOfPpm pp = do
       , MaxBBSize             <$> genSize
       , MaxTxSize             <$> genSize
       , MaxBHSize             <$> genSize
-      -- TODO @uroboros - these params lead to ValueNotConserved predicate failures
-      -- , KeyDeposit            <$> genKeyDeposit
-      -- , KeyMinRefund          <$> genKeyMinRefund
-      -- , KeyDecayRate          <$> genKeyDecayRate
-      -- , PoolDeposit           <$> genPoolDeposit
-      -- , PoolMinRefund         <$> genPoolMinRefund
+      , KeyDeposit            <$> genKeyDeposit
+      , KeyMinRefund          <$> genKeyMinRefund
+      , KeyDecayRate          <$> genKeyDecayRate
+      , PoolDeposit           <$> genPoolDeposit
+      , PoolMinRefund         <$> genPoolMinRefund
       , PoolDecayRate         <$> genPoolDecayRate
       , EMax                  <$> genEMax
       , Nopt                  <$> genNOpt

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
@@ -216,5 +216,5 @@ propAbstractSizeNotTooBig = property $ do
     all notTooBig txs
 
 onlyValidChainSignalsAreGenerated :: Property
-onlyValidChainSignalsAreGenerated = withMaxSuccess 100 $
+onlyValidChainSignalsAreGenerated = withMaxSuccess 200 $
   onlyValidSignalsAreGeneratedFromInitState @CHAIN testGlobals 200 (200::Word64) (Just mkGenesisChainState)


### PR DESCRIPTION
When the protocol parameters are changed, the new ones have to be used to
generate the transactions for LEDGERS.

There can also be a change to the reserves in TICK, so we also used the
potentially new value to pass it on to the signal generator of LEDGERS.

Closes #1211