### PR TITLE
Simple fee calculation

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
@@ -96,11 +96,11 @@ maxNumKeyPairs = 150
 
 -- | minimal coin value for generated genesis outputs
 minGenesisOutputVal :: Integer
-minGenesisOutputVal = 1000
+minGenesisOutputVal = 1000000
 
 -- | maximal coin value for generated genesis outputs
 maxGenesisOutputVal :: Integer
-maxGenesisOutputVal = 10000
+maxGenesisOutputVal = 100000000
 
 -- | Number of base scripts from which multi sig scripts are built.
 numBaseScripts :: Int

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
@@ -3,6 +3,7 @@ module Generator.Core.Constants
 where
 
 import           Data.Word (Word64)
+import           Numeric.Natural (Natural)
 
 -- | minimal number of addresses for transaction outputs
 minNumGenAddr :: Int
@@ -135,3 +136,9 @@ maxSlotTrace = 5000
 -- | Lower bound of the MaxEpoch protocol parameter
 frequencyLowMaxEpoch :: Word64
 frequencyLowMaxEpoch = 6
+
+maxMinFeeA :: Integer
+maxMinFeeA = 1000
+
+maxMinFeeB :: Natural
+maxMinFeeB = 3

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -196,7 +196,7 @@ genSetOfPpm
 genSetOfPpm pp = do
   n <- QC.elements [1 .. 3] -- pick up to three param updates
   subsetOf n [
-        MinFeeB               <$> pure 0 -- TODO @uroboros disable until tx fees are dealt with (genNatural 0 10)
+        MinFeeB               <$> genNatural 0 3
       , MaxBBSize             <$> genSize
       , MaxTxSize             <$> genSize
       , MaxBHSize             <$> genSize

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -55,8 +55,8 @@ genIntervalInThousands lower upper =
 
 -- TODO @uroboros for now, keeping minA/B at zero until we generate fees in genTx
 genPParams :: Gen PParams
-genPParams = mkPParams <$> pure 0 -- _minfeeA
-                       <*> pure 0 -- _minfeeB
+genPParams = mkPParams <$> genInteger 0 1000 -- _minfeeA
+                       <*> genNatural 0 2    -- _minfeeB
                        <*> szGen  -- (maxBBSize, maxBHSize, maxTxSize)
                        <*> genKeyDeposit
                        <*> genKeyMinRefund

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -30,7 +30,8 @@ import           Coin (Coin (..))
 import           ConcreteCryptoTypes (AVUpdate, Applications, CoreKeyPair, DPState, GenKeyHash,
                      KeyHash, KeyPair, Mdt, PPUpdate, UTxOState, Update)
 import           Examples (unsafeMkUnitInterval)
-import           Generator.Core.Constants (frequencyLowMaxEpoch, frequencyTxUpdates)
+import           Generator.Core.Constants (frequencyLowMaxEpoch, frequencyTxUpdates, maxMinFeeA,
+                     maxMinFeeB)
 import           Generator.Core.QuickCheck (AllPoolKeys (cold), genInteger, genNatural, genWord64,
                      increasingProbabilityAt, tooLateInEpoch)
 import           Keys (GenDelegs (..), hash, hashKey, vKey)
@@ -53,10 +54,9 @@ genIntervalInThousands :: Integer -> Integer -> Gen UnitInterval
 genIntervalInThousands lower upper =
   unsafeMkUnitInterval <$> genRationalInThousands lower upper
 
--- TODO @uroboros for now, keeping minA/B at zero until we generate fees in genTx
 genPParams :: Gen PParams
-genPParams = mkPParams <$> genInteger 0 1000 -- _minfeeA
-                       <*> genNatural 0 2    -- _minfeeB
+genPParams = mkPParams <$> genInteger 0 maxMinFeeA -- _minfeeA
+                       <*> genNatural 0 maxMinFeeB -- _minfeeB
                        <*> szGen  -- (maxBBSize, maxBHSize, maxTxSize)
                        <*> genKeyDeposit
                        <*> genKeyMinRefund
@@ -196,7 +196,7 @@ genSetOfPpm
 genSetOfPpm pp = do
   n <- QC.elements [1 .. 3] -- pick up to three param updates
   subsetOf n [
-        MinFeeB               <$> genNatural 0 3
+        MinFeeB               <$> genNatural 0 maxMinFeeB
       , MaxBBSize             <$> genSize
       , MaxTxSize             <$> genSize
       , MaxBHSize             <$> genSize

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
@@ -176,8 +176,12 @@ genTxBody inputs outputs certs wdrls update fee slotWithTTL = do
              update
              Nothing -- TODO generate metadata
 
--- | Calculate the fee and distribute the remainder of the balance
--- to the given addresses (as transaction outputs)
+-- | Distribute the sum of `balance_` and `fee` over the addresses, return the
+-- sum of `fee` and the remainder of the equal distribution and the list ouf
+-- transaction outputs that cover the balance and fees.
+--
+-- The idea is to have an specified spending balance and fees that must be paid
+-- by the selected addresses.
 calcFeeAndOutputs
   :: Coin
   -> [Addr]
@@ -187,12 +191,6 @@ calcFeeAndOutputs balance_ addrs fee =
   ( fee + splitCoinRem
   , (`TxOut` amountPerOutput) <$> Seq.fromList addrs)
   where
-    -- TODO @uroboros fee=0 works for now since PParams minFeeA/B == 0.
-    --      We need to instead add a "draft" TxBody as argument, which will
-    --      give a measure of the minimum fee for this transaction.
-    --      This estimated fee can then be used to create the actual TxBody,
-    --      with the new fee baked in.
-    -- fee = 0
     -- split the available balance into equal portions (one for each address),
     -- if there is a remainder, then add it to the fee.
     balanceAfterFee = balance_ - fee


### PR DESCRIPTION
This introduces a simple fee calculation for the generated transactions.

Effectively we use the original transaction, then-recalculate the fees and update the Tx fees and pay the fees from the generated TxOuts.

If the fees cannot be covered we discard the Tx.

resolve #876 