### PR TITLE
protocol version as two naturals

### DIFF
--- a/shelley/chain-and-ledger/cddl-spec/shelley.cddl
+++ b/shelley/chain-and-ledger/cddl-spec/shelley.cddl
@@ -1,7 +1,5 @@
 ; Shelley Types
 
-output = transaction_metadata
-
 block =
   [ header
   , transaction_bodies         : [* transaction_body]  ; 19
@@ -15,32 +13,32 @@ transaction_index = uint
 
 header =
   ( header_body
-  , body_signature : $kes_signature  ; 18
+  , body_signature : $kes_signature
   )
 
 header_body =
-  ( prev_hash        : $hash       ; 1
-  , issuer_vkey      : $vkey       ; 2
-  , vrf_vkey         : $vrf_vkey   ; 3
-  , slot             : uint        ; 4
-  , nonce_vrf        : $vrf_cert   ; 5
-  , leader_vrf       : $vrf_cert   ; 6
-  , size             : uint        ; 7
-  , block_number     : uint        ; 8
-  , block_body_hash  : $hash       ; 9    ; merkle triple root
+  ( prev_hash        : $hash
+  , issuer_vkey      : $vkey
+  , vrf_vkey         : $vrf_vkey
+  , slot             : uint
+  , nonce_vrf        : $vrf_cert
+  , leader_vrf       : $vrf_cert
+  , size             : uint
+  , block_number     : uint
+  , block_body_hash  : $hash ; merkle triple root
   , operational_cert
   , protocol_version
   )
 
 operational_cert =
-  ( hot_vkey        : $kes_vkey    ; 10
-  , cold_vkey       : $vkey        ; 11
-  , sequence_number : uint         ; 12
-  , kes_period      : uint         ; 13
-  , sigma           : $signature   ; 14
+  ( hot_vkey        : $kes_vkey
+  , cold_vkey       : $vkey
+  , sequence_number : uint
+  , kes_period      : uint
+  , sigma           : $signature
   )
 
-protocol_version = (uint, uint, uint)   ; 15 16 17
+protocol_version = (uint, uint)
 
 ; Do we want to use a Map here? Is it actually cheaper?
 ; Do we want to add extension points here?
@@ -148,8 +146,8 @@ application_version_update = { * application_name =>  [uint, application_metadat
 
 application_metadata = { * system_tag => installerhash }
 
-application_name = tstr .size 12
-system_tag = tstr .size 10
+application_name = tstr .size 64
+system_tag = tstr .size 64
 
 transaction_witness_set =
   { ?0 => [* pubkey_witness]
@@ -170,12 +168,13 @@ transaction_metadata = { * transaction_metadadum_label => transaction_metadatum 
 
 vkeywitness = [$vkey, $signature]
 
-unit_interval = rational    ; FIXME: replace with uint for fixed precision
+unit_interval = rational
 
-rational =                  ; FIXME: replace with uint for fixed precision
+; rational =  #6.30( TODO use the cbor tag
+rational =
    [ numerator   : uint
    , denominator : uint
-   ]
+   ] ;)
 
 coin = uint
 epoch = uint

--- a/shelley/chain-and-ledger/executable-spec/src/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/PParams.hs
@@ -81,7 +81,7 @@ data PParams = PParams
     -- | Extra entropy
   , _extraEntropy    :: Nonce
     -- | Protocol version
-  , _protocolVersion :: (Natural, Natural, Natural)
+  , _protocolVersion :: (Natural, Natural)
   } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks PParams
@@ -183,5 +183,5 @@ emptyPParams =
      , _activeSlotCoeff = interval0
      , _d = interval0
      , _extraEntropy = NeutralNonce
-     , _protocolVersion = (0, 0, 0)
+     , _protocolVersion = (0, 0)
      }

--- a/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Ppup.hs
@@ -19,7 +19,6 @@ import           Cardano.Ledger.Shelley.Crypto (Crypto)
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Control.Monad.Trans.Reader (asks)
 import           Control.State.Transition
-import           Data.Ix (inRange)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import           Data.Typeable (Typeable)
@@ -105,12 +104,9 @@ instance
       5 -> matchSize "PVCannotFollowPPUP" 1 n >> pure PVCannotFollowPPUP
       k -> invalidKey k
 
-pvCanFollow :: (Natural, Natural, Natural) -> Ppm -> Bool
-pvCanFollow (mjp, mip, ap) (ProtocolVersion (mjn, mn, an))
-  = (mjp, mip, ap) < (mjn, mn, an)
-  && inRange (0,1) (mjn - mjp)
-  && ((mjp == mjn) ==> (mip + 1 == mn))
-  && ((mjp + 1 == mjn) ==> (mn == 0))
+pvCanFollow :: (Natural, Natural) -> Ppm -> Bool
+pvCanFollow (m, n) (ProtocolVersion (m', n'))
+  = (m+1, 0) == (m', n') || (m, n+1) == (m', n')
 pvCanFollow _ _ = True
 
 ppupTransitionEmpty :: TransitionRule (PPUP crypto)

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -117,10 +117,9 @@ import           TxData (pattern AddrPtr, pattern DCertDeleg, pattern DCertGenes
                      addStakeCreds, _poolCost, _poolMargin, _poolOwners, _poolPledge, _poolPubKey,
                      _poolRAcnt, _poolVrf)
 import qualified TxData (TxBody (..))
-import           Updates (pattern AVUpdate, ApName (..), ApVer (..), pattern Applications,
-                     InstallerHash (..), pattern Mdt, pattern PPUpdate, PParamsUpdate (..),
-                     Ppm (..), SystemTag (..), pattern Update, pattern UpdateState, emptyUpdate,
-                     emptyUpdateState)
+import           Updates (pattern AVUpdate, ApVer (..), pattern Applications, InstallerHash (..),
+                     pattern Mdt, pattern PPUpdate, PParamsUpdate (..), Ppm (..), pattern Update,
+                     pattern UpdateState, apName, emptyUpdate, emptyUpdateState, systemTag)
 import           UTxO (pattern UTxO, balance, makeGenWitnessesVKey, makeWitnessesVKey, txid)
 
 data CHAINExample =
@@ -169,8 +168,8 @@ genDelegs = Map.fromList [ (hashKey $ snd gkey, hashKey . vKey $ cold pkeys) | (
 -- | There are only two applications on test Byron blockchain:
 byronApps :: Applications
 byronApps = Applications $ Map.fromList
-                            [ (ApName $ T.pack "Daedalus", (ApVer 16, Mdt Map.empty))
-                            , (ApName $ T.pack "Yoroi", (ApVer 4, Mdt Map.empty))
+                            [ (apName $ T.pack "Daedalus", (ApVer 16, Mdt Map.empty))
+                            , (apName $ T.pack "Yoroi", (ApVer 4, Mdt Map.empty))
                             ]
 
 alicePay :: KeyPair
@@ -1817,12 +1816,12 @@ ex3C = CHAINExample (SlotNo 110) expectedStEx3B blockEx3C (Right expectedStEx3C)
 
 daedalusMDEx4A :: Mdt
 daedalusMDEx4A = Mdt $ Map.singleton
-                              (SystemTag $ T.pack "DOS")
+                              (systemTag $ T.pack "DOS")
                               (InstallerHash $ hash $ BS.pack "ABC")
 
 appsEx4A :: Applications
 appsEx4A = Applications $ Map.singleton
-                            (ApName $ T.pack "Daedalus")
+                            (apName $ T.pack "Daedalus")
                             (ApVer 17, daedalusMDEx4A)
 
 avupEx4A :: AVUpdate
@@ -2035,8 +2034,8 @@ updateStEx4C = UpdateState
   (AVUpdate Map.empty)
   Map.empty
   (Applications $ Map.fromList
-                     [ (ApName $ T.pack "Daedalus", (ApVer 17, daedalusMDEx4A))
-                     , (ApName $ T.pack "Yoroi", (ApVer 4, Mdt Map.empty))
+                     [ (apName $ T.pack "Daedalus", (ApVer 17, daedalusMDEx4A))
+                     , (apName $ T.pack "Yoroi", (ApVer 4, Mdt Map.empty))
                      ])
 
 expectedLSEx4C :: LedgerState

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
@@ -43,7 +43,7 @@ import           Shrinkers (shrinkBlock)
 import           Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import           STS.Chain (initialShelleyState)
 import           Test.Utils (runShelleyBase)
-import           Updates (ApName (..), ApVer (..), pattern Applications, pattern Mdt)
+import           Updates (ApVer (..), pattern Applications, pattern Mdt, apName)
 import           UTxO (balance)
 
 -- The CHAIN STS at the root of the STS allows for generating blocks of transactions
@@ -74,11 +74,11 @@ lastByronHeaderHash = HashHeader $ unsafeCoerce (hash 0 :: Hash ShortHash Int)
 
 byronApps :: Applications
 byronApps = Applications $ Map.fromList
-                            [ (ApName $ T.pack "Daedalus", (ApVer 16, Mdt Map.empty))
-                            , (ApName $ T.pack "Yoroi", (ApVer 4, Mdt Map.empty))
-                            , (ApName $ T.pack "Ahoy", (ApVer 7, Mdt Map.empty))
-                            , (ApName $ T.pack "Shebang", (ApVer 11, Mdt Map.empty))
-                            , (ApName $ T.pack "Icarus", (ApVer 13, Mdt Map.empty))
+                            [ (apName $ T.pack "Daedalus", (ApVer 16, Mdt Map.empty))
+                            , (apName $ T.pack "Yoroi", (ApVer 4, Mdt Map.empty))
+                            , (apName $ T.pack "Ahoy", (ApVer 7, Mdt Map.empty))
+                            , (apName $ T.pack "Shebang", (ApVer 11, Mdt Map.empty))
+                            , (apName $ T.pack "Icarus", (ApVer 13, Mdt Map.empty))
                             ]
 
 -- Note: this function must be usable in place of 'applySTS' and needs to align

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
@@ -51,9 +51,9 @@ import           TxData (pattern AddrBase, pattern AddrEnterprise, pattern AddrP
                      pattern RewardAcnt, pattern ScriptHash, pattern TxBody, pattern TxIn,
                      pattern TxOut, Wdrl (..), WitVKey (..), _TxId, _poolCost, _poolMargin,
                      _poolOwners, _poolPledge, _poolPubKey, _poolRAcnt, _poolVrf)
-import           Updates (pattern AVUpdate, ApName (..), ApVer (..), pattern Applications,
-                     pattern InstallerHash, pattern Mdt, pattern PPUpdate, PParamsUpdate (..),
-                     Ppm (..), SystemTag (..), pattern Update, emptyUpdate)
+import           Updates (pattern AVUpdate, ApVer (..), pattern Applications, pattern InstallerHash,
+                     pattern Mdt, pattern PPUpdate, PParamsUpdate (..), Ppm (..), pattern Update,
+                     apName, emptyUpdate, systemTag)
 
 import           ConcreteCryptoTypes (Addr, BHBody, CoreKeyPair, GenKeyHash, HashHeader,
                      InstallerHash, KeyHash, KeyPair, MultiSig, PoolDistr, RewardUpdate, SKeyES,
@@ -498,7 +498,7 @@ serializationTests = testGroup "Serialization Tests"
         activeSlotCoefficient = UnsafeUnitInterval $ 1 % 8
         d                     = UnsafeUnitInterval $ 1 % 9
         extraEntropy          = NeutralNonce
-        protocolVersion       = (0,1,2)
+        protocolVersion       = (0,1)
     in
     checkEncodingCBOR "pparams_update_all"
     (PParamsUpdate $ Set.fromList
@@ -547,28 +547,28 @@ serializationTests = testGroup "Serialization Tests"
 
   -- checkEncodingCBOR "avupdate"
   , let
-      appName   = ApName $ T.pack "Daedalus"
-      systemTag = SystemTag $ T.pack "DOS"
+      apname   = apName $ T.pack "Daedalus"
+      systemtag = systemTag $ T.pack "DOS"
       apVer    = ApVer 17
     in
     checkEncodingCBOR "avupdate"
     (AVUpdate (Map.singleton
                 testGKeyHash
                 (Applications (Map.singleton
-                       appName
+                       apname
                        (apVer
                        , Mdt $ Map.singleton
-                           systemTag
+                           systemtag
                            testInstallerHash
                        )))))
     ( (T $ TkMapLen 1 )
       <> S testGKeyHash
       <> (T $ TkMapLen 1 )
-        <> S appName
+        <> S apname
         <> (T $ TkListLen 2)
         <> S apVer
         <> (T $ TkMapLen 1 )
-        <> S systemTag
+        <> S systemtag
         <> S testInstallerHash
     )
 
@@ -580,10 +580,10 @@ serializationTests = testGroup "Serialization Tests"
       avup = AVUpdate (Map.singleton
                   testGKeyHash
                   (Applications (Map.singleton
-                         (ApName $ T.pack "Daedalus")
+                         (apName $ T.pack "Daedalus")
                          (ApVer 17
                          , Mdt $ Map.singleton
-                             (SystemTag $ T.pack "DOS")
+                             (systemTag $ T.pack "DOS")
                              testInstallerHash
                          ))))
       e = Just $ EpochNo 0
@@ -635,10 +635,10 @@ serializationTests = testGroup "Serialization Tests"
              (AVUpdate (Map.singleton
                          testGKeyHash
                          (Applications (Map.singleton
-                                (ApName $ T.pack "Daedalus")
+                                (apName $ T.pack "Daedalus")
                                 (ApVer 17
                                 , Mdt $ Map.singleton
-                                    (SystemTag $ T.pack "DOS")
+                                    (systemTag $ T.pack "DOS")
                                     testInstallerHash
                                 )))))
              (Just $ EpochNo 0)
@@ -683,10 +683,10 @@ serializationTests = testGroup "Serialization Tests"
              (AVUpdate (Map.singleton
                          testGKeyHash
                          (Applications (Map.singleton
-                                (ApName $ T.pack "Daedalus")
+                                (apName $ T.pack "Daedalus")
                                 (ApVer 17
                                 , Mdt $ Map.singleton
-                                    (SystemTag $ T.pack "DOS")
+                                    (systemTag $ T.pack "DOS")
                                     testInstallerHash
                                 )))))
              (Just $ EpochNo 0)

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -205,10 +205,6 @@ determines what is being voted on, e.g. the application version.
 Recall here that $\type{T}^?$ is the option type, see \ref{sec:notation-shelley},
 and a term of this type can have a value of type $\type{T}$ or no value.
 
-The function $\fun{validAV}$ uses three functions from \cite{byron_ledger_spec}, namely
-$\fun{apNameValid}$, $\fun{svCanFollow}$, and $\fun{sTagValid}$. It determines
-whether an application version is valid, given its name, version number,
-metadata, and a set of applications to compare against.
 The function $\fun{newAVs}$ adds the most recent valid application
 versions to a finite map of applications using right override.
 This helper function will be used in the ledger update.
@@ -317,19 +313,15 @@ this update will become the current AV.
 All other update proposals are scrapped.
 \end{itemize}
 
-The AVUP rule has three predicate failures:
+The AVUP rule has two predicate failures:
 \begin{itemize}
 \item In the case of \var{aup} being non-empty, if the check $\dom aup \subseteq
   \dom genDelegs$ fails, there is a \emph{NonGenesisUpdate} failure as only genesis keys
   can be used in the application version update.
-\item In the case of \var{aup} being non-empty, if any of the application names
-  in the proposal are invalid, there is a \emph{InvalidName} failure.
 \item In the case of \var{aup} being non-empty, if any of the application versions
   in the proposal are not exactly one more than the greatest version for the given
   application name in the current application versions or the future application
   versions, there is a \emph{CannotFollow} failure.
-\item In the case of \var{aup} being non-empty, if any of the metadata in
-  in the proposal contains an invalid system tag, there is a \emph{InvalidSystemTags} failure.
 \end{itemize}
 
 \begin{figure}[htb]
@@ -406,14 +398,8 @@ The AVUP rule has three predicate failures:
       &
       \dom{\var{aup}}\subseteq\dom{\var{genDelegs}}
       \\
-      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\in\dom{vote},~
-        \fun{apNameValid}~\var{v}
-      \\
       \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\mapsto(v,~\wcard)\in\var{vote},~
       \fun{svCanFollow}~\var{avs}~\var{favs}~\var{n}~\var{v}
-      \\
-      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall \wcard\mapsto(\wcard,~m)\in\var{vote},~
-      \forall \var{st}\mapsto\wcard\in\var{m},~ \fun{sTagValid}~\var{st}
       \\
       \var{aup'}\leteq\var{aup_s}\unionoverrideRight\var{aup}
       \\
@@ -454,14 +440,8 @@ The AVUP rule has three predicate failures:
       &
       \dom{\var{aup}}\subseteq\dom{\var{genDelegs}}
       \\
-      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\in\dom{vote},~
-        \fun{apNameValid}~\var{v}
-      \\
       \forall \wcard\mapsto\var{vote}\in\var{aup},\forall n\mapsto(v,~\wcard)\in\var{vote},~
         \fun{svCanFollow}~\var{avs}~\var{favs}~\var{n}~\var{v}
-      \\
-      \forall \wcard\mapsto\var{vote}\in\var{aup},\forall \wcard\mapsto(\wcard,~m)\in\var{vote},~
-      \forall \var{st}\mapsto\wcard\in\var{m},~ \fun{sTagValid}~\var{st}
       \\
       \var{aup'}\leteq\var{aup_s}\unionoverrideRight\var{aup}
       \\


### PR DESCRIPTION
This PR does two main things:
* the protocol version is now a pair of numbers instead of a triple. The rules for increasing the protocol version now simplify to `(m,n) -> (m,n+1)` or `(m,n) -> (m+1, n)`
* inside of application version updates, the `ApName` and `SystemTag` types are now restricted to UTF8 (instead of ascii) and 64 bytes instead of 10 and 12.  I think it no longer makes much sense to enforce the sizes in the formal spec, but in the types and the serialization. I have removed the restrictions from the pdf, and in the exec model we now replace the constructors with functions that do not allow more than 64 bytes, and the FromCBOR instances no longer allow for deserializing more than 64 bytes.

closes #1148 