### PR TITLE
stake pool desirability ranking

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -29,6 +29,7 @@ library
                      Shelley.Spec.Ledger.UTxO
                      Shelley.Spec.Ledger.Slot
                      Shelley.Spec.Ledger.PParams
+                     Shelley.Spec.Ledger.Rewards
                      Shelley.Spec.Ledger.EpochBoundary
                      Shelley.Spec.Ledger.LedgerState
                      Shelley.Spec.Ledger.MetaData

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -16,6 +16,7 @@ module Shelley.Spec.Ledger.EpochBoundary
   , BlocksMade(..)
   , SnapShot(..)
   , SnapShots(..)
+  , emptySnapShot
   , emptySnapShots
   , rewardStake
   , aggregateOuts
@@ -60,7 +61,7 @@ newtype BlocksMade crypto
 
 -- | Type of stake as map from hash key to coins associated.
 newtype Stake crypto
-  = Stake (Map (Credential crypto) Coin)
+  = Stake { unStake :: (Map (Credential crypto) Coin) }
   deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
 -- | Add two stake distributions
@@ -257,7 +258,8 @@ instance
       f <- fromCBOR
       pure $ SnapShots mark set go f
 
+emptySnapShot :: SnapShot crypto
+emptySnapShot = SnapShot (Stake Map.empty) Map.empty Map.empty
+
 emptySnapShots :: SnapShots crypto
-emptySnapShots =
-    SnapShots snapEmpty snapEmpty snapEmpty (Coin 0)
-    where snapEmpty   = SnapShot (Stake Map.empty) Map.empty Map.empty
+emptySnapShots = SnapShots emptySnapShot emptySnapShot emptySnapShot (Coin 0)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -1,0 +1,300 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Shelley.Spec.Ledger.Rewards
+  ( desirability
+  , ApparentPerformance (..)
+  , NonMyopic (..)
+  , emptyNonMyopic
+  , getTopRankedPools
+  , StakeShare(..)
+  , mkApparentPerformance
+  , reward
+  , nonMyopicStake
+  , nonMyopicMemberRew
+  ) where
+
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeDouble, encodeDouble,
+                     encodeListLen, enforceSize)
+import           Cardano.Ledger.Shelley.Crypto (Crypto)
+import           Cardano.Prelude (NoUnexpectedThunks (..))
+
+import           Data.Function (on)
+import           Data.List (sortBy)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Data.Maybe (fromMaybe)
+import           Data.Ratio ((%))
+import           Data.Set (Set)
+import qualified Data.Set as Set
+import           GHC.Generics (Generic)
+import           Numeric.Natural (Natural)
+
+import           Ledger.Core ((◁))
+import           Shelley.Spec.Ledger.BaseTypes (UnitInterval (..), intervalValue, mkUnitInterval)
+import           Shelley.Spec.Ledger.Coin (Coin (..))
+import           Shelley.Spec.Ledger.Delegation.PoolParams (poolSpec)
+import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), SnapShot (..), Stake (..),
+                     emptySnapShot, maxPool, poolStake)
+import           Shelley.Spec.Ledger.Keys (KeyHash)
+import           Shelley.Spec.Ledger.PParams (PParams (..))
+import           Shelley.Spec.Ledger.TxData (Credential (..), PoolParams (..), RewardAcnt (..))
+
+
+newtype ApparentPerformance = ApparentPerformance { unApparentPerformance :: Double }
+  deriving (Show, Eq, Generic, NoUnexpectedThunks)
+
+instance ToCBOR ApparentPerformance
+ where toCBOR = encodeDouble . unApparentPerformance
+
+instance FromCBOR ApparentPerformance
+ where fromCBOR = ApparentPerformance <$> decodeDouble
+
+data NonMyopic crypto= NonMyopic
+  { apparentPerformances :: Map (KeyHash crypto) ApparentPerformance
+  , rewardPot :: Coin
+  , snap :: SnapShot crypto
+  } deriving (Show, Eq, Generic)
+
+emptyNonMyopic :: NonMyopic crypto
+emptyNonMyopic = NonMyopic Map.empty (Coin 0) emptySnapShot
+
+instance NoUnexpectedThunks (NonMyopic crypto)
+
+instance Crypto crypto => ToCBOR (NonMyopic crypto)
+ where
+  toCBOR NonMyopic
+           { apparentPerformances = aps
+           , rewardPot = rp
+           , snap = s
+           } =
+    encodeListLen 3
+      <> toCBOR aps
+      <> toCBOR rp
+      <> toCBOR s
+
+instance Crypto crypto => FromCBOR (NonMyopic crypto)
+ where
+  fromCBOR = do
+    enforceSize "NonMyopic" 3
+    aps <- fromCBOR
+    rp <- fromCBOR
+    s <- fromCBOR
+    pure $ NonMyopic { apparentPerformances = aps
+                     , rewardPot = rp
+                     , snap = s
+                     }
+
+-- | Desirability calculation for non-myopic utily,
+-- corresponding to f^~ in section 5.6.1 of
+-- "Design Specification for Delegation and Incentives in Cardano"
+desirability
+  :: PParams
+  -> Coin
+  -> PoolParams crypto
+  -> ApparentPerformance
+  -> Coin
+  -> Double
+desirability pp r pool (ApparentPerformance p) (Coin total) =
+  if fTilde <= cost
+    then 0
+    else (fTilde - cost)*(1 - margin)
+  where
+    fTilde      = fTildeNumer / fTildeDenom
+    fTildeNumer = p * fromRational (fromIntegral r * (z0 + min s z0 * a0))
+    fTildeDenom = fromRational $ 1 + a0
+
+    cost   = (fromIntegral . _poolCost) pool
+    margin = (fromRational . intervalValue . _poolMargin) pool
+    tot = max 1 (fromIntegral total)
+
+    Coin pledge = _poolPledge pool
+    s = fromIntegral pledge % tot
+    a0 = _a0 pp
+    z0 = 1 % max 1 (fromIntegral (_nOpt pp))
+
+-- | Computes the top ranked stake pools
+-- corresponding to section 5.6.1 of
+-- "Design Specification for Delegation and Incentives in Cardano"
+getTopRankedPools
+  :: Coin
+  -> Coin
+  -> PParams
+  -> Map (KeyHash crypto) (PoolParams crypto)
+  -> Map (KeyHash crypto) ApparentPerformance
+  -> Set (KeyHash crypto)
+getTopRankedPools rPot total pp poolParams aps =
+  Set.fromList $ fmap fst $
+    take (fromIntegral $ _nOpt pp) (sortBy (flip compare `on` snd) rankings)
+  where
+    pdata =
+      [ ( hk
+        , ( poolParams Map.! hk
+          , aps Map.! hk))
+      | hk <-
+          Set.toList $ Map.keysSet poolParams `Set.intersection` Map.keysSet aps
+      ]
+    rankings =
+      [ ( hk
+        , desirability pp rPot pool ap total)
+      | (hk, (pool, ap)) <- pdata
+      ]
+
+-- | StakeShare type
+newtype StakeShare =
+  StakeShare Rational
+  deriving (Show, Ord, Eq, NoUnexpectedThunks)
+
+-- | Calculate pool reward
+mkApparentPerformance
+  :: UnitInterval
+  -> UnitInterval
+  -> Natural
+  -> Natural
+  -> Rational
+mkApparentPerformance d_ sigma blocksN blocksTotal
+  | sigma' == 0 = 0
+  | intervalValue d_ < 0.8 = beta / sigma'
+  | otherwise = 1
+  where
+    beta = fromIntegral blocksN / fromIntegral (max 1 blocksTotal)
+    sigma' = intervalValue sigma
+
+-- | Calculate pool leader reward
+leaderRew
+  :: Coin
+  -> PoolParams crypto
+  -> StakeShare
+  -> StakeShare
+  -> Coin
+leaderRew f@(Coin f') pool (StakeShare s) (StakeShare sigma)
+  | f' <= c = f
+  | otherwise =
+    Coin $ c + floor (fromIntegral (f' - c) * (m' + (1 - m') * s / sigma))
+  where
+    (Coin c, m, _) = poolSpec pool
+    m' = intervalValue m
+
+-- | Calculate pool member reward
+memberRew
+  :: Coin
+  -> PoolParams crypto
+  -> StakeShare
+  -> StakeShare
+  -> Coin
+memberRew (Coin f') pool (StakeShare t) (StakeShare sigma)
+  | f' <= c = 0
+  | otherwise = floor $ fromIntegral (f' - c) * (1 - m') * t / sigma
+  where
+    (Coin c, m, _) = poolSpec pool
+    m' = intervalValue m
+
+-- | Reward one pool
+rewardOnePool
+  :: PParams
+  -> Coin
+  -> Natural
+  -> Natural
+  -> Credential crypto
+  -> PoolParams crypto
+  -> Stake crypto
+  -> Coin
+  -> Set (RewardAcnt crypto)
+  -> (Map (RewardAcnt crypto) Coin, Rational)
+rewardOnePool pp r blocksN blocksTotal poolHK pool (Stake stake) (Coin total) addrsRew =
+  (rewards', appPerf)
+  where
+    Coin pstake = sum stake
+    Coin ostake = Set.foldl
+                    (\c o -> c + (stake Map.! KeyHashObj o))
+                    (Coin 0)
+                    (_poolOwners pool)
+    sigma = fromIntegral pstake % fromIntegral total
+    Coin pledge = _poolPledge pool
+    pr = fromIntegral pledge % fromIntegral total
+    (Coin maxP) =
+      if pledge <= ostake
+        then maxPool pp r sigma pr
+        else 0
+    s' = fromMaybe (error "LedgerState.rewardOnePool: Unexpected Nothing") $ mkUnitInterval sigma
+    appPerf = mkApparentPerformance (_d pp) s' blocksN blocksTotal
+    poolR = floor (appPerf * fromIntegral maxP)
+    tot = fromIntegral total
+    mRewards = Map.fromList
+     [(RewardAcnt hk,
+       memberRew poolR pool (StakeShare (fromIntegral c % tot)) (StakeShare sigma))
+     | (hk, Coin c) <- Map.toList stake, hk /= poolHK]
+    iReward  = leaderRew poolR pool (StakeShare $ fromIntegral ostake % tot) (StakeShare sigma)
+    potentialRewards = Map.insert (_poolRAcnt pool) iReward mRewards
+    rewards' = Map.filter (/= Coin 0) $ addrsRew ◁ potentialRewards
+
+reward
+  :: PParams
+  -> BlocksMade crypto
+  -> Coin
+  -> Set (RewardAcnt crypto)
+  -> Map (KeyHash crypto) (PoolParams crypto)
+  -> Stake crypto
+  -> Map (Credential crypto) (KeyHash crypto)
+  -> Coin
+  -> (Map (RewardAcnt crypto) Coin, Map (KeyHash crypto) Rational)
+reward pp (BlocksMade b) r addrsRew poolParams stake delegs total =
+  (rewards', appPerformances)
+  where
+    pdata =
+      [ ( hk
+        , ( poolParams Map.! hk
+          , b Map.! hk
+          , poolStake hk delegs stake))
+      | hk <-
+          Set.toList $ Map.keysSet poolParams `Set.intersection` Map.keysSet b
+      ]
+    results =
+      [ ( hk
+        , rewardOnePool pp r n totalBlocks (KeyHashObj hk) pool actgr total addrsRew)
+      | (hk, (pool, n, actgr)) <- pdata
+      ]
+    rewards' = foldl (\m (_, r') -> Map.union m (fst r')) Map.empty results
+    appPerformances = Map.fromList $ fmap (\(hk, r') -> (hk, snd r')) results
+    totalBlocks = sum b
+
+nonMyopicStake
+  :: KeyHash crypto
+  -> StakeShare
+  -> StakeShare
+  -> PParams
+  -> Set (KeyHash crypto)
+  -> StakeShare
+nonMyopicStake kh (StakeShare sigma) (StakeShare s) pp topPools =
+  let
+    z0 = 1 % max 1 (fromIntegral (_nOpt pp))
+  in
+    if kh `Set.member` topPools
+      then StakeShare (max sigma z0)
+      else StakeShare s
+
+nonMyopicMemberRew
+  :: PParams
+  -> PoolParams crypto
+  -> Coin
+  -> StakeShare
+  -> StakeShare
+  -> StakeShare
+  -> ApparentPerformance
+  -> Coin
+nonMyopicMemberRew
+  pp
+  pool
+  rPot
+  (StakeShare s)
+  (StakeShare t)
+  (StakeShare nm)
+  (ApparentPerformance p) =
+
+  let
+    nm' = max t nm -- TODO check with researchers that this is how to handle t > nm
+    (Coin f) = maxPool pp rPot nm' s
+    fHat = floor (p * fromIntegral f)
+  in
+    memberRew (Coin fHat) pool (StakeShare s) (StakeShare nm')

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -82,13 +82,13 @@ newEpochTransition = do
       es' <- case ru of
                Nothing  -> pure es
                Just ru' -> do
-                 let RewardUpdate dt dr rs_ df = ru'
+                 let RewardUpdate dt dr rs_ df _ = ru'
                  dt + dr + (sum rs_) + df == 0 ?! CorruptRewardUpdate ru'
                  pure $ applyRUpd ru' es
 
       es'' <- trans @(MIR crypto) $ TRC ((), es', ())
       es''' <- trans @(EPOCH crypto) $ TRC ((), es'', e)
-      let EpochState _acnt ss _ls pp = es'''
+      let EpochState _acnt ss _ls pp _ = es'''
           SnapShot (Stake stake) delegs poolParams = _pstakeSet ss
           Coin total = Map.foldl (+) (Coin 0) stake
           sd =

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -17,6 +17,7 @@ import qualified Shelley.Spec.Ledger.EpochBoundary as EpochBoundary
 import qualified Shelley.Spec.Ledger.Keys as Keys
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import qualified Shelley.Spec.Ledger.OCert as OCert
+import qualified Shelley.Spec.Ledger.Rewards as Rewards
 import qualified Shelley.Spec.Ledger.Scripts as Scripts
 import qualified Shelley.Spec.Ledger.STS.Chain as STS.Chain
 import qualified Shelley.Spec.Ledger.STS.Deleg as STS.Deleg
@@ -139,6 +140,8 @@ type OCertEnv = STS.Ocert.OCertEnv ConcreteCrypto
 type HashHeader = BlockChain.HashHeader ConcreteCrypto
 
 type NewEpochState = LedgerState.NewEpochState ConcreteCrypto
+
+type NonMyopic = Rewards.NonMyopic ConcreteCrypto
 
 type RewardUpdate = LedgerState.RewardUpdate ConcreteCrypto
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -39,8 +39,9 @@ import           Shelley.Spec.Ledger.Keys (DiscVKey (..), pattern GenKeyHash, Ha
                      undiscriminateKeyHash, vKey)
 import           Shelley.Spec.Ledger.LedgerState (AccountState (..), EpochState (..),
                      NewEpochState (..), pattern RewardUpdate, deltaF, deltaR, deltaT,
-                     emptyLedgerState, genesisId, rs)
+                     emptyLedgerState, genesisId, nonMyopic, rs)
 import           Shelley.Spec.Ledger.PParams (ProtVer (..), emptyPParams, mkActiveSlotCoeff)
+import           Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
 import           Shelley.Spec.Ledger.Serialization (FromCBORGroup (..), ToCBORGroup (..))
 import           Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import           Shelley.Spec.Ledger.Tx (Tx (..), hashScript)
@@ -1037,12 +1038,14 @@ serializationTests = testGroup "Serialization Tests"
       ls = emptyLedgerState
       pps = emptyPParams
       bs = Map.singleton testKeyHash1 1
-      es = EpochState ac ss ls pps
+      nm = emptyNonMyopic
+      es = EpochState ac ss ls pps nm
       ru = (Just RewardUpdate
              { deltaT        = Coin 100
              , deltaR        = Coin (-200)
              , rs            = Map.empty
              , deltaF        = Coin (-10)
+             , nonMyopic     = nm
              }) :: Maybe RewardUpdate
       pd = (PoolDistr Map.empty) :: PoolDistr
       os = Map.singleton (SlotNo 1) (Just testGKeyHash)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -149,7 +149,7 @@ genBlock sNow chainSt coreNodeKeys keysByStakeHash = do
       Left _ -> QC.discard
       Right _nes' -> do
         let NewEpochState _ _ _ es _ _ _ = _nes'
-            EpochState acnt _ ls pp'     = es
+            EpochState acnt _ ls pp' _   = es
         mkBlock
           <$> pure (chainHashHeader chainSt)
           <*> pure keys'


### PR DESCRIPTION
EDIT: I've drastically redone this PR.

Reward updates now include a new component, `nonMyopic`, which stores the info needed to compute the non-mypopic rewards:
* the mapping of moving averages apparent performances
* the reward pot
* the snapshot used to create the reward update (the one marked "go").

I've created a new module, `Shelley.Spec.Ledger.Reward`. I moved the reward calculations to this module, and implemented all the non-myopic reward calculations in it.

There are still some TODOs relating to questions for the researchers. The spec still needs to be updated, and the `Cardano.Shelley.API` module and helper functions still need to be written.

see #1236 