### PR TITLE
Generate larger UTxO for more variance

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
@@ -5,21 +5,13 @@ where
 import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 
--- | minimal number of addresses for transaction outputs
-minNumGenAddr :: Int
-minNumGenAddr = 1
-
--- | minimal number of addresses for transaction outputs
-maxNumGenAddr :: Int
-maxNumGenAddr = 2
-
 -- | minimal number of transaction inputs to select
 minNumGenInputs :: Int
 minNumGenInputs = 1
 
 -- | maximal number of transaction inputs to select
 maxNumGenInputs :: Int
-maxNumGenInputs = 5
+maxNumGenInputs = 10
 
 -- | Relative frequency of generated credential registration certificates
 frequencyRegKeyCert :: Int
@@ -85,11 +77,11 @@ frequencyTxUpdates = 10
 
 -- | minimal number of genesis UTxO outputs
 minGenesisUTxOouts :: Int
-minGenesisUTxOouts = 1
+minGenesisUTxOouts = 10
 
 -- | maximal number of genesis UTxO outputs
 maxGenesisUTxOouts :: Int
-maxGenesisUTxOouts = 5
+maxGenesisUTxOouts = 100
 
 -- | maximal numbers of generated keypairs
 maxNumKeyPairs :: Word64


### PR DESCRIPTION
Before, we generated at most 5 initial UTxO entries and created at most 2
outputs in a transaction which consumed betweed 1 and 5 inputs. Therefore the
size of the UTxO quickly converged to 1-2.

This commit changed this to generate between 10 and 100 initial UTxO entries and
then using somewhere between 1 and 10 as inputs. The number of receipients is
generated using then number of inputs, contracting by 1 or expanding by one with
a relative frequency of 1 and generating the same number of outputs as consumed
inputs, with a relative frequency of 2.