### PR TITLE
Clarify when to use total/active stake.

### DIFF
--- a/shelley/design-spec/CHANGELOG.md
+++ b/shelley/design-spec/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Delegation Design Document Changelog
 
+## 2020-02-28
+Clarify when we use active stake vs total stake.
+
 ## 2019-06-07
 Update section on script addresses.
 
@@ -48,16 +51,16 @@ into the document.
 - Elaborating further on why stake pool registrations will not be censored.
 - Capture choice of KES scheme in design doc.
 - Streamlining information on deposits
-    
+
     Replacing an explanation of the concept with a link to the section where it's
     already explained.
 - Elaborate on certificate replay protection
-    
+
     The paragraph was not entirely true, it said there was only one possible source
     of funds in addition to UTxO entries, but with rewards accounts, there is
     another one.
 - Fix that rewards go to treasury if reward key unregistered.
-    
+
     We can not move them to the rewards pool -- if we did, it would create an
     incentive for all other leaders to censor a certificate that caused the pool to
     use a valid certificate.
@@ -91,9 +94,9 @@ Changes after the first day of the Berlin workshop.
 - Add todo to clarify stakepool metadata
 - Add section on TTL for transactions
 - Elaboration and slight change to stake pool registration.
-    
+
   After the first day of discussions in Berlin, we came to the conclusions that
-    
+
   - we need a _registered_ staking key to collect rewards
   - this should _not_ be the same key that's used for participating in the
     protocol. For participation in the protocol, we want cold and operational

--- a/shelley/design-spec/CHANGELOG.md
+++ b/shelley/design-spec/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Delegation Design Document Changelog
 
-## 2020-02-25
-Include factor of relative stake over total stake in monetary expansion, to
-counter an incentive to censor delegation certificates that would increase the
-amount of active stake.
-
 ## 2019-06-07
 Update section on script addresses.
 

--- a/shelley/design-spec/CHANGELOG.md
+++ b/shelley/design-spec/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Delegation Design Document Changelog
 
+## 2020-02-25
+Include factor of relative stake over total stake in monetary expansion, to
+counter an incentive to censor delegation certificates that would increase the
+amount of active stake.
+
 ## 2019-06-07
 Update section on script addresses.
 

--- a/shelley/design-spec/delegation_design_spec.tex
+++ b/shelley/design-spec/delegation_design_spec.tex
@@ -12,7 +12,7 @@
    \\[1em]
    Duncan Coutts  \quad \texttt{<duncan.coutts@iohk.io>}
 }
-\DueDate{1$^{\textrm{st}}$ November 2019}
+\DueDate{25$^{\textrm{st}}$ February 2020}
 \SubmissionDate{28$^{\textrm{th}}$ October 2019}{2019/10/28}
 \LeaderName{Philipp Kant, \IOHK}
 \InstitutionAddress{\IOHK}
@@ -1549,6 +1549,12 @@ excludes all addresses that hold no stake, and excludes addresses with
 stake rights but that have not correctly registered their staking key or
 delegation choice.
 
+We will call stake that is correctly delegated to an existing pool \emph{active
+  stake}, sometimes contrasted to the \emph{total stake}, which includes stake
+that is not delegated (or delegated to pools that are already retired). Unless
+specifically stated otherwise, when we talk about relative stake, we always
+normalise to the active stake, not the total stake.
+
 \subsubsection{Chain Delegation}
 \label{chain-delegation}
 
@@ -2799,9 +2805,10 @@ Every epoch, the total amount of ada in circulation \(T\) will be increased by
 adding ada to the rewards pot. To ensure the amount of ada never exceeds a
 finite, specified limit \(T_\infty\), the increase will reduce exponentially.
 Also, the increase will depend on the number of blocks that have been produced
-during the epoch. Specifically, each epoch, the contribution from monetary
-expansion to the rewards pot is given by
-\[\min(\eta, 1) \rho \left(T_\infty - T\right)\,,\]
+during the epoch, and on the amount of active stake in the system. Specifically,
+each epoch, the contribution from monetary expansion to the rewards pot is given
+by
+\[\min(\eta, 1) \,\bar{s}\, \rho \left(T_\infty - T\right)\,,\]
 where
 \begin{itemize}
 \item[\(\eta\)] is the ratio between the number of blocks that have been produced
@@ -2816,6 +2823,10 @@ where
   will be the number of slots in an epoch, while for Ouroboros Praos, we will
   use the number of slots per epoch times the active slots coefficient \(f\)
   (see Equation (1) in \citep{ouroboros_praos}).
+\item[\(\bar{s}\)] is the ratio of \emph{active} and \emph{total} stake. As
+  explained in \cref{overall-stake-distribution}, stake that is not delegated to
+  a stake pool is not considered to be active, and is disregarded for the
+  purpose of leader election.
 \item[\(\rho\)] is the monetary expansion parameter.
 \item[\(T_\infty\)] is the maximal amount of ada to ever be in circulation
   (i.e., \(45\cdot10^{9}\) ada).
@@ -2824,11 +2835,19 @@ where
 \end{itemize}
 
 The dependence on \(\eta\) incentivises cooperative behaviour, and in particular
-discourages the pools sabotaging each others blocks. Note that \(\eta\) can
-exceed \(1\) when there are more blocks produced in an epoch than would be
-expected on average. But the product \(\min(\eta, 1)\rho\) is always bounded by
-\(1\), which is necessary to ensure we never exceed \(T_\infty\) ada in
-circulation.
+discourages the pools sabotaging each others blocks. Similarly, the factor of
+\(\bar{s}\) is used to prevent an incentive to block delegation certificates.
+Since the relative stake of a stakeholder (the stake they themselves have
+delegated, divided by the overall active stake) is the deciding factor in
+determining their rewards, there would an incentive to keep the amount of active
+stake as small as possible, which could lead to a collective censorship of
+delegation certificates. Reducing the rewards from monetary expansion by
+\(\bar{s}\) counters this incentive.
+
+Note that \(\eta\) can exceed \(1\) when there are more blocks produced in an
+epoch than would be expected on average. But the product \(\min(\eta,
+1)\,\bar{s}\,\rho\) is always bounded by \(1\), which is necessary to ensure we
+never exceed \(T_\infty\) ada in circulation.
 
 Since \(T_\infty\) is finite, rewards from monetary expansion will
 decrease over time. This has to be compensated by
@@ -2975,6 +2994,9 @@ Here
   owner(s) (the amount of ada pledged during pool registration,
   see \cref{stake-pool-registration}).
 \end{itemize}
+
+As stated in \cref{overall-stake-distribution}, relative stake refers to stake
+divided by the amount of \emph{active} stake.
 
 As mentioned in \cref{stake-pool-registration}, the rewards for a pool
 where the owner(s) fail to honour their pledge of stake will receive

--- a/shelley/design-spec/delegation_design_spec.tex
+++ b/shelley/design-spec/delegation_design_spec.tex
@@ -12,8 +12,8 @@
    \\[1em]
    Duncan Coutts  \quad \texttt{<duncan.coutts@iohk.io>}
 }
-\DueDate{25$^{\textrm{st}}$ February 2020}
-\SubmissionDate{28$^{\textrm{th}}$ October 2019}{2019/10/28}
+\DueDate{28$^{\textrm{st}}$ February 2020}
+\SubmissionDate{28$^{\textrm{th}}$ February 2020}{2020/02/28}
 \LeaderName{Philipp Kant, \IOHK}
 \InstitutionAddress{\IOHK}
 \Version{1.10}
@@ -1551,9 +1551,7 @@ delegation choice.
 
 We will call stake that is correctly delegated to an existing pool \emph{active
   stake}, sometimes contrasted to the \emph{total stake}, which includes stake
-that is not delegated (or delegated to pools that are already retired). Unless
-specifically stated otherwise, when we talk about relative stake, we always
-normalise to the active stake, not the total stake.
+that is not delegated (or delegated to pools that are already retired).
 
 \subsubsection{Chain Delegation}
 \label{chain-delegation}
@@ -2805,10 +2803,9 @@ Every epoch, the total amount of ada in circulation \(T\) will be increased by
 adding ada to the rewards pot. To ensure the amount of ada never exceeds a
 finite, specified limit \(T_\infty\), the increase will reduce exponentially.
 Also, the increase will depend on the number of blocks that have been produced
-during the epoch, and on the amount of active stake in the system. Specifically,
-each epoch, the contribution from monetary expansion to the rewards pot is given
-by
-\[\min(\eta, 1) \,\bar{s}\, \rho \left(T_\infty - T\right)\,,\]
+during the epoch. Specifically, each epoch, the contribution from monetary
+expansion to the rewards pot is given by
+\[\min(\eta, 1) \rho \left(T_\infty - T\right)\,,\]
 where
 \begin{itemize}
 \item[\(\eta\)] is the ratio between the number of blocks that have been produced
@@ -2823,10 +2820,6 @@ where
   will be the number of slots in an epoch, while for Ouroboros Praos, we will
   use the number of slots per epoch times the active slots coefficient \(f\)
   (see Equation (1) in \citep{ouroboros_praos}).
-\item[\(\bar{s}\)] is the ratio of \emph{active} and \emph{total} stake. As
-  explained in \cref{overall-stake-distribution}, stake that is not delegated to
-  a stake pool is not considered to be active, and is disregarded for the
-  purpose of leader election.
 \item[\(\rho\)] is the monetary expansion parameter.
 \item[\(T_\infty\)] is the maximal amount of ada to ever be in circulation
   (i.e., \(45\cdot10^{9}\) ada).
@@ -2835,19 +2828,11 @@ where
 \end{itemize}
 
 The dependence on \(\eta\) incentivises cooperative behaviour, and in particular
-discourages the pools sabotaging each others blocks. Similarly, the factor of
-\(\bar{s}\) is used to prevent an incentive to block delegation certificates.
-Since the relative stake of a stakeholder (the stake they themselves have
-delegated, divided by the overall active stake) is the deciding factor in
-determining their rewards, there would an incentive to keep the amount of active
-stake as small as possible, which could lead to a collective censorship of
-delegation certificates. Reducing the rewards from monetary expansion by
-\(\bar{s}\) counters this incentive.
-
-Note that \(\eta\) can exceed \(1\) when there are more blocks produced in an
-epoch than would be expected on average. But the product \(\min(\eta,
-1)\,\bar{s}\,\rho\) is always bounded by \(1\), which is necessary to ensure we
-never exceed \(T_\infty\) ada in circulation.
+discourages the pools sabotaging each others blocks. Note that \(\eta\) can
+exceed \(1\) when there are more blocks produced in an epoch than would be
+expected on average. But the product \(\min(\eta, 1)\rho\) is always bounded by
+\(1\), which is necessary to ensure we never exceed \(T_\infty\) ada in
+circulation.
 
 Since \(T_\infty\) is finite, rewards from monetary expansion will
 decrease over time. This has to be compensated by
@@ -2995,8 +2980,6 @@ Here
   see \cref{stake-pool-registration}).
 \end{itemize}
 
-As stated in \cref{overall-stake-distribution}, relative stake refers to stake
-divided by the amount of \emph{active} stake.
 
 As mentioned in \cref{stake-pool-registration}, the rewards for a pool
 where the owner(s) fail to honour their pledge of stake will receive

--- a/shelley/design-spec/delegation_design_spec.tex
+++ b/shelley/design-spec/delegation_design_spec.tex
@@ -167,8 +167,9 @@ obsolete things.
 First version officially published on the IOHK blog.}
 \change{2019-05-17}{PK, LB, DC}{FM (IOHK)}{Some clarifications in response to review by the auditors.}
 \change{2019-06-07}{PK, LB, DC}{FM (IOHK)}{Update section on script addresses.}
-     \change{2019/10/09}{Kevin Hammond}{FM (IOHK)}{Added standard cover page.}
-      \end{changelog}
+\change{2019/10/09}{Kevin Hammond}{FM (IOHK)}{Added standard cover page.}
+\change{2020-02-28}{PK}{FM (IOHK)}{Clarify when to use active/total stake.}
+  \end{changelog}
       \clearpage%
 \begin{landscape}
 \floatstyle{plain}
@@ -2874,6 +2875,42 @@ These calculations proceed in two steps: First, rewards are split
 amongst \emph{pools}. Next, each pool splits its share of \(R\) amongst
 its operator and its members.
 
+\subsubsection{Relative Stake: Active vs Total}
+As explained in \cref{overall-stake-distribution}, we distinguish the amount of
+\emph{active stake} and the \emph{total stake}. Stake is only considered active
+when it is correctly delegated to a non-retired pool. Whenever we look at
+fractions of stake (in the leader election, or when distributing rewards
+according to stake), we need to specify whether we normalise to the active or to
+the total stake.
+
+\begin{description}
+\item[Leader Schedule] For the purpose of determining the leader schedule, we
+  use the construction in \cref{overall-stake-distribution}, which yields the
+  stake relative to the amount of \emph{active} stake.
+
+  The benefit of doing this is that the chain growth will be independent of how
+  many stakeholders do delegate their stake.
+\item[Rewards Distribution] When we distribute rewards depending on how much
+  stake any party provides, we will always use the stake relative to the
+  \emph{total} stake.
+
+  That way, we ensure that the share of the rewards that any one party gets does
+  not change when the amount of active stake changes. Not only is this more
+  predictable for individual players, it also prevents creating an incentive to
+  block new delegation certificates. If we were using the stake relative to the
+  active stake, then any player who already had active stake would lose rewards
+  when other players started delegating their stake, which could lead to a
+  collective censorship of transactions with delegation certificates.
+\item[Performance Estimations] The rewards of a pool will depend on how well
+  they perform, i.e., on how many blocks they produce, and on how many blocks we
+  would expect a pool with their stake to produce
+  (\cref{stake-performance-and-block-production}).
+
+  Since leader election depends on the fraction of \emph{active} stake that a
+  pool controls, we have to normalise to active stake when estimating
+  performance as well.
+\end{description}
+
 \subsubsection{Stake, Performance, and Block Production}
 \label{stake-performance-and-block-production}
 
@@ -2902,11 +2939,11 @@ performance of the other pools and the network. We can write\footnote{We assume
   Praos. However, the error when linearising the leader election function is
   small, particularly for the range of parameters we are considering for
   Cardano.}
-\[\beta = \sigma p r_e \,,\]
+\[\beta = \sigma_a p r_e \,,\]
 where
 \begin{enumerate}
-\item[\(\sigma\)] is the relative stake \(\sigma\) of the pool (the fraction of
-  the absolute stake that the pool controls),
+\item[\(\sigma_a\)] is the relative stake \(\sigma\) of the pool (the fraction of
+  the \emph{active} stake that the pool controls),
 \item[\(p\)] is the performance \(p\) of the pool, i.e. the fraction
   \[
   p = \frac{n}{\max(N,1)}
@@ -2914,10 +2951,10 @@ where
   of the number \(n\) of blocks it successfully added to the chain and the
   number \(N\) of slots it was elected as a leader, and
 \item[\(r_e\)] is a factor that captures the relation between the relative stake
-  \(\sigma\) of the pool, the number \(N\) of slots it is elected as a leader,
+  \(\sigma_a\) of the pool, the number \(N\) of slots it is elected as a leader,
   and the total number \(\Nbar\) of blocks that were added to the chain during
   the epoch. To be precise, we have
-  \[r_e = \frac{N}{\sigma \max(1, \Nbar)}\,.\]
+  \[r_e = \frac{N}{\sigma_a \max(1, \Nbar)}\,.\]
   The factor \(r_e\) captures random influences on \(\beta\): the
   randomness in the leader election that influences \(N\), and the randomness
   both from the leader election and the bunch of random influences on
@@ -2927,14 +2964,14 @@ where
 
 If we insert the definitions of \(p\) and \(r_e\) into \(\beta\), we find that
 \[
-\beta = \sigma \frac{n}{\max(N,1)} \frac{N}{\sigma \max(1, \Nbar)}
+\beta = \sigma_a \frac{n}{\max(N,1)} \frac{N}{\sigma_a \max(1, \Nbar)}
 = \frac{n}{\max(1, \Nbar)}\,,
 \]
 which is indeed the fraction of blocks produced by the pool\footnote{When
   cancelling \(N\) and \(\max(N,1)\), note that for \(N=0\), also \(n=0\), and
   the equation trivially holds.}.
 
-In Ouroboros Praos, we can observe \(\sigma\), \(n\), and \(\Nbar\), but
+In Ouroboros Praos, we can observe \(\sigma_a\), \(n\), and \(\Nbar\), but
 we do not have a direct handle on any of \(N\), \(r_e\), or \(p\). From the
 observables, we can extract
 \begin{equation}
@@ -2944,7 +2981,7 @@ observables, we can extract
 While the true performance \(p\) is not accessible, we can define and measure
 the \emph{apparent performance}
 \[
-\pbar := p r_e = \frac{\beta}{\sigma}\,.
+\pbar := p r_e = \frac{\beta}{\sigma_a}\,.
 \]
 We will use the apparent performance \(\pbar\) as a proxy for the performance
 when determining the rewards for pools.
@@ -2972,14 +3009,14 @@ Here
 \item
   \(z_0:=1/k\) is the size of a saturated pool.
 \item
-  \(\sigma':=\min(\sigma, z_0)\), where \(\sigma\) is the relative stake
-  of the pool.
+  \(\sigma':=\min(\sigma, z_0)\), where \(\sigma\) is the relative stake of the
+  pool (note that this is relative to the \emph{total stake}, not the active
+  stake).
 \item
   \(s':=\min(s, z_0)\), where \(s\) is the relative stake of the pool
   owner(s) (the amount of ada pledged during pool registration,
   see \cref{stake-pool-registration}).
 \end{itemize}
-
 
 As mentioned in \cref{stake-pool-registration}, the rewards for a pool
 where the owner(s) fail to honour their pledge of stake will receive


### PR DESCRIPTION
Adding a factor of (active stake)/(total stake) to the monetary expansion, to prevent an incentive to censor new stake key registration or delegation certificates.