### PR TITLE
[868] Generate multiple certs per tx

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/delegation.cabal
+++ b/shelley/chain-and-ledger/executable-spec/delegation.cabal
@@ -116,6 +116,7 @@ test-suite delegation-test
                          Generator.Core.QuickCheck
                          Generator.ChainTrace
                          Generator.LedgerTrace.QuickCheck
+                         Generator.DCertTrace
                          Generator.Delegation.QuickCheck
                          Generator.Update.QuickCheck
                          Generator.Utxo.QuickCheck

--- a/shelley/chain-and-ledger/executable-spec/test/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/ConcreteCryptoTypes.hs
@@ -20,6 +20,7 @@ import qualified OCert
 import qualified STS.Chain
 import qualified STS.Deleg
 import qualified STS.Delegs
+import qualified STS.Delpl
 import qualified STS.Ledger
 import qualified STS.Ledgers
 import qualified STS.NewEpoch
@@ -153,6 +154,8 @@ type UTXO = STS.Utxo.UTXO ConcreteCrypto
 type UtxoEnv = STS.Utxo.UtxoEnv ConcreteCrypto
 
 type DELEG = STS.Deleg.DELEG ConcreteCrypto
+
+type DELPL = STS.Delpl.DELPL ConcreteCrypto
 
 type LEDGER = STS.Ledger.LEDGER ConcreteCrypto
 

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/Constants.hs
@@ -83,6 +83,10 @@ minGenesisUTxOouts = 10
 maxGenesisUTxOouts :: Int
 maxGenesisUTxOouts = 100
 
+-- | maximal number of certificates per transaction
+maxCertsPerTx :: Word64
+maxCertsPerTx = 3
+
 -- | maximal numbers of generated keypairs
 maxNumKeyPairs :: Word64
 maxNumKeyPairs = 150
@@ -97,7 +101,7 @@ maxGenesisOutputVal = 100000000
 
 -- | Number of base scripts from which multi sig scripts are built.
 numBaseScripts :: Int
-numBaseScripts = 5
+numBaseScripts = 3
 
 -- | Relative frequency that a transaction does not include any reward withdrawals
 frequencyNoWithdrawals :: Int

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/DCertTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/DCertTrace.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+
+module Generator.DCertTrace
+  (genDCerts)
+  where
+
+import           Control.Monad.Trans.Reader (runReaderT)
+import           Data.Functor.Identity (runIdentity)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map (lookup)
+import           Data.Maybe (catMaybes)
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import           Data.Word (Word64)
+import           Lens.Micro ((^.))
+import           Numeric.Natural (Natural)
+import           Test.QuickCheck (Gen)
+
+import           BaseTypes (ShelleyBase)
+import           BaseTypes (Globals)
+import           Coin (Coin)
+import           ConcreteCryptoTypes (AnyKeyHash, DCert, DELPL, DPState, KeyPair)
+import           Control.State.Transition (BaseM, Embed, Environment, PredicateFailure, STS, Signal,
+                     State, TRC (..), TransitionRule, initialRules, judgmentContext, trans,
+                     transitionRules, wrapFailed)
+import           Control.State.Transition.Trace (TraceOrder (OldestFirst), traceSignals)
+import qualified Control.State.Transition.Trace.Generator.QuickCheck as QC
+import           Delegation.Certificates (decayKey, isDeRegKey)
+import           Generator.Core.Constants (maxCertsPerTx, numBaseScripts)
+import           Generator.Core.QuickCheck (coreNodeKeys, traceKeyPairs, traceKeyPairsByStakeHash,
+                     traceMSigCombinations, traceMSigScripts, traceVRFKeyPairs)
+import           Generator.Delegation.QuickCheck (CertCred (..), genDCert)
+import           GHC.Generics (Generic)
+import           LedgerState (dstate, keyRefund, stkCreds, _pstate, _stPools)
+import           PParams (PParams)
+import           Slot (SlotNo (..))
+import           STS.Delpl (DelplEnv (..))
+import           Tx (getKeyCombination)
+import           TxData (Ix, Ptr (..))
+import           UTxO (totalDeposits)
+
+import           Test.Utils (testGlobals)
+
+-- | This is a non-spec STS used to generate a sequence of certificates with
+-- witnesses.
+data CERTS
+
+instance STS CERTS where
+  type Environment CERTS = (SlotNo, Ix, PParams, Coin)
+  type State CERTS = (DPState, Ix)
+  type Signal CERTS = Maybe (DCert, CertCred)
+
+  type BaseM CERTS = ShelleyBase
+
+  data PredicateFailure CERTS
+    = CertsFailure (PredicateFailure DELPL)
+    deriving (Show, Eq, Generic)
+
+  initialRules = []
+  transitionRules = [certsTransition]
+
+certsTransition :: TransitionRule CERTS
+certsTransition = do
+  TRC ( (slot, txIx, pp, reserves)
+      , (dpState, nextCertIx)
+      , c) <- judgmentContext
+
+  case c of
+    Just (cert, _wits) -> do
+      let ptr = Ptr slot txIx nextCertIx
+      dpState' <- trans @DELPL $ TRC (DelplEnv slot ptr pp reserves, dpState, cert)
+
+      pure (dpState', nextCertIx + 1)
+    Nothing ->
+      pure (dpState, nextCertIx)
+
+instance Embed DELPL CERTS where
+  wrapFailed = CertsFailure
+
+instance QC.HasTrace CERTS Word64 where
+  envGen _ = error "HasTrace CERTS - envGen not required"
+
+  sigGen _ (slot, _txIx, pparams, _reserves) (dpState, _certIx) =
+    genDCert
+      traceKeyPairs
+      (traceMSigCombinations $ take numBaseScripts traceMSigScripts)
+      (fst <$> coreNodeKeys)
+      traceVRFKeyPairs
+      traceKeyPairsByStakeHash
+      pparams
+      dpState
+      slot
+
+  shrinkSignal = const []
+
+  type BaseEnv CERTS = Globals
+  interpretSTS globals act = runIdentity $ runReaderT act globals
+
+-- | Generate certificates and also return the associated witnesses and
+-- deposits and refunds required.
+genDCerts
+  :: Map AnyKeyHash KeyPair
+  -> PParams
+  -> DPState
+  -> SlotNo
+  -> Natural
+  -> Natural
+  -> Coin
+  -> Gen (Seq DCert, [CertCred], Coin, Coin)
+genDCerts keyHashMap pparams dpState slot ttl txIx reserves = do
+  let env = (slot, txIx, pparams, reserves)
+      st0 = (dpState, 0)
+
+  certsCreds <-
+    catMaybes . traceSignals OldestFirst <$>
+      QC.traceFrom @CERTS testGlobals maxCertsPerTx maxCertsPerTx env st0
+
+  let (certs, creds) = unzip certsCreds
+      deRegStakeCreds = filter isDeRegKey certs
+      slotWithTTL = slot + SlotNo (fromIntegral ttl)
+
+  withScriptCreds <- concat <$> mapM extendWithScriptCred creds
+
+  pure ( Seq.fromList certs
+       , withScriptCreds
+       , totalDeposits pparams (_stPools (_pstate dpState)) certs
+       , sum (certRefund slotWithTTL <$> deRegStakeCreds) )
+
+  where
+    (dval, dmin, lambda) = decayKey pparams
+    stkCreds_ = dpState ^. dstate . stkCreds
+    certRefund = keyRefund dval dmin lambda stkCreds_
+
+    extendWithScriptCred cred =
+      case cred of
+        ScriptCred (_, stakeScript) -> do
+          let witnessHashes = getKeyCombination stakeScript
+              witnesses = KeyCred <$> catMaybes (map lookupWit witnessHashes)
+          pure (witnesses ++ [cred])
+        _ ->
+          return [cred]
+
+    lookupWit = flip Map.lookup keyHashMap

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -122,7 +122,7 @@ genExtraEntropy  = QC.frequency [ (1, pure NeutralNonce)
 -- Note: we keep the lower bound high enough so that we can more likely
 -- generate valid transactions and blocks
 low, hi :: Natural
-low = 30000
+low = 50000
 hi = 200000
 
 -- keyMinRefund: 0.1-0.5

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/ClassifyTraces.hs
@@ -30,6 +30,7 @@ import           Control.State.Transition.Trace.Generator.QuickCheck (classifyTr
 import           Delegation.Certificates (isDeRegKey, isDelegation, isGenesisDelegation,
                      isInstantaneousRewards, isRegKey, isRegPool, isRetirePool)
 import           Generator.ChainTrace (mkGenesisChainState)
+import           Generator.Core.Constants (maxCertsPerTx)
 import           Generator.LedgerTrace.QuickCheck (mkGenesisLedgerState)
 import           LedgerState (txsize)
 import           Slot (SlotNo (..), epochInfoSize)
@@ -53,63 +54,68 @@ relevantCasesAreCovered = withMaxSuccess 200 . property $ do
        classifyTraceLength tl 5 tr
 
      , cover_ 60
-              (traceLength tr <= 5 * length certs_)
-              "there is at least 1 certificate for every 5 transactions"
+              (traceLength tr <= 3 * length certs_)
+              "there is at least 1 certificate for every 3 transactions"
 
      , cover_ 60
-              (traceLength tr <= 20 * length (filter isRegKey certs_))
+              (traceLength tr <= 10 * length (filter isRegKey certs_))
               "there is at least 1 RegKey certificate for every 10 transactions"
 
-     , cover_ 40
-              (traceLength tr <= 20 * length (filter isDeRegKey certs_))
-              "there is at least 1 DeRegKey certificate for every 20 transactions"
+     , cover_ 60
+              (traceLength tr <= 10 * length (filter isDeRegKey certs_))
+              "there is at least 1 DeRegKey certificate for every 10 transactions"
 
      , cover_ 60
-              (traceLength tr <= 20 * length (filter isDelegation certs_))
+              (traceLength tr <= 10 * length (filter isDelegation certs_))
               "there is at least 1 Delegation certificate for every 10 transactions"
 
      , cover_ 60
-              (traceLength tr <= 40 * length (filter isGenesisDelegation certs_))
-              "there is at least 1 Genesis Delegation certificate for every 40 transactions"
+              (traceLength tr <= 20 * length (filter isGenesisDelegation certs_))
+              "there is at least 1 Genesis Delegation certificate for every 20 transactions"
 
      , cover_ 60
-              (traceLength tr <= 20 * length (filter isRegPool certs_))
+              (traceLength tr <= 10 * length (filter isRegPool certs_))
               "there is at least 1 RegPool certificate for every 10 transactions"
 
      , cover_ 60
-              (traceLength tr <= 20 * length (filter isRetirePool certs_))
-              "there is at least 1 RetirePool certificate for every 20 transactions"
+              (traceLength tr <= 10 * length (filter isRetirePool certs_))
+              "there is at least 1 RetirePool certificate for every 10 transactions"
 
-     , cover_ 40
-              (traceLength tr <= 50 * length (filter isInstantaneousRewards certs_))
-              "there is at least 1 MIR certificate for every 50 transactions"
+     , cover_ 60
+              (traceLength tr <= 30 * length (filter isInstantaneousRewards certs_))
+              "there is at least 1 MIR certificate for every 30 transactions"
 
-     , cover_ 25
-              (0.75 >= noCertsRatio (certsByTx txs))
-              "at most 75% of transactions have no certificates"
-     , cover_ 25
+     , cover_ 60
+              (0.6 >= noCertsRatio (certsByTx txs))
+              "at most 60% of transactions have no certificates"
+
+     , cover_ 60
+              (0.1 <= maxCertsRatio (certsByTx txs))
+              ("at least 10% of transactions have " <> (show maxCertsPerTx) <> " certificates")
+
+     , cover_ 20
               (0.1 <= txScriptOutputsRatio (map (_outputs . _body) txs))
               "at least 10% of transactions have script TxOuts"
-     , cover_ 10
+     , cover_ 60
               (0.1 <= scriptCredentialCertsRatio certs_)
               "at least 10% of `DCertDeleg` certificates have script credentials"
-     , cover_ 50
+     , cover_ 60
               (0.1 <= withdrawalRatio txs)
               "at least 10% of transactions have a reward withdrawal"
 
      , cover_ 60
-              (0.99 >= noPPUpdateRatio (ppUpdatesByTx txs))
-              "at least 1% of transactions have non-trivial protocol param updates"
+              (0.98 >= noPPUpdateRatio (ppUpdatesByTx txs))
+              "at least 2% of transactions have non-trivial protocol param updates"
 
      , cover_ 60
-              (0.99 >= noAVUpdateRatio (avUpdatesByTx txs))
-              "at least 1% of transactions have non-trivial application updates"
+              (0.98 >= noAVUpdateRatio (avUpdatesByTx txs))
+              "at least 2% of transactions have non-trivial application updates"
 
      , cover_ 60
               (2 <= epochBoundariesInTrace bs)
               "at least 2 epoch changes in trace"
 
-     , cover_ 10
+     , cover_ 20
               (5 <= epochBoundariesInTrace bs)
               "at least 5 epoch changes in trace"
      ]
@@ -146,6 +152,10 @@ allCerts = concat . certsByTx
 -- | Ratio of the number of empty certificate groups and the number of groups
 noCertsRatio :: [[DCert]] -> Double
 noCertsRatio = lenRatio (filter null)
+
+-- | Ratio of the number of certificate groups of max size and the number of groups
+maxCertsRatio :: [[DCert]] -> Double
+maxCertsRatio = lenRatio (filter ((== maxCertsPerTx) . fromIntegral . length))
 
 -- | Extract non-trivial protocol param  updates from the given transactions
 ppUpdatesByTx :: [Tx] -> [[PParamsUpdate]]


### PR DESCRIPTION
Closes #868 

* introduces a custom CERTS STS that thinly wraps the DELPL STS and adds a HasTrace instance (the Env and State of CERTS is constrained by the context available in genTx from which we generate certs)

* replaces `genDCerts` with a new one based on the CERTS Trace

* change `genRegKeyCert` to return _no witness_ (was returning a superfluous witness that needed special handling at a few sites)

* reduce `numBaseScripts` from 5 to 3 until we solve the test perf issues

* add a trace classification for multiple certs per transaction and also recalibrates the classifier now that we have more certs being produced

* increase lower bound on block size from 30k -> 50k (our generated blocks have been getting bigger)

* incorporate transaction IX in LEDGERS generation of `Seq Tx`
