### PR TITLE
fix AVUP STS rule

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/STS/Avup.hs
@@ -96,14 +96,15 @@ instance
 avUpCombined :: TransitionRule (AVUP crypto)
 avUpCombined = do
   TRC ( _
-      , _
+      , AVUPState (AVUpdate aupS) _ _
       , AVUpdate _aup) <- judgmentContext
 
   if Map.null _aup
     then avUpdateEmpty
     else do
     coreNodeQuorum <- liftSTS $ asks quorum
-    let fav  = votedValue _aup (fromIntegral coreNodeQuorum)
+    let aup' = aupS ⨃ Map.toList _aup
+        fav  = votedValue aup' (fromIntegral coreNodeQuorum)
     case fav of
       Nothing -> avUpdateNoConsensus
       Just _  -> avUpdateConsensus


### PR DESCRIPTION
small fix to the `AVUP` transition, fixing the test `CHAIN example 4B - create a future app version`.