### PR TITLE
optional pool metadata and pool relays in pool params

### DIFF
--- a/shelley/chain-and-ledger/cddl-spec/shelley.cddl
+++ b/shelley/chain-and-ledger/cddl-spec/shelley.cddl
@@ -104,7 +104,12 @@ pool_params = ( keyhash             ; operator
               , unit_interval       ; margin
               , [credential]        ; reward account
               , finite_set<keyhash> ; pool owners
+              , [* url]             ; relays
+              , [?pool_metadata]    ; pool metadata
               )
+
+url = tstr .size 64
+pool_metadata = [url, metadata_hash]
 
 withdrawals = { * [credential] => coin }
 

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -12,12 +12,10 @@ module Updates
   , PPUpdateEnv(..)
   , PPUpdate(..)
   , PParamsUpdate(..)
-  , ApName
-  , apName
+  , ApName (..)
   , ApVer(..)
   , Mdt(..)
-  , SystemTag
-  , systemTag
+  , SystemTag (..)
   , InstallerHash(..)
   , Applications(..)
   , AVUpdate(..)
@@ -36,24 +34,21 @@ module Updates
   )
 where
 
-import           Cardano.Binary (DecoderError (..), Encoding, FromCBOR (..), ToCBOR (..),
-                     decodeMapLenOrIndef, encodeListLen, encodeMapLen, enforceSize)
+import           Cardano.Binary (Encoding, FromCBOR (..), ToCBOR (..), decodeMapLenOrIndef,
+                     encodeListLen, encodeMapLen, enforceSize)
 import           Cardano.Crypto.Hash (Hash)
 import           Cardano.Ledger.Shelley.Crypto
-import           Cardano.Prelude (NoUnexpectedThunks (..), cborError)
+import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import qualified Data.List as List (group)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import qualified Data.Text as T
-import           Data.Text.Encoding (encodeUtf8)
 import           Data.Word (Word8)
 import           GHC.Generics (Generic)
 
-import           BaseTypes (Nonce, UnitInterval)
+import           BaseTypes (Nonce, Text64, UnitInterval)
 import           Coin (Coin)
 import           Keys (GenDelegs, GenKeyHash)
 import           PParams (ActiveSlotCoeff, PParams (..))
@@ -67,46 +62,11 @@ import           Ledger.Core (range, (◁))
 newtype ApVer = ApVer Natural
   deriving (Show, Ord, Eq, FromCBOR, ToCBOR, NoUnexpectedThunks)
 
-newtype ApName = ApName T.Text
-  deriving (Show, Ord, Eq, ToCBOR, NoUnexpectedThunks)
+newtype ApName = ApName Text64
+  deriving (Show, Ord, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
-textSize :: T.Text -> Int
-textSize = BS.length . encodeUtf8
-
-apName :: T.Text -> ApName
-apName t =
-  let numBytes = textSize t
-  in
-    if numBytes <= 64
-      then ApName t
-      else error $ "apName received too many bytes (expected 64): " <> show numBytes
-
-instance FromCBOR ApName
- where
-  fromCBOR = do
-    t <- fromCBOR
-    if textSize t > 64
-      then cborError $ DecoderErrorCustom "ApName has too many bytes:" t
-      else pure $ ApName t
-
-newtype SystemTag = SystemTag T.Text
-  deriving (Show, Ord, Eq, ToCBOR, NoUnexpectedThunks)
-
-systemTag :: T.Text -> SystemTag
-systemTag t =
-  let numBytes = (BS.length . encodeUtf8) t
-  in
-    if numBytes <= 64
-      then SystemTag t
-      else error $ "systemTag received too many bytes (expected 64): " <> show numBytes
-
-instance FromCBOR SystemTag
- where
-  fromCBOR = do
-    t <- fromCBOR
-    if textSize t > 64
-      then cborError $ DecoderErrorCustom "SystemTag has too many bytes:" t
-      else pure $ SystemTag t
+newtype SystemTag = SystemTag Text64
+  deriving (Show, Ord, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
 newtype InstallerHash crypto = InstallerHash (Hash (HASH crypto) ByteString)
   deriving (Show, Ord, Eq, NoUnexpectedThunks)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
@@ -15,14 +16,13 @@ module Generator.ChainTrace where
 import           Data.Functor.Identity (runIdentity)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (elems, empty, fromList, keysSet)
-import qualified Data.Text as T (pack)
 import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
 import           Unsafe.Coerce (unsafeCoerce)
 
-import           BaseTypes (Globals)
+import           BaseTypes (Globals, text64)
 import           BlockChain (pattern HashHeader)
 import           Cardano.Crypto.Hash (ShortHash)
 import           ConcreteCryptoTypes (Applications, CHAIN, ChainState, GenDelegs, HashHeader,
@@ -43,7 +43,7 @@ import           Shrinkers (shrinkBlock)
 import           Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import           STS.Chain (initialShelleyState)
 import           Test.Utils (runShelleyBase)
-import           Updates (ApVer (..), pattern Applications, pattern Mdt, apName)
+import           Updates (ApName (..), ApVer (..), pattern Applications, pattern Mdt)
 import           UTxO (balance)
 
 -- The CHAIN STS at the root of the STS allows for generating blocks of transactions
@@ -74,11 +74,11 @@ lastByronHeaderHash = HashHeader $ unsafeCoerce (hash 0 :: Hash ShortHash Int)
 
 byronApps :: Applications
 byronApps = Applications $ Map.fromList
-                            [ (apName $ T.pack "Daedalus", (ApVer 16, Mdt Map.empty))
-                            , (apName $ T.pack "Yoroi", (ApVer 4, Mdt Map.empty))
-                            , (apName $ T.pack "Ahoy", (ApVer 7, Mdt Map.empty))
-                            , (apName $ T.pack "Shebang", (ApVer 11, Mdt Map.empty))
-                            , (apName $ T.pack "Icarus", (ApVer 13, Mdt Map.empty))
+                            [ (ApName $ text64 "Daedalus", (ApVer 16, Mdt Map.empty))
+                            , (ApName $ text64 "Yoroi", (ApVer 4, Mdt Map.empty))
+                            , (ApName $ text64 "Ahoy", (ApVer 7, Mdt Map.empty))
+                            , (ApName $ text64 "Shebang", (ApVer 11, Mdt Map.empty))
+                            , (ApName $ text64 "Icarus", (ApVer 13, Mdt Map.empty))
                             ]
 
 -- Note: this function must be usable in place of 'applySTS' and needs to align

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Delegation/QuickCheck.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -15,6 +16,7 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (elems, findWithDefault, fromList, keys, lookup, size)
 import           Data.Maybe (fromMaybe)
 import           Data.Ratio ((%))
+import qualified Data.Sequence as Seq
 import           Data.Set ((\\))
 import qualified Data.Set as Set
 import           Lens.Micro (to, (^.))
@@ -269,6 +271,8 @@ genStakePool skeys vrfKeys =
                 interval
                 (RewardAcnt $ KeyHashObj $ hashKey acntKey)
                 Set.empty
+                Seq.empty
+                Nothing
      in (pps, snd poolKeyPair)
 
 -- | Generate `RegPool` and the key witness.

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Update/QuickCheck.hs
@@ -25,7 +25,7 @@ import qualified Data.Text as T (pack)
 import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
 
-import           BaseTypes (Nonce (NeutralNonce), UnitInterval, mkNonce)
+import           BaseTypes (Nonce (NeutralNonce), UnitInterval, mkNonce, text64)
 import           Coin (Coin (..))
 import           ConcreteCryptoTypes (AVUpdate, Applications, CoreKeyPair, DPState, GenKeyHash,
                      KeyHash, KeyPair, Mdt, PPUpdate, UTxOState, Update)
@@ -39,9 +39,10 @@ import           LedgerState (_dstate, _genDelegs, _ups)
 import           Numeric.Natural (Natural)
 import           PParams (ActiveSlotCoeff, PParams (..), mkActiveSlotCoeff)
 import           Slot (EpochNo (EpochNo), SlotNo)
-import           Updates (pattern AVUpdate, pattern ApVer, pattern Applications, InstallerHash (..),
-                     pattern Mdt, pattern PPUpdate, PParamsUpdate (..), Ppm (..), pattern Update,
-                     pattern UpdateState, apName, apps, emptyUpdate, maxVer, systemTag)
+import           Updates (pattern AVUpdate, ApName (..), pattern ApVer, pattern Applications,
+                     InstallerHash (..), pattern Mdt, pattern PPUpdate, PParamsUpdate (..),
+                     Ppm (..), SystemTag (..), pattern Update, pattern UpdateState, apps,
+                     emptyUpdate, maxVer)
 
 import           Test.Utils (epochFromSlotNo)
 
@@ -274,7 +275,7 @@ genApplications utxoSt = do
     genInstallers i =
       Mdt <$> Map.fromList
           <$> QC.vectorOf i
-                          ((,) <$> (systemTag . T.pack <$> genShortAscii)
+                          ((,) <$> (SystemTag . text64 . T.pack <$> genShortAscii)
                                <*> (InstallerHash . hash . BS.pack <$> genShortAscii))
 
     genApplication i = QC.frequency [ (2, genNewApp i)
@@ -288,7 +289,7 @@ genApplications utxoSt = do
     incrVersion (apname, (ApVer apVer, mdt)) = (apname, (ApVer (apVer+1), mdt))
 
     genNewApp i = (,) <$> genNewAppName <*> ((ApVer 1,) <$> (genInstallers i))
-    genNewAppName = apName . T.pack <$> genShortAscii
+    genNewAppName = ApName . text64 . T.pack <$> genShortAscii
 
     genShortAscii = QC.vectorOf 5 QC.arbitraryASCIIChar
 

--- a/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Mutator.hs
@@ -171,12 +171,14 @@ mutateDCert keys _ (DCertPool (RetirePool _ epoch@(EpochNo e))) = do
     key'   <- getAnyStakeKey keys
     pure $ DCertPool (RetirePool (hashKey key') epoch')
 
-mutateDCert keys _ (DCertPool (RegPool (PoolParams _ vrfHk pledge cost margin rwdacnt owners))) = do
+mutateDCert keys _ (DCertPool (RegPool
+  (PoolParams _ vrfHk pledge cost margin rwdacnt owners relays poolMD))) = do
   key'    <- getAnyStakeKey keys
   cost'   <- mutateCoin 0 100 cost
   p'      <- mutateNat 0 100 (fromIntegral $ numerator $ intervalValue margin)
   let interval = fromMaybe interval0 (mkUnitInterval $ fromIntegral p' % 100)
-  pure $ (DCertPool . RegPool) (PoolParams (hashKey key') vrfHk pledge cost' interval rwdacnt owners)
+  pure $ (DCertPool . RegPool)
+    (PoolParams (hashKey key') vrfHk pledge cost' interval rwdacnt owners relays poolMD)
 
 mutateDCert keys _ (DCertDeleg (Delegate (Delegation _ _))) = do
   delegator' <- getAnyStakeKey keys

--- a/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/UnitTests.hs
@@ -26,8 +26,8 @@ import           Delegation.Certificates (pattern Delegate, pattern RegKey, patt
 import           Generator (asStateTransition)
 import           TxData (pattern AddrBase, Credential (..), pattern DCertDeleg, pattern DCertPool,
                      Delegation (..), pattern PoolParams, pattern Ptr, pattern RewardAcnt,
-                     Wdrl (..), _poolCost, _poolMargin, _poolOwners, _poolPledge, _poolPubKey,
-                     _poolRAcnt, _poolVrf)
+                     Wdrl (..), _poolCost, _poolMD, _poolMargin, _poolOwners, _poolPledge,
+                     _poolPubKey, _poolRAcnt, _poolRelays, _poolVrf)
 import           Validation (ValidationError (..))
 
 import           Keys (pattern KeyPair, hashKey, vKey)
@@ -346,13 +346,15 @@ stakeKeyRegistration1 = LedgerState.emptyDelegation
 stakePool :: PoolParams
 stakePool = PoolParams
             {
-              _poolPubKey = hashKey $ vKey stakePoolKey1
-            , _poolVrf = hashKeyVRF stakePoolVRFKey1
+              _poolPubKey  = hashKey $ vKey stakePoolKey1
+            , _poolVrf     = hashKeyVRF stakePoolVRFKey1
             , _poolPledge  = Coin 0
-            , _poolCost = Coin 0      -- TODO: what is a sensible value?
-            , _poolMargin = interval0     --          or here?
+            , _poolCost    = Coin 0      -- TODO: what is a sensible value?
+            , _poolMargin  = interval0     --          or here?
             , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
             , _poolOwners  = Set.empty
+            , _poolRelays  = Seq.empty
+            , _poolMD      = Nothing
             }
 
 halfInterval :: UnitInterval
@@ -362,13 +364,15 @@ halfInterval =
 stakePoolUpdate :: PoolParams
 stakePoolUpdate = PoolParams
                    {
-                     _poolPubKey = hashKey $ vKey stakePoolKey1
-                   , _poolVrf = hashKeyVRF stakePoolVRFKey1
+                     _poolPubKey  = hashKey $ vKey stakePoolKey1
+                   , _poolVrf     = hashKeyVRF stakePoolVRFKey1
                    , _poolPledge  = Coin 0
-                   , _poolCost = Coin 100      -- TODO: what is a sensible value?
-                   , _poolMargin = halfInterval     --          or here?
+                   , _poolCost    = Coin 100      -- TODO: what is a sensible value?
+                   , _poolMargin  = halfInterval     --          or here?
                    , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
                    , _poolOwners  = Set.empty
+                   , _poolRelays  = Seq.empty
+                   , _poolMD      = Nothing
                    }
 
 tx4Body :: TxBody

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -67,12 +67,16 @@ The following derived types are introduced:
     \item the pool pledge.
     \item the pool reward account.
     \item the hash of the VRF verification key.
+    \item the pool relays.
+    \item optional pool medata (a url and a hash).
   \end{itemize}
   The idea of pool owners is explained in Section 4.4.4 of \cite{delegation_design}.
   The pool cost and margin indicate how much more of the rewards pool leaders
   get than the members.
   The pool pledge is explained in Section 5.1 of \cite{delegation_design}.
   The pool reward account is where all pool rewards go.
+  The pool relays and metadata url are explained in Sections
+  3.4.4 and 4.2 of \cite{delegation_design}.
 \end{itemize}
 
 Accessor functions for certificates and pool parameters are also defined, but
@@ -103,6 +107,8 @@ It does the following:
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
+      \var{url} & \URL & \text{a url}\\
+      \var{pmd} & \PoolMD & \text{pool metadata}\\
     \end{array}
   \end{equation*}
   %
@@ -131,11 +137,17 @@ It does the following:
       & \KeyHash \mapsto \Slot
       & \text{registered stake pools} \\
       %
+      \PoolMD
+      & ~=~
+      & \URL \times \type{PoolMDHash}
+      & \text{stake pool metadata} \\
+      %
       \PoolParam
       & ~=~
       & \powerset{\KeyHash} \times \Coin \times \unitInterval \times \Coin
       & \text{stake pool parameters} \\
-      & & \qquad \times \AddrRWD \times \KeyHash_{vrf}
+      & & \qquad \times \AddrRWD \times \KeyHash_{vrf} \\
+      & & \qquad \seqof{\URL} \times \PoolMD^?
     \end{array}
   \end{equation*}
   %

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -108,6 +108,8 @@
 \newcommand{\DCertGen}{\type{DCert_{genesis}}}
 \newcommand{\DCertMir}{\type{DCert_{mir}}}
 \newcommand{\PoolParam}{\type{PoolParam}}
+\newcommand{\PoolMD}{\type{PoolMD}}
+\newcommand{\URL}{\type{Url}}
 \newcommand{\UTxOState}{\ensuremath{\type{UTxOState}}}
 \newcommand{\ledgerState}{\ensuremath{\type{ledgerState}}}
 


### PR DESCRIPTION
This PR adds optional pool metadata (a url and a hash) to the registered stake pool parameters, as per section 3.4.4 and 4.2 of the Delegation Design document. This is the third 64 byte UTF-8 type I've added, so I tried to reduce code duplication by adding a new `Text64` type to the base types module.

It also adds the list of pool relays to the registered stake pool parameters, which is an upcoming change to the delegation design doc.

closes #1132 