### PR TITLE
adding in two more preservation of ada unit tests

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -34,6 +34,7 @@ module Examples
   , ex6C
   , ex6D
   , ex6E
+  , ex6F'
   , test6F
   , maxLovelaceSupply
   -- key pairs and example addresses

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -3,7 +3,7 @@
 
 module STSTests (stsTests) where
 
-import           Data.Either (isRight)
+import           Data.Either (isRight, fromRight)
 import qualified Data.Map.Strict as Map (empty, singleton)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCase, (@?=))
@@ -12,7 +12,7 @@ import           ConcreteCryptoTypes (CHAIN)
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
                      ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, ex6A, ex6B, ex6C,
-                     ex6D, ex6E, maxLovelaceSupply, test6F)
+                     ex6D, ex6E, ex6F', maxLovelaceSupply, test6F)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
 
@@ -94,6 +94,9 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 4C - Preservation of ADA" $ testPreservationOfAda ex4C
   , testCase "CHAIN example 5A - Preservation of ADA" $ testPreservationOfAda ex5A
   , testCase "CHAIN example 5B - Preservation of ADA" $ testPreservationOfAda ex5B
+  , testCase "CHAIN example 6A - Preservation of ADA" $ testPreservationOfAda ex6A
+  , testCase "CHAIN example 6F - Preservation of ADA" $
+      (totalAda (fromRight (error "CHAIN example 6F" ) ex6F') @?= maxLovelaceSupply)
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
   , testCase "Everybody signs in multi-sig" testEverybodySigns


### PR DESCRIPTION
Mirco PR! This adds two more "preservation of ADA" unit tests. probably not necessary since we have property tests for this, but it was easy to add :)