### PR TITLE
mechanism to halt obsolete nodes

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
@@ -177,6 +177,8 @@ data Globals = Globals
   , maxKESEvo :: Word64
     -- | Quorum for update system votes and MIR certificates
   , quorum :: Word64
+    -- | All blocks invalid after this protocol version
+  , maxMajorPV :: Natural
   }
 
 type ShelleyBase = ReaderT Globals Identity

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Utils.hs
@@ -99,6 +99,7 @@ testGlobals = Globals
   , securityParameter = 10
   , maxKESEvo = 10
   , quorum = 5
+  , maxMajorPV = 1000
   }
 
 runShelleyBase :: ShelleyBase a -> a

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -1569,7 +1569,7 @@ part of the STS. It calls $\mathsf{BHEAD}$, $\mathsf{PRTCL}$, and $\mathsf{BBODY
 
 The environment for the chain rule is the current slot number \var{s_{now}}.
 
-The transition checks two properties of the block header \var{bh}:
+The transition checks three things:
 \begin{itemize}
 \item The size of \var{bh} is less than or equal to the maximal size that the
   protocol parameters allow for block headers.
@@ -1577,6 +1577,9 @@ The transition checks two properties of the block header \var{bh}:
   maximal size that the protocol parameters allow for block bodies.
   It will later be verified that the size of the block body matches the size claimed
   in the header (see Figure~\ref{fig:rules:bbody}).
+\item The node is not obsolete, meaning that the major component of the
+  protocol version in the protocol parameters
+  is not bigger than the constant $\MaxMajorPV$.
 \end{itemize}
 
 
@@ -1680,6 +1683,10 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
       \var{s} \leteq \bslot{bhb}
       \\
       (\wcard,~\wcard,~\wcard,~(\wcard,~\wcard,~\wcard,~\var{pp}),~\wcard,~\wcard,\wcard) \leteq \var{nes}
+      &
+      (m,~\wcard)\leteq\fun{pv}~\var{pp}
+      \\~\\
+      m \leq \MaxMajorPV
       \\
       \bHeaderSize{bh} \leq \fun{maxHeaderSize}~\var{pp}
       &
@@ -1785,12 +1792,14 @@ The transition uses a few helper functions defined in Figure~\ref{fig:funcs:chai
   \label{fig:rules:chain}
 \end{figure}
 
-The CHAIN rule has two predicate failures:
+The CHAIN rule has three predicate failures:
 \begin{itemize}
 \item If the size of the block header is larger than the maximally allowed size,
   there is a \emph{HeaderSizeTooLarge} failure.
 \item If the size of the block body is larger than the maximally allowed size,
   there is a \emph{BlockSizeTooLarge} failure.
+\item If the major component of the protocol version is larger than $\MaxMajorPV$,
+  there is a \emph{ObsoleteNode} failure.
 \end{itemize}
 
 \clearpage

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -75,6 +75,7 @@
 \newcommand{\SlotsPrior}{\ensuremath{\mathsf{SlotsPrior}}}
 \newcommand{\SlotsPerEpoch}{\mathsf{SlotsPerEpoch}}
 \newcommand{\SlotsPerKESPeriod}{\mathsf{SlotsPerKESPeriod}}
+\newcommand{\MaxMajorPV}{\mathsf{MaxMajorPV}}
 \newcommand{\BlockNo}{\type{BlockNo}}
 \newcommand{\StartRewards}{\ensuremath{\mathsf{StartRewards}}}
 \newcommand{\MaxKESEvo}{\ensuremath{\mathsf{MaxKESEvo}}}

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -14,7 +14,7 @@ The type $\Coin$ is defined as an alias for the integers.
 Negative values will not be allowed in UTxO outputs or reward accounts,
 and $\Z$ is only chosen over $\N$ for its additive inverses.
 
-Six global constants are defined.
+Seven global constants are defined.
 As global constants, these values can only be changed by updating the software.
 The constants $\SlotsPerEpoch$ and $\SlotsPerKESPeriod$
 represent the number of slots in an epoch/KES period (for a brief explanation
@@ -25,9 +25,13 @@ must create a new operational certificate is given by $\MaxKESEvo$.
 \textbf{Note that if } $\MaxKESEvo$
 \textbf{is changed, the KES signature format may have to change as well.}
 
-Finally, $\Quorum$ determines the quorum amount needed for votes on the
+The constant $\Quorum$ determines the quorum amount needed for votes on the
 protocol parameter updates and the application version updates.
 
+Finally, $\MaxMajorPV$ provides a mechanism for halting outdated nodes.
+Once the major component of the protocol version in the protocol parameters
+exceeds this value, every subsequent block is invalid.
+See Figure~\ref{fig:rules:chain}.
 
 Some helper functions are defined in Figure~\ref{fig:defs:protocol-parameters-helpers}.
 The $\fun{minfee}$ function calculates the minimum fee that must be paid by a transaction.
@@ -67,7 +71,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
       \\
       \var{pv}
       & \ProtVer
-      & \N\times\N\times\N
+      & \N\times\N
       & \text{protocol version}
     \end{array}
   \end{equation*}
@@ -143,6 +147,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
       \StartRewards & \Duration & \text{duration to start reward calculations}\\
       \MaxKESEvo & \N & \text{maximum KES key evolutions}\\
       \Quorum & \N & \text{quorum for update system votes}\\
+      \MaxMajorPV & \N & \text{all blocks are invalid after this value}\\
     \end{array}
   \end{equation*}
   %

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -106,7 +106,7 @@ This rule has the following predicate failures:
 \end{enumerate}
 
 Note that $\fun{pvCanFollow}$
-was defined in \cite{byron_ledger_spec}. The constant $\SlotsPrior$
+is defined in Figure~\ref{fig:funcs:helper-updates}.
 is used in defining the blockchain layer functionality (specifically,
 properties of header validation),
 and is explained in detail in the paper \cite{byron_chain_spec}.
@@ -238,6 +238,12 @@ $\Quorum > |\var{genDelegs}|/2$ \textbf{.}
         \bigcup_{\var{fav}\in\var{favs}}
         \range{favs}
         \Bigg)
+  \end{align*}
+
+  \begin{align*}
+      & \fun{pvCanFollow} \in \ProtVer \to  \ProtVer \to \Bool \\
+      & \fun{pvCanFollow}~\var{(m,~n)}~\var{(m', n')} = \\
+      & ~~~~ (m', n') = (m+1,~0) \lor (m', n') = (m,~n+1) \\
   \end{align*}
 
   \begin{align*}


### PR DESCRIPTION
This PR adds a mechanism for halting outdated nodes.

There is a new constant, `MaxPV`, a protocol version, and a new predicate in the `CHAIN` rule that checks that the current protocol version is less than or equal to `MaxPV`.

The constant appears in the executable model as a new field in `Globals`.

Additionally, I discovered that the the formal spec wasn't updated everywhere it should have been in #1238, and so I've done that in this PR.

closes #1149 