### PR TITLE
using total (not active) stake for reward calc

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BaseTypes.hs
@@ -179,6 +179,8 @@ data Globals = Globals
   , quorum :: Word64
     -- | All blocks invalid after this protocol version
   , maxMajorPV :: Natural
+    -- | Maximum number of lovelace in the system
+  , maxLovelaceSupply :: Word64
   }
 
 type ShelleyBase = ReaderT Globals Identity

--- a/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/LedgerState.hs
@@ -1050,11 +1050,11 @@ reward
   -> Map (KeyHash crypto) (PoolParams crypto)
   -> Stake crypto
   -> Map (Credential crypto) (KeyHash crypto)
+  -> Coin
   -> Map (RewardAcnt crypto) Coin
-reward pp (BlocksMade b) r addrsRew poolParams stake@(Stake stake') delegs =
+reward pp (BlocksMade b) r addrsRew poolParams stake delegs total =
   rewards'
   where
-    total = Map.foldl (+) (Coin 0) stake'
     pdata =
       [ ( hk
         , ( poolParams Map.! hk
@@ -1120,8 +1120,9 @@ createRUpd
   :: EpochNo
   -> BlocksMade crypto
   -> EpochState crypto
+  -> Coin
   -> ShelleyBase (RewardUpdate crypto)
-createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pp) = do
+createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pp) total = do
     ei <- asks epochInfo
     slotsPerEpoch <- epochInfoSize ei e
     let (stake', delegs') = _pstakeGo ss
@@ -1139,7 +1140,7 @@ createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pp) = do
         deltaT1 = floor $ intervalValue (_tau pp) * fromIntegral rewardPot
         _R = Coin $ rewardPot - deltaT1
 
-        rs_ = reward pp b _R (Map.keysSet $ _rewards ds) poolsSS' stake' delegs'
+        rs_ = reward pp b _R (Map.keysSet $ _rewards ds) poolsSS' stake' delegs' total
         deltaT2 = _R - (Map.foldr (+) (Coin 0) rs_)
 
         blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/ChainTrace.hs
@@ -35,14 +35,14 @@ import           Generator.Block (genBlock)
 import           Generator.Core.Constants (maxGenesisUTxOouts, maxSlotTrace, minGenesisUTxOouts,
                      minSlotTrace)
 import           Generator.Core.QuickCheck (coreNodeKeys, genUtxo0, genesisDelegs0,
-                     maxLovelaceSupply, traceKeyPairsByStakeHash)
+                     traceKeyPairsByStakeHash)
 import           Generator.Update.QuickCheck (genPParams)
 import           Keys (pattern GenDelegs, Hash, hash)
 import           LedgerState (overlaySchedule)
 import           Shrinkers (shrinkBlock)
 import           Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import           STS.Chain (initialShelleyState)
-import           Test.Utils (runShelleyBase)
+import           Test.Utils (maxLLSupply, runShelleyBase)
 import           Updates (ApName (..), ApVer (..), pattern Applications, pattern Mdt)
 import           UTxO (balance)
 
@@ -103,7 +103,7 @@ mkGenesisChainState (IRC _slotNo) = do
     epoch0
     lastByronHeaderHash
     utxo0
-    (maxLovelaceSupply - balance utxo0)
+    (maxLLSupply - balance utxo0)
     delegs0
     osched_
     byronApps

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Core/QuickCheck.hs
@@ -23,7 +23,6 @@ module Generator.Core.QuickCheck
   , genesisAccountState
   , genesisDelegs0
   , increasingProbabilityAt
-  , maxLovelaceSupply
   , numCoreNodes
   , coreKeyPairs
   , coreNodeKeys
@@ -89,7 +88,7 @@ import           TxData (pattern AddrBase, pattern AddrPtr, pattern KeyHashObj,
                      pattern RequireAllOf, pattern RequireAnyOf, pattern RequireMOf,
                      pattern RequireSignature, pattern ScriptHashObj)
 
-import           Test.Utils (epochFromSlotNo, runShelleyBase)
+import           Test.Utils (epochFromSlotNo, maxLLSupply, runShelleyBase)
 
 genBool :: Gen Bool
 genBool = QC.arbitraryBoundedRandom
@@ -325,11 +324,8 @@ genesisAccountState :: AccountState
 genesisAccountState =
   AccountState
   { _treasury = Coin 0
-  , _reserves = maxLovelaceSupply
+  , _reserves = maxLLSupply
   }
-
-maxLovelaceSupply :: Coin
-maxLovelaceSupply = Coin 45*1000*1000*1000*1000*1000
 
 -- | Generate values the given distribution in 90% of the cases, and values at
 -- the bounds of the range in 10% of the cases.

--- a/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/STSTests.hs
@@ -12,7 +12,7 @@ import           ConcreteCryptoTypes (CHAIN)
 import           Examples (CHAINExample (..), alicePay, bobPay, carlPay, dariaPay, ex1, ex2A, ex2B,
                      ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D, ex2E, ex2F, ex2G, ex2H, ex2I, ex2J,
                      ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B, ex4C, ex5A, ex5B, ex6A, ex6B, ex6C,
-                     ex6D, ex6E, ex6F', maxLovelaceSupply, test6F)
+                     ex6D, ex6E, ex6F', test6F)
 import           MultiSigExamples (aliceAndBob, aliceAndBobOrCarl, aliceAndBobOrCarlAndDaria,
                      aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob, applyTxWithScript, bobOnly)
 
@@ -20,7 +20,7 @@ import           Control.State.Transition.Extended (TRC (..), applySTS)
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
 import           STS.Chain (totalAda)
 import           STS.Utxow (PredicateFailure (..))
-import           Test.Utils
+import           Test.Utils (maxLLSupply, runShelleyBase)
 import           Tx (hashScript)
 import           TxData (pattern RewardAcnt, pattern ScriptHashObj, Wdrl (..))
 
@@ -37,7 +37,7 @@ testCHAINExample (CHAINExample slotNow initSt block predicateFailure@(Left _)) =
 
 testPreservationOfAda :: CHAINExample -> Assertion
 testPreservationOfAda (CHAINExample _ _ _ (Right expectedSt)) =
-  totalAda expectedSt @?= maxLovelaceSupply
+  totalAda expectedSt @?= maxLLSupply
 testPreservationOfAda (CHAINExample _ _ _ (Left predicateFailure)) =
   assertFailure $ "Ada not preserved " ++ show predicateFailure
 
@@ -96,7 +96,7 @@ stsTests = testGroup "STS Tests"
   , testCase "CHAIN example 5B - Preservation of ADA" $ testPreservationOfAda ex5B
   , testCase "CHAIN example 6A - Preservation of ADA" $ testPreservationOfAda ex6A
   , testCase "CHAIN example 6F - Preservation of ADA" $
-      (totalAda (fromRight (error "CHAIN example 6F" ) ex6F') @?= maxLovelaceSupply)
+      (totalAda (fromRight (error "CHAIN example 6F" ) ex6F') @?= maxLLSupply)
   , testCase "Alice uses SingleSig script" testAliceSignsAlone
   , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
   , testCase "Everybody signs in multi-sig" testEverybodySigns

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Utils.hs
@@ -16,6 +16,7 @@ module Test.Utils
   , maxKESIterations
   , unsafeMkUnitInterval
   , slotsPerKESIteration
+  , maxLLSupply
   ) where
 
 import           BaseTypes (Globals (..), ShelleyBase, UnitInterval, mkUnitInterval)
@@ -26,6 +27,7 @@ import           Cardano.Crypto.VRF (deriveVerKeyVRF, evalCertified, genKeyVRF)
 import           Cardano.Crypto.VRF.Fake (WithResult (..))
 import           Cardano.Prelude (asks)
 import           Cardano.Slotting.EpochInfo (epochInfoEpoch, epochInfoFirst, fixedSizeEpochInfo)
+import           Coin (Coin (..))
 import           ConcreteCryptoTypes (Addr, CertifiedVRF, KeyPair, SKey, SKeyES, SignKeyVRF, VKey,
                      VKeyES, VKeyGenesis, VerKeyVRF)
 import           Control.Monad.Trans.Reader (runReaderT)
@@ -100,6 +102,7 @@ testGlobals = Globals
   , maxKESEvo = 10
   , quorum = 5
   , maxMajorPV = 1000
+  , maxLovelaceSupply = 45*1000*1000*1000*1000*1000
   }
 
 runShelleyBase :: ShelleyBase a -> a
@@ -126,3 +129,6 @@ maxKESIterations = runShelleyBase (asks maxKESEvo)
 
 slotsPerKESIteration :: Word64
 slotsPerKESIteration = runShelleyBase (asks slotsPerKESPeriod)
+
+maxLLSupply :: Coin
+maxLLSupply = Coin $ fromIntegral $ runShelleyBase (asks maxLovelaceSupply)

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -789,7 +789,7 @@ execution of the transition role is as follows:
       &
       ru = \Nothing
       \\~\\
-      ru' \leteq \createRUpd{b}{es}
+      ru' \leteq \createRUpd{b}{es}{\MaxLovelaceSupply}
     }
     {
       {\begin{array}{c}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -15,8 +15,8 @@
 \newcommand{\RewardUpdate}{\type{RewardUpdate}}
 
 \newcommand{\obligation}[4]{\fun{obligation}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
-\newcommand{\reward}[7]{\fun{reward}
-  ~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}~ \var{#5}~ \var{#6}~ \var{#7}}
+\newcommand{\reward}[8]{\fun{reward}
+  ~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}~ \var{#5}~ \var{#6}~ \var{#7}~ \var{#8}}
 \newcommand{\rewardOnePool}[9]{\fun{rewardOnePool}
   ~\var{#1}~\var{#2}~\var{#3}~\var{#4}~\var{#5}~\var{#6}~\var{#7}~\var{#8}~\var{#9}}
 \newcommand{\isActive}[4]{\fun{isActive}~ \var{#1}~ \var{#2}~ \var{#3}~ \var{#4}}
@@ -27,7 +27,7 @@
 \newcommand{\lReward}[4]{\fun{r_{operator}}~ \var{#1}~ \var{#2}~ \var{#3}~ {#4}}
 \newcommand{\mReward}[4]{\fun{r_{member}}~ \var{#1}~ \var{#2}~ \var{#3}~ {#4}}
 \newcommand{\poolReward}[5]{\fun{poolReward}~\var{#1}~{#2}~\var{#3}~\var{#4}~\var{#5}}
-\newcommand{\createRUpd}[2]{\fun{createRUpd}~\var{#1}~\var{#2}}
+\newcommand{\createRUpd}[3]{\fun{createRUpd}~\var{#1}~\var{#2}~\var{#3}}
 \newcommand{\getIR}[1]{\fun{getIR}~\var{#1}}
 
 This chapter introduces the epoch boundary transition system and the related reward calculation.
@@ -1152,8 +1152,8 @@ The calculation is done pool-by-pool.
       & \fun{reward} \in \PParams \to \BlocksMade \to \Coin\to \powerset{\AddrRWD}
       \to (\KeyHash \mapsto \PoolParam) \\
       & ~~~\to \Stake \to (\KeyHash_{stake} \mapsto \KeyHash_{pool}) \to
-      (\AddrRWD \mapsto \Coin)\\
-      & \reward{pp}{blocks}{R}{addrs_{rew}}{poolParams}{stake}{delegs}
+      \Coin \to (\AddrRWD \mapsto \Coin)\\
+      & \reward{pp}{blocks}{R}{addrs_{rew}}{poolParams}{stake}{delegs}{total}
           = \var{rewards}\\
       & ~~~\where \\
       & ~~~~~~~tot = \sum_{\_\mapsto c\in \var{stake}}c \\
@@ -1323,8 +1323,8 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
   \emph{Calculation to create a reward update}
   %
   \begin{align*}
-    & \fun{createRUpd} \in \BlocksMade \to \EpochState \to \RewardUpdate \\
-    & \createRUpd{b}{es} = \left(
+    & \fun{createRUpd} \in \BlocksMade \to \EpochState \to \Coin \to \RewardUpdate \\
+    & \createRUpd{b}{es}{total} = \left(
       \Delta t_1+\Delta t_2,-~\Delta r,~\var{rs},~-\var{feeSS}\right) \\
     & ~~~\where \\
     & ~~~~~~~(\var{acnt},~\var{ss},~\var{ls},~\var{pp}) = \var{es} \\
@@ -1346,7 +1346,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
     & ~~~~~~~\Delta t_1 = \floor*{(\fun{tau}~{pp}) \cdot \var{rewardPot}} \\
     & ~~~~~~~\var{R} = \var{rewardPot} - \Delta t_1 \\
     & ~~~~~~~\var{rs}
-      = \reward{pp}{b}{R}{(\dom{rewards})}{poolsSS}{stake}{delegs} \\
+      = \reward{pp}{b}{R}{(\dom{rewards})}{poolsSS}{stake}{delegs}{total} \\
     & ~~~~~~~\Delta t_{2} = R - \left(\sum\limits_{\_\mapsto c\in\var{rs}}c\right) \\
     & ~~~~~~~blocksMade = \sum_{\wcard \mapsto m \in b}m
   \end{align*}

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -80,6 +80,7 @@
 \newcommand{\StartRewards}{\ensuremath{\mathsf{StartRewards}}}
 \newcommand{\MaxKESEvo}{\ensuremath{\mathsf{MaxKESEvo}}}
 \newcommand{\Quorum}{\ensuremath{\mathsf{Quorum}}}
+\newcommand{\MaxLovelaceSupply}{\ensuremath{\mathsf{MaxLovelaceSupply}}}
 \newcommand{\Duration}{\type{Duration}}
 \newcommand{\StakePools}{\type{StakePools}}
 \newcommand{\StakeCreds}{\type{StakeCreds}}

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -14,7 +14,7 @@ The type $\Coin$ is defined as an alias for the integers.
 Negative values will not be allowed in UTxO outputs or reward accounts,
 and $\Z$ is only chosen over $\N$ for its additive inverses.
 
-Seven global constants are defined.
+Eight global constants are defined.
 As global constants, these values can only be changed by updating the software.
 The constants $\SlotsPerEpoch$ and $\SlotsPerKESPeriod$
 represent the number of slots in an epoch/KES period (for a brief explanation
@@ -28,10 +28,17 @@ must create a new operational certificate is given by $\MaxKESEvo$.
 The constant $\Quorum$ determines the quorum amount needed for votes on the
 protocol parameter updates and the application version updates.
 
-Finally, $\MaxMajorPV$ provides a mechanism for halting outdated nodes.
+The constant $\MaxMajorPV$ provides a mechanism for halting outdated nodes.
 Once the major component of the protocol version in the protocol parameters
 exceeds this value, every subsequent block is invalid.
 See Figure~\ref{fig:rules:chain}.
+
+Finally, $\MaxLovelaceSupply$ gives the total number of lovelace in the system,
+which is used in the reward calculation.
+It is always equal to the sum of the values in the UTxO, plus the sum of the
+values in the reward accounts, plus the deposit pot, plus the fee pot,
+plus the treasury and the reserves.
+
 
 Some helper functions are defined in Figure~\ref{fig:defs:protocol-parameters-helpers}.
 The $\fun{minfee}$ function calculates the minimum fee that must be paid by a transaction.
@@ -148,6 +155,7 @@ between epochs and slots and one function $\fun{kesPeriod}$ for getting the cycl
       \MaxKESEvo & \N & \text{maximum KES key evolutions}\\
       \Quorum & \N & \text{quorum for update system votes}\\
       \MaxMajorPV & \N & \text{all blocks are invalid after this value}\\
+      \MaxLovelaceSupply & \Coin & \text{total lovelace in the system}\\
     \end{array}
   \end{equation*}
   %


### PR DESCRIPTION
This PR corresponds to the changes described in #1243 

The reward calculation now computes relative stake based on total stake instead of active stake.

I made total stake a new global parameter, `maxLovelaceSupply`.

Using total stake instead of active stake made the reward calculations in the examples trivial: since the active stake was so small compared to 45B ADA, the rewards were zero. So I gave more stake to the initial genesis UTxO, and used this opportunity to make the example less brittle.

closes #1244 