### PR TITLE
report std error in shelley CDDL tests, fix tests

### DIFF
--- a/shelley/chain-and-ledger/cddl-spec/shelley.cddl
+++ b/shelley/chain-and-ledger/cddl-spec/shelley.cddl
@@ -89,20 +89,20 @@ delegation_certificate =
   // 9, move_instantaneous_reward     ; move instantaneous rewards
   ]
 
-move_instantaneous_reward = { * [credential] => coin }
+move_instantaneous_reward = { * credential => coin }
 pointer = (uint, uint, uint)
 
 credential =
-  (  0, keyhash
+  [  0, keyhash
   // 1, scripthash
-  )
+  ]
 
 pool_params = ( keyhash             ; operator
               , $vrf_keyhash        ; vrf keyhash
               , coin                ; pledge
               , coin                ; cost
               , unit_interval       ; margin
-              , [credential]        ; reward account
+              , credential        ; reward account
               , finite_set<keyhash> ; pool owners
               , [* url]             ; relays
               , [?pool_metadata]    ; pool metadata
@@ -111,7 +111,7 @@ pool_params = ( keyhash             ; operator
 url = tstr .size 64
 pool_metadata = [url, metadata_hash]
 
-withdrawals = { * [credential] => coin }
+withdrawals = { * credential => coin }
 
 full_update = [ protocol_param_update_votes
               , application_version_update_votes
@@ -155,8 +155,8 @@ application_name = tstr .size 64
 system_tag = tstr .size 64
 
 transaction_witness_set =
-  { ?0 => [* pubkey_witness]
-  , ?1 => [* script]
+  { ?0 => [* vkeywitness ]
+  , ?1 => [* script ]
   }
 
 transaction_metadatum =
@@ -171,7 +171,14 @@ transaction_metadadum_label = uint
 transaction_metadata = { * transaction_metadadum_label => transaction_metadatum }
 
 
-vkeywitness = [$vkey, $signature]
+vkeywitness = [ $vkey, $signature ]
+
+script =
+  [  0, keyhash
+  // 1, [ * script ]
+  // 2, [ * script ]
+  // 3, uint, [ * script ]
+  ]
 
 unit_interval = rational
 

--- a/shelley/chain-and-ledger/executable-spec/src/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Tx.hs
@@ -61,7 +61,7 @@ import           GHC.Generics (Generic)
 import           Lens.Micro.TH (makeLenses)
 import           MetaData (MetaData)
 
-import           Serialization (CborSeq (..), mapHelper)
+import           Serialization (CborSeq (..), decodeMapContents)
 import           TxData (Credential (..), MultiSig (..), Script (..), ScriptHash (..), TxBody (..),
                      TxId (..), TxIn (..), TxOut (..), WitVKey (..), certs, inputs,
                      nativeMultiSigTag, outputs, ttl, txUpdate, txfee, wdrls, witKeyHash)
@@ -126,7 +126,7 @@ instance (Crypto crypto) =>
 instance (Crypto crypto) =>
   FromCBOR (CBORWits crypto) where
   fromCBOR = do
-    mapParts <- mapHelper $
+    mapParts <- decodeMapContents $
       decodeWord >>= \case
         0 -> fromCBOR >>= \x -> pure (\w -> w { _cborWitsVKeys  = x })
         1 -> fromCBOR >>= \x -> pure (\w -> w { _cborWitsScripts  = x })

--- a/shelley/chain-and-ledger/executable-spec/src/Updates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Updates.hs
@@ -34,8 +34,8 @@ module Updates
   )
 where
 
-import           Cardano.Binary (Encoding, FromCBOR (..), ToCBOR (..), decodeMapLenOrIndef,
-                     encodeListLen, encodeMapLen, enforceSize)
+import           Cardano.Binary (Encoding, FromCBOR (..), ToCBOR (..), encodeListLen, encodeMapLen,
+                     enforceSize)
 import           Cardano.Crypto.Hash (Hash)
 import           Cardano.Ledger.Shelley.Crypto
 import           Cardano.Prelude (NoUnexpectedThunks (..))
@@ -52,7 +52,7 @@ import           BaseTypes (Nonce, Text64, UnitInterval)
 import           Coin (Coin)
 import           Keys (GenDelegs, GenKeyHash)
 import           PParams (ActiveSlotCoeff, PParams (..))
-import           Serialization (CBORMap (..), decodeCollection)
+import           Serialization (CBORMap (..), decodeMapContents)
 import           Slot (EpochNo (..), SlotNo)
 
 import           Numeric.Natural (Natural)
@@ -195,7 +195,7 @@ instance ToCBOR PParamsUpdate where
 
 instance FromCBOR PParamsUpdate where
   fromCBOR = fmap (PParamsUpdate . Set.fromList)
-    $ decodeCollection decodeMapLenOrIndef
+    $ decodeMapContents
     $ fromCBOR @Word8 >>= \case
          0  -> MinFeeA <$> fromCBOR
          1  -> MinFeeB <$> fromCBOR

--- a/shelley/chain-and-ledger/executable-spec/test/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Examples.hs
@@ -122,7 +122,7 @@ import           Updates (pattern AVUpdate, ApName (..), ApVer (..), pattern App
                      InstallerHash (..), pattern Mdt, pattern PPUpdate, PParamsUpdate (..),
                      Ppm (..), SystemTag (..), pattern Update, pattern UpdateState, emptyUpdate,
                      emptyUpdateState)
-import           UTxO (pattern UTxO, balance, makeGenWitnessesVKey, makeWitnessesVKey, txid)
+import           UTxO (pattern UTxO, balance, makeWitnessesVKey, txid)
 
 data CHAINExample =
   CHAINExample { currentSlotNo    :: SlotNo       -- ^ Current slot
@@ -443,7 +443,7 @@ txEx2A = Tx
             -- since it is an owner of the stake pool being registered,
             -- and *not* because of the stake key registration.
                      `Set.union`
-           makeGenWitnessesVKey txbodyEx2A [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
+           makeWitnessesVKey txbodyEx2A [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
              , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
              , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
              , KeyPair (coreNodeVKG 3) (coreNodeSKG 3)
@@ -2148,7 +2148,7 @@ txbodyEx5A = TxBody
 txEx5A :: Tx
 txEx5A = Tx
            txbodyEx5A
-           (makeWitnessesVKey txbodyEx5A [ alicePay ] `Set.union` makeGenWitnessesVKey txbodyEx5A [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0) ])
+           (makeWitnessesVKey txbodyEx5A [ alicePay ] `Set.union` makeWitnessesVKey txbodyEx5A [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0) ])
            Map.empty
            Nothing
 
@@ -2297,7 +2297,7 @@ txbodyEx6A = TxBody
 txEx6A :: Tx
 txEx6A = Tx
            txbodyEx6A
-           (makeWitnessesVKey txbodyEx6A [ alicePay ] `Set.union` makeGenWitnessesVKey txbodyEx6A
+           (makeWitnessesVKey txbodyEx6A [ alicePay ] `Set.union` makeWitnessesVKey txbodyEx6A
              [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
              , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
              , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
@@ -2370,7 +2370,7 @@ ex6A = CHAINExample (SlotNo 10) initStEx2A blockEx6A (Right expectedStEx6A)
 txEx6B :: Tx
 txEx6B = Tx
            txbodyEx6A
-           (makeWitnessesVKey txbodyEx6A [ alicePay ] `Set.union` makeGenWitnessesVKey txbodyEx6A
+           (makeWitnessesVKey txbodyEx6A [ alicePay ] `Set.union` makeWitnessesVKey txbodyEx6A
              [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
              , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
              , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
@@ -2461,7 +2461,7 @@ txbodyEx6F = TxBody
 
 txEx6F :: Tx
 txEx6F = Tx txbodyEx6F
-            (makeWitnessesVKey txbodyEx6F [ alicePay, aliceStake ]  `Set.union` makeGenWitnessesVKey txbodyEx6F
+            (makeWitnessesVKey txbodyEx6F [ alicePay, aliceStake ]  `Set.union` makeWitnessesVKey txbodyEx6F
              [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
              , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
              , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)

--- a/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Generator/Utxo/QuickCheck.hs
@@ -41,8 +41,7 @@ import           STS.Ledger (LedgerEnv (..))
 import           Tx (pattern Tx, pattern TxBody, pattern TxOut, getKeyCombination, hashScript)
 import           TxData (pattern AddrBase, pattern AddrPtr, pattern KeyHashObj,
                      pattern ScriptHashObj, Wdrl (..), getRwdCred, _outputs, _txfee)
-import           UTxO (pattern UTxO, balance, makeGenWitnessesVKey, makeWitnessesFromScriptKeys,
-                     makeWitnessesVKey)
+import           UTxO (pattern UTxO, balance, makeWitnessesFromScriptKeys, makeWitnessesVKey)
 
 import           Debug.Trace as D
 
@@ -178,7 +177,7 @@ mkTxWits
   -> Set WitVKey
 mkTxWits txBody keyWits genesisWits keyHashMap msigs =
   makeWitnessesVKey txBody keyWits
-  `Set.union` makeGenWitnessesVKey txBody genesisWits
+  `Set.union` makeWitnessesVKey txBody genesisWits
   `Set.union` makeWitnessesFromScriptKeys txBody keyHashMap msigs
 
 -- | Generate a transaction body with the given inputs/outputs and certificates

--- a/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Rules/TestUtxow.hs
@@ -24,12 +24,11 @@ import           Control.State.Transition.Trace (SourceSignalTarget, pattern Sou
                      signal, source, target)
 
 import           ConcreteCryptoTypes (StakeCreds, StakePools, Tx, UTXO, UTXOW)
-import           Keys (hashAnyKey)
 import           Ledger.Core (dom, (<|))
 import           LedgerState (pattern UTxOState, keyRefunds)
 import           PParams (PParams)
 import           Tx (getKeyCombinations, _body, _witnessMSigMap, _witnessVKeySet)
-import           TxData (pattern TxIn, pattern WitGVKey, pattern WitVKey, _certs, _inputs, _txfee)
+import           TxData (pattern TxIn, witKeyHash, _certs, _inputs, _txfee)
 import           UTxO (pattern UTxO, balance, totalDeposits, txins, txouts)
 
 --------------------------
@@ -174,6 +173,4 @@ requiredMSigSignaturesSubset tr =
     existsReqKeyComb keyHashes msig  =
       any (\kl -> (Set.fromList kl) `Set.isSubsetOf` keyHashes) (getKeyCombinations msig)
     keyHashSet sst =
-      Set.map (\case
-                  WitVKey vk _   -> hashAnyKey vk
-                  WitGVKey vkg _ -> hashAnyKey vkg) (_witnessVKeySet $ signal sst)
+      Set.map witKeyHash (_witnessVKeySet $ signal sst)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Serialization.hs
@@ -62,7 +62,7 @@ import           ConcreteCryptoTypes (Addr, BHBody, CoreKeyPair, GenKeyHash, Has
                      VerKeyVRF, hashKeyVRF)
 import           OCert (KESPeriod (..), pattern OCert)
 import           Unsafe.Coerce (unsafeCoerce)
-import           UTxO (makeGenWitnessVKey, makeWitnessVKey)
+import           UTxO (makeWitnessVKey)
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
@@ -329,20 +329,10 @@ serializationTests = testGroup "Serialization Tests"
       <> S (Coin 2)
     )
   , case makeWitnessVKey testTxb testKey1 of
-    (WitGVKey _ _) -> error "unreachable"
     w@(WitVKey vk sig) ->
       checkEncodingCBOR "vkey_witnesses"
       w  -- Transaction _witnessVKeySet element
-      ( T (TkListLen 3 . TkWord 0)
-        <> S vk -- vkey
-        <> S sig -- signature
-      )
-  , case makeGenWitnessVKey testTxb testGKey of
-    (WitVKey _ _) -> error "unreachable"
-    w@(WitGVKey vk sig) ->
-      checkEncodingCBOR "genesis_vkey_witnesses"
-      w  -- Transaction _witnessVKeySet element
-      ( T (TkListLen 3 . TkWord 1)
+      ( T (TkListLen 2)
         <> S vk -- vkey
         <> S sig -- signature
       )


### PR DESCRIPTION
When the ruby script returns standard error, the CDDL tests now report a failure. A few tests needed fixing on the Haskell side. The full transactions `Tx` now pass, but there are still some problems with the full block, so those tests are commented out. The tests now pass for me locally, but we still do not have them working in CI.

The remain test fixes will be done in #1270

closes #1253 