### PR TITLE
removing prev hash todo

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/BlockChain.hs
@@ -181,10 +181,6 @@ instance FromCBORGroup ProtVer where
 
 data BHBody crypto = BHBody
   { -- | Hash of the previous block header
-    -- The first block in a chain will set this field to Nothing.
-    -- TODO Since the Shelley chain will begins with blocks from
-    -- the Byron era, we should probably use a sum type here,
-    -- so that the first shelley block can point to the last Byron block.
     bheaderPrev           :: HashHeader crypto
     -- | verification key of block issuer
   , bheaderVk             :: VKey crypto


### PR DESCRIPTION
Micro PR! :microscope:  Just removing a comment about the previous header hash inside the Shelley block header. See #1266