### PR TITLE
active slot coefficient optimization edge cases

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -316,7 +316,7 @@ instance VRFValue Nonce where
 
 instance VRFValue UnitInterval where
   -- TODO Consider whether this is a reasonable thing to do
-  fromNatural k = truncateUnitInterval $ toInteger (k `mod` 10000) % 10000
+  fromNatural k = truncateUnitInterval $ toInteger k % 10000
 
 hashKeyVRF
   :: Crypto crypto


### PR DESCRIPTION
handle the edge cases in the active slot coefficient optimizations for the VRF leader check.

closes #1271 