### PR TITLE
Zero 'raus' on epoch change/

### DIFF
--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -983,7 +983,7 @@ expires.
             \epsilon\\
             \var{avs}\\
             \emptyset\\
-            \var{raus}\\
+            \emptyset\\
             \emptyset\\
             \emptyset\\
             \emptyset\\


### PR DESCRIPTION
Per Damian's comment in the exec spec:

            -- Note that we delete the registered application proposals from the
            -- state on epoch change, since adopting these depends on the @cps@
            -- and @pws@ sets, which are deleted as well. So it doesn't seem
            -- sensible to keep @raus@ around

This brings the formal spec in line with the exec spec and the implementation.