### PR TITLE
Prevent replay attacks using votes

### DIFF
--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -578,6 +578,7 @@ instance STS ADDVOTE where
     = AVSigDoesNotVerify
     | NoUpdateProposal UpId
     | VoteByNonGenesisDelegate VKey
+    | RepeatVoteByGenesisDelegate VKey
     deriving (Eq, Show, Data, Typeable, Generic, NoUnexpectedThunks)
 
   initialRules = []
@@ -594,6 +595,7 @@ instance STS ADDVOTE where
                 Just vks -> Set.singleton (pid, vks)
                 Nothing  -> Set.empty
         vtsPid /= Set.empty ?! VoteByNonGenesisDelegate vk
+        not (vtsPid `Set.isSubsetOf` vts) ?! RepeatVoteByGenesisDelegate vk
         Set.member pid rups ?! NoUpdateProposal pid
         Core.verify vk pid (vote ^. vSig) ?! AVSigDoesNotVerify
         return $! vts <> vtsPid

--- a/byron/ledger/formal-spec/default.nix
+++ b/byron/ledger/formal-spec/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import  ../../../default.nix {}).pkgs
+{ pkgs ? (import  ../../../nix/default.nix {}).pkgs
 }:
 
 with pkgs;

--- a/byron/ledger/formal-spec/update-mechanism.tex
+++ b/byron/ledger/formal-spec/update-mechanism.tex
@@ -799,9 +799,9 @@ In Rule~\ref{eq:rule:voting}:
   casting the vote.
 \item The vote must refer to a registered update proposal.
 \item The proposal id must be signed by the key that is casting the vote.
-\item It is possible for the same genesis key to vote multiple times for
-  the same proposal, however this vote will be counted once (note that we're
-  taking the union of the key-proposal-id pairs).
+\item A given genesis key is only allowed to vote for a proposal once. This
+  provision guards against replay attacks, where a third party may replay the
+  vote in multiple blocks.
 \end{itemize}
 
 \begin{figure}[htb]
@@ -813,6 +813,7 @@ In Rule~\ref{eq:rule:voting}:
       \var{vts}_{\var{pid}} \leteq
       \{ (\var{pid}, \var{vk_s}) \mid \var{vk_s} \mapsto \var{vk} \in \var{dms} \} &
       \var{vts}_{\var{pid}} \neq \emptyset &
+      \var{vts}_{\var{pid}} \nsubseteq \var{vts} \\
       \mathcal{V}_{\var{vk}}\serialised{\var{pid}}_{(\vSig{v})}\\
     }
     {


### PR DESCRIPTION
Addresses part of https://github.com/input-output-hk/cardano-ledger/issues/739 by disallowing (rather than coaelescing) duplicate votes.

It is now an error to include a vote in a block which has already been included in the vote tally. The mempool should therefore reject it.

There will be a corresponding change to `cardano-ledger` updating this in the implementation.