### PR TITLE
removing redundant vkey from block

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
@@ -34,7 +34,6 @@ header_body =
 
 operational_cert =
   ( hot_vkey        : $kes_vkey
-  , cold_vkey       : $vkey
   , sequence_number : uint
   , kes_period      : uint
   , sigma           : $signature

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -35,7 +35,6 @@ module Shelley.Spec.Ledger.BlockChain
     --
   , seedEta
   , seedL
-  , bvkcold
   , vrfChecks
   , incrBlocks
   , mkSeed
@@ -379,7 +378,7 @@ vrfChecks eta0 (PoolDistr pd) f bhb =
                          (coerce $ bheaderL bhb)
             && checkVRFValue (VRF.certifiedNatural $ bheaderL bhb) sigma f
  where
-  hk = hashKey $ bvkcold bhb
+  hk = hashKey $ bheaderVk bhb
   vrfK = bheaderVrfVk bhb
   prevHash = bheaderPrev bhb
   slot = bheaderSlotNo bhb
@@ -431,9 +430,6 @@ seedEta = mkNonce 0
 
 seedL :: Nonce
 seedL = mkNonce 1
-
-bvkcold :: BHBody crypto -> VKey crypto
-bvkcold bhb = ocertVkCold $ bheaderOCert bhb
 
 hBbsize :: BHBody crypto -> Natural
 hBbsize = bsize

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OCert.hs
@@ -26,7 +26,7 @@ import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
 
 import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.Keys (KeyHash, Sig, VKey, VKeyES)
+import           Shelley.Spec.Ledger.Keys (KeyHash, Sig, VKeyES)
 import           Shelley.Spec.Ledger.Serialization (CBORGroup (..), FromCBORGroup (..), ToCBORGroup (..))
 import           Shelley.Spec.Ledger.Slot (SlotNo (..))
 
@@ -52,8 +52,6 @@ newtype KESPeriod = KESPeriod Natural
 data OCert crypto = OCert
   { -- | The operational hot key
     ocertVkHot     :: VKeyES crypto
-    -- | The cold key
-  , ocertVkCold    :: VKey crypto
     -- | counter
   , ocertN         :: Natural
     -- | Start of key evolving signature period
@@ -71,11 +69,10 @@ instance
  where
   toCBORGroup ocert =
          toCBOR (ocertVkHot ocert)
-      <> toCBOR (ocertVkCold ocert)
       <> toCBOR (ocertN ocert)
       <> toCBOR (ocertKESPeriod ocert)
       <> toCBOR (ocertSigma ocert)
-  listLen _ = 5
+  listLen _ = 4
 
 instance
   (Crypto crypto)
@@ -84,7 +81,6 @@ instance
   fromCBORGroup =
     OCert
       <$> fromCBOR
-      <*> fromCBOR
       <*> fromCBOR
       <*> fromCBOR
       <*> fromCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -84,7 +84,7 @@ bbodyTransition = do
   TRC ( BbodyEnv oslots pp _reserves
       , BbodyState ls b
       , Block (BHeader bhb _) txsSeq@(TxSeq txs)) <- judgmentContext
-  let hk = hashKey $ bvkcold bhb
+  let hk = hashKey $ bheaderVk bhb
 
   bBodySize txsSeq == fromIntegral (hBbsize bhb) ?! WrongBlockBodySizeBBODY
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
@@ -62,8 +62,9 @@ ocertTransition
 ocertTransition = do
   TRC (env, cs, BHeader bhb sigma) <- judgmentContext
 
-  let OCert vk_hot vk_cold n c0@(KESPeriod c0_) tau = bheaderOCert bhb
-      hk = hashKey vk_cold
+  let OCert vk_hot n c0@(KESPeriod c0_) tau = bheaderOCert bhb
+      vkey = bheaderVk bhb
+      hk = hashKey vkey
       s = bheaderSlotNo bhb
   kp@(KESPeriod kp_) <- liftSTS $ kesPeriod s
 
@@ -79,7 +80,7 @@ ocertTransition = do
                                               -- predicate failure in the
                                               -- transition.
 
-  verify vk_cold (vk_hot, n, c0) tau ?! InvalidSignatureOCERT
+  verify vkey (vk_hot, n, c0) tau ?! InvalidSignatureOCERT
   verifyKES vk_hot bhb sigma t ?! InvalidKesSignatureOCERT
 
   case currentIssueNo env cs hk of

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -88,7 +88,7 @@ overlayTransition = do
   TRC ( OverlayEnv pp osched eta0 pd (GenDelegs genDelegs)
       , cs
       , bh@(BHeader bhb _)) <- judgmentContext
-  let vk = bvkcold bhb
+  let vk = bheaderVk bhb
       vkh = hashKey vk
 
   case Map.lookup (bheaderSlotNo bhb) osched of

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -221,7 +221,7 @@ testBHB = BHBody
           , bsize          = 0
           , bheaderBlockNo = BlockNo 44
           , bhash          = bbHash $ TxSeq Seq.empty
-          , bheaderOCert   = OCert (snd testKESKeys) (vKey testKey1)
+          , bheaderOCert   = OCert (snd testKESKeys)
             0 (KESPeriod 0) (sign (sKey testKey1) (snd testKESKeys, 0, KESPeriod 0))
           , bprotvert      = ProtVer 0 0
           }
@@ -796,7 +796,6 @@ serializationTests = testGroup "Serialization Tests"
       bbhash = bbHash $ TxSeq Seq.empty
       ocert = OCert
                 (snd testKESKeys)
-                (vKey testKey1)
                 0
                 (KESPeriod 0)
                 (sign (sKey testKey1) (snd testKESKeys, 0, KESPeriod 0))
@@ -817,7 +816,7 @@ serializationTests = testGroup "Serialization Tests"
       , bprotvert      = protover
       }
     )
-    ( T (TkListLen $ 9 + 5 + 2)
+    ( T (TkListLen $ 9 + 4 + 2)
       <> S prevhash
       <> S issuerVkey
       <> S vrfVkey
@@ -833,15 +832,13 @@ serializationTests = testGroup "Serialization Tests"
 
   -- checkEncodingCBOR "operational_cert"
   , let vkHot     = snd testKESKeys
-        vkCol     = vKey testKey1
         counter   = 0
         kesperiod = KESPeriod 0
         signature = sign (sKey testKey1) (snd testKESKeys, 0, KESPeriod 0)
     in
     checkEncodingCBORCBORGroup "operational_cert"
-    (OCert vkHot vkCol counter kesperiod signature)
+    (OCert vkHot counter kesperiod signature)
     (    S vkHot
-      <> S vkCol
       <> S counter
       <> S kesperiod
       <> S signature
@@ -852,7 +849,7 @@ serializationTests = testGroup "Serialization Tests"
     in
     checkEncodingCBOR "block_header"
     (BHeader testBHB sig)
-    ( (T $ TkListLen 17)
+    ( (T $ TkListLen 16)
         <> G testBHB
         <> S sig
     )
@@ -864,7 +861,7 @@ serializationTests = testGroup "Serialization Tests"
     in
     checkEncodingCBOR "empty_block"
     (Block bh txns)
-    ( (T $ TkListLen 20)
+    ( (T $ TkListLen 19)
         <> G bh
         <> T (TkListLen 0 . TkListLen 0 . TkMapLen 0)
     )
@@ -895,7 +892,7 @@ serializationTests = testGroup "Serialization Tests"
     in
     checkEncodingCBOR "rich_block"
     (Block bh txns)
-    ( (T $ TkListLen 20)
+    ( (T $ TkListLen 19)
         -- header
         <> G bh
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -418,10 +418,9 @@ newtype NatNonce = NatNonce Natural
 mkOCert :: AllPoolKeys -> Natural -> KESPeriod -> OCert
 mkOCert pkeys n c0 =
   let (_, (_, vKeyHot)) = head $ hot pkeys
-      KeyPair vKeyCold sKeyCold = cold pkeys in
+      KeyPair _vKeyCold sKeyCold = cold pkeys in
   OCert
    vKeyHot
-   vKeyCold
    n
    c0
    (sign sKeyCold (vKeyHot, n, c0))

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -139,7 +139,6 @@ $\mathsf{NEWEPOCH}$ and $\mathsf{UPDN}$, $\mathsf{VRF}$ and $\mathsf{BBODY}$.
     \left(
       \begin{array}{r@{~\in~}lr}
         \var{vk_{hot}} & \VKeyEv & \text{operational (hot) key}\\
-        \var{vk_{cold}} & \VKey & \text{cold key}\\
         \var{n} & \N & \text{certificate issue number}\\
         c_0 & \KESPeriod & \text{start KES period}\\
         \sigma & \Sig & \text{cold key signature}\\
@@ -964,10 +963,10 @@ The transition rule is shown in Figure~\ref{fig:rules:ocert}. From the block
 header body \var{bhb} we first extract the following:
 
 \begin{itemize}
-  \item The operational certificate, consisting of the hot key \var{vk_{hot}}, the cold key
-    \var{vk_{cold}}, the KES period number \var{n}, the KES period start \var{c_0} and the cold key
+  \item The operational certificate, consisting of the hot key \var{vk_{hot}},
+    the KES period number \var{n}, the KES period start \var{c_0} and the cold key
   signature.
-\item The hash \var{hk} of \var{vk_{cold}}.
+\item The cold key \var{vk_{cold}}.
 \item The slot \var{s} for the block.
 \item The number of KES periods that have elapsed since the start period on the certificate.
 \end{itemize}
@@ -998,7 +997,9 @@ of the key \var{hk} with the KES period \var{n}.
     {
       (\var{bhb},~\sigma)\leteq\var{bh}
       &
-      (\var{vk_{hot}},~\var{vk_{cold}},~n,~c_{0},~\tau) \leteq \bocert{bhb}
+      (\var{vk_{hot}},~n,~c_{0},~\tau) \leteq \bocert{bhb}
+      &
+      \var{vk_{cold}} \leteq \bvkcold{bhb}
       \\
       \var{hk} \leteq \hashKey{vk_{cold}}
       &


### PR DESCRIPTION
The operator verification key was redundantly being stored in both the block header and the operational certificate. now it's not.

closes #1290 