### PR TITLE
testing serialization against the CDDL file

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
@@ -48,7 +48,7 @@ transaction_body =
   , 1 : [* transaction_output]
   , 2 : coin ; fee
   , 3 : uint ; ttl
-  , 4 : [* delegation_certificate]
+  , ? 4 : [* delegation_certificate]
   , ? 5 : withdrawals
   , ? 6 : full_update
   , ? 7 : metadata_hash

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -163,6 +163,7 @@ test-suite shelley-spec-ledger-test
     build-depends:
       QuickCheck,
       base,
+      base16-bytestring,
       bytestring,
       cardano-binary,
       cardano-crypto-class,

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -172,6 +172,7 @@ test-suite shelley-spec-ledger-test
       containers,
       cryptonite,
       cs-ledger,
+      directory,
       shelley-spec-ledger,
       hedgehog,
       multiset,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/CDDL.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/CDDL.hs
@@ -16,11 +16,13 @@ import qualified Prelude
 
 import           Cardano.Binary
 import           Cardano.Prelude
+import           Control.Exception (bracket)
 import qualified Data.ByteString.Lazy as BSL
 import           Data.ByteString.Lazy.Char8 as Char8 (lines, unpack)
+import qualified System.Directory as Sys
+import qualified System.IO as Sys
+import qualified System.IO.Error as Sys
 import           System.Process.ByteString.Lazy
-
-
 
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -30,29 +32,33 @@ import           Shelley.Spec.Ledger.Serialization
 import           Shelley.Spec.Ledger.Updates (PParamsUpdate)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (AVUpdate, Addr, BHBody, BHeader,
-                     DCert, LaxBlock, MultiSig, OCert, PPUpdate, Tx, TxBody, TxIn, TxOut, Update)
+                     Credential, DCert, LaxBlock, MultiSig, OCert, PPUpdate, Tx, TxBody, TxIn,
+                     TxOut, Update)
 
 cddlTests :: TestTree
 cddlTests = withResource combinedCDDL (const (pure ())) $ \cddl ->
   testGroup "CDDL roundtrip tests" $
     [
-      cddlGroupTest @BHeader  30 "header"
-    , cddlGroupTest @BHBody   30 "header_body"
-    , cddlGroupTest @OCert    30 "operational_cert"
-    , cddlGroupTest @Addr     20 "address"
-    , cddlTest @TxBody        30 "transaction_body"
-    , cddlTest @TxOut         30 "transaction_output"
-    , cddlTest @DCert         30 "delegation_certificate"
-    , cddlTest @TxIn          30 "transaction_input"
-    , cddlTest @MetaData      10 "transaction_metadata"
-    , cddlTest @MultiSig      30 "script"
-    , cddlTest @Update        30 "full_update"
-    , cddlTest @AVUpdate      30 "application_version_update_votes"
-    , cddlTest @PPUpdate      30 "protocol_param_update_votes"
-    , cddlTest @PParamsUpdate 30 "protocol_param_update"
-    , cddlTest @Tx            30 "transaction"
-    , cddlTest @LaxBlock      30 "block"
+      cddlGroupTest @BHeader  n "header"
+    , cddlGroupTest @BHBody   n "header_body"
+    , cddlGroupTest @OCert    n "operational_cert"
+    , cddlGroupTest @Addr     n "address"
+    , cddlTest @Credential    n "credential"
+    , cddlTest @TxBody        n "transaction_body"
+    , cddlTest @TxOut         n "transaction_output"
+    , cddlTest @DCert         n "delegation_certificate"
+    , cddlTest @TxIn          n "transaction_input"
+    , cddlTest @MetaData      n "transaction_metadata"
+    , cddlTest @MultiSig      n "script"
+    , cddlTest @Update        n "full_update"
+    , cddlTest @AVUpdate      n "application_version_update_votes"
+    , cddlTest @PPUpdate      n "protocol_param_update_votes"
+    , cddlTest @PParamsUpdate n "protocol_param_update"
+    , cddlTest @Tx            n "transaction"
+    , cddlTest @LaxBlock      n "block"
     ] <*> pure cddl
+  where
+    n = 1
 
 combinedCDDL :: IO BSL.ByteString
 combinedCDDL = do
@@ -72,19 +78,7 @@ cddlTest n entryName cddlRes = testCase
   $ do
   basecddl <- cddlRes
   let cddl = "output = " <> entryName <> "\n" <> basecddl
-  examples <- Char8.lines <$> generateCBORDiagStdIn n cddl :: IO [BSL.ByteString]
-  forM_ examples $ \exampleDiag -> do
-    exampleBytes <- diagToBytes exampleDiag
-    decoded <- case decodeFull @a exampleBytes of
-      Right x -> pure x
-      Left e  ->
-        assertFailure $ Prelude.unlines
-          [ "Failed to deserialize"
-          , "Error: " <> show e
-          , "Data: " <> Char8.unpack exampleDiag
-          ]
-    let reencoded = serialize decoded
-    verifyConforming reencoded cddl
+  cddlTestCommon @a serialize fromCBOR n cddl
 
 cddlGroupTest
   :: forall a. (ToCBORGroup a, FromCBORGroup a)
@@ -92,25 +86,36 @@ cddlGroupTest
   -> BSL.ByteString
   -> IO BSL.ByteString
   -> TestTree
-cddlGroupTest n entryName cddlRes = testCase
-  ("cddl roundtrip " <> show (typeRep (Proxy @a)))
-  $ do
+cddlGroupTest n entryName cddlRes = testCase ("cddl roundtrip " <> show (typeRep (Proxy @a))) $ do
   basecddl <- cddlRes
   let cddl = "output = [" <> entryName <> "]\n" <> basecddl
-  examples <- Char8.lines <$> generateCBORDiagStdIn n cddl :: IO [BSL.ByteString]
-  let decoder = groupRecord :: forall s. Decoder s a
-  forM_ examples $ \exampleDiag -> do
-    exampleBytes <- diagToBytes exampleDiag
-    decoded <- case decodeFullDecoder "CBORGroup" decoder exampleBytes of
-      Right x -> pure x
-      Left e  ->
-        assertFailure $ Prelude.unlines
-          [ "Failed to deserialize"
-          , "Error: " <> show e
-          , "Data: " <> Char8.unpack exampleDiag
-          ]
-    let reencoded = serializeEncoding $ encodeListLen 1 <> toCBORGroup decoded
-    verifyConforming reencoded cddl
+  cddlTestCommon @a
+    (\x -> serializeEncoding $ encodeListLen (listLen x) <> toCBORGroup x)
+    groupRecord
+    n
+    cddl
+
+cddlTestCommon
+  :: (a -> BSL.ByteString)
+  -> (forall s. Decoder s a)
+  -> Int
+  -> BSL.ByteString
+  -> IO ()
+cddlTestCommon serializer decoder n cddlData = do
+  usingFile cddlData $ \cddl -> do
+    examples <- Char8.lines <$> generateCBORDiagStdIn n cddlData :: IO [BSL.ByteString]
+    forM_ examples $ \exampleDiag -> do
+      exampleBytes <- diagToBytes exampleDiag
+      decoded <- case decodeFullDecoder "cbor test" decoder exampleBytes of
+        Right x -> pure x
+        Left e  ->
+          assertFailure $ Prelude.unlines
+            [ "Failed to deserialize"
+            , "Error: " <> show e
+            , "Data: " <> Char8.unpack exampleDiag
+            ]
+      let reencoded = serializer decoded
+      verifyConforming reencoded cddl
 
 
 data StdErr = StdErr Prelude.String BSL.ByteString
@@ -147,5 +152,22 @@ readProcessWithExitCode2 exec args stdIn = do
     ExitSuccess -> pure (Right stdOut)
     ExitFailure _i -> pure (Left stdErr)
 
-verifyConforming :: BSL.ByteString -> BSL.ByteString -> Assertion
-verifyConforming _value _cddl = pure () -- TODO
+withTempFile :: FilePath -> String -> (FilePath -> Handle -> IO a) -> IO a
+withTempFile dir nameTemplate k = bracket (Sys.openBinaryTempFile dir nameTemplate) cleanup (uncurry k)
+  where
+  cleanup (fileName, h) = do
+    Sys.hClose h
+    catch (Sys.removeFile fileName) $ \err ->
+      if Sys.isDoesNotExistError err then return () else throwIO err
+
+usingFile :: BSL.ByteString -> (FilePath -> IO a) -> IO a
+usingFile bytes k = withTempFile "." "tmp" $ \fileName h -> do
+  BSL.hPut h bytes
+  Sys.hClose h
+  k fileName
+
+verifyConforming :: BSL.ByteString -> FilePath -> Assertion
+verifyConforming value cddl = readProcessWithExitCode2 "cddl" [cddl, "validate", "-"] value >>=
+    \case
+      Right _ -> pure ()
+      Left stdErr -> throwStdErr "Got failing exit code when validating against cddl" stdErr


### PR DESCRIPTION
The CDDL test now test that the serializations validate against the CCDL spec.

The tests do now take a lot longer, so we reduced the number of trials. We can run a lot more once we get the nightly tests running.

closes #1254 