### PR TITLE
reducing proto param update voting period

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -131,7 +131,7 @@ ppupTransitionNonEmpty = do
     ei <- asks epochInfo
     EpochNo e <- epochInfoEpoch ei slot
     epochInfoFirst ei (EpochNo $ e + 1)
-  slot < firstSlotNextEpoch *- (Duration sp) ?! PPUpdateTooLatePPUP
+  slot < firstSlotNextEpoch *- (Duration (2 * sp)) ?! PPUpdateTooLatePPUP
 
   currentEpoch <- liftSTS $ do
     ei <- asks epochInfo

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -434,7 +434,7 @@ getKESPeriodRenewalNo keys (KESPeriod kp) =
           then n
           else go rest (n + 1) k
 
--- | True if the given slot is within the last `slotsPrior`
+-- | True if the given slot is within the last `2 * slotsPrior`
 -- slots of the current epoch.
 tooLateInEpoch :: SlotNo -> Bool
 tooLateInEpoch s = runShelleyBase $ do
@@ -442,4 +442,4 @@ tooLateInEpoch s = runShelleyBase $ do
   firstSlotNo <- epochInfoFirst ei (epochFromSlotNo s + 1)
   slotsPrior_ <- asks slotsPrior
 
-  return (s >= firstSlotNo *- Duration slotsPrior_)
+  return (s >= firstSlotNo *- Duration (2 * slotsPrior_))

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -81,6 +81,12 @@ proposed updates (indexed by genesis keys) and an optional epoch
 The purpose of the $\Seed$ type in the $\PPUpdate$ derived type is explained
 in the protocol parameter adoption rules.
 
+Protocol updates are only allowed up until ($2\cdot\SlotsPrior$)-many slots before the
+end of the epoch. The reason for this involves how we safely predict hard forks.
+Changing the protocol version can result in a hard fork, and we would like an
+entire stability period between when we know that an hard fork will neccessarily happen
+and when the current epoch ends.
+
 \begin{itemize}
   \item PP-Update-Empty : no new updates were proposed, do nothing
   \item PP-Update-Nonempty : some new updates $\var{pup}$ were proposed
@@ -94,7 +100,7 @@ This rule has the following predicate failures:
 
 \begin{enumerate}
 \item In the case of \var{slot} being greater than or equal to
-  $\fun{firstSlot}~((\epoch{slot}) + 1) - \fun{SlotsPrior}$, there is
+  $\fun{firstSlot}~((\epoch{slot}) + 1) - 2\cdot\fun{SlotsPrior}$, there is
   a \emph{PPUpdateTooLate} failure.
 \item In the case that the epoch number in the signal is not the current epoch,
   there is a \emph{PPUpdateNoEpoch} failure.
@@ -169,7 +175,7 @@ and will be rejected otherwise.
       \forall\var{ps}\in\range{pup},~
         \var{pv}\mapsto\var{v}\in\var{ps}\implies\fun{pvCanFollow}~(\fun{pv}~\var{pp})~\var{v}
       \\
-      \var{slot} < \fun{firstSlot}~((\epoch{slot}) + 1) - \SlotsPrior
+      \var{slot} < \fun{firstSlot}~((\epoch{slot}) + 1) - 2\cdot\SlotsPrior
       \\
       \epoch{slot} = e
     }

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -84,7 +84,7 @@ in the protocol parameter adoption rules.
 Protocol updates are only allowed up until ($2\cdot\SlotsPrior$)-many slots before the
 end of the epoch. The reason for this involves how we safely predict hard forks.
 Changing the protocol version can result in a hard fork, and we would like an
-entire stability period between when we know that an hard fork will neccessarily happen
+entire stability period between when we know that a hard fork will necessarily happen
 and when the current epoch ends.
 
 \begin{itemize}


### PR DESCRIPTION
This PR restricts the protocol parameter update window by another "2k" slots, this giving us an entire stability period between when we know that the protocol version is changing and the end of the epoch.

This addresses the shelley concerns regarding #1288 