### PR TITLE
aligning pool params with stake distribution

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -89,7 +89,7 @@ newEpochTransition = do
       es'' <- trans @(MIR crypto) $ TRC ((), es', ())
       es''' <- trans @(EPOCH crypto) $ TRC ((), es'', e)
       let EpochState _acnt ss _ls pp = es'''
-          (Stake stake, delegs) = _pstakeSet ss
+          SnapShot (Stake stake) delegs poolParams = _pstakeSet ss
           Coin total = Map.foldl (+) (Coin 0) stake
           sd =
             aggregatePlus $
@@ -99,7 +99,7 @@ newEpochTransition = do
                                        -- particular when shrinking)
                   | (hk, Coin c) <- Map.toList stake
                 ]
-          pd' = Map.intersectionWith (,) sd (Map.map _poolVrf (_poolsSS ss))
+          pd' = Map.intersectionWith (,) sd (Map.map _poolVrf poolParams)
       osched' <- liftSTS $ overlaySchedule e gkeys pp
       pure $
         NewEpochState

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -59,7 +59,7 @@ snapTransition = do
 
   let UTxOState utxo deposits' fees _ = u
   let DState stkCreds _ _ _ _ _ _ = dstate
-  let PState stpools poolParams _ = pstate
+  let PState stpools _ _          = pstate
   let stake = stakeDistr utxo dstate pstate
   _slot <- liftSTS $ do
     ei <- asks epochInfo
@@ -70,7 +70,6 @@ snapTransition = do
     s { _pstakeMark = stake
       , _pstakeSet = _pstakeMark s
       , _pstakeGo = _pstakeSet s
-      , _poolsSS = poolParams
       , _feeSS = fees + decayed}
     u { _deposited = oblg
       , _fees = fees + decayed}

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -183,6 +183,8 @@ type WitVKey = TxData.WitVKey ConcreteCrypto
 
 type Wdrl = TxData.Wdrl ConcreteCrypto
 
+type SnapShot = EpochBoundary.SnapShot ConcreteCrypto
+
 type SnapShots = EpochBoundary.SnapShots ConcreteCrypto
 
 type Stake = EpochBoundary.Stake ConcreteCrypto

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -32,7 +32,8 @@ import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, pattern Delegate,
                      pattern GenesisDelegate, pattern MIRCert, pattern PoolDistr, pattern RegKey,
                      pattern RegPool, pattern RetirePool)
-import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), SnapShots (..), Stake (..))
+import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), SnapShot (..), SnapShots (..),
+                     Stake (..))
 import           Shelley.Spec.Ledger.Keys (DiscVKey (..), pattern GenKeyHash, Hash, pattern KeyHash,
                      pattern KeyPair, pattern UnsafeSig, hash, hashKey, sKey, sign, signKES,
                      undiscriminateKeyHash, vKey)
@@ -963,12 +964,18 @@ serializationTests = testGroup "Serialization Tests"
     ( T (TkMapLen 1)
       <> S (KeyHashObj testKeyHash1)
       <> S (Coin 13))
-  , let mark = ( Stake $ Map.singleton (KeyHashObj testKeyHash1) (Coin 11)
-               , Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
-        set  = ( Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22)
-               , Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
-        go   = ( Stake $ Map.singleton (KeyHashObj testKeyHash1) (Coin 33)
-               , Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
+  , let mark = SnapShot
+                 (Stake $ Map.singleton (KeyHashObj testKeyHash1) (Coin 11))
+                 (Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
+                 ps
+        set  = SnapShot
+                 (Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22))
+                 (Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
+                 ps
+        go   = SnapShot
+                 (Stake $ Map.singleton (KeyHashObj testKeyHash1) (Coin 33))
+                 (Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
+                 ps
         p = PoolParams
               { _poolPubKey = testKeyHash1
               , _poolVrf = testVRFKH
@@ -987,22 +994,27 @@ serializationTests = testGroup "Serialization Tests"
         fs = Coin 123
     in
     checkEncodingCBOR "snapshots"
-    (SnapShots mark set go ps fs)
-    ( T (TkListLen 5)
+    (SnapShots mark set go fs)
+    ( T (TkListLen 4)
       <> S mark
       <> S set
       <> S go
-      <> S ps
       <> S fs )
   , let
       e  = EpochNo 0
       ac = AccountState (Coin 100) (Coin 100)
-      mark = ( Stake $ Map.singleton (KeyHashObj testKeyHash1) (Coin 11)
-             , Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
-      set  = ( Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22)
-             , Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
-      go   = ( Stake $ Map.singleton (KeyHashObj testKeyHash1) (Coin 33)
-             , Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
+      mark = SnapShot
+               (Stake $ Map.singleton (KeyHashObj testKeyHash1) (Coin 11))
+               (Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
+               ps
+      set  = SnapShot
+               (Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22))
+               (Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
+               ps
+      go   = SnapShot
+               (Stake $ Map.singleton (KeyHashObj testKeyHash1) (Coin 33))
+               (Map.singleton (KeyHashObj testKeyHash1) testKeyHash3)
+               ps
       p = PoolParams
             { _poolPubKey = testKeyHash1
             , _poolVrf = testVRFKH
@@ -1019,7 +1031,7 @@ serializationTests = testGroup "Serialization Tests"
             }
       ps = Map.singleton testKeyHash1 p
       fs = Coin 123
-      ss = SnapShots mark set go ps fs
+      ss = SnapShots mark set go fs
       ls = emptyLedgerState
       pps = emptyPParams
       bs = Map.singleton testKeyHash1 1

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -482,8 +482,8 @@ In the first case, the new epoch state is updated as follows:
       \\~\\
       {\begin{array}{r@{~\leteq~}l}
           (\var{acnt},~\var{ss},~\var{ls}, \var{pp}) & \var{es'''} \\
-         (\wcard,~\var{pstake_{set}},~\wcard,~\var{pools},~\wcard) & \var{ss} \\
-         (\var{stake}, \var{delegs}) & \var{pstake_{set}} \\
+         (\wcard,~\var{pstake_{set}},~\wcard,~\wcard) & \var{ss} \\
+         (\var{stake},~\var{delegs},~\var{poolPrms}) & \var{pstake_{set}} \\
          total & \sum_{\_ \mapsto c\in\var{stake}} c \\
           \var{sd} & \fun{aggregate_{+}}~\left(\var{delegs}^{-1}\circ
                      \left\{
@@ -496,7 +496,7 @@ In the first case, the new epoch state is updated as follows:
             {
               \begin{array}{r@{~\in~}l}
                 \var{hk_p}\mapsto\sigma & \var{sd} \\
-                \var{hk_p}\mapsto\var{p} & \var{pools}
+                \var{hk_p}\mapsto\var{p} & \var{poolPrms}
               \end{array}
             }
             \right\}\\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -5,6 +5,7 @@
 \newcommand{\Acnt}{\type{Acnt}}
 \newcommand{\PlReapState}{\type{PlReapState}}
 \newcommand{\NewPParamEnv}{\type{NewPParamEnv}}
+\newcommand{\Snapshot}{\type{Snapshot}}
 \newcommand{\Snapshots}{\type{Snapshots}}
 \newcommand{\SnapshotEnv}{\type{SnapshotEnv}}
 \newcommand{\SnapshotState}{\type{SnapshotState}}
@@ -236,7 +237,7 @@ Figure~\ref{fig:epoch-defs} introduces three new derived types:
       & \text{blocks made by stake pools} \\
       \var{stake}
       & \Stake
-      & \KeyHash_{stake} \mapsto \Coin
+      & \Credential \mapsto \Coin
       & \text{stake} \\
     \end{array}
   \end{equation*}
@@ -305,13 +306,20 @@ The stake distribution calculation is given in Figure~\ref{fig:functions:stake-d
 \label{sec:snapshots}
 
 The state transition types for stake distribution snapshots are given in
-Figure~\ref{fig:ts-types:snapshot}. The type $\type{\Snapshots}$ contains the
+Figure~\ref{fig:ts-types:snapshot}.
+Each snapshot consists of:
+\begin{itemize}
+  \item $\var{stake}$, a stake distribution, which is defined in
+    Figure~\ref{fig:epoch-defs} as a mapping of credentials to coin.
+  \item $\var{delegations}$, a delegation map, mapping credentials to stake pools.
+  \item $\var{poolParameters}$, storing the pool parameters of each stake pool.
+\end{itemize}
+
+The type $\type{\Snapshots}$ contains the
 information needing to be saved on the epoch boundary:
 \begin{itemize}
   \item $\var{pstake_{mark}}$, $\var{pstake_{set}}$ and $\var{pstake_{go}}$ are the three
-    stake distribution snapshots (paired with the corresponding delegation map),
-    as explained in Section~\ref{sec:reward-overview}.
-  \item $\var{poolsSS}$ stores the pool parameters from the epoch boundary.
+    snapshots as explained in Section~\ref{sec:reward-overview}.
   \item $\var{feeSS}$ stores the fees and decayed deposit amounts at the epoch boundary.
 \end{itemize}
 
@@ -333,16 +341,24 @@ information needing to be saved on the epoch boundary:
   %
   \emph{Snapshots}
   \begin{equation*}
+    \Snapshot =
+    \left(
+      \begin{array}{r@{~\in~}ll}
+        \var{stake} & \Stake & \text{stake distribution}\\
+        \var{delegations} & \Credential\mapsto\KeyHash_{pool}
+                          & \text{stake delegations}\\
+        \var{poolParameters} & \KeyHash_{pool} \mapsto \PoolParam & \text{pool parameters }\\
+      \end{array}
+    \right)
+  \end{equation*}
+
+  \begin{equation*}
     \Snapshots =
     \left(
       \begin{array}{r@{~\in~}ll}
-        \var{pstake_{mark}} & \Stake\times(\KeyHash_{stake}\mapsto\KeyHash_{pool})
-                            & \text{newest stake}\\
-        \var{pstake_{set}} & \Stake\times(\KeyHash_{stake}\mapsto\KeyHash_{pool})
-                           & \text{middle stake}\\
-        \var{pstake_{go}} & \Stake\times(\KeyHash_{stake}\mapsto\KeyHash_{pool})
-                          & \text{oldest stake}\\
-        \var{poolsSS} & \KeyHash \mapsto \PoolParam & \text{pool parameters }\\
+        \var{pstake_{mark}} & \Snapshot & \text{newest stake}\\
+        \var{pstake_{set}}  & \Snapshot & \text{middle stake}\\
+        \var{pstake_{go}}   & \Snapshot & \text{oldest stake}\\
         \var{feeSS} & \Coin & \text{fee snapshot}\\
       \end{array}
     \right)
@@ -377,8 +393,6 @@ This transition has no preconditions and results in the following state change:
   \item The oldest snapshot is replaced with the penultimate one.
   \item The penultimate snapshot is replaced with the newest one.
   \item The newest snapshot is replaced with one just calculated.
-  \item The pool parameters are stored.
-  \item The pool performance is stored.
   \item The fees and decayed deposits are stored in $\var{feeSS}$. Note that this value will not
     change between epochs, unlike the $\var{fees}$ and $\var{deposits}$ values in the UTxO state.
   \item In the UTxO state, the decayed deposit amounts are moved from the deposit pot
@@ -417,7 +431,6 @@ This transition has no preconditions and results in the following state change:
           \var{pstake_{mark}}\\
           \var{pstake_{set}}\\
           \var{pstake_{go}}\\
-          \var{poolsSS}\\
           \var{feeSS} \\
           ~ \\
           \var{utxo} \\
@@ -429,10 +442,9 @@ This transition has no preconditions and results in the following state change:
       \trans{snap}{e}
       \left(
         \begin{array}{r}
-          \varUpdate{(\var{stake},~\var{delegations})} \\
+          \varUpdate{(\var{stake},~\var{delegations},~\var{poolParams})} \\
           \varUpdate{\var{pstake_{mark}}} \\
           \varUpdate{\var{pstake_{set}}} \\
-          \varUpdate{\var{poolParams}} \\
           \varUpdate{\var{fees} + \var{decayed}} \\
           ~ \\
           \var{utxo} \\


### PR DESCRIPTION
This PR aligns the pool parameters for a given reward calculation with the corresponding stake pool distribution instead of the corresponding performance period (performance is always based upon the previous distribution).

In detail, this means removing `_poolsSS` from the `Snapshots` record and adding this parameter mapping to each individual snapshot. Since each snapshot now has three things (stake distribution, delegation mapping, and pool parameters), I've turned the snapshot into its own type.

closes #1297 