### PR TITLE
Script stuff moved to Scripts

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -40,6 +40,7 @@ library
                      Shelley.Spec.Ledger.TxData
                      Shelley.Spec.Ledger.Updates
                      Shelley.Spec.Ledger.Validation
+                     Shelley.Spec.Ledger.Scripts
                      Shelley.Spec.Ledger.STS.Avup
                      Shelley.Spec.Ledger.STS.Bbody
                      Shelley.Spec.Ledger.STS.Tick

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address.hs
@@ -13,7 +13,8 @@ where
 import           Cardano.Ledger.Shelley.Crypto
 import           Shelley.Spec.Ledger.Keys (KeyDiscriminator (..), KeyPair, hashKey, vKey)
 import           Shelley.Spec.Ledger.Tx (hashScript)
-import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), MultiSig, RewardAcnt (..))
+import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), RewardAcnt (..))
+import           Shelley.Spec.Ledger.Scripts
 
 mkVKeyRwdAcnt
   :: Crypto crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -107,7 +107,7 @@ import           Shelley.Spec.Ledger.Tx (Tx (..), extractGenKeyHash, extractKeyH
 import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), DelegCert (..), Ix,
                      MIRCert (..), PoolCert (..), PoolMetaData (..), PoolParams (..), Ptr (..),
                      RewardAcnt (..), TxBody (..), TxId (..), TxIn (..), TxOut (..), Url (..),
-                     Wdrl (..), countMSigNodes, getRwdCred, witKeyHash)
+                     Wdrl (..), getRwdCred, witKeyHash)
 import           Shelley.Spec.Ledger.Updates (AVUpdate (..), Mdt (..), PPUpdate (..), Update (..),
                      UpdateState (..), apps, emptyUpdate, emptyUpdateState)
 import           Shelley.Spec.Ledger.UTxO (UTxO (..), balance, totalDeposits, txinLookup, txins,
@@ -122,6 +122,7 @@ import           Shelley.Spec.Ledger.Delegation.PoolParams (poolSpec)
 import           Ledger.Core (dom, (∪), (∪+), (⋪), (▷), (◁))
 import           Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase, UnitInterval,
                      intervalValue, mkUnitInterval, text64Size)
+import           Shelley.Spec.Ledger.Scripts                     
 
 
 -- | Representation of a list of pairs of key pairs, e.g., pay and stake keys

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Shelley.Spec.Ledger.Scripts
+  where
+
+import           Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR), decodeWord,
+                     encodeListLen, encodeWord, encodeWord8, matchSize, decodeListLen)
+import           Shelley.Spec.Ledger.Serialization (decodeList, encodeFoldable)
+import           Cardano.Crypto.Hash (hashWithSerialiser)
+import qualified Data.List as List (concat, concatMap, permutations)
+import           Cardano.Prelude (Generic, NoUnexpectedThunks(..))
+import           Cardano.Ledger.Shelley.Crypto (Crypto(..), HASH)
+import           Data.Word (Word8)
+import           Shelley.Spec.Ledger.BaseTypes (invalidKey)
+import           Shelley.Spec.Ledger.Keys (AnyKeyHash, pattern AnyKeyHash, Hash)
+
+
+-- | Magic number representing the tag of the native multi-signature script
+-- language. For each script language included, a new tag is chosen and the tag
+-- is included in the script hash for a script.
+nativeMultiSigTag :: Word8
+nativeMultiSigTag = 0
+
+
+-- | A simple language for expressing conditions under which it is valid to
+-- withdraw from a normal UTxO payment address or to use a stake address.
+--
+-- The use case is for expressing multi-signature payment addresses and
+-- multi-signature stake addresses. These can be combined arbitrarily using
+-- logical operations:
+--
+-- * multi-way \"and\";
+-- * multi-way \"or\";
+-- * multi-way \"N of M\".
+--
+-- This makes it easy to express multi-signature addresses, and provides an
+-- extension point to express other validity conditions, e.g., as needed for
+-- locking funds used with lightning.
+--
+data MultiSig crypto =
+       -- | Require the redeeming transaction be witnessed by the spending key
+       --   corresponding to the given verification key hash.
+       RequireSignature   (AnyKeyHash crypto)
+
+       -- | Require all the sub-terms to be satisfied.
+     | RequireAllOf      [MultiSig crypto]
+
+       -- | Require any one of the sub-terms to be satisfied.
+     | RequireAnyOf      [MultiSig crypto]
+
+       -- | Require M of the given sub-terms to be satisfied.
+     | RequireMOf    Int [MultiSig crypto]
+  deriving (Show, Eq, Ord, Generic)
+
+instance NoUnexpectedThunks (MultiSig crypto)
+
+newtype ScriptHash crypto =
+  ScriptHash (Hash (HASH crypto) (Script crypto))
+  deriving (Show, Eq, Ord, NoUnexpectedThunks)
+
+data Script crypto = MultiSigScript (MultiSig crypto)
+                     -- new languages go here
+  deriving (Show, Eq, Ord, Generic)
+
+instance NoUnexpectedThunks (Script crypto)
+
+deriving instance Crypto crypto => ToCBOR (ScriptHash crypto)
+deriving instance Crypto crypto => FromCBOR (ScriptHash crypto)
+
+
+-- | Count nodes and leaves of multi signature script
+countMSigNodes :: MultiSig crypto -> Int
+countMSigNodes (RequireSignature _) = 1
+countMSigNodes (RequireAllOf msigs) = 1 + sum (map countMSigNodes msigs)
+countMSigNodes (RequireAnyOf msigs) = 1 + sum (map countMSigNodes msigs)
+countMSigNodes (RequireMOf _ msigs) = 1 + sum (map countMSigNodes msigs)
+
+
+
+-- | Hashes native multi-signature script, appending the 'nativeMultiSigTag' in
+-- front and then calling the script CBOR function.
+hashAnyScript
+  :: Crypto crypto
+  => Script crypto
+  -> ScriptHash crypto
+hashAnyScript (MultiSigScript msig) =
+  ScriptHash $ hashWithSerialiser (\x -> encodeWord8 nativeMultiSigTag
+                                          <> toCBOR x) (MultiSigScript msig)
+
+-- | Get one possible combination of keys for multi signature script
+getKeyCombination :: MultiSig crypto -> [AnyKeyHash crypto]
+
+getKeyCombination (RequireSignature hk) = [hk]
+getKeyCombination (RequireAllOf msigs) =
+  List.concatMap getKeyCombination msigs
+getKeyCombination (RequireAnyOf msigs) =
+  case msigs of
+    []  -> []
+    x:_ -> getKeyCombination x
+getKeyCombination (RequireMOf m msigs) =
+  List.concatMap getKeyCombination (take m msigs)
+
+
+-- | Get all valid combinations of keys for given multi signature. This is
+-- mainly useful for testing.
+getKeyCombinations :: MultiSig crypto -> [[AnyKeyHash crypto]]
+
+getKeyCombinations (RequireSignature hk) = [[hk]]
+
+getKeyCombinations (RequireAllOf msigs) = [List.concat $
+  List.concatMap getKeyCombinations msigs]
+
+getKeyCombinations (RequireAnyOf msigs) = List.concatMap getKeyCombinations msigs
+
+getKeyCombinations (RequireMOf m msigs) =
+  let perms = map (take m) $ List.permutations msigs in
+    map (concat . List.concatMap getKeyCombinations) perms
+
+
+
+-- CBOR
+
+instance (Crypto crypto) =>
+  ToCBOR (MultiSig crypto) where
+  toCBOR (RequireSignature hk) =
+    encodeListLen 2 <> encodeWord 0 <> toCBOR hk
+  toCBOR (RequireAllOf msigs) =
+    encodeListLen 2 <> encodeWord 1 <> encodeFoldable msigs
+  toCBOR (RequireAnyOf msigs) =
+    encodeListLen 2 <> encodeWord 2 <> encodeFoldable msigs
+  toCBOR (RequireMOf m msigs) =
+    encodeListLen 3 <> encodeWord 3 <> toCBOR m <> encodeFoldable msigs
+
+instance (Crypto crypto) =>
+  FromCBOR (MultiSig crypto) where
+  fromCBOR = do
+    n <- decodeListLen
+    decodeWord >>= \case
+      0 -> matchSize "RequireSignature" 2 n >> (RequireSignature . AnyKeyHash) <$> fromCBOR
+      1 -> matchSize "RequireAllOf" 2 n >> RequireAllOf <$> decodeList fromCBOR
+      2 -> matchSize "RequireAnyOf" 2 n >> RequireAnyOf <$> decodeList fromCBOR
+      3 -> do
+        matchSize "RequireMOf" 3 n
+        m     <- fromCBOR
+        msigs <- decodeList fromCBOR
+        pure $ RequireMOf m msigs
+      k -> invalidKey k
+
+instance (Crypto crypto) =>
+  ToCBOR (Script crypto) where
+  toCBOR (MultiSigScript msig) =
+    toCBOR nativeMultiSigTag <> toCBOR msig
+
+instance (Crypto crypto) =>
+  FromCBOR (Script crypto) where
+  fromCBOR = do
+    decodeWord >>= \case
+      0 -> MultiSigScript <$> fromCBOR
+      k -> invalidKey k

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -38,15 +38,16 @@ import           Numeric.Natural (Natural)
 import           Ledger.Core (Relation (..))
 import           Shelley.Spec.Ledger.BaseTypes (Text64, UnitInterval, invalidKey)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Keys (AnyKeyHash, pattern AnyKeyHash, GenKeyHash, Hash,
+import           Shelley.Spec.Ledger.Keys (AnyKeyHash, GenKeyHash, Hash,
                      KeyHash, pattern KeyHash, Sig, VKey, VerKeyVRF, hashAnyKey)
 import           Shelley.Spec.Ledger.MetaData (MetaDataHash)
 import           Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
 import           Shelley.Spec.Ledger.Updates (Update, emptyUpdate, updateNull)
 
 import           Shelley.Spec.Ledger.Serialization (CBORGroup (..), CBORMap (..), CborSeq (..),
-                     FromCBORGroup (..), ToCBORGroup (..), decodeList, decodeMapContents,
-                     encodeFoldable)
+                     FromCBORGroup (..), ToCBORGroup (..), decodeMapContents)
+
+import           Shelley.Spec.Ledger.Scripts
 
 -- |The delegation of one stake key to another.
 data Delegation crypto = Delegation
@@ -128,63 +129,6 @@ data Ptr
   deriving (ToCBOR, FromCBOR) via CBORGroup Ptr
 
 instance NoUnexpectedThunks Ptr
-
--- | A simple language for expressing conditions under which it is valid to
--- withdraw from a normal UTxO payment address or to use a stake address.
---
--- The use case is for expressing multi-signature payment addresses and
--- multi-signature stake addresses. These can be combined arbitrarily using
--- logical operations:
---
--- * multi-way \"and\";
--- * multi-way \"or\";
--- * multi-way \"N of M\".
---
--- This makes it easy to express multi-signature addresses, and provides an
--- extension point to express other validity conditions, e.g., as needed for
--- locking funds used with lightning.
---
-data MultiSig crypto =
-       -- | Require the redeeming transaction be witnessed by the spending key
-       --   corresponding to the given verification key hash.
-       RequireSignature   (AnyKeyHash crypto)
-
-       -- | Require all the sub-terms to be satisfied.
-     | RequireAllOf      [MultiSig crypto]
-
-       -- | Require any one of the sub-terms to be satisfied.
-     | RequireAnyOf      [MultiSig crypto]
-
-       -- | Require M of the given sub-terms to be satisfied.
-     | RequireMOf    Int [MultiSig crypto]
-  deriving (Show, Eq, Ord, Generic)
-
-instance NoUnexpectedThunks (MultiSig crypto)
-
--- | Magic number representing the tag of the native multi-signature script
--- language. For each script language included, a new tag is chosen and the tag
--- is included in the script hash for a script.
-nativeMultiSigTag :: Word8
-nativeMultiSigTag = 0
-
-newtype ScriptHash crypto =
-  ScriptHash (Hash (HASH crypto) (Script crypto))
-  deriving (Show, Eq, Ord, NoUnexpectedThunks)
-
-data Script crypto = MultiSigScript (MultiSig crypto)
-                  -- constructors for new languages go here
-                   -- e.g | PlutusScriptV1 ScriptPLC
-  deriving (Show, Eq, Ord, Generic)
-
-deriving instance Crypto crypto => ToCBOR (ScriptHash crypto)
-deriving instance Crypto crypto => FromCBOR (ScriptHash crypto)
-
--- | Count nodes and leaves of multi signature script
-countMSigNodes :: MultiSig crypto -> Int
-countMSigNodes (RequireSignature _) = 1
-countMSigNodes (RequireAllOf msigs) = 1 + sum (map countMSigNodes msigs)
-countMSigNodes (RequireAnyOf msigs) = 1 + sum (map countMSigNodes msigs)
-countMSigNodes (RequireMOf _ msigs) = 1 + sum (map countMSigNodes msigs)
 
 newtype Wdrl crypto = Wdrl { unWdrl :: Map (RewardAcnt crypto) Coin }
   deriving (Show, Eq, Generic, NoUnexpectedThunks)
@@ -522,43 +466,6 @@ instance
           , _mdHash   = Nothing
           }
 
-instance (Crypto crypto) =>
-  ToCBOR (MultiSig crypto) where
-  toCBOR (RequireSignature hk) =
-    encodeListLen 2 <> encodeWord 0 <> toCBOR hk
-  toCBOR (RequireAllOf msigs) =
-    encodeListLen 2 <> encodeWord 1 <> encodeFoldable msigs
-  toCBOR (RequireAnyOf msigs) =
-    encodeListLen 2 <> encodeWord 2 <> encodeFoldable msigs
-  toCBOR (RequireMOf m msigs) =
-    encodeListLen 3 <> encodeWord 3 <> toCBOR m <> encodeFoldable msigs
-
-instance (Crypto crypto) =>
-  FromCBOR (MultiSig crypto) where
-  fromCBOR = do
-    n <- decodeListLen
-    decodeWord >>= \case
-      0 -> matchSize "RequireSignature" 2 n >> (RequireSignature . AnyKeyHash) <$> fromCBOR
-      1 -> matchSize "RequireAllOf" 2 n >> RequireAllOf <$> decodeList fromCBOR
-      2 -> matchSize "RequireAnyOf" 2 n >> RequireAnyOf <$> decodeList fromCBOR
-      3 -> do
-        matchSize "RequireMOf" 3 n
-        m     <- fromCBOR
-        msigs <- decodeList fromCBOR
-        pure $ RequireMOf m msigs
-      k -> invalidKey k
-
-instance (Crypto crypto) =>
-  ToCBOR (Script crypto) where
-  toCBOR (MultiSigScript msig) =
-    toCBOR nativeMultiSigTag <> toCBOR msig
-
-instance (Crypto crypto) =>
-  FromCBOR (Script crypto) where
-  fromCBOR = do
-    decodeWord >>= \case
-      0 -> MultiSigScript <$> fromCBOR
-      k -> invalidKey k
 
 instance (Typeable crypto, Crypto crypto)
   => ToCBORGroup (Credential crypto) where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -54,13 +54,14 @@ import           Shelley.Spec.Ledger.PParams (PParams (..))
 import           Shelley.Spec.Ledger.Tx (Tx (..))
 import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), pattern DeRegKey,
                      pattern Delegate, pattern Delegation, PoolCert (..), PoolParams (..),
-                     ScriptHash, TxBody (..), TxId (..), TxIn (..), TxOut (..), Wdrl (..),
+                     TxBody (..), TxId (..), TxIn (..), TxOut (..), Wdrl (..),
                      WitVKey (..), getRwdCred)
 import           Shelley.Spec.Ledger.Updates (Update)
 
 import           Data.Coerce (coerce)
 import           Shelley.Spec.Ledger.Delegation.Certificates (DCert (..), StakePools (..), dvalue,
                      requiresVKeyWitness)
+import           Shelley.Spec.Ledger.Scripts
 
 -- |The unspent transaction outputs.
 newtype UTxO crypto

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -17,6 +17,7 @@ import qualified Shelley.Spec.Ledger.EpochBoundary as EpochBoundary
 import qualified Shelley.Spec.Ledger.Keys as Keys
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import qualified Shelley.Spec.Ledger.OCert as OCert
+import qualified Shelley.Spec.Ledger.Scripts as Scripts
 import qualified Shelley.Spec.Ledger.STS.Chain as STS.Chain
 import qualified Shelley.Spec.Ledger.STS.Deleg as STS.Deleg
 import qualified Shelley.Spec.Ledger.STS.Delegs as STS.Delegs
@@ -175,9 +176,9 @@ type Credential = TxData.Credential ConcreteCrypto
 
 type StakeCreds = TxData.StakeCreds ConcreteCrypto
 
-type MultiSig = TxData.MultiSig ConcreteCrypto
+type MultiSig = Scripts.MultiSig ConcreteCrypto
 
-type ScriptHash = TxData.ScriptHash ConcreteCrypto
+type ScriptHash = Scripts.ScriptHash ConcreteCrypto
 
 type WitVKey = TxData.WitVKey ConcreteCrypto
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
@@ -27,13 +27,14 @@ import           Shelley.Spec.Ledger.Tx (pattern Tx, hashScript, _body, _metadat
                      _witnessVKeySet)
 import           Shelley.Spec.Ledger.TxData (pattern DCertDeleg, pattern DCertPool,
                      pattern Delegation, pattern KeyHashObj, PoolMetaData (..), pattern PoolParams,
-                     pattern RequireMOf, pattern RequireSignature, pattern RewardAcnt,
+                     pattern RewardAcnt,
                      pattern TxBody, pattern TxIn, pattern TxOut, Url (..), Wdrl (..), _certs,
                      _inputs, _mdHash, _outputs, _poolCost, _poolMD, _poolMDHash, _poolMDUrl,
                      _poolMargin, _poolOwners, _poolPledge, _poolPubKey, _poolRAcnt, _poolRelays,
                      _poolVrf, _ttl, _txUpdate, _txfee, _wdrls)
 import           Shelley.Spec.Ledger.Updates (emptyUpdate)
 import           Shelley.Spec.Ledger.UTxO (makeWitnessesVKey)
+import           Shelley.Spec.Ledger.Scripts (pattern RequireMOf, pattern RequireSignature)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, ConcreteCrypto, Credential,
                      KeyHash, KeyPair, MultiSig, PoolParams, SignKeyVRF, Tx, TxBody, VerKeyVRF,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
@@ -30,12 +30,13 @@ import           Shelley.Spec.Ledger.Slot (SlotNo (..))
 import           Shelley.Spec.Ledger.STS.Utxo (UtxoEnv (..))
 import           Shelley.Spec.Ledger.Tx (pattern Tx, hashScript, _body)
 import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern KeyHashObj,
-                     pattern RequireAllOf, pattern RequireAnyOf, pattern RequireMOf,
-                     pattern RequireSignature, pattern ScriptHashObj, pattern StakeCreds,
+                     pattern ScriptHashObj, pattern StakeCreds,
                      pattern StakePools, pattern TxBody, pattern TxIn, pattern TxOut, pattern Wdrl,
                      unWdrl)
 import           Shelley.Spec.Ledger.Updates (emptyUpdate)
 import           Shelley.Spec.Ledger.UTxO (makeWitnessesVKey, txid)
+import           Shelley.Spec.Ledger.Scripts (pattern RequireAllOf, pattern RequireAnyOf, pattern RequireMOf,
+                 pattern RequireSignature)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, KeyPair, LedgerState, MultiSig,
                      ScriptHash, Tx, TxBody, TxId, TxIn, UTXOW, UTxOState, Wdrl)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -46,8 +46,8 @@ import           Shelley.Spec.Ledger.Tx (Tx (..), hashScript)
 import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern AddrEnterprise,
                      pattern AddrPtr, Credential (..), pattern DCertDeleg, pattern DCertGenesis,
                      pattern DCertMir, pattern DCertPool, pattern Delegation, PoolMetaData (..),
-                     pattern PoolParams, Ptr (..), pattern RequireSignature, pattern RewardAcnt,
-                     pattern ScriptHash, pattern TxBody, pattern TxIn, pattern TxOut, Url (..),
+                     pattern PoolParams, Ptr (..), pattern RewardAcnt,
+                     pattern TxBody, pattern TxIn, pattern TxOut, Url (..),
                      Wdrl (..), WitVKey (..), _TxId, _poolCost, _poolMD, _poolMDHash, _poolMDUrl,
                      _poolMargin, _poolOwners, _poolPledge, _poolPubKey, _poolRAcnt, _poolRelays,
                      _poolVrf)
@@ -57,6 +57,8 @@ import           Shelley.Spec.Ledger.Updates (pattern AVUpdate, ApName (..), ApV
 
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..), pattern OCert)
 import           Shelley.Spec.Ledger.UTxO (makeWitnessVKey)
+import           Shelley.Spec.Ledger.Scripts (pattern RequireSignature,
+                 pattern ScriptHash)
 
 import           Test.Cardano.Crypto.VRF.Fake (WithResult (..))
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, BHBody, CoreKeyPair,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -78,9 +78,9 @@ import           Shelley.Spec.Ledger.PParams (ProtVer (..))
 import           Shelley.Spec.Ledger.Slot (BlockNo (..), Duration (..), SlotNo (..), epochInfoFirst,
                      (*-))
 import           Shelley.Spec.Ledger.Tx (pattern TxOut, hashScript)
-import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern AddrPtr, pattern KeyHashObj,
-                     pattern RequireAllOf, pattern RequireAnyOf, pattern RequireMOf,
-                     pattern RequireSignature, pattern ScriptHashObj)
+import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern AddrPtr, pattern KeyHashObj, pattern ScriptHashObj)
+import           Shelley.Spec.Ledger.Scripts (pattern RequireAllOf, pattern RequireAnyOf, pattern RequireMOf,
+                 pattern RequireSignature)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, AnyKeyHash, Block, CoreKeyPair,
                      Credential, GenKeyHash, HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Shrinkers.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Shrinkers.hs
@@ -14,7 +14,7 @@ import           Shelley.Spec.Ledger.Slot
 import           Shelley.Spec.Ledger.Tx
 import           Shelley.Spec.Ledger.TxData
 import           Shelley.Spec.Ledger.Updates
-
+import           Shelley.Spec.Ledger.Scripts 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Block)
 
 shrinkBlock


### PR DESCRIPTION
New module `Shelley.Spec.Ledger.Scripts` added. Much of the MultiSig stuff (except for the evaluation function) moved to it. This is in preparation for Goguen, so that it is possible to have Plutus script - related things in this module as well. 