### PR TITLE
Remove unused PredicateFailure constructors

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -45,14 +45,14 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3893f21db1665e7bab9e8c6504c547fc7c28f98c
-  --sha256: 09qqcjzmjsa3r7f1yiwk4bn8bpv7nvqf7hfyg784shasspwfq8n4
+  tag: 50c0c76c8913fd4bf07c421eba2227009cb09b81
+  --sha256: 12i9w7r776vll1shixbxnv925iaa34vgpw8rs79ybwcw22nss855
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 3893f21db1665e7bab9e8c6504c547fc7c28f98c
-  --sha256: 09qqcjzmjsa3r7f1yiwk4bn8bpv7nvqf7hfyg784shasspwfq8n4
+  tag: 50c0c76c8913fd4bf07c421eba2227009cb09b81
+  --sha256: 12i9w7r776vll1shixbxnv925iaa34vgpw8rs79ybwcw22nss855
   subdir: test
 
 source-repository-package

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -35,7 +36,6 @@ instance STS (MIR crypto) where
     type Environment (MIR crypto) = ()
     type BaseM (MIR crypto) = ShelleyBase
     data PredicateFailure (MIR crypto)
-      = MirFailure (PredicateFailure (MIR crypto))
       deriving (Show, Generic, Eq)
 
     initialRules = [ initialMir ]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -41,8 +41,7 @@ instance STS (NEWPP crypto) where
   type Environment (NEWPP crypto) = NewppEnv crypto
   type BaseM (NEWPP crypto) = ShelleyBase
   data PredicateFailure (NEWPP crypto)
-    = FailureNEWPP
-    | UnexpectedDepositPot
+    = UnexpectedDepositPot
     deriving (Show, Eq, Generic)
 
   initialRules = [initialNewPp]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -41,7 +42,6 @@ instance STS (POOLREAP crypto) where
   type Environment (POOLREAP crypto) = PParams
   type BaseM (POOLREAP crypto) = ShelleyBase
   data PredicateFailure (POOLREAP crypto)
-    = FailurePOOLREAP
     deriving (Show, Eq, Generic)
   initialRules = [pure $ PoolreapState emptyUTxOState emptyAccount emptyDState emptyPState]
   transitionRules = [poolReapTransition]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -34,7 +35,6 @@ instance STS (RUPD crypto) where
   type Environment (RUPD crypto) = RupdEnv crypto
   type BaseM (RUPD crypto) = ShelleyBase
   data PredicateFailure (RUPD crypto)
-    = FailureRUPD
     deriving (Show, Eq, Generic)
 
   initialRules = [pure Nothing]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -44,7 +45,6 @@ instance STS (SNAP crypto) where
   type Environment (SNAP crypto) = SnapEnv crypto
   type BaseM (SNAP crypto) = ShelleyBase
   data PredicateFailure (SNAP crypto)
-    = FailureSNAP
     deriving (Show, Generic, Eq)
 
   initialRules =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -33,8 +34,8 @@ instance
   type Signal (UPDN crypto) = SlotNo
   type Environment (UPDN crypto) = UpdnEnv crypto
   type BaseM (UPDN crypto) = ShelleyBase
-  data PredicateFailure (UPDN crypto) = FailureUPDN
-                               deriving (Generic, Show, Eq)
+  data PredicateFailure (UPDN crypto)
+    deriving (Generic, Show, Eq)
   initialRules = [pure (UpdnState (mkNonce 0) (mkNonce 0) (mkNonce 0) (mkNonce 0))]
   transitionRules = [updTransition]
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/3893f21db1665e7bab9e8c6504c547fc7c28f98c/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/50c0c76c8913fd4bf07c421eba2227009cb09b81/snapshot.yaml
 
 packages:
 - shelley/chain-and-ledger/executable-spec
@@ -20,7 +20,7 @@ extra-deps:
 - monad-stm-0.1.0.2
 
 - git: https://github.com/input-output-hk/cardano-prelude
-  commit: 3893f21db1665e7bab9e8c6504c547fc7c28f98c
+  commit: 50c0c76c8913fd4bf07c421eba2227009cb09b81
 
 - git: https://github.com/input-output-hk/cardano-base
   commit: 9091c30f1a689acd0abc024ce4dc18bf0052701a


### PR DESCRIPTION
This commit removes the following `Failure*` constructors that do not occur outside of their own definition.

```
$ git grep -e ' Failure' 5d7e2705 -- 'shelley/*hs'
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs:    = FailureNEWPP
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs:    = FailurePOOLREAP
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs:    = FailureRUPD
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs:    = FailureSNAP
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs:  data PredicateFailure (UPDN crypto) = FailureUPDN
$ git grep -e FailureNEWPP -e FailurePOOLREAP -e FailureRUPD -e FailureSNAP -e FailureUPDN  5d7e2705 -- 'shelley/*hs'
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs:    = FailureNEWPP
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs:    = FailurePOOLREAP
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs:    = FailureRUPD
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs:    = FailureSNAP
5d7e2705:shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs:  data PredicateFailure (UPDN crypto) = FailureUPDN
```

Edit: It now also removes `MirFailure` from `Shelley/Spec/ledger/STS/Mir.hs`, which seems like it was erroneously copy-pasted from `NewEpoch.hs`.