### PR TITLE
Add cabal-install to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,7 @@ let
 
     # These programs will be available inside the nix-shell.
     buildInputs = with haskellPackages; [
+      cabal-install
       niv
       hlint
       stylish-haskell


### PR DESCRIPTION
I needed to add this line in order to use `cabal` commands from inside the `nix-shell`. That's my typical local workflow; I don't know if the owner's of this repo want to support it. If so, this PR might suffice... For Your Consideration :)