### PR TITLE
Change how endorsements are counted

### DIFF
--- a/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
+++ b/byron/chain/executable-spec/src/Cardano/Spec/Chain/STS/Rule/Epoch.hs
@@ -50,7 +50,7 @@ instance STS EPOCH where
           then
             pure $! us
           else do
-            us' <- trans @UPIEC $ TRC ((s, k), us, ())
+            us' <- trans @UPIEC $ TRC ((sEpoch s k, k), us, ())
             pure $! us'
     ]
 

--- a/byron/chain/formal-spec/blockchain-spec.tex
+++ b/byron/chain/formal-spec/blockchain-spec.tex
@@ -728,7 +728,7 @@ updates the update state to the correct version.
   {
     \var{e_c} < \sepoch{s}{k}
     &
-    s\vdash \var{us} \trans{\hyperlink{byron_ledger_spec_link}{upiec}}{} \var{us'}
+    \sepoch{s}{k}\vdash \var{us} \trans{\hyperlink{byron_ledger_spec_link}{upiec}}{} \var{us'}
   }
   {
     \var{e_c}

--- a/byron/chain/formal-spec/default.nix
+++ b/byron/chain/formal-spec/default.nix
@@ -1,6 +1,5 @@
-{ pkgs ? (import ../../../default.nix {}).pkgs
+{ pkgs ? (import ../../../nix/default.nix {}).pkgs
 }:
-
 
 with pkgs;
 

--- a/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
+++ b/byron/ledger/executable-spec/src/Ledger/GlobalParams.hs
@@ -1,7 +1,8 @@
 -- | Ledger global parameters.
 
 module Ledger.GlobalParams
-  ( lovelaceCap
+  ( epochFirstSlot
+  , lovelaceCap
   , slotsPerEpoch
   , slotsPerEpochToK
   , c
@@ -10,7 +11,7 @@ where
 
 import           Data.Word (Word64)
 
-import           Ledger.Core (BlockCount (BlockCount), lovelaceCap)
+import           Ledger.Core (BlockCount (BlockCount), Epoch(..), Slot(..), lovelaceCap)
 
 
 -- | Given the chain stability parameter, often referred to as @k@, which is
@@ -23,6 +24,11 @@ slotsPerEpoch (BlockCount bc) = fromIntegral $ bc * 10
 -- the chain stability parameter @k@.
 slotsPerEpochToK :: (Integral n) => n -> BlockCount
 slotsPerEpochToK n = BlockCount $ floor $ (fromIntegral n :: Double) / 10
+
+-- | Given the chain stability parameter, calculate the first slot in a given
+-- epoch.
+epochFirstSlot :: BlockCount -> Epoch -> Slot
+epochFirstSlot bc (Epoch epochs) = Slot $ epochs * slotsPerEpoch bc
 
 -- | Factor used to bound the concrete size by the abstract size.
 --

--- a/byron/ledger/executable-spec/src/Ledger/Update.hs
+++ b/byron/ledger/executable-spec/src/Ledger/Update.hs
@@ -1611,7 +1611,7 @@ instance STS PVBUMP where
   transitionRules =
     [ do
         TRC ((s_n, fads, k), (pv, pps), ()) <- judgmentContext
-        case s_n  -. 2 *. k <=◁ fads of
+        case s_n  -. 4 *. k <=◁ fads of
           [] ->
             pure $! (pv, pps)
           (_s, (pv_c, pps_c)): _xs ->
@@ -1622,7 +1622,7 @@ data UPIEC deriving (Generic, Data, Typeable)
 
 instance STS UPIEC where
   type Environment UPIEC =
-    ( Core.Slot
+    ( Core.Epoch
     , BlockCount -- Chain stability parameter; this is a global
                  -- constant in the formal specification, which we put
                  -- in this environment so that we can test with
@@ -1637,11 +1637,12 @@ instance STS UPIEC where
   initialRules = []
   transitionRules =
     [ do
-        TRC ((s_n, k), us, ()) <- judgmentContext
+        TRC ((e_n, k), us, ()) <- judgmentContext
         let
           (pv, pps) = us ^. _1 :: (ProtVer, PParams)
           fads      = us ^. _2 :: [(Core.Slot, (ProtVer, PParams))]
-        (pv', pps') <- trans @PVBUMP $ TRC ((s_n, fads, k), (pv, pps), ())
+        (pv', pps') <- trans @PVBUMP
+          $ TRC ((GP.epochFirstSlot k e_n, fads, k), (pv, pps), ())
         return $! if pv == pv'
           then us
           else

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -472,7 +472,7 @@ Figure~\ref{fig:st-diagram-pt-up}.
 
   \draw[->] (confirmed)
   edge node [right, text width=8em]
-  {Proposal was confirmed at least $2 \cdot k$ slots ago}
+  {Proposal was confirmed at least $4 \cdot k$ slots ago}
   (adopted);
 
 
@@ -772,9 +772,13 @@ Rule~\ref{eq:rule:upi-ec-pv-change} models how the protocol-version and its
 parameters are changed depending on an epoch change signal.
 %
 On an epoch change, this rule will pick a candidate that gathered enough
-endorsements at least $2 \cdot k$ slots ago. If a protocol-version candidate
-cannot gather enough endorsements $2 \cdot k$ slots before the end of an
-epoch, the proposal can only be adopted in the next epoch.
+endorsements at least $4 \cdot k$ slots ago. If a protocol-version candidate
+cannot gather enough endorsements $4 \cdot k$ slots before the end of an epoch,
+the proposal can only be adopted in the next epoch. The reason for the $4 \cdot
+k$ slot delay is to allow a period between knowing when a proposal will be
+adopted, and the event of its being adopted. Since update proposals can and will
+make large changes to the way the chain operates, it is useful to be able to
+guarantee a window in which it is known that no update will take place.
 %
 Figure~\ref{fig:up-confirmed-too-late} shows an example of a proposal being
 confirmed too late in an epoch, where it is not possible to get enough
@@ -811,7 +815,7 @@ expires.
     \label{eq:rule:pvbump-change-epoch-only}
     \inference
     {
-      [.., s_n - 2 \cdot k] \restrictdom \var{fads} = \epsilon
+      [.., s_n - 4 \cdot k] \restrictdom \var{fads} = \epsilon
     }
     {
       {\left(\begin{array}{l}
@@ -841,7 +845,7 @@ expires.
     \label{eq:rule:pvbump-change}
     \inference
     {
-      \wcard ; (\wcard , (\var{pv_c}, \var{pps_c})) \leteq [.., s_n - 2 \cdot k] \restrictdom \var{fads}
+      \wcard ; (\wcard , (\var{pv_c}, \var{pps_c})) \leteq [.., s_n - 4 \cdot k] \restrictdom \var{fads}
     }
     {
       {\left(\begin{array}{l}
@@ -1131,7 +1135,7 @@ proposal can be in, and what causes the transitions between them.
 
   \draw[->] (confirmed)
   edge node [right, text width=8em]
-  {Proposal gets enough endorsements $2 \cdot k$ slots before the end of an epoch}
+  {Proposal gets enough endorsements $4 \cdot k$ slots before the end of an epoch}
   (adopted);
 
   \end{tikzpicture}

--- a/byron/ledger/formal-spec/blockchain-interface.tex
+++ b/byron/ledger/formal-spec/blockchain-interface.tex
@@ -206,6 +206,8 @@ In these rules we make use of the abstract constant $\var{ngk}$, defined in
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
       \var{ngk} & \mathbb{N} & \text{number of genesis keys}\\
+      \fun{firstSlot} & \in ~ \Epoch \to \Slot
+      & \text{first slot of an epoch}
     \end{array}
   \end{equation*}
 
@@ -259,7 +261,7 @@ In these rules we make use of the abstract constant $\var{ngk}$, defined in
       \powerset (\UPIEnv \times \UPIState
       \times (\ProtVer \times \VKey) \times \UPIState)\\
       \_ \vdash \_ \trans{upiec}{} \_ &
-      \powerset (\Slot \times \UPIState \times \UPIState)
+      \powerset (\Epoch \times \UPIState \times \UPIState)
     \end{array}
   \end{equation*}
   \caption{Update-proposals interface transition-system types}
@@ -874,7 +876,7 @@ expires.
     \inference
     {
       {\left(\begin{array}{l}
-         s_n\\
+         \fun{firstSlot}~e_n\\
          \var{fads}
        \end{array}\right)}
       \vdash
@@ -895,7 +897,7 @@ expires.
       } &\var{pv} = \var{pv'}
     }
     {
-      (s_n)
+      (e_n)
       \vdash
       {
         \left(
@@ -936,7 +938,7 @@ expires.
     \inference
     {
       {\left(\begin{array}{l}
-         s_n\\
+         \fun{firstSlot}~e_n\\
          \var{fads}
        \end{array}\right)}
       \vdash
@@ -958,7 +960,7 @@ expires.
       & \var{pv} \neq \var{pv'}
     }
     {
-      (s_n)
+      (e_n)
       \vdash
       {
         \left(


### PR DESCRIPTION
This addresses both #1288 and https://github.com/input-output-hk/cardano-ledger/issues/743

Endorsements are now counted up until 4k slots from the start of the epoch, not 2k from the first block in the epoch.