### PR TITLE
Adding multicurrency to Shelley

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -42,6 +42,7 @@ library
                      Shelley.Spec.Ledger.Updates
                      Shelley.Spec.Ledger.Validation
                      Shelley.Spec.Ledger.Scripts
+                     Shelley.Spec.Ledger.Value
                      Shelley.Spec.Ledger.STS.Avup
                      Shelley.Spec.Ledger.STS.Bbody
                      Shelley.Spec.Ledger.STS.Tick

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -37,7 +37,7 @@ import           Shelley.Spec.Ledger.Keys (KeyHash)
 import           Shelley.Spec.Ledger.PParams (PParams (..))
 import           Shelley.Spec.Ledger.Slot (SlotNo, (-*))
 import           Shelley.Spec.Ledger.TxData (Addr (..), Credential, PoolParams, Ptr, RewardAcnt,
-                     TxOut (..), getRwdCred)
+                     getRwdCred, getAddress, getCoin)
 import           Shelley.Spec.Ledger.UTxO (UTxO (..))
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
@@ -76,9 +76,10 @@ getStakeHK :: Addr crypto -> Maybe (Credential crypto)
 getStakeHK (AddrBase _ hk) = Just hk
 getStakeHK _               = Nothing
 
-aggregateOuts :: UTxO crypto -> Map (Addr crypto) Coin
+-- | Add up only the Ada with the getCoin function
+aggregateOuts :: Crypto crypto => UTxO crypto -> Map (Addr crypto) Coin
 aggregateOuts (UTxO u) =
-  Map.fromListWith (+) (map (\(_, TxOut a c) -> (a, c)) $ Map.toList u)
+  Map.fromListWith (+) (map (\(_, ot) -> (getAddress ot, getCoin ot)) $ Map.toList u)
 
 -- | Get Stake of base addresses in TxOut set.
 baseStake

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -41,6 +41,7 @@ import           Shelley.Spec.Ledger.Tx (TxBody)
 import           Shelley.Spec.Ledger.Updates (AVUpdate (..), Applications, PPUpdate (..),
                      UpdateState (..))
 import           Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
+import           Shelley.Spec.Ledger.Value
 
 import qualified Cardano.Crypto.VRF as VRF
 import           Cardano.Ledger.Shelley.Crypto
@@ -219,9 +220,9 @@ instance
   wrapFailed = PrtclFailure
 
 -- |Calculate the total ada in the chain state
-totalAda :: ChainState crypto -> Coin
+totalAda :: (Crypto crypto) => ChainState crypto -> Coin
 totalAda (ChainState nes _ _ _ _ _ _) =
-  treasury_ + reserves_ + rewards_ + circulation + deposits + fees_
+  treasury_ + reserves_ + rewards_ + (getAdaAmount circulation) + deposits + fees_
   where
     (EpochState (AccountState treasury_ reserves_) _ ls _ _) = nesEs nes
     (UTxOState u deposits fees_ _) = _utxoState ls

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -13,6 +13,7 @@ module Shelley.Spec.Ledger.STS.Epoch
 where
 
 import           Cardano.Prelude (NoUnexpectedThunks (..), asks)
+import           Cardano.Ledger.Shelley.Crypto
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           GHC.Generics (Generic)
@@ -34,7 +35,7 @@ import           Shelley.Spec.Ledger.STS.Snap
 
 data EPOCH crypto
 
-instance STS (EPOCH crypto) where
+instance (Crypto crypto) => STS (EPOCH crypto) where
     type State (EPOCH crypto) = EpochState crypto
     type Signal (EPOCH crypto) = EpochNo
     type Environment (EPOCH crypto) = ()
@@ -77,7 +78,7 @@ votedValuePParams (PPUpdate ppup) pps quorumN =
       1 -> (Just . updatePParams pps . fst . head . Map.toList) consensus
       _ -> Nothing
 
-epochTransition :: forall crypto . TransitionRule (EPOCH crypto)
+epochTransition :: forall crypto. (Crypto crypto) => TransitionRule (EPOCH crypto)
 epochTransition = do
   TRC (_, EpochState { esAccountState = acnt
                      , esSnapshots = ss
@@ -105,11 +106,11 @@ epochTransition = do
     pp'
     nm
 
-instance Embed (SNAP crypto) (EPOCH crypto) where
+instance (Crypto crypto) => Embed (SNAP crypto) (EPOCH crypto) where
     wrapFailed = SnapFailure
 
-instance Embed (POOLREAP crypto) (EPOCH crypto) where
+instance (Crypto crypto) => Embed (POOLREAP crypto) (EPOCH crypto) where
     wrapFailed = PoolReapFailure
 
-instance Embed (NEWPP crypto) (EPOCH crypto) where
+instance (Crypto crypto) => Embed (NEWPP crypto) (EPOCH crypto) where
     wrapFailed = NewPpFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -11,6 +11,7 @@ module Shelley.Spec.Ledger.STS.Snap
   )
 where
 
+import           Cardano.Ledger.Shelley.Crypto
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Control.Monad.Trans.Reader (asks)
 import           Control.State.Transition
@@ -39,7 +40,7 @@ data SnapEnv crypto
       (DState crypto)
       (PState crypto)
 
-instance STS (SNAP crypto) where
+instance (Crypto crypto) => STS (SNAP crypto) where
   type State (SNAP crypto) = SnapState crypto
   type Signal (SNAP crypto) = EpochNo
   type Environment (SNAP crypto) = SnapEnv crypto
@@ -53,7 +54,7 @@ instance STS (SNAP crypto) where
 
 instance NoUnexpectedThunks (PredicateFailure (SNAP crypto))
 
-snapTransition :: TransitionRule (SNAP crypto)
+snapTransition :: (Crypto crypto) => TransitionRule (SNAP crypto)
 snapTransition = do
   TRC (SnapEnv pp dstate pstate, SnapState s u, eNew) <- judgmentContext
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -39,7 +39,7 @@ import           Shelley.Spec.Ledger.PParams
 import           Shelley.Spec.Ledger.Slot
 import           Shelley.Spec.Ledger.STS.Up
 import           Shelley.Spec.Ledger.Tx
-import           Shelley.Spec.Ledger.TxData (UTxOOut(..))
+import           Shelley.Spec.Ledger.TxData (getValue)
 import           Shelley.Spec.Ledger.Updates (emptyUpdateState)
 import           Shelley.Spec.Ledger.UTxO
 import           Shelley.Spec.Ledger.Value
@@ -167,16 +167,8 @@ utxoInductive = do
   -- process Update Proposals
   ups' <- trans @(UP crypto) $ TRC (UpdateEnv slot pp genDelegs, ups, txup tx)
 
-  let outputValues = [v | (UTxOOut _ v) <- Set.toList (range (txouts txb))]
-  all (valueToCompactValue zeroV <=) outputValues ?! NegativeOutputsUTxO
-<<<<<<< HEAD
-
-  let (Value vls) = _forge txb
-  let cids = Map.keys vls
-  all (adaID /=) cids  ?! ForgingAda
-
-=======
->>>>>>> multicur no testing
+  let outputValues = [getValue utxoout | utxoout <- Set.toList (range (txouts txb))]
+  all (zeroV <=) outputValues ?! NegativeOutputsUTxO
 
   let (Value vls) = _forge txb
   let cids = Map.keys vls

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -69,7 +69,7 @@ instance
     | MaxTxSizeUTxO Integer Integer
     | InputSetEmptyUTxO
     | FeeTooSmallUTxO Coin Coin
-    | ValueNotConservedUTxO (Value crypto) (Value crypto)
+    | ValueNotConservedUTxO ValueBSType ValueBSType
     | NegativeOutputsUTxO
     | ForgingAda
     | UpdateFailure (PredicateFailure (UP crypto))
@@ -162,7 +162,7 @@ utxoInductive = do
 
   let consumed_ = consumed pp utxo stakeCreds txb
       produced_ = produced pp stakepools txb
-  consumed_ == produced_ ?! ValueNotConservedUTxO consumed_ produced_
+  consumed_ == produced_ ?! ValueNotConservedUTxO (toValBST consumed_) (toValBST produced_)
 
   -- process Update Proposals
   ups' <- trans @(UP crypto) $ TRC (UpdateEnv slot pp genDelegs, ups, txup tx)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -71,6 +71,7 @@ instance
     | FeeTooSmallUTxO Coin Coin
     | ValueNotConservedUTxO (Value crypto) (Value crypto)
     | NegativeOutputsUTxO
+    | ForgingAda
     | UpdateFailure (PredicateFailure (UP crypto))
     deriving (Eq, Show, Generic)
   transitionRules = [utxoInductive]
@@ -94,7 +95,8 @@ instance
      (ValueNotConservedUTxO a b) -> encodeListLen 3 <> toCBOR (5 :: Word8)
                                       <> toCBOR a <> toCBOR b
      NegativeOutputsUTxO         -> encodeListLen 1 <> toCBOR (6 :: Word8)
-     (UpdateFailure a)           -> encodeListLen 2 <> toCBOR (7 :: Word8)
+     ForgingAda                  -> encodeListLen 1 <> toCBOR (7 :: Word8)
+     (UpdateFailure a)           -> encodeListLen 2 <> toCBOR (8 :: Word8)
                                       <> toCBOR a
 
 instance
@@ -127,7 +129,8 @@ instance
         b <- fromCBOR
         pure $ ValueNotConservedUTxO a b
       6 -> matchSize "NegativeOutputsUTxO" 1 n >> pure NegativeOutputsUTxO
-      7 -> do
+      7 -> matchSize "ForgingAda" 1 n >> pure ForgingAda
+      8 -> do
         matchSize "UpdateFailure" 2 n
         a <- fromCBOR
         pure $ UpdateFailure a
@@ -166,6 +169,11 @@ utxoInductive = do
 
   let outputValues = [v | (UTxOOut _ v) <- Set.toList (range (txouts txb))]
   all (valueToCompactValue zeroV <=) outputValues ?! NegativeOutputsUTxO
+
+  let (Value vls) = _forge txb
+  let cids = Map.keys vls
+  all (adaID /=) cids  ?! ForgingAda
+
 
   let maxTxSize_ = fromIntegral (_maxTxSize pp)
       txSize_ = txsize tx

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -169,11 +169,14 @@ utxoInductive = do
 
   let outputValues = [v | (UTxOOut _ v) <- Set.toList (range (txouts txb))]
   all (valueToCompactValue zeroV <=) outputValues ?! NegativeOutputsUTxO
+<<<<<<< HEAD
 
   let (Value vls) = _forge txb
   let cids = Map.keys vls
   all (adaID /=) cids  ?! ForgingAda
 
+=======
+>>>>>>> multicur no testing
 
   let maxTxSize_ = fromIntegral (_maxTxSize pp)
       txSize_ = txsize tx

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxo.hs
@@ -178,6 +178,11 @@ utxoInductive = do
 =======
 >>>>>>> multicur no testing
 
+  let (Value vls) = _forge txb
+  let cids = Map.keys vls
+  all (adaID /=) cids  ?! ForgingAda
+
+
   let maxTxSize_ = fromIntegral (_maxTxSize pp)
       txSize_ = txsize tx
   txSize_ <= maxTxSize_ ?! MaxTxSizeUTxO txSize_ maxTxSize_

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -244,8 +244,8 @@ txinsScript
   -> Set (TxIn crypto)
 txinsScript txInps (UTxO u) =
   txInps `Set.intersection`
-  Map.keysSet (Map.filter (\(UTxOOut a _) ->
-                               case a of
+  Map.keysSet (Map.filter (\utxoout ->
+                               case getAddress utxoout of
                                  AddrBase (ScriptHashObj _) _     -> True
                                  AddrEnterprise (ScriptHashObj _) -> True
                                  AddrPtr (ScriptHashObj _) _      -> True

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -39,7 +39,7 @@ module Shelley.Spec.Ledger.UTxO
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Data.Foldable (toList)
-import           Data.Map.Strict (Map)
+import           Data.Map.Strict (Map, keys)
 import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe
 import           Data.Set (Set)
@@ -54,23 +54,24 @@ import           Shelley.Spec.Ledger.PParams (PParams (..))
 import           Shelley.Spec.Ledger.Tx (Tx (..))
 import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), pattern DeRegKey,
                      pattern Delegate, pattern Delegation, PoolCert (..), PoolParams (..),
-                     TxBody (..), TxId (..), TxIn (..), TxOut (..), Wdrl (..),
-                     WitVKey (..), getRwdCred)
+                     TxBody (..), TxId (..), TxIn (..), Wdrl (..), UTxOOut(..),
+                     WitVKey (..), getRwdCred, getAddress, getValue, getAddressTx, getValueTx)
 import           Shelley.Spec.Ledger.Updates (Update)
 
 import           Data.Coerce (coerce)
 import           Shelley.Spec.Ledger.Delegation.Certificates (DCert (..), StakePools (..), dvalue,
                      requiresVKeyWitness)
 import           Shelley.Spec.Ledger.Scripts
+import           Shelley.Spec.Ledger.Value
 
 -- |The unspent transaction outputs.
 newtype UTxO crypto
-  = UTxO (Map (TxIn crypto) (TxOut crypto))
+  = UTxO (Map (TxIn crypto) (UTxOOut crypto))
   deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
 instance Relation (UTxO crypto) where
   type Domain (UTxO crypto) = TxIn crypto
-  type Range (UTxO crypto)  = TxOut crypto
+  type Range (UTxO crypto)  = UTxOOut crypto
 
   singleton k v = UTxO $ Map.singleton k v
 
@@ -117,7 +118,8 @@ txouts
   => TxBody crypto
   -> UTxO crypto
 txouts tx = UTxO $
-  Map.fromList [(TxIn transId idx, out) | (out, idx) <- zip (toList $ _outputs tx) [0..]]
+  Map.fromList [(TxIn transId idx, UTxOOut (getAddressTx out) (valueToCompactValue $ getValueTx out)) |
+    (out, idx) <- zip (toList $ _outputs tx) [0..]]
   where
     transId = txid tx
 
@@ -125,7 +127,7 @@ txouts tx = UTxO $
 txinLookup
   :: TxIn crypto
   -> UTxO crypto
-  -> Maybe (TxOut crypto)
+  -> Maybe (UTxOOut crypto)
 txinLookup txin (UTxO utxo') = Map.lookup txin utxo'
 
 -- |Verify a transaction body witness
@@ -146,7 +148,7 @@ makeWitnessVKey
   => TxBody crypto
   -> KeyPair a crypto
   -> WitVKey crypto
-makeWitnessVKey tx keys = WitVKey (coerce $ vKey keys) (sign (sKey keys) tx)
+makeWitnessVKey tx vkeys = WitVKey (coerce $ vKey vkeys) (sign (sKey vkeys) tx)
 
 -- |Create witnesses for transaction
 makeWitnessesVKey
@@ -172,9 +174,8 @@ makeWitnessesFromScriptKeys txb hashKeyMap scriptHashes =
   in  makeWitnessesVKey txb (Map.elems witKeys)
 
 -- |Determine the total balance contained in the UTxO.
-balance :: UTxO crypto -> Coin
-balance (UTxO utxo) = foldr addCoins 0 utxo
-  where addCoins (TxOut _ a) b = a + b
+balance :: Crypto crypto => UTxO crypto -> Value crypto
+balance (UTxO utxo) = foldr (+) zeroV (Set.map getValue (range utxo))
 
 -- |Determine the total deposit amount needed
 totalDeposits
@@ -218,18 +219,20 @@ scriptCred (ScriptHashObj hs) = Just hs
 
 -- | Computes the set of script hashes required to unlock the transcation inputs
 -- and the withdrawals.
+-- now runs the forging scripts too
 scriptsNeeded
   :: UTxO crypto
   -> Tx crypto
   -> Set (ScriptHash crypto)
 scriptsNeeded u tx =
-  Set.fromList (Map.elems $ Map.mapMaybe (getScriptHash . unTxOut) u'')
+  Set.fromList (Map.elems $ Map.mapMaybe (getScriptHash . getAddress) u'')
   `Set.union`
   Set.fromList (Maybe.mapMaybe (scriptCred . getRwdCred) $ Map.keys withdrawals)
   `Set.union`
   Set.fromList (Maybe.mapMaybe scriptStakeCred (filter requiresVKeyWitness certificates))
-  where unTxOut (TxOut a _) = a
-        withdrawals = unWdrl $ _wdrls $ _body tx
+  `Set.union`
+  Set.fromList (keys $ val $ _forge $ _body tx)
+  where withdrawals = unWdrl $ _wdrls $ _body tx
         UTxO u'' = txinsScript (txins $ _body tx) u <| u
         certificates = (toList . _certs . _body) tx
 
@@ -241,7 +244,7 @@ txinsScript
   -> Set (TxIn crypto)
 txinsScript txInps (UTxO u) =
   txInps `Set.intersection`
-  Map.keysSet (Map.filter (\(TxOut a _) ->
+  Map.keysSet (Map.filter (\(UTxOOut a _) ->
                                case a of
                                  AddrBase (ScriptHashObj _) _     -> True
                                  AddrEnterprise (ScriptHashObj _) -> True

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Validation.hs
@@ -11,7 +11,7 @@ import           Shelley.Spec.Ledger.Value
 
 -- |Validation errors represent the failures of a transaction to be valid
 -- for a given ledger state.
-data ValidationError crypto =
+data ValidationError =
   -- | The transaction inputs are not valid.
     BadInputs
   -- | The transaction has expired
@@ -21,7 +21,7 @@ data ValidationError crypto =
   -- | The transaction fee is too small
   | FeeTooSmall Coin Coin
   -- | Value is not conserved
-  | ValueNotConserved (Value crypto) (Value crypto)
+  | ValueNotConserved ValueBSType ValueBSType
   -- | Unknown reward account
   | IncorrectRewards
   -- | One of the transaction witnesses is invalid.
@@ -42,17 +42,17 @@ data ValidationError crypto =
   | UnknownValidationError
     deriving (Show, Eq, Generic)
 
-instance NoUnexpectedThunks (ValidationError crypto)
+instance NoUnexpectedThunks ValidationError
 
 -- |The validity of a transaction, where an invalid transaction
 -- is represented by list of errors.
-data Validity crypto = Valid | Invalid [(ValidationError crypto)] deriving (Show, Eq)
+data Validity = Valid | Invalid [ValidationError] deriving (Show, Eq)
 
-instance Semigroup (Validity crypto) where
+instance Semigroup Validity where
   Valid <> b                 = b
   a <> Valid                 = a
   (Invalid a) <> (Invalid b) = Invalid (a ++ b)
 
-instance Monoid (Validity crypto) where
+instance Monoid Validity where
   mempty = Valid
   mappend = (<>)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Validation.hs
@@ -7,10 +7,11 @@ import           GHC.Generics (Generic)
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Shelley.Spec.Ledger.Coin (Coin)
 import           Shelley.Spec.Ledger.Slot (SlotNo)
+import           Shelley.Spec.Ledger.Value
 
 -- |Validation errors represent the failures of a transaction to be valid
 -- for a given ledger state.
-data ValidationError =
+data ValidationError crypto =
   -- | The transaction inputs are not valid.
     BadInputs
   -- | The transaction has expired
@@ -20,7 +21,7 @@ data ValidationError =
   -- | The transaction fee is too small
   | FeeTooSmall Coin Coin
   -- | Value is not conserved
-  | ValueNotConserved Coin Coin
+  | ValueNotConserved (Value crypto) (Value crypto)
   -- | Unknown reward account
   | IncorrectRewards
   -- | One of the transaction witnesses is invalid.
@@ -41,17 +42,17 @@ data ValidationError =
   | UnknownValidationError
     deriving (Show, Eq, Generic)
 
-instance NoUnexpectedThunks ValidationError
+instance NoUnexpectedThunks (ValidationError crypto)
 
 -- |The validity of a transaction, where an invalid transaction
 -- is represented by list of errors.
-data Validity = Valid | Invalid [ValidationError] deriving (Show, Eq)
+data Validity crypto = Valid | Invalid [(ValidationError crypto)] deriving (Show, Eq)
 
-instance Semigroup Validity where
+instance Semigroup (Validity crypto) where
   Valid <> b                 = b
   a <> Valid                 = a
   (Invalid a) <> (Invalid b) = Invalid (a ++ b)
 
-instance Monoid Validity where
+instance Monoid (Validity crypto) where
   mempty = Valid
   mappend = (<>)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Value.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Value.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Shelley.Spec.Ledger.Value
+ where
+
+import           Cardano.Binary (ToCBOR, FromCBOR, toCBOR, fromCBOR, encodeListLen,
+                  decodeWord)
+import           Cardano.Prelude (NoUnexpectedThunks(..))
+
+import           Shelley.Spec.Ledger.BaseTypes (invalidKey)
+import           Shelley.Spec.Ledger.Coin (Coin (..))
+import           GHC.Generics (Generic)
+import           Data.Word (Word8)
+import           Cardano.Crypto.Hash (hash)
+import           Data.Map.Strict (Map, elems, empty, unionWith, toList, singleton, filterWithKey, keys, map)
+import           Cardano.Ledger.Shelley.Crypto
+import           Data.ByteString.Char8 (ByteString, pack)
+import           Shelley.Spec.Ledger.Scripts
+
+
+-- | Quantity
+newtype Quantity = Quantity Integer
+  deriving (Show, Eq, Generic, ToCBOR, FromCBOR, Ord, Integral, Num, Real, Enum, NoUnexpectedThunks)
+
+
+-- | Value type
+data Value crypto = Value
+  { val :: Map (ScriptHash crypto) (Map ByteString Quantity) }
+  deriving (Show, Eq, Generic)
+
+instance NoUnexpectedThunks (Value crypto)
+
+-- | compact representation of Value
+data CompactValue crypto = AdaOnly Coin | MixValue (Value crypto)
+  deriving (Show, Eq, Generic, Ord)
+
+instance NoUnexpectedThunks (CompactValue crypto)
+
+-- adding and subtracting values
+-- TODO this must be an instance of something else - a Group?
+-- needs + - and <=
+instance (Crypto crypto) => Num (Value crypto) where
+   (Value v1) + (Value v2) = Value (unionWith (unionWith (+)) v1 v2)
+   (Value v1) - (Value v2) = Value (unionWith (unionWith (-)) v1 v2)
+   (Value v1) * (Value v2) = Value (unionWith (unionWith (*)) v1 v2)
+   abs (Value v1)          = Value (Data.Map.Strict.map (Data.Map.Strict.map abs) v1)
+   signum v1
+    | and $ fmap ((<) 0) (getQs v1) = 1
+    | and $ fmap ((>) 0) (getQs v1) = -1
+    | otherwise                     = 0
+   fromInteger x           = Value $ singleton adaID (singleton adaToken (Quantity x))
+
+-- Values are compared as functions that are 0 almost everywhere
+instance (Crypto crypto) => Ord (Value crypto) where
+   (<=) (Value v1) (Value v2) =
+     and $ fmap ((<=) 0) (getQs $ (Value v1) - (Value v2))
+
+-- get the quantities in the tokens of a value term
+getQs :: Value crypto -> [Quantity]
+getQs (Value v) = fmap snd (concat $ fmap toList (elems v))
+
+-- zero value
+zeroV :: Value crypto
+zeroV = Value empty
+
+-- | make a value out of a coin
+coinToValue :: Crypto crypto => Coin -> Value crypto
+coinToValue (Coin c) = Value $ singleton adaID (singleton adaToken (Quantity c))
+
+-- | make a value out of a coin
+getAdaAmount :: Crypto crypto => Value crypto -> Coin
+getAdaAmount (Value v) = Coin $ c
+  where
+    Quantity c = foldl (+) (Quantity 0) (getQs $ Value $ filterWithKey (\k _ -> k == adaID) v)
+
+-- | currency ID of Ada
+-- TODO use the right script here
+adaID :: Crypto crypto => ScriptHash crypto
+adaID = ScriptHash $ hash $ MultiSigScript (RequireAllOf [])
+
+-- | token of Ada
+adaToken :: ByteString
+adaToken = pack "Ada"
+
+valueToCompactValue :: Crypto crypto => Value crypto -> CompactValue crypto
+valueToCompactValue (Value v)
+  | keys v == [adaID] = AdaOnly $ getAdaAmount $ Value v
+  | otherwise                                 = MixValue $ Value v
+
+compactValueToValue :: Crypto crypto => CompactValue crypto -> Value crypto
+compactValueToValue (AdaOnly c)  = coinToValue c
+compactValueToValue (MixValue v) = v
+
+-- CBOR
+
+instance
+  (Crypto crypto)
+  => ToCBOR (CompactValue crypto)
+ where
+   toCBOR = \case
+     AdaOnly c ->
+           encodeListLen 2
+           <> toCBOR (0 :: Word8)
+           <> toCBOR c
+     MixValue (Value v) ->
+           encodeListLen 2
+           <> toCBOR (1 :: Word8)
+           <> toCBOR v
+
+instance
+  (Crypto crypto)
+  => FromCBOR (CompactValue crypto)
+ where
+  fromCBOR = do
+    decodeWord >>= \case
+      0 -> do
+        c <- fromCBOR
+        pure $ AdaOnly c
+      1 -> do
+        v <- fromCBOR
+        pure $ MixValue $ Value v
+      k -> invalidKey k
+
+
+instance
+  (Crypto crypto)
+  => ToCBOR (Value crypto)
+ where
+   toCBOR = (\case
+     AdaOnly c ->
+           encodeListLen 2
+           <> toCBOR (0 :: Word8)
+           <> toCBOR c
+     MixValue (Value v) ->
+           encodeListLen 2
+           <> toCBOR (1 :: Word8)
+           <> toCBOR v) . valueToCompactValue
+
+instance
+  (Crypto crypto)
+  => FromCBOR (Value crypto)
+ where
+  fromCBOR = do
+    decodeWord >>= \case
+      0 -> do
+        c <- fromCBOR
+        pure $ compactValueToValue $ AdaOnly c
+      1 -> do
+        v <- fromCBOR
+        pure $ compactValueToValue $ MixValue $ Value v
+      k -> invalidKey k

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -82,7 +82,7 @@ import           Shelley.Spec.Ledger.Slot (BlockNo (..), Duration (..), SlotNo (
 import           Shelley.Spec.Ledger.Tx (pattern TxOut, hashScript)
 import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern AddrPtr, pattern KeyHashObj,
                      pattern ScriptHashObj)
-
+import           Shelley.Spec.Ledger.Value
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, AnyKeyHash, Block, CoreKeyPair,
                      Credential, GenKeyHash, HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig,
                      MultiSigPairs, OCert, SKeyES, SignKeyVRF, Tx, TxOut, UTxO, VKey, VKeyES,
@@ -291,10 +291,11 @@ pickStakeKey keys = vKey . snd <$> QC.elements keys
 -- Note: we need to keep the initial utxo coin sizes large enough so that
 -- when we simulate sequences of transactions, we have enough funds available
 -- to include certificates that require deposits.
+-- TODO - make this work with value
 genTxOut :: [Addr] -> Gen [TxOut]
 genTxOut addrs = do
   ys <- genCoinList minGenesisOutputVal maxGenesisOutputVal (length addrs) (length addrs)
-  return (uncurry TxOut <$> zip addrs ys)
+  return (uncurry TxOut <$> zip addrs (fmap coinToValue ys))
 
 -- | Generates a list of 'Coin' values of length between 'lower' and 'upper'
 -- and with values between 'minCoin' and 'maxCoin'.

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
@@ -14,6 +14,7 @@ module Test.Shelley.Spec.Ledger.PreSTSMutator
     , mutateTx
     , mutateTxBody
     , mutateDCert
+    , mutateValue
     , getAnyStakeKey
     ) where
 
@@ -30,6 +31,7 @@ import           Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
+import           Cardano.Ledger.Shelley.Crypto
 import           Shelley.Spec.Ledger.BaseTypes
 import           Shelley.Spec.Ledger.Coin
 import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, pattern Delegate,
@@ -37,10 +39,11 @@ import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, 
                      pattern RetirePool)
 import           Shelley.Spec.Ledger.Keys (hashKey, vKey)
 import           Shelley.Spec.Ledger.Updates
+import           Shelley.Spec.Ledger.Value
 
 import           Shelley.Spec.Ledger.Slot
 import           Shelley.Spec.Ledger.Tx (pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut,
-                     _body, _certs, _inputs, _outputs, _ttl, _txfee, _wdrls, _witnessMSigMap,
+                     _body, _certs, _inputs, _outputs, _ttl, _txfee, _wdrls, _forge, _witnessMSigMap,
                      _witnessVKeySet)
 import           Shelley.Spec.Ledger.TxData (Credential (..), pattern DCertDeleg,
                      pattern DCertGenesis, pattern DCertMir, pattern DCertPool, pattern Delegation,
@@ -84,7 +87,13 @@ mutateInteger lower upper n =
 
 -- | Mutator for 'Coin' values, based on mutation of the contained value field.
 mutateCoin :: Integer -> Integer -> Coin -> Gen Coin
-mutateCoin lower upper (Coin val) = Coin <$> mutateInteger lower upper val
+mutateCoin lower upper (Coin c) = Coin <$> mutateInteger lower upper c
+
+-- | Mutator for 'Value', based on mutation of the contained value field.
+-- TODO make this correct
+mutateValue :: (Crypto crypto) => Integer -> Integer -> Value crypto -> Gen (Value crypto)
+mutateValue lower upper v = (coinToValue . Coin) <$> mutateInteger lower upper c
+  where (Coin c) = getAdaAmount v
 
 -- | Mutator of 'Tx' which mutates the contained transaction
 mutateTx :: Tx -> Gen Tx
@@ -101,6 +110,7 @@ mutateTxBody tx = do
   pure $ TxBody (Set.fromList inputs')
     outputs'
     (_certs tx)
+    (_forge tx)
     (_wdrls tx)
     (_txfee tx)
     (_ttl tx)
@@ -136,7 +146,7 @@ mutateOutputs (txout :<| txouts) = do
 -- the output.
 mutateOutput :: TxOut -> Gen TxOut
 mutateOutput (TxOut addr c) = do
-  c' <- mutateCoin 0 100 c
+  c' <- mutateValue 0 100 c
   pure $ TxOut addr c'
 
 
@@ -151,8 +161,8 @@ getAnyStakeKey keys = vKey . snd <$> Gen.element keys
 
 -- | Mutate 'Epoch' analogously to 'Coin' data.
 mutateEpoch :: Natural -> Natural -> EpochNo -> Gen EpochNo
-mutateEpoch lower upper (EpochNo val) = EpochNo . fromIntegral
-  <$> mutateNat lower upper (fromIntegral val)
+mutateEpoch lower upper (EpochNo v) = EpochNo . fromIntegral
+  <$> mutateNat lower upper (fromIntegral v)
 
 -- | Mutator for delegation certificates.
 -- A 'RegKey' and 'DeRegKey' select randomly a key fomr the supplied list of

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Shrinkers.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Shrinkers.hs
@@ -8,13 +8,15 @@ import qualified Data.Sequence as Seq
 import           Data.Set (Set)
 import qualified Data.Set as S
 import           Test.QuickCheck (shrinkIntegral, shrinkList)
+import           Cardano.Ledger.Shelley.Crypto
 
+import           Shelley.Spec.Ledger.Value
 import           Shelley.Spec.Ledger.Coin
 import           Shelley.Spec.Ledger.Slot
 import           Shelley.Spec.Ledger.Tx
 import           Shelley.Spec.Ledger.TxData
 import           Shelley.Spec.Ledger.Updates
-import           Shelley.Spec.Ledger.Scripts 
+import           Shelley.Spec.Ledger.Scripts
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Block)
 
 shrinkBlock
@@ -23,7 +25,8 @@ shrinkBlock
 shrinkBlock _ = []
 
 shrinkTx
-  :: Tx crypto
+  :: (Crypto crypto)
+  => Tx crypto
   -> [Tx crypto]
 shrinkTx (Tx _b _ws _wm _md) =
   [ Tx b' _ws _wm _md | b' <- shrinkTxBody _b ]
@@ -32,32 +35,39 @@ shrinkTx (Tx _b _ws _wm _md) =
   [ Tx b ws wm' | wm' <- shrinkMap shrinkScriptHash shrinkMultiSig wm ]
   -}
 
-shrinkTxBody :: TxBody crypto -> [TxBody crypto]
-shrinkTxBody (TxBody is os cs ws tf tl tu md) =
+-- TODO proper forge shrink!
+shrinkTxBody :: (Crypto crypto) => TxBody crypto -> [TxBody crypto]
+shrinkTxBody (TxBody is os cs fg ws tf tl tu md) =
   -- shrinking inputs is probably not very beneficial
   -- [ TxBody is' os cs ws tf tl tu | is' <- shrinkSet shrinkTxIn is ] ++
 
   -- Shrink outputs, add the differing balance of the original and new outputs
   -- to the fees in order to preserve the invariant
-  [ TxBody is os' cs ws (tf + (outBalance - outputBalance os')) tl tu md |
+  [ TxBody is os' cs fg ws (tf + getAdaAmount (outBalance - outputBalance os')) tl tu md |
     os' <- toList $ shrinkSeq shrinkTxOut os ]
 
-  -- [ TxBody is os cs' ws tf tl tu | cs' <- shrinkSeq shrinkDCert cs ] ++
-  -- [ TxBody is os cs ws' tf tl tu | ws' <- shrinkWdrl ws ] ++
-  -- [ TxBody is os cs ws tf' tl tu | tf' <- shrinkCoin tf ] ++
-  -- [ TxBody is os cs ws tf tl' tu | tl' <- shrinkSlotNo tl ] ++
-  -- [ TxBody is os cs ws tf tl tu' | tu' <- shrinkUpdate tu ]
+  -- [ TxBody is os cs' fg ws tf tl tu | cs' <- shrinkSeq shrinkDCert cs ] ++
+  -- [ TxBody is os cs fg ws' tf tl tu | ws' <- shrinkForge fg ] ++
+  -- [ TxBody is os cs fg ws' tf tl tu | ws' <- shrinkWdrl ws ] ++
+  -- [ TxBody is os cs fg ws tf' tl tu | tf' <- shrinkCoin tf ] ++
+  -- [ TxBody is os cs fg ws tf tl' tu | tl' <- shrinkSlotNo tl ] ++
+  -- [ TxBody is os cs fg ws tf tl tu' | tu' <- shrinkUpdate tu ]
   where outBalance = outputBalance os
 
-outputBalance :: Seq (TxOut crypto) -> Coin
-outputBalance = foldl (\v (TxOut _ c) -> v + c) (Coin 0)
+outputBalance :: (Crypto crypto) => Seq (TxOut crypto) -> Value crypto
+outputBalance = foldl (\v (TxOut _ c) -> v + c) zeroV
 
 shrinkTxIn :: TxIn crypto -> [TxIn crypto]
 shrinkTxIn = const []
 
-shrinkTxOut :: TxOut crypto -> [TxOut crypto]
-shrinkTxOut (TxOut addr coin) =
-  TxOut addr <$> shrinkCoin coin
+shrinkTxOut :: (Crypto crypto) => TxOut crypto -> [TxOut crypto]
+shrinkTxOut (TxOut addr v) =
+  TxOut addr <$> shrinkValue v
+
+--TODO proper value shrink
+shrinkValue :: (Crypto crypto) => Value crypto -> [Value crypto]
+shrinkValue x = (coinToValue . Coin) <$> shrinkIntegral c
+  where (Coin c) = getAdaAmount x
 
 shrinkCoin :: Coin -> [Coin]
 shrinkCoin (Coin x) = Coin <$> shrinkIntegral x


### PR DESCRIPTION
This is a sketch of what Multicurrency would look like if it goes in the Shelley ledger (mostly adjusted from what I was working on for Plutus integration)

As is, MSig scripts can be used to do multicurrency things, but there is no special language defined.

These changes are only to the src. The executable spec builds, but so far I did nothing about 
- testing 
- CDDL files
- making the correct size calculation which includes the forge field
- making the `ScriptHash` representing the Ada currency ID the right one
- `Num` instance for `Value` is questionable 