### PR TITLE
Expose the shelley-spec-ledger test helpers as a package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -6,6 +6,7 @@ packages:
   byron/semantics/executable-spec
   shelley/chain-and-ledger/dependencies/non-integer
   shelley/chain-and-ledger/executable-spec
+  shelley/chain-and-ledger/executable-spec/test
 
 constraints:
   hashable < 1.3,

--- a/shelley/chain-and-ledger/executable-spec/test/Setup.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -179,9 +179,8 @@ data CHAINExample =
   CHAINExample { currentSlotNo    :: SlotNo       -- ^ Current slot
                , startState     :: ChainState -- ^ State to start testing with
                , newBlock       :: Block      -- ^ Block to run chain state transition system on
-               , intendedResult :: (Either [[PredicateFailure CHAIN]] -- ^ type of fatal error, if failure expected
-                                           ChainState                 --   and final chain state if success expected
-                                   )
+               , intendedResult :: Either [[PredicateFailure CHAIN]] ChainState
+                  -- ^ type of fatal error, if failure expected and final chain state if success expected
                }
 
 data MIRExample =

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -51,6 +51,49 @@ module Test.Shelley.Spec.Ledger.Examples.Examples
   , dariaStake
   , dariaAddr
   , coreNodeSKG -- TODO remove
+  -- blocks
+  , blockEx1
+  , blockEx2A
+  , blockEx2B
+  , blockEx2C
+  , blockEx2D
+  , blockEx2E
+  , blockEx2F
+  , blockEx2G
+  , blockEx2H
+  , blockEx2I
+  , blockEx2J
+  , blockEx2K
+  , blockEx2L
+  , blockEx3A
+  , blockEx3B
+  , blockEx3C
+  , blockEx4A
+  , blockEx4B
+  , blockEx4C
+  , blockEx5A
+  , blockEx5B
+  , blockEx6A
+  , blockEx6B
+  , blockEx6F
+  , blockEx6F'
+  , blockEx6F''
+  -- transactions
+  , txEx2A
+  , txEx2B
+  , txEx2D
+  , txEx2J
+  , txEx2K
+  , txEx3A
+  , txEx3B
+  , txEx4A
+  , txEx4B
+  , txEx5A
+  , txEx6A
+  , txEx6B
+  , txEx6F
+  , txEx6F'
+  , txEx6F''
   -- helpers
   , unsafeMkUnitInterval
   )

--- a/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
@@ -1,0 +1,68 @@
+name:                shelley-spec-ledger-test
+version:             0.1.0.0
+description:         Test helpers from shelley-spec-ledger exposed to other packages
+author:              IOHK Formal Methods Team
+maintainer:          formal.methods@iohk.io
+build-type:          Simple
+cabal-version:       >=1.8
+
+source-repository head
+  type: git
+  location: https://github.com/input-output-hk/cardano-ledger-specs.git
+
+flag development
+    description: Disable '-Werror'
+    default: False
+    manual: True
+
+library
+  exposed-modules:   Test.Cardano.Crypto.VRF.Fake
+                     Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+                     Test.Shelley.Spec.Ledger.Examples.Examples
+                     Test.Shelley.Spec.Ledger.Examples.MultiSigExamples
+                     Test.Shelley.Spec.Ledger.Examples.Serialization
+                     Test.Shelley.Spec.Ledger.Generator.Block
+                     Test.Shelley.Spec.Ledger.Generator.Constants
+                     Test.Shelley.Spec.Ledger.Generator.Core
+                     Test.Shelley.Spec.Ledger.Generator.Delegation
+                     Test.Shelley.Spec.Ledger.Generator.Trace.Chain
+                     Test.Shelley.Spec.Ledger.Generator.Trace.DCert
+                     Test.Shelley.Spec.Ledger.Generator.Trace.Ledger
+                     Test.Shelley.Spec.Ledger.Generator.Update
+                     Test.Shelley.Spec.Ledger.Generator.Utxo
+                     Test.Shelley.Spec.Ledger.PreSTSGenerator
+                     Test.Shelley.Spec.Ledger.PreSTSMutator
+                     Test.Shelley.Spec.Ledger.Shrinkers
+                     Test.Shelley.Spec.Ledger.Utils
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+  if (!flag(development))
+    ghc-options:
+      -Werror
+  build-depends:
+    QuickCheck,
+    base,
+    bytestring,
+    cardano-binary,
+    cardano-crypto-class,
+    cardano-prelude,
+    cardano-slotting,
+    cborg,
+    containers,
+    cryptonite,
+    cs-ledger,
+    shelley-spec-ledger,
+    hedgehog,
+    multiset,
+    process-extras,
+    small-steps,
+    tasty,
+    tasty-hedgehog,
+    tasty-hunit,
+    tasty-quickcheck,
+    text,
+    transformers

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,6 +2,7 @@ resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/3893
 
 packages:
 - shelley/chain-and-ledger/executable-spec
+- shelley/chain-and-ledger/executable-spec/test
 - byron/chain/executable-spec
 - byron/ledger/executable-spec
 - byron/semantics/executable-spec


### PR DESCRIPTION
Similarly to how `cardano-ledger` exposes its test suite as the `cardano-ledger-test` package, this commit exposes the generators and examples (but not the tests themselves) from the testsuite of `shelley-spec-ledger` as the `shelley-spec-ledger-test` package.

This makes it possible for consensus to reuse the existing generators and examples for testing the Shelley ledger integration instead of having to write them from scratch.