### PR TITLE
Allow Shelley ledger to start at origin

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
@@ -19,7 +19,7 @@ header =
   )
 
 header_body =
-  ( prev_hash        : $hash
+  ( prev_hash        : ($hash / null)
   , issuer_vkey      : $vkey
   , vrf_vkey         : $vrf_vkey
   , slot             : uint

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -139,6 +139,8 @@ type OCertEnv = STS.Ocert.OCertEnv ConcreteCrypto
 
 type HashHeader = BlockChain.HashHeader ConcreteCrypto
 
+type PrevHash = BlockChain.PrevHash ConcreteCrypto
+
 type NewEpochState = LedgerState.NewEpochState ConcreteCrypto
 
 type NonMyopic = Rewards.NonMyopic ConcreteCrypto

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -114,11 +114,12 @@ import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 import           Unsafe.Coerce (unsafeCoerce)
 
+import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
 import           Shelley.Spec.Ledger.Address (mkRwdAcnt)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), mkNonce, startRewards, text64, (⭒))
-import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader, bhHash, bheader,
-                     hashHeaderToNonce)
+import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader, LastAppliedBlock (..), bhHash,
+                     bheader, hashHeaderToNonce)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, pattern Delegate,
                      pattern GenesisDelegate, pattern MIRCert, pattern PoolDistr, pattern RegKey,
@@ -389,16 +390,15 @@ esEx1 = EpochState acntEx1 emptySnapShots lsEx1 ppsEx1 emptyNonMyopic
 --   No blocks of Shelley have been processed yet.
 initStEx1 :: ChainState
 initStEx1 = initialShelleyState
-  (SlotNo 0)
-  (BlockNo 0)
+  (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
   (EpochNo 0)
-  lastByronHeaderHash
   (UTxO Map.empty)
   maxLLSupply
   genDelegs
   (Map.singleton (SlotNo 1) (Just . hashKey $ coreNodeVKG 0))
   (Applications Map.empty)
   ppsEx1
+  (hashHeaderToNonce lastByronHeaderHash)
 
 -- | Null initial block. Just records the Byron hash, and contains no transactions.
 blockEx1 :: Block
@@ -432,9 +432,10 @@ expectedStEx1 = ChainState
   (nonce0 ⭒ mkNonce 1)
   (nonce0 ⭒ mkNonce 1)
   NeutralNonce
-  (bhHash (bheader blockEx1))
-  (SlotNo 1)
-  (BlockNo 1)
+  (At $ LastAppliedBlock
+    (BlockNo 1)
+    (SlotNo 1)
+    (bhHash . bheader $ blockEx1))
 
 -- | Wraps example all together.
 ex1 :: CHAINExample
@@ -544,16 +545,15 @@ initNesEx2A = NewEpochState
 
 initStEx2A :: ChainState
 initStEx2A = initialShelleyState
-  (SlotNo 0)
-  (BlockNo 0)
+  (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
   (EpochNo 0)
-  lastByronHeaderHash
   utxoEx2A
   (maxLLSupply - balance utxoEx2A)
   genDelegs
   overlayEx2A
   byronApps
   ppsEx1
+  (hashHeaderToNonce lastByronHeaderHash)
 
 blockEx2A :: Block
 blockEx2A = mkBlock
@@ -632,9 +632,10 @@ expectedStEx2A = ChainState
   (nonce0 ⭒ mkNonce 1)
   (nonce0 ⭒ mkNonce 1)
   NeutralNonce
-  blockEx2AHash
-  (SlotNo 10)
-  (BlockNo 1)
+  (At $ LastAppliedBlock
+    (BlockNo 1)
+    (SlotNo 10)
+    blockEx2AHash)
 
 ex2A :: CHAINExample
 ex2A = CHAINExample (SlotNo 10) initStEx2A blockEx2A (Right expectedStEx2A)
@@ -747,9 +748,10 @@ expectedStEx2Bgeneric pp = ChainState
   (nonce0 ⭒ mkNonce 1 ⭒ mkNonce 2) -- ^ Evolving nonce
   (nonce0 ⭒ mkNonce 1)             -- ^ Candidate nonce
   NeutralNonce
-  blockEx2BHash                    -- ^ Hash header of the chain
-  (SlotNo 90)                      -- ^ Current slot
-  (BlockNo 2)                      -- ^ Current block no
+  (At $ LastAppliedBlock
+    (BlockNo 2)                    -- ^ Current block no
+    (SlotNo 90)                    -- ^ Current slot
+    blockEx2BHash)                 -- ^ Hash header of the chain
 
 -- | Expected state after transition
 expectedStEx2B :: ChainState
@@ -868,9 +870,10 @@ expectedStEx2Cgeneric ss ls pp = ChainState
   (mkSeqNonce 3)
   (mkSeqNonce 3)
   (hashHeaderToNonce blockEx2BHash)
-  blockEx2CHash
-  (SlotNo 110)
-  (BlockNo 3)
+  (At $ LastAppliedBlock
+    (BlockNo 3)
+    (SlotNo 110)
+    blockEx2CHash)
 
 -- ** Expected chain state after STS
 expectedStEx2C :: ChainState
@@ -1007,9 +1010,10 @@ expectedStEx2D = ChainState
   (mkSeqNonce 4)
   (mkSeqNonce 3)
   (hashHeaderToNonce blockEx2BHash)
-  blockEx2DHash
-  (SlotNo 190)
-  (BlockNo 4)
+  (At $ LastAppliedBlock
+    (BlockNo 4)
+    (SlotNo 190)
+    blockEx2DHash)
 
 ex2D :: CHAINExample
 ex2D = CHAINExample (SlotNo 190) expectedStEx2C blockEx2D (Right expectedStEx2D)
@@ -1098,9 +1102,10 @@ expectedStEx2E = ChainState
   (mkSeqNonce 5)
   (mkSeqNonce 5)
   (hashHeaderToNonce blockEx2DHash)
-  blockEx2EHash
-  (SlotNo 220)
-  (BlockNo 5)
+  (At $ LastAppliedBlock
+    (BlockNo 5)
+    (SlotNo 220)
+    blockEx2EHash)
 
 ex2E :: CHAINExample
 ex2E = CHAINExample (SlotNo 220) expectedStEx2D blockEx2E (Right expectedStEx2E)
@@ -1151,9 +1156,10 @@ expectedStEx2F = ChainState
   (mkSeqNonce 6)
   (mkSeqNonce 5)
   (hashHeaderToNonce blockEx2DHash)
-  blockEx2FHash
-  (SlotNo 295)
-  (BlockNo 6)
+  (At $ LastAppliedBlock
+    (BlockNo 6)
+    (SlotNo 295)
+    blockEx2FHash)
 
 ex2F :: CHAINExample
 ex2F = CHAINExample (SlotNo 295) expectedStEx2E blockEx2F (Right expectedStEx2F)
@@ -1225,9 +1231,10 @@ expectedStEx2G = ChainState
   (mkSeqNonce 7)
   (mkSeqNonce 7)
   (hashHeaderToNonce blockEx2FHash)
-  blockEx2GHash
-  (SlotNo 310)
-  (BlockNo 7)
+  (At $ LastAppliedBlock
+    (BlockNo 7)
+    (SlotNo 310)
+    blockEx2GHash)
 
 ex2G :: CHAINExample
 ex2G = CHAINExample (SlotNo 310) expectedStEx2F blockEx2G (Right expectedStEx2G)
@@ -1297,9 +1304,10 @@ expectedStEx2H = ChainState
   (mkSeqNonce 8)
   (mkSeqNonce 7)
   (hashHeaderToNonce blockEx2FHash)
-  blockEx2HHash
-  (SlotNo 390)
-  (BlockNo 8)
+  (At $ LastAppliedBlock
+    (BlockNo 8)
+    (SlotNo 390)
+    blockEx2HHash)
 
 ex2H :: CHAINExample
 ex2H = CHAINExample (SlotNo 390) expectedStEx2G blockEx2H (Right expectedStEx2H)
@@ -1382,9 +1390,10 @@ expectedStEx2I = ChainState
   (mkSeqNonce 9)
   (mkSeqNonce 9)
   (hashHeaderToNonce blockEx2HHash)
-  blockEx2IHash
-  (SlotNo 410)
-  (BlockNo 9)
+  (At $ LastAppliedBlock
+    (BlockNo 9)
+    (SlotNo 410)
+    blockEx2IHash)
 
 ex2I :: CHAINExample
 ex2I = CHAINExample (SlotNo 410) expectedStEx2H blockEx2I (Right expectedStEx2I)
@@ -1477,9 +1486,10 @@ expectedStEx2J = ChainState
   (mkSeqNonce 10)
   (mkSeqNonce 10)
   (hashHeaderToNonce blockEx2HHash)
-  blockEx2JHash
-  (SlotNo 420)
-  (BlockNo 10)
+  (At $ LastAppliedBlock
+    (BlockNo 10)
+    (SlotNo 420)
+    blockEx2JHash)
 
 ex2J :: CHAINExample
 ex2J = CHAINExample (SlotNo 420) expectedStEx2I blockEx2J (Right expectedStEx2J)
@@ -1567,9 +1577,10 @@ expectedStEx2K = ChainState
   (mkSeqNonce 11)
   (mkSeqNonce 10)
   (hashHeaderToNonce blockEx2HHash)
-  blockEx2KHash
-  (SlotNo 490)
-  (BlockNo 11)
+  (At $ LastAppliedBlock
+    (BlockNo 11)
+    (SlotNo 490)
+    blockEx2KHash)
 
 ex2K :: CHAINExample
 ex2K = CHAINExample (SlotNo 490) expectedStEx2J blockEx2K (Right expectedStEx2K)
@@ -1650,9 +1661,10 @@ expectedStEx2L = ChainState
   (mkSeqNonce 12)
   (mkSeqNonce 12)
   (hashHeaderToNonce blockEx2KHash)
-  blockEx2LHash
-  (SlotNo 510)
-  (BlockNo 12)
+  (At $ LastAppliedBlock
+    (BlockNo 12)
+    (SlotNo 510)
+    blockEx2LHash)
 
 ex2L :: CHAINExample
 ex2L = CHAINExample (SlotNo 510) expectedStEx2K blockEx2L (Right expectedStEx2L)
@@ -1752,9 +1764,10 @@ expectedStEx3A = ChainState
   (nonce0 ⭒ mkNonce 1)
   (nonce0 ⭒ mkNonce 1)
   NeutralNonce
-  blockEx3AHash
-  (SlotNo 10)
-  (BlockNo 1)
+  (At $ LastAppliedBlock
+    (BlockNo 1)
+    (SlotNo 10)
+    blockEx3AHash)
 
 ex3A :: CHAINExample
 ex3A = CHAINExample (SlotNo 10) initStEx2A blockEx3A (Right expectedStEx3A)
@@ -1852,9 +1865,10 @@ expectedStEx3B = ChainState
   (mkSeqNonce 2)
   (mkSeqNonce 2)
   NeutralNonce
-  blockEx3BHash
-  (SlotNo 20)
-  (BlockNo 2)
+  (At $ LastAppliedBlock
+    (BlockNo 2)
+    (SlotNo 20)
+    blockEx3BHash)
 
 ex3B :: CHAINExample
 ex3B = CHAINExample (SlotNo 20) expectedStEx3A blockEx3B (Right expectedStEx3B)
@@ -1916,9 +1930,10 @@ expectedStEx3C = ChainState
   (mkSeqNonce 3)
   (mkSeqNonce 3)
   (hashHeaderToNonce blockEx3BHash)
-  blockEx3CHash
-  (SlotNo 110)
-  (BlockNo 3)
+  (At $ LastAppliedBlock
+    (BlockNo 3)
+    (SlotNo 110)
+    blockEx3CHash)
 
 ex3C :: CHAINExample
 ex3C = CHAINExample (SlotNo 110) expectedStEx3B blockEx3C (Right expectedStEx3C)
@@ -2025,9 +2040,10 @@ expectedStEx4A = ChainState
   (nonce0 ⭒ mkNonce 1)
   (nonce0 ⭒ mkNonce 1)
   NeutralNonce
-  blockEx4AHash
-  (SlotNo 10)
-  (BlockNo 1)
+  (At $ LastAppliedBlock
+    (BlockNo 1)
+    (SlotNo 10)
+    blockEx4AHash)
 
 ex4A :: CHAINExample
 ex4A = CHAINExample (SlotNo 10) initStEx2A blockEx4A (Right expectedStEx4A)
@@ -2123,9 +2139,10 @@ expectedStEx4B = ChainState
   (mkSeqNonce 2)
   (mkSeqNonce 2)
   NeutralNonce
-  blockEx4BHash
-  (SlotNo 20)
-  (BlockNo 2)
+  (At $ LastAppliedBlock
+    (BlockNo 2)
+    (SlotNo 20)
+    blockEx4BHash)
 
 ex4B :: CHAINExample
 ex4B = CHAINExample (SlotNo 20) expectedStEx4A blockEx4B (Right expectedStEx4B)
@@ -2190,9 +2207,10 @@ expectedStEx4C = ChainState
   (mkSeqNonce 3)
   (mkSeqNonce 3)
   NeutralNonce
-  blockEx4CHash
-  (SlotNo 60)
-  (BlockNo 3)
+  (At $ LastAppliedBlock
+    (BlockNo 3)
+    (SlotNo 60)
+    blockEx4CHash)
 
 
 ex4C :: CHAINExample
@@ -2281,9 +2299,10 @@ expectedStEx5A = ChainState
   (nonce0 ⭒ mkNonce 1)
   (nonce0 ⭒ mkNonce 1)
   NeutralNonce
-  blockEx5AHash
-  (SlotNo 10)
-  (BlockNo 1)
+  (At $ LastAppliedBlock
+    (BlockNo 1)
+    (SlotNo 10)
+    blockEx5AHash)
 
 ex5A :: CHAINExample
 ex5A = CHAINExample (SlotNo 10) initStEx2A blockEx5A (Right expectedStEx5A)
@@ -2344,9 +2363,10 @@ expectedStEx5B = ChainState
   (mkSeqNonce 2)
   (mkSeqNonce 2)
   NeutralNonce
-  blockEx5BHash
-  (SlotNo 50)
-  (BlockNo 2)
+  (At $ LastAppliedBlock
+    (BlockNo 2)
+    (SlotNo 50)
+    blockEx5BHash)
 
 ex5B :: CHAINExample
 ex5B = CHAINExample (SlotNo 50) expectedStEx5A blockEx5B (Right expectedStEx5B)
@@ -2435,9 +2455,10 @@ expectedStEx6A = ChainState
   (nonce0 ⭒ mkNonce 1)
   (nonce0 ⭒ mkNonce 1)
   NeutralNonce
-  blockEx6AHash
-  (SlotNo 10)
-  (BlockNo 1)
+  (At $ LastAppliedBlock
+    (BlockNo 1)
+    (SlotNo 10)
+    blockEx6AHash)
 
 ex6A :: CHAINExample
 ex6A = CHAINExample (SlotNo 10) initStEx2A blockEx6A (Right expectedStEx6A)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -25,9 +25,10 @@ import           Data.Ratio ((%))
 import           Numeric.Natural (Natural)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), UnitInterval (..), mkNonce, text64)
 import           Shelley.Spec.Ledger.BlockChain (pattern BHBody, pattern BHeader, Block (..),
-                     pattern HashHeader, TxSeq (..), bbHash, bhash, bheaderBlockNo, bheaderEta,
-                     bheaderL, bheaderOCert, bheaderPrev, bheaderSlotNo, bheaderVk, bheaderVrfVk,
-                     bprotver, bsize, mkSeed, seedEta, seedL)
+                     pattern BlockHash, pattern HashHeader, TxSeq (..), bbHash, bhash,
+                     bheaderBlockNo, bheaderEta, bheaderL, bheaderOCert, bheaderPrev,
+                     bheaderSlotNo, bheaderVk, bheaderVrfVk, bprotver, bsize, mkSeed, seedEta,
+                     seedL)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, pattern Delegate,
                      pattern GenesisDelegate, pattern MIRCert, pattern PoolDistr, pattern RegKey,
@@ -48,19 +49,17 @@ import           Shelley.Spec.Ledger.Tx (Tx (..), hashScript)
 import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern AddrEnterprise,
                      pattern AddrPtr, Credential (..), pattern DCertDeleg, pattern DCertGenesis,
                      pattern DCertMir, pattern DCertPool, pattern Delegation, PoolMetaData (..),
-                     pattern PoolParams, Ptr (..), pattern RewardAcnt,
-                     pattern TxBody, pattern TxIn, pattern TxOut, Url (..),
-                     Wdrl (..), WitVKey (..), _TxId, _poolCost, _poolMD, _poolMDHash, _poolMDUrl,
-                     _poolMargin, _poolOwners, _poolPledge, _poolPubKey, _poolRAcnt, _poolRelays,
-                     _poolVrf)
+                     pattern PoolParams, Ptr (..), pattern RewardAcnt, pattern TxBody,
+                     pattern TxIn, pattern TxOut, Url (..), Wdrl (..), WitVKey (..), _TxId,
+                     _poolCost, _poolMD, _poolMDHash, _poolMDUrl, _poolMargin, _poolOwners,
+                     _poolPledge, _poolPubKey, _poolRAcnt, _poolRelays, _poolVrf)
 import           Shelley.Spec.Ledger.Updates (pattern AVUpdate, ApName (..), ApVer (..),
                      pattern Applications, pattern InstallerHash, pattern Mdt, pattern PPUpdate,
                      PParamsUpdate (..), Ppm (..), SystemTag (..), pattern Update, emptyUpdate)
 
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..), pattern OCert)
+import           Shelley.Spec.Ledger.Scripts (pattern RequireSignature, pattern ScriptHash)
 import           Shelley.Spec.Ledger.UTxO (makeWitnessVKey)
-import           Shelley.Spec.Ledger.Scripts (pattern RequireSignature,
-                 pattern ScriptHash)
 
 import           Test.Cardano.Crypto.VRF.Fake (WithResult (..))
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, BHBody, CoreKeyPair,
@@ -214,7 +213,7 @@ testHeaderHash = HashHeader $ unsafeCoerce (hash 0 :: Hash ShortHash Int)
 
 testBHB :: BHBody
 testBHB = BHBody
-          { bheaderPrev    = testHeaderHash
+          { bheaderPrev    = BlockHash testHeaderHash
           , bheaderVk      = vKey testKey1
           , bheaderVrfVk   = snd testVRF
           , bheaderSlotNo  = SlotNo 33
@@ -787,7 +786,7 @@ serializationTests = testGroup "Serialization Tests"
 
   -- checkEncodingCBOR "block_header_body"
   , let
-      prevhash = testHeaderHash
+      prevhash = BlockHash testHeaderHash
       issuerVkey = vKey testKey1
       vrfVkey = snd testVRF
       slot = SlotNo 33

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -68,19 +68,20 @@ import           Shelley.Spec.Ledger.Address (scriptsToAddr, toAddr, toCred)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), UnitInterval, epochInfo, intervalValue,
                      slotsPrior)
 import           Shelley.Spec.Ledger.BlockChain (pattern BHBody, pattern BHeader, pattern Block,
-                     TxSeq (..), bBodySize, bbHash, mkSeed, seedEta, seedL)
+                     pattern BlockHash, TxSeq (..), bBodySize, bbHash, mkSeed, seedEta, seedL)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Keys (pattern KeyPair, hashAnyKey, hashKey, sKey, sign,
                      signKES, undiscriminateKeyHash, vKey)
 import           Shelley.Spec.Ledger.LedgerState (AccountState (..), genesisCoins)
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..), pattern OCert)
 import           Shelley.Spec.Ledger.PParams (ProtVer (..))
+import           Shelley.Spec.Ledger.Scripts (pattern RequireAllOf, pattern RequireAnyOf,
+                     pattern RequireMOf, pattern RequireSignature)
 import           Shelley.Spec.Ledger.Slot (BlockNo (..), Duration (..), SlotNo (..), epochInfoFirst,
                      (*-))
 import           Shelley.Spec.Ledger.Tx (pattern TxOut, hashScript)
-import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern AddrPtr, pattern KeyHashObj, pattern ScriptHashObj)
-import           Shelley.Spec.Ledger.Scripts (pattern RequireAllOf, pattern RequireAnyOf, pattern RequireMOf,
-                 pattern RequireSignature)
+import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern AddrPtr, pattern KeyHashObj,
+                     pattern ScriptHashObj)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, AnyKeyHash, Block, CoreKeyPair,
                      Credential, GenKeyHash, HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig,
@@ -385,7 +386,7 @@ mkBlock prev pkeys txns s blockNo enonce (NatNonce bnonce) l kesPeriod c0 oCert 
     nonceNonce = mkSeed seedEta s enonce prev
     leaderNonce = mkSeed seedL s enonce prev
     bhb = BHBody
-            prev
+            (BlockHash prev)
             vKeyCold
             (snd $ vrf pkeys)
             s

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -23,12 +23,14 @@ import qualified Test.QuickCheck as QC
 import           Unsafe.Coerce (unsafeCoerce)
 
 import           Cardano.Crypto.Hash (ShortHash)
+import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.Monad.Trans.Reader (runReaderT)
 import           Control.State.Transition (IRC (..))
 import           Control.State.Transition.Trace.Generator.QuickCheck (BaseEnv, HasTrace, envGen,
                      interpretSTS, shrinkSignal, sigGen)
 import           Shelley.Spec.Ledger.BaseTypes (Globals, text64)
-import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader)
+import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader, LastAppliedBlock (..),
+                     hashHeaderToNonce)
 import           Shelley.Spec.Ledger.Keys (pattern GenDelegs, Hash, hash)
 import           Shelley.Spec.Ledger.LedgerState (overlaySchedule)
 import           Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
@@ -100,16 +102,15 @@ mkGenesisChainState (IRC _slotNo) = do
                 pParams
 
   pure . Right $ initialShelleyState
-    (SlotNo 0)
-    (BlockNo 0)
+    (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
     epoch0
-    lastByronHeaderHash
     utxo0
     (maxLLSupply - balance utxo0)
     delegs0
     osched_
     byronApps
     pParams
+    (hashHeaderToNonce lastByronHeaderHash)
   where
     epoch0 = EpochNo 0
     delegs0 = genesisDelegs0


### PR DESCRIPTION
The Shelley ledger can now start from origin or from Byron, and should integrate better with the consensus layer.  The previous hash is now essentially a maybe type, and the chain state now stores the last slot, block number, and prev hash only if they exist.

Here are a couple potentially interesting subtleties:

* The VRF check takes as an input (among other things) the previous header hash. We could provide some arbitrary value for the genesis block, but the check itself doesn't really make sense in this case. Instead, I've just skipped the VRF checks for the first block. Note that that the VRF checks would not even happen on the first block if the decentralization parameter was set to 1.
* As a part of the evolution of the epoch nonce, we add the previous hash of the last block of the previous epoch. In order to keep the function which computes this nonce total, we skip this step on the `GenesisHash`, though this case is impossible.

The updates to the formal spec will happen in another (upcoming!) PR.

closes #1317 (and double closes #1266 :smile:)