### PR TITLE
do not generate negative transaction tx outs

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
@@ -56,9 +56,6 @@ mutateId = pure
 mutateNatRange :: Natural -> Natural -> Natural -> Gen Natural
 mutateNatRange lower upper _ = Gen.integral $ Range.linear lower upper
 
-mutateIntegerRange :: Integer -> Integer -> Integer -> Gen Integer
-mutateIntegerRange lower upper _ = Gen.integral $ Range.linear lower upper
-
 -- | Mutator that adds or subtracts 1 from a given input value. In the case of
 -- underflow it returns 0.
 mutateNatSmall :: Natural -> Gen Natural
@@ -66,24 +63,16 @@ mutateNatSmall n = do
   b <- Gen.enumBounded :: Gen Bool
   pure $ if b then n + 1 else (if n > 0 then n - 1 else 0)
 
-mutateIntegerSmall :: Integer -> Gen Integer
-mutateIntegerSmall n = do
-  b <- Gen.enumBounded :: Gen Bool
-  pure $ if b then n + 1 else n - 1
-
 -- | Mutator that combines the identity, range selector and small change mutator
 -- in a random choice.
 mutateNat :: Natural -> Natural -> Natural -> Gen Natural
 mutateNat lower upper n =
   Gen.choice [mutateId n, mutateNatRange lower upper n, mutateNatSmall n]
 
-mutateInteger :: Integer -> Integer -> Integer -> Gen Integer
-mutateInteger lower upper n =
-  Gen.choice [mutateId n, mutateIntegerRange lower upper n, mutateIntegerSmall n]
-
 -- | Mutator for 'Coin' values, based on mutation of the contained value field.
-mutateCoin :: Integer -> Integer -> Coin -> Gen Coin
-mutateCoin lower upper (Coin val) = Coin <$> mutateInteger lower upper val
+mutateCoin :: Natural -> Natural -> Coin -> Gen Coin
+mutateCoin lower upper (Coin val) =
+  Coin . fromIntegral <$> mutateNat lower upper (fromIntegral val)
 
 -- | Mutator of 'Tx' which mutates the contained transaction
 mutateTx :: Tx -> Gen Tx

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -269,7 +269,10 @@ propertyTests = testGroup "Property-Based Testing"
                    propBalanceTxInTxOut'
                   , testProperty
                     "Classify double spend"
-                    classifyInvalidDoubleSpend
+                     classifyInvalidDoubleSpend
+                  , testProperty
+                    "NonNegative TxOuts"
+                    propNonNegativeTxOuts
                   ]
                 , testGroup "Properties of Trace generators"
                   [ TQC.testProperty
@@ -280,6 +283,12 @@ propertyTests = testGroup "Property-Based Testing"
                        onlyValidChainSignalsAreGenerated
                   ]
                 ]
+
+propNonNegativeTxOuts :: Property
+propNonNegativeTxOuts =
+  withTests 100000 $ property $ do
+  (_, _, _, tx, _)  <- forAll genStateTx
+  all (\(TxOut _ (Coin x)) -> x >= 0) (_outputs . _body $ tx) === True
 
 -- | Mutations for Property 7.2
 propBalanceTxInTxOut' :: Property

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -269,7 +269,7 @@ propertyTests = testGroup "Property-Based Testing"
                    propBalanceTxInTxOut'
                   , testProperty
                     "Classify double spend"
-                     classifyInvalidDoubleSpend
+                    classifyInvalidDoubleSpend
                   , testProperty
                     "NonNegative TxOuts"
                     propNonNegativeTxOuts


### PR DESCRIPTION
The `mutateCoin` function would sometimes subtract one from a coin value, which gives a negative values when passed zero. This mutator now uses the natural number mutators instead.

I also changed how `Coin` is serialized. It will become a cbor integer if it holds a negative value, and a uint otherwise. The idea is that this will provide clear errors, and will fail to validate against the cddl spec. For derserialization, we return a `DecoderError` for negative values.

closes #1341