### PR TITLE
Make types stored in consensus state strict

### DIFF
--- a/semantics/executable-spec/src/Control/State/Transition/Trace.hs
+++ b/semantics/executable-spec/src/Control/State/Transition/Trace.hs
@@ -52,8 +52,8 @@ import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Control.Monad.Reader (MonadReader, ReaderT, ask, runReaderT)
 import           Data.Data (Data, Typeable, cast, gmapQ)
 import           Data.Maybe (catMaybes)
-import           Data.Sequence.Strict (StrictSeq(Empty, (:<|)))
-import qualified Data.Sequence.Strict as Seq
+import           Data.Sequence.Strict (StrictSeq ((:<|), Empty))
+import qualified Data.Sequence.Strict as StrictSeq
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
 import           Test.Tasty.HUnit (assertFailure, (@?=))
@@ -92,7 +92,7 @@ data Trace s
       -- ^ Environment under which the trace was run.
       , _traceInitState :: !(State s)
       -- ^ Initial state in the trace
-      , _traceTrans :: !(Seq.StrictSeq (SigState s))
+      , _traceTrans :: !(StrictSeq (SigState s))
       -- ^ Signals and resulting states observed in the trace. New elements are
       -- put in front of the list.
     } deriving Generic
@@ -115,7 +115,7 @@ instance
 mkTrace :: Environment s -> State s -> [(State s, Signal s)] -> Trace s
 mkTrace env initState sigs = Trace env initState sigs'
   where
-    sigs' = uncurry SigState <$> Seq.fromList sigs
+    sigs' = uncurry SigState <$> StrictSeq.fromList sigs
 
 -- $setup
 -- |

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -35,9 +35,9 @@ import           Shelley.Spec.Ledger.BaseTypes (Globals (epochInfo))
 
 import           GHC.Generics (Generic)
 import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr)
-import           Shelley.Spec.Ledger.Keys (GenDelegs, GenKeyHash)
+import           Shelley.Spec.Ledger.Keys (GenDelegs)
 import           Shelley.Spec.Ledger.LedgerState (EpochState (..), NewEpochEnv (..),
-                     NewEpochState (..), getGKeys, _delegationState, _dstate, _genDelegs)
+                     NewEpochState (..), OBftSlot, getGKeys, _delegationState, _dstate, _genDelegs)
 import           Shelley.Spec.Ledger.PParams (PParams)
 import           Shelley.Spec.Ledger.Slot (SlotNo)
 import           Shelley.Spec.Ledger.STS.NewEpoch (NEWEPOCH)
@@ -47,7 +47,7 @@ import qualified Shelley.Spec.Ledger.STS.Prtcl as STS.Prtcl
 data LedgerView crypto
   = LedgerView
       { lvProtParams :: PParams,
-        lvOverlaySched :: Map SlotNo (Maybe (GenKeyHash crypto)),
+        lvOverlaySched :: Map SlotNo (OBftSlot crypto),
         lvPoolDistr :: PoolDistr crypto,
         lvGenDelegs :: GenDelegs crypto
       }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
@@ -102,7 +102,7 @@ interval1 = UnsafeUnitInterval 1
 
 -- | Evolving nonce type.
 data Nonce
-  = Nonce (Hash SHA256 Nonce)
+  = Nonce !(Hash SHA256 Nonce)
   | NeutralNonce -- ^ Identity element
   deriving (Eq, Generic, Ord, Show)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -73,7 +73,7 @@ import           Cardano.Prelude (AllowThunksIn (..), LByteString, NoUnexpectedT
 import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.Monad (unless)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), Seed (..), UnitInterval, intervalValue,
-                     mkNonce)
+                     mkNonce, strictMaybeToMaybe)
 import           Shelley.Spec.Ledger.Crypto
 import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
 import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
@@ -346,7 +346,7 @@ extractMetaData txns =
         . Seq.mapWithIndex (\i -> \t -> (i, _metadata t))
         . StrictSeq.getSeq
         $ txns
-  in ((Map.mapMaybe id) . Map.fromList . toList) metadata
+  in ((Map.mapMaybe strictMaybeToMaybe) . Map.fromList . toList) metadata
 
 -- |Given a size and a mapping from indices to maybe metadata,
 -- return a sequence whose size is the size paramater and

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -60,7 +60,7 @@ poolCWitness (RegPool pool)            = KeyHashObj $ _poolPubKey pool
 poolCWitness (RetirePool k _)          = KeyHashObj k
 
 genesisCWitness :: GenesisDelegate crypto -> GenKeyHash crypto
-genesisCWitness (GenesisDelegate (gk, _)) = gk
+genesisCWitness (GenesisDelegate gk _) = gk
 
 -- |Retrieve the deposit amount for a certificate
 dvalue :: DCert crypto-> PParams -> Coin
@@ -94,7 +94,7 @@ isDelegation _ = False
 
 -- | Check for `GenesisDelegate` constructor
 isGenesisDelegation :: DCert crypto-> Bool
-isGenesisDelegation (DCertGenesis (GenesisDelegate _)) = True
+isGenesisDelegation (DCertGenesis (GenesisDelegate {})) = True
 isGenesisDelegation _ = False
 
 -- | Check for `RegPool` constructor

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -192,9 +192,9 @@ groupByPool active delegs =
 -- | Snapshot of the stake distribution.
 data SnapShot crypto
   = SnapShot
-    { _stake :: Stake crypto
-    , _delegations :: Map (Credential crypto) (KeyHash crypto)
-    , _poolParams :: Map (KeyHash crypto) (PoolParams crypto)
+    { _stake       :: !(Stake crypto)
+    , _delegations :: !(Map (Credential crypto) (KeyHash crypto))
+    , _poolParams  :: !(Map (KeyHash crypto) (PoolParams crypto))
     } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (SnapShot crypto)
@@ -227,10 +227,10 @@ instance
 -- | Snapshots of the stake distribution.
 data SnapShots crypto
   = SnapShots
-    { _pstakeMark :: SnapShot crypto
-    , _pstakeSet  :: SnapShot crypto
-    , _pstakeGo   :: SnapShot crypto
-    , _feeSS :: Coin
+    { _pstakeMark :: !(SnapShot crypto)
+    , _pstakeSet  :: !(SnapShot crypto)
+    , _pstakeGo   :: !(SnapShot crypto)
+    , _feeSS      :: !Coin
     } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (SnapShots crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -82,7 +82,7 @@ import           Data.Foldable (toList)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Proxy (Proxy (..))
-import qualified Data.Sequence as Seq (Seq (..))
+import qualified Data.Sequence.Strict as StrictSeq
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           GHC.Generics (Generic)
@@ -137,19 +137,19 @@ type RewardAccounts crypto
 -- | State of staking pool delegations and rewards
 data DState crypto = DState
     {  -- |The active stake keys.
-      _stkCreds    :: StakeCreds           crypto
+      _stkCreds    :: !(StakeCreds           crypto)
       -- |The active reward accounts.
-    ,  _rewards    :: RewardAccounts       crypto
+    ,  _rewards    :: !(RewardAccounts       crypto)
       -- |The current delegations.
-    , _delegations :: Map (Credential crypto) (KeyHash crypto)
+    , _delegations :: !(Map (Credential crypto) (KeyHash crypto))
       -- |The pointed to hash keys.
-    , _ptrs        :: Map Ptr (Credential crypto)
+    , _ptrs        :: !(Map Ptr (Credential crypto))
       -- | future genesis key delegations
-    , _fGenDelegs  :: Map (SlotNo, GenKeyHash crypto) (KeyHash crypto)
+    , _fGenDelegs  :: !(Map (SlotNo, GenKeyHash crypto) (KeyHash crypto))
       -- |Genesis key delegations
-    , _genDelegs   :: GenDelegs crypto
+    , _genDelegs   :: !(GenDelegs crypto)
       -- | Instantaneous Rewards
-    , _irwd        :: Map (Credential crypto) Coin
+    , _irwd        :: !(Map (Credential crypto) Coin)
     } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (DState crypto)
@@ -176,11 +176,11 @@ instance Crypto crypto => FromCBOR (DState crypto)
 -- | Current state of staking pools and their certificate counters.
 data PState crypto = PState
     { -- |The active stake pools.
-      _stPools     :: StakePools crypto
+      _stPools     :: !(StakePools crypto)
       -- |The pool parameters.
-    , _pParams     :: Map (KeyHash crypto) (PoolParams crypto)
+    , _pParams     :: !(Map (KeyHash crypto) (PoolParams crypto))
       -- |A map of retiring stake pools to the epoch when they retire.
-    , _retiring    :: Map (KeyHash crypto) EpochNo
+    , _retiring    :: !(Map (KeyHash crypto) EpochNo)
     } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (PState crypto)
@@ -203,8 +203,8 @@ instance Crypto crypto => FromCBOR (PState crypto)
 data DPState crypto =
     DPState
     {
-      _dstate :: DState crypto
-    , _pstate :: PState crypto
+      _dstate :: !(DState crypto)
+    , _pstate :: !(PState crypto)
     } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (DPState crypto)
@@ -223,11 +223,11 @@ instance Crypto crypto => FromCBOR (DPState crypto)
     pure $ DPState ds ps
 
 data RewardUpdate crypto= RewardUpdate
-  { deltaT        :: Coin
-  , deltaR        :: Coin
-  , rs            :: Map (RewardAcnt crypto) Coin
-  , deltaF        :: Coin
-  , nonMyopic     :: NonMyopic crypto
+  { deltaT        :: !Coin
+  , deltaR        :: !Coin
+  , rs            :: !(Map (RewardAcnt crypto) Coin)
+  , deltaF        :: !Coin
+  , nonMyopic     :: !(NonMyopic crypto)
   } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (RewardUpdate crypto)
@@ -257,8 +257,8 @@ emptyRewardUpdate :: RewardUpdate crypto
 emptyRewardUpdate = RewardUpdate (Coin 0) (Coin 0) Map.empty (Coin 0) emptyNonMyopic
 
 data AccountState = AccountState
-  { _treasury  :: Coin
-  , _reserves  :: Coin
+  { _treasury  :: !Coin
+  , _reserves  :: !Coin
   } deriving (Show, Eq, Generic)
 
 instance ToCBOR AccountState
@@ -278,12 +278,12 @@ instance NoUnexpectedThunks AccountState
 
 data EpochState crypto
   = EpochState
-    { esAccountState :: AccountState
-    , esSnapshots :: SnapShots crypto
-    , esLState :: LedgerState crypto
-    , esPrevPp :: PParams
-    , esPp :: PParams
-    , esNonMyopic :: NonMyopic crypto
+    { esAccountState :: !AccountState
+    , esSnapshots :: !(SnapShots crypto)
+    , esLState :: !(LedgerState crypto)
+    , esPrevPp :: !PParams
+    , esPp :: !PParams
+    , esNonMyopic :: !(NonMyopic crypto)
     }
   deriving (Show, Eq, Generic)
 
@@ -346,9 +346,9 @@ clearPpup utxoSt = utxoSt {_ppups = emptyPPPUpdates}
 data UTxOState crypto=
     UTxOState
     { _utxo      :: !(UTxO crypto)
-    , _deposited :: Coin
-    , _fees      :: Coin
-    , _ppups     :: ProposedPPUpdates crypto
+    , _deposited :: !Coin
+    , _fees      :: !Coin
+    , _ppups     :: !(ProposedPPUpdates crypto)
     } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (UTxOState crypto)
@@ -371,15 +371,14 @@ instance Crypto crypto => FromCBOR (UTxOState crypto)
 -- | New Epoch state and environment
 data NewEpochState crypto=
   NewEpochState {
-    nesEL     :: EpochNo                       -- ^ Last epoch
-  , nesBprev  :: BlocksMade          crypto  -- ^ Blocks made before current epoch
-  , nesBcur   :: BlocksMade          crypto  -- ^ Blocks made in current epoch
-  , nesEs     :: EpochState          crypto  -- ^ Epoch state before current
-  , nesRu     :: Maybe (RewardUpdate crypto) -- ^ Possible reward update
-  , nesPd     :: PoolDistr           crypto  -- ^ Stake distribution within the stake pool
-  , nesOsched :: Map  SlotNo
-                     (Maybe
-                       (GenKeyHash   crypto))  -- ^ Overlay schedule for PBFT vs Praos
+    nesEL     :: !EpochNo                       -- ^ Last epoch
+  , nesBprev  :: !(BlocksMade          crypto)  -- ^ Blocks made before current epoch
+  , nesBcur   :: !(BlocksMade          crypto)  -- ^ Blocks made in current epoch
+  , nesEs     :: !(EpochState          crypto)  -- ^ Epoch state before current
+  , nesRu     :: !(Maybe (RewardUpdate crypto)) -- ^ Possible reward update
+  , nesPd     :: !(PoolDistr           crypto)  -- ^ Stake distribution within the stake pool
+  , nesOsched :: !(Map SlotNo
+                   (Maybe (GenKeyHash  crypto)))  -- ^ Overlay schedule for PBFT vs Praos
   } deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (NewEpochState crypto)
@@ -451,8 +450,8 @@ genesisId =
   TxId $ hash
   (TxBody
    Set.empty
-   Seq.Empty
-   Seq.Empty
+   StrictSeq.Empty
+   StrictSeq.Empty
    (Wdrl Map.empty)
    (Coin 0)
    (SlotNo 0)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
@@ -31,6 +31,8 @@ import           GHC.Generics (Generic)
 import           Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR)
 
 -- | A generic metadatum type.
+--
+-- TODO make strict
 data MetaDatum
     = Map [(MetaDatum, MetaDatum)]
     | List [MetaDatum]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/OCert.hs
@@ -51,13 +51,13 @@ newtype KESPeriod = KESPeriod Natural
 
 data OCert crypto = OCert
   { -- | The operational hot key
-    ocertVkHot     :: VKeyES crypto
+    ocertVkHot     :: !(VKeyES crypto)
     -- | counter
-  , ocertN         :: Natural
+  , ocertN         :: !Natural
     -- | Start of key evolving signature period
-  , ocertKESPeriod :: KESPeriod
+  , ocertKESPeriod :: !KESPeriod
     -- | Signature of block operational certificate content
-  , ocertSigma     :: Sig crypto (VKeyES crypto, Natural, KESPeriod)
+  , ocertSigma     :: !(Sig crypto (VKeyES crypto, Natural, KESPeriod))
   } deriving (Show, Eq, Generic)
     deriving ToCBOR via (CBORGroup (OCert crypto))
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -40,9 +40,10 @@ import           Numeric.Natural (Natural)
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord, encodeListLen,
                      encodeMapLen, encodeWord, enforceSize)
-import           Cardano.Prelude (NoUnexpectedThunks (..), catMaybes)
-import           Shelley.Spec.Ledger.BaseTypes (FixedPoint, Nonce (NeutralNonce), UnitInterval,
-                     fpPrecision, interval0, intervalValue, invalidKey)
+import           Cardano.Prelude (NoUnexpectedThunks (..), mapMaybe)
+import           Shelley.Spec.Ledger.BaseTypes (FixedPoint, Nonce (NeutralNonce), StrictMaybe (..),
+                     UnitInterval, fpPrecision, interval0, intervalValue, invalidKey,
+                     strictMaybeToMaybe)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Crypto
 import           Shelley.Spec.Ledger.Keys (GenDelegs, GenKeyHash)
@@ -285,16 +286,16 @@ data PPUpdateEnv crypto = PPUpdateEnv SlotNo (GenDelegs crypto)
 
 instance NoUnexpectedThunks (PPUpdateEnv crypto)
 
-type PParamsUpdate = PParams' Maybe
-deriving instance Eq (PParams' Maybe)
-deriving instance Show (PParams' Maybe)
-deriving instance Ord (PParams' Maybe)
+type PParamsUpdate = PParams' StrictMaybe
+deriving instance Eq (PParams' StrictMaybe)
+deriving instance Show (PParams' StrictMaybe)
+deriving instance Ord (PParams' StrictMaybe)
 
 instance NoUnexpectedThunks PParamsUpdate where
 
 instance ToCBOR PParamsUpdate where
   toCBOR ppup =
-    let l = catMaybes
+    let l = mapMaybe strictMaybeToMaybe
           [ encodeMapElement  0 toCBOR         =<< _minfeeA         ppup
           , encodeMapElement  1 toCBOR         =<< _minfeeB         ppup
           , encodeMapElement  2 toCBOR         =<< _maxBBSize       ppup
@@ -319,56 +320,56 @@ instance ToCBOR PParamsUpdate where
         n = fromIntegral $ length l
     in encodeMapLen n <> fold l
     where
-      encodeMapElement ix encoder x = Just (encodeWord ix <> encoder x)
+      encodeMapElement ix encoder x = SJust (encodeWord ix <> encoder x)
 
 emptyPParamsUpdate :: PParamsUpdate
 emptyPParamsUpdate   = PParams
-  { _minfeeA         = Nothing
-  , _minfeeB         = Nothing
-  , _maxBBSize       = Nothing
-  , _maxTxSize       = Nothing
-  , _maxBHSize       = Nothing
-  , _keyDeposit      = Nothing
-  , _keyMinRefund    = Nothing
-  , _keyDecayRate    = Nothing
-  , _poolDeposit     = Nothing
-  , _poolMinRefund   = Nothing
-  , _poolDecayRate   = Nothing
-  , _eMax            = Nothing
-  , _nOpt            = Nothing
-  , _a0              = Nothing
-  , _rho             = Nothing
-  , _tau             = Nothing
-  , _activeSlotCoeff = Nothing
-  , _d               = Nothing
-  , _extraEntropy    = Nothing
-  , _protocolVersion = Nothing
+  { _minfeeA         = SNothing
+  , _minfeeB         = SNothing
+  , _maxBBSize       = SNothing
+  , _maxTxSize       = SNothing
+  , _maxBHSize       = SNothing
+  , _keyDeposit      = SNothing
+  , _keyMinRefund    = SNothing
+  , _keyDecayRate    = SNothing
+  , _poolDeposit     = SNothing
+  , _poolMinRefund   = SNothing
+  , _poolDecayRate   = SNothing
+  , _eMax            = SNothing
+  , _nOpt            = SNothing
+  , _a0              = SNothing
+  , _rho             = SNothing
+  , _tau             = SNothing
+  , _activeSlotCoeff = SNothing
+  , _d               = SNothing
+  , _extraEntropy    = SNothing
+  , _protocolVersion = SNothing
   }
 
 instance FromCBOR PParamsUpdate where
    fromCBOR = do
      mapParts <- decodeMapContents $
        decodeWord >>= \case
-         0  -> fromCBOR         >>= \x -> pure ( 0, \up -> up { _minfeeA         = Just x })
-         1  -> fromCBOR         >>= \x -> pure ( 1, \up -> up { _minfeeB         = Just x })
-         2  -> fromCBOR         >>= \x -> pure ( 2, \up -> up { _maxBBSize       = Just x })
-         3  -> fromCBOR         >>= \x -> pure ( 3, \up -> up { _maxTxSize       = Just x })
-         4  -> fromCBOR         >>= \x -> pure ( 4, \up -> up { _maxBHSize       = Just x })
-         5  -> fromCBOR         >>= \x -> pure ( 5, \up -> up { _keyDeposit      = Just x })
-         6  -> fromCBOR         >>= \x -> pure ( 6, \up -> up { _keyMinRefund    = Just x })
-         7  -> rationalFromCBOR >>= \x -> pure ( 7, \up -> up { _keyDecayRate    = Just x })
-         8  -> fromCBOR         >>= \x -> pure ( 8, \up -> up { _poolDeposit     = Just x })
-         9  -> fromCBOR         >>= \x -> pure ( 9, \up -> up { _poolMinRefund   = Just x })
-         10 -> rationalFromCBOR >>= \x -> pure (10, \up -> up { _poolDecayRate   = Just x })
-         11 -> fromCBOR         >>= \x -> pure (11, \up -> up { _eMax            = Just x })
-         12 -> fromCBOR         >>= \x -> pure (12, \up -> up { _nOpt            = Just x })
-         13 -> rationalFromCBOR >>= \x -> pure (13, \up -> up { _a0              = Just x })
-         14 -> fromCBOR         >>= \x -> pure (14, \up -> up { _rho             = Just x })
-         15 -> fromCBOR         >>= \x -> pure (15, \up -> up { _tau             = Just x })
-         16 -> fromCBOR         >>= \x -> pure (16, \up -> up { _activeSlotCoeff = Just x })
-         17 -> fromCBOR         >>= \x -> pure (17, \up -> up { _d               = Just x })
-         18 -> fromCBOR         >>= \x -> pure (18, \up -> up { _extraEntropy    = Just x })
-         19 -> fromCBOR         >>= \x -> pure (19, \up -> up { _protocolVersion = Just x })
+         0  -> fromCBOR         >>= \x -> pure ( 0, \up -> up { _minfeeA         = SJust x })
+         1  -> fromCBOR         >>= \x -> pure ( 1, \up -> up { _minfeeB         = SJust x })
+         2  -> fromCBOR         >>= \x -> pure ( 2, \up -> up { _maxBBSize       = SJust x })
+         3  -> fromCBOR         >>= \x -> pure ( 3, \up -> up { _maxTxSize       = SJust x })
+         4  -> fromCBOR         >>= \x -> pure ( 4, \up -> up { _maxBHSize       = SJust x })
+         5  -> fromCBOR         >>= \x -> pure ( 5, \up -> up { _keyDeposit      = SJust x })
+         6  -> fromCBOR         >>= \x -> pure ( 6, \up -> up { _keyMinRefund    = SJust x })
+         7  -> rationalFromCBOR >>= \x -> pure ( 7, \up -> up { _keyDecayRate    = SJust x })
+         8  -> fromCBOR         >>= \x -> pure ( 8, \up -> up { _poolDeposit     = SJust x })
+         9  -> fromCBOR         >>= \x -> pure ( 9, \up -> up { _poolMinRefund   = SJust x })
+         10 -> rationalFromCBOR >>= \x -> pure (10, \up -> up { _poolDecayRate   = SJust x })
+         11 -> fromCBOR         >>= \x -> pure (11, \up -> up { _eMax            = SJust x })
+         12 -> fromCBOR         >>= \x -> pure (12, \up -> up { _nOpt            = SJust x })
+         13 -> rationalFromCBOR >>= \x -> pure (13, \up -> up { _a0              = SJust x })
+         14 -> fromCBOR         >>= \x -> pure (14, \up -> up { _rho             = SJust x })
+         15 -> fromCBOR         >>= \x -> pure (15, \up -> up { _tau             = SJust x })
+         16 -> fromCBOR         >>= \x -> pure (16, \up -> up { _activeSlotCoeff = SJust x })
+         17 -> fromCBOR         >>= \x -> pure (17, \up -> up { _d               = SJust x })
+         18 -> fromCBOR         >>= \x -> pure (18, \up -> up { _extraEntropy    = SJust x })
+         19 -> fromCBOR         >>= \x -> pure (19, \up -> up { _protocolVersion = SJust x })
          k -> invalidKey k
      let fields = fst <$> mapParts :: [Int]
      unless (nub fields == fields)
@@ -393,24 +394,27 @@ emptyPPPUpdates = ProposedPPUpdates Map.empty
 
 updatePParams :: PParams -> PParamsUpdate -> PParams
 updatePParams pp ppup = PParams
-  { _minfeeA = fromMaybe (_minfeeA pp) (_minfeeA ppup)
-  , _minfeeB = fromMaybe (_minfeeB pp) (_minfeeB ppup)
-  , _maxBBSize = fromMaybe (_maxBBSize pp) (_maxBBSize ppup)
-  , _maxTxSize = fromMaybe (_maxTxSize pp) (_maxTxSize ppup)
-  , _maxBHSize = fromMaybe (_maxBHSize pp) (_maxBHSize ppup)
-  , _keyDeposit = fromMaybe (_keyDeposit pp) (_keyDeposit ppup)
-  , _keyMinRefund = fromMaybe (_keyMinRefund pp) (_keyMinRefund ppup)
-  , _keyDecayRate = fromMaybe (_keyDecayRate pp) (_keyDecayRate ppup)
-  , _poolDeposit = fromMaybe (_poolDeposit pp) (_poolDeposit ppup)
-  , _poolMinRefund = fromMaybe (_poolMinRefund pp) (_poolMinRefund ppup)
-  , _poolDecayRate = fromMaybe (_poolDecayRate pp) (_poolDecayRate ppup)
-  , _eMax = fromMaybe (_eMax pp) (_eMax ppup)
-  , _nOpt = fromMaybe (_nOpt pp) (_nOpt ppup)
-  , _a0 = fromMaybe (_a0 pp) (_a0 ppup)
-  , _rho = fromMaybe (_rho pp) (_rho ppup)
-  , _tau = fromMaybe (_tau pp) (_tau ppup)
-  , _activeSlotCoeff = fromMaybe (_activeSlotCoeff pp) (_activeSlotCoeff ppup)
-  , _d = fromMaybe (_d pp) (_d ppup)
-  , _extraEntropy = fromMaybe (_extraEntropy pp) (_extraEntropy ppup)
-  , _protocolVersion = fromMaybe (_protocolVersion pp) (_protocolVersion ppup)
+  { _minfeeA = fromMaybe' (_minfeeA pp) (_minfeeA ppup)
+  , _minfeeB = fromMaybe' (_minfeeB pp) (_minfeeB ppup)
+  , _maxBBSize = fromMaybe' (_maxBBSize pp) (_maxBBSize ppup)
+  , _maxTxSize = fromMaybe' (_maxTxSize pp) (_maxTxSize ppup)
+  , _maxBHSize = fromMaybe' (_maxBHSize pp) (_maxBHSize ppup)
+  , _keyDeposit = fromMaybe' (_keyDeposit pp) (_keyDeposit ppup)
+  , _keyMinRefund = fromMaybe' (_keyMinRefund pp) (_keyMinRefund ppup)
+  , _keyDecayRate = fromMaybe' (_keyDecayRate pp) (_keyDecayRate ppup)
+  , _poolDeposit = fromMaybe' (_poolDeposit pp) (_poolDeposit ppup)
+  , _poolMinRefund = fromMaybe' (_poolMinRefund pp) (_poolMinRefund ppup)
+  , _poolDecayRate = fromMaybe' (_poolDecayRate pp) (_poolDecayRate ppup)
+  , _eMax = fromMaybe' (_eMax pp) (_eMax ppup)
+  , _nOpt = fromMaybe' (_nOpt pp) (_nOpt ppup)
+  , _a0 = fromMaybe' (_a0 pp) (_a0 ppup)
+  , _rho = fromMaybe' (_rho pp) (_rho ppup)
+  , _tau = fromMaybe' (_tau pp) (_tau ppup)
+  , _activeSlotCoeff = fromMaybe' (_activeSlotCoeff pp) (_activeSlotCoeff ppup)
+  , _d = fromMaybe' (_d pp) (_d ppup)
+  , _extraEntropy = fromMaybe' (_extraEntropy pp) (_extraEntropy ppup)
+  , _protocolVersion = fromMaybe' (_protocolVersion pp) (_protocolVersion ppup)
   }
+  where
+    fromMaybe' :: a -> StrictMaybe a -> a
+    fromMaybe' x = fromMaybe x . strictMaybeToMaybe

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -60,45 +60,45 @@ type family HKD f a where
 -- | Protocol parameters
 data PParams' f = PParams
   { -- |The linear factor for the minimum fee calculation
-    _minfeeA         :: HKD f Natural
+    _minfeeA         :: !(HKD f Natural)
     -- |The constant factor for the minimum fee calculation
-  , _minfeeB         :: HKD f Natural
+  , _minfeeB         :: !(HKD f Natural)
     -- | Maximal block body size
-  , _maxBBSize       :: HKD f Natural
+  , _maxBBSize       :: !(HKD f Natural)
     -- | Maximal transaction size
-  , _maxTxSize       :: HKD f Natural
+  , _maxTxSize       :: !(HKD f Natural)
     -- | Maximal block header size
-  , _maxBHSize       :: HKD f Natural
+  , _maxBHSize       :: !(HKD f Natural)
     -- |The amount of a key registration deposit
-  , _keyDeposit      :: HKD f Coin
+  , _keyDeposit      :: !(HKD f Coin)
     -- |The minimum percent refund guarantee
-  , _keyMinRefund    :: HKD f UnitInterval
+  , _keyMinRefund    :: !(HKD f UnitInterval)
     -- |The deposit decay rate
-  , _keyDecayRate    :: HKD f Rational
+  , _keyDecayRate    :: !(HKD f Rational)
     -- |The amount of a pool registration deposit
-  , _poolDeposit     :: HKD f Coin
+  , _poolDeposit     :: !(HKD f Coin)
     -- | The minimum percent pool refund
-  , _poolMinRefund   :: HKD f UnitInterval
+  , _poolMinRefund   :: !(HKD f UnitInterval)
     -- | Decay rate for pool deposits
-  , _poolDecayRate   :: HKD f Rational
+  , _poolDecayRate   :: !(HKD f Rational)
     -- | epoch bound on pool retirement
-  , _eMax            :: HKD f EpochNo
+  , _eMax            :: !(HKD f EpochNo)
     -- | Desired number of pools
-  , _nOpt            :: HKD f Natural
+  , _nOpt            :: !(HKD f Natural)
     -- | Pool influence
-  , _a0              :: HKD f Rational
+  , _a0              :: !(HKD f Rational)
     -- | Treasury expansion
-  , _rho             :: HKD f UnitInterval
+  , _rho             :: !(HKD f UnitInterval)
     -- | Monetary expansion
-  , _tau             :: HKD f UnitInterval
+  , _tau             :: !(HKD f UnitInterval)
     -- | Active slot coefficient
-  , _activeSlotCoeff :: HKD f ActiveSlotCoeff
+  , _activeSlotCoeff :: !(HKD f ActiveSlotCoeff)
     -- | Decentralization parameter
-  , _d               :: HKD f UnitInterval
+  , _d               :: !(HKD f UnitInterval)
     -- | Extra entropy
-  , _extraEntropy    :: HKD f Nonce
+  , _extraEntropy    :: !(HKD f Nonce)
     -- | Protocol version
-  , _protocolVersion :: HKD f ProtVer
+  , _protocolVersion :: !(HKD f ProtVer)
   } deriving (Generic)
 
 type PParams = PParams' Identity
@@ -107,10 +107,10 @@ deriving instance Show (PParams' Identity)
 
 data ActiveSlotCoeff =
   ActiveSlotCoeff
-  { unActiveSlotVal :: UnitInterval
-  , unActiveSlotLog :: Integer  -- TODO mgudemann make this FixedPoint,
-                                -- currently a problem because of
-                                -- NoUnexpectedThunks instance for FixedPoint
+  { unActiveSlotVal :: !UnitInterval
+  , unActiveSlotLog :: !Integer  -- TODO mgudemann make this FixedPoint,
+                                 -- currently a problem because of
+                                 -- NoUnexpectedThunks instance for FixedPoint
   } deriving (Eq, Ord, Show, Generic)
 
 instance NoUnexpectedThunks ActiveSlotCoeff
@@ -146,7 +146,7 @@ activeSlotVal = unActiveSlotVal
 activeSlotLog :: ActiveSlotCoeff -> FixedPoint
 activeSlotLog f = (fromIntegral $ unActiveSlotLog f) / fpPrecision
 
-data ProtVer = ProtVer Natural Natural
+data ProtVer = ProtVer !Natural !Natural
   deriving (Show, Eq, Generic, Ord)
   deriving ToCBOR via (CBORGroup ProtVer)
   deriving FromCBOR via (CBORGroup ProtVer)
@@ -265,7 +265,7 @@ emptyPParams =
 
 -- | Update Proposal
 data Update crypto
-  = Update (ProposedPPUpdates crypto) EpochNo
+  = Update !(ProposedPPUpdates crypto) !EpochNo
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (Update crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -52,9 +52,9 @@ instance FromCBOR ApparentPerformance
  where fromCBOR = ApparentPerformance <$> decodeDouble
 
 data NonMyopic crypto= NonMyopic
-  { apparentPerformances :: Map (KeyHash crypto) ApparentPerformance
-  , rewardPot :: Coin
-  , snap :: SnapShot crypto
+  { apparentPerformances :: !(Map (KeyHash crypto) ApparentPerformance)
+  , rewardPot :: !Coin
+  , snap :: !(SnapShot crypto)
   } deriving (Show, Eq, Generic)
 
 emptyNonMyopic :: NonMyopic crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -20,6 +20,7 @@ where
 import           Byron.Spec.Ledger.Core ((∈))
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Control.State.Transition
+import qualified Data.Sequence.Strict as StrictSeq
 import           Data.Set (Set)
 import           GHC.Generics (Generic)
 import           Shelley.Spec.Ledger.BaseTypes
@@ -92,7 +93,7 @@ bbodyTransition = judgmentContext >>=
   bbHash txsSeq == bhash bhb ?! InvalidBodyHashBBODY
 
   ls' <- trans @(LEDGERS crypto)
-         $ TRC (LedgersEnv (bheaderSlotNo bhb) pp _reserves, ls, txs)
+         $ TRC (LedgersEnv (bheaderSlotNo bhb) pp _reserves, ls, StrictSeq.getSeq txs)
 
   pure $ BbodyState ls' (incrBlocks (bheaderSlotNo bhb ∈ oslots) hk b)
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -22,7 +22,8 @@ import           Numeric.Natural (Natural)
 
 import           Cardano.Prelude (MonadError (..), asks, unless)
 import           Cardano.Slotting.Slot (WithOrigin (..))
-import           Shelley.Spec.Ledger.BaseTypes (Globals (..), Nonce (..), Seed (..), ShelleyBase)
+import           Shelley.Spec.Ledger.BaseTypes (Globals (..), Nonce (..), Seed (..), ShelleyBase,
+                     StrictMaybe (..))
 import           Shelley.Spec.Ledger.BlockChain (BHBody, BHeader, Block (..), LastAppliedBlock (..),
                      bHeaderSize, bhbody, bheaderSlotNo, hBbsize)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
@@ -96,7 +97,7 @@ initialShelleyState lab e utxo reserves genDelegs os pp initNonce =
          pp
          emptyNonMyopic
        )
-       Nothing
+       SNothing
        (PoolDistr Map.empty)
        os
     )

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -31,7 +31,7 @@ import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapSh
 import           Shelley.Spec.Ledger.Keys (GenDelegs (..), GenKeyHash, KESignable, KeyHash,
                      Signable, VKeyES)
 import           Shelley.Spec.Ledger.LedgerState (AccountState (..), DPState (..), DState (..),
-                     EpochState (..), LedgerState (..), NewEpochState (..), PState (..),
+                     EpochState (..), LedgerState (..), NewEpochState (..), OBftSlot, PState (..),
                      UTxOState (..), emptyDState, emptyPState, getGKeys, updateNES, _genDelegs)
 import           Shelley.Spec.Ledger.OCert (KESPeriod)
 import           Shelley.Spec.Ledger.PParams (PParams, ProposedPPUpdates (..), ProtVer (..),
@@ -70,7 +70,7 @@ initialShelleyState
   -> UTxO crypto
   -> Coin
   -> Map (GenKeyHash crypto) (KeyHash crypto)
-  -> Map SlotNo (Maybe (GenKeyHash crypto))
+  -> Map SlotNo (OBftSlot crypto)
   -> PParams
   -> Nonce
   -> ChainState crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -134,7 +134,7 @@ delegationTransition = do
       pure $ ds
         { _delegations = _delegations ds ⨃ [(hk, dpool)] }
 
-    DCertGenesis (GenesisDelegate (gkh, vkh)) -> do
+    DCertGenesis (GenesisDelegate gkh vkh) -> do
       sp <- liftSTS $ asks slotsPrior
       -- note that pattern match is used instead of genesisDeleg, as in the spec
       let s' = slot +* Duration sp

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -27,8 +27,8 @@ import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Crypto
 import           Shelley.Spec.Ledger.Delegation.Certificates
 import           Shelley.Spec.Ledger.Keys
-import           Shelley.Spec.Ledger.LedgerState (DState, emptyDState, _delegations, _fGenDelegs,
-                     _genDelegs, _irwd, _ptrs, _rewards, _stkCreds)
+import           Shelley.Spec.Ledger.LedgerState (DState, FutureGenDeleg (..), emptyDState,
+                     _delegations, _fGenDelegs, _genDelegs, _irwd, _ptrs, _rewards, _stkCreds)
 import           Shelley.Spec.Ledger.Slot
 import           Shelley.Spec.Ledger.TxData
 
@@ -143,7 +143,7 @@ delegationTransition = do
       gkh ∈ dom genDelegs ?! GenesisKeyNotInpMappingDELEG
       vkh ∉ range genDelegs ?! DuplicateGenesisDelegateDELEG
       pure $ ds
-        { _fGenDelegs = _fGenDelegs ds ⨃ [((s', gkh), vkh)]}
+        { _fGenDelegs = _fGenDelegs ds ⨃ [(FutureGenDeleg s' gkh, vkh)]}
 
     DCertMir (MIRCert credCoinMap) -> do
       sp <- liftSTS $ asks slotsPrior

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
@@ -116,7 +116,7 @@ delplTransition = do
       ps <-
         trans @(POOL crypto) $ TRC (PoolEnv slot pp, _pstate d, c)
       pure $ d { _pstate = ps }
-    DCertGenesis (GenesisDelegate _) -> do
+    DCertGenesis (GenesisDelegate {}) -> do
       ds <-
         trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
       pure $ d { _dstate = ds }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -22,6 +22,7 @@ import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLen, deco
                      encodeListLen, matchSize)
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Control.State.Transition
+import qualified Data.Sequence.Strict as StrictSeq
 import           Data.Typeable (Typeable)
 import           Data.Word (Word8)
 import           GHC.Generics (Generic)
@@ -109,7 +110,7 @@ ledgerTransition = do
 
   dpstate' <-
     trans @(DELEGS crypto)
-      $ TRC (DelegsEnv slot txIx pp tx reserves, dpstate, _certs $ _body tx)
+      $ TRC (DelegsEnv slot txIx pp tx reserves, dpstate, StrictSeq.getSeq $ _certs $ _body tx)
 
   let
     DPState dstate pstate = dpstate

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -56,7 +56,7 @@ instance
           (BlocksMade Map.empty)
           (BlocksMade Map.empty)
           emptyEpochState
-          Nothing
+          SNothing
           (PoolDistr Map.empty)
           Map.empty
     ]
@@ -80,8 +80,8 @@ newEpochTransition = do
     then pure src
     else do
       es' <- case ru of
-               Nothing  -> pure es
-               Just ru' -> do
+               SNothing  -> pure es
+               SJust ru' -> do
                  let RewardUpdate dt dr rs_ df _ = ru'
                  dt + dr + (sum rs_) + df == 0 ?! CorruptRewardUpdate ru'
                  pure $ applyRUpd ru' es
@@ -107,7 +107,7 @@ newEpochTransition = do
           bcur
           (BlocksMade Map.empty)
           es'''
-          Nothing
+          SNothing
           (PoolDistr pd')
           osched'
   where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -24,6 +24,7 @@ import           Shelley.Spec.Ledger.BaseTypes
 import           Shelley.Spec.Ledger.BlockChain
 import           Shelley.Spec.Ledger.Delegation.Certificates
 import           Shelley.Spec.Ledger.Keys
+import           Shelley.Spec.Ledger.LedgerState (OBftSlot (..))
 import           Shelley.Spec.Ledger.OCert
 import           Shelley.Spec.Ledger.PParams
 import           Shelley.Spec.Ledger.Slot
@@ -39,7 +40,7 @@ data OVERLAY crypto
 data OverlayEnv crypto
   = OverlayEnv
       PParams
-      (Map SlotNo (Maybe (GenKeyHash crypto)))
+      (Map SlotNo (OBftSlot crypto))
       Nonce
       (PoolDistr crypto)
       (GenDelegs crypto)
@@ -95,9 +96,9 @@ overlayTransition = judgmentContext >>=
   case Map.lookup (bheaderSlotNo bhb) osched of
     Nothing ->
       vrfChecks eta0 pd (_activeSlotCoeff pp) bhb ?! NotPraosLeaderOVERLAY
-    Just Nothing ->
+    Just NonActiveSlot ->
       failBecause NotActiveSlotOVERLAY
-    Just (Just gkey) ->
+    Just (ActiveSlot gkey) ->
       case Map.lookup gkey genDelegs of
         Nothing ->
           failBecause NoGenesisStakingOVERLAY

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -86,9 +86,9 @@ instance
       3 -> matchSize "PVCannotFollowPPUP" 1 n >> pure PVCannotFollowPPUP
       k -> invalidKey k
 
-pvCanFollow :: ProtVer -> Maybe ProtVer -> Bool
-pvCanFollow _ Nothing = True
-pvCanFollow (ProtVer m n) (Just (ProtVer m' n'))
+pvCanFollow :: ProtVer -> StrictMaybe ProtVer -> Bool
+pvCanFollow _ SNothing = True
+pvCanFollow (ProtVer m n) (SJust (ProtVer m' n'))
   = (m+1, 0) == (m', n') || (m, n+1) == (m', n')
 
 ppupTransitionNonEmpty :: TransitionRule (PPUP crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -25,6 +25,7 @@ import           Shelley.Spec.Ledger.BaseTypes
 import           Shelley.Spec.Ledger.BlockChain
 import           Shelley.Spec.Ledger.Delegation.Certificates
 import           Shelley.Spec.Ledger.Keys
+import           Shelley.Spec.Ledger.LedgerState (OBftSlot)
 import           Shelley.Spec.Ledger.OCert
 import           Shelley.Spec.Ledger.PParams
 import           Shelley.Spec.Ledger.Slot
@@ -78,7 +79,7 @@ instance Crypto crypto => NoUnexpectedThunks (PrtclState crypto)
 data PrtclEnv crypto
   = PrtclEnv
       PParams
-      (Map SlotNo (Maybe (GenKeyHash crypto)))
+      (Map SlotNo (OBftSlot crypto))
       (PoolDistr crypto)
       (GenDelegs crypto)
       SlotNo

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -44,12 +44,12 @@ data PRTCL crypto
 
 data PrtclState crypto
   = PrtclState
-      (Map (KeyHash crypto) Natural)
-      (WithOrigin (LastAppliedBlock crypto))
-      Nonce -- ^ Current epoch nonce
-      Nonce -- ^ Evolving nonce
-      Nonce -- ^ Candidate nonce
-      Nonce -- ^ Prev epoch hash nonce
+      !(Map (KeyHash crypto) Natural)
+      !(WithOrigin (LastAppliedBlock crypto))
+      !Nonce -- ^ Current epoch nonce
+      !Nonce -- ^ Evolving nonce
+      !Nonce -- ^ Candidate nonce
+      !Nonce -- ^ Prev epoch hash nonce
   deriving (Generic, Show, Eq)
 
 instance Crypto crypto => ToCBOR (PrtclState crypto) where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -23,6 +23,7 @@ import           Cardano.Prelude (NoUnexpectedThunks (..), asks)
 import           Control.State.Transition
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq (filter)
+import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
 import           Data.Word (Word8)
@@ -154,7 +155,11 @@ utxoWitnessed = do
 
   -- check genesis keys signatures for instantaneous rewards certificates
   let genSig = (Set.map undiscriminateKeyHash $ dom genMapping) ∩ Set.map witKeyHash wits
-      mirCerts = Seq.filter isInstantaneousRewards $ _certs txbody
+      mirCerts =
+          StrictSeq.toStrict
+        . Seq.filter isInstantaneousRewards
+        . StrictSeq.getSeq
+        $ _certs txbody
       GenDelegs genMapping = genDelegs
 
   coreNodeQuorum <- liftSTS $ asks quorum

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -28,8 +28,8 @@ import qualified Data.Set as Set
 import           Data.Typeable (Typeable)
 import           Data.Word (Word8)
 import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase, intervalValue, invalidKey, quorum,
-                     (==>))
+import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), intervalValue,
+                     invalidKey, quorum, (==>))
 import           Shelley.Spec.Ledger.Crypto
 import           Shelley.Spec.Ledger.Delegation.Certificates (isInstantaneousRewards)
 import           Shelley.Spec.Ledger.Keys
@@ -148,10 +148,10 @@ utxoWitnessed = do
 
   -- check metadata hash
   case (_mdHash txbody) of
-    Nothing  -> md == Nothing ?! BadMetaDataHashUTXOW
-    Just mdh -> case md of
-                  Nothing  -> failBecause BadMetaDataHashUTXOW
-                  Just md' -> hashMetaData md' == mdh ?! BadMetaDataHashUTXOW
+    SNothing  -> md == SNothing ?! BadMetaDataHashUTXOW
+    SJust mdh -> case md of
+                  SNothing  -> failBecause BadMetaDataHashUTXOW
+                  SJust md' -> hashMetaData md' == mdh ?! BadMetaDataHashUTXOW
 
   -- check genesis keys signatures for instantaneous rewards certificates
   let genSig = (Set.map undiscriminateKeyHash $ dom genMapping) ∩ Set.map witKeyHash wits

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -47,16 +47,16 @@ nativeMultiSigTag = 0
 data MultiSig crypto =
        -- | Require the redeeming transaction be witnessed by the spending key
        --   corresponding to the given verification key hash.
-       RequireSignature   (AnyKeyHash crypto)
+       RequireSignature  !(AnyKeyHash crypto)
 
        -- | Require all the sub-terms to be satisfied.
-     | RequireAllOf      [MultiSig crypto]
+     | RequireAllOf      ![MultiSig crypto]
 
        -- | Require any one of the sub-terms to be satisfied.
-     | RequireAnyOf      [MultiSig crypto]
+     | RequireAnyOf      ![MultiSig crypto]
 
        -- | Require M of the given sub-terms to be satisfied.
-     | RequireMOf    Int [MultiSig crypto]
+     | RequireMOf   !Int ![MultiSig crypto]
   deriving (Show, Eq, Ord, Generic)
 
 instance NoUnexpectedThunks (MultiSig crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Serialization.hs
@@ -11,6 +11,7 @@ module Shelley.Spec.Ledger.Serialization
   , FromCBORGroup (..)
   , CBORGroup (..)
   , CborSeq (..)
+  , unwrapCborStrictSeq
   , decodeList
   , decodeMapContents
   , encodeFoldable
@@ -34,6 +35,8 @@ import qualified Data.Map as Map
 import           Data.Ratio (Rational, denominator, numerator, (%))
 import           Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
+import           Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
 import           Data.Typeable
 
 class Typeable a => ToCBORGroup a where
@@ -89,6 +92,9 @@ instance ToCBOR a => ToCBOR (CborSeq a) where
 
 instance FromCBOR a => FromCBOR (CborSeq a) where
   fromCBOR = CborSeq . Seq.fromList <$> decodeList fromCBOR
+
+unwrapCborStrictSeq :: CborSeq a -> StrictSeq a
+unwrapCborStrictSeq = StrictSeq.toStrict . unwrapCborSeq
 
 encodeFoldable :: (ToCBOR a, Foldable f) => f a -> Encoding
 encodeFoldable xs = wrapCBORArray len contents

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -57,9 +57,8 @@ data Tx crypto
   = Tx
       { _body           :: !(TxBody crypto)
       , _witnessVKeySet :: !(Set (WitVKey crypto))
-      , _witnessMSigMap ::
-          Map (ScriptHash crypto) (MultiSig crypto)
-      , _metadata       :: Maybe MetaData
+      , _witnessMSigMap :: !(Map (ScriptHash crypto) (MultiSig crypto))
+      , _metadata       :: !(Maybe MetaData)
       } deriving (Show, Eq, Generic)
 
 instance Crypto crypto => NoUnexpectedThunks (Tx crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -30,7 +30,7 @@ module Shelley.Spec.Ledger.Tx
 where
 
 
-import           Shelley.Spec.Ledger.BaseTypes (invalidKey)
+import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe, invalidKey, maybeToStrictMaybe)
 import           Shelley.Spec.Ledger.Keys (AnyKeyHash, GenKeyHash, undiscriminateKeyHash)
 
 import           Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR), decodeListLenOf, decodeWord,
@@ -58,7 +58,7 @@ data Tx crypto
       { _body           :: !(TxBody crypto)
       , _witnessVKeySet :: !(Set (WitVKey crypto))
       , _witnessMSigMap :: !(Map (ScriptHash crypto) (MultiSig crypto))
-      , _metadata       :: !(Maybe MetaData)
+      , _metadata       :: !(StrictMaybe MetaData)
       } deriving (Show, Eq, Generic)
 
 instance Crypto crypto => NoUnexpectedThunks (Tx crypto)
@@ -86,7 +86,7 @@ cborWitsToTx b ws md = Tx
         fmap
           (\x -> (hashScript x, x))
           ((toList . unwrapCborSeq . _cborWitsScripts) ws)
-  , _metadata = md
+  , _metadata = maybeToStrictMaybe md
   }
 
 data CBORWits crypto

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -46,6 +46,7 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 
 import           Byron.Spec.Ledger.Core (Relation (..))
+import           Shelley.Spec.Ledger.BaseTypes (strictMaybeToMaybe)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Crypto
 import           Shelley.Spec.Ledger.Keys (AnyKeyHash, KeyDiscriminator (..), KeyPair, Signable,
@@ -190,7 +191,7 @@ totalDeposits pc (StakePools stpools) cs = foldl f (Coin 0) cs'
     cs' = filter notRegisteredPool cs
 
 txup :: Tx crypto -> Maybe (Update crypto)
-txup (Tx txbody _ _ _) = _txUpdate txbody
+txup (Tx txbody _ _ _) = strictMaybeToMaybe (_txUpdate txbody)
 
 -- | Extract script hash from value address with script.
 getScriptHash :: Addr crypto -> Maybe (ScriptHash crypto)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -147,6 +147,8 @@ type NonMyopic = Rewards.NonMyopic ConcreteCrypto
 
 type RewardUpdate = LedgerState.RewardUpdate ConcreteCrypto
 
+type OBftSlot = LedgerState.OBftSlot ConcreteCrypto
+
 type ChainState = STS.Chain.ChainState ConcreteCrypto
 
 type CHAIN = STS.Chain.CHAIN ConcreteCrypto

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -121,13 +121,14 @@ import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), pattern Sna
                      _pstakeMark, _pstakeSet)
 import           Shelley.Spec.Ledger.Keys (pattern GenDelegs, Hash, pattern KeyPair, hash, hashKey,
                      vKey)
-import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern DPState,
-                     pattern EpochState, pattern LedgerState, pattern NewEpochState,
-                     pattern RewardUpdate, pattern UTxOState, deltaF, deltaR, deltaT, emptyDState,
-                     emptyPState, esAccountState, esLState, esPp, genesisCoins, genesisId, nesEs,
-                     nonMyopic, overlaySchedule, rs, _delegationState, _delegations, _dstate,
-                     _fGenDelegs, _genDelegs, _irwd, _pParams, _ptrs, _reserves, _retiring,
-                     _rewards, _stPools, _stkCreds, _treasury)
+import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern ActiveSlot,
+                     pattern DPState, pattern EpochState, pattern LedgerState,
+                     pattern NewEpochState, pattern RewardUpdate, pattern UTxOState, deltaF,
+                     deltaR, deltaT, emptyDState, emptyPState, esAccountState, esLState, esPp,
+                     genesisCoins, genesisId, nesEs, nonMyopic, overlaySchedule, rs,
+                     _delegationState, _delegations, _dstate, _fGenDelegs, _genDelegs, _irwd,
+                     _pParams, _ptrs, _reserves, _retiring, _rewards, _stPools, _stkCreds,
+                     _treasury)
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import           Shelley.Spec.Ledger.PParams (PParams, PParams' (PParams), PParamsUpdate,
                      pattern ProposedPPUpdates, pattern Update, emptyPPPUpdates, emptyPParams,
@@ -162,9 +163,9 @@ import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, makeWitnessesV
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, Block, CHAIN, ChainState,
                      Credential, DState, EpochState, GenKeyHash, HashHeader, KeyHash, KeyPair,
-                     LedgerState, NewEpochState, PState, PoolDistr, PoolParams, ProposedPPUpdates,
-                     RewardAcnt, SKey, SnapShot, SnapShots, Tx, TxBody, UTxO, UTxOState, Update,
-                     VKeyGenesis, hashKeyVRF)
+                     LedgerState, NewEpochState, OBftSlot, PState, PoolDistr, PoolParams,
+                     ProposedPPUpdates, RewardAcnt, SKey, SnapShot, SnapShots, Tx, TxBody, UTxO,
+                     UTxOState, Update, VKeyGenesis, hashKeyVRF)
 import           Test.Shelley.Spec.Ledger.Generator.Core (AllPoolKeys (..), NatNonce (..),
                      genesisAccountState, mkBlock, mkOCert, zero)
 import           Test.Shelley.Spec.Ledger.Utils
@@ -381,7 +382,7 @@ initStEx1 = initialShelleyState
   (UTxO Map.empty)
   maxLLSupply
   genDelegs
-  (Map.singleton (SlotNo 1) (Just . hashKey $ coreNodeVKG 0))
+  (Map.singleton (SlotNo 1) (ActiveSlot . hashKey $ coreNodeVKG 0))
   ppsEx1
   (hashHeaderToNonce lastByronHeaderHash)
 
@@ -411,7 +412,7 @@ expectedStEx1 = ChainState
      esEx1
      Nothing
      (PoolDistr Map.empty)
-     (Map.singleton (SlotNo 1) (Just . hashKey $ coreNodeVKG 0)))
+     (Map.singleton (SlotNo 1) (ActiveSlot . hashKey $ coreNodeVKG 0)))
   oCertIssueNosEx1
   nonce0
   (nonce0 ⭒ mkNonce 1)
@@ -528,7 +529,7 @@ acntEx2A = AccountState
 esEx2A :: EpochState
 esEx2A = EpochState acntEx2A emptySnapShots lsEx2A ppsEx1 ppsEx1 emptyNonMyopic
 
-overlayEx2A :: Map SlotNo (Maybe GenKeyHash)
+overlayEx2A :: Map SlotNo OBftSlot
 overlayEx2A = runShelleyBase
   $ overlaySchedule
     (EpochNo 0)
@@ -786,7 +787,7 @@ blockEx2C = mkBlock
              0
              (mkOCert (coreNodeKeys 2) 0 (KESPeriod 0))
 
-epoch1OSchedEx2C :: Map SlotNo (Maybe GenKeyHash)
+epoch1OSchedEx2C :: Map SlotNo OBftSlot
 epoch1OSchedEx2C = runShelleyBase $ overlaySchedule
                     (EpochNo 1)
                     (Map.keysSet genDelegs)
@@ -1033,7 +1034,7 @@ blockEx2E = mkBlock
              10
              (mkOCert (coreNodeKeys 5) 1 (KESPeriod 10))
 
-epoch1OSchedEx2E :: Map SlotNo (Maybe GenKeyHash)
+epoch1OSchedEx2E :: Map SlotNo OBftSlot
 epoch1OSchedEx2E = runShelleyBase $ overlaySchedule
                     (EpochNo 2)
                     (Map.keysSet genDelegs)
@@ -1182,7 +1183,7 @@ blockEx2G = mkBlock
 blockEx2GHash :: HashHeader
 blockEx2GHash = bhHash (bheader blockEx2G)
 
-epoch1OSchedEx2G :: Map SlotNo (Maybe GenKeyHash)
+epoch1OSchedEx2G :: Map SlotNo OBftSlot
 epoch1OSchedEx2G = runShelleyBase $ overlaySchedule
                     (EpochNo 3)
                     (Map.keysSet genDelegs)
@@ -1329,7 +1330,7 @@ blockEx2I = mkBlock
 blockEx2IHash :: HashHeader
 blockEx2IHash = bhHash (bheader blockEx2I)
 
-epoch1OSchedEx2I :: Map SlotNo (Maybe GenKeyHash)
+epoch1OSchedEx2I :: Map SlotNo OBftSlot
 epoch1OSchedEx2I = runShelleyBase $ overlaySchedule
                      (EpochNo 4)
                      (Map.keysSet genDelegs)
@@ -1902,7 +1903,7 @@ blockEx3C = mkBlock
 blockEx3CHash :: HashHeader
 blockEx3CHash = bhHash (bheader blockEx3C)
 
-overlayEx3C :: Map SlotNo (Maybe GenKeyHash)
+overlayEx3C :: Map SlotNo OBftSlot
 overlayEx3C = runShelleyBase $ overlaySchedule
                     (EpochNo 1)
                     (Map.keysSet genDelegs)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -109,7 +109,8 @@ import           Unsafe.Coerce (unsafeCoerce)
 import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
 import           Shelley.Spec.Ledger.Address (mkRwdAcnt)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), mkNonce, startRewards, text64, (⭒))
+import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), mkNonce, startRewards,
+                     text64, (⭒))
 import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader, LastAppliedBlock (..), bhHash,
                      bheader, hashHeaderToNonce)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
@@ -260,7 +261,7 @@ alicePoolParams =
     , _poolRAcnt = RewardAcnt aliceSHK
     , _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake
     , _poolRelays = StrictSeq.empty
-    , _poolMD = Just $ PoolMetaData
+    , _poolMD = SJust $ PoolMetaData
                   { _poolMDUrl  = Url $ text64 "alice.pool"
                   , _poolMDHash = BS.pack "{}"
                   }
@@ -410,7 +411,7 @@ expectedStEx1 = ChainState
      (BlocksMade Map.empty)
      -- Note that blocks in the overlay schedule do not add to this count.
      esEx1
-     Nothing
+     SNothing
      (PoolDistr Map.empty)
      (Map.singleton (SlotNo 1) (ActiveSlot . hashKey $ coreNodeVKG 0)))
   oCertIssueNosEx1
@@ -443,26 +444,26 @@ ppupEx2A :: ProposedPPUpdates
 ppupEx2A = ProposedPPUpdates $ Map.singleton
              (hashKey $ coreNodeVKG 0) -- stake key
              (PParams
-                { _minfeeA = Nothing
-                , _minfeeB = Nothing
-                , _maxBBSize = Nothing
-                , _maxTxSize = Nothing
-                , _maxBHSize = Nothing
-                , _keyDeposit = Just 255
-                , _keyMinRefund = Nothing
-                , _keyDecayRate = Nothing
-                , _poolDeposit = Nothing
-                , _poolMinRefund = Nothing
-                , _poolDecayRate = Nothing
-                , _eMax = Nothing
-                , _nOpt = Nothing
-                , _a0 = Nothing
-                , _rho = Nothing
-                , _tau = Nothing
-                , _activeSlotCoeff = Nothing
-                , _d = Nothing
-                , _extraEntropy = Nothing
-                , _protocolVersion = Nothing
+                { _minfeeA = SNothing
+                , _minfeeB = SNothing
+                , _maxBBSize = SNothing
+                , _maxTxSize = SNothing
+                , _maxBHSize = SNothing
+                , _keyDeposit = SJust 255
+                , _keyMinRefund = SNothing
+                , _keyDecayRate = SNothing
+                , _poolDeposit = SNothing
+                , _poolMinRefund = SNothing
+                , _poolDecayRate = SNothing
+                , _eMax = SNothing
+                , _nOpt = SNothing
+                , _a0 = SNothing
+                , _rho = SNothing
+                , _tau = SNothing
+                , _activeSlotCoeff = SNothing
+                , _d = SNothing
+                , _extraEntropy = SNothing
+                , _protocolVersion = SNothing
                 })
 
 -- | Update proposal that just changes protocol parameters,
@@ -488,8 +489,8 @@ txbodyEx2A = TxBody
            (Wdrl Map.empty)
            (Coin 3)
            (SlotNo 10)
-           (Just updateEx2A)
-           Nothing
+           (SJust updateEx2A)
+           SNothing
 
 txEx2A :: Tx
 txEx2A = Tx
@@ -508,7 +509,7 @@ txEx2A = Tx
              , KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
              ])
           Map.empty
-          Nothing
+          SNothing
 
 -- | Pointer address to address of Alice address.
 alicePtrAddr :: Addr
@@ -542,7 +543,7 @@ initNesEx2A = NewEpochState
                (BlocksMade Map.empty)
                (BlocksMade Map.empty)
                esEx2A
-               Nothing
+               SNothing
                (PoolDistr Map.empty)
                overlayEx2A
 
@@ -616,7 +617,7 @@ expectedStEx2A = ChainState
      (BlocksMade Map.empty) -- Still no blocks
      (BlocksMade Map.empty) -- Still no blocks
      (EpochState acntEx2A emptySnapShots expectedLSEx2A ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      (PoolDistr Map.empty)
      overlayEx2A)
   -- Operational certificate issue numbers are now only updated during block
@@ -659,8 +660,8 @@ txbodyEx2B = TxBody
       , TxData._wdrls    = Wdrl Map.empty
       , TxData._txfee    = Coin 4
       , TxData._ttl      = SlotNo 90
-      , TxData._txUpdate = Nothing
-      , TxData._mdHash   = Nothing
+      , TxData._txUpdate = SNothing
+      , TxData._mdHash   = SNothing
       }
 
 txEx2B :: Tx
@@ -669,7 +670,7 @@ txEx2B = Tx
           (makeWitnessesVKey txbodyEx2B [alicePay, aliceStake, bobStake])
                      -- Witness verification key set
           Map.empty  -- Witness signature map
-          Nothing
+          SNothing
 
 blockEx2B :: Block
 blockEx2B = mkBlock
@@ -731,12 +732,12 @@ expectedStEx2Bgeneric pp = ChainState
      (BlocksMade Map.empty) -- Blocks made before current
      (EpochState acntEx2A emptySnapShots expectedLSEx2B pp pp emptyNonMyopic)
                             -- Previous epoch state
-     (Just RewardUpdate { deltaT        = Coin 0
-                        , deltaR        = Coin 0
-                        , rs            = Map.empty
-                        , deltaF        = Coin 0
-                        , nonMyopic     = emptyNonMyopic
-                        })  -- Update reward
+     (SJust RewardUpdate { deltaT        = Coin 0
+                         , deltaR        = Coin 0
+                         , rs            = Map.empty
+                         , deltaF        = Coin 0
+                         , nonMyopic     = emptyNonMyopic
+                         })  -- Update reward
      (PoolDistr Map.empty)
      overlayEx2A)
   oCertIssueNosEx1
@@ -858,7 +859,7 @@ expectedStEx2Cgeneric ss ls pp = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2A { _reserves = _reserves acntEx2A - carlMIR } ss ls pp pp emptyNonMyopic)
-     Nothing
+     SNothing
      (PoolDistr Map.empty)
      epoch1OSchedEx2C)
   oCertIssueNosEx1
@@ -925,8 +926,8 @@ txbodyEx2D = TxBody
       , TxData._wdrls    = Wdrl Map.empty
       , TxData._txfee    = Coin 5
       , TxData._ttl      = SlotNo 500
-      , TxData._txUpdate = Nothing
-      , TxData._mdHash   = Nothing
+      , TxData._txUpdate = SNothing
+      , TxData._mdHash   = SNothing
       }
 
 txEx2D :: Tx
@@ -934,7 +935,7 @@ txEx2D = Tx
           txbodyEx2D
           (makeWitnessesVKey txbodyEx2D [alicePay, carlStake])
           Map.empty
-          Nothing
+          SNothing
 
 blockEx2D :: Block
 blockEx2D = mkBlock
@@ -994,12 +995,12 @@ expectedStEx2D = ChainState
         ppsEx1
         ppsEx1
         emptyNonMyopic)
-     (Just RewardUpdate { deltaT        = Coin 21
-                        , deltaR        = Coin 0
-                        , rs            = Map.empty
-                        , deltaF        = Coin (-21)
-                        , nonMyopic     = emptyNonMyopic { rewardPot = Coin 17 }
-                        })
+     (SJust RewardUpdate { deltaT        = Coin 21
+                         , deltaR        = Coin 0
+                         , rs            = Map.empty
+                         , deltaF        = Coin (-21)
+                         , nonMyopic     = emptyNonMyopic { rewardPot = Coin 17 }
+                         })
      (PoolDistr Map.empty)
      epoch1OSchedEx2C)
   oCertIssueNosEx1
@@ -1088,7 +1089,7 @@ expectedStEx2E = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      (PoolDistr
        (Map.singleton
           (hk alicePool)
@@ -1140,12 +1141,12 @@ expectedStEx2F = ChainState
      (BlocksMade Map.empty)
      (BlocksMade $ Map.singleton (hk alicePool) 1)
      (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1 ppsEx1 emptyNonMyopic)
-     (Just RewardUpdate { deltaT        = Coin 19
-                        , deltaR        = Coin 0
-                        , rs            = Map.empty
-                        , deltaF        = Coin (-19)
-                        , nonMyopic     = emptyNonMyopic { rewardPot = Coin 16 }
-                        })
+     (SJust RewardUpdate { deltaT        = Coin 19
+                         , deltaR        = Coin 0
+                         , rs            = Map.empty
+                         , deltaF        = Coin (-19)
+                         , nonMyopic     = emptyNonMyopic { rewardPot = Coin 16 }
+                         })
      pdEx2F
      epoch1OSchedEx2E)
   oCertIssueNosEx2F
@@ -1220,7 +1221,7 @@ expectedStEx2G = ChainState
      (BlocksMade $ Map.singleton (hk alicePool) 1)
      (BlocksMade Map.empty)
      (EpochState acntEx2G snapsEx2G expectedLSEx2G ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      pdEx2F
      epoch1OSchedEx2G)
   oCertIssueNosEx2G
@@ -1285,15 +1286,15 @@ expectedStEx2H = ChainState
      (BlocksMade $ Map.singleton (hk alicePool) 1)
      (BlocksMade Map.empty)
      (EpochState acntEx2G snapsEx2G expectedLSEx2G ppsEx1 ppsEx1 emptyNonMyopic)
-     (Just RewardUpdate { deltaT        = Coin 767369696984
-                        , deltaR        = Coin (-793333333333)
-                        , rs            = rewardsEx2H
-                        , deltaF        = Coin (-10)
-                        , nonMyopic     = NonMyopic
-                            (Map.singleton (hk alicePool) alicePerfEx2H)
-                            (Coin 634666666675)
-                            snapEx2C
-                        })
+     (SJust RewardUpdate { deltaT        = Coin 767369696984
+                         , deltaR        = Coin (-793333333333)
+                         , rs            = rewardsEx2H
+                         , deltaF        = Coin (-10)
+                         , nonMyopic     = NonMyopic
+                             (Map.singleton (hk alicePool) alicePerfEx2H)
+                             (Coin 634666666675)
+                             snapEx2C
+                         })
      pdEx2F
      epoch1OSchedEx2G)
   oCertIssueNosEx2H
@@ -1379,7 +1380,7 @@ expectedStEx2I = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2I snapsEx2I expectedLSEx2I ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      pdEx2F
      epoch1OSchedEx2I)
   oCertIssueNosEx2I
@@ -1412,15 +1413,15 @@ txbodyEx2J = TxBody
            (Wdrl $ Map.singleton (RewardAcnt bobSHK) bobRAcnt2H)
            (Coin 9)
            (SlotNo 500)
-           Nothing
-           Nothing
+           SNothing
+           SNothing
 
 txEx2J :: Tx
 txEx2J = Tx
           txbodyEx2J
           (makeWitnessesVKey txbodyEx2J [bobPay, bobStake])
           Map.empty
-          Nothing
+          SNothing
 
 blockEx2J :: Block
 blockEx2J = mkBlock
@@ -1475,7 +1476,7 @@ expectedStEx2J = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2I snapsEx2I expectedLSEx2J ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      pdEx2F
      epoch1OSchedEx2I)
   oCertIssueNosEx2J
@@ -1505,15 +1506,15 @@ txbodyEx2K = TxBody
            (Wdrl Map.empty)
            (Coin 2)
            (SlotNo 500)
-           Nothing
-           Nothing
+           SNothing
+           SNothing
 
 txEx2K :: Tx
 txEx2K = Tx
           txbodyEx2K
           (makeWitnessesVKey txbodyEx2K [cold alicePool, alicePay])
           Map.empty
-          Nothing
+          SNothing
 
 blockEx2K :: Block
 blockEx2K = mkBlock
@@ -1558,15 +1559,15 @@ expectedStEx2K = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2I snapsEx2I expectedLSEx2K ppsEx1 ppsEx1 emptyNonMyopic)
-     (Just RewardUpdate { deltaT        = Coin 9
-                        , deltaR        = Coin 0
-                        , rs            = Map.empty
-                        , deltaF        = Coin (-9)
-                        , nonMyopic     = NonMyopic
-                            (Map.singleton (hk alicePool) (ApparentPerformance 0))
-                            (Coin 8)
-                            snapEx2E
-                        })
+     (SJust RewardUpdate { deltaT        = Coin 9
+                         , deltaR        = Coin 0
+                         , rs            = Map.empty
+                         , deltaF        = Coin (-9)
+                         , nonMyopic     = NonMyopic
+                             (Map.singleton (hk alicePool) (ApparentPerformance 0))
+                             (Coin 8)
+                             snapEx2E
+                         })
      pdEx2F
      epoch1OSchedEx2I)
   oCertIssueNosEx2J
@@ -1650,7 +1651,7 @@ expectedStEx2L = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2L snapsEx2L expectedLSEx2L ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      pdEx2F
      (runShelleyBase $ overlaySchedule (EpochNo 5) (Map.keysSet genDelegs) ppsEx1))
   oCertIssueNosEx2L
@@ -1673,26 +1674,26 @@ ex2L = CHAINExample (SlotNo 510) expectedStEx2K blockEx2L (Right expectedStEx2L)
 
 ppVote3A :: PParamsUpdate
 ppVote3A = PParams
-             { _minfeeA = Nothing
-             , _minfeeB = Nothing
-             , _maxBBSize = Nothing
-             , _maxTxSize = Nothing
-             , _maxBHSize = Nothing
-             , _keyDeposit = Nothing
-             , _keyMinRefund = Nothing
-             , _keyDecayRate = Nothing
-             , _poolDeposit = Just 200
-             , _poolMinRefund = Nothing
-             , _poolDecayRate = Nothing
-             , _eMax = Nothing
-             , _nOpt = Nothing
-             , _a0 = Nothing
-             , _rho = Nothing
-             , _tau = Nothing
-             , _activeSlotCoeff = Nothing
-             , _d = Nothing
-             , _extraEntropy = Just (mkNonce 123)
-             , _protocolVersion = Nothing
+             { _minfeeA = SNothing
+             , _minfeeB = SNothing
+             , _maxBBSize = SNothing
+             , _maxTxSize = SNothing
+             , _maxBHSize = SNothing
+             , _keyDeposit = SNothing
+             , _keyMinRefund = SNothing
+             , _keyDecayRate = SNothing
+             , _poolDeposit = SJust 200
+             , _poolMinRefund = SNothing
+             , _poolDecayRate = SNothing
+             , _eMax = SNothing
+             , _nOpt = SNothing
+             , _a0 = SNothing
+             , _rho = SNothing
+             , _tau = SNothing
+             , _activeSlotCoeff = SNothing
+             , _d = SNothing
+             , _extraEntropy = SJust (mkNonce 123)
+             , _protocolVersion = SNothing
              }
 
 ppupEx3A :: ProposedPPUpdates
@@ -1716,8 +1717,8 @@ txbodyEx3A = TxBody
            (Wdrl Map.empty)
            (Coin 1)
            (SlotNo 10)
-           (Just updateEx3A)
-           Nothing
+           (SJust updateEx3A)
+           SNothing
 
 txEx3A :: Tx
 txEx3A = Tx
@@ -1730,7 +1731,7 @@ txEx3A = Tx
             , cold $ coreNodeKeys 4
             ])
           Map.empty
-          Nothing
+          SNothing
 
 blockEx3A :: Block
 blockEx3A = mkBlock
@@ -1768,7 +1769,7 @@ expectedStEx3A = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2A emptySnapShots expectedLSEx3A ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      (PoolDistr Map.empty)
      overlayEx2A)
   oCertIssueNosEx1
@@ -1808,8 +1809,8 @@ txbodyEx3B = TxBody
            (Wdrl Map.empty)
            (Coin 1)
            (SlotNo 31)
-           (Just updateEx3B)
-           Nothing
+           (SJust updateEx3B)
+           SNothing
 
 txEx3B :: Tx
 txEx3B = Tx
@@ -1821,7 +1822,7 @@ txEx3B = Tx
             , cold $ coreNodeKeys 5
             ])
           Map.empty
-          Nothing
+          SNothing
 
 blockEx3B :: Block
 blockEx3B = mkBlock
@@ -1866,7 +1867,7 @@ expectedStEx3B = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2A emptySnapShots expectedLSEx3B ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      (PoolDistr Map.empty)
      overlayEx2A)
   oCertIssueNosEx1
@@ -1931,7 +1932,7 @@ expectedStEx3C = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2A snapsEx3C expectedLSEx3C ppsEx1 ppsEx3C emptyNonMyopic)
-     Nothing
+     SNothing
      (PoolDistr Map.empty)
      overlayEx3C)
   oCertIssueNosEx1
@@ -1968,15 +1969,15 @@ txbodyEx4A = TxBody
               (Wdrl Map.empty)
               (Coin 1)
               (SlotNo 10)
-              Nothing
-              Nothing
+              SNothing
+              SNothing
 
 txEx4A :: Tx
 txEx4A = Tx
            txbodyEx4A
            (makeWitnessesVKey txbodyEx4A [ alicePay ] `Set.union` makeWitnessesVKey txbodyEx4A [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0) ])
            Map.empty
-           Nothing
+           SNothing
 
 blockEx4A :: Block
 blockEx4A = mkBlock
@@ -2022,7 +2023,7 @@ expectedStEx4A = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2A emptySnapShots expectedLSEx4A ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      (PoolDistr Map.empty)
      overlayEx2A)
   oCertIssueNosEx1
@@ -2081,12 +2082,12 @@ expectedStEx4B = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2A emptySnapShots expectedLSEx4B ppsEx1 ppsEx1 emptyNonMyopic)
-     (Just RewardUpdate { deltaT        = Coin 0
-                        , deltaR        = Coin 0
-                        , rs            = Map.empty
-                        , deltaF        = Coin 0
-                        , nonMyopic     = emptyNonMyopic
-                        })
+     (SJust RewardUpdate { deltaT        = Coin 0
+                         , deltaR        = Coin 0
+                         , rs            = Map.empty
+                         , deltaF        = Coin 0
+                         , nonMyopic     = emptyNonMyopic
+                         })
      (PoolDistr Map.empty)
      overlayEx2A)
   oCertIssueNosEx1
@@ -2120,8 +2121,8 @@ txbodyEx5A = TxBody
               (Wdrl Map.empty)
               (Coin 1)
               (SlotNo 10)
-              Nothing
-              Nothing
+              SNothing
+              SNothing
 
 txEx5A :: Tx
 txEx5A = Tx
@@ -2134,7 +2135,7 @@ txEx5A = Tx
              , KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
            ])
            Map.empty
-           Nothing
+           SNothing
 
 blockEx5A :: Block
 blockEx5A = mkBlock
@@ -2178,7 +2179,7 @@ expectedStEx5A = ChainState
      (BlocksMade Map.empty)
      (BlocksMade Map.empty)
      (EpochState acntEx2A emptySnapShots expectedLSEx5A ppsEx1 ppsEx1 emptyNonMyopic)
-     Nothing
+     SNothing
      (PoolDistr Map.empty)
      overlayEx2A)
   oCertIssueNosEx1
@@ -2207,7 +2208,7 @@ txEx5B = Tx
              , KeyPair (coreNodeVKG 3) (coreNodeSKG 3)
            ])
            Map.empty
-           Nothing
+           SNothing
 
 blockEx5B :: Block
 blockEx5B = mkBlock
@@ -2286,8 +2287,8 @@ txbodyEx5F = TxBody
               (Wdrl Map.empty)
               (Coin 1)
               (SlotNo 99)
-              Nothing
-              Nothing
+              SNothing
+              SNothing
 
 txEx5F :: Tx
 txEx5F = Tx txbodyEx5F
@@ -2299,7 +2300,7 @@ txEx5F = Tx txbodyEx5F
              , KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
              ])
             Map.empty
-            Nothing
+            SNothing
 
 blockEx5F :: Block
 blockEx5F = mkBlock
@@ -2331,11 +2332,11 @@ txbodyEx5F' = TxBody
                (Coin 1)
                ((slotFromEpoch $ EpochNo 1)
                 +* Duration (startRewards testGlobals) + SlotNo 7)
-               Nothing
-               Nothing
+               SNothing
+               SNothing
 
 txEx5F' :: Tx
-txEx5F' = Tx txbodyEx5F' (makeWitnessesVKey txbodyEx5F' [ alicePay ]) Map.empty Nothing
+txEx5F' = Tx txbodyEx5F' (makeWitnessesVKey txbodyEx5F' [ alicePay ]) Map.empty SNothing
 
 blockEx5F' :: Block
 blockEx5F' = mkBlock
@@ -2367,11 +2368,11 @@ txbodyEx5F'' = TxBody
                 (Wdrl Map.empty)
                 (Coin 1)
                 ((slotFromEpoch $ EpochNo 2) + SlotNo 10)
-                Nothing
-                Nothing
+                SNothing
+                SNothing
 
 txEx5F'' :: Tx
-txEx5F'' = Tx txbodyEx5F'' (makeWitnessesVKey txbodyEx5F'' [ alicePay ]) Map.empty Nothing
+txEx5F'' = Tx txbodyEx5F'' (makeWitnessesVKey txbodyEx5F'' [ alicePay ]) Map.empty SNothing
 
 blockEx5F'' :: Block
 blockEx5F'' = mkBlock

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -123,7 +123,7 @@ import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), pattern Sna
 import           Shelley.Spec.Ledger.Keys (pattern GenDelegs, Hash, pattern KeyPair, hash, hashKey,
                      vKey)
 import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern ActiveSlot,
-                     pattern DPState, pattern EpochState, pattern LedgerState,
+                     pattern DPState, pattern EpochState, FutureGenDeleg (..), pattern LedgerState,
                      pattern NewEpochState, pattern RewardUpdate, pattern UTxOState, deltaF,
                      deltaR, deltaT, emptyDState, emptyPState, esAccountState, esLState, esPp,
                      genesisCoins, genesisId, nesEs, nonMyopic, overlaySchedule, rs,
@@ -1998,7 +1998,7 @@ blockEx4AHash = bhHash (bheader blockEx4A)
 
 dsEx4A :: DState
 dsEx4A = dsEx1 { _fGenDelegs = Map.singleton
-                          ( SlotNo 43, hashKey $ coreNodeVKG 0 )
+                          ( FutureGenDeleg (SlotNo 43) (hashKey $ coreNodeVKG 0) )
                           ( (hashKey . vKey) newGenDelegate ) }
 
 utxoEx4A :: UTxO

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -100,7 +100,7 @@ import qualified Data.Map.Strict as Map (elems, empty, fromList, insert, keysSet
                      (!?))
 import           Data.Maybe (isJust, maybe)
 import           Data.Ratio ((%))
-import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
@@ -258,7 +258,7 @@ alicePoolParams =
     , _poolMargin = unsafeMkUnitInterval 0.1
     , _poolRAcnt = RewardAcnt aliceSHK
     , _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake
-    , _poolRelays = Seq.empty
+    , _poolRelays = StrictSeq.empty
     , _poolMD = Just $ PoolMetaData
                   { _poolMDUrl  = Url $ text64 "alice.pool"
                   , _poolMDHash = BS.pack "{}"
@@ -477,8 +477,8 @@ aliceCoinEx2A = aliceInitCoin - (_poolDeposit ppsEx1) - 3 * (_keyDeposit ppsEx1)
 txbodyEx2A :: TxBody
 txbodyEx2A = TxBody
            (Set.fromList [TxIn genesisId 0])
-           (Seq.fromList [TxOut aliceAddr aliceCoinEx2A])
-           (Seq.fromList ([ DCertDeleg (RegKey aliceSHK)
+           (StrictSeq.fromList [TxOut aliceAddr aliceCoinEx2A])
+           (StrictSeq.fromList ([ DCertDeleg (RegKey aliceSHK)
            , DCertDeleg (RegKey bobSHK)
            , DCertDeleg (RegKey carlSHK)
            , DCertPool (RegPool alicePoolParams)
@@ -649,12 +649,12 @@ aliceCoinEx2BPtr = aliceCoinEx2A - (aliceCoinEx2BBase + 4)
 txbodyEx2B :: TxBody
 txbodyEx2B = TxBody
       { TxData._inputs   = Set.fromList [TxIn (txid txbodyEx2A) 0]
-      , TxData._outputs  = Seq.fromList [ TxOut aliceAddr    aliceCoinEx2BBase
-                                        , TxOut alicePtrAddr aliceCoinEx2BPtr ]
+      , TxData._outputs  = StrictSeq.fromList [ TxOut aliceAddr    aliceCoinEx2BBase
+                                              , TxOut alicePtrAddr aliceCoinEx2BPtr ]
       --  Delegation certificates
       , TxData._certs    =
-        Seq.fromList [ DCertDeleg (Delegate $ Delegation aliceSHK (hk alicePool))
-                     , DCertDeleg (Delegate $ Delegation bobSHK   (hk alicePool))]
+        StrictSeq.fromList [ DCertDeleg (Delegate $ Delegation aliceSHK (hk alicePool))
+                           , DCertDeleg (Delegate $ Delegation bobSHK   (hk alicePool))]
       , TxData._wdrls    = Wdrl Map.empty
       , TxData._txfee    = Coin 4
       , TxData._ttl      = SlotNo 90
@@ -918,9 +918,9 @@ aliceCoinEx2DBase = aliceCoinEx2BBase - 5
 txbodyEx2D :: TxBody
 txbodyEx2D = TxBody
       { TxData._inputs   = Set.fromList [TxIn (txid txbodyEx2B) 0]
-      , TxData._outputs  = Seq.fromList [ TxOut aliceAddr aliceCoinEx2DBase ]
+      , TxData._outputs  = StrictSeq.fromList [ TxOut aliceAddr aliceCoinEx2DBase ]
       , TxData._certs    =
-        Seq.fromList [ DCertDeleg (Delegate $ Delegation carlSHK (hk alicePool)) ]
+        StrictSeq.fromList [ DCertDeleg (Delegate $ Delegation carlSHK (hk alicePool)) ]
       , TxData._wdrls    = Wdrl Map.empty
       , TxData._txfee    = Coin 5
       , TxData._ttl      = SlotNo 500
@@ -1406,8 +1406,8 @@ bobAda2J = bobRAcnt2H -- reward account
 txbodyEx2J :: TxBody
 txbodyEx2J = TxBody
            (Set.fromList [TxIn genesisId 1])
-           (Seq.singleton $ TxOut bobAddr bobAda2J)
-           (Seq.fromList [DCertDeleg (DeRegKey bobSHK)])
+           (StrictSeq.singleton $ TxOut bobAddr bobAda2J)
+           (StrictSeq.fromList [DCertDeleg (DeRegKey bobSHK)])
            (Wdrl $ Map.singleton (RewardAcnt bobSHK) bobRAcnt2H)
            (Coin 9)
            (SlotNo 500)
@@ -1499,8 +1499,8 @@ aliceCoinEx2KPtr = aliceCoinEx2DBase - 2
 txbodyEx2K :: TxBody
 txbodyEx2K = TxBody
            (Set.fromList [TxIn (txid txbodyEx2D) 0])
-           (Seq.singleton $ TxOut alicePtrAddr aliceCoinEx2KPtr)
-           (Seq.fromList [DCertPool (RetirePool (hk alicePool) (EpochNo 5))])
+           (StrictSeq.singleton $ TxOut alicePtrAddr aliceCoinEx2KPtr)
+           (StrictSeq.fromList [DCertPool (RetirePool (hk alicePool) (EpochNo 5))])
            (Wdrl Map.empty)
            (Coin 2)
            (SlotNo 500)
@@ -1710,8 +1710,8 @@ aliceCoinEx3A = aliceInitCoin - 1
 txbodyEx3A :: TxBody
 txbodyEx3A = TxBody
            (Set.fromList [TxIn genesisId 0])
-           (Seq.singleton $ TxOut aliceAddr aliceCoinEx3A)
-           Seq.empty
+           (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx3A)
+           StrictSeq.empty
            (Wdrl Map.empty)
            (Coin 1)
            (SlotNo 10)
@@ -1802,8 +1802,8 @@ aliceCoinEx3B = aliceCoinEx3A - 1
 txbodyEx3B :: TxBody
 txbodyEx3B = TxBody
            (Set.fromList [TxIn (txid txbodyEx3A) 0])
-           (Seq.singleton $ TxOut aliceAddr aliceCoinEx3B)
-           Seq.empty
+           (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx3B)
+           StrictSeq.empty
            (Wdrl Map.empty)
            (Coin 1)
            (SlotNo 31)
@@ -1960,10 +1960,10 @@ aliceCoinEx4A = aliceInitCoin - 1
 txbodyEx4A :: TxBody
 txbodyEx4A = TxBody
               (Set.fromList [TxIn genesisId 0])
-              (Seq.singleton $ TxOut aliceAddr aliceCoinEx4A)
-              (Seq.fromList [DCertGenesis (GenesisDelegate
-                                       ( (hashKey . coreNodeVKG) 0
-                                       , (hashKey . vKey) newGenDelegate))])
+              (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx4A)
+              (StrictSeq.fromList [DCertGenesis (GenesisDelegate
+                                       (hashKey (coreNodeVKG 0))
+                                       (hashKey (vKey newGenDelegate)))])
               (Wdrl Map.empty)
               (Coin 1)
               (SlotNo 10)
@@ -2114,8 +2114,8 @@ aliceCoinEx5A = aliceInitCoin - 1
 txbodyEx5A :: TxBody
 txbodyEx5A = TxBody
               (Set.fromList [TxIn genesisId 0])
-              (Seq.singleton $ TxOut aliceAddr aliceCoinEx5A)
-              (Seq.fromList [DCertMir (MIRCert ir)])
+              (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5A)
+              (StrictSeq.fromList [DCertMir (MIRCert ir)])
               (Wdrl Map.empty)
               (Coin 1)
               (SlotNo 10)
@@ -2280,8 +2280,8 @@ aliceCoinEx5F = aliceInitCoin - (_keyDeposit ppsEx1) - 1
 txbodyEx5F :: TxBody
 txbodyEx5F = TxBody
               (Set.fromList [TxIn genesisId 0])
-              (Seq.singleton $ TxOut aliceAddr aliceCoinEx5F)
-              (Seq.fromList [DCertDeleg (RegKey aliceSHK), DCertMir (MIRCert ir)])
+              (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5F)
+              (StrictSeq.fromList [DCertDeleg (RegKey aliceSHK), DCertMir (MIRCert ir)])
               (Wdrl Map.empty)
               (Coin 1)
               (SlotNo 99)
@@ -2324,8 +2324,8 @@ aliceCoinEx5F' = aliceCoinEx5F - 1
 txbodyEx5F' :: TxBody
 txbodyEx5F' = TxBody
                (Set.fromList [TxIn (txid txbodyEx5F) 0])
-               (Seq.singleton $ TxOut aliceAddr aliceCoinEx5F')
-               Seq.empty
+               (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5F')
+               StrictSeq.empty
                (Wdrl Map.empty)
                (Coin 1)
                ((slotFromEpoch $ EpochNo 1)
@@ -2361,8 +2361,8 @@ aliceCoinEx5F'' = aliceCoinEx5F' - 1
 txbodyEx5F'' :: TxBody
 txbodyEx5F'' = TxBody
                 (Set.fromList [TxIn (txid txbodyEx5F') 0])
-                (Seq.singleton $ TxOut aliceAddr aliceCoinEx5F'')
-                Seq.empty
+                (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5F'')
+                StrictSeq.empty
                 (Wdrl Map.empty)
                 (Coin 1)
                 ((slotFromEpoch $ EpochNo 2) + SlotNo 10)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
@@ -14,7 +14,7 @@ import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Char8 as BS (pack)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Map.Strict as Map (empty, singleton)
-import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 
 import           Cardano.Binary (decodeFullDecoder, fromCBOR)
@@ -82,7 +82,7 @@ alicePoolParams =
     , _poolMargin = unsafeMkUnitInterval 0.1
     , _poolRAcnt = RewardAcnt aliceSHK
     , _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake
-    , _poolRelays = (Seq.singleton . Url . text64) "relay.io"
+    , _poolRelays = (StrictSeq.singleton . Url . text64) "relay.io"
     , _poolMD = Just $ PoolMetaData
                   { _poolMDUrl  = Url $ text64 "alice.pool"
                   , _poolMDHash = BS.pack "{}"
@@ -117,8 +117,8 @@ carlPay = KeyPair vk sk
 txbSimpleUTxO :: TxBody
 txbSimpleUTxO = TxBody
   { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = Seq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = Seq.empty
+  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
+  , _certs    = StrictSeq.empty
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
@@ -146,13 +146,14 @@ txbMutiUTxO = TxBody
   { _inputs   = Set.fromList [ TxIn genesisId 0
                              , TxIn genesisId 1
                              ]
-  , _outputs  = Seq.fromList [ TxOut aliceAddr (Coin 10)
-                             , TxOut aliceAddr (Coin 20)
-                             , TxOut aliceAddr (Coin 30)
-                             , TxOut bobAddr   (Coin 40)
-                             , TxOut bobAddr   (Coin 50)
-                             ]
-  , _certs    = Seq.empty
+  , _outputs  = StrictSeq.fromList
+                [ TxOut aliceAddr (Coin 10)
+                , TxOut aliceAddr (Coin 20)
+                , TxOut aliceAddr (Coin 30)
+                , TxOut bobAddr   (Coin 40)
+                , TxOut bobAddr   (Coin 50)
+                ]
+  , _certs    = StrictSeq.empty
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 199
   , _ttl      = SlotNo 10
@@ -179,8 +180,8 @@ txMutiUTxOBytes16 = "83a400d90102828244b45c4891008244b45c4891010185840044cfb2c41
 txbRegisterStake :: TxBody
 txbRegisterStake = TxBody
   { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = Seq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = Seq.fromList [ DCertDeleg (RegKey aliceSHK) ]
+  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
+  , _certs    = StrictSeq.fromList [ DCertDeleg (RegKey aliceSHK) ]
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
@@ -204,8 +205,8 @@ txRegisterStakeBytes16 = "83a500d90102818244b45c4891000181840044cfb2c4144476394f
 txbDelegateStake :: TxBody
 txbDelegateStake = TxBody
   { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = Seq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = Seq.fromList [ DCertDeleg (Delegate $ Delegation bobSHK alicePoolKH) ]
+  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
+  , _certs    = StrictSeq.fromList [ DCertDeleg (Delegate $ Delegation bobSHK alicePoolKH) ]
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
@@ -229,8 +230,8 @@ txDelegateStakeBytes16 = "83a500d90102818244b45c4891000181840044cfb2c4144476394f
 txbDeregisterStake :: TxBody
 txbDeregisterStake = TxBody
   { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = Seq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = Seq.fromList [ DCertDeleg (DeRegKey aliceSHK) ]
+  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
+  , _certs    = StrictSeq.fromList [ DCertDeleg (DeRegKey aliceSHK) ]
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
@@ -255,8 +256,8 @@ txDeregisterStakeBytes16 = "83a500d90102818244b45c4891000181840044cfb2c414447639
 txbRegisterPool :: TxBody
 txbRegisterPool = TxBody
   { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = Seq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = Seq.fromList [ DCertPool (RegPool alicePoolParams) ]
+  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
+  , _certs    = StrictSeq.fromList [ DCertPool (RegPool alicePoolParams) ]
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
@@ -280,8 +281,8 @@ txRegisterPoolBytes16 = "83a500d90102818244b45c4891000181840044cfb2c4144476394f7
 txbRetirePool :: TxBody
 txbRetirePool = TxBody
   { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = Seq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = Seq.fromList [ DCertPool (RetirePool alicePoolKH (EpochNo 5)) ]
+  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
+  , _certs    = StrictSeq.fromList [ DCertPool (RetirePool alicePoolKH (EpochNo 5)) ]
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
@@ -309,8 +310,8 @@ md = MD.MetaData $ Map.singleton 0 (MD.List [ MD.I 5, MD.S "hello"])
 txbWithMD :: TxBody
 txbWithMD = TxBody
   { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = Seq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = Seq.empty
+  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
+  , _certs    = StrictSeq.empty
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
@@ -341,8 +342,8 @@ msig = RequireMOf 2
 txbWithMultiSig :: TxBody
 txbWithMultiSig = TxBody
   { _inputs   = Set.fromList [TxIn genesisId 0] -- acting as if this is multi-sig
-  , _outputs  = Seq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = Seq.empty
+  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
+  , _certs    = StrictSeq.empty
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
@@ -366,8 +367,8 @@ txWithMultiSigBytes16 = "83a400d90102818244b45c4891000181840044cfb2c4144476394f7
 txbWithWithdrawal :: TxBody
 txbWithWithdrawal = TxBody
   { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = Seq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = Seq.empty
+  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
+  , _certs    = StrictSeq.empty
   , _wdrls    = Wdrl $ Map.singleton (RewardAcnt aliceSHK) 100
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
@@ -18,7 +18,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 
 import           Cardano.Binary (decodeFullDecoder, fromCBOR)
-import           Shelley.Spec.Ledger.BaseTypes (text64)
+import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), text64)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, pattern Delegate,
                      pattern RegKey, pattern RegPool, pattern RetirePool)
@@ -83,7 +83,7 @@ alicePoolParams =
     , _poolRAcnt = RewardAcnt aliceSHK
     , _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake
     , _poolRelays = (StrictSeq.singleton . Url . text64) "relay.io"
-    , _poolMD = Just $ PoolMetaData
+    , _poolMD = SJust $ PoolMetaData
                   { _poolMDUrl  = Url $ text64 "alice.pool"
                   , _poolMDHash = BS.pack "{}"
                   }
@@ -122,8 +122,8 @@ txbSimpleUTxO = TxBody
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Nothing
+  , _txUpdate = SNothing
+  , _mdHash   = SNothing
   }
 
 txSimpleUTxO :: Tx
@@ -131,7 +131,7 @@ txSimpleUTxO = Tx
   { _body           = txbSimpleUTxO
   , _witnessVKeySet = makeWitnessesVKey txbSimpleUTxO [alicePay]
   , _witnessMSigMap = Map.empty
-  , _metadata       = Nothing
+  , _metadata       = SNothing
   }
 
 txSimpleUTxOBytes16 :: BSL.ByteString
@@ -157,8 +157,8 @@ txbMutiUTxO = TxBody
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 199
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Nothing
+  , _txUpdate = SNothing
+  , _mdHash   = SNothing
   }
 
 txMutiUTxO :: Tx
@@ -169,7 +169,7 @@ txMutiUTxO = Tx
                       , bobPay
                       ]
   , _witnessMSigMap = Map.empty
-  , _metadata       = Nothing
+  , _metadata       = SNothing
   }
 
 txMutiUTxOBytes16 :: BSL.ByteString
@@ -185,8 +185,8 @@ txbRegisterStake = TxBody
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Nothing
+  , _txUpdate = SNothing
+  , _mdHash   = SNothing
   }
 
 txRegisterStake :: Tx
@@ -194,7 +194,7 @@ txRegisterStake = Tx
   { _body           = txbRegisterStake
   , _witnessVKeySet = makeWitnessesVKey txbRegisterStake [alicePay]
   , _witnessMSigMap = Map.empty
-  , _metadata       = Nothing
+  , _metadata       = SNothing
   }
 
 txRegisterStakeBytes16 :: BSL.ByteString
@@ -210,8 +210,8 @@ txbDelegateStake = TxBody
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Nothing
+  , _txUpdate = SNothing
+  , _mdHash   = SNothing
   }
 
 txDelegateStake :: Tx
@@ -219,7 +219,7 @@ txDelegateStake = Tx
   { _body           = txbDelegateStake
   , _witnessVKeySet = makeWitnessesVKey txbDelegateStake [alicePay, bobStake]
   , _witnessMSigMap = Map.empty
-  , _metadata       = Nothing
+  , _metadata       = SNothing
   }
 
 txDelegateStakeBytes16 :: BSL.ByteString
@@ -235,8 +235,8 @@ txbDeregisterStake = TxBody
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Nothing
+  , _txUpdate = SNothing
+  , _mdHash   = SNothing
   }
 
 txDeregisterStake :: Tx
@@ -244,7 +244,7 @@ txDeregisterStake = Tx
   { _body           = txbDeregisterStake
   , _witnessVKeySet = makeWitnessesVKey txbDeregisterStake [alicePay]
   , _witnessMSigMap = Map.empty
-  , _metadata       = Nothing
+  , _metadata       = SNothing
   }
 
 
@@ -261,8 +261,8 @@ txbRegisterPool = TxBody
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Nothing
+  , _txUpdate = SNothing
+  , _mdHash   = SNothing
   }
 
 txRegisterPool :: Tx
@@ -270,7 +270,7 @@ txRegisterPool = Tx
   { _body           = txbRegisterPool
   , _witnessVKeySet = makeWitnessesVKey txbRegisterPool [alicePay]
   , _witnessMSigMap = Map.empty
-  , _metadata       = Nothing
+  , _metadata       = SNothing
   }
 
 txRegisterPoolBytes16 :: BSL.ByteString
@@ -286,8 +286,8 @@ txbRetirePool = TxBody
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Nothing
+  , _txUpdate = SNothing
+  , _mdHash   = SNothing
   }
 
 txRetirePool :: Tx
@@ -295,7 +295,7 @@ txRetirePool = Tx
   { _body           = txbRetirePool
   , _witnessVKeySet = makeWitnessesVKey txbRetirePool [alicePay]
   , _witnessMSigMap = Map.empty
-  , _metadata       = Nothing
+  , _metadata       = SNothing
   }
 
 txRetirePoolBytes16 :: BSL.ByteString
@@ -315,8 +315,8 @@ txbWithMD = TxBody
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Just $ MD.hashMetaData @ConcreteCrypto md
+  , _txUpdate = SNothing
+  , _mdHash   = SJust $ MD.hashMetaData @ConcreteCrypto md
   }
 
 txWithMD :: Tx
@@ -324,7 +324,7 @@ txWithMD = Tx
   { _body           = txbWithMD
   , _witnessVKeySet = makeWitnessesVKey txbWithMD [alicePay]
   , _witnessMSigMap = Map.empty
-  , _metadata       = Just md
+  , _metadata       = SJust md
   }
 
 txWithMDBytes16 :: BSL.ByteString
@@ -347,8 +347,8 @@ txbWithMultiSig = TxBody
   , _wdrls    = Wdrl Map.empty
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Nothing
+  , _txUpdate = SNothing
+  , _mdHash   = SNothing
   }
 
 txWithMultiSig :: Tx
@@ -356,7 +356,7 @@ txWithMultiSig = Tx
   { _body           = txbWithMultiSig
   , _witnessVKeySet = makeWitnessesVKey txbWithMultiSig [alicePay, bobPay]
   , _witnessMSigMap = Map.singleton (hashScript msig) msig
-  , _metadata       = Nothing
+  , _metadata       = SNothing
   }
 
 txWithMultiSigBytes16 :: BSL.ByteString
@@ -372,8 +372,8 @@ txbWithWithdrawal = TxBody
   , _wdrls    = Wdrl $ Map.singleton (RewardAcnt aliceSHK) 100
   , _txfee    = Coin 94
   , _ttl      = SlotNo 10
-  , _txUpdate = Nothing
-  , _mdHash   = Nothing
+  , _txUpdate = SNothing
+  , _mdHash   = SNothing
   }
 
 txWithWithdrawal :: Tx
@@ -381,7 +381,7 @@ txWithWithdrawal = Tx
   { _body           = txbWithWithdrawal
   , _witnessVKeySet = makeWitnessesVKey txbWithWithdrawal [alicePay, aliceStake]
   , _witnessMSigMap = Map.empty
-  , _metadata       = Nothing
+  , _metadata       = SNothing
   }
 
 txWithWithdrawalBytes16 :: BSL.ByteString

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
@@ -21,6 +21,7 @@ import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set (fromList)
 
 import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
+import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
 import           Shelley.Spec.Ledger.Coin
 import           Shelley.Spec.Ledger.Keys (pattern GenDelegs, undiscriminateKeyHash)
 import           Shelley.Spec.Ledger.LedgerState (genesisCoins, genesisId, genesisState, _utxoState)
@@ -82,8 +83,8 @@ initTxBody addrs = TxBody
         (Wdrl Map.empty)
         (Coin 0)
         (SlotNo 0)
-        Nothing
-        Nothing
+        SNothing
+        SNothing
 
 makeTxBody :: [TxIn] -> [(Addr, Coin)] -> Wdrl -> TxBody
 makeTxBody inp addrCs wdrl =
@@ -94,12 +95,12 @@ makeTxBody inp addrCs wdrl =
     wdrl
     (Coin 0)
     (SlotNo 10)
-    Nothing
-    Nothing
+    SNothing
+    SNothing
 
 makeTx :: TxBody -> [KeyPair] -> Map ScriptHash MultiSig -> Maybe MetaData -> Tx
-makeTx txBody keyPairs =
-  Tx txBody (makeWitnessesVKey txBody keyPairs)
+makeTx txBody keyPairs msigs =
+  Tx txBody (makeWitnessesVKey txBody keyPairs) msigs . maybeToStrictMaybe
 
 aliceInitCoin :: Coin
 aliceInitCoin = 10000

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
@@ -15,8 +15,8 @@ module Test.Shelley.Spec.Ledger.Examples.MultiSigExamples
 
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (empty, fromList)
-import           Data.Sequence (Seq (..))
-import qualified Data.Sequence as Seq
+import           Data.Sequence.Strict (StrictSeq (..))
+import qualified Data.Sequence.Strict as StrictSeq
 
 import qualified Data.Set as Set (fromList)
 
@@ -77,7 +77,7 @@ aliceAndBobOrCarlOrDaria =
 initTxBody :: [(Addr, Coin)] -> TxBody
 initTxBody addrs = TxBody
         (Set.fromList [TxIn genesisId 0, TxIn genesisId 1])
-        (Seq.fromList $ map (uncurry TxOut) addrs)
+        (StrictSeq.fromList $ map (uncurry TxOut) addrs)
         Empty
         (Wdrl Map.empty)
         (Coin 0)
@@ -89,7 +89,7 @@ makeTxBody :: [TxIn] -> [(Addr, Coin)] -> Wdrl -> TxBody
 makeTxBody inp addrCs wdrl =
   TxBody
     (Set.fromList inp)
-    (Seq.fromList [uncurry TxOut addrC | addrC <- addrCs])
+    (StrictSeq.fromList [uncurry TxOut addrC | addrC <- addrCs])
     Empty
     wdrl
     (Coin 0)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -27,7 +27,8 @@ import           Test.Tasty.HUnit (Assertion, assertEqual, assertFailure, testCa
 import           Data.Coerce (coerce)
 import           Data.Ratio ((%))
 import           Numeric.Natural (Natural)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), UnitInterval (..), mkNonce, text64)
+import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), UnitInterval (..),
+                     mkNonce, text64)
 import           Shelley.Spec.Ledger.BlockChain (pattern BHBody, pattern BHeader, Block (..),
                      pattern BlockHash, pattern HashHeader, TxSeq (..), bbHash, bhash,
                      bheaderBlockNo, bheaderEta, bheaderL, bheaderOCert, bheaderPrev,
@@ -169,7 +170,7 @@ testVRFKH :: VRFKeyHash
 testVRFKH = hashKeyVRF $ snd testVRF
 
 testTxb :: TxBody
-testTxb = TxBody Set.empty StrictSeq.empty StrictSeq.empty (Wdrl Map.empty) (Coin 0) (SlotNo 0) Nothing Nothing
+testTxb = TxBody Set.empty StrictSeq.empty StrictSeq.empty (Wdrl Map.empty) (Coin 0) (SlotNo 0) SNothing SNothing
 
 testKey1 :: KeyPair
 testKey1 = KeyPair vk sk
@@ -452,7 +453,7 @@ serializationTests = testGroup "Serialization Tests"
                , _poolRAcnt = poolRAcnt
                , _poolOwners = Set.singleton poolOwner
                , _poolRelays = StrictSeq.empty
-               , _poolMD = Just $ PoolMetaData
+               , _poolMD = SJust $ PoolMetaData
                              { _poolMDUrl = Url $ text64 poolUrl
                              , _poolMDHash = poolMDHash
                              }
@@ -516,26 +517,26 @@ serializationTests = testGroup "Serialization Tests"
 
   , checkEncodingCBOR "pparams_update_key_deposit_only"
     (PParams
-       { _minfeeA = Nothing
-       , _minfeeB = Nothing
-       , _maxBBSize = Nothing
-       , _maxTxSize = Nothing
-       , _maxBHSize = Nothing
-       , _keyDeposit = Just (Coin 5)
-       , _keyMinRefund = Nothing
-       , _keyDecayRate = Nothing
-       , _poolDeposit = Nothing
-       , _poolMinRefund = Nothing
-       , _poolDecayRate = Nothing
-       , _eMax = Nothing
-       , _nOpt = Nothing
-       , _a0 = Nothing
-       , _rho = Nothing
-       , _tau = Nothing
-       , _activeSlotCoeff = Nothing
-       , _d = Nothing
-       , _extraEntropy = Nothing
-       , _protocolVersion = Nothing
+       { _minfeeA = SNothing
+       , _minfeeB = SNothing
+       , _maxBBSize = SNothing
+       , _maxTxSize = SNothing
+       , _maxBHSize = SNothing
+       , _keyDeposit = SJust (Coin 5)
+       , _keyMinRefund = SNothing
+       , _keyDecayRate = SNothing
+       , _poolDeposit = SNothing
+       , _poolMinRefund = SNothing
+       , _poolDecayRate = SNothing
+       , _eMax = SNothing
+       , _nOpt = SNothing
+       , _a0 = SNothing
+       , _rho = SNothing
+       , _tau = SNothing
+       , _activeSlotCoeff = SNothing
+       , _d = SNothing
+       , _extraEntropy = SNothing
+       , _protocolVersion = SNothing
        } :: PParamsUpdate)
     ((T $ TkMapLen 1 . TkWord 5) <> S (Coin 5))
 
@@ -563,26 +564,26 @@ serializationTests = testGroup "Serialization Tests"
     in
     checkEncodingCBOR "pparams_update_all"
     (PParams
-       { _minfeeA         = Just minfeea
-       , _minfeeB         = Just minfeeb
-       , _maxBBSize       = Just maxbbsize
-       , _maxTxSize       = Just maxtxsize
-       , _maxBHSize       = Just maxbhsize
-       , _keyDeposit      = Just keydeposit
-       , _keyMinRefund    = Just keyminrefund
-       , _keyDecayRate    = Just keydecayrate
-       , _poolDeposit     = Just pooldeposit
-       , _poolMinRefund   = Just poolminrefund
-       , _poolDecayRate   = Just pooldecayrate
-       , _eMax            = Just emax
-       , _nOpt            = Just nopt
-       , _a0              = Just a0
-       , _rho             = Just rho
-       , _tau             = Just tau
-       , _activeSlotCoeff = Just activeSlotCoefficient
-       , _d               = Just d
-       , _extraEntropy    = Just extraEntropy
-       , _protocolVersion = Just protocolVersion
+       { _minfeeA         = SJust minfeea
+       , _minfeeB         = SJust minfeeb
+       , _maxBBSize       = SJust maxbbsize
+       , _maxTxSize       = SJust maxtxsize
+       , _maxBHSize       = SJust maxbhsize
+       , _keyDeposit      = SJust keydeposit
+       , _keyMinRefund    = SJust keyminrefund
+       , _keyDecayRate    = SJust keydecayrate
+       , _poolDeposit     = SJust pooldeposit
+       , _poolMinRefund   = SJust poolminrefund
+       , _poolDecayRate   = SJust pooldecayrate
+       , _eMax            = SJust emax
+       , _nOpt            = SJust nopt
+       , _a0              = SJust a0
+       , _rho             = SJust rho
+       , _tau             = SJust tau
+       , _activeSlotCoeff = SJust activeSlotCoefficient
+       , _d               = SJust d
+       , _extraEntropy    = SJust extraEntropy
+       , _protocolVersion = SJust protocolVersion
        } :: PParamsUpdate)
     ((T $ TkMapLen 20)
       <> (T $ TkWord 0) <> S minfeea
@@ -611,26 +612,26 @@ serializationTests = testGroup "Serialization Tests"
       ppup = ProposedPPUpdates (Map.singleton
                testGKeyHash
                (PParams
-                  { _minfeeA = Nothing
-                  , _minfeeB = Nothing
-                  , _maxBBSize = Nothing
-                  , _maxTxSize = Nothing
-                  , _maxBHSize = Nothing
-                  , _keyDeposit = Nothing
-                  , _keyMinRefund = Nothing
-                  , _keyDecayRate = Nothing
-                  , _poolDeposit = Nothing
-                  , _poolMinRefund = Nothing
-                  , _poolDecayRate = Nothing
-                  , _eMax = Nothing
-                  , _nOpt = Just 100
-                  , _a0 = Nothing
-                  , _rho = Nothing
-                  , _tau = Nothing
-                  , _activeSlotCoeff = Nothing
-                  , _d = Nothing
-                  , _extraEntropy = Nothing
-                  , _protocolVersion = Nothing
+                  { _minfeeA = SNothing
+                  , _minfeeB = SNothing
+                  , _maxBBSize = SNothing
+                  , _maxTxSize = SNothing
+                  , _maxBHSize = SNothing
+                  , _keyDeposit = SNothing
+                  , _keyMinRefund = SNothing
+                  , _keyDecayRate = SNothing
+                  , _poolDeposit = SNothing
+                  , _poolMinRefund = SNothing
+                  , _poolDecayRate = SNothing
+                  , _eMax = SNothing
+                  , _nOpt = SJust 100
+                  , _a0 = SNothing
+                  , _rho = SNothing
+                  , _tau = SNothing
+                  , _activeSlotCoeff = SNothing
+                  , _d = SNothing
+                  , _extraEntropy = SNothing
+                  , _protocolVersion = SNothing
                   }))
       e = EpochNo 0
     in checkEncodingCBOR "full_update"
@@ -652,8 +653,8 @@ serializationTests = testGroup "Serialization Tests"
       (Wdrl Map.empty)
       (Coin 9)
       (SlotNo 500)
-      Nothing
-      Nothing
+      SNothing
+      SNothing
     )
     ( T (TkMapLen 4)
       <> T (TkWord 0) -- Tx Ins
@@ -676,26 +677,26 @@ serializationTests = testGroup "Serialization Tests"
       up = Update (ProposedPPUpdates (Map.singleton
              testGKeyHash
              (PParams
-                { _minfeeA = Nothing
-                , _minfeeB = Nothing
-                , _maxBBSize = Nothing
-                , _maxTxSize = Nothing
-                , _maxBHSize = Nothing
-                , _keyDeposit = Nothing
-                , _keyMinRefund = Nothing
-                , _keyDecayRate = Nothing
-                , _poolDeposit = Nothing
-                , _poolMinRefund = Nothing
-                , _poolDecayRate = Nothing
-                , _eMax = Nothing
-                , _nOpt = Just 100
-                , _a0 = Nothing
-                , _rho = Nothing
-                , _tau = Nothing
-                , _activeSlotCoeff = Nothing
-                , _d = Nothing
-                , _extraEntropy = Nothing
-                , _protocolVersion = Nothing
+                { _minfeeA = SNothing
+                , _minfeeB = SNothing
+                , _maxBBSize = SNothing
+                , _maxTxSize = SNothing
+                , _maxBHSize = SNothing
+                , _keyDeposit = SNothing
+                , _keyMinRefund = SNothing
+                , _keyDecayRate = SNothing
+                , _poolDeposit = SNothing
+                , _poolMinRefund = SNothing
+                , _poolDecayRate = SNothing
+                , _eMax = SNothing
+                , _nOpt = SJust 100
+                , _a0 = SNothing
+                , _rho = SNothing
+                , _tau = SNothing
+                , _activeSlotCoeff = SNothing
+                , _d = SNothing
+                , _extraEntropy = SNothing
+                , _protocolVersion = SNothing
                 })))
              (EpochNo 0)
     in checkEncodingCBOR "txbody_partial"
@@ -706,8 +707,8 @@ serializationTests = testGroup "Serialization Tests"
         (Wdrl ras)
         (Coin 9)
         (SlotNo 500)
-        (Just up)
-        Nothing
+        (SJust up)
+        SNothing
      )
      ( T (TkMapLen 6)
        <> T (TkWord 0) -- Tx Ins
@@ -736,26 +737,26 @@ serializationTests = testGroup "Serialization Tests"
              (ProposedPPUpdates (Map.singleton
                          testGKeyHash
                          (PParams
-                            { _minfeeA = Nothing
-                            , _minfeeB = Nothing
-                            , _maxBBSize = Nothing
-                            , _maxTxSize = Nothing
-                            , _maxBHSize = Nothing
-                            , _keyDeposit = Nothing
-                            , _keyMinRefund = Nothing
-                            , _keyDecayRate = Nothing
-                            , _poolDeposit = Nothing
-                            , _poolMinRefund = Nothing
-                            , _poolDecayRate = Nothing
-                            , _eMax = Nothing
-                            , _nOpt = Just 100
-                            , _a0 = Nothing
-                            , _rho = Nothing
-                            , _tau = Nothing
-                            , _activeSlotCoeff = Nothing
-                            , _d = Nothing
-                            , _extraEntropy = Nothing
-                            , _protocolVersion = Nothing
+                            { _minfeeA = SNothing
+                            , _minfeeB = SNothing
+                            , _maxBBSize = SNothing
+                            , _maxTxSize = SNothing
+                            , _maxBHSize = SNothing
+                            , _keyDeposit = SNothing
+                            , _keyMinRefund = SNothing
+                            , _keyDecayRate = SNothing
+                            , _poolDeposit = SNothing
+                            , _poolMinRefund = SNothing
+                            , _poolDecayRate = SNothing
+                            , _eMax = SNothing
+                            , _nOpt = SJust 100
+                            , _a0 = SNothing
+                            , _rho = SNothing
+                            , _tau = SNothing
+                            , _activeSlotCoeff = SNothing
+                            , _d = SNothing
+                            , _extraEntropy = SNothing
+                            , _protocolVersion = SNothing
                             })))
              (EpochNo 0)
       mdh = MD.hashMetaData $ MD.MetaData $ Map.singleton 13 (MD.I 17)
@@ -767,8 +768,8 @@ serializationTests = testGroup "Serialization Tests"
         (Wdrl ras)
         (Coin 9)
         (SlotNo 500)
-        (Just up)
-        (Just mdh)
+        (SJust up)
+        (SJust mdh)
      )
      ( T (TkMapLen 8)
        <> T (TkWord 0) -- Tx Ins
@@ -799,10 +800,10 @@ serializationTests = testGroup "Serialization Tests"
                 (Wdrl Map.empty)
                 (Coin 9)
                 (SlotNo 500)
-                Nothing
-                Nothing
+                SNothing
+                SNothing
         w = makeWitnessVKey txb testKey1
-        md = Nothing :: Maybe MD.MetaData
+        md = SNothing :: StrictMaybe MD.MetaData
     in
     checkEncodingCBOR "tx_min"
     ( Tx txb (Set.singleton w) Map.empty md )
@@ -823,11 +824,11 @@ serializationTests = testGroup "Serialization Tests"
                 (Wdrl Map.empty)
                 (Coin 9)
                 (SlotNo 500)
-                Nothing
-                Nothing
+                SNothing
+                SNothing
         w = makeWitnessVKey txb testKey1
         s = Map.singleton (hashScript testScript) testScript
-        md = Just $ MD.MetaData $ Map.singleton 17 (MD.I 42)
+        md = SJust $ MD.MetaData $ Map.singleton 17 (MD.I 42)
     in
     checkEncodingCBOR "tx_full"
     ( Tx txb (Set.singleton w) s md )
@@ -934,7 +935,7 @@ serializationTests = testGroup "Serialization Tests"
         bh = BHeader testBHB sig
         tin = Set.fromList [TxIn genesisId 1]
         tout = StrictSeq.singleton $ TxOut testAddrE (Coin 2)
-        txb s = TxBody tin tout StrictSeq.empty (Wdrl Map.empty) (Coin 9) (SlotNo s) Nothing Nothing
+        txb s = TxBody tin tout StrictSeq.empty (Wdrl Map.empty) (Coin 9) (SlotNo s) SNothing SNothing
         txb1 = txb 500
         txb2 = txb 501
         txb3 = txb 502
@@ -943,14 +944,14 @@ serializationTests = testGroup "Serialization Tests"
         w1 = makeWitnessVKey txb1 testKey1
         w2 = makeWitnessVKey txb1 testKey2
         ws = Set.fromList [w1, w2]
-        tx1 = Tx txb1 (Set.singleton w1) mempty Nothing
-        tx2 = Tx txb2 ws mempty Nothing
-        tx3 = Tx txb3 mempty (Map.singleton (hashScript testScript) testScript) Nothing
+        tx1 = Tx txb1 (Set.singleton w1) mempty SNothing
+        tx2 = Tx txb2 ws mempty SNothing
+        tx3 = Tx txb3 mempty (Map.singleton (hashScript testScript) testScript) SNothing
         ss = Map.fromList [ (hashScript testScript, testScript)
                           , (hashScript testScript2, testScript2)]
-        tx4 = Tx txb4 mempty ss Nothing
+        tx4 = Tx txb4 mempty ss SNothing
         tx5MD = MD.MetaData $ Map.singleton 17 (MD.I 42)
-        tx5 = Tx txb5 ws ss (Just tx5MD)
+        tx5 = Tx txb5 ws ss (SJust tx5MD)
         txns = TxSeq $ StrictSeq.fromList [tx1, tx2, tx3, tx4, tx5]
     in
     checkEncodingCBORAnnotated "rich_block"
@@ -1047,7 +1048,7 @@ serializationTests = testGroup "Serialization Tests"
               , _poolRAcnt = RewardAcnt (KeyHashObj testKeyHash1)
               , _poolOwners = Set.singleton testKeyHash2
               , _poolRelays = StrictSeq.empty
-              , _poolMD = Just $ PoolMetaData
+              , _poolMD = SJust $ PoolMetaData
                             { _poolMDUrl  = Url $ text64 "web.site"
                             , _poolMDHash = BS.pack "{}"
                             }
@@ -1086,7 +1087,7 @@ serializationTests = testGroup "Serialization Tests"
             , _poolRAcnt = RewardAcnt (KeyHashObj testKeyHash1)
             , _poolOwners = Set.singleton testKeyHash2
             , _poolRelays = StrictSeq.empty
-            , _poolMD = Just $ PoolMetaData
+            , _poolMD = SJust $ PoolMetaData
                           { _poolMDUrl  = Url $ text64 "web.site"
                           , _poolMDHash = BS.pack "{}"
                           }
@@ -1099,13 +1100,13 @@ serializationTests = testGroup "Serialization Tests"
       bs = Map.singleton testKeyHash1 1
       nm = emptyNonMyopic
       es = EpochState ac ss ls pps pps nm
-      ru = (Just RewardUpdate
+      ru = (SJust RewardUpdate
              { deltaT        = Coin 100
              , deltaR        = Coin (-200)
              , rs            = Map.empty
              , deltaF        = Coin (-10)
              , nonMyopic     = nm
-             }) :: Maybe RewardUpdate
+             }) :: StrictMaybe RewardUpdate
       pd = (PoolDistr Map.empty) :: PoolDistr
       os = Map.singleton (SlotNo 1) (ActiveSlot testGKeyHash)
       nes = NewEpochState

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -42,9 +42,9 @@ import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), SnapShot (.
 import           Shelley.Spec.Ledger.Keys (DiscVKey (..), pattern GenKeyHash, Hash, pattern KeyHash,
                      pattern KeyPair, pattern UnsafeSig, hash, hashKey, sKey, sign, signKES,
                      undiscriminateKeyHash, vKey)
-import           Shelley.Spec.Ledger.LedgerState (AccountState (..), EpochState (..),
-                     NewEpochState (..), pattern RewardUpdate, deltaF, deltaR, deltaT,
-                     emptyLedgerState, genesisId, nonMyopic, rs)
+import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern ActiveSlot,
+                     EpochState (..), NewEpochState (..), pattern RewardUpdate, deltaF, deltaR,
+                     deltaT, emptyLedgerState, genesisId, nonMyopic, rs)
 import           Shelley.Spec.Ledger.PParams (PParams' (PParams), PParamsUpdate,
                      pattern ProposedPPUpdates, ProtVer (..), pattern Update, emptyPParams,
                      mkActiveSlotCoeff, _a0, _activeSlotCoeff, _d, _eMax, _extraEntropy,
@@ -1107,7 +1107,7 @@ serializationTests = testGroup "Serialization Tests"
              , nonMyopic     = nm
              }) :: Maybe RewardUpdate
       pd = (PoolDistr Map.empty) :: PoolDistr
-      os = Map.singleton (SlotNo 1) (Just testGKeyHash)
+      os = Map.singleton (SlotNo 1) (ActiveSlot testGKeyHash)
       nes = NewEpochState
               e
               (BlocksMade bs)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
@@ -186,15 +186,15 @@ testValidWithdrawal =
            (Wdrl bobWithdrawal)
            (Coin 1000)
            (SlotNo 0)
-           Nothing
-           Nothing
+           SNothing
+           SNothing
     wits = makeWitnessesVKey tx [alicePay, bobStake]
     utxo' = Map.fromList
        [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
        , (TxIn (txid tx) 0, TxOut aliceAddr (Coin 6000))
        , (TxIn (txid tx) 1, TxOut bobAddr (Coin 3010)) ]
     ls = asStateTransition
-           (SlotNo 0) testPCs genesisWithReward (Tx tx wits Map.empty Nothing) (Coin 0)
+           (SlotNo 0) testPCs genesisWithReward (Tx tx wits Map.empty SNothing) (Coin 0)
     dstate' = _dstate emptyDelegation
     expectedDS = emptyDelegation
       { _dstate = dstate' {_rewards = Map.singleton (mkVKeyRwdAcnt bobStake) (Coin 0)}}
@@ -216,11 +216,11 @@ testInvalidWintess =
            (Wdrl Map.empty)
            (Coin 1000)
            (SlotNo 1)
-           Nothing
-           Nothing
+           SNothing
+           SNothing
     tx' = tx { _ttl = SlotNo  2}
     wits = makeWitnessesVKey tx' [alicePay]
-  in ledgerState [Tx tx wits Map.empty Nothing] @?= Left [InvalidWitness]
+  in ledgerState [Tx tx wits Map.empty SNothing] @?= Left [InvalidWitness]
 
 testWithdrawalNoWit :: Assertion
 testWithdrawalNoWit =
@@ -234,11 +234,11 @@ testWithdrawalNoWit =
            (Wdrl bobWithdrawal)
            (Coin 1000)
            (SlotNo 0)
-           Nothing
-           Nothing
+           SNothing
+           SNothing
     wits = Set.singleton $ makeWitnessVKey tx alicePay
     ls = asStateTransition
-      (SlotNo 0) testPCs genesisWithReward (Tx tx wits Map.empty Nothing) (Coin 0)
+      (SlotNo 0) testPCs genesisWithReward (Tx tx wits Map.empty SNothing) (Coin 0)
   in ls @?= Left [MissingWitnesses]
 
 testWithdrawalWrongAmt :: Assertion
@@ -253,16 +253,16 @@ testWithdrawalWrongAmt =
            (Wdrl $ Map.singleton (mkVKeyRwdAcnt bobStake) (Coin 11))
            (Coin 1000)
            (SlotNo 0)
-           Nothing
-           Nothing
+           SNothing
+           SNothing
     wits = makeWitnessesVKey tx [alicePay, bobStake]
     ls =asStateTransition
-          (SlotNo 0) testPCs genesisWithReward (Tx tx wits Map.empty Nothing) (Coin 0)
+          (SlotNo 0) testPCs genesisWithReward (Tx tx wits Map.empty SNothing) (Coin 0)
   in ls @?= Left [IncorrectRewards]
 
 aliceGivesBobLovelace :: TxIn -> Coin -> Coin -> Coin -> Coin ->
   [DCert] -> SlotNo -> [KeyPair] -> Tx
-aliceGivesBobLovelace txin coin fee txdeps txrefs cs s signers = Tx txbody wits Map.empty Nothing
+aliceGivesBobLovelace txin coin fee txdeps txrefs cs s signers = Tx txbody wits Map.empty SNothing
   where
     aliceCoin = aliceInitCoin + txrefs - (coin + fee + txdeps)
     txbody = TxBody
@@ -274,8 +274,8 @@ aliceGivesBobLovelace txin coin fee txdeps txrefs cs s signers = Tx txbody wits 
                (Wdrl Map.empty)
                fee
                s
-               Nothing
-               Nothing
+               SNothing
+               SNothing
     wits = makeWitnessesVKey txbody signers
 
 tx1 :: Tx
@@ -332,11 +332,11 @@ tx3Body = TxBody
           (Wdrl Map.empty)
           (Coin 1200)
           (SlotNo 100)
-          Nothing
-          Nothing
+          SNothing
+          SNothing
 
 tx3 :: Tx
-tx3 = Tx tx3Body (makeWitnessesVKey tx3Body keys) Map.empty Nothing
+tx3 = Tx tx3Body (makeWitnessesVKey tx3Body keys) Map.empty SNothing
       where keys = [alicePay, aliceStake, stakePoolKey1]
 
 utxoSt3 :: UTxOState
@@ -380,7 +380,7 @@ stakePool = PoolParams
             , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
             , _poolOwners  = Set.empty
             , _poolRelays  = StrictSeq.empty
-            , _poolMD      = Nothing
+            , _poolMD      = SNothing
             }
 
 halfInterval :: UnitInterval
@@ -398,7 +398,7 @@ stakePoolUpdate = PoolParams
                    , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
                    , _poolOwners  = Set.empty
                    , _poolRelays  = StrictSeq.empty
-                   , _poolMD      = Nothing
+                   , _poolMD      = SNothing
                    }
 
 tx4Body :: TxBody
@@ -409,11 +409,11 @@ tx4Body = TxBody
           (Wdrl Map.empty)
           (Coin 1000)
           (SlotNo 100)
-          Nothing
-          Nothing
+          SNothing
+          SNothing
 
 tx4 :: Tx
-tx4 = Tx tx4Body (makeWitnessesVKey tx4Body [alicePay, stakePoolKey1]) Map.empty Nothing
+tx4 = Tx tx4Body (makeWitnessesVKey tx4Body [alicePay, stakePoolKey1]) Map.empty SNothing
 
 utxoSt4 :: UTxOState
 utxoSt4 = UTxOState
@@ -443,11 +443,11 @@ tx5Body e = TxBody
           (Wdrl Map.empty)
           (Coin 1000)
           (SlotNo 100)
-          Nothing
-          Nothing
+          SNothing
+          SNothing
 
 tx5 :: EpochNo -> Tx
-tx5 e = Tx (tx5Body e) (makeWitnessesVKey (tx5Body e) [alicePay, stakePoolKey1]) Map.empty Nothing
+tx5 e = Tx (tx5Body e) (makeWitnessesVKey (tx5Body e) [alicePay, stakePoolKey1]) Map.empty SNothing
 
 
 testsValidLedger :: TestTree
@@ -525,9 +525,9 @@ testWitnessNotIncluded =
               (Wdrl Map.empty)
               (Coin 596)
               (SlotNo 100)
-              Nothing
-              Nothing
-    tx = Tx txbody Set.empty Map.empty Nothing
+              SNothing
+              SNothing
+    tx = Tx txbody Set.empty Map.empty SNothing
   in ledgerState [tx] @?= Left [MissingWitnesses]
 
 testSpendNotOwnedUTxO :: Assertion
@@ -540,10 +540,10 @@ testSpendNotOwnedUTxO =
               (Wdrl Map.empty)
               (Coin 768)
               (SlotNo 100)
-              Nothing
-              Nothing
+              SNothing
+              SNothing
     aliceWit = makeWitnessVKey txbody alicePay
-    tx = Tx txbody (Set.fromList [aliceWit]) Map.empty Nothing
+    tx = Tx txbody (Set.fromList [aliceWit]) Map.empty SNothing
   in ledgerState [tx] @?= Left [MissingWitnesses]
 
 testWitnessWrongUTxO :: Assertion
@@ -556,8 +556,8 @@ testWitnessWrongUTxO =
               (Wdrl Map.empty)
               (Coin 770)
               (SlotNo 100)
-              Nothing
-              Nothing
+              SNothing
+              SNothing
     tx2body = TxBody
               (Set.fromList [TxIn genesisId 1])
               (StrictSeq.singleton $ TxOut aliceAddr (Coin 230))
@@ -565,10 +565,10 @@ testWitnessWrongUTxO =
               (Wdrl Map.empty)
               (Coin 770)
               (SlotNo 101)
-              Nothing
-              Nothing
+              SNothing
+              SNothing
     aliceWit = makeWitnessVKey  tx2body alicePay
-    tx = Tx txbody (Set.fromList [aliceWit]) Map.empty Nothing
+    tx = Tx txbody (Set.fromList [aliceWit]) Map.empty SNothing
   in ledgerState [tx] @?= Left [ InvalidWitness
                                , MissingWitnesses]
 
@@ -583,12 +583,12 @@ testEmptyInputSet =
            (Wdrl aliceWithdrawal)
            (Coin 1000)
            (SlotNo 0)
-           Nothing
-           Nothing
+           SNothing
+           SNothing
     wits = makeWitnessesVKey tx [aliceStake]
     genesisWithReward' = changeReward genesis (mkVKeyRwdAcnt aliceStake) (Coin 2000)
     ls = asStateTransition
-           (SlotNo 0) testPCs genesisWithReward' (Tx tx wits Map.empty Nothing) (Coin 0)
+           (SlotNo 0) testPCs genesisWithReward' (Tx tx wits Map.empty SNothing) (Coin 0)
   in ls @?= Left [ InputSetEmpty ]
 
 testFeeTooSmall :: Assertion

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
@@ -8,8 +8,8 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           Data.Ratio ((%))
-import           Data.Sequence (Seq (..))
-import qualified Data.Sequence as Seq
+import           Data.Sequence.Strict (StrictSeq (..))
+import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 
 import           Test.Tasty
@@ -180,8 +180,8 @@ testValidWithdrawal =
   let
     tx = TxBody
            (Set.fromList [TxIn genesisId 0])
-           (Seq.fromList [ TxOut aliceAddr (Coin 6000)
-                         , TxOut bobAddr (Coin 3010) ])
+           (StrictSeq.fromList [ TxOut aliceAddr (Coin 6000)
+                               , TxOut bobAddr (Coin 3010) ])
            Empty
            (Wdrl bobWithdrawal)
            (Coin 1000)
@@ -209,7 +209,7 @@ testInvalidWintess =
   let
     tx = TxBody
            (Set.fromList [TxIn genesisId 0])
-           (Seq.fromList
+           (StrictSeq.fromList
               [ TxOut aliceAddr (Coin 6000)
               , TxOut bobAddr (Coin 3000) ])
            Empty
@@ -227,7 +227,7 @@ testWithdrawalNoWit =
   let
     tx = TxBody
            (Set.fromList [TxIn genesisId 0])
-           (Seq.fromList
+           (StrictSeq.fromList
              [ TxOut aliceAddr (Coin 6000)
              , TxOut bobAddr (Coin 3010) ])
            Empty
@@ -246,7 +246,7 @@ testWithdrawalWrongAmt =
   let
     tx = TxBody
            (Set.fromList [TxIn genesisId 0])
-           (Seq.fromList
+           (StrictSeq.fromList
              [ TxOut aliceAddr (Coin 6000)
              , TxOut bobAddr (Coin 3011) ])
            Empty
@@ -267,10 +267,10 @@ aliceGivesBobLovelace txin coin fee txdeps txrefs cs s signers = Tx txbody wits 
     aliceCoin = aliceInitCoin + txrefs - (coin + fee + txdeps)
     txbody = TxBody
                (Set.fromList [txin])
-               (Seq.fromList
+               (StrictSeq.fromList
                  [ TxOut aliceAddr aliceCoin
                  , TxOut bobAddr coin ])
-               (Seq.fromList cs)
+               (StrictSeq.fromList cs)
                (Wdrl Map.empty)
                fee
                s
@@ -324,11 +324,11 @@ utxoSt2 = UTxOState
 tx3Body :: TxBody
 tx3Body = TxBody
           (Set.fromList [TxIn (txid $ _body tx2) 0])
-          (Seq.singleton $ TxOut aliceAddr (Coin 3950))
-          (Seq.fromList [ DCertPool (RegPool stakePool)
-                        , DCertDeleg (Delegate (Delegation
-                                            (KeyHashObj $ hashKey $ vKey aliceStake)
-                                            (hashKey $ vKey stakePoolKey1)))])
+          (StrictSeq.singleton $ TxOut aliceAddr (Coin 3950))
+          (StrictSeq.fromList [ DCertPool (RegPool stakePool)
+                              , DCertDeleg (Delegate (Delegation
+                                                  (KeyHashObj $ hashKey $ vKey aliceStake)
+                                                  (hashKey $ vKey stakePoolKey1)))])
           (Wdrl Map.empty)
           (Coin 1200)
           (SlotNo 100)
@@ -379,7 +379,7 @@ stakePool = PoolParams
             , _poolMargin  = interval0     --          or here?
             , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
             , _poolOwners  = Set.empty
-            , _poolRelays  = Seq.empty
+            , _poolRelays  = StrictSeq.empty
             , _poolMD      = Nothing
             }
 
@@ -397,15 +397,15 @@ stakePoolUpdate = PoolParams
                    , _poolMargin  = halfInterval     --          or here?
                    , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
                    , _poolOwners  = Set.empty
-                   , _poolRelays  = Seq.empty
+                   , _poolRelays  = StrictSeq.empty
                    , _poolMD      = Nothing
                    }
 
 tx4Body :: TxBody
 tx4Body = TxBody
           (Set.fromList [TxIn (txid $ _body tx3) 0])
-          (Seq.singleton $ TxOut aliceAddr (Coin 2950)) -- Note the deposit is not charged
-          (Seq.fromList [ DCertPool (RegPool stakePoolUpdate) ])
+          (StrictSeq.singleton $ TxOut aliceAddr (Coin 2950)) -- Note the deposit is not charged
+          (StrictSeq.fromList [ DCertPool (RegPool stakePoolUpdate) ])
           (Wdrl Map.empty)
           (Coin 1000)
           (SlotNo 100)
@@ -438,8 +438,8 @@ utxo5 e = UTxOState
 tx5Body :: EpochNo -> TxBody
 tx5Body e = TxBody
           (Set.fromList [TxIn (txid $ _body tx3) 0])
-          (Seq.singleton $ TxOut aliceAddr (Coin 2950))
-          (Seq.fromList [ DCertPool (RetirePool (hashKey $ vKey stakePoolKey1) e) ])
+          (StrictSeq.singleton $ TxOut aliceAddr (Coin 2950))
+          (StrictSeq.fromList [ DCertPool (RetirePool (hashKey $ vKey stakePoolKey1) e) ])
           (Wdrl Map.empty)
           (Coin 1000)
           (SlotNo 100)
@@ -518,7 +518,7 @@ testWitnessNotIncluded =
   let
     txbody = TxBody
               (Set.fromList [TxIn genesisId 0])
-              (Seq.fromList
+              (StrictSeq.fromList
                 [ TxOut aliceAddr (Coin 6404)
                 , TxOut bobAddr (Coin 3000) ])
               Empty
@@ -535,7 +535,7 @@ testSpendNotOwnedUTxO =
   let
     txbody = TxBody
               (Set.fromList [TxIn genesisId 1])
-              (Seq.singleton $ TxOut aliceAddr (Coin 232))
+              (StrictSeq.singleton $ TxOut aliceAddr (Coin 232))
               Empty
               (Wdrl Map.empty)
               (Coin 768)
@@ -551,7 +551,7 @@ testWitnessWrongUTxO =
   let
     txbody = TxBody
               (Set.fromList [TxIn genesisId 1])
-              (Seq.singleton $ TxOut aliceAddr (Coin 230))
+              (StrictSeq.singleton $ TxOut aliceAddr (Coin 230))
               Empty
               (Wdrl Map.empty)
               (Coin 770)
@@ -560,7 +560,7 @@ testWitnessWrongUTxO =
               Nothing
     tx2body = TxBody
               (Set.fromList [TxIn genesisId 1])
-              (Seq.singleton $ TxOut aliceAddr (Coin 230))
+              (StrictSeq.singleton $ TxOut aliceAddr (Coin 230))
               Empty
               (Wdrl Map.empty)
               (Coin 770)
@@ -578,7 +578,7 @@ testEmptyInputSet =
     aliceWithdrawal = Map.singleton (mkVKeyRwdAcnt aliceStake) (Coin 2000)
     tx = TxBody
            Set.empty
-           (Seq.singleton $ TxOut aliceAddr (Coin 1000))
+           (StrictSeq.singleton $ TxOut aliceAddr (Coin 1000))
            Empty
            (Wdrl aliceWithdrawal)
            (Coin 1000)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -51,7 +51,7 @@ import qualified Data.List as List (findIndex, (\\))
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (empty, fromList, insert, lookup)
 import           Data.Ratio ((%))
-import           Data.Sequence (fromList)
+import qualified Data.Sequence.Strict as StrictSeq
 import           Data.Tuple (swap)
 import           Data.Word (Word64)
 import           GHC.Stack (HasCallStack)
@@ -361,8 +361,8 @@ mkBlock prev pkeys txns s blockNo enonce (NatNonce bnonce) l kesPeriod c0 oCert 
             blockNo
             (coerce $ mkCertifiedVRF (WithResult nonceNonce bnonce) (fst $ vrf pkeys))
             (coerce $ mkCertifiedVRF (WithResult leaderNonce $ unitIntervalToNatural l) (fst $ vrf pkeys))
-            (fromIntegral $ bBodySize $ (TxSeq . fromList) txns)
-            (bbHash $ TxSeq $ fromList txns)
+            (fromIntegral $ bBodySize $ (TxSeq . StrictSeq.fromList) txns)
+            (bbHash $ TxSeq $ StrictSeq.fromList txns)
             oCert
             (ProtVer 0 0)
     kpDiff = kesPeriod - c0
@@ -375,7 +375,7 @@ mkBlock prev pkeys txns s blockNo enonce (NatNonce bnonce) l kesPeriod c0 oCert 
             Just sig' -> sig'
     bh = BHeader bhb sig
   in
-    Block bh (TxSeq $ fromList txns)
+    Block bh (TxSeq $ StrictSeq.fromList txns)
 
 -- | We provide our own nonces to 'mkBlock', which we then wish to recover as
 -- the output of the VRF functions. In general, however, we just derive them

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
@@ -30,7 +30,7 @@ import qualified Test.QuickCheck as QC
 
 import           Byron.Spec.Ledger.Core (dom, range, (∈), (∉))
 import           Shelley.Spec.Ledger.Address (mkRwdAcnt, scriptToCred)
-import           Shelley.Spec.Ledger.BaseTypes (interval0)
+import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), interval0)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DCertMir, pattern DeRegKey,
                      pattern Delegate, pattern GenesisDelegate, pattern MIRCert, pattern RegKey,
@@ -294,7 +294,7 @@ genStakePool skeys vrfKeys =
                 (RewardAcnt $ KeyHashObj $ hashKey acntKey)
                 Set.empty
                 StrictSeq.empty
-                Nothing
+                SNothing
      in (pps, snd poolKeyPair)
 
 -- | Generate `RegPool` and the key witness.

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
@@ -19,7 +19,7 @@ import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (elems, findWithDefault, fromList, keys, lookup, size)
 import           Data.Maybe (fromMaybe)
 import           Data.Ratio ((%))
-import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as StrictSeq
 import           Data.Set ((\\))
 import qualified Data.Set as Set
 import           GHC.Stack (HasCallStack)
@@ -238,7 +238,7 @@ genGenesisDelegation keys coreKeys dpState =
   where
     hashVKey = hashKey . vKey
     mkCert gkey key = Just
-      ( DCertGenesis (GenesisDelegate (hashVKey gkey, (hashVKey . snd) key))
+      ( DCertGenesis (GenesisDelegate (hashVKey gkey) (hashVKey (snd key)))
       , CoreKeyCred [gkey])
 
     (GenDelegs genDelegs_) = _genDelegs $ _dstate dpState
@@ -293,7 +293,7 @@ genStakePool skeys vrfKeys =
                 interval
                 (RewardAcnt $ KeyHashObj $ hashKey acntKey)
                 Set.empty
-                Seq.empty
+                StrictSeq.empty
                 Nothing
      in (pps, snd poolKeyPair)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -5,8 +5,8 @@
 
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -20,8 +20,8 @@ import           Control.Monad.Trans.Reader (runReaderT)
 import           Data.Functor.Identity (runIdentity)
 import qualified Data.Map.Strict as Map (lookup)
 import           Data.Maybe (catMaybes)
-import           Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
+import           Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
 import           Numeric.Natural (Natural)
 import           Test.QuickCheck (Gen)
 
@@ -43,8 +43,8 @@ import           Shelley.Spec.Ledger.TxData (Ix, Ptr (..))
 import           Shelley.Spec.Ledger.UTxO (totalDeposits)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DCert, DELPL, DPState)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants(..))
-import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv(..), KeySpace(..))
+import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..), KeySpace (..))
 import           Test.Shelley.Spec.Ledger.Generator.Delegation (CertCred (..), genDCert)
 import           Test.Shelley.Spec.Ledger.Utils (testGlobals)
 
@@ -127,7 +127,7 @@ genDCerts
   -> Natural
   -> Natural
   -> Coin
-  -> Gen (Seq DCert, [CertCred], Coin, Coin)
+  -> Gen (StrictSeq DCert, [CertCred], Coin, Coin)
 genDCerts
   ge@( GenEnv
          KeySpace_ {ksKeyPairsByHash}
@@ -152,7 +152,7 @@ genDCerts
 
   withScriptCreds <- concat <$> mapM extendWithScriptCred creds
 
-  pure ( Seq.fromList certs
+  pure ( StrictSeq.fromList certs
        , withScriptCreds
        , totalDeposits pparams (_stPools (_pstate dpState)) certs
        , sum (certRefund slotWithTTL <$> deRegStakeCreds) )

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
@@ -25,7 +25,8 @@ import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
 
 import           Numeric.Natural (Natural)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (NeutralNonce), UnitInterval, mkNonce)
+import           Shelley.Spec.Ledger.BaseTypes (Nonce (NeutralNonce), StrictMaybe (..),
+                     UnitInterval, mkNonce)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Keys (GenDelegs (..), hashKey, vKey)
 import           Shelley.Spec.Ledger.LedgerState (_dstate, _genDelegs)
@@ -228,26 +229,26 @@ genPPUpdate (c@Constants{maxMinFeeA, maxMinFeeB}) s pp genesisKeys =
       d                     <- genDecentralisationParam
       extraEntropy          <- genExtraEntropy
       protocolVersion       <- genNextProtocolVersion pp
-      let pps = PParams { _minfeeA               = Just minFeeA
-                        , _minfeeB               = Just minFeeB
-                        , _maxBBSize             = Just maxBBSize
-                        , _maxTxSize             = Just maxTxSize
-                        , _maxBHSize             = Just maxBHSize
-                        , _keyDeposit            = Just keyDeposit
-                        , _keyMinRefund          = Just keyMinRefund
-                        , _keyDecayRate          = Just keyDecayRate
-                        , _poolDeposit           = Just poolDeposit
-                        , _poolMinRefund         = Just poolMinRefund
-                        , _poolDecayRate         = Just poolDecayRate
-                        , _eMax                  = Just eMax
-                        , _nOpt                  = Just nopt
-                        , _a0                    = Just a0
-                        , _rho                   = Just rho
-                        , _tau                   = Just tau
-                        , _activeSlotCoeff       = Just activeSlotCoefficient
-                        , _d                     = Just d
-                        , _extraEntropy          = Just extraEntropy
-                        , _protocolVersion       = Just protocolVersion
+      let pps = PParams { _minfeeA               = SJust minFeeA
+                        , _minfeeB               = SJust minFeeB
+                        , _maxBBSize             = SJust maxBBSize
+                        , _maxTxSize             = SJust maxTxSize
+                        , _maxBHSize             = SJust maxBHSize
+                        , _keyDeposit            = SJust keyDeposit
+                        , _keyMinRefund          = SJust keyMinRefund
+                        , _keyDecayRate          = SJust keyDecayRate
+                        , _poolDeposit           = SJust poolDeposit
+                        , _poolMinRefund         = SJust poolMinRefund
+                        , _poolDecayRate         = SJust poolDecayRate
+                        , _eMax                  = SJust eMax
+                        , _nOpt                  = SJust nopt
+                        , _a0                    = SJust a0
+                        , _rho                   = SJust rho
+                        , _tau                   = SJust tau
+                        , _activeSlotCoeff       = SJust activeSlotCoefficient
+                        , _d                     = SJust d
+                        , _extraEntropy          = SJust extraEntropy
+                        , _protocolVersion       = SJust protocolVersion
                         }
       let ppUpdate = zip genesisKeys (repeat pps)
       pure $

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -27,6 +27,7 @@ import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
 
 import           Shelley.Spec.Ledger.Address (scriptToCred, toCred)
+import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
 import           Shelley.Spec.Ledger.Coin (Coin (..), splitCoin)
 import           Shelley.Spec.Ledger.LedgerState (pattern UTxOState, minfee, _dstate, _ptrs,
                      _rewards)
@@ -154,7 +155,7 @@ genTx ge@(GenEnv KeySpace_ { ksCoreNodes
           ksKeyPairsByHash
           msigSignatures
 
-    let metadata = Nothing -- TODO generate metadata
+    let metadata = SNothing -- TODO generate metadata
 
     -- calculate real fees of witnesses transaction
     let minimalFees = minfee pparams (Tx txBody wits multiSig metadata)
@@ -210,8 +211,8 @@ genTxBody inputs outputs certs wdrls update fee slotWithTTL = do
              (Wdrl wdrls)
              fee
              slotWithTTL
-             update
-             Nothing -- TODO generate metadata
+             (maybeToStrictMaybe update)
+             SNothing -- TODO generate metadata
 
 -- | Distribute the sum of `balance_` and `fee` over the addresses, return the
 -- sum of `fee` and the remainder of the equal distribution and the list ouf

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -17,8 +17,8 @@ import qualified Data.Either as Either (lefts, rights)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe (catMaybes)
-import           Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
+import           Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import           GHC.Stack (HasCallStack)
@@ -195,8 +195,8 @@ mkTxWits txBody keyWits genesisWits keyHashMap msigs =
 genTxBody
   :: HasCallStack
   => Set TxIn
-  -> Seq TxOut
-  -> Seq DCert
+  -> StrictSeq TxOut
+  -> StrictSeq DCert
   -> Map RewardAcnt Coin
   -> Maybe Update
   -> Coin
@@ -224,10 +224,10 @@ calcOutputsFromBalance
   => Coin
   -> [Addr]
   -> Coin
-  -> (Coin, Seq TxOut)
+  -> (Coin, StrictSeq TxOut)
 calcOutputsFromBalance balance_ addrs fee =
   ( fee + splitCoinRem
-  , (`TxOut` amountPerOutput) <$> Seq.fromList addrs)
+  , (`TxOut` amountPerOutput) <$> StrictSeq.fromList addrs)
   where
     -- split the available balance into equal portions (one for each address),
     -- if there is a remainder, then add it to the fee.

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSGenerator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSGenerator.hs
@@ -42,6 +42,7 @@ import qualified Hedgehog.Range as Range
 
 
 import           Control.State.Transition.Extended (TRC (..), applySTS)
+import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
 import           Shelley.Spec.Ledger.Coin
 import           Shelley.Spec.Ledger.Keys (pattern KeyPair, hashKey, vKey)
 import           Shelley.Spec.Ledger.LedgerState (pattern LedgerValidation, applyTxBody,
@@ -178,10 +179,10 @@ genTx keyList (UTxO m) cslot = do
            (Wdrl Map.empty) -- TODO generate witdrawals
            txfee'
            (cslot + SlotNo txttl)
-           Nothing
-           Nothing
+           SNothing
+           SNothing
   let !txwit = makeWitnessVKey txbody selectedKeyPair
-  pure (txfee', Tx txbody (Set.fromList [txwit]) Map.empty Nothing)
+  pure (txfee', Tx txbody (Set.fromList [txwit]) Map.empty SNothing)
             where utxoInputs = Map.keys m
                   addr inp   = getTxOutAddr $ m Map.! inp
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSGenerator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSGenerator.hs
@@ -29,8 +29,8 @@ module Test.Shelley.Spec.Ledger.PreSTSGenerator
 
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Sequence (Seq (..))
 import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
 import           Data.Word (Word64)
 
@@ -173,8 +173,8 @@ genTx keyList (UTxO m) cslot = do
   txttl <- genWord64 1 100
   let !txbody = TxBody
            (Map.keysSet selectedUTxO)
-           ((`TxOut` perReceipient) <$> receipientAddrs)
-           Empty
+           (StrictSeq.toStrict ((`TxOut` perReceipient) <$> receipientAddrs))
+           StrictSeq.Empty
            (Wdrl Map.empty) -- TODO generate witdrawals
            txfee'
            (cslot + SlotNo txttl)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
@@ -78,7 +78,7 @@ mutateCoin lower upper (Coin val) =
 mutateTx :: Tx -> Gen Tx
 mutateTx txwits = do
   body' <- mutateTxBody $ _body txwits
-  pure $ Tx body' (_witnessVKeySet txwits) (_witnessMSigMap txwits) Nothing
+  pure $ Tx body' (_witnessVKeySet txwits) (_witnessMSigMap txwits) SNothing
 
 -- | Mutator for Transaction which mutates the set of inputs and the set of
 -- unspent outputs.
@@ -92,8 +92,8 @@ mutateTxBody tx = do
     (_wdrls tx)
     (_txfee tx)
     (_ttl tx)
-    Nothing
-    Nothing
+    SNothing
+    SNothing
 
 -- | Mutator for a list of 'TxIn'.
 mutateInputs :: [TxIn] -> Gen [TxIn]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
@@ -21,8 +21,8 @@ import qualified Data.List as List (map)
 import qualified Data.Map.Strict as Map (fromList, toList)
 import           Data.Maybe (fromMaybe)
 import           Data.Ratio
-import           Data.Sequence (Seq (..))
-import qualified Data.Sequence as Seq
+import           Data.Sequence.Strict (StrictSeq (..))
+import qualified Data.Sequence.Strict as StrictSeq
 import           Data.Set as Set
 import           Numeric.Natural
 
@@ -112,8 +112,8 @@ mutateInput (TxIn idx index) = do
   pure $ TxIn idx index'
 
 -- | Mutator for a list of 'TxOut'.
-mutateOutputs :: Seq TxOut -> Gen (Seq TxOut)
-mutateOutputs Seq.Empty = pure Seq.Empty
+mutateOutputs :: StrictSeq TxOut -> Gen (StrictSeq TxOut)
+mutateOutputs StrictSeq.Empty = pure StrictSeq.Empty
 mutateOutputs (txout :<| txouts) = do
   mtxout    <- mutateOutput txout
   mtxouts   <- mutateOutputs txouts
@@ -175,9 +175,9 @@ mutateDCert keys _ (DCertDeleg (Delegate (Delegation _ _))) = do
   delegatee' <- getAnyStakeKey keys
   pure $ DCertDeleg $ Delegate $ Delegation (KeyHashObj $ hashKey delegator') (hashKey delegatee')
 
-mutateDCert keys _ (DCertGenesis (GenesisDelegate (gk, _))) = do
+mutateDCert keys _ (DCertGenesis (GenesisDelegate gk _)) = do
   _delegatee <- getAnyStakeKey keys
-  pure $ DCertGenesis $ GenesisDelegate (gk, hashKey _delegatee)
+  pure $ DCertGenesis $ GenesisDelegate gk (hashKey _delegatee)
 
 mutateDCert _ _ (DCertMir (MIRCert credCoinMap)) = do
   let credCoinList = Map.toList credCoinMap

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -15,7 +15,7 @@ module Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
 import qualified Data.ByteString as BS
 import           Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
-import           Data.Sequence (Seq)
+import           Data.Sequence.Strict (StrictSeq)
 import           Test.QuickCheck (Property, checkCoverage, conjoin, cover, property, withMaxSuccess)
 import qualified Test.QuickCheck.Gen
 import           Cardano.Binary (serialize')
@@ -201,7 +201,7 @@ ratioInt x y
   = fromIntegral x / fromIntegral y
 
 -- | Transaction has script locked TxOuts
-txScriptOutputsRatio :: [Seq TxOut] -> Double
+txScriptOutputsRatio :: [StrictSeq TxOut] -> Double
 txScriptOutputsRatio txoutsList =
   ratioInt
    (sum (map countScriptOuts txoutsList))

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -24,7 +24,7 @@ import           Control.State.Transition.Trace (TraceOrder (OldestFirst), trace
                      traceSignals)
 import           Control.State.Transition.Trace.Generator.QuickCheck (classifyTraceLength,
                      forAllTraceFromInitState, onlyValidSignalsAreGeneratedFromInitState)
-import           Shelley.Spec.Ledger.BaseTypes (Globals (epochInfo))
+import           Shelley.Spec.Ledger.BaseTypes (Globals (epochInfo), StrictMaybe (..))
 import           Shelley.Spec.Ledger.BlockChain (pattern Block, pattern TxSeq, bhbody,
                      bheaderSlotNo)
 import           Shelley.Spec.Ledger.Delegation.Certificates (isDeRegKey, isDelegation,
@@ -189,8 +189,8 @@ maxCertsRatio Constants{maxCertsPerTx} = lenRatio (filter ((== maxCertsPerTx) . 
 ppUpdatesByTx :: [Tx] -> [[PParamsUpdate]]
 ppUpdatesByTx txs = ppUpdates . _txUpdate . _body <$> txs
   where
-    ppUpdates Nothing = mempty
-    ppUpdates (Just (Update (ProposedPPUpdates ppUpd) _)) = Map.elems ppUpd
+    ppUpdates SNothing = mempty
+    ppUpdates (SJust (Update (ProposedPPUpdates ppUpd) _)) = Map.elems ppUpd
 
 -- | Ratio of the number of empty PParamsUpdate to Updates
 noPPUpdateRatio :: [[PParamsUpdate]] -> Double

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
@@ -31,6 +31,7 @@ module Test.Shelley.Spec.Ledger.Rules.TestLedger
 where
 
 import           Data.Foldable (toList)
+import qualified Data.Sequence.Strict as StrictSeq
 import           Data.Word (Word64)
 
 import           Test.QuickCheck (Property, Testable, conjoin, property, withMaxSuccess, (===))
@@ -274,7 +275,7 @@ ledgerToDelegsSsts
   -> (Wdrl, SourceSignalTarget DELEGS)
 ledgerToDelegsSsts (SourceSignalTarget (_, dpSt) (_, dpSt') tx) =
   ( (_wdrls . _body) tx
-  , SourceSignalTarget dpSt dpSt' ((_certs . _body) tx))
+  , SourceSignalTarget dpSt dpSt' ((StrictSeq.getSeq . _certs . _body) tx))
 
 -- | Transform LEDGER `SourceSignalTargets`s to POOL ones.
 ledgerToPoolSsts


### PR DESCRIPTION
This is to avoid space leaks and to pass the `NoUnexpectedThunks` test.

We add bangs where needed and use `StrictSeq` instead of `Seq`.

To fix the thunk in the overlay schedule (map), replace `Maybe (GenKeyHash crypto)` with a new isomorphic (up to strictness) type.

In consensus, we have to deal with the result of the lookup in this map, i.e., `Maybe (Maybe GenKeyHash crypto)`. As nested `Maybe`s can be confusing, replacing the inner `Maybe` with a new type also helps with code clarity.

Wherever we have `!(Maybe x)`, the bang won't forced `x`, just `Nothing` or `Just _`, so we need a strict variant of `Maybe`. In consensus, we typically introduce a new isomorphic type (up to strictness) for each such `Maybe`, but there were simply too many, so I succumbed and introduced `StrictMaybe`.

~Until https://github.com/input-output-hk/cardano-base/pull/87, which fixes the
thunks in `SigDSIGN MockDSIGN`, is merged, we temporarily ignore the thunks in `Sig`.~ *Merged*