### PR TITLE
fix a couple typos

### DIFF
--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -636,7 +636,7 @@ This does assume that the first block in an epoch will occur before
 \SlotsPrior{} slots before the beginning of the next epoch.
 
 Note that in \ref{eq:update-both}, the nonce candidate $\eta_c$ transitions to
-$\eta_v\star\eta$, not $\eta_c\star\eta$. The reason for this is that even
+$\eta_v\seedOp\eta$, not $\eta_c\seedOp\eta$. The reason for this is that even
 though the nonce candidate is frozen sometime during the epoch, we want the two
 nonces to again be equal at the start of a new epoch (so that the entropy added
 near the end of the epoch is not discarded).

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -505,7 +505,6 @@ and will always be large enough to meet all of its obligations.
       Let
       $$
         {\begin{array}{c}
-           \eta_c \\
            \var{gkeys} \\
          \end{array}}
         \vdash\var{nes}\trans{\hyperref[fig:rules:tick]{tick}}{\var{bh}}\var{nes'}


### PR DESCRIPTION
I'm guessing the TICK environment used to contain a nonce and its occurrence in that particular explanation was overlooked when it was removed.

The star vs seedOp patch is invisible in the rendered PDF but caused me a tiny bit of confusion when I was trying to track down the definition of that operator symbol (since I could not copy-and-paste the symbol into the CTRL-F dialog).