### PR TITLE
Rewrite tests to not use fixed key sets

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "8099da8fe035efe49e81a6eb974eea9e5656b9c6",
-        "sha256": "195rldxg6bmhxfrjz0bzqs0099wiq956wv49fz1i6h6rznaxy5y4",
+        "rev": "303ed1133d779c6ffc5151137171766cc9d46246",
+        "sha256": "1309n8xaxh26cgid0hibz0w4ipwinhz7i54hbqcii9parfwn469y",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/8099da8fe035efe49e81a6eb974eea9e5656b9c6.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/303ed1133d779c6ffc5151137171766cc9d46246.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "30cf81c421d7fca198660e1e995038dd8b6f3d13",
-        "sha256": "0sy9gza5gsrbqfbizp0dd98njnymigchj0aszswkfzxndskknarj",
+        "rev": "50eb9c4ececf383309ada328545b788c3493cd42",
+        "sha256": "0hz5rlzb92cyk3z93p7ms538c33c4a7znlgv03aijcih2fwflyqr",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/30cf81c421d7fca198660e1e995038dd8b6f3d13.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/50eb9c4ececf383309ada328545b788c3493cd42.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -119,6 +119,7 @@ test-suite shelley-spec-ledger-test
                          Test.Shelley.Spec.Ledger.Generator.Trace.Ledger
                          Test.Shelley.Spec.Ledger.Generator.Trace.DCert
                          Test.Shelley.Spec.Ledger.Generator.Delegation
+                         Test.Shelley.Spec.Ledger.Generator.Presets
                          Test.Shelley.Spec.Ledger.Generator.Update
                          Test.Shelley.Spec.Ledger.Generator.Utxo
                          Test.Shelley.Spec.Ledger.PropertyTests

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Constants.hs
@@ -87,6 +87,10 @@ maxGenesisUTxOouts = 100
 maxCertsPerTx :: Word64
 maxCertsPerTx = 1
 
+-- | maximal number of Txs per block
+maxTxsPerBlock :: Word64
+maxTxsPerBlock = 10
+
 -- | maximal numbers of generated keypairs
 maxNumKeyPairs :: Word64
 maxNumKeyPairs = 150
@@ -138,3 +142,6 @@ maxMinFeeA = 1000
 
 maxMinFeeB :: Natural
 maxMinFeeB = 3
+
+numCoreNodes :: Word64
+numCoreNodes = 7

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -238,7 +238,7 @@ findPayKeyPairCred c keyHashMap =
   where
     lookforKeyHash addr' =
       case Map.lookup (undiscriminateKeyHash addr') keyHashMap of
-        Nothing -> error "findPayKeyPairCred: could not find a match for the given credential"
+        Nothing -> error $ "findPayKeyPairCred: could not find a match for the given credential: " <> show addr'
         Just kp -> kp
 
 -- | Find first matching key pair for address. Returns the matching key pair

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Presets.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Presets.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE PatternSynonyms #-}
+
+-- | Pre-generated items to use in traces.
+--
+--   Functions in this module make specific assumptions about the sets of keys
+--   involved, and thus cannot be used as generic generators.
+module Test.Shelley.Spec.Ledger.Generator.Presets
+  ( keySpace,
+    genUtxo0,
+    genesisDelegs0,
+  )
+where
+
+import Cardano.Crypto.VRF (deriveVerKeyVRF, genKeyVRF)
+import Crypto.Random (drgNewTest, withDRG)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Shelley.Spec.Ledger.Address (scriptsToAddr, toAddr)
+import Shelley.Spec.Ledger.Keys
+  ( hashKey,
+    sKey,
+    vKey,
+    pattern KeyPair,
+  )
+import Shelley.Spec.Ledger.LedgerState (genesisCoins)
+import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Test.QuickCheck (Gen)
+import qualified Test.QuickCheck as QC
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( CoreKeyPair,
+    GenKeyHash,
+    KeyHash,
+    KeyPairs,
+    MultiSigPairs,
+    SignKeyVRF,
+    UTxO,
+    VerKeyVRF,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Constants
+  ( maxNumKeyPairs,
+    maxSlotTrace,
+    numBaseScripts,
+    numCoreNodes,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core
+import Test.Shelley.Spec.Ledger.Utils
+  ( maxKESIterations,
+    mkGenKey,
+    mkKESKeyPair,
+    mkKeyPair,
+    mkVRFKeyPair,
+    slotsPerKESIteration,
+  )
+
+-- | Example keyspace for use in generators
+keySpace :: KeySpace
+keySpace = KeySpace
+  coreNodeKeys
+  keyPairs
+  mSigCombinedScripts
+  vrfKeyPairs
+
+-- | Constant list of KeyPairs intended to be used in the generators.
+keyPairs :: KeyPairs
+keyPairs = mkKeyPairs <$> [1 .. maxNumKeyPairs]
+
+-- | A pre-populated space of VRF keys for use in the generators.
+vrfKeyPairs :: [(SignKeyVRF, VerKeyVRF)]
+vrfKeyPairs = [body (0, 0, 0, 0, i) | i <- [1 .. 50]]
+  where
+    body seed = fst . withDRG (drgNewTest seed) $ do
+      sk <- genKeyVRF
+      return (sk, deriveVerKeyVRF sk)
+
+-- | Select between _lower_ and _upper_ keys from 'keyPairs'
+someKeyPairs :: Int -> Int -> Gen KeyPairs
+someKeyPairs lower upper =
+  take
+    <$> QC.choose (lower, upper)
+    <*> QC.shuffle keyPairs
+
+mSigBaseScripts :: MultiSigPairs
+mSigBaseScripts = mkMSigScripts keyPairs
+
+mSigCombinedScripts :: MultiSigPairs
+mSigCombinedScripts = mkMSigCombinations $ take numBaseScripts mSigBaseScripts
+
+-- | Select between _lower_ and _upper_ scripts from the possible combinations
+-- of the first `numBaseScripts` multi-sig scripts of `mSigScripts`.
+someScripts :: Int -> Int -> Gen MultiSigPairs
+someScripts lower upper =
+  take
+    <$> QC.choose (lower, upper)
+    <*> QC.shuffle mSigCombinedScripts
+
+-- Pairs of (genesis key, node keys)
+--
+-- NOTE: we use a seed range in the [1000...] range
+-- to create keys that don't overlap with any of the other generated keys
+coreNodeKeys :: [(CoreKeyPair, AllPoolKeys)]
+coreNodeKeys =
+  [ ( (toKeyPair . mkGenKey) (x, 0, 0, 0, 0),
+      let (skCold, vkCold) = mkKeyPair (x, 0, 0, 0, 1)
+       in AllPoolKeys
+            (toKeyPair (skCold, vkCold))
+            (mkVRFKeyPair (x, 0, 0, 0, 2))
+            [ ( KESPeriod (fromIntegral (iter * fromIntegral maxKESIterations)),
+                mkKESKeyPair (x, 0, 0, fromIntegral iter, 3)
+              )
+              | iter <-
+                  [ 0
+                    .. ( 1
+                           + div
+                             maxSlotTrace
+                             ( fromIntegral
+                                 (maxKESIterations * slotsPerKESIteration)
+                             )
+                       )
+                  ]
+            ]
+            (hashKey vkCold)
+    )
+    | x <- [1001 .. 1000 + numCoreNodes]
+  ]
+  where
+    toKeyPair (sk, vk) = KeyPair {sKey = sk, vKey = vk}
+
+genUtxo0 :: Int -> Int -> Gen UTxO
+genUtxo0 lower upper = do
+  genesisKeys <- someKeyPairs lower upper
+  genesisScripts <- someScripts lower upper
+  outs <- genTxOut (fmap toAddr genesisKeys ++ fmap scriptsToAddr genesisScripts)
+  return (genesisCoins outs)
+
+genesisDelegs0 :: Map GenKeyHash KeyHash
+genesisDelegs0 =
+  Map.fromList
+    [ (hashVKey gkey, hashVKey (cold pkeys))
+      | (gkey, pkeys) <- coreNodeKeys
+    ]
+  where
+    hashVKey = hashKey . vKey

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -16,7 +16,6 @@ module Test.Shelley.Spec.Ledger.Generator.Trace.Chain where
 import           Data.Functor.Identity (runIdentity)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (elems, fromList, keysSet)
-import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 import           Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
@@ -42,25 +41,24 @@ import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN, ChainState
 import           Test.Shelley.Spec.Ledger.Generator.Block (genBlock)
 import           Test.Shelley.Spec.Ledger.Generator.Constants (maxGenesisUTxOouts, maxSlotTrace,
                      minGenesisUTxOouts, minSlotTrace)
-import           Test.Shelley.Spec.Ledger.Generator.Core (coreNodeKeys, genUtxo0, genesisDelegs0,
-                     traceKeyPairsByStakeHash)
+import           Test.Shelley.Spec.Ledger.Generator.Core (KeySpace(..))
+import           Test.Shelley.Spec.Ledger.Generator.Presets (genUtxo0, genesisDelegs0)
 import           Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
 import           Test.Shelley.Spec.Ledger.Shrinkers (shrinkBlock)
 import           Test.Shelley.Spec.Ledger.Utils (maxLLSupply, runShelleyBase)
 
 -- The CHAIN STS at the root of the STS allows for generating blocks of transactions
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
-instance HasTrace CHAIN Word64 where
+instance HasTrace CHAIN KeySpace where
   -- the current slot needs to be large enough to allow for many blocks
   -- to be processed (in large CHAIN traces)
   envGen _ = SlotNo <$> QC.choose (fromIntegral minSlotTrace, fromIntegral maxSlotTrace)
 
-  sigGen _ env st =
+  sigGen ks env st =
     genBlock
+      ks
       env
       st
-      coreNodeKeys
-      traceKeyPairsByStakeHash
 
   shrinkSignal = shrinkBlock
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Ledger.hs
@@ -17,7 +17,6 @@ module Test.Shelley.Spec.Ledger.Generator.Trace.Ledger where
 import           Control.Monad (foldM)
 import           Data.Functor.Identity (runIdentity)
 import qualified Data.Sequence as Seq
-import           Data.Word (Word64)
 import           Test.QuickCheck (Gen)
 
 import           Control.Monad.Trans.Reader (runReaderT)
@@ -33,45 +32,43 @@ import           Shelley.Spec.Ledger.TxData (Ix)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DPState, LEDGER, LEDGERS, Tx,
                      UTxOState)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (maxGenesisUTxOouts,
-                     minGenesisUTxOouts, numBaseScripts)
-import           Test.Shelley.Spec.Ledger.Generator.Core (coreNodeKeys, genCoin, genUtxo0,
-                     genesisDelegs0, traceKeyHashMap, traceKeyPairs, traceKeyPairsByStakeHash,
-                     traceMSigCombinations, traceMSigScripts)
+import           Test.Shelley.Spec.Ledger.Generator.Constants (maxGenesisUTxOouts, maxTxsPerBlock,
+                     minGenesisUTxOouts)
+import           Test.Shelley.Spec.Ledger.Generator.Core (KeySpace(..), genCoin)
 import           Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
 import           Test.Shelley.Spec.Ledger.Generator.Utxo (genTx)
 import           Test.Shelley.Spec.Ledger.Shrinkers (shrinkTx)
-
+import           Test.Shelley.Spec.Ledger.Generator.Presets (genUtxo0, genesisDelegs0)
 import           Test.Shelley.Spec.Ledger.Utils (runShelleyBase)
 
 -- The LEDGER STS combines utxo and delegation rules and allows for generating transactions
 -- with meaningful delegation certificates.
-instance TQC.HasTrace LEDGER Word64 where
+instance TQC.HasTrace LEDGER KeySpace where
   envGen _ =
     LedgerEnv <$> pure (SlotNo 0)
               <*> pure 0
               <*> genPParams
               <*> genCoin 1000000 10000000
 
-  sigGen _ = genTx_
+  sigGen = genTx
 
   shrinkSignal = shrinkTx
 
   type BaseEnv LEDGER = Globals
   interpretSTS globals act = runIdentity $ runReaderT act globals
 
-instance TQC.HasTrace LEDGERS Word64 where
+instance TQC.HasTrace LEDGERS KeySpace where
   envGen _ =
     LedgersEnv <$> pure (SlotNo 0)
                <*> genPParams
                <*> genCoin 1000000 10000000
 
   -- a LEDGERS signal is a sequence of LEDGER signals
-  sigGen maxTxs (LedgersEnv slotNo pParams reserves) (LedgerState utxoSt dpSt) = do
+  sigGen ks (LedgersEnv slotNo pParams reserves) (LedgerState utxoSt dpSt) = do
       (_, _, txs') <-
         foldM genAndApplyTx
               (utxoSt, dpSt, [])
-              [0 .. (fromIntegral maxTxs - 1)]
+              [0 .. (fromIntegral maxTxsPerBlock - 1)]
 
       pure $ Seq.fromList (reverse txs') -- reverse Newest first to Oldest first
     where
@@ -81,7 +78,7 @@ instance TQC.HasTrace LEDGERS Word64 where
         -> Gen (UTxOState, DPState, [Tx])
       genAndApplyTx (u, dp, txs) ix = do
         let ledgerEnv = LedgerEnv slotNo ix pParams reserves
-        tx <- genTx_ ledgerEnv (u, dp)
+        tx <- genTx ks ledgerEnv (u, dp)
 
         let res = runShelleyBase $ applySTS @LEDGER (TRC (ledgerEnv, (u, dp), tx))
         pure $ case res of
@@ -94,20 +91,6 @@ instance TQC.HasTrace LEDGERS Word64 where
 
   type BaseEnv LEDGERS = Globals
   interpretSTS globals act = runIdentity $ runReaderT act globals
-
-genTx_
-  :: LedgerEnv
-  -> (UTxOState, DPState)
-  -> Gen Tx
-genTx_ env st =
-  genTx
-    env
-    st
-    traceKeyPairs
-    traceKeyHashMap
-    (traceMSigCombinations $ take numBaseScripts traceMSigScripts)
-    coreNodeKeys
-    traceKeyPairsByStakeHash
 
 -- | Generate initial state for the LEDGER STS using the STS environment.
 --

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -50,8 +50,6 @@ import           Test.Shelley.Spec.Ledger.Generator.Delegation (CertCred (..))
 import           Test.Shelley.Spec.Ledger.Generator.Trace.DCert (genDCerts)
 import           Test.Shelley.Spec.Ledger.Generator.Update (genUpdate)
 
-import           Debug.Trace as D
-
 -- | Generate a new transaction in the context of the LEDGER STS environment and state.
 --
 -- Selects unspent outputs and spends the funds on a some valid addresses.
@@ -98,7 +96,7 @@ genTx (LedgerEnv slot txIx pparams reserves) (utxoSt@(UTxOState utxo _ _ _), dpS
     <- genDCerts keyHashMap pparams dpState slot ttl txIx reserves
 
   if spendingBalance < deposits_
-    then D.trace ("discarded") QC.discard
+    then QC.discard
     else do
 
     -- attempt to make provision for certificate deposits (otherwise discard this generator)
@@ -156,10 +154,7 @@ genTx (LedgerEnv slot txIx pparams reserves) (utxoSt@(UTxOState utxo _ _ _), dpS
 
     -- discard generated transaction if the balance cannot cover the fees
     if minimalFees > balance_
-      then D.trace (  "discarded bc. of real fees, minimal: "
-                   ++ show minimalFees ++ " Output balance: "
-                   ++ show balance_
-                   ) QC.discard
+      then QC.discard
       else do
 
       -- update model transaction with real fees and outputs

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -15,7 +15,6 @@ import qualified Data.ByteString as BS
 import           Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import           Data.Sequence (Seq)
-import           Data.Word (Word64)
 import           Test.QuickCheck (Property, checkCoverage, conjoin, cover, property, withMaxSuccess)
 
 import           Cardano.Binary (serialize')
@@ -42,6 +41,7 @@ import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern DCertDele
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Block, CHAIN, DCert, LEDGER, Tx,
                      TxOut)
 import           Test.Shelley.Spec.Ledger.Generator.Constants (maxCertsPerTx)
+import           Test.Shelley.Spec.Ledger.Generator.Presets (keySpace)
 import           Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
 import           Test.Shelley.Spec.Ledger.Generator.Trace.Ledger (mkGenesisLedgerState)
 import           Test.Shelley.Spec.Ledger.Utils
@@ -49,7 +49,7 @@ import           Test.Shelley.Spec.Ledger.Utils
 relevantCasesAreCovered :: Property
 relevantCasesAreCovered = withMaxSuccess 200 . property $ do
   let tl = 100
-  forAllTraceFromInitState @CHAIN testGlobals tl tl (Just mkGenesisChainState) $ \tr -> do
+  forAllTraceFromInitState @CHAIN testGlobals tl keySpace (Just mkGenesisChainState) $ \tr -> do
     let blockTxs (Block _ (TxSeq txSeq)) = toList txSeq
         bs = traceSignals OldestFirst tr
         txs = concat (blockTxs <$> bs)
@@ -197,7 +197,7 @@ lenRatio f xs
 
 onlyValidLedgerSignalsAreGenerated :: Property
 onlyValidLedgerSignalsAreGenerated = withMaxSuccess 200 $
-    onlyValidSignalsAreGeneratedFromInitState @LEDGER testGlobals 100 (100::Word64) (Just mkGenesisLedgerState)
+    onlyValidSignalsAreGeneratedFromInitState @LEDGER testGlobals 100 keySpace (Just mkGenesisLedgerState)
 
 -- | Check that the abstract transaction size function
 -- actually bounds the number of bytes in the serialized transaction.
@@ -205,7 +205,7 @@ propAbstractSizeBoundsBytes :: Property
 propAbstractSizeBoundsBytes = property $ do
   let tl = 100
       numBytes = toInteger . BS.length . serialize'
-  forAllTraceFromInitState @LEDGER testGlobals tl tl (Just mkGenesisLedgerState) $ \tr -> do
+  forAllTraceFromInitState @LEDGER testGlobals tl keySpace (Just mkGenesisLedgerState) $ \tr -> do
     let txs :: [Tx]
         txs = traceSignals OldestFirst tr
     all (\tx -> txsize tx >= numBytes tx) txs
@@ -223,14 +223,14 @@ propAbstractSizeNotTooBig = property $ do
       acceptableMagnitude = (3 :: Integer)
       numBytes = toInteger . BS.length . serialize'
       notTooBig txb = txsize txb <= acceptableMagnitude * numBytes txb
-  forAllTraceFromInitState @LEDGER testGlobals tl tl (Just mkGenesisLedgerState) $ \tr -> do
+  forAllTraceFromInitState @LEDGER testGlobals tl keySpace (Just mkGenesisLedgerState) $ \tr -> do
     let txs :: [Tx]
         txs = traceSignals OldestFirst tr
     all notTooBig txs
 
 onlyValidChainSignalsAreGenerated :: Property
 onlyValidChainSignalsAreGenerated = withMaxSuccess 100 $
-  onlyValidSignalsAreGeneratedFromInitState @CHAIN testGlobals 100 (100::Word64) (Just mkGenesisChainState)
+  onlyValidSignalsAreGeneratedFromInitState @CHAIN testGlobals 100 keySpace (Just mkGenesisChainState)
 
 epochBoundariesInTrace :: [Block] -> Int
 epochBoundariesInTrace bs

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -24,6 +24,7 @@ import           Shelley.Spec.Ledger.STS.PoolReap (PoolreapState (..))
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN, NEWEPOCH, POOLREAP)
 import           Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
+import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (keySpace)
 import qualified Test.Shelley.Spec.Ledger.Rules.TestNewEpoch as TestNewEpoch
 import qualified Test.Shelley.Spec.Ledger.Rules.TestPoolreap as TestPoolreap
 import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, testGlobals)
@@ -87,7 +88,7 @@ forAllChainTrace
   -> Property
 forAllChainTrace prop =
   withMaxSuccess (fromIntegral numberOfTests) . property $
-    forAllTraceFromInitState testGlobals traceLen traceLen (Just mkGenesisChainState) prop
+    forAllTraceFromInitState testGlobals traceLen Preset.keySpace (Just mkGenesisChainState) prop
 
 -- | Transform CHAIN `sourceSignalTargets`s to POOLREAP ones.
 chainToPoolreapSst

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
@@ -51,6 +51,7 @@ import           Shelley.Spec.Ledger.UTxO (balance)
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DELEG, DELEGS, LEDGER, POOL,
                      StakeCreds, StakePools, UTXO, UTXOW, Wdrl)
 import           Test.Shelley.Spec.Ledger.Generator.Trace.Ledger (mkGenesisLedgerState)
+import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (keySpace)
 import qualified Test.Shelley.Spec.Ledger.Rules.TestDeleg as TestDeleg
 import qualified Test.Shelley.Spec.Ledger.Rules.TestDelegs as TestDelegs
 import qualified Test.Shelley.Spec.Ledger.Rules.TestPool as TestPool
@@ -257,7 +258,7 @@ forAllLedgerTrace
   -> Property
 forAllLedgerTrace prop =
   withMaxSuccess (fromIntegral numberOfTests) . property $
-    forAllTraceFromInitState testGlobals traceLen traceLen (Just mkGenesisLedgerState) prop
+    forAllTraceFromInitState testGlobals traceLen Preset.keySpace (Just mkGenesisLedgerState) prop
 
 -- | Transform LEDGER `sourceSignalTargets`s to DELEG ones.
 ledgerToDelegSsts

--- a/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
@@ -25,6 +25,7 @@ library
                      Test.Shelley.Spec.Ledger.Generator.Constants
                      Test.Shelley.Spec.Ledger.Generator.Core
                      Test.Shelley.Spec.Ledger.Generator.Delegation
+                     Test.Shelley.Spec.Ledger.Generator.Presets
                      Test.Shelley.Spec.Ledger.Generator.Trace.Chain
                      Test.Shelley.Spec.Ledger.Generator.Trace.DCert
                      Test.Shelley.Spec.Ledger.Generator.Trace.Ledger


### PR DESCRIPTION
The various trace tests were using fixed sets of keys, referenced in various places. This made it pretty difficult to use outside of the standard test generators.

This PR unifies the various keys needed during trace generation into a `KeySpace`, which is passed in from the top of the tests.