### PR TITLE
clarify which tau in Praos reference

### DIFF
--- a/byron/cddl-spec/default.nix
+++ b/byron/cddl-spec/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import  ../../default.nix  {}).pkgs
+{ pkgs ? (import  ../../nix/default.nix  {}).pkgs
 }:
 
 with pkgs;

--- a/semantics/formal-spec/default.nix
+++ b/semantics/formal-spec/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import ../../../default.nix {}).pkgs
+{ pkgs ? (import ../../nix/default.nix {}).pkgs
 }:
 
 with pkgs;

--- a/shelley/chain-and-ledger/dependencies/non-integer/doc/default.nix
+++ b/shelley/chain-and-ledger/dependencies/non-integer/doc/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import  ../../../../../default.nix {}).pkgs
+{ pkgs ? (import  ../../../../../nix/default.nix {}).pkgs
 }:
 
 with pkgs;

--- a/shelley/chain-and-ledger/formal-spec/default.nix
+++ b/shelley/chain-and-ledger/formal-spec/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import  ../../../default.nix {}).pkgs
+{ pkgs ? (import  ../../../nix/default.nix {}).pkgs
 }:
 
 with pkgs;

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -166,7 +166,7 @@ without being explicit about the types and conversion.
     \begin{array}{r@{~\in~}lr}
       \SlotsPerEpoch & \N & \text{slots per epoch} \\
       \SlotsPerKESPeriod & \N & \text{slots per KES period} \\
-      \SlotsPrior & \Duration & \tau\text{ in \cite{ouroboros_praos}}\\
+      \SlotsPrior & \Duration & \text{nonce leakage parameter }\tau\text{ in \cite{ouroboros_praos}}\\
       \StartRewards & \Duration & \text{duration to start reward calculations}\\
       \MaxKESEvo & \N & \text{maximum KES key evolutions}\\
       \Quorum & \N & \text{quorum for update system votes}\\

--- a/shelley/design-spec/default.nix
+++ b/shelley/design-spec/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import  ../../default.nix {}).pkgs
+{ pkgs ? (import  ../../nix/default.nix {}).pkgs
 }:
 
 with pkgs;


### PR DESCRIPTION
There are at least two taus in the Praos paper: one is a parameter of the Chain
Growth property and the other is a parameter of the Resettable Leaky Beacon
Functionality. The SlotsPrior global constant refers to the RLB Functionality
parameter.

@JaredCorduan @uroboros, it is the RLB tau, right? Thanks!