### PR TITLE
Abstract over constants.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -34,7 +34,7 @@ let
 
     # Prevents cabal from choosing alternate plans, so that
     # *all* dependencies are provided by Nix.
-    exactDeps = true;
+    exactDeps = false;
 
     inherit withHoogle;
   };

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -38,7 +38,7 @@ import           Shelley.Spec.Ledger.STS.Tick (TickEnv (..))
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Block, ChainState,
                      GenKeyHash, LEDGERS, TICK)
-import           Test.Shelley.Spec.Ledger.Generator.Core (AllPoolKeys (..), KeySpace(..), NatNonce (..),
+import           Test.Shelley.Spec.Ledger.Generator.Core (AllPoolKeys (..), GenEnv(..), KeySpace(..), NatNonce (..),
                      genNatural, getKESPeriodRenewalNo, mkBlock, mkOCert)
 import           Test.Shelley.Spec.Ledger.Generator.Trace.Ledger ()
 import           Test.Shelley.Spec.Ledger.Utils (maxKESIterations, runShelleyBase,
@@ -74,11 +74,11 @@ getPraosSlot start tooFar os nos =
   in List.find (not . (`Map.member` schedules)) [start .. tooFar-1]
 
 genBlock
-  :: KeySpace
+  :: GenEnv
   -> SlotNo
   -> ChainState
   -> Gen Block
-genBlock ks@(KeySpace_ {ksCoreNodes, ksKeyPairsByStakeHash, ksVRFKeyPairsByHash })
+genBlock ge@(GenEnv KeySpace_ {ksCoreNodes, ksKeyPairsByStakeHash, ksVRFKeyPairsByHash } _)
           sNow chainSt = do
   let os = (nesOsched . chainNes) chainSt
       dpstate = (_delegationState . esLState . nesEs . chainNes) chainSt
@@ -213,4 +213,4 @@ genBlock ks@(KeySpace_ {ksCoreNodes, ksKeyPairsByStakeHash, ksVRFKeyPairsByHash 
     genTxs pp reserves ls s = do
       let ledgerEnv = LedgersEnv s pp reserves
 
-      sigGen @LEDGERS ks ledgerEnv ls
+      sigGen @LEDGERS ge ledgerEnv ls

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Constants.hs
@@ -1,147 +1,156 @@
 module Test.Shelley.Spec.Ledger.Generator.Constants
-
+  ( Constants (..)
+  , defaultConstants
+  )
 where
 
 import           Data.Word (Word64)
 import           Numeric.Natural (Natural)
 
--- | minimal number of transaction inputs to select
-minNumGenInputs :: Int
-minNumGenInputs = 1
+data Constants = Constants
+  {
+    -- | minimal number of transaction inputs to select
+    minNumGenInputs :: Int
 
--- | maximal number of transaction inputs to select
-maxNumGenInputs :: Int
-maxNumGenInputs = 10
+    -- | maximal number of transaction inputs to select
+  , maxNumGenInputs :: Int
 
--- | Relative frequency of generated credential registration certificates
-frequencyRegKeyCert :: Int
-frequencyRegKeyCert = 2
+    -- | Relative frequency of generated credential registration certificates
+  , frequencyRegKeyCert :: Int
 
--- | Relative frequency of generated pool registration certificates
-frequencyRegPoolCert :: Int
-frequencyRegPoolCert = 2
+    -- | Relative frequency of generated pool registration certificates
+  , frequencyRegPoolCert :: Int
 
--- | Relative frequency of generated delegation certificates
-frequencyDelegationCert :: Int
-frequencyDelegationCert = 3
+    -- | Relative frequency of generated delegation certificates
+  , frequencyDelegationCert :: Int
 
--- | Relative frequency of generated genesis delegation certificates
-frequencyGenesisDelegationCert :: Int
-frequencyGenesisDelegationCert = 1
+    -- | Relative frequency of generated genesis delegation certificates
+  , frequencyGenesisDelegationCert :: Int
 
--- | Relative frequency of generated credential de-registration certificates
-frequencyDeRegKeyCert :: Int
-frequencyDeRegKeyCert = 1
+    -- | Relative frequency of generated credential de-registration certificates
+  , frequencyDeRegKeyCert :: Int
 
--- | Relative frequency of generated pool retirement certificates
-frequencyRetirePoolCert :: Int
-frequencyRetirePoolCert = 1
+    -- | Relative frequency of generated pool retirement certificates
+  , frequencyRetirePoolCert :: Int
 
--- | Relative frequency of generated MIR certificates
-frequencyMIRCert :: Int
-frequencyMIRCert = 1
+    -- | Relative frequency of generated MIR certificates
+  , frequencyMIRCert :: Int
 
--- | Relative frequency of script credentials in credential registration
--- certificates
-frequencyScriptCredReg :: Int
-frequencyScriptCredReg = 1
+    -- | Relative frequency of script credentials in credential registration
+    -- certificates
+  , frequencyScriptCredReg :: Int
 
--- | Relative frequency of key credentials in credential registration
--- certificates
-frequencyKeyCredReg :: Int
-frequencyKeyCredReg = 2
+    -- | Relative frequency of key credentials in credential registration
+    -- certificates
+  , frequencyKeyCredReg :: Int
 
--- | Relative frequency of script credentials in credential de-registration
--- certificates
-frequencyScriptCredDeReg :: Int
-frequencyScriptCredDeReg = 1
+    -- | Relative frequency of script credentials in credential de-registration
+    -- certificates
+  , frequencyScriptCredDeReg :: Int
 
--- | Relative frequency of key credentials in credential de-registration
--- certificates
-frequencyKeyCredDeReg :: Int
-frequencyKeyCredDeReg = 2
+    -- | Relative frequency of key credentials in credential de-registration
+    -- certificates
+  , frequencyKeyCredDeReg :: Int
 
--- | Relative frequency of script credentials in credential delegation
--- certificates
-frequencyScriptCredDelegation :: Int
-frequencyScriptCredDelegation = 1
+    -- | Relative frequency of script credentials in credential delegation
+    -- certificates
+  , frequencyScriptCredDelegation :: Int
 
--- | Relative frequency of key credentials in credential delegation
--- certificates
-frequencyKeyCredDelegation :: Int
-frequencyKeyCredDelegation = 2
+    -- | Relative frequency of key credentials in credential delegation
+    -- certificates
+  , frequencyKeyCredDelegation :: Int
 
--- | Relative frequency of Prototol/Application Updates in a transaction
-frequencyTxUpdates :: Int
-frequencyTxUpdates = 10
+    -- | Relative frequency of Prototol/Application Updates in a transaction
+  , frequencyTxUpdates :: Int
 
--- | minimal number of genesis UTxO outputs
-minGenesisUTxOouts :: Int
-minGenesisUTxOouts = 10
+    -- | minimal number of genesis UTxO outputs
+  , minGenesisUTxOouts :: Int
 
--- | maximal number of genesis UTxO outputs
-maxGenesisUTxOouts :: Int
-maxGenesisUTxOouts = 100
+    -- | maximal number of genesis UTxO outputs
+  , maxGenesisUTxOouts :: Int
 
--- | maximal number of certificates per transaction
-maxCertsPerTx :: Word64
-maxCertsPerTx = 1
+    -- | maximal number of certificates per transaction
+  , maxCertsPerTx :: Word64
 
--- | maximal number of Txs per block
-maxTxsPerBlock :: Word64
-maxTxsPerBlock = 10
+    -- | maximal number of Txs per block
+  , maxTxsPerBlock :: Word64
 
--- | maximal numbers of generated keypairs
-maxNumKeyPairs :: Word64
-maxNumKeyPairs = 150
+    -- | maximal numbers of generated keypairs
+  , maxNumKeyPairs :: Word64
 
--- | minimal coin value for generated genesis outputs
-minGenesisOutputVal :: Integer
-minGenesisOutputVal = 1000000
+    -- | minimal coin value for generated genesis outputs
+  , minGenesisOutputVal :: Integer
 
--- | maximal coin value for generated genesis outputs
-maxGenesisOutputVal :: Integer
-maxGenesisOutputVal = 100000000
+    -- | maximal coin value for generated genesis outputs
+  , maxGenesisOutputVal :: Integer
 
--- | Number of base scripts from which multi sig scripts are built.
-numBaseScripts :: Int
-numBaseScripts = 3
+    -- | Number of base scripts from which multi sig scripts are built.
+  , numBaseScripts :: Int
 
--- | Relative frequency that a transaction does not include any reward withdrawals
-frequencyNoWithdrawals :: Int
-frequencyNoWithdrawals = 75
+    -- | Relative frequency that a transaction does not include any reward withdrawals
+  , frequencyNoWithdrawals :: Int
 
--- | Relative frequency that a transaction includes a small number of
--- reward withdrawals, bounded by 'maxAFewWithdrawals'.
-frequencyAFewWithdrawals :: Int
-frequencyAFewWithdrawals = 20
+    -- | Relative frequency that a transaction includes a small number of
+    -- reward withdrawals, bounded by 'maxAFewWithdrawals'.
+  , frequencyAFewWithdrawals :: Int
 
--- | Maximum number of reward withdrawals that counts as a small number.
-maxAFewWithdrawals :: Int
-maxAFewWithdrawals = 10
+    -- | Maximum number of reward withdrawals that counts as a small number.
+  , maxAFewWithdrawals :: Int
 
--- | Relative frequency that a transaction includes any positive number of
--- reward withdrawals
-frequencyPotentiallyManyWithdrawals :: Int
-frequencyPotentiallyManyWithdrawals = 5
+    -- | Relative frequency that a transaction includes any positive number of
+    -- reward withdrawals
+  , frequencyPotentiallyManyWithdrawals :: Int
 
--- | Minimal slot for CHAIN trace generation.
-minSlotTrace :: Int
-minSlotTrace = 1000
+    -- | Minimal slot for CHAIN trace generation.
+  , minSlotTrace :: Int
 
--- | Maximal slot for CHAIN trace generation.
-maxSlotTrace :: Int
-maxSlotTrace = 5000
+    -- | Maximal slot for CHAIN trace generation.
+  , maxSlotTrace :: Int
 
--- | Lower bound of the MaxEpoch protocol parameter
-frequencyLowMaxEpoch :: Word64
-frequencyLowMaxEpoch = 6
+    -- | Lower bound of the MaxEpoch protocol parameter
+  , frequencyLowMaxEpoch :: Word64
 
-maxMinFeeA :: Natural
-maxMinFeeA = 1000
+  , maxMinFeeA :: Natural
 
-maxMinFeeB :: Natural
-maxMinFeeB = 3
+  , maxMinFeeB :: Natural
 
-numCoreNodes :: Word64
-numCoreNodes = 7
+  , numCoreNodes :: Word64
+  } deriving Show
+
+defaultConstants :: Constants
+defaultConstants = Constants
+  { minNumGenInputs = 1
+  , maxNumGenInputs = 10
+  , frequencyRegKeyCert = 2
+  , frequencyRegPoolCert = 2
+  , frequencyDelegationCert = 3
+  , frequencyGenesisDelegationCert = 1
+  , frequencyDeRegKeyCert = 1
+  , frequencyRetirePoolCert = 1
+  , frequencyMIRCert = 1
+  , frequencyScriptCredReg = 1
+  , frequencyKeyCredReg = 2
+  , frequencyScriptCredDeReg = 1
+  , frequencyKeyCredDeReg = 2
+  , frequencyScriptCredDelegation = 1
+  , frequencyKeyCredDelegation = 2
+  , frequencyTxUpdates = 10
+  , minGenesisUTxOouts = 10
+  , maxGenesisUTxOouts = 100
+  , maxCertsPerTx = 1
+  , maxTxsPerBlock = 10
+  , maxNumKeyPairs = 150
+  , minGenesisOutputVal = 1000000
+  , maxGenesisOutputVal = 100000000
+  , numBaseScripts = 3
+  , frequencyNoWithdrawals = 75
+  , frequencyAFewWithdrawals = 20
+  , maxAFewWithdrawals = 10
+  , frequencyPotentiallyManyWithdrawals = 5
+  , minSlotTrace = 1000
+  , maxSlotTrace = 5000
+  , frequencyLowMaxEpoch = 6
+  , maxMinFeeA = 1000
+  , maxMinFeeB = 3
+  , numCoreNodes = 7
+  }

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -8,6 +8,7 @@
 
 module Test.Shelley.Spec.Ledger.Generator.Core
   ( AllPoolKeys (..)
+  , GenEnv(..)
   , KeySpace(..)
   , pattern KeySpace
   , NatNonce (..)
@@ -83,7 +84,7 @@ import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, AnyKeyHash,
                      Credential, HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig,
                      MultiSigPairs, OCert, SKeyES, SignKeyVRF, Tx, TxOut, VKey, VKeyES,
                      VRFKeyHash, VerKeyVRF, hashKeyVRF)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (maxGenesisOutputVal, minGenesisOutputVal)
+import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants(..))
 import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, evolveKESUntil, maxKESIterations,
                      maxLLSupply, mkCertifiedVRF, mkGenKey, mkKeyPair,
                      runShelleyBase, unsafeMkUnitInterval)
@@ -94,6 +95,12 @@ data AllPoolKeys = AllPoolKeys
   , hot :: [(KESPeriod, (SKeyES, VKeyES))]
   , hk  :: KeyHash
   } deriving (Show)
+
+-- | Generator environment.
+data GenEnv = GenEnv
+  { geKeySpace :: KeySpace
+  , geConstants :: Constants
+  }
 
 -- | Collection of all keys which are required to generate a trace.
 --
@@ -281,8 +288,8 @@ pickStakeKey keys = vKey . snd <$> QC.elements keys
 -- Note: we need to keep the initial utxo coin sizes large enough so that
 -- when we simulate sequences of transactions, we have enough funds available
 -- to include certificates that require deposits.
-genTxOut :: HasCallStack => [Addr] -> Gen [TxOut]
-genTxOut addrs = do
+genTxOut :: HasCallStack => Constants -> [Addr] -> Gen [TxOut]
+genTxOut Constants {maxGenesisOutputVal, minGenesisOutputVal} addrs = do
   ys <- genCoinList minGenesisOutputVal maxGenesisOutputVal (length addrs) (length addrs)
   return (uncurry TxOut <$> zip addrs ys)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -22,9 +22,10 @@ import           Shelley.Spec.Ledger.LedgerState (pattern DPState, esAccountStat
 import           Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import           Shelley.Spec.Ledger.STS.PoolReap (PoolreapState (..))
 
+import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv(geConstants))
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN, NEWEPOCH, POOLREAP)
 import           Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
-import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (keySpace)
+import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (genEnv)
 import qualified Test.Shelley.Spec.Ledger.Rules.TestNewEpoch as TestNewEpoch
 import qualified Test.Shelley.Spec.Ledger.Rules.TestPoolreap as TestPoolreap
 import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, testGlobals)
@@ -88,7 +89,7 @@ forAllChainTrace
   -> Property
 forAllChainTrace prop =
   withMaxSuccess (fromIntegral numberOfTests) . property $
-    forAllTraceFromInitState testGlobals traceLen Preset.keySpace (Just mkGenesisChainState) prop
+    forAllTraceFromInitState testGlobals traceLen Preset.genEnv (Just $ mkGenesisChainState (geConstants Preset.genEnv)) prop
 
 -- | Transform CHAIN `sourceSignalTargets`s to POOLREAP ones.
 chainToPoolreapSst

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
@@ -51,7 +51,8 @@ import           Shelley.Spec.Ledger.UTxO (balance)
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DELEG, DELEGS, LEDGER, POOL,
                      StakeCreds, StakePools, UTXO, UTXOW, Wdrl)
 import           Test.Shelley.Spec.Ledger.Generator.Trace.Ledger (mkGenesisLedgerState)
-import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (keySpace)
+import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv(geConstants))
+import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (genEnv)
 import qualified Test.Shelley.Spec.Ledger.Rules.TestDeleg as TestDeleg
 import qualified Test.Shelley.Spec.Ledger.Rules.TestDelegs as TestDelegs
 import qualified Test.Shelley.Spec.Ledger.Rules.TestPool as TestPool
@@ -258,7 +259,7 @@ forAllLedgerTrace
   -> Property
 forAllLedgerTrace prop =
   withMaxSuccess (fromIntegral numberOfTests) . property $
-    forAllTraceFromInitState testGlobals traceLen Preset.keySpace (Just mkGenesisLedgerState) prop
+    forAllTraceFromInitState testGlobals traceLen Preset.genEnv (Just $ mkGenesisLedgerState (geConstants Preset.genEnv)) prop
 
 -- | Transform LEDGER `sourceSignalTargets`s to DELEG ones.
 ledgerToDelegSsts


### PR DESCRIPTION
Second step of abstracting over things in the tests. We now pull out the various constants which guide test generation. Needed for integration into ouroboros-consensus testing.