### PR TITLE
Formal Spec - unpack NES state in NEWEPOCH rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ following links:
 - [Byron Ledger Specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/byronLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec)
 - [Byron blocks CDDL specification](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/blocksCDDLSpec/latest/download-by-type/doc-pdf/binary)
 - [Explanation of the Small-step-semantics Framework](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/semanticsSpec/latest/download-by-type/doc-pdf/semantics-spec)
-- [Simple Script-Based Multi-Signature Scheme](https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/shelleyLedgerSpec/latest/download-by-type/doc-pdf/multi-sig)
 
 In addition, there is a formalization of the Ledger Specification in Isabelle/HOL which can be found [here](https://github.com/input-output-hk/fm-ledger-formalization).
 

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -542,6 +542,8 @@ In the first case, the new epoch state is updated as follows:
   \begin{equation}\label{eq:not-new-epoch}
     \inference[Not-New-Epoch]
     {
+      (e_\ell,~\wcard,~\wcard,~\wcard,~\wcard,~\wcard,~\wcard)\leteq\var{nes}
+      &
       e \neq e_\ell + 1
     }
     {
@@ -558,6 +560,8 @@ In the first case, the new epoch state is updated as follows:
   \begin{equation}\label{eq:no-reward-update}
     \inference[No-Reward-Update]
     {
+      (e_\ell,~\wcard,~\wcard,~\wcard,~\var{ru},~\wcard,~\wcard)\leteq\var{nes}
+      &
       e = e_\ell + 1
       &
       \var{ru} = \Nothing


### PR DESCRIPTION
Micro PR :microscope: 

1) Unpack the `nes` variable in the `NEWEPOCH` rules
1) Remove the broken standalone multi-sig document link from the README. The document still builds, but it has been incorporated into the main spec and is no longer being built in hydra. The document can still be built, however (I waffled on whether or not to delete it...).