### PR TITLE
better address types for symmetry

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address.hs
@@ -19,7 +19,8 @@ import           Shelley.Spec.Ledger.Crypto
 import           Shelley.Spec.Ledger.Keys (KeyDiscriminator (..), KeyPair, hashKey, vKey)
 import           Shelley.Spec.Ledger.Scripts
 import           Shelley.Spec.Ledger.Tx (hashScript)
-import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), RewardAcnt (..))
+import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), RewardAcnt (..),
+                     StakeReference (..))
 
 mkVKeyRwdAcnt
   :: Crypto crypto
@@ -37,7 +38,7 @@ toAddr
   :: Crypto crypto
   => (KeyPair 'Regular crypto, KeyPair 'Regular crypto)
   -> Addr crypto
-toAddr (payKey, stakeKey) = AddrBase (toCred payKey) (toCred stakeKey)
+toAddr (payKey, stakeKey) = Addr (toCred payKey) (StakeRefBase $ toCred stakeKey)
 
 toCred
   :: Crypto crypto
@@ -53,7 +54,7 @@ scriptToCred = ScriptHashObj . hashScript
 -- | Create a base address from a pair of multi-sig scripts (pay and stake)
 scriptsToAddr :: Crypto crypto => (MultiSig crypto, MultiSig crypto) -> Addr crypto
 scriptsToAddr (payScript, stakeScript) =
-  AddrBase (scriptToCred payScript) (scriptToCred stakeScript)
+  Addr (scriptToCred payScript) (StakeRefBase $ scriptToCred stakeScript)
 
 -- | Serialise an address to the external format.
 --
@@ -75,4 +76,3 @@ serialiseAddr = serialize'
 --
 deserialiseAddr :: Crypto crypto => ByteString -> Maybe (Addr crypto)
 deserialiseAddr = either (const Nothing) id . decodeFull'
-

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -37,7 +37,7 @@ import           Shelley.Spec.Ledger.Keys (KeyHash)
 import           Shelley.Spec.Ledger.PParams (PParams, _a0, _nOpt)
 import           Shelley.Spec.Ledger.Slot (SlotNo, (-*))
 import           Shelley.Spec.Ledger.TxData (Addr (..), Credential, PoolParams, Ptr, RewardAcnt,
-                     TxOut (..), getRwdCred)
+                     StakeReference (..), TxOut (..), getRwdCred)
 import           Shelley.Spec.Ledger.UTxO (UTxO (..))
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
@@ -73,8 +73,8 @@ newtype Stake crypto
 
 -- | Extract hash of staking key from base address.
 getStakeHK :: Addr crypto -> Maybe (Credential crypto)
-getStakeHK (AddrBase _ hk) = Just hk
-getStakeHK _               = Nothing
+getStakeHK (Addr _ (StakeRefBase hk)) = Just hk
+getStakeHK _                          = Nothing
 
 aggregateOuts :: UTxO crypto -> Map (Addr crypto) Coin
 aggregateOuts (UTxO u) =
@@ -95,7 +95,7 @@ baseStake vals =
 
 -- | Extract pointer from pointer address.
 getStakePtr :: Addr crypto -> Maybe Ptr
-getStakePtr (AddrPtr _ ptr) = Just ptr
+getStakePtr (Addr _ (StakeRefPtr ptr)) = Just ptr
 getStakePtr _               = Nothing
 
 -- | Calculate stake of pointer addresses in TxOut set.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -813,8 +813,8 @@ witsVKeyNeeded utxo' tx@(Tx txbody _ _ _) _genDelegs =
     inputAuthors = undiscriminateKeyHash `Set.map` Set.foldr insertHK Set.empty (_inputs txbody)
     insertHK txin hkeys =
       case txinLookup txin utxo' of
-        Just (TxOut (AddrBase (KeyHashObj pay) _) _) -> Set.insert pay hkeys
-        _                               -> hkeys
+        Just (TxOut (Addr (KeyHashObj pay) _) _) -> Set.insert pay hkeys
+        _                                        -> hkeys
 
     wdrlAuthors =
       Set.fromList $ extractKeyHash $ map getRwdCred (Map.keys (unWdrl $ _wdrls txbody))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/UTxO.hs
@@ -195,10 +195,8 @@ txup (Tx txbody _ _ _) = strictMaybeToMaybe (_txUpdate txbody)
 
 -- | Extract script hash from value address with script.
 getScriptHash :: Addr crypto -> Maybe (ScriptHash crypto)
-getScriptHash (AddrBase (ScriptHashObj hs) _)     = Just hs
-getScriptHash (AddrPtr (ScriptHashObj hs) _)      = Just hs
-getScriptHash (AddrEnterprise (ScriptHashObj hs)) = Just hs
-getScriptHash _                                   = Nothing
+getScriptHash (Addr (ScriptHashObj hs) _) = Just hs
+getScriptHash _                           = Nothing
 
 scriptStakeCred
   :: DCert crypto
@@ -243,7 +241,5 @@ txinsScript txInps (UTxO u) =
   txInps `Set.intersection`
   Map.keysSet (Map.filter (\(TxOut a _) ->
                                case a of
-                                 AddrBase (ScriptHashObj _) _     -> True
-                                 AddrEnterprise (ScriptHashObj _) -> True
-                                 AddrPtr (ScriptHashObj _) _      -> True
+                                 Addr (ScriptHashObj _) _     -> True
                                  _                                -> False) u)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -10,8 +10,8 @@ import           Cardano.Crypto.Hash (ShortHash)
 import           Cardano.Crypto.KES (MockKES)
 import           Test.Cardano.Crypto.VRF.Fake (FakeVRF)
 
-import           Shelley.Spec.Ledger.Crypto
 import qualified Shelley.Spec.Ledger.BlockChain as BlockChain
+import           Shelley.Spec.Ledger.Crypto
 import qualified Shelley.Spec.Ledger.Delegation.Certificates as Delegation.Certificates
 import qualified Shelley.Spec.Ledger.EpochBoundary as EpochBoundary
 import qualified Shelley.Spec.Ledger.Keys as Keys
@@ -94,6 +94,8 @@ type DState = LedgerState.DState ConcreteCrypto
 type PState = LedgerState.PState ConcreteCrypto
 
 type DPState = LedgerState.DPState ConcreteCrypto
+
+type StakeReference = TxData.StakeReference ConcreteCrypto
 
 type Addr = TxData.Addr ConcreteCrypto
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -152,10 +152,10 @@ import           Shelley.Spec.Ledger.STS.Ledgers (pattern LedgerFailure)
 import           Shelley.Spec.Ledger.STS.Utxow (pattern MIRImpossibleInDecentralizedNetUTXOW,
                      pattern MIRInsufficientGenesisSigsUTXOW)
 import           Shelley.Spec.Ledger.Tx (pattern Tx)
-import           Shelley.Spec.Ledger.TxData (pattern AddrPtr, pattern DCertDeleg,
-                     pattern DCertGenesis, pattern DCertMir, pattern DCertPool, pattern Delegation,
-                     pattern KeyHashObj, PoolMetaData (..), pattern PoolParams, Ptr (..),
-                     pattern RewardAcnt, pattern StakeCreds, pattern StakePools, pattern TxBody,
+import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern DCertDeleg, pattern DCertGenesis,
+                     pattern DCertMir, pattern DCertPool, pattern Delegation, pattern KeyHashObj,
+                     PoolMetaData (..), pattern PoolParams, Ptr (..), pattern RewardAcnt,
+                     pattern StakeCreds, pattern StakePools, pattern StakeRefPtr, pattern TxBody,
                      pattern TxIn, pattern TxOut, Url (..), Wdrl (..), addStakeCreds, _poolCost,
                      _poolMD, _poolMDHash, _poolMDUrl, _poolMargin, _poolOwners, _poolPledge,
                      _poolPubKey, _poolRAcnt, _poolRelays, _poolVrf)
@@ -513,7 +513,7 @@ txEx2A = Tx
 
 -- | Pointer address to address of Alice address.
 alicePtrAddr :: Addr
-alicePtrAddr = AddrPtr (KeyHashObj . hashKey $ vKey alicePay) (Ptr (SlotNo 10) 0 0)
+alicePtrAddr = Addr (KeyHashObj . hashKey $ vKey alicePay) (StakeRefPtr $ Ptr (SlotNo 10) 0 0)
 
 utxostEx2A :: UTxOState
 utxostEx2A = UTxOState utxoEx2A (Coin 0) (Coin 0) emptyPPPUpdates

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
@@ -32,9 +32,10 @@ import           Shelley.Spec.Ledger.Scripts (pattern RequireAllOf, pattern Requ
 import           Shelley.Spec.Ledger.Slot (SlotNo (..))
 import           Shelley.Spec.Ledger.STS.Utxo (UtxoEnv (..))
 import           Shelley.Spec.Ledger.Tx (pattern Tx, hashScript, _body)
-import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern KeyHashObj,
-                     pattern ScriptHashObj, pattern StakeCreds, pattern StakePools, pattern TxBody,
-                     pattern TxIn, pattern TxOut, pattern Wdrl, unWdrl)
+import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj,
+                     pattern ScriptHashObj, pattern StakeCreds, pattern StakePools,
+                     pattern StakeRefBase, pattern TxBody, pattern TxIn, pattern TxOut,
+                     pattern Wdrl, unWdrl)
 import           Shelley.Spec.Ledger.UTxO (makeWitnessesVKey, txid)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, KeyPair, LedgerState, MultiSig,
@@ -47,7 +48,7 @@ import           Test.Shelley.Spec.Ledger.Utils
 
 -- Multi-signature scripts
 singleKeyOnly :: Addr -> MultiSig
-singleKeyOnly (AddrBase (KeyHashObj pk) _ ) = RequireSignature $ undiscriminateKeyHash pk
+singleKeyOnly (Addr (KeyHashObj pk) _ ) = RequireSignature $ undiscriminateKeyHash pk
 singleKeyOnly _ = error "use VKey address"
 
 aliceOnly :: MultiSig
@@ -131,9 +132,9 @@ initialUTxOState aliceKeep msigs =
   let addresses =
         [(aliceAddr, aliceKeep) | aliceKeep > 0] ++
         map (\(msig, c) ->
-               (AddrBase
+               (Addr
                 (ScriptHashObj $ hashScript msig)
-                (ScriptHashObj $ hashScript msig), c)) msigs
+                (StakeRefBase $ ScriptHashObj $ hashScript msig), c)) msigs
   in
   let tx = makeTx (initTxBody addresses)
                   [alicePay, bobPay]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
@@ -21,10 +21,11 @@ import           Shelley.Spec.Ledger.BlockChain (checkVRFValue)
 import           Shelley.Spec.Ledger.Coin
 import           Shelley.Spec.Ledger.Delegation.Certificates (pattern Delegate, pattern RegKey,
                      pattern RegPool, pattern RetirePool, StakeCreds (..), StakePools (..))
-import           Shelley.Spec.Ledger.TxData (pattern AddrBase, Credential (..), pattern DCertDeleg,
+import           Shelley.Spec.Ledger.TxData (pattern Addr, Credential (..), pattern DCertDeleg,
                      pattern DCertPool, Delegation (..), pattern PoolParams, pattern Ptr,
-                     pattern RewardAcnt, Wdrl (..), _poolCost, _poolMD, _poolMargin, _poolOwners,
-                     _poolPledge, _poolPubKey, _poolRAcnt, _poolRelays, _poolVrf)
+                     pattern RewardAcnt, pattern StakeRefBase, Wdrl (..), _poolCost, _poolMD,
+                     _poolMargin, _poolOwners, _poolPledge, _poolPubKey, _poolRAcnt, _poolRelays,
+                     _poolVrf)
 import           Shelley.Spec.Ledger.Validation (ValidationError (..))
 
 import           Shelley.Spec.Ledger.Keys (pattern KeyPair, hashKey, vKey)
@@ -53,9 +54,9 @@ aliceStake :: KeyPair
 aliceStake = KeyPair 2 2
 
 aliceAddr :: Addr
-aliceAddr = AddrBase
+aliceAddr = Addr
              (KeyHashObj . hashKey $ vKey alicePay)
-             (KeyHashObj . hashKey $ vKey aliceStake)
+             (StakeRefBase . KeyHashObj . hashKey $ vKey aliceStake)
 
 bobPay :: KeyPair
 bobPay = KeyPair 3 3
@@ -64,9 +65,9 @@ bobStake :: KeyPair
 bobStake = KeyPair 4 4
 
 bobAddr :: Addr
-bobAddr = AddrBase
+bobAddr = Addr
            (KeyHashObj . hashKey $ vKey bobPay)
-           (KeyHashObj . hashKey $ vKey bobStake)
+           (StakeRefBase . KeyHashObj . hashKey $ vKey bobStake)
 
 testPCs :: PParams
 testPCs = emptyPParams {

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -67,8 +67,8 @@ import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), UnitInterval, epochI
 import           Shelley.Spec.Ledger.BlockChain (pattern BHBody, pattern BHeader, pattern Block,
                      pattern BlockHash, TxSeq (..), bBodySize, bbHash, mkSeed, seedEta, seedL)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Keys (pattern KeyPair, hashAnyKey, hashKey, sign,
-                     signKES, undiscriminateKeyHash, vKey)
+import           Shelley.Spec.Ledger.Keys (pattern KeyPair, hashAnyKey, hashKey, sign, signKES,
+                     undiscriminateKeyHash, vKey)
 import           Shelley.Spec.Ledger.LedgerState (AccountState (..))
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..), pattern OCert)
 import           Shelley.Spec.Ledger.PParams (ProtVer (..))
@@ -77,17 +77,17 @@ import           Shelley.Spec.Ledger.Scripts (pattern RequireAllOf, pattern Requ
 import           Shelley.Spec.Ledger.Slot (BlockNo (..), Duration (..), SlotNo (..), epochInfoFirst,
                      (*-))
 import           Shelley.Spec.Ledger.Tx (pattern TxOut, hashScript)
-import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern AddrPtr, pattern KeyHashObj,
-                     pattern ScriptHashObj)
+import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj,
+                     pattern ScriptHashObj, pattern StakeRefBase, pattern StakeRefPtr)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, AnyKeyHash, Block, CoreKeyPair,
-                     Credential, HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig,
-                     MultiSigPairs, OCert, SKeyES, SignKeyVRF, Tx, TxOut, VKey, VKeyES,
-                     VRFKeyHash, VerKeyVRF, hashKeyVRF)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants(..))
+                     Credential, HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig, MultiSigPairs,
+                     OCert, SKeyES, SignKeyVRF, Tx, TxOut, VKey, VKeyES, VRFKeyHash, VerKeyVRF,
+                     hashKeyVRF)
+import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
 import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, evolveKESUntil, maxKESIterations,
-                     maxLLSupply, mkCertifiedVRF, mkGenKey, mkKeyPair,
-                     runShelleyBase, unsafeMkUnitInterval)
+                     maxLLSupply, mkCertifiedVRF, mkGenKey, mkKeyPair, runShelleyBase,
+                     unsafeMkUnitInterval)
 
 data AllPoolKeys = AllPoolKeys
   { cold :: KeyPair
@@ -238,10 +238,10 @@ findPayKeyPairCred c keyHashMap =
 findPayKeyPairAddr :: HasCallStack => Addr -> Map AnyKeyHash KeyPair -> KeyPair
 findPayKeyPairAddr a keyHashMap =
   case a of
-    AddrBase addr _ -> findPayKeyPairCred addr keyHashMap
-    AddrPtr addr _  -> findPayKeyPairCred addr keyHashMap
+    Addr addr (StakeRefBase _) -> findPayKeyPairCred addr keyHashMap
+    Addr addr (StakeRefPtr _)  -> findPayKeyPairCred addr keyHashMap
     _                            ->
-      error "findPayKeyPairAddr: expects only AddrBase or AddrPtr addresses"
+      error "findPayKeyPairAddr: expects only Base or Ptr addresses"
 
 -- | Find first matching script for a credential.
 findPayScriptFromCred :: HasCallStack => Credential -> MultiSigPairs -> (MultiSig, MultiSig)
@@ -274,8 +274,8 @@ findStakeScriptFromCred c scripts =
 findPayScriptFromAddr :: HasCallStack => Addr -> MultiSigPairs -> (MultiSig, MultiSig)
 findPayScriptFromAddr a scripts =
   case a of
-    AddrBase scriptHash _ -> findPayScriptFromCred scriptHash scripts
-    AddrPtr scriptHash _  -> findPayScriptFromCred scriptHash scripts
+    Addr scriptHash (StakeRefBase _) -> findPayScriptFromCred scriptHash scripts
+    Addr scriptHash (StakeRefPtr _)  -> findPayScriptFromCred scriptHash scripts
     _                     ->
       error "findPayScriptFromAddr: expects only base and pointer script addresses"
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -12,18 +12,16 @@ module Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
   , propAbstractSizeNotTooBig)
   where
 
-import qualified Data.ByteString as BS
-import           Data.Foldable (toList)
-import qualified Data.Map.Strict as Map
-import           Data.Sequence.Strict (StrictSeq)
-import           Test.QuickCheck (Property, checkCoverage, conjoin, cover, property, withMaxSuccess)
-import qualified Test.QuickCheck.Gen
 import           Cardano.Binary (serialize')
 import           Cardano.Slotting.Slot (EpochSize (..))
 import           Control.State.Transition.Trace (TraceOrder (OldestFirst), traceLength,
                      traceSignals)
 import           Control.State.Transition.Trace.Generator.QuickCheck (classifyTraceLength,
                      forAllTraceFromInitState, onlyValidSignalsAreGeneratedFromInitState)
+import qualified Data.ByteString as BS
+import           Data.Foldable (toList)
+import qualified Data.Map.Strict as Map
+import           Data.Sequence.Strict (StrictSeq)
 import           Shelley.Spec.Ledger.BaseTypes (Globals (epochInfo), StrictMaybe (..))
 import           Shelley.Spec.Ledger.BlockChain (pattern Block, pattern TxSeq, bhbody,
                      bheaderSlotNo)
@@ -35,19 +33,21 @@ import           Shelley.Spec.Ledger.PParams (PParamsUpdate, pattern ProposedPPU
                      pattern Update)
 import           Shelley.Spec.Ledger.Slot (SlotNo (..), epochInfoSize)
 import           Shelley.Spec.Ledger.Tx (_body)
-import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern DCertDeleg, pattern DeRegKey,
+import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern DCertDeleg, pattern DeRegKey,
                      pattern Delegate, pattern Delegation, pattern RegKey, pattern ScriptHashObj,
                      pattern TxOut, Wdrl (..), _certs, _outputs, _txUpdate, _wdrls)
+import           Test.QuickCheck (Property, checkCoverage, conjoin, cover, property, withMaxSuccess)
+import qualified Test.QuickCheck.Gen
 
-import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv(..))
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (ChainState, Block, CHAIN, DCert, LEDGER, Tx,
-                     TxOut, DPState, UTxOState)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants(..))
+import qualified Control.State.Transition.Extended
+import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Block, CHAIN, ChainState, DCert,
+                     DPState, LEDGER, Tx, TxOut, UTxOState)
+import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..))
 import           Test.Shelley.Spec.Ledger.Generator.Presets (genEnv)
 import           Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
 import           Test.Shelley.Spec.Ledger.Generator.Trace.Ledger (mkGenesisLedgerState)
 import           Test.Shelley.Spec.Ledger.Utils
-import qualified Control.State.Transition.Extended
 
 
 
@@ -208,7 +208,7 @@ txScriptOutputsRatio txoutsList =
    (sum (map length txoutsList))
   where countScriptOuts txouts =
           sum $ fmap (\case
-                        TxOut (AddrBase (ScriptHashObj _) _) _ -> 1
+                        TxOut (Addr (ScriptHashObj _) _) _ -> 1
                         _ -> 0) txouts
 
 -- | Transaction has a reward withdrawal

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
@@ -39,7 +39,7 @@ import           Shelley.Spec.Ledger.Keys (pattern SKey, pattern SKeyES, pattern
                      pattern VKeyES, pattern VKeyGenesis, hashKey, updateKESKey, vKey)
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import           Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
-import           Shelley.Spec.Ledger.TxData (pattern AddrBase, pattern KeyHashObj)
+import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj, pattern StakeRefBase)
 
 import           Test.Cardano.Crypto.VRF.Fake (WithResult (..))
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, CertifiedVRF, KeyPair, SKey,
@@ -86,8 +86,8 @@ mkKESKeyPair seed = fst . withDRG (drgNewTest seed) $ do
 
 mkAddr :: (KeyPair, KeyPair) -> Addr
 mkAddr (payKey, stakeKey) =
-  AddrBase (KeyHashObj . hashKey $ vKey payKey)
-           (KeyHashObj . hashKey $ vKey stakeKey)
+  Addr (KeyHashObj . hashKey $ vKey payKey)
+       (StakeRefBase . KeyHashObj . hashKey $ vKey stakeKey)
 
 -- | You vouch that argument is in [0; 1].
 unsafeMkUnitInterval :: Rational -> UnitInterval


### PR DESCRIPTION
Addresses are now either a pair of a payment credential and a stake reference (which can be null), or a bootstrap address.

Note that the serialization is the same, we will overhaul the binary format soon.

closes #1364 