### PR TITLE
Derive NFData instances and export VKey and VKeyGenesis patterns as data constructors

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -81,7 +81,7 @@ import           Cardano.Crypto.KES (KESAlgorithm (SignKeyKES, VerKeyKES, curren
 import qualified Cardano.Crypto.KES as KES
 import           Cardano.Crypto.VRF (VRFAlgorithm (VerKeyVRF))
 import qualified Cardano.Crypto.VRF as VRF
-import           Cardano.Prelude (NoUnexpectedThunks (..))
+import           Cardano.Prelude (NFData, NoUnexpectedThunks (..))
 import           Shelley.Spec.Ledger.BaseTypes (Nonce, UnitInterval, mkNonce, truncateUnitInterval)
 
 -- | Discriminate between keys based on their usage in the system.
@@ -92,6 +92,7 @@ data KeyDiscriminator
 
 newtype SKey crypto = SKey (SignKeyDSIGN (DSIGN crypto))
 
+deriving instance (Crypto crypto, NFData (SignKeyDSIGN (DSIGN crypto))) => NFData (SKey crypto)
 deriving instance Crypto crypto => NoUnexpectedThunks (SKey crypto)
 
 deriving instance Crypto crypto => Show (SKey crypto)
@@ -103,6 +104,7 @@ newtype DiscVKey (kd :: KeyDiscriminator) crypto = DiscVKey (VerKeyDSIGN (DSIGN 
 deriving instance Crypto crypto => Show (DiscVKey kd crypto)
 deriving instance Crypto crypto => Eq   (DiscVKey kd crypto)
 deriving instance Num (VerKeyDSIGN (DSIGN crypto)) => Num (DiscVKey kd crypto)
+deriving instance (Crypto crypto, NFData (VerKeyDSIGN (DSIGN crypto))) => NFData (DiscVKey kd crypto)
 deriving instance Crypto crypto => NoUnexpectedThunks (DiscVKey kd crypto)
 
 instance (Crypto crypto, Typeable kd) => FromCBOR (DiscVKey kd crypto) where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -19,11 +19,9 @@ module Shelley.Spec.Ledger.Keys
   , DSIGNAlgorithm
   , Signable
   , SKey(..)
-  , DiscVKey(..)
+  , DiscVKey(VKey, VKeyGenesis, ..)
   , VKey
-  , pattern VKey
   , VKeyGenesis
-  , pattern VKeyGenesis
   , DiscKeyHash(..)
   , KeyHash
   , pattern KeyHash
@@ -118,6 +116,8 @@ pattern VKey a = DiscVKey a
 type VKeyGenesis = DiscVKey 'Genesis
 pattern VKeyGenesis :: VerKeyDSIGN (DSIGN crypto) -> DiscVKey 'Genesis crypto
 pattern VKeyGenesis a = DiscVKey a
+
+{-# COMPLETE VKey, VKeyGenesis #-}
 
 data KeyPair (kd :: KeyDiscriminator) crypto
   = KeyPair

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -121,10 +121,14 @@ pattern VKeyGenesis a = DiscVKey a
 
 data KeyPair (kd :: KeyDiscriminator) crypto
   = KeyPair
-      { vKey :: DiscVKey kd crypto
-      , sKey :: SKey crypto
+      { vKey :: !(DiscVKey kd crypto)
+      , sKey :: !(SKey crypto)
       } deriving (Generic, Show)
 
+instance ( Crypto crypto
+         , NFData (VerKeyDSIGN (DSIGN crypto))
+         , NFData (SignKeyDSIGN (DSIGN crypto))
+         ) => NFData (KeyPair kd crypto)
 instance Crypto crypto => NoUnexpectedThunks (KeyPair kd crypto)
 
 newtype Sig crypto a = UnsafeSig (SignedDSIGN (DSIGN crypto) a)


### PR DESCRIPTION
- The `NFData` instances are required for work being done as part of https://github.com/input-output-hk/cardano-node/pull/799.

- The patterns `VKey` and `VKeyGenesis` are exported as data constructors of the type `DiscVKey` in order to prevent modules that import these symbols from being forced to enable `PatternSynonyms`.

  i.e., you can do:

  ```import Shelley.Spec.Ledger.Keys (DiscVKey(VKey, VKeyGenesis))```

  instead of:

  ```import Shelley.Spec.Ledger.Keys (pattern VKey, pattern VKeyGenesis)```

- The `COMPLETE` pragma to indicate that the set of patterns `VKey` and `VKeyGenesis` are complete, therefore preventing non-exhaustive pattern match warnings.