### PR TITLE
Export PredicateFailure from all STS modules

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -8,8 +8,8 @@
 -- API.
 module Shelley.Spec.Ledger.API.Validation
   ( ShelleyState,
-    TickTransitionError,
-    BlockTransitionError,
+    TickTransitionError(..),
+    BlockTransitionError(..),
     chainChecks,
     applyTickTransition,
     applyBlockTransition,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -9,6 +9,7 @@
 
 module Shelley.Spec.Ledger.STS.Epoch
   ( EPOCH
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -10,6 +10,7 @@
 
 module Shelley.Spec.Ledger.STS.Mir
   ( MIR
+  , PredicateFailure
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -9,6 +9,7 @@
 
 module Shelley.Spec.Ledger.STS.NewEpoch
   ( NEWEPOCH
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Newpp.hs
@@ -9,6 +9,7 @@ module Shelley.Spec.Ledger.STS.Newpp
   ( NEWPP
   , NewppState (..)
   , NewppEnv (..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
@@ -7,6 +7,7 @@
 
 module Shelley.Spec.Ledger.STS.Ocert
   ( OCERT
+  , PredicateFailure(..)
   , OCertEnv(..)
   )
 where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -10,6 +10,7 @@
 
 module Shelley.Spec.Ledger.STS.Overlay
   ( OVERLAY
+  , PredicateFailure(..)
   , OverlayEnv(..)
   )
 where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -6,8 +6,9 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Pool
-  ( POOL,
-    PoolEnv (..),
+  ( POOL
+  , PoolEnv(..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/PoolReap.hs
@@ -7,6 +7,7 @@
 module Shelley.Spec.Ledger.STS.PoolReap
   ( POOLREAP
   , PoolreapState(..)
+  , PredicateFailure
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -9,6 +9,7 @@
 module Shelley.Spec.Ledger.STS.Ppup
   ( PPUP
   , PPUPEnv(..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -10,10 +10,10 @@
 
 module Shelley.Spec.Ledger.STS.Prtcl
   ( PRTCL
-  , PredicateFailure(..)
   , State
   , PrtclEnv(..)
   , PrtclState(..)
+  , PredicateFailure(..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
@@ -7,6 +7,7 @@
 module Shelley.Spec.Ledger.STS.Rupd
   ( RUPD
   , RupdEnv(..)
+  , PredicateFailure
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -8,6 +8,7 @@ module Shelley.Spec.Ledger.STS.Snap
   ( SNAP
   , SnapState (..)
   , SnapEnv (..)
+  , PredicateFailure
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -9,8 +9,8 @@
 module Shelley.Spec.Ledger.STS.Tick
   ( TICK
   , TickEnv (..)
-  , PredicateFailure (..)
   , State
+  , PredicateFailure (..)
   )
 where
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
@@ -10,6 +10,7 @@ module Shelley.Spec.Ledger.STS.Updn
   ( UPDN
   , UpdnEnv(..)
   , UpdnState(..)
+  , PredicateFailure
   )
 where
 


### PR DESCRIPTION
We need access to the constructors of all the failures so that we can render them as errors in the log files.

The `PredicateFailure` for some STS rules have no constructors of course but for uniformity we just export them from every module.