### PR TITLE
Use all key hashes for stake pool retire certs.

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -92,7 +92,7 @@ instance QC.HasTrace CERTS GenEnv where
         ( KeySpace_
             { ksCoreNodes,
               ksKeyPairs,
-              ksKeyPairsByStakeHash,
+              ksKeyPairsByHash,
               ksMSigScripts,
               ksVRFKeyPairs
             }
@@ -107,7 +107,7 @@ instance QC.HasTrace CERTS GenEnv where
         ksMSigScripts
         (fst <$> ksCoreNodes)
         ksVRFKeyPairs
-        ksKeyPairsByStakeHash
+        ksKeyPairsByHash
         pparams
         dpState
         slot


### PR DESCRIPTION
The generators previously assumed that the public key for a stake pool
was a _staking key_. But this is somewhat strange - it's neither a
payment key nor a staking key, it's in a completely different domain. In
the shelley testing, we would like these to correspond to the genesis
key delegate, so they can issue blocks either under Praos or the
Overlay.

This PR just looks them up in the wider set of key hashes, which
includes the staking keys anyway.