### PR TITLE
Make the active slot coeff a constant (not a protocol parameter)

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/shelley.cddl
@@ -159,10 +159,9 @@ protocol_param_update =
   , ? 13: rational           ; pool pledge influence
   , ? 14: unit_interval      ; expansion rate
   , ? 15: unit_interval      ; treasury growth rate
-  , ? 16: unit_interval      ; active slot coefficient
-  , ? 17: unit_interval      ; d. decentralization constant
-  , ? 18: $nonce             ; extra entropy
-  , ? 19: [protocol_version] ; protocol version
+  , ? 16: unit_interval      ; d. decentralization constant
+  , ? 17: $nonce             ; extra entropy
+  , ? 18: [protocol_version] ; protocol version
   }
 
 transaction_witness_set =

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
@@ -371,6 +371,9 @@ data Globals = Globals
   , maxMajorPV :: !Natural
     -- | Maximum number of lovelace in the system
   , maxLovelaceSupply :: !Word64
+    -- | Active Slot Coefficient, named f in
+    -- "Ouroboros Praos: An adaptively-secure, semi-synchronous proof-of-stake protocol"
+  , activeSlotCoeff :: !ActiveSlotCoeff
   } deriving (Generic)
 
 instance NoUnexpectedThunks Globals

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
@@ -45,6 +45,10 @@ module Shelley.Spec.Ledger.BaseTypes
   , mkIPv6
   , Port
   , unPort
+  , ActiveSlotCoeff
+  , mkActiveSlotCoeff
+  , activeSlotVal
+  , activeSlotLog
     -- * STS Base
   , Globals (..)
   , ShelleyBase
@@ -73,6 +77,7 @@ import           Network.Socket (HostAddress, HostAddress6, hostAddress6ToTuple)
 import           Numeric.Natural (Natural)
 
 import           Shelley.Spec.Ledger.Serialization (rationalFromCBOR, rationalToCBOR)
+import           Shelley.Spec.NonIntegral (ln')
 
 data E34
 
@@ -292,6 +297,52 @@ instance FromCBOR IPv6 where
 
 newtype Port = Port { unPort :: Word16 }
   deriving (Eq, Ord, Num, Generic, Show, ToCBOR, FromCBOR, NoUnexpectedThunks)
+
+--------------------------------------------------------------------------------
+-- Active Slot Coefficent, named f in
+-- "Ouroboros Praos: An adaptively-secure, semi-synchronous proof-of-stake protocol"
+--------------------------------------------------------------------------------
+
+data ActiveSlotCoeff =
+  ActiveSlotCoeff
+  { unActiveSlotVal :: !UnitInterval
+  , unActiveSlotLog :: !Integer  -- TODO mgudemann make this FixedPoint,
+                                 -- currently a problem because of
+                                 -- NoUnexpectedThunks instance for FixedPoint
+  } deriving (Eq, Ord, Show, Generic)
+
+instance NoUnexpectedThunks ActiveSlotCoeff
+
+instance FromCBOR ActiveSlotCoeff
+ where
+   fromCBOR = do
+     v <- fromCBOR
+     pure $ mkActiveSlotCoeff v
+
+instance ToCBOR ActiveSlotCoeff
+ where
+   toCBOR (ActiveSlotCoeff { unActiveSlotVal = slotVal
+                           , unActiveSlotLog = _logVal}) =
+     toCBOR slotVal
+
+mkActiveSlotCoeff :: UnitInterval -> ActiveSlotCoeff
+mkActiveSlotCoeff v =
+  ActiveSlotCoeff { unActiveSlotVal = v
+                  , unActiveSlotLog =
+                    if (intervalValue v) == 1
+                      -- If the active slot coefficient is equal to one,
+                      -- then nearly every stake pool can produce a block every slot.
+                      -- In this degenerate case, where ln (1-f) is not defined,
+                      -- we set the unActiveSlotLog to zero.
+                      then 0
+                      else floor (fpPrecision * (
+                        ln' $ (1 :: FixedPoint) - (fromRational $ intervalValue v))) }
+
+activeSlotVal :: ActiveSlotCoeff -> UnitInterval
+activeSlotVal = unActiveSlotVal
+
+activeSlotLog :: ActiveSlotCoeff -> FixedPoint
+activeSlotLog f = (fromIntegral $ unActiveSlotLog f) / fpPrecision
 
 --------------------------------------------------------------------------------
 -- Base monad for all STS systems

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -72,15 +72,14 @@ import           Cardano.Prelude (AllowThunksIn (..), ByteString, LByteString,
 import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.Monad (unless)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), Seed (..), UnitInterval, intervalValue,
-                     mkNonce)
+                     mkNonce, ActiveSlotCoeff, activeSlotLog, activeSlotVal)
 import           Shelley.Spec.Ledger.Crypto
 import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
 import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
 import           Shelley.Spec.Ledger.Keys (Hash, KESig, KeyHash, VKey, VRFValue (..), hash, hashKey,
                      hashKeyVRF)
 import           Shelley.Spec.Ledger.OCert (OCert (..))
-import           Shelley.Spec.Ledger.PParams (ActiveSlotCoeff, ProtVer (..), activeSlotLog,
-                     activeSlotVal)
+import           Shelley.Spec.Ledger.PParams (ProtVer (..))
 import           Shelley.Spec.Ledger.Serialization (FromCBORGroup (..), ToCBORGroup (..), decodeMap,
                      decodeSeq, encodeFoldableEncoder, encodeFoldableMapEncoder)
 import           Shelley.Spec.Ledger.Slot (BlockNo (..), SlotNo (..))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -102,7 +102,7 @@ import           Shelley.Spec.Ledger.Keys (AnyKeyHash, GenDelegs (..), GenKeyHas
                      undiscriminateKeyHash)
 import qualified Shelley.Spec.Ledger.MetaData as MD
 import           Shelley.Spec.Ledger.PParams (PParams, ProposedPPUpdates (..), Update (..),
-                     activeSlotVal, emptyPPPUpdates, emptyPParams, _activeSlotCoeff, _d,
+                     emptyPPPUpdates, emptyPParams, _activeSlotCoeff, _d,
                      _keyDecayRate, _keyDeposit, _keyMinRefund, _minfeeA, _minfeeB, _rho, _tau)
 import           Shelley.Spec.Ledger.Slot (Duration (..), EpochNo (..), SlotNo (..), epochInfoEpoch,
                      epochInfoFirst, epochInfoSize, (+*), (-*))
@@ -123,7 +123,8 @@ import           Shelley.Spec.Ledger.Rewards (ApparentPerformance (..), NonMyopi
 
 import           Byron.Spec.Ledger.Core (dom, (∪), (∪+), (⋪), (▷), (◁))
 import           Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase, StrictMaybe (..),
-                     UnitInterval, dnsSize, intervalValue, text64Size, unIPv4, unIPv6, unUrl)
+                     UnitInterval, dnsSize, intervalValue, text64Size, unIPv4, unIPv6,
+                     unUrl, activeSlotVal)
 import           Shelley.Spec.Ledger.Scripts (countMSigNodes)
 
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -37,9 +37,8 @@ import           Numeric.Natural (Natural)
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord, encodeListLen,
                      encodeMapLen, encodeWord, enforceSize)
 import           Cardano.Prelude (NoUnexpectedThunks (..), mapMaybe)
-import           Shelley.Spec.Ledger.BaseTypes (FixedPoint, Nonce (NeutralNonce), StrictMaybe (..),
-                     UnitInterval, fpPrecision, interval0, intervalValue, invalidKey,
-                     strictMaybeToMaybe, ActiveSlotCoeff, mkActiveSlotCoeff)
+import           Shelley.Spec.Ledger.BaseTypes (Nonce (NeutralNonce), StrictMaybe (..),
+                     UnitInterval, interval0, invalidKey, strictMaybeToMaybe)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Crypto
 import           Shelley.Spec.Ledger.Keys (GenDelegs, GenKeyHash)
@@ -87,8 +86,6 @@ data PParams' f = PParams
   , _rho             :: !(HKD f UnitInterval)
     -- | Monetary expansion
   , _tau             :: !(HKD f UnitInterval)
-    -- | Active slot coefficient
-  , _activeSlotCoeff :: !(HKD f ActiveSlotCoeff)
     -- | Decentralization parameter
   , _d               :: !(HKD f UnitInterval)
     -- | Extra entropy
@@ -139,7 +136,6 @@ instance ToCBOR PParams
     , _a0              = a0'
     , _rho             = rho'
     , _tau             = tau'
-    , _activeSlotCoeff = activeSlotCoeff'
     , _d               = d'
     , _extraEntropy    = extraEntropy'
     , _protocolVersion = protocolVersion'
@@ -161,7 +157,6 @@ instance ToCBOR PParams
         <> rationalToCBOR a0'
         <> toCBOR rho'
         <> toCBOR tau'
-        <> toCBOR activeSlotCoeff'
         <> toCBOR d'
         <> toCBOR extraEntropy'
         <> toCBORGroup protocolVersion'
@@ -187,7 +182,6 @@ instance FromCBOR PParams
       <*> rationalFromCBOR -- _a0              :: Rational
       <*> fromCBOR         -- _rho             :: UnitInterval
       <*> fromCBOR         -- _tau             :: UnitInterval
-      <*> fromCBOR         -- _activeSlotCoeff :: ActiveSlotCoeff
       <*> fromCBOR         -- _d               :: UnitInterval
       <*> fromCBOR         -- _extraEntropy    :: Nonce
       <*> fromCBORGroup    -- _protocolVersion :: ProtVer
@@ -212,7 +206,6 @@ emptyPParams =
      , _a0 = 0
      , _rho = interval0
      , _tau = interval0
-     , _activeSlotCoeff = mkActiveSlotCoeff interval0
      , _d = interval0
      , _extraEntropy = NeutralNonce
      , _protocolVersion = ProtVer 0 0
@@ -266,10 +259,9 @@ instance ToCBOR PParamsUpdate where
           , encodeMapElement 13 rationalToCBOR =<< _a0              ppup
           , encodeMapElement 14 toCBOR         =<< _rho             ppup
           , encodeMapElement 15 toCBOR         =<< _tau             ppup
-          , encodeMapElement 16 toCBOR         =<< _activeSlotCoeff ppup
-          , encodeMapElement 17 toCBOR         =<< _d               ppup
-          , encodeMapElement 18 toCBOR         =<< _extraEntropy    ppup
-          , encodeMapElement 19 toCBOR         =<< _protocolVersion ppup
+          , encodeMapElement 16 toCBOR         =<< _d               ppup
+          , encodeMapElement 17 toCBOR         =<< _extraEntropy    ppup
+          , encodeMapElement 18 toCBOR         =<< _protocolVersion ppup
           ]
         n = fromIntegral $ length l
     in encodeMapLen n <> fold l
@@ -294,7 +286,6 @@ emptyPParamsUpdate   = PParams
   , _a0              = SNothing
   , _rho             = SNothing
   , _tau             = SNothing
-  , _activeSlotCoeff = SNothing
   , _d               = SNothing
   , _extraEntropy    = SNothing
   , _protocolVersion = SNothing
@@ -320,10 +311,9 @@ instance FromCBOR PParamsUpdate where
          13 -> rationalFromCBOR >>= \x -> pure (13, \up -> up { _a0              = SJust x })
          14 -> fromCBOR         >>= \x -> pure (14, \up -> up { _rho             = SJust x })
          15 -> fromCBOR         >>= \x -> pure (15, \up -> up { _tau             = SJust x })
-         16 -> fromCBOR         >>= \x -> pure (16, \up -> up { _activeSlotCoeff = SJust x })
-         17 -> fromCBOR         >>= \x -> pure (17, \up -> up { _d               = SJust x })
-         18 -> fromCBOR         >>= \x -> pure (18, \up -> up { _extraEntropy    = SJust x })
-         19 -> fromCBOR         >>= \x -> pure (19, \up -> up { _protocolVersion = SJust x })
+         16 -> fromCBOR         >>= \x -> pure (17, \up -> up { _d               = SJust x })
+         17 -> fromCBOR         >>= \x -> pure (18, \up -> up { _extraEntropy    = SJust x })
+         18 -> fromCBOR         >>= \x -> pure (19, \up -> up { _protocolVersion = SJust x })
          k -> invalidKey k
      let fields = fst <$> mapParts :: [Int]
      unless (nub fields == fields)
@@ -364,7 +354,6 @@ updatePParams pp ppup = PParams
   , _a0 = fromMaybe' (_a0 pp) (_a0 ppup)
   , _rho = fromMaybe' (_rho pp) (_rho ppup)
   , _tau = fromMaybe' (_tau pp) (_tau ppup)
-  , _activeSlotCoeff = fromMaybe' (_activeSlotCoeff pp) (_activeSlotCoeff ppup)
   , _d = fromMaybe' (_d pp) (_d ppup)
   , _extraEntropy = fromMaybe' (_extraEntropy pp) (_extraEntropy ppup)
   , _protocolVersion = fromMaybe' (_protocolVersion pp) (_protocolVersion ppup)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Prtcl.hs
@@ -21,17 +21,19 @@ import           Data.Map.Strict (Map)
 import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
 
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.BlockChain
-import           Shelley.Spec.Ledger.Delegation.Certificates
-import           Shelley.Spec.Ledger.Keys
+import           Shelley.Spec.Ledger.BaseTypes (Nonce, Seed, ShelleyBase)
+import           Shelley.Spec.Ledger.BlockChain (BHBody (..), BHeader (..), LastAppliedBlock (..),
+                     bhHash, bhbody, lastAppliedHash)
+import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr)
+import           Shelley.Spec.Ledger.Keys (GenDelegs (..), KESignable, KeyHash, Signable, VKeyES,
+                     fromNatural)
 import           Shelley.Spec.Ledger.LedgerState (OBftSlot)
-import           Shelley.Spec.Ledger.OCert
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Slot
+import           Shelley.Spec.Ledger.OCert (KESPeriod)
+import           Shelley.Spec.Ledger.PParams (PParams)
+import           Shelley.Spec.Ledger.Slot (BlockNo, SlotNo)
 
-import           Shelley.Spec.Ledger.STS.Overlay
-import           Shelley.Spec.Ledger.STS.Updn
+import           Shelley.Spec.Ledger.STS.Overlay (OVERLAY, OverlayEnv (..))
+import           Shelley.Spec.Ledger.STS.Updn (UPDN, UpdnEnv (..), UpdnState (..))
 
 import           Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR), decodeListLenOf,
                      encodeListLen)
@@ -39,7 +41,7 @@ import qualified Cardano.Crypto.VRF as VRF
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Cardano.Slotting.Slot (WithOrigin (..), withOriginFromMaybe, withOriginToMaybe)
 import           Control.State.Transition
-import           Shelley.Spec.Ledger.Crypto
+import           Shelley.Spec.Ledger.Crypto (Crypto, DSIGN, VRF)
 
 data PRTCL crypto
 
@@ -150,7 +152,7 @@ prtclTransition = do
                                   , slot)
   cs'
     <- trans @(OVERLAY crypto)
-        $ TRC (OverlayEnv pp osched eta0' pd dms, cs, bh)
+        $ TRC (OverlayEnv osched eta0' pd dms, cs, bh)
 
   pure $ PrtclState
            cs'

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -110,7 +110,7 @@ import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
 import           Shelley.Spec.Ledger.Address (mkRwdAcnt)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), mkNonce, mkUrl,
-                     startRewards, (⭒))
+                     startRewards, (⭒), mkActiveSlotCoeff)
 import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader, LastAppliedBlock (..), bhHash,
                      bheader, hashHeaderToNonce)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
@@ -133,7 +133,7 @@ import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern Act
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import           Shelley.Spec.Ledger.PParams (PParams, PParams' (PParams), PParamsUpdate,
                      pattern ProposedPPUpdates, pattern Update, emptyPPPUpdates, emptyPParams,
-                     mkActiveSlotCoeff, _a0, _activeSlotCoeff, _d, _eMax, _extraEntropy,
+                     _a0, _activeSlotCoeff, _d, _eMax, _extraEntropy,
                      _keyDecayRate, _keyDeposit, _keyMinRefund, _maxBBSize, _maxBHSize, _maxTxSize,
                      _minfeeA, _minfeeB, _nOpt, _poolDecayRate, _poolDeposit, _poolMinRefund,
                      _protocolVersion, _rho, _tau)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -110,7 +110,7 @@ import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
 import           Shelley.Spec.Ledger.Address (mkRwdAcnt)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), mkNonce, mkUrl,
-                     startRewards, (⭒), mkActiveSlotCoeff)
+                     startRewards, (⭒))
 import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader, LastAppliedBlock (..), bhHash,
                      bheader, hashHeaderToNonce)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
@@ -132,11 +132,10 @@ import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern Act
                      _treasury)
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import           Shelley.Spec.Ledger.PParams (PParams, PParams' (PParams), PParamsUpdate,
-                     pattern ProposedPPUpdates, pattern Update, emptyPPPUpdates, emptyPParams,
-                     _a0, _activeSlotCoeff, _d, _eMax, _extraEntropy,
-                     _keyDecayRate, _keyDeposit, _keyMinRefund, _maxBBSize, _maxBHSize, _maxTxSize,
-                     _minfeeA, _minfeeB, _nOpt, _poolDecayRate, _poolDeposit, _poolMinRefund,
-                     _protocolVersion, _rho, _tau)
+                     pattern ProposedPPUpdates, pattern Update, emptyPPPUpdates, emptyPParams, _a0,
+                     _d, _eMax, _extraEntropy, _keyDecayRate, _keyDeposit, _keyMinRefund,
+                     _maxBBSize, _maxBHSize, _maxTxSize, _minfeeA, _minfeeB, _nOpt, _poolDecayRate,
+                     _poolDeposit, _poolMinRefund, _protocolVersion, _rho, _tau)
 import           Shelley.Spec.Ledger.Rewards (ApparentPerformance (..), pattern NonMyopic,
                      emptyNonMyopic, rewardPot)
 import           Shelley.Spec.Ledger.Slot (BlockNo (..), Duration (..), EpochNo (..), SlotNo (..),
@@ -340,8 +339,6 @@ ppsEx1 = emptyPParams { _maxBBSize       =       50000
                       , _keyDeposit      = Coin      7
                       , _poolDeposit     = Coin    250
                       , _d               = unsafeMkUnitInterval 0.5
-                      , _activeSlotCoeff =
-                        mkActiveSlotCoeff (unsafeMkUnitInterval 0.9)
                       , _tau             = unsafeMkUnitInterval 0.2
                       , _rho             = unsafeMkUnitInterval 0.0021
                       , _keyDecayRate    =                      0.002
@@ -460,7 +457,6 @@ ppupEx2A = ProposedPPUpdates $ Map.singleton
                 , _a0 = SNothing
                 , _rho = SNothing
                 , _tau = SNothing
-                , _activeSlotCoeff = SNothing
                 , _d = SNothing
                 , _extraEntropy = SNothing
                 , _protocolVersion = SNothing
@@ -1690,7 +1686,6 @@ ppVote3A = PParams
              , _a0 = SNothing
              , _rho = SNothing
              , _tau = SNothing
-             , _activeSlotCoeff = SNothing
              , _d = SNothing
              , _extraEntropy = SJust (mkNonce 123)
              , _protocolVersion = SNothing

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -28,7 +28,7 @@ import           Data.Coerce (coerce)
 import           Data.Ratio ((%))
 import           Numeric.Natural (Natural)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), UnitInterval (..),
-                     mkDnsName, mkIPv4, mkNonce, mkUrl, unIPv4, mkActiveSlotCoeff)
+                     mkDnsName, mkIPv4, mkNonce, mkUrl, unIPv4)
 import           Shelley.Spec.Ledger.BlockChain (pattern BHBody, pattern BHeader, Block (..),
                      pattern BlockHash, pattern HashHeader, TxSeq (..), bbHash, bhash,
                      bheaderBlockNo, bheaderEta, bheaderL, bheaderOCert, bheaderPrev,
@@ -47,11 +47,10 @@ import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern Act
                      EpochState (..), NewEpochState (..), pattern RewardUpdate, deltaF, deltaR,
                      deltaT, emptyLedgerState, genesisId, nonMyopic, rs)
 import           Shelley.Spec.Ledger.PParams (PParams' (PParams), PParamsUpdate,
-                     pattern ProposedPPUpdates, ProtVer (..), pattern Update, emptyPParams,
-                     _a0, _activeSlotCoeff, _d, _eMax, _extraEntropy,
-                     _keyDecayRate, _keyDeposit, _keyMinRefund, _maxBBSize, _maxBHSize, _maxTxSize,
-                     _minfeeA, _minfeeB, _nOpt, _poolDecayRate, _poolDeposit, _poolMinRefund,
-                     _protocolVersion, _rho, _tau)
+                     pattern ProposedPPUpdates, ProtVer (..), pattern Update, emptyPParams, _a0,
+                     _d, _eMax, _extraEntropy, _keyDecayRate, _keyDeposit, _keyMinRefund,
+                     _maxBBSize, _maxBHSize, _maxTxSize, _minfeeA, _minfeeB, _nOpt, _poolDecayRate,
+                     _poolDeposit, _poolMinRefund, _protocolVersion, _rho, _tau)
 import           Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
 import           Shelley.Spec.Ledger.Serialization (FromCBORGroup (..), ToCBORGroup (..))
 import           Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
@@ -515,7 +514,6 @@ serializationTests = testGroup "Serialization Tests"
        , _a0 = SNothing
        , _rho = SNothing
        , _tau = SNothing
-       , _activeSlotCoeff = SNothing
        , _d = SNothing
        , _extraEntropy = SNothing
        , _protocolVersion = SNothing
@@ -539,7 +537,6 @@ serializationTests = testGroup "Serialization Tests"
         a0                    = 1 % 6
         rho                   = UnsafeUnitInterval $ 1 % 6
         tau                   = UnsafeUnitInterval $ 1 % 7
-        activeSlotCoefficient = mkActiveSlotCoeff $ UnsafeUnitInterval $ 1 % 8
         d                     = UnsafeUnitInterval $ 1 % 9
         extraEntropy          = NeutralNonce
         protocolVersion       = ProtVer 0 1
@@ -562,12 +559,11 @@ serializationTests = testGroup "Serialization Tests"
        , _a0              = SJust a0
        , _rho             = SJust rho
        , _tau             = SJust tau
-       , _activeSlotCoeff = SJust activeSlotCoefficient
        , _d               = SJust d
        , _extraEntropy    = SJust extraEntropy
        , _protocolVersion = SJust protocolVersion
        } :: PParamsUpdate)
-    ((T $ TkMapLen 20)
+    ((T $ TkMapLen 19)
       <> (T $ TkWord 0) <> S minfeea
       <> (T $ TkWord 1) <> S minfeeb
       <> (T $ TkWord 2) <> S maxbbsize
@@ -584,10 +580,9 @@ serializationTests = testGroup "Serialization Tests"
       <> (T $ TkWord 13 . TkTag 30) <> S a0
       <> (T $ TkWord 14) <> S rho
       <> (T $ TkWord 15) <> S tau
-      <> (T $ TkWord 16) <> S activeSlotCoefficient
-      <> (T $ TkWord 17) <> S d
-      <> (T $ TkWord 18) <> S extraEntropy
-      <> (T $ TkWord 19) <> S protocolVersion)
+      <> (T $ TkWord 16) <> S d
+      <> (T $ TkWord 17) <> S extraEntropy
+      <> (T $ TkWord 18) <> S protocolVersion)
 
     -- checkEncodingCBOR "full_update"
   , let
@@ -610,7 +605,6 @@ serializationTests = testGroup "Serialization Tests"
                   , _a0 = SNothing
                   , _rho = SNothing
                   , _tau = SNothing
-                  , _activeSlotCoeff = SNothing
                   , _d = SNothing
                   , _extraEntropy = SNothing
                   , _protocolVersion = SNothing
@@ -675,7 +669,6 @@ serializationTests = testGroup "Serialization Tests"
                 , _a0 = SNothing
                 , _rho = SNothing
                 , _tau = SNothing
-                , _activeSlotCoeff = SNothing
                 , _d = SNothing
                 , _extraEntropy = SNothing
                 , _protocolVersion = SNothing
@@ -735,7 +728,6 @@ serializationTests = testGroup "Serialization Tests"
                             , _a0 = SNothing
                             , _rho = SNothing
                             , _tau = SNothing
-                            , _activeSlotCoeff = SNothing
                             , _d = SNothing
                             , _extraEntropy = SNothing
                             , _protocolVersion = SNothing

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -28,7 +28,7 @@ import           Data.Coerce (coerce)
 import           Data.Ratio ((%))
 import           Numeric.Natural (Natural)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), UnitInterval (..),
-                     mkDnsName, mkIPv4, mkNonce, mkUrl, unIPv4)
+                     mkDnsName, mkIPv4, mkNonce, mkUrl, unIPv4, mkActiveSlotCoeff)
 import           Shelley.Spec.Ledger.BlockChain (pattern BHBody, pattern BHeader, Block (..),
                      pattern BlockHash, pattern HashHeader, TxSeq (..), bbHash, bhash,
                      bheaderBlockNo, bheaderEta, bheaderL, bheaderOCert, bheaderPrev,
@@ -48,7 +48,7 @@ import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern Act
                      deltaT, emptyLedgerState, genesisId, nonMyopic, rs)
 import           Shelley.Spec.Ledger.PParams (PParams' (PParams), PParamsUpdate,
                      pattern ProposedPPUpdates, ProtVer (..), pattern Update, emptyPParams,
-                     mkActiveSlotCoeff, _a0, _activeSlotCoeff, _d, _eMax, _extraEntropy,
+                     _a0, _activeSlotCoeff, _d, _eMax, _extraEntropy,
                      _keyDecayRate, _keyDeposit, _keyMinRefund, _maxBBSize, _maxBHSize, _maxTxSize,
                      _minfeeA, _minfeeB, _nOpt, _poolDecayRate, _poolDeposit, _poolMinRefund,
                      _protocolVersion, _rho, _tau)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -21,7 +21,7 @@ import           Byron.Spec.Ledger.Core (dom, range)
 import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.State.Transition.Extended (TRC (..), applySTS)
 import           Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
-import           Shelley.Spec.Ledger.BaseTypes (intervalValue)
+import           Shelley.Spec.Ledger.BaseTypes (intervalValue, activeSlotVal)
 import           Shelley.Spec.Ledger.BlockChain (LastAppliedBlock (..))
 import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
 import           Shelley.Spec.Ledger.Keys (GenDelegs (..), hashKey, vKey)
@@ -29,7 +29,7 @@ import           Shelley.Spec.Ledger.LedgerState (pattern ActiveSlot, pattern Ep
                      pattern NewEpochState, esLState, esPp, getGKeys, nesEL, nesEs, nesOsched,
                      nesPd, overlaySchedule, _delegationState, _dstate, _genDelegs, _reserves)
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..), currentIssueNo, kesPeriod)
-import           Shelley.Spec.Ledger.PParams (PParams' (_activeSlotCoeff), activeSlotVal)
+import           Shelley.Spec.Ledger.PParams (PParams' (_activeSlotCoeff))
 import           Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
 import           Shelley.Spec.Ledger.STS.Chain (chainEpochNonce, chainLastAppliedBlock, chainNes,
                      chainOCertIssue)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
@@ -26,12 +26,12 @@ import qualified Test.QuickCheck as QC
 
 import           Numeric.Natural (Natural)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (NeutralNonce), StrictMaybe (..),
-                     UnitInterval, mkNonce)
+                     UnitInterval, mkNonce, ActiveSlotCoeff, mkActiveSlotCoeff)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Keys (GenDelegs (..), hashKey, vKey)
 import           Shelley.Spec.Ledger.LedgerState (_dstate, _genDelegs)
-import           Shelley.Spec.Ledger.PParams (ActiveSlotCoeff, PParams, PParams' (PParams),
-                     pattern ProposedPPUpdates, ProtVer (..), pattern Update, mkActiveSlotCoeff,
+import           Shelley.Spec.Ledger.PParams (PParams, PParams' (PParams),
+                     pattern ProposedPPUpdates, ProtVer (..), pattern Update,
                      _a0, _activeSlotCoeff, _d, _eMax, _extraEntropy, _keyDecayRate, _keyDeposit,
                      _keyMinRefund, _maxBBSize, _maxBHSize, _maxTxSize, _minfeeA, _minfeeB, _nOpt,
                      _poolDecayRate, _poolDeposit, _poolMinRefund, _protocolVersion,

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
@@ -26,22 +26,21 @@ import qualified Test.QuickCheck as QC
 
 import           Numeric.Natural (Natural)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (NeutralNonce), StrictMaybe (..),
-                     UnitInterval, mkNonce, ActiveSlotCoeff, mkActiveSlotCoeff)
+                     UnitInterval, mkNonce)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Keys (GenDelegs (..), hashKey, vKey)
 import           Shelley.Spec.Ledger.LedgerState (_dstate, _genDelegs)
 import           Shelley.Spec.Ledger.PParams (PParams, PParams' (PParams),
-                     pattern ProposedPPUpdates, ProtVer (..), pattern Update,
-                     _a0, _activeSlotCoeff, _d, _eMax, _extraEntropy, _keyDecayRate, _keyDeposit,
-                     _keyMinRefund, _maxBBSize, _maxBHSize, _maxTxSize, _minfeeA, _minfeeB, _nOpt,
-                     _poolDecayRate, _poolDeposit, _poolMinRefund, _protocolVersion,
-                     _protocolVersion, _rho, _tau)
+                     pattern ProposedPPUpdates, ProtVer (..), pattern Update, _a0, _d, _eMax,
+                     _extraEntropy, _keyDecayRate, _keyDeposit, _keyMinRefund, _maxBBSize,
+                     _maxBHSize, _maxTxSize, _minfeeA, _minfeeB, _nOpt, _poolDecayRate,
+                     _poolDeposit, _poolMinRefund, _protocolVersion, _protocolVersion, _rho, _tau)
 import           Shelley.Spec.Ledger.Slot (EpochNo (EpochNo), SlotNo)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CoreKeyPair, DPState, GenKeyHash,
                      KeyHash, KeyPair, ProposedPPUpdates, UTxOState, Update)
 import           Test.Shelley.Spec.Ledger.Examples.Examples (unsafeMkUnitInterval)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants(..))
+import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
 import           Test.Shelley.Spec.Ledger.Generator.Core (AllPoolKeys (cold), genInteger,
                      genNatural, genWord64, increasingProbabilityAt, tooLateInEpoch)
 import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo)
@@ -70,7 +69,6 @@ genPParams c@(Constants {maxMinFeeA, maxMinFeeB})
               <*> genA0
               <*> genRho
               <*> genTau
-              <*> genActiveSlotCoeff
               <*> genDecentralisationParam
               <*> genExtraEntropy
               <*> genProtocolVersion
@@ -164,16 +162,6 @@ genRho = genIntervalInThousands 1 9
 genTau :: HasCallStack => Gen UnitInterval
 genTau = genIntervalInThousands 100 300
 
--- | activeSlotCoeff: 0.1-1
-genActiveSlotCoeff :: HasCallStack => Gen ActiveSlotCoeff
-genActiveSlotCoeff =
-  (mkActiveSlotCoeff . unsafeMkUnitInterval)
-  <$> QC.elements [0.025, 0.05, 0.075, 0.1, 0.2, 0.5]
--- ^^ This is a somewhat arbitrary group of values.
--- In the real system, we will probably be using a value near 1/10,
--- and we know that we would not ever choose values too small (say below 1/40)
--- or greater than a 1/2.
-
 genDecentralisationParam :: HasCallStack => Gen UnitInterval
 genDecentralisationParam = unsafeMkUnitInterval <$> QC.elements [0.1, 0.2 .. 1]
 -- ^^ TODO jc - generating d=0 takes some care, if there are no registered
@@ -225,7 +213,6 @@ genPPUpdate (c@Constants{maxMinFeeA, maxMinFeeB}) s pp genesisKeys =
       a0                    <- genA0
       rho                   <- genRho
       tau                   <- genTau
-      activeSlotCoefficient <- genActiveSlotCoeff
       d                     <- genDecentralisationParam
       extraEntropy          <- genExtraEntropy
       protocolVersion       <- genNextProtocolVersion pp
@@ -245,7 +232,6 @@ genPPUpdate (c@Constants{maxMinFeeA, maxMinFeeB}) s pp genesisKeys =
                         , _a0                    = SJust a0
                         , _rho                   = SJust rho
                         , _tau                   = SJust tau
-                        , _activeSlotCoeff       = SJust activeSlotCoefficient
                         , _d                     = SJust d
                         , _extraEntropy          = SJust extraEntropy
                         , _protocolVersion       = SJust protocolVersion

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
@@ -33,7 +33,7 @@ import           Data.Maybe (fromMaybe)
 import           Data.Word (Word64)
 import           Hedgehog (MonadTest, (===))
 import           Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase, UnitInterval,
-                     mkUnitInterval)
+                     mkActiveSlotCoeff, mkUnitInterval)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Keys (pattern SKey, pattern SKeyES, pattern VKey,
                      pattern VKeyES, pattern VKeyGenesis, hashKey, updateKESKey, vKey)
@@ -105,6 +105,7 @@ testGlobals = Globals
   , quorum = 5
   , maxMajorPV = 1000
   , maxLovelaceSupply = 45*1000*1000*1000*1000*1000
+  , activeSlotCoeff = mkActiveSlotCoeff . unsafeMkUnitInterval $ 0.9
   }
 
 runShelleyBase :: ShelleyBase a -> a

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -4,7 +4,6 @@
 \newcommand{\Proof}{\type{Proof}}
 \newcommand{\Seedl}{\mathsf{Seed}_\ell}
 \newcommand{\Seede}{\mathsf{Seed}_\eta}
-\newcommand{\activeSlotCoeff}[1]{\fun{activeSlotCoeff}~ \var{#1}}
 \newcommand{\slotToSeed}[1]{\fun{slotToSeed}~ \var{#1}}
 \newcommand{\prevHashToNonce}[1]{\fun{prevHashToNonce}~ \var{#1}}
 
@@ -418,7 +417,7 @@ of which are active.
     \range{osched}\subseteq\var{gkeys} \\
     |\var{osched}| = \floor{(\fun{d}~\var{pp})\cdot\SlotsPerEpoch} \\
     |\{s\mapsto k\in\var{osched}~\mid~k\neq\Nothing\}| =
-    \floor{(\activeSlotCoeff{pp})\cdot(\fun{d}~\var{pp})\cdot\SlotsPerEpoch} \\
+    \floor{\ActiveSlotCoeff(\fun{d}~\var{pp})\cdot\SlotsPerEpoch} \\
     \forall s\in\dom{osched},~\epoch{s}=e\\
   \end{align*}
   %
@@ -1111,7 +1110,6 @@ and the Praos blocks, depending on the overlay schedule.
 
 The environments for this transition are:
 \begin{itemize}
-  \item The protocol parameters $\var{pp}$.
   \item A mapping $\var{osched}$ of slots to an optional genesis key.
     In the terminology of \cite{delegation_design},
     the slots in $\var{osched}$ are the ``OBFT slots''.
@@ -1151,7 +1149,6 @@ it is worth examining the interaction in Equation~\ref{eq:decentralized} closely
     \OverlayEnv =
     \left(
       \begin{array}{r@{~\in~}lr}
-        \var{pp} & \PParams & \text{protocol parameters} \\
         \var{osched} & \Slot\mapsto\KeyHashGen^? & \text{OBFT overlay schedule} \\
         \eta_0 & \Seed & \text{epoch nonce} \\
         \var{pd} & \PoolDistr & \text{pool stake distribution} \\
@@ -1195,7 +1192,6 @@ it is worth examining the interaction in Equation~\ref{eq:decentralized} closely
     }
     {
       {\begin{array}{c}
-         \var{pp} \\
          \var{osched} \\
          \eta_0 \\
          \var{pd} \\
@@ -1221,11 +1217,10 @@ it is worth examining the interaction in Equation~\ref{eq:decentralized} closely
         \vdash\var{cs}\trans{\hyperref[fig:rules:ocert]{ocert}}{\var{bh}}\var{cs'}
       }
       \\~\\
-      \fun{vrfChecks}~\eta_0~\var{pd}~(\activeSlotCoeff{pp})~\var{bhb}
+      \fun{vrfChecks}~\eta_0~\var{pd}~\ActiveSlotCoeff~\var{bhb}
     }
     {
       {\begin{array}{c}
-         \var{pp} \\
          \var{osched} \\
          \eta_0 \\
          \var{pd} \\
@@ -1407,7 +1402,6 @@ The states for this transition consists of:
       }\\~\\
       {
         {\begin{array}{c}
-          \var{pp} \\
           \var{osched} \\
           \eta_0' \\
           \var{pd} \\

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -1377,7 +1377,7 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
     & ~~~~~~~\Delta r = \floor*{\min(1,\eta) \cdot (\fun{rho}~\var{prevPp}) \cdot
       \var{reserves}}
     \\
-    & ~~~~~~~\eta = \frac{blocksMade}{\SlotsPerEpoch \cdot \fun{activeSlotCoeff}~\var{prevPp}} \\
+    & ~~~~~~~\eta = \frac{blocksMade}{\SlotsPerEpoch \cdot \ActiveSlotCoeff} \\
     & ~~~~~~~\var{rewardPot} = \var{feeSS} + \Delta r \\
     & ~~~~~~~\Delta t_1 = \floor*{(\fun{tau}~\var{prevPp}) \cdot \var{rewardPot}} \\
     & ~~~~~~~\var{R} = \var{rewardPot} - \Delta t_1 \\

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -80,6 +80,7 @@
 \newcommand{\SlotsPerEpoch}{\mathsf{SlotsPerEpoch}}
 \newcommand{\SlotsPerKESPeriod}{\mathsf{SlotsPerKESPeriod}}
 \newcommand{\MaxMajorPV}{\mathsf{MaxMajorPV}}
+\newcommand{\ActiveSlotCoeff}{\mathsf{ActiveSlotCoeff}}
 \newcommand{\BlockNo}{\type{BlockNo}}
 \newcommand{\StartRewards}{\ensuremath{\mathsf{StartRewards}}}
 \newcommand{\MaxKESEvo}{\ensuremath{\mathsf{MaxKESEvo}}}

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -20,7 +20,7 @@ The type $\Coin$ is defined as an alias for the integers.
 Negative values will not be allowed in UTxO outputs or reward accounts,
 and $\Z$ is only chosen over $\N$ for its additive inverses.
 
-Eight global constants are defined.
+Nine global constants are defined.
 As global constants, these values can only be changed by updating the software,
 i.e. a soft or a hard fork.
 For the software update mechanism, see Section~\ref{sec:software-updates}.
@@ -32,6 +32,8 @@ The maximum number of time a KES key can be evolved before a pool operator
 must create a new operational certificate is given by $\MaxKESEvo$.
 \textbf{Note that if } $\MaxKESEvo$
 \textbf{is changed, the KES signature format may have to change as well.}
+The constant $\ActiveSlotCoeff$ is the value $f$ from the
+Praos paper \cite{ouroboros_praos}.
 
 The constant $\Quorum$ determines the quorum amount needed for votes on the
 protocol parameter updates and the application version updates.
@@ -119,7 +121,6 @@ without being explicit about the types and conversion.
         \var{a_0} \mapsto \posReals & \PParams & \text{pool influence}\\
         \tau \mapsto \unitInterval & \PParams & \text{treasury expansion}\\
         \rho \mapsto \unitInterval & \PParams & \text{monetary expansion}\\
-        \var{activeSlotCoeff} \mapsto (0, 1] & \PParams & f\text{ in \cite{ouroboros_praos}}\\
         \var{d} \mapsto \{0,~0.1,~0.2,~\ldots,~1\} & \PParams & \text{decentralization parameter}\\
         \var{extraEntropy} \mapsto \Seed & \PParams & \text{extra entropy}\\
         \var{pv} \mapsto \ProtVer & \PParams & \text{protocol version}\\
@@ -145,7 +146,6 @@ without being explicit about the types and conversion.
     \fun{influence},
     \fun{tau},
     \fun{rho},
-    \fun{activeSlotCoeff},
     \fun{d},
     \fun{extraEntropy},
     \fun{pv}
@@ -172,6 +172,7 @@ without being explicit about the types and conversion.
       \Quorum & \N & \text{quorum for update system votes}\\
       \MaxMajorPV & \N & \text{all blocks are invalid after this value}\\
       \MaxLovelaceSupply & \Coin & \text{total lovelace in the system}\\
+      \ActiveSlotCoeff & (0, 1] & f\text{ in \cite{ouroboros_praos}}\\
     \end{array}
   \end{equation*}
   %


### PR DESCRIPTION
closes #1386 

Note that there is no longer a collection of protocol parameters in the environment of the `OVERLAY` transition.