### PR TITLE
Adopt genesis delegations in the TICK rule

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/TestScenario.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/TestScenario.hs
@@ -16,6 +16,7 @@ data TestScenario
   = ContinuousIntegration
   | Development
   | Nightly
+  | Fast
   deriving (Read, Show)
 
 instance IsOption TestScenario where
@@ -39,5 +40,5 @@ mainWithTestScenario = defaultMainWithIngredients
 
 helpText :: [Char]
 helpText =
-  "Run under one of Development (default), ContinuousIntegration, or "
-    <> "Nightly, to affect how tests are run"
+  "Run under one of Development (default), ContinuousIntegration, "
+    <> "Nightly, or Fast, to affect how tests are run"

--- a/shelley/chain-and-ledger/executable-spec/test/Tests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Tests.hs
@@ -11,11 +11,12 @@ import           Test.TestScenario (TestScenario (..), mainWithTestScenario)
 tests :: TestTree
 tests = askOption $ \case
   Nightly -> nightlyTests
+  Fast -> fastTests
   _ -> mainTests
 
 mainTests :: TestTree
 mainTests = testGroup "Ledger with Delegation"
-  [ cddlTests 1
+  [ cddlTests 5
   , minimalPropertyTests
   , serializationTests
   , stsTests
@@ -26,6 +27,14 @@ nightlyTests :: TestTree
 nightlyTests = testGroup "Ledger with Delegation nightly"
   [ propertyTests
   , cddlTests 50
+  ]
+
+fastTests :: TestTree
+fastTests = testGroup "Ledger with Delegation fast"
+  [ cddlTests 1
+  , serializationTests
+  , stsTests
+  , unitTests
   ]
 
 -- main entry point

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -856,6 +856,12 @@ The Chain Tick Transition performs some chain level
 upkeep. The environment consists of a set of genesis keys, and the state is the
 epoch specific state necessary for the $\mathsf{NEWEPOCH}$ transition.
 
+Part of the upkeep is updating the genesis key delegation mapping
+according to the future delegation mapping.
+For each genesis key, we adopt the most recent delegation in $\var{fGenDelegs}$
+that is past the current slot, and any future genesis key delegations past the current
+slot is removed. The helper function $\fun{adoptGenesisDelegs}$ accomplishes the update.
+
 \begin{figure}
   \emph{Chain Tick Transitions}
   \begin{equation*}
@@ -864,6 +870,52 @@ epoch specific state necessary for the $\mathsf{NEWEPOCH}$ transition.
   \end{equation*}
   \caption{Tick transition-system types}
   \label{fig:ts-types:tick}
+  %
+  \emph{helper function}
+  \begin{align*}
+      & \fun{adoptGenesisDelegs} \in \EpochState \to \Slot \to EpochState
+      \\
+      & \fun{adoptGenesisDelegs}~\var{es}~\var{slot} = \var{es'}
+      \\
+      & ~~~~\where
+      \\
+      & ~~~~~~~~~~
+      (\var{acnt},~\var{ss},(\var{us},(\var{ds},\var{ps})),~\var{prevPp},~\var{pp})
+      \leteq\var{es}
+      \\
+      & ~~~~~~~~~~
+      (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},
+      ~\var{fGenDelegs},~\var{genDelegs},~\var{i_{rwd}})\leteq\var{ds}
+      \\
+      & ~~~~~~~~~~\var{curr}\leteq
+        \{
+          (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{fGenDelegs}
+          ~\mid~
+          \var{s}\leq\var{slot}
+        \}
+      \\
+      & ~~~~~~~~~~\var{fGenDelegs'}\leteq
+          \var{fGenDelegs}\setminus\var{curr}
+      \\
+      & ~~~~~~~~~~\var{genDelegs'}\leteq
+          \left\{
+            \var{gkh}\mapsto\var{vkh}
+            ~\mathrel{\Bigg|}~
+            {
+              \begin{array}{l}
+                (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{curr}\\
+                \var{s}=\max\{s'~\mid~(s',~\var{gkh})\in\dom{\var{curr}}\}
+              \end{array}
+            }
+          \right\}
+      \\
+      & ~~~~~~~~~~\var{ds'}\leteq
+          (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},
+          ~\var{fGenDelegs'},~\var{genDelegs}\unionoverrideRight\var{genDelegs'},~\var{i_{rwd}})
+      \\
+      & ~~~~~~~~~~\var{es'}\leteq
+      (\var{acnt},~\var{ss},(\var{us},(\var{ds'},\var{ps})),~\var{prevPp},~\var{pp})
+  \end{align*}
 \end{figure}
 
 The $\mathsf{TICK}$ transition rule is shown in Figure~\ref{fig:rules:tick}.
@@ -896,9 +948,6 @@ Three transitions are done:
       }
       \\~\\
       (\wcard,~\var{b_{prev}},~\wcard,~\var{es},~\wcard,~\wcard,~\wcard)\leteq\var{nes} \\
-      \\
-      (\var{e_\ell'},~\var{b_{prev}'},~\var{b_{cur}'},~\var{es'},~\var{ru'},~\var{pd'},\var{osched'})
-      \leteq\var{nes'}
       \\~\\
       {
         {\begin{array}{c}
@@ -908,8 +957,13 @@ Three transitions are done:
         \vdash \var{ru'}\trans{\hyperref[fig:rules:reward-update]{rupd}}{\var{s}} \var{ru''}
       }
       \\~\\
+      (\var{e_\ell'},~\var{b_{prev}'},~\var{b_{cur}'},~\var{es'},~\var{ru'},~\var{pd'},\var{osched'})
+      \leteq\var{nes'}
+      \\
+      \var{es''}\leteq\fun{adoptGenesisDelegs}~\var{es'}~\var{s}
+      \\
       \var{nes''}\leteq
-      (\var{e_\ell'},~\var{b_{prev}'},~\var{b_{cur}'},~\var{es'},~\var{ru''},~\var{pd'},\var{osched'})
+      (\var{e_\ell'},~\var{b_{prev}'},~\var{b_{cur}'},~\var{es''},~\var{ru''},~\var{pd'},\var{osched'})
       \\~\\
     }
     {

--- a/shelley/chain-and-ledger/formal-spec/ledger.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger.tex
@@ -121,14 +121,6 @@ then calls the $\mathsf{DELEGS}$ transition.
 
 The transition system $\mathsf{LEDGER}$ in Figure~\ref{fig:rules:ledger} is iterated
 in $\mathsf{LEDGERS}$ in order to process a list of transactions.
-The base case also adopts new application versions at the appropriate times
-and cleans up the future application versions mapping.
-Note that it is better to handle this logic here than in the $\mathsf{AVUP}$ transiton,
-because here it will happen even if the block contains no transactions.
-Similarly, the genesis key delegation mapping is updated according to the future delegation
-mapping. For each genesis key, we adopt the most recent delegation in $\var{fGenDelegs}$
-that is past the current slot, and any future genesis key delegations past the current
-slot is removed.
 
 \begin{figure}[htb]
   \emph{Ledger Sequence transitions}
@@ -145,56 +137,7 @@ slot is removed.
   \begin{equation}
     \label{eq:ledgers-base}
     \inference[Seq-ledger-base]
-    {
-      ((\var{utxo},~\var{deposits},~\var{fees},~\var{us})
-      ,~(\var{ds}, \var{ps}))
-      \leteq\var{ls}
-      \\
-      (\var{pup},~\var{aup},~\var{favs},~\var{avs}) \leteq\var{us}
-      \\
-      (\var{stkeys},~\var{rewards},~\var{delegations}, ~\var{ptrs},
-      ~\var{fGenDelegs},~\var{genDelegs},~\var{i_{rwd}})
-      \leteq\var{ds}
-      \\~\\
-      {\begin{array}{r@{~\leteq~}l}
-        \var{favs'} & \{\var{s}\mapsto\var{v}\in\var{favs} ~\mid~ s>\var{slot}\}
-        \\
-        \var{avs'}
-        & \var{avs}\unionoverrideRight\fun{newAVs}~\var{avs}~(\var{favs}\setminus\var{favs'})
-      \end{array}}
-      \\~\\
-      {\begin{array}{r@{~\leteq~}l}
-          \var{curr}
-          &
-          \{
-            (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{fGenDelegs}
-            ~\mid~
-            \var{s}\leq\var{slot}
-          \}\\
-          \var{fGenDelegs'}
-          &
-          \var{fGenDelegs}\setminus\var{curr}\\
-      \end{array}}\\
-      \var{genDelegs'}\leteq
-      \left\{
-        \var{gkh}\mapsto\var{vkh}
-        ~\mathrel{\Bigg|}~
-        {
-          \begin{array}{l}
-            (\var{s},~\var{gkh})\mapsto\var{vkh}\in\var{curr}\\
-            \var{s}=\max\{s'~\mid~(s',~\var{gkh})\in\dom{\var{curr}}\}
-          \end{array}
-        }
-      \right\}
-      \\~\\
-      \var{us'}\leteq(\var{pup},~\var{aup},~\var{favs'},~\var{avs'})
-      \\
-      \var{ds'}\leteq
-      (\var{stkeys},~\var{rewards},~\var{delegations},~\var{ptrs},
-      ~\var{fGenDelegs'},~\var{genDelegs}\unionoverrideRight\var{genDelegs'},~\var{i_{rwd}})
-      \\
-      \var{ls'}\leteq((\var{utxo},~\var{deposits},~\var{fees},~\var{us'}),~(\var{ds'}, \var{ps}))
-    }
+    { }
     {
       \begin{array}{r}
         \var{slot}\\


### PR DESCRIPTION
Previously, new genesis key delegations were adopted in the base case of the `LEDGERS` transition.

This is unfortunate for the consensus integration, and would cause the header validation properties to fail. This PR moves this update to the `TICK` transition.