### PR TITLE
shelley-spec-ledger-test: Expose coreNodeKeys function

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Presets.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Presets.hs
@@ -6,7 +6,8 @@
 --   Functions in this module make specific assumptions about the sets of keys
 --   involved, and thus cannot be used as generic generators.
 module Test.Shelley.Spec.Ledger.Generator.Presets
-  ( keySpace,
+  ( coreNodeKeys,
+    keySpace,
     genEnv,
     genUtxo0,
     genesisDelegs0,


### PR DESCRIPTION
Useful for testing in the 'node' repo.