### PR TITLE
fix overlay schedule bug with no genesis nodes

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -1158,11 +1158,12 @@ overlaySchedule e gkeys pp = do
         numInactivePerActive = floor (1 / ascValue) - 1
         activitySchedule = cycle (True:replicate numInactivePerActive False)
         unassignedSched = zip activitySchedule genesisSlots
+        genesisCycle = if Set.null gkeys then [] else cycle (Set.toList gkeys)
 
         active =
           Map.fromList $ fmap
             (\(gk,(_,s))->(s, ActiveSlot gk))
-            (zip (cycle (Set.toList gkeys)) (filter fst unassignedSched))
+            (zip genesisCycle (filter fst unassignedSched))
         inactive =
           Map.fromList $ fmap
             (\x -> (snd x, NonActiveSlot))

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
@@ -482,6 +482,16 @@ testOverlayScheduleZero =
         (emptyPParams {_d = unsafeMkUnitInterval 0})
   in os @?= Map.empty
 
+testNoGenesisOverlay :: Assertion
+testNoGenesisOverlay =
+  let
+    os = runShelleyBase
+      $ overlaySchedule
+        (EpochNo 0)
+        mempty
+        (emptyPParams {_d = unsafeMkUnitInterval 0.5})
+  in os @?= Map.empty
+
 testVRFCheckWithActiveSlotCoeffOne :: Assertion
 testVRFCheckWithActiveSlotCoeffOne =
   checkVRFValue 0 (1 % 2) (mkActiveSlotCoeff $ unsafeMkUnitInterval 1) @?= True
@@ -496,6 +506,8 @@ testsPParams =
   testGroup "Test the protocol parameters."
     [ testCase "Overlay Schedule when d is zero" $
         testOverlayScheduleZero
+    , testCase "generate overlay schedule without genesis nodes" $
+        testNoGenesisOverlay
     , testCase "VRF checks when the activeSlotCoeff is one" $
         testVRFCheckWithActiveSlotCoeffOne
     , testCase "VRF checks when the VRF leader value is one" $


### PR DESCRIPTION
Avoid calling `cycle []`