### PR TITLE
Separate COMPLETE pragmas for VKey and VKeyGenesis

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Keys.hs
@@ -113,11 +113,11 @@ instance (Crypto crypto, Typeable kd) => ToCBOR (DiscVKey kd crypto) where
 type VKey = DiscVKey 'Regular
 pattern VKey :: VerKeyDSIGN (DSIGN crypto) -> DiscVKey 'Regular crypto
 pattern VKey a = DiscVKey a
+{-# COMPLETE VKey #-}
 type VKeyGenesis = DiscVKey 'Genesis
 pattern VKeyGenesis :: VerKeyDSIGN (DSIGN crypto) -> DiscVKey 'Genesis crypto
 pattern VKeyGenesis a = DiscVKey a
-
-{-# COMPLETE VKey, VKeyGenesis #-}
+{-# COMPLETE VKeyGenesis #-}
 
 data KeyPair (kd :: KeyDiscriminator) crypto
   = KeyPair


### PR DESCRIPTION
Looking back at #1373, it looks like I mistakenly utilized both the `VKey` and `VKeyGenesis` patterns in a single `COMPLETE` pragma when they should actually be separate (alike the `COMPLETE` pragmas for both the `KeyHash` and `GenKeyHash` patterns in this same module).