### PR TITLE
Rewrite Keys

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,42 +18,42 @@ write-ghc-environment-files: always
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 4490c6cd3ad32423ef2265d61d936efb694c63d0
-  --sha256: 1rf5zxmyws7fbgismkkg0m52l26lsa494zw9ws4zffilavz31g68
+  tag: 6e28d0913ff0f27ac64a6fa517250362897b0869
+  --sha256: 1saa37c13n8xwrcwb6b6k0fi1jla64fvpb4xmm34cvagxhkj9hyy
   subdir: binary
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 4490c6cd3ad32423ef2265d61d936efb694c63d0
-  --sha256: 1rf5zxmyws7fbgismkkg0m52l26lsa494zw9ws4zffilavz31g68
+  tag: 6e28d0913ff0f27ac64a6fa517250362897b0869
+  --sha256: 1saa37c13n8xwrcwb6b6k0fi1jla64fvpb4xmm34cvagxhkj9hyy
   subdir: binary/test
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 4490c6cd3ad32423ef2265d61d936efb694c63d0
-  --sha256: 1rf5zxmyws7fbgismkkg0m52l26lsa494zw9ws4zffilavz31g68
+  tag: 6e28d0913ff0f27ac64a6fa517250362897b0869
+  --sha256: 1saa37c13n8xwrcwb6b6k0fi1jla64fvpb4xmm34cvagxhkj9hyy
   subdir: cardano-crypto-class
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-base
-  tag: 4490c6cd3ad32423ef2265d61d936efb694c63d0
-  --sha256: 1rf5zxmyws7fbgismkkg0m52l26lsa494zw9ws4zffilavz31g68
+  tag: 6e28d0913ff0f27ac64a6fa517250362897b0869
+  --sha256: 1saa37c13n8xwrcwb6b6k0fi1jla64fvpb4xmm34cvagxhkj9hyy
   subdir: slotting
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 91f357abae16099858193b999807323ca9a7c63c
-  --sha256: 11ya7j7ga0axvjb583pkcyxdza1p5219857817mwga7djzm5gb0b
+  tag: 398e5279e36c92df5ca30f1e68a9482d139686f4
+  --sha256: 0ckdbvca5hjqxf3a5p6w0kd2c54qc4c4f92jglaqs27nfvd262xh
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 91f357abae16099858193b999807323ca9a7c63c
-  --sha256: 11ya7j7ga0axvjb583pkcyxdza1p5219857817mwga7djzm5gb0b
+  tag: 398e5279e36c92df5ca30f1e68a9482d139686f4
+  --sha256: 0ckdbvca5hjqxf3a5p6w0kd2c54qc4c4f92jglaqs27nfvd262xh
   subdir: test
 
 source-repository-package

--- a/shelley/chain-and-ledger/executable-spec/cddl-files/mock/crypto.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/mock/crypto.cddl
@@ -9,7 +9,7 @@ natural = #6.2(bytes)
 
 $kes_vkey /= int
 $kes_signature /= [natural,signkeyKES]
-signkeyKES = [int, natural, natural] ; publishing the private key because this is fake
+signkeyKES = [int, natural] ; publishing the private key because this is fake
 
 $signature /= [bytes, int]
 

--- a/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
+++ b/shelley/chain-and-ledger/executable-spec/shelley-spec-ledger.cabal
@@ -170,6 +170,7 @@ test-suite shelley-spec-ledger-test
       base,
       base16-bytestring,
       bytestring,
+      bytestring-conversion,
       cardano-binary,
       cardano-crypto-class,
       cardano-prelude,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -18,7 +18,6 @@ module Shelley.Spec.Ledger.API.Mempool
 where
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import qualified Cardano.Crypto.DSIGN as DSIGN
 import           Shelley.Spec.Ledger.API.Validation
 import           Shelley.Spec.Ledger.Crypto
 import           Control.Arrow (left)
@@ -29,6 +28,7 @@ import           Data.Sequence (Seq)
 import           Data.Typeable (Typeable)
 import           Shelley.Spec.Ledger.BaseTypes (Globals)
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
+import           Shelley.Spec.Ledger.Keys
 import           Shelley.Spec.Ledger.Slot (SlotNo)
 import           Shelley.Spec.Ledger.STS.Ledgers (LEDGERS)
 import qualified Shelley.Spec.Ledger.STS.Ledgers as Ledgers
@@ -98,7 +98,7 @@ applyTxs ::
   forall crypto m.
   ( Crypto crypto,
     MonadError (ApplyTxError crypto) m,
-    DSIGN.Signable (DSIGN crypto) (Tx.TxBody crypto)
+    DSignable crypto (Tx.TxBody crypto)
   ) =>
   Globals ->
   MempoolEnv ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -17,7 +17,6 @@ module Shelley.Spec.Ledger.API.Validation
 where
 
 import           Byron.Spec.Ledger.Core (Relation (..))
-import qualified Cardano.Crypto.DSIGN as DSIGN
 import           Cardano.Prelude (NoUnexpectedThunks (..))
 import           Control.Arrow (left, right)
 import           Control.Monad.Except
@@ -28,6 +27,7 @@ import           GHC.Generics (Generic)
 import           Shelley.Spec.Ledger.BaseTypes (Globals (..))
 import           Shelley.Spec.Ledger.BlockChain
 import           Shelley.Spec.Ledger.Crypto
+import           Shelley.Spec.Ledger.Keys
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import           Shelley.Spec.Ledger.PParams (PParams)
 import           Shelley.Spec.Ledger.Slot (SlotNo)
@@ -111,7 +111,7 @@ applyBlockTransition ::
   forall crypto m.
   ( Crypto crypto,
     MonadError (BlockTransitionError crypto) m,
-    DSIGN.Signable (DSIGN crypto) (Tx.TxBody crypto)
+    DSignable crypto (Tx.TxBody crypto)
   ) =>
   Globals ->
   ShelleyState crypto ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 module Shelley.Spec.Ledger.API.Wallet
   ( getNonMyopicMemberRewards
   , getFilteredUTxO
@@ -14,7 +15,7 @@ import           Shelley.Spec.Ledger.API.Validation (ShelleyState)
 import           Shelley.Spec.Ledger.BaseTypes (Globals (..))
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.EpochBoundary (SnapShot (..), Stake (..), poolStake)
-import           Shelley.Spec.Ledger.Keys (KeyHash)
+import           Shelley.Spec.Ledger.Keys (KeyHash, KeyRole(..))
 import           Shelley.Spec.Ledger.LedgerState (esLState, esNonMyopic, esPp, nesEs, _utxo,
                      _utxoState)
 import           Shelley.Spec.Ledger.Rewards (NonMyopic (..), StakeShare (..), getTopRankedPools,
@@ -31,8 +32,8 @@ import           Shelley.Spec.Ledger.UTxO (UTxO (..))
 getNonMyopicMemberRewards
   :: Globals
   -> ShelleyState crypto
-  -> Set (Credential crypto)
-  -> Map (Credential crypto) (Map (KeyHash crypto) Coin)
+  -> Set (Credential 'Staking crypto)
+  -> Map (Credential 'Staking crypto) (Map (KeyHash 'StakePool crypto) Coin)
 getNonMyopicMemberRewards globals ss creds = Map.fromList $
   fmap
     (\cred -> (cred, Map.mapWithKey (mkNMMRewards $ memShare cred) poolData))

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Address.hs
@@ -16,7 +16,7 @@ import           Data.ByteString (ByteString)
 import           Cardano.Binary (serialize', decodeFull')
 
 import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Keys (KeyDiscriminator (..), KeyPair, hashKey, vKey)
+import           Shelley.Spec.Ledger.Keys (KeyRole (..), KeyPair(..), hashKey)
 import           Shelley.Spec.Ledger.Scripts
 import           Shelley.Spec.Ledger.Tx (hashScript)
 import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), RewardAcnt (..),
@@ -24,31 +24,33 @@ import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), RewardA
 
 mkVKeyRwdAcnt
   :: Crypto crypto
-  => KeyPair 'Regular crypto
+  => KeyPair 'Staking crypto
   -> RewardAcnt crypto
 mkVKeyRwdAcnt keys = RewardAcnt $ KeyHashObj (hashKey $ vKey keys)
 
 mkRwdAcnt
-  :: Credential crypto
+  :: Credential 'Staking crypto
   -> RewardAcnt crypto
 mkRwdAcnt script@(ScriptHashObj _) = RewardAcnt script
 mkRwdAcnt key@(KeyHashObj _) = RewardAcnt key
 
 toAddr
   :: Crypto crypto
-  => (KeyPair 'Regular crypto, KeyPair 'Regular crypto)
+  => (KeyPair 'Payment crypto, KeyPair 'Staking crypto)
   -> Addr crypto
 toAddr (payKey, stakeKey) = Addr (toCred payKey) (StakeRefBase $ toCred stakeKey)
 
 toCred
   :: Crypto crypto
-  => KeyPair 'Regular crypto
-  -> Credential crypto
+  => KeyPair kr crypto
+  -> Credential kr crypto
 toCred k = KeyHashObj . hashKey $ vKey k
 
 -- | Convert a given multi-sig script to a credential by hashing it and wrapping
 -- into the `Credential` data type.
-scriptToCred :: Crypto crypto => MultiSig crypto -> Credential crypto
+--
+-- TODO nc what is the role of this credential?
+scriptToCred :: Crypto crypto => MultiSig crypto -> Credential kr crypto
 scriptToCred = ScriptHashObj . hashScript
 
 -- | Create a base address from a pair of multi-sig scripts (pay and stake)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
@@ -18,9 +18,7 @@ module Shelley.Spec.Ledger.MetaData
 
 import           Cardano.Binary (Annotator (..), DecoderError (..), FromCBOR (fromCBOR),
                      ToCBOR (toCBOR), encodePreEncoded, serializeEncoding, withSlice)
-import           Cardano.Crypto.Hash (Hash, hash)
-import           Cardano.Prelude (AllowThunksIn (..), LByteString, NoUnexpectedThunks (..), Word64,
-                     cborError)
+import           Cardano.Prelude (AllowThunksIn(..), LByteString, NoUnexpectedThunks (..), Word64, cborError)
 import           Data.Bifunctor (bimap)
 import           Data.Bitraversable (bitraverse)
 import           Data.ByteString as B
@@ -28,12 +26,13 @@ import           Data.ByteString.Lazy as BL
 import           Data.Map.Strict (Map)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
-import           Shelley.Spec.Ledger.Crypto (Crypto, HASH)
+import           Shelley.Spec.Ledger.Crypto (Crypto)
+import           Shelley.Spec.Ledger.Keys (Hash, hash)
 
 import qualified Codec.CBOR.Term as CBOR
 
 import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.Serialization (mapToCBOR, mapFromCBOR)
+import           Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR)
 
 -- | A generic metadatum type.
 --
@@ -117,7 +116,7 @@ instance FromCBOR MetaDatum
        Left e   -> (cborError . DecoderErrorCustom "metadata" . T.pack) e
 
 newtype MetaDataHash crypto
-  = MetaDataHash { unsafeMetaDataHash :: Hash (HASH crypto) MetaData }
+  = MetaDataHash { unsafeMetaDataHash :: Hash crypto MetaData }
   deriving (Show, Eq, Ord, NoUnexpectedThunks)
 
 deriving instance Crypto crypto => ToCBOR (MetaDataHash crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -41,7 +42,7 @@ import           Shelley.Spec.Ledger.BaseTypes (Nonce (NeutralNonce), StrictMayb
                      UnitInterval, interval0, invalidKey, strictMaybeToMaybe)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Keys (GenDelegs, GenKeyHash)
+import           Shelley.Spec.Ledger.Keys (GenDelegs, KeyHash, KeyRole(..))
 import           Shelley.Spec.Ledger.Serialization (CBORGroup (..), FromCBORGroup (..),
                      ToCBORGroup (..), decodeMapContents, mapFromCBOR, mapToCBOR, rationalFromCBOR,
                      rationalToCBOR)
@@ -322,7 +323,7 @@ instance FromCBOR PParamsUpdate where
 
 -- | Update operation for protocol parameters structure @PParams
 newtype ProposedPPUpdates crypto
-  = ProposedPPUpdates (Map (GenKeyHash crypto) PParamsUpdate)
+  = ProposedPPUpdates (Map (KeyHash 'Genesis crypto) PParamsUpdate)
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (ProposedPPUpdates crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -32,8 +33,8 @@ import           Shelley.Spec.Ledger.BlockChain (BHBody, BHeader, Block (..), La
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
 import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
-import           Shelley.Spec.Ledger.Keys (GenDelegs (..), GenKeyHash, KESignable, KeyHash,
-                     Signable, VKeyES)
+import           Shelley.Spec.Ledger.Keys (KeyRole(..), GenDelegs (..), KESignable, KeyHash,
+                     DSignable, VerKeyKES, coerceKeyRole)
 import           Shelley.Spec.Ledger.LedgerState (AccountState (..), DPState (..), DState (..),
                      EpochState (..), LedgerState (..), NewEpochState (..), OBftSlot, PState (..),
                      UTxOState (..), emptyDState, emptyPState, getGKeys, updateNES, _genDelegs)
@@ -58,7 +59,7 @@ data CHAIN crypto
 data ChainState crypto
   = ChainState
     { chainNes              :: NewEpochState crypto
-    , chainOCertIssue       :: Map.Map (KeyHash crypto) Natural
+    , chainOCertIssue       :: Map.Map (KeyHash 'BlockIssuer crypto) Natural
     , chainEpochNonce       :: Nonce
     , chainEvolvingNonce    :: Nonce
     , chainCandidateNonce   :: Nonce
@@ -73,7 +74,7 @@ initialShelleyState
   -> EpochNo
   -> UTxO crypto
   -> Coin
-  -> Map (GenKeyHash crypto) (KeyHash crypto)
+  -> Map (KeyHash 'Genesis crypto) (KeyHash 'GenesisDelegate crypto)
   -> Map SlotNo (OBftSlot crypto)
   -> PParams
   -> Nonce
@@ -111,12 +112,12 @@ initialShelleyState lab e utxo reserves genDelegs os pp initNonce =
     NeutralNonce
     lab
   where
-    cs = Map.fromList (fmap (\hk -> (hk,0)) (Map.elems genDelegs))
+    cs = Map.fromList (fmap (\hk -> (coerceKeyRole hk,0)) (Map.elems genDelegs))
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
+  , DSignable crypto (TxBody crypto)
   , KESignable crypto (BHBody crypto)
   , VRF.Signable (VRF crypto) Seed
   )
@@ -162,8 +163,8 @@ chainChecks maxpv pp bh = do
 chainTransition
   :: forall crypto
    . ( Crypto crypto
-     , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
-     , Signable (DSIGN crypto) (TxBody crypto)
+     , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
+     , DSignable crypto (TxBody crypto)
      , KESignable crypto (BHBody crypto)
      , VRF.Signable (VRF crypto) Seed
      )
@@ -204,8 +205,8 @@ chainTransition = judgmentContext >>=
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
+  , DSignable crypto (TxBody crypto)
   , KESignable crypto (BHBody crypto)
   , VRF.Signable (VRF crypto) Seed
   )
@@ -215,8 +216,8 @@ instance
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
+  , DSignable crypto (TxBody crypto)
   , KESignable crypto (BHBody crypto)
   , VRF.Signable (VRF crypto) Seed
   )
@@ -226,8 +227,8 @@ instance
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (VKeyES crypto, Natural, KESPeriod)
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
+  , DSignable crypto (TxBody crypto)
   , KESignable crypto (BHBody crypto)
   , VRF.Signable (VRF crypto) Seed
   )

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -135,7 +135,7 @@ delegationTransition = do
       pure $ ds
         { _delegations = _delegations ds ⨃ [(hk, dpool)] }
 
-    DCertGenesis (GenesisDelegate gkh vkh) -> do
+    DCertGenesis (GenesisDelegCert gkh vkh) -> do
       sp <- liftSTS $ asks slotsPrior
       -- note that pattern match is used instead of genesisDeleg, as in the spec
       let s' = slot +* Duration sp

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
@@ -116,7 +116,7 @@ delplTransition = do
       ps <-
         trans @(POOL crypto) $ TRC (PoolEnv slot pp, _pstate d, c)
       pure $ d { _pstate = ps }
-    DCertGenesis (GenesisDelegate {}) -> do
+    DCertGenesis (GenesisDelegCert {}) -> do
       ds <-
         trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
       pure $ d { _dstate = ds }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -55,7 +55,7 @@ data LedgerEnv
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (TxBody crypto)
   )
   => STS (LEDGER crypto)
  where
@@ -102,7 +102,7 @@ instance
 ledgerTransition
   :: forall crypto
    . ( Crypto crypto
-     , Signable (DSIGN crypto) (TxBody crypto)
+     , DSignable crypto (TxBody crypto)
      )
   => TransitionRule (LEDGER crypto)
 ledgerTransition = do
@@ -126,7 +126,7 @@ ledgerTransition = do
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (TxBody crypto)
   )
   => Embed (DELEGS crypto) (LEDGER crypto)
  where
@@ -134,7 +134,7 @@ instance
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (TxBody crypto)
   )
   => Embed (UTXOW crypto) (LEDGER crypto)
  where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
@@ -25,8 +25,8 @@ import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
 import           Shelley.Spec.Ledger.Coin (Coin)
-import           Shelley.Spec.Ledger.Crypto (Crypto, DSIGN)
-import           Shelley.Spec.Ledger.Keys (Signable)
+import           Shelley.Spec.Ledger.Crypto (Crypto)
+import           Shelley.Spec.Ledger.Keys (DSignable)
 import           Shelley.Spec.Ledger.LedgerState (LedgerState (..), emptyLedgerState,
                      _delegationState, _utxoState)
 import           Shelley.Spec.Ledger.PParams (PParams)
@@ -45,7 +45,7 @@ data LedgersEnv
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (TxBody crypto)
   )
   => STS (LEDGERS crypto)
  where
@@ -77,7 +77,7 @@ instance
 ledgersTransition
   :: forall crypto
    . ( Crypto crypto
-     , Signable (DSIGN crypto) (TxBody crypto)
+     , DSignable crypto (TxBody crypto)
      )
   => TransitionRule (LEDGERS crypto)
 ledgersTransition = do
@@ -96,7 +96,7 @@ ledgersTransition = do
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (TxBody crypto)
   )
   => Embed (LEDGER crypto) (LEDGERS crypto)
  where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -121,13 +121,13 @@ poolDelegationTransition = do
 -- Instead, we just define these operators here.
 
 (⨃) ::
-  Map (KeyHash crypto) a ->
-  (KeyHash crypto, a) ->
-  Map (KeyHash crypto) a
+  Map (KeyHash kr crypto) a ->
+  (KeyHash kr crypto, a) ->
+  Map (KeyHash kr crypto) a
 m ⨃ (k, v) = Map.union (Map.singleton k v) m
 
 (∪) ::
-  Map (KeyHash crypto) a ->
-  (KeyHash crypto, a) ->
-  Map (KeyHash crypto) a
+  Map (KeyHash kr crypto) a ->
+  (KeyHash kr crypto, a) ->
+  Map (KeyHash kr crypto) a
 m ∪ (k, v) = Map.union m (Map.singleton k v)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -41,7 +42,7 @@ instance STS (PPUP crypto) where
   type Environment (PPUP crypto) = PPUPEnv crypto
   type BaseM (PPUP crypto) = ShelleyBase
   data PredicateFailure (PPUP crypto)
-    = NonGenesisUpdatePPUP (Set (GenKeyHash crypto)) (Set (GenKeyHash crypto))
+    = NonGenesisUpdatePPUP (Set (KeyHash 'Genesis crypto)) (Set (KeyHash 'Genesis crypto))
     | PPUpdateTooLatePPUP
     | PPUpdateWrongEpoch EpochNo
     | PVCannotFollowPPUP

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -23,7 +24,7 @@ import           Data.Set (Set)
 import           GHC.Generics (Generic)
 import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase, epochInfo)
 import           Shelley.Spec.Ledger.Crypto (Crypto)
-import           Shelley.Spec.Ledger.Keys (GenDelegs (..), GenKeyHash)
+import           Shelley.Spec.Ledger.Keys (KeyHash, KeyRole(..), GenDelegs (..))
 import           Shelley.Spec.Ledger.LedgerState (DPState (..), DState (..), EpochState (..),
                      FutureGenDeleg (..), LedgerState (..), NewEpochEnv (..), NewEpochState (..))
 import           Shelley.Spec.Ledger.Slot (SlotNo, epochInfoEpoch)
@@ -33,7 +34,7 @@ import           Shelley.Spec.Ledger.STS.Rupd (RUPD, RupdEnv (..))
 data TICK crypto
 
 data TickEnv crypto
-  = TickEnv (Set (GenKeyHash crypto))
+  = TickEnv (Set (KeyHash 'Genesis crypto))
 
 instance Crypto crypto
   => STS (TICK crypto)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -46,7 +46,7 @@ data UTXOW crypto
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (TxBody crypto)
   )
   => STS (UTXOW crypto)
  where
@@ -112,7 +112,7 @@ instance
 initialLedgerStateUTXOW
   :: forall crypto
    . ( Crypto crypto
-     , Signable (DSIGN crypto) (TxBody crypto)
+     , DSignable crypto (TxBody crypto)
      )
    => InitialRule (UTXOW crypto)
 initialLedgerStateUTXOW = do
@@ -122,7 +122,7 @@ initialLedgerStateUTXOW = do
 utxoWitnessed
   :: forall crypto
    . ( Crypto crypto
-     , Signable (DSIGN crypto) (TxBody crypto)
+     , DSignable crypto (TxBody crypto)
      )
    => TransitionRule (UTXOW crypto)
 utxoWitnessed = judgmentContext >>=
@@ -153,7 +153,7 @@ utxoWitnessed = judgmentContext >>=
                   SJust md' -> hashMetaData md' == mdh ?! BadMetaDataHashUTXOW
 
   -- check genesis keys signatures for instantaneous rewards certificates
-  let genSig = (Set.map undiscriminateKeyHash $ dom genMapping) ∩ Set.map witKeyHash wits
+  let genSig = (Set.map asWitness $ dom genMapping) ∩ Set.map witKeyHash wits
       mirCerts =
           StrictSeq.toStrict
         . Seq.filter isInstantaneousRewards
@@ -174,7 +174,7 @@ utxoWitnessed = judgmentContext >>=
 
 instance
   ( Crypto crypto
-  , Signable (DSIGN crypto) (TxBody crypto)
+  , DSignable crypto (TxBody crypto)
   )
   => Embed (UTXO crypto) (UTXOW crypto)
  where

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/CDDL.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/CDDL.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -32,6 +33,7 @@ import           System.Process.ByteString.Lazy
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
+import           Shelley.Spec.Ledger.Keys (KeyRole(Staking))
 import           Shelley.Spec.Ledger.MetaData (MetaData)
 import           Shelley.Spec.Ledger.PParams (PParamsUpdate)
 import           Shelley.Spec.Ledger.Serialization
@@ -49,7 +51,7 @@ cddlTests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
     , cddlTest @BHBody            n "header_body"
     , cddlGroupTest @OCert        n "operational_cert"
     , cddlGroupTest @Addr         n "address"
-    , cddlTest @Credential        n "stake_credential"
+    , cddlTest @(Credential 'Staking)   n "stake_credential"
     , cddlTest' @TxBody           n "transaction_body"
     , cddlTest @TxOut             n "transaction_output"
     , cddlTest @StakePoolRelay    n "relay"

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -213,7 +213,7 @@ coreNodeKeys = snd . (coreNodes !!)
 
 genDelegs :: Map (KeyHash 'Genesis) (KeyHash 'GenesisDelegate)
 genDelegs = Map.fromList
-  [ (coerceKeyRole . hashKey $ snd gkey
+  [ ( hashKey $ snd gkey
     , coerceKeyRole . hashKey . vKey $ cold pkeys)
   | (gkey, pkeys) <- coreNodes]
 
@@ -566,7 +566,7 @@ initStEx2A = initialShelleyState
 blockEx2A :: Block
 blockEx2A = mkBlock
              lastByronHeaderHash
-             (coreNodeKeys 2)
+             (coreNodeKeys 0)
              [txEx2A]
              (SlotNo 10)
              (BlockNo 1)
@@ -575,7 +575,7 @@ blockEx2A = mkBlock
              zero
              0
              0
-             (mkOCert (coreNodeKeys 2) 0 (KESPeriod 0))
+             (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 dsEx2A :: DState
 dsEx2A = dsEx1
@@ -680,7 +680,7 @@ txEx2B = Tx
 blockEx2B :: Block
 blockEx2B = mkBlock
              blockEx2AHash    -- Hash of previous block
-             (coreNodeKeys 5)
+             (coreNodeKeys 3)
              [txEx2B]         -- Single transaction to record
              (SlotNo 90)      -- Current slot
              (BlockNo 2)
@@ -689,7 +689,7 @@ blockEx2B = mkBlock
              zero             -- Praos leader value
              4                -- Period of KES (key evolving signature scheme)
              0
-             (mkOCert (coreNodeKeys 5) 0 (KESPeriod 0))
+             (mkOCert (coreNodeKeys 3) 0 (KESPeriod 0))
 
 blockEx2BHash :: HashHeader
 blockEx2BHash = bhHash (bheader blockEx2B)
@@ -782,7 +782,7 @@ ex2B = CHAINExample (SlotNo 90) expectedStEx2A blockEx2B (Right expectedStEx2B)
 blockEx2C :: Block
 blockEx2C = mkBlock
              blockEx2BHash    -- Hash of previous block
-             (coreNodeKeys 2)
+             (coreNodeKeys 0)
              []               -- No transactions at all (empty block)
              (SlotNo 110)     -- Current slot
              (BlockNo 3)      -- Second block within the epoch
@@ -791,7 +791,7 @@ blockEx2C = mkBlock
              zero             -- Praos leader value
              5                -- Period of KES (key evolving signature scheme)
              0
-             (mkOCert (coreNodeKeys 2) 0 (KESPeriod 0))
+             (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 epoch1OSchedEx2C :: Map SlotNo OBftSlot
 epoch1OSchedEx2C = runShelleyBase $ overlaySchedule
@@ -945,7 +945,7 @@ txEx2D = Tx
 blockEx2D :: Block
 blockEx2D = mkBlock
              blockEx2CHash
-             (coreNodeKeys 5)
+             (coreNodeKeys 3)
              [txEx2D]
              (SlotNo 190)
              (BlockNo 4)
@@ -954,7 +954,7 @@ blockEx2D = mkBlock
              zero
              9
              0
-             (mkOCert (coreNodeKeys 5) 0 (KESPeriod 0))
+             (mkOCert (coreNodeKeys 3) 0 (KESPeriod 0))
 
 blockEx2DHash :: HashHeader
 blockEx2DHash = bhHash (bheader blockEx2D)
@@ -1029,7 +1029,7 @@ ex2D = CHAINExample (SlotNo 190) expectedStEx2C blockEx2D (Right expectedStEx2D)
 blockEx2E :: Block
 blockEx2E = mkBlock
              blockEx2DHash
-             (coreNodeKeys 5)
+             (coreNodeKeys 3)
              []
              (SlotNo 220)
              (BlockNo 5)
@@ -1038,7 +1038,7 @@ blockEx2E = mkBlock
              zero
              11
              10
-             (mkOCert (coreNodeKeys 5) 1 (KESPeriod 10))
+             (mkOCert (coreNodeKeys 3) 1 (KESPeriod 10))
 
 epoch1OSchedEx2E :: Map SlotNo OBftSlot
 epoch1OSchedEx2E = runShelleyBase $ overlaySchedule
@@ -1086,7 +1086,7 @@ acntEx2E = AccountState
 oCertIssueNosEx2 :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2 =
   Map.insert
-    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 5)
+    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 3)
     1
     oCertIssueNosEx1
 
@@ -1178,7 +1178,7 @@ ex2F = CHAINExample (SlotNo 295) expectedStEx2E blockEx2F (Right expectedStEx2F)
 blockEx2G :: Block
 blockEx2G = mkBlock
              blockEx2FHash
-             (coreNodeKeys 2)
+             (coreNodeKeys 0)
              []
              (SlotNo 310)
              (BlockNo 7)
@@ -1187,7 +1187,7 @@ blockEx2G = mkBlock
              zero
              15
              15
-             (mkOCert (coreNodeKeys 2) 1 (KESPeriod 15))
+             (mkOCert (coreNodeKeys 0) 1 (KESPeriod 15))
 
 blockEx2GHash :: HashHeader
 blockEx2GHash = bhHash (bheader blockEx2G)
@@ -1218,7 +1218,7 @@ expectedLSEx2G = LedgerState
 oCertIssueNosEx2G :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2G =
   Map.insert
-    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 2)
+    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 0)
     1
     oCertIssueNosEx2F
 
@@ -1255,7 +1255,7 @@ ex2G = CHAINExample (SlotNo 310) expectedStEx2F blockEx2G (Right expectedStEx2G)
 blockEx2H :: Block
 blockEx2H = mkBlock
              blockEx2GHash
-             (coreNodeKeys 5)
+             (coreNodeKeys 3)
              []
              (SlotNo 390)
              (BlockNo 8)
@@ -1264,7 +1264,7 @@ blockEx2H = mkBlock
              zero
              19
              19
-             (mkOCert (coreNodeKeys 5) 2 (KESPeriod 19))
+             (mkOCert (coreNodeKeys 3) 2 (KESPeriod 19))
 
 blockEx2HHash :: HashHeader
 blockEx2HHash = bhHash (bheader blockEx2H)
@@ -1282,7 +1282,7 @@ rewardsEx2H = Map.fromList [ (RewardAcnt aliceSHK, aliceRAcnt2H)
 oCertIssueNosEx2H :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2H =
   Map.insert
-    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 5)
+    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 3)
     2
     oCertIssueNosEx2G
 
@@ -1331,7 +1331,7 @@ ex2H = CHAINExample (SlotNo 390) expectedStEx2G blockEx2H (Right expectedStEx2H)
 blockEx2I :: Block
 blockEx2I = mkBlock
               blockEx2HHash
-              (coreNodeKeys 2)
+              (coreNodeKeys 0)
               []
               (SlotNo 410)
               (BlockNo 9)
@@ -1340,7 +1340,7 @@ blockEx2I = mkBlock
               zero
               20
               20
-              (mkOCert (coreNodeKeys 2) 2 (KESPeriod 20))
+              (mkOCert (coreNodeKeys 0) 2 (KESPeriod 20))
 
 blockEx2IHash :: HashHeader
 blockEx2IHash = bhHash (bheader blockEx2I)
@@ -1386,7 +1386,7 @@ snapsEx2I = snapsEx2G { _pstakeMark = SnapShot
 oCertIssueNosEx2I :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2I =
   Map.insert
-    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 2)
+    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 0)
     2
     oCertIssueNosEx2H
 
@@ -1443,7 +1443,7 @@ txEx2J = Tx
 blockEx2J :: Block
 blockEx2J = mkBlock
               blockEx2IHash
-              (coreNodeKeys 5)
+              (coreNodeKeys 3)
               [txEx2J]
               (SlotNo 420)
               (BlockNo 10)
@@ -1452,7 +1452,7 @@ blockEx2J = mkBlock
               zero
               21
               19
-              (mkOCert (coreNodeKeys 5) 2 (KESPeriod 19))
+              (mkOCert (coreNodeKeys 3) 2 (KESPeriod 19))
 
 blockEx2JHash :: HashHeader
 blockEx2JHash = bhHash (bheader blockEx2J)
@@ -1485,7 +1485,7 @@ expectedLSEx2J = LedgerState
 oCertIssueNosEx2J :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2J =
   Map.insert
-    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 2)
+    (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 0)
     2
     oCertIssueNosEx2H
 
@@ -1539,7 +1539,7 @@ txEx2K = Tx
 blockEx2K :: Block
 blockEx2K = mkBlock
               blockEx2JHash
-              (coreNodeKeys 5)
+              (coreNodeKeys 3)
               [txEx2K]
               (SlotNo 490)
               (BlockNo 11)
@@ -1548,7 +1548,7 @@ blockEx2K = mkBlock
               zero
               24
               19
-              (mkOCert (coreNodeKeys 5) 2 (KESPeriod 19))
+              (mkOCert (coreNodeKeys 3) 2 (KESPeriod 19))
 
 blockEx2KHash :: HashHeader
 blockEx2KHash = bhHash (bheader blockEx2K)
@@ -1610,7 +1610,7 @@ ex2K = CHAINExample (SlotNo 490) expectedStEx2J blockEx2K (Right expectedStEx2K)
 blockEx2L :: Block
 blockEx2L = mkBlock
               blockEx2KHash
-              (coreNodeKeys 2)
+              (coreNodeKeys 0)
               []
               (SlotNo 510)
               (BlockNo 12)
@@ -1619,7 +1619,7 @@ blockEx2L = mkBlock
               zero
               25
               25
-              (mkOCert (coreNodeKeys 2) 3 (KESPeriod 25))
+              (mkOCert (coreNodeKeys 0) 3 (KESPeriod 25))
 
 blockEx2LHash :: HashHeader
 blockEx2LHash = bhHash (bheader blockEx2L)
@@ -1662,7 +1662,7 @@ expectedLSEx2L = LedgerState
 
 oCertIssueNosEx2L :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2L =
-  Map.insert (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 2) 3 oCertIssueNosEx2J
+  Map.insert (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 0) 3 oCertIssueNosEx2J
 
 expectedStEx2L :: ChainState
 expectedStEx2L = ChainState
@@ -1755,7 +1755,7 @@ txEx3A = Tx
 blockEx3A :: Block
 blockEx3A = mkBlock
              lastByronHeaderHash
-             (coreNodeKeys 2)
+             (coreNodeKeys 0)
              [txEx3A]
              (SlotNo 10)
              (BlockNo 1)
@@ -1764,7 +1764,7 @@ blockEx3A = mkBlock
              zero
              0
              0
-             (mkOCert (coreNodeKeys 2) 0 (KESPeriod 0))
+             (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 expectedLSEx3A :: LedgerState
 expectedLSEx3A = LedgerState
@@ -1846,7 +1846,7 @@ txEx3B = Tx
 blockEx3B :: Block
 blockEx3B = mkBlock
              blockEx3AHash
-             (coreNodeKeys 5)
+             (coreNodeKeys 3)
              [txEx3B]
              (SlotNo 20)
              (BlockNo 2)
@@ -1855,7 +1855,7 @@ blockEx3B = mkBlock
              zero
              1
              0
-             (mkOCert (coreNodeKeys 5) 0 (KESPeriod 0))
+             (mkOCert (coreNodeKeys 3) 0 (KESPeriod 0))
 
 utxoEx3B :: UTxO
 utxoEx3B = UTxO . Map.fromList $
@@ -1909,7 +1909,7 @@ ex3B = CHAINExample (SlotNo 20) expectedStEx3A blockEx3B (Right expectedStEx3B)
 blockEx3C :: Block
 blockEx3C = mkBlock
              blockEx3BHash
-             (coreNodeKeys 2)
+             (coreNodeKeys 0)
              []
              (SlotNo 110)
              (BlockNo 3)
@@ -1918,7 +1918,7 @@ blockEx3C = mkBlock
              zero
              5
              0
-             (mkOCert (coreNodeKeys 2) 0 (KESPeriod 0))
+             (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 blockEx3CHash :: HashHeader
 blockEx3CHash = bhHash (bheader blockEx3C)
@@ -2001,7 +2001,7 @@ txEx4A = Tx
 blockEx4A :: Block
 blockEx4A = mkBlock
               lastByronHeaderHash
-              (coreNodeKeys 2)
+              (coreNodeKeys 0)
               [txEx4A]
               (SlotNo 10)
               (BlockNo 1)
@@ -2010,7 +2010,7 @@ blockEx4A = mkBlock
               zero
               0
               0
-              (mkOCert (coreNodeKeys 2) 0 (KESPeriod 0))
+              (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 blockEx4AHash :: HashHeader
 blockEx4AHash = bhHash (bheader blockEx4A)
@@ -2064,7 +2064,7 @@ ex4A = CHAINExample (SlotNo 10) initStEx2A blockEx4A (Right expectedStEx4A)
 blockEx4B :: Block
 blockEx4B = mkBlock
              blockEx4AHash
-             (coreNodeKeys 1)
+             (coreNodeKeys 6)
              []
              (SlotNo 50)
              (BlockNo 2)
@@ -2073,7 +2073,7 @@ blockEx4B = mkBlock
              zero
              2
              0
-             (mkOCert (coreNodeKeys 1) 0 (KESPeriod 0))
+             (mkOCert (coreNodeKeys 6) 0 (KESPeriod 0))
 
 blockEx4BHash :: HashHeader
 blockEx4BHash = bhHash (bheader blockEx4B)
@@ -2159,7 +2159,7 @@ txEx5A = Tx
 blockEx5A :: Block
 blockEx5A = mkBlock
               lastByronHeaderHash
-              (coreNodeKeys 2)
+              (coreNodeKeys 0)
               [txEx5A]
               (SlotNo 10)
               (BlockNo 1)
@@ -2168,7 +2168,7 @@ blockEx5A = mkBlock
               zero
               0
               0
-              (mkOCert (coreNodeKeys 2) 0 (KESPeriod 0))
+              (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 blockEx5AHash :: HashHeader
 blockEx5AHash = bhHash (bheader blockEx5A)
@@ -2232,7 +2232,7 @@ txEx5B = Tx
 blockEx5B :: Block
 blockEx5B = mkBlock
               lastByronHeaderHash
-              (coreNodeKeys 2)
+              (coreNodeKeys 0)
               [txEx5B]
               (SlotNo 10)
               (BlockNo 1)
@@ -2241,7 +2241,7 @@ blockEx5B = mkBlock
               zero
               0
               0
-              (mkOCert (coreNodeKeys 2) 0 (KESPeriod 0))
+              (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 expectedStEx5B :: PredicateFailure CHAIN
 expectedStEx5B = BbodyFailure (LedgersFailure (LedgerFailure (UtxowFailure MIRInsufficientGenesisSigsUTXOW)))
@@ -2325,7 +2325,7 @@ txEx5F = Tx txbodyEx5F
 blockEx5F :: Block
 blockEx5F = mkBlock
               lastByronHeaderHash
-              (coreNodeKeys 2)
+              (coreNodeKeys 0)
               [txEx5F]
               (SlotNo 10)
               (BlockNo 1)
@@ -2334,7 +2334,7 @@ blockEx5F = mkBlock
               zero
               0
               0
-              (mkOCert (coreNodeKeys 2) 0 (KESPeriod 0))
+              (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 -- | The second transaction in the next epoch and at least `startRewards` slots
 -- after the transaction carrying the MIR certificate, then creates the rewards
@@ -2361,7 +2361,7 @@ txEx5F' = Tx txbodyEx5F' (makeWitnessesVKey txbodyEx5F' [ alicePay ]) Map.empty 
 blockEx5F' :: Block
 blockEx5F' = mkBlock
               (bhHash (bheader blockEx5F))
-              (coreNodeKeys 0)
+              (coreNodeKeys 5)
               [txEx5F']
               ((slotFromEpoch $ EpochNo 1)
                 +* Duration (startRewards testGlobals) + SlotNo 7)
@@ -2371,7 +2371,7 @@ blockEx5F' = mkBlock
               zero
               7
               0
-              (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+              (mkOCert (coreNodeKeys 5) 0 (KESPeriod 0))
 
 -- | The third transaction in the next epoch applies the reward update to 1)
 -- register a staking credential for Alice, 2) deducing the key deposit from the
@@ -2397,7 +2397,7 @@ txEx5F'' = Tx txbodyEx5F'' (makeWitnessesVKey txbodyEx5F'' [ alicePay ]) Map.emp
 blockEx5F'' :: Block
 blockEx5F'' = mkBlock
                (bhHash (bheader blockEx5F'))
-               (coreNodeKeys 2)
+               (coreNodeKeys 0)
                [txEx5F'']
                ((slotFromEpoch $ EpochNo 2) + SlotNo 10)
                (BlockNo 3)
@@ -2406,7 +2406,7 @@ blockEx5F'' = mkBlock
                zero
                10
                10
-               (mkOCert (coreNodeKeys 2) 0 (KESPeriod 10))
+               (mkOCert (coreNodeKeys 0) 0 (KESPeriod 10))
 
 ex5F' :: Either [[PredicateFailure CHAIN]] ChainState
 ex5F' = do

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
@@ -134,7 +134,7 @@ txSimpleUTxO = Tx
   }
 
 txSimpleUTxOBytes16 :: BSL.ByteString
-txSimpleUTxOBytes16 = "83a4009f82446050074300ff0181840044cfb2c4144476394f7a0a02185e030aa10081821a6753449f8244843dbcfc1a6753449ff6"
+txSimpleUTxOBytes16 = "83a4009f82446050074300ff0181840044aee84c70440acd1b520a02185e030aa10081821b303030303032313482447c5af1ef1b3030303030323134f6"
 
 -- | Transaction which consumes two UTxO and creates five UTxO
 -- | and has two witness
@@ -171,7 +171,7 @@ txMutiUTxO = Tx
   }
 
 txMutiUTxOBytes16 :: BSL.ByteString
-txMutiUTxOBytes16 = "83a4009f8244605007430082446050074301ff0185840044cfb2c4144476394f7a0a840044cfb2c4144476394f7a14840044cfb2c4144476394f7a181e840044f079394944bcbe39001828840044f079394944bcbe390018320218c7030aa10082821a6753449f824441a0c70f1a6753449f821a3344eb56824441a0c70f1a3344eb56f6"
+txMutiUTxOBytes16 = "83a4009f8244605007430082446050074301ff0185840044aee84c70440acd1b520a840044aee84c70440acd1b5214840044aee84c70440acd1b52181e840044d42eadb144d42eadb11828840044d42eadb144d42eadb118320218c7030aa10082821b30303030303231348244aac4968a1b3030303030323134821b31353438353836378244aac4968a1b3135343835383637f6"
 
 -- | Transaction which registers a stake key
 
@@ -196,7 +196,7 @@ txRegisterStake = Tx
   }
 
 txRegisterStakeBytes16 :: BSL.ByteString
-txRegisterStakeBytes16 = "83a5009f82446050074300ff0181840044cfb2c4144476394f7a0a02185e030a0481820082004476394f7aa10081821a6753449f8244f70aa3b61a6753449ff6"
+txRegisterStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048182008200440acd1b52a10081821b303030303032313482446724004d1b3030303030323134f6"
 
 -- | Transaction which delegates a stake key
 
@@ -221,7 +221,7 @@ txDelegateStake = Tx
   }
 
 txDelegateStakeBytes16 :: BSL.ByteString
-txDelegateStakeBytes16 = "83a5009f82446050074300ff0181840044cfb2c4144476394f7a0a02185e030a04818302820044bcbe3900442b7dd894a10082821a687c686f8244eab20f0c1a687c686f821a6753449f8244eab20f0c1a6753449ff6"
+txDelegateStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a04818302820044d42eadb14450d474d0a10082821b303030303032313482448b8c22791b3030303030323134821b313534383538363782448b8c22791b3135343835383637f6"
 
 -- | Transaction which de-registers a stake key
 
@@ -247,7 +247,7 @@ txDeregisterStake = Tx
 
 
 txDeregisterStakeBytes16 :: BSL.ByteString
-txDeregisterStakeBytes16 = "83a5009f82446050074300ff0181840044cfb2c4144476394f7a0a02185e030a0481820182004476394f7aa10081821a6753449f8244e55d50821a6753449ff6"
+txDeregisterStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048182018200440acd1b52a10081821b303030303032313482446262964d1b3030303030323134f6"
 
 -- | Transaction which registers a stake pool
 
@@ -272,7 +272,7 @@ txRegisterPool = Tx
   }
 
 txRegisterPoolBytes16 :: BSL.ByteString
-txRegisterPoolBytes16 = "83a5009f82446050074300ff0181840044cfb2c4144476394f7a0a02185e030a04818a03442b7dd89444bf6afc170105d81e82010a82004476394f7a814476394f7a818301f66872656c61792e696f826a616c6963652e706f6f6c427b7da10081821a6753449f8244b7006ffc1a6753449ff6"
+txRegisterPoolBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a04818a034450d474d04495286b7b0105d81e82010a8200440acd1b5281440acd1b52818301f66872656c61792e696f826a616c6963652e706f6f6c427b7da10081821b303030303032313482444a0fe82d1b3030303030323134f6"
 
 -- | Transaction which retires a stake pool
 
@@ -297,7 +297,7 @@ txRetirePool = Tx
   }
 
 txRetirePoolBytes16 :: BSL.ByteString
-txRetirePoolBytes16 = "83a5009f82446050074300ff0181840044cfb2c4144476394f7a0a02185e030a04818304442b7dd89405a10081821a6753449f824468032e891a6753449ff6"
+txRetirePoolBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048183044450d474d005a10081821b30303030303231348244acbec7831b3030303030323134f6"
 
 -- | Simple Transaction which consumes one UTxO and creates one UTxO
 -- | and has one witness
@@ -326,7 +326,7 @@ txWithMD = Tx
   }
 
 txWithMDBytes16 :: BSL.ByteString
-txWithMDBytes16 = "83a5009f82446050074300ff0181840044cfb2c4144476394f7a0a02185e030a07444eece652a10081821a6753449f8244287d60081a6753449fa10082056568656c6c6f"
+txWithMDBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a07444eece652a10081821b303030303032313482444731ea781b3030303030323134a10082056568656c6c6f"
 
 -- | Spending from a multi-sig address
 
@@ -358,7 +358,7 @@ txWithMultiSig = Tx
   }
 
 txWithMultiSigBytes16 :: BSL.ByteString
-txWithMultiSigBytes16 = "83a4009f82446050074300ff0181840044cfb2c4144476394f7a0a02185e030aa20082821a6753449f8244843dbcfc1a6753449f821a3344eb568244843dbcfc1a3344eb56018183030283820044cfb2c414820044f0793949820044cfff2840f6"
+txWithMultiSigBytes16 = "83a4009f82446050074300ff0181840044aee84c70440acd1b520a02185e030aa20082821b303030303032313482447c5af1ef1b3030303030323134821b313534383538363782447c5af1ef1b3135343835383637018183030283820044aee84c70820044d42eadb1820044ae010e05f6"
 
 -- | Transaction with a Reward Withdrawal
 
@@ -383,7 +383,7 @@ txWithWithdrawal = Tx
   }
 
 txWithWithdrawalBytes16 :: BSL.ByteString
-txWithWithdrawalBytes16 = "83a5009f82446050074300ff0181840044cfb2c4144476394f7a0a02185e030a05a182004476394f7a1864a10082821afdd63a1582447310d7861afdd63a15821a6753449f82447310d7861a6753449ff6"
+txWithWithdrawalBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a05a18200440acd1b521864a10082821b303030303836303282444ce091651b3030303038363032821b303030303032313482444ce091651b3030303030323134f6"
 
 -- NOTE the txsize function takes into account which actual crypto parameter is use.
 -- These tests are using ShortHash and MockDSIGN so that:
@@ -393,14 +393,14 @@ txWithWithdrawalBytes16 = "83a5009f82446050074300ff0181840044cfb2c4144476394f7a0
 
 sizeTests :: TestTree
 sizeTests = testGroup "Fee Tests"
-  [ testCase "simple utxo" $ sizeTest txSimpleUTxOBytes16 txSimpleUTxO 137
-  , testCase "multiple utxo" $ sizeTest txMutiUTxOBytes16 txMutiUTxO 454
-  , testCase "register stake key" $ sizeTest txRegisterStakeBytes16 txRegisterStake 148
-  , testCase "delegate stake key" $ sizeTest txDelegateStakeBytes16 txDelegateStake 170
-  , testCase "deregister stake key" $ sizeTest txDeregisterStakeBytes16 txDeregisterStake 148
-  , testCase "register stake pool" $ sizeTest txRegisterPoolBytes16 txRegisterPool 199
-  , testCase "retire stake pool" $ sizeTest txRetirePoolBytes16 txRetirePool 147
-  , testCase "metadata" $ sizeTest txWithMDBytes16 txWithMD 152
-  , testCase "multisig" $ sizeTest txWithMultiSigBytes16 txWithMultiSig 181
-  , testCase "reward withdrawal" $ sizeTest txWithWithdrawalBytes16 txWithWithdrawal 165
+  [ testCase "simple utxo" $ sizeTest txSimpleUTxOBytes16 txSimpleUTxO 145
+  , testCase "multiple utxo" $ sizeTest txMutiUTxOBytes16 txMutiUTxO 470
+  , testCase "register stake key" $ sizeTest txRegisterStakeBytes16 txRegisterStake 156
+  , testCase "delegate stake key" $ sizeTest txDelegateStakeBytes16 txDelegateStake 186
+  , testCase "deregister stake key" $ sizeTest txDeregisterStakeBytes16 txDeregisterStake 156
+  , testCase "register stake pool" $ sizeTest txRegisterPoolBytes16 txRegisterPool 207
+  , testCase "retire stake pool" $ sizeTest txRetirePoolBytes16 txRetirePool 155
+  , testCase "metadata" $ sizeTest txWithMDBytes16 txWithMD 160
+  , testCase "multisig" $ sizeTest txWithMultiSigBytes16 txWithMultiSig 197
+  , testCase "reward withdrawal" $ sizeTest txWithWithdrawalBytes16 txWithWithdrawal 181
   ]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/STSTests.hs
@@ -10,6 +10,7 @@ import           Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCas
 
 import           Control.State.Transition.Extended (TRC (..), applySTS)
 import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
+import           Shelley.Spec.Ledger.Keys (asWitness)
 import           Shelley.Spec.Ledger.STS.Chain (totalAda)
 import           Shelley.Spec.Ledger.STS.Utxow (PredicateFailure (..))
 import           Shelley.Spec.Ledger.Tx (hashScript)
@@ -124,108 +125,108 @@ testAliceSignsAlone :: Assertion
 testAliceSignsAlone =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [alicePay]
+          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [asWitness alicePay]
         s = "problem: " ++ show utxoSt'
 
 testAliceDoesntSign :: Assertion
 testAliceDoesntSign =
   utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW]]
   where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [bobPay, carlPay, dariaPay]
+          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [asWitness bobPay, asWitness carlPay, asWitness dariaPay]
 
 testEverybodySigns :: Assertion
 testEverybodySigns =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [alicePay, bobPay, carlPay, dariaPay]
+          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay, asWitness carlPay, asWitness dariaPay]
         s = "problem: " ++ show utxoSt'
 
 testWrongScript :: Assertion
 testWrongScript =
   utxoSt' @?= Left [[MissingScriptWitnessesUTXOW]]
   where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [alicePay, bobPay]
+          applyTxWithScript [(aliceOnly, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
 
 testAliceOrBob :: Assertion
 testAliceOrBob =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceOrBob, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [alicePay]
+          applyTxWithScript [(aliceOrBob, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [asWitness alicePay]
         s = "problem: " ++ show utxoSt'
 
 testAliceOrBob' :: Assertion
 testAliceOrBob' =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceOrBob, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [bobPay]
+          applyTxWithScript [(aliceOrBob, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [asWitness bobPay]
         s = "problem: " ++ show utxoSt'
 
 testAliceAndBob :: Assertion
 testAliceAndBob =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [alicePay, bobPay]
+          applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
         s = "problem: " ++ show utxoSt'
 
 testAliceAndBob' :: Assertion
 testAliceAndBob' =
   utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW]]
   where utxoSt' =
-          applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [alicePay]
+          applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [asWitness alicePay]
 
 testAliceAndBob'' :: Assertion
 testAliceAndBob'' =
   utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW]]
   where utxoSt' =
-          applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [bobPay]
+          applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [asWitness bobPay]
 
 testAliceAndBobOrCarl :: Assertion
 testAliceAndBobOrCarl =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarl, 11000)] [aliceAndBobOrCarl] (Wdrl Map.empty) 0 [alicePay, bobPay]
+          applyTxWithScript [(aliceAndBobOrCarl, 11000)] [aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
         s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarl' :: Assertion
 testAliceAndBobOrCarl' =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarl, 11000)] [aliceAndBobOrCarl] (Wdrl Map.empty) 0 [carlPay]
+          applyTxWithScript [(aliceAndBobOrCarl, 11000)] [aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness carlPay]
         s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlAndDaria :: Assertion
 testAliceAndBobOrCarlAndDaria =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlAndDaria, 11000)] [aliceAndBobOrCarlAndDaria] (Wdrl Map.empty) 0 [alicePay, bobPay]
+          applyTxWithScript [(aliceAndBobOrCarlAndDaria, 11000)] [aliceAndBobOrCarlAndDaria] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
         s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlAndDaria' :: Assertion
 testAliceAndBobOrCarlAndDaria' =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlAndDaria, 11000)] [aliceAndBobOrCarlAndDaria] (Wdrl Map.empty) 0 [carlPay, dariaPay]
+          applyTxWithScript [(aliceAndBobOrCarlAndDaria, 11000)] [aliceAndBobOrCarlAndDaria] (Wdrl Map.empty) 0 [asWitness carlPay, asWitness dariaPay]
         s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlOrDaria :: Assertion
 testAliceAndBobOrCarlOrDaria =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [alicePay, bobPay]
+          applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
         s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlOrDaria' :: Assertion
 testAliceAndBobOrCarlOrDaria' =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [carlPay]
+          applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [asWitness carlPay]
         s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlOrDaria'' :: Assertion
 testAliceAndBobOrCarlOrDaria'' =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [dariaPay]
+          applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [asWitness dariaPay]
         s = "problem: " ++ show utxoSt'
 
 -- multiple script-locked outputs
@@ -237,7 +238,7 @@ testTwoScripts =
                    [ (aliceOrBob, 10000)
                    , (aliceAndBobOrCarl, 1000)]
                    [ aliceOrBob
-                   , aliceAndBobOrCarl] (Wdrl Map.empty) 0 [bobPay, carlPay]
+                   , aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness bobPay, asWitness carlPay]
         s = "problem: " ++ show utxoSt'
 
 testTwoScripts' :: Assertion
@@ -247,7 +248,7 @@ testTwoScripts' =
                    [ (aliceAndBob, 10000)
                    , (aliceAndBobOrCarl, 1000)]
                    [ aliceAndBob
-                   , aliceAndBobOrCarl] (Wdrl Map.empty) 0 [bobPay, carlPay]
+                   , aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness bobPay, asWitness carlPay]
 
 -- script and skey locked
 
@@ -256,7 +257,7 @@ testScriptAndSKey =
   assertBool s (isRight utxoSt')
   where utxoSt' = applyTxWithScript
                    [(aliceAndBob, 10000)]
-                   [aliceAndBob] (Wdrl Map.empty) 1000 [alicePay, bobPay]
+                   [aliceAndBob] (Wdrl Map.empty) 1000 [asWitness alicePay, asWitness bobPay]
         s = "problem: " ++ show utxoSt'
 
 testScriptAndSKey' :: Assertion
@@ -264,14 +265,14 @@ testScriptAndSKey' =
   utxoSt' @?= Left [[MissingVKeyWitnessesUTXOW]]
   where utxoSt' = applyTxWithScript
                    [(aliceOrBob, 10000)]
-                   [aliceOrBob] (Wdrl Map.empty) 1000 [bobPay]
+                   [aliceOrBob] (Wdrl Map.empty) 1000 [asWitness bobPay]
 
 testScriptAndSKey'' :: Assertion
 testScriptAndSKey'' =
   assertBool s (isRight utxoSt')
   where utxoSt' = applyTxWithScript
                    [(aliceOrBob, 10000)]
-                   [aliceOrBob] (Wdrl Map.empty) 1000 [alicePay]
+                   [aliceOrBob] (Wdrl Map.empty) 1000 [asWitness alicePay]
         s = "problem: " ++ show utxoSt'
 
 testScriptAndSKey''' :: Assertion
@@ -279,7 +280,7 @@ testScriptAndSKey''' =
   assertBool s (isRight utxoSt')
   where utxoSt' = applyTxWithScript
                    [(aliceAndBobOrCarl, 10000)]
-                   [aliceAndBobOrCarl] (Wdrl Map.empty) 1000 [alicePay, carlPay]
+                   [aliceAndBobOrCarl] (Wdrl Map.empty) 1000 [asWitness alicePay, asWitness carlPay]
         s = "problem: " ++ show utxoSt'
 
 -- Withdrawals
@@ -288,24 +289,24 @@ testRwdAliceSignsAlone :: Assertion
 testRwdAliceSignsAlone =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript aliceOnly)) 1000) 0 [alicePay]
+          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript aliceOnly)) 1000) 0 [asWitness alicePay]
         s = "problem: " ++ show utxoSt'
 
 testRwdAliceSignsAlone' :: Assertion
 testRwdAliceSignsAlone' =
   utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW]]
   where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly, bobOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [alicePay]
+          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly, bobOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [asWitness alicePay]
 
 testRwdAliceSignsAlone'' :: Assertion
 testRwdAliceSignsAlone'' =
   assertBool s (isRight utxoSt')
   where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly, bobOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [alicePay, bobPay]
+          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly, bobOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [asWitness alicePay, asWitness bobPay]
         s = "problem: " ++ show utxoSt'
 
 testRwdAliceSignsAlone''' :: Assertion
 testRwdAliceSignsAlone''' =
   utxoSt' @?= Left [[MissingScriptWitnessesUTXOW]]
   where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [alicePay, bobPay]
+          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [asWitness alicePay, asWitness bobPay]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -413,7 +413,7 @@ serializationTests = testGroup "Serialization Tests"
     (Map.singleton (RewardAcnt testStakeCred) (Coin 123))
     ( (T $ TkMapLen 1 . TkListLen 2)
         <> (T $ TkWord 0)
-        <> S testKeyHash1
+        <> S testKeyHash2
         <> S (Coin 123)
     )
 
@@ -973,8 +973,8 @@ serializationTests = testGroup "Serialization Tests"
           -- tx 2, two keys
           <> T (TkMapLen 1 . TkWord 0)
           <> T (TkListLen 2)
-          <> S w2
           <> S w1
+          <> S w2
 
           -- tx 3, one script
           <> T (TkMapLen 1 . TkWord 1)
@@ -991,8 +991,8 @@ serializationTests = testGroup "Serialization Tests"
           <> T (TkMapLen 2)
           <> T (TkWord 0)
             <> T (TkListLen 2)
-            <> S w2
             <> S w1
+            <> S w2
           <> T (TkWord 1)
             <> T (TkListLen 2)
             <> S testScript

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDeleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDeleg.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeApplications #-}
@@ -31,6 +32,7 @@ import           Control.State.Transition.Trace (SourceSignalTarget, pattern Sou
                      signal, source, target)
 
 import           Shelley.Spec.Ledger.Coin (Coin, pattern Coin)
+import           Shelley.Spec.Ledger.Keys (KeyRole(..))
 import           Shelley.Spec.Ledger.LedgerState (_delegations, _irwd, _rewards, _stkCreds)
 import           Shelley.Spec.Ledger.TxData (pattern DCertDeleg, pattern DCertMir, pattern DeRegKey,
                      pattern Delegate, pattern Delegation, pattern MIRCert, pattern RegKey)
@@ -42,13 +44,13 @@ import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Credential, DELEG
 -- helper accessor functions --
 -------------------------------
 
-getStDelegs :: DState -> Set Credential
+getStDelegs :: DState -> Set (Credential 'Staking)
 getStDelegs = dom . _stkCreds
 
 getRewards :: DState -> Map RewardAcnt Coin
 getRewards = _rewards
 
-getDelegations :: DState -> Map Credential KeyHash
+getDelegations :: DState -> Map (Credential 'Staking) (KeyHash 'StakePool)
 getDelegations = _delegations
 
 --------------------------

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -24,6 +25,7 @@ import           Shelley.Spec.Ledger.BaseTypes ((==>))
 import           Shelley.Spec.Ledger.Delegation.Certificates (poolCWitness)
 import           Shelley.Spec.Ledger.LedgerState (pattern PState, _pParams, _retiring, _stPools,
                      _stPools)
+import           Shelley.Spec.Ledger.Keys (KeyRole(..))
 import           Shelley.Spec.Ledger.PParams (_eMax)
 import           Shelley.Spec.Ledger.Slot (EpochNo (..))
 import           Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (ledgerPp, ledgerSlotNo))
@@ -38,7 +40,7 @@ import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo)
 -- helper accessor functions --
 -------------------------------
 
-getRetiring :: PState -> Map KeyHash EpochNo
+getRetiring :: PState -> Map (KeyHash 'StakePool) EpochNo
 getRetiring = _retiring
 
 getStPools :: PState -> StakePools
@@ -166,7 +168,7 @@ poolIsMarkedForRetirement ssts =
       DCertPool (RetirePool hk _epoch) -> wasRemoved hk
       _ -> property ()
    where
-    wasRemoved :: KeyHash -> Property
+    wasRemoved :: KeyHash 'StakePool -> Property
     wasRemoved hk = conjoin
       [ counterexample "hk not in stPools"
           (hk ∈ dom ((unStakePools . _stPools) (source sst)))

--- a/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
@@ -48,6 +48,7 @@ library
     QuickCheck,
     base,
     bytestring,
+    bytestring-conversion,
     cardano-binary,
     cardano-crypto-class,
     cardano-prelude,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/91f357abae16099858193b999807323ca9a7c63c/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/398e5279e36c92df5ca30f1e68a9482d139686f4/snapshot.yaml
 
 packages:
 - shelley/chain-and-ledger/executable-spec
@@ -21,10 +21,10 @@ extra-deps:
 - monad-stm-0.1.0.2
 
 - git: https://github.com/input-output-hk/cardano-prelude
-  commit: 91f357abae16099858193b999807323ca9a7c63c
+  commit: 398e5279e36c92df5ca30f1e68a9482d139686f4
 
 - git: https://github.com/input-output-hk/cardano-base
-  commit: 4490c6cd3ad32423ef2265d61d936efb694c63d0
+  commit: 6e28d0913ff0f27ac64a6fa517250362897b0869
   subdirs:
     - binary
     - cardano-crypto-class


### PR DESCRIPTION
Rewrite the Keys infrastructure.

- Introduce the concept of a key role. This reflects that we use keys (or their hashes) for a multitude of purposes - as payment and staking credentials, as the identifier for a stake pool or genesis delegate, etc. It's easy to get these confused. As such, we now have an explicit role for a key. This can help catch bugs where we try to use one key in multiple places, or use the wrong key for some operation.

- Remove any indirection in the `Keys` module beyond that necessary for the key role.

- Add a bunch of helpful aliases and re-exports to the keys module.

Unfortunately, this PR is somewhat larger than I had hoped. This is mostly because of the extensive changes needed in tests, which use keys in multiple roles.

Since this PR is so large, some advice for reviewing:
- The first commit makes some supporting changes in the small-specs package, and should be reviewed independently.
- The second commit updates the cardano-crypto-class version, and makes corresponding changes there.
- The last commit is the big one. I suggest paying attention to the following:
  - The `Keys` module and all changes there.
  - Anywhere that `coerceKeyRole` is used in library code.
  - mkSeedFromWords in the testing `Utils` module.

Hopefully most of the test changes should be skimmable, since they are largely just adding `coerceKeyRole` everywhere.