### PR TITLE
[1351] Re-enable the removedAfterPoolReap property

### DIFF
--- a/semantics/executable-spec/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
+++ b/semantics/executable-spec/src/Control/State/Transition/Trace/Generator/QuickCheck.hs
@@ -151,8 +151,6 @@ forAllTraceFromInitState
    . ( HasTrace sts traceGenEnv
      , QuickCheck.Testable prop
      , Show (Environment sts)
-     , Show (State sts)
-     , Show (Signal sts)
      )
   => BaseEnv sts
   -> Word64
@@ -163,7 +161,7 @@ forAllTraceFromInitState
   -> (Trace sts -> prop)
   -> QuickCheck.Property
 forAllTraceFromInitState baseEnv maxTraceLength traceGenEnv genSt0 prop =
-  QuickCheck.forAllShrink
+  QuickCheck.forAllShrinkBlind
     (traceFromInitState @sts @traceGenEnv baseEnv maxTraceLength traceGenEnv genSt0)
     (shrinkTrace @sts @traceGenEnv baseEnv)
     prop
@@ -174,8 +172,6 @@ forAllTrace
    . ( HasTrace sts traceGenEnv
      , QuickCheck.Testable prop
      , Show (Environment sts)
-     , Show (State sts)
-     , Show (Signal sts)
      )
   => BaseEnv sts
   -> Word64
@@ -230,7 +226,6 @@ onlyValidSignalsAreGenerated
   :: forall sts traceGenEnv
    . ( HasTrace sts traceGenEnv
      , Show (Environment sts)
-     , Show (State sts)
      , Show (Signal sts)
      )
   => BaseEnv sts
@@ -248,7 +243,6 @@ onlyValidSignalsAreGeneratedFromInitState
   :: forall sts traceGenEnv
    . ( HasTrace sts traceGenEnv
      , Show (Environment sts)
-     , Show (State sts)
      , Show (Signal sts)
      )
   => BaseEnv sts
@@ -286,8 +280,6 @@ traceLengthsAreClassified
   :: forall sts traceGenEnv
    . ( HasTrace sts traceGenEnv
      , Show (Environment sts)
-     , Show (State sts)
-     , Show (Signal sts)
      )
   => BaseEnv sts
   -> Word64

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -16,8 +16,8 @@ import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.Hedgehog (testProperty)
 import qualified Test.Tasty.QuickCheck as TQC
 
-import           Hedgehog (Gen, Property, (/==), (===), classify, failure, label, property,
-                     success, withTests)
+import           Hedgehog (Gen, Property, classify, failure, label, property, success, withTests,
+                     (/==), (===))
 import qualified Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -42,7 +42,7 @@ import           Test.Shelley.Spec.Ledger.PreSTSGenerator
 import           Test.Shelley.Spec.Ledger.Rules.ClassifyTraces (onlyValidChainSignalsAreGenerated,
                      onlyValidLedgerSignalsAreGenerated, relevantCasesAreCovered)
 import           Test.Shelley.Spec.Ledger.Rules.TestChain (constantSumPots, nonNegativeDeposits,
-                     preservationOfAda)
+                     preservationOfAda, removedAfterPoolreap)
 import           Test.Shelley.Spec.Ledger.Rules.TestLedger (consumedEqualsProduced,
                      credentialMappingAfterDelegation, credentialRemovedAfterDereg,
                      eliminateTxInputs, feesNonDecreasing, newEntriesAndUniqueTxIns, noDoubleSpend,
@@ -262,10 +262,8 @@ propertyTests = testGroup "Property-Based Testing"
                                      constantSumPots
                   , TQC.testProperty "deposits are always non-negative"
                                      nonNegativeDeposits
-                  {- TODO @uroboros failing property - fix and include
                   , TQC.testProperty "pool is removed from stake pool and retiring maps"
                                      removedAfterPoolreap
-                  -}
                   ]
                 , testGroup "STS Rules - NewEpoch Properties"
                   [ TQC.testProperty "total amount of Ada is preserved"

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/ClassifyTraces.hs
@@ -36,7 +36,7 @@ import           Shelley.Spec.Ledger.Tx (_body)
 import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern DCertDeleg, pattern DeRegKey,
                      pattern Delegate, pattern Delegation, pattern RegKey, pattern ScriptHashObj,
                      pattern TxOut, Wdrl (..), _certs, _outputs, _txUpdate, _wdrls)
-import           Test.QuickCheck (Property, checkCoverage, conjoin, cover, forAll, property,
+import           Test.QuickCheck (Property, checkCoverage, conjoin, cover, forAllBlind, property,
                      withMaxSuccess)
 import qualified Test.QuickCheck.Gen
 
@@ -78,7 +78,7 @@ relevantCasesAreCovered = do
   let tl = 100
       GenEnv _ c@(Constants{maxCertsPerTx}) = genEnv
 
-  forAll (traceFromInitState @CHAIN testGlobals tl genEnv genesisChainState) $ \tr -> do
+  forAllBlind (traceFromInitState @CHAIN testGlobals tl genEnv genesisChainState) $ \tr -> do
     let blockTxs (Block _ (TxSeq txSeq)) = toList txSeq
         bs = traceSignals OldestFirst tr
         txs = concat (blockTxs <$> bs)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestChain
   ( -- TestPoolReap
@@ -13,24 +15,24 @@ where
 import           Data.Word (Word64)
 import           Test.QuickCheck (Property, Testable, property, withMaxSuccess)
 
-import           Control.State.Transition.Trace (SourceSignalTarget (..), Trace,
+import           Control.State.Transition.Extended (TRC (TRC), applySTS)
+import           Control.State.Transition.Trace (SourceSignalTarget (..), Trace (..),
                      sourceSignalTargets)
 import           Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState)
+
 import           Shelley.Spec.Ledger.BlockChain (Block (..), bhbody, bheaderSlotNo)
-import           Shelley.Spec.Ledger.LedgerState (pattern DPState, esAccountState, esLState, nesEs,
-                     _delegationState, _utxoState)
+import           Shelley.Spec.Ledger.LedgerState (pattern DPState, esAccountState, esLState,
+                     getGKeys, nesEs, _delegationState, _utxoState)
 import           Shelley.Spec.Ledger.STS.Chain (ChainState (..))
 import           Shelley.Spec.Ledger.STS.PoolReap (PoolreapState (..))
-
-import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv(geConstants))
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN, NEWEPOCH, POOLREAP)
-import           Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
+import           Shelley.Spec.Ledger.STS.Tick (TickEnv (TickEnv))
+import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN, NEWEPOCH, POOLREAP, TICK)
+import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (geConstants))
 import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (genEnv)
+import           Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
 import qualified Test.Shelley.Spec.Ledger.Rules.TestNewEpoch as TestNewEpoch
 import qualified Test.Shelley.Spec.Ledger.Rules.TestPoolreap as TestPoolreap
-import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, testGlobals)
-
-
+import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, runShelleyBase, testGlobals)
 ------------------------------
 -- Constants for Properties --
 ------------------------------
@@ -60,8 +62,8 @@ nonNegativeDeposits =
 removedAfterPoolreap :: Property
 removedAfterPoolreap =
   forAllChainTrace $ \tr ->
-    let sst = map chainToPoolreapSst (sourceSignalTargets tr)
-    in TestPoolreap.removedAfterPoolreap sst
+    let ssts = map chainToPoolreapSst (chainSstWithTick tr)
+    in TestPoolreap.removedAfterPoolreap ssts
 
 ----------------------------------------------------------------------
 -- Properties for NewEpoch (using the CHAIN Trace) --
@@ -126,3 +128,31 @@ chainToNewEpochSst (SourceSignalTarget ChainState {chainNes = nes}
   SourceSignalTarget nes nes' (epochFromSlotNo s)
   where
     s = (bheaderSlotNo . bhbody) bh
+
+-- | Transform the [(source, signal, target)] of a CHAIN Trace
+-- by manually applying the Chain TICK Rule to each source and producing
+-- [(source, signal, target)].
+--
+-- This allows for testing properties on traces that exclude effects of the
+-- "UTXO branches" of the STS Rule tree.
+chainSstWithTick :: Trace CHAIN -> [SourceSignalTarget CHAIN]
+chainSstWithTick ledgerTr =
+  map applyTick ssts
+  where
+    ssts = sourceSignalTargets ledgerTr
+
+    applyTick
+      :: SourceSignalTarget CHAIN
+      -> SourceSignalTarget CHAIN
+    applyTick (SourceSignalTarget
+                chainSt@ChainState {chainNes = nes}
+                _
+                b@(Block bh _)) =
+      case runShelleyBase (applySTS @TICK (TRC(TickEnv (getGKeys nes), nes, (bheaderSlotNo . bhbody) bh))) of
+        Left pf ->
+          error ("chainSstWithTick.applyTick Predicate failure " <> show pf)
+        Right nes' ->
+          SourceSignalTarget
+            chainSt
+            (chainSt {chainNes = nes'})
+            b

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestNewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestNewEpoch.hs
@@ -8,7 +8,7 @@ module Test.Shelley.Spec.Ledger.Rules.TestNewEpoch
   , circulationDepositsInvariant)
 where
 
-import           Test.QuickCheck (Property, conjoin)
+import           Test.QuickCheck (Property, conjoin, counterexample, (===))
 
 import           Control.State.Transition.Trace (SourceSignalTarget, pattern SourceSignalTarget,
                      source, target)
@@ -109,4 +109,8 @@ circulationDepositsInvariant tr =
                     , _deposited = d'
                     }}}}}
             ) =
-          d == d' && (balance u) == (balance u')
+          counterexample ("circulationDepositsInvariant: balance delta= "
+                          <> show (balance u - balance u')
+                          <> " && deposit delta= " <> show (d - d'))
+            $ conjoin
+              [d === d', (balance u) === (balance u')]


### PR DESCRIPTION
Closes #1351 
Closes #1392 

* re-introduces the removedAfterPoolReap prop which was failing when tested on CHAIN traces because these traces include the effects of LEDGER rules, which introduce new txs/certificates. These new certificates creates "noise" when testing for just the non-ledger effects of the POOLREAP rule
* switched from QC.forAllShrink to forAllShrinkBlind - this change solves the Heap Exhaustion we were getting when a property failed for a trace that was too large to Show
