### PR TITLE
sign transaction body hashes, not the body

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -98,7 +98,7 @@ applyTxs ::
   forall crypto m.
   ( Crypto crypto,
     MonadError (ApplyTxError crypto) m,
-    DSignable crypto (Tx.TxBody crypto)
+    DSignable crypto (Hash crypto (Tx.TxBody crypto))
   ) =>
   Globals ->
   MempoolEnv ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -111,7 +111,7 @@ applyBlockTransition ::
   forall crypto m.
   ( Crypto crypto,
     MonadError (BlockTransitionError crypto) m,
-    DSignable crypto (Tx.TxBody crypto)
+    DSignable crypto (Hash crypto (Tx.TxBody crypto))
   ) =>
   Globals ->
   ShelleyState crypto ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -50,7 +50,7 @@ data BbodyEnv
 
 instance
   ( Crypto crypto
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   )
   => STS (BBODY crypto)
  where
@@ -78,7 +78,7 @@ instance NoUnexpectedThunks (PredicateFailure (BBODY crypto))
 bbodyTransition
   :: forall crypto
    . ( Crypto crypto
-     , DSignable crypto (TxBody crypto)
+     , DSignable crypto (Hash crypto (TxBody crypto))
      )
   => TransitionRule (BBODY crypto)
 bbodyTransition = judgmentContext >>=
@@ -104,7 +104,7 @@ bbodyTransition = judgmentContext >>=
 
 instance
   ( Crypto crypto
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   )
   => Embed (LEDGERS crypto) (BBODY crypto)
  where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -33,8 +33,8 @@ import           Shelley.Spec.Ledger.BlockChain (BHBody, BHeader, Block (..), La
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
 import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), GenDelegs (..), KESignable, KeyHash,
-                     DSignable, VerKeyKES, coerceKeyRole)
+import           Shelley.Spec.Ledger.Keys (DSignable, GenDelegs (..), Hash, KESignable, KeyHash,
+                     KeyRole (..), VerKeyKES, coerceKeyRole)
 import           Shelley.Spec.Ledger.LedgerState (AccountState (..), DPState (..), DState (..),
                      EpochState (..), LedgerState (..), NewEpochState (..), OBftSlot, PState (..),
                      UTxOState (..), emptyDState, emptyPState, getGKeys, updateNES, _genDelegs)
@@ -117,7 +117,7 @@ initialShelleyState lab e utxo reserves genDelegs os pp initNonce =
 instance
   ( Crypto crypto
   , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   , KESignable crypto (BHBody crypto)
   , VRF.Signable (VRF crypto) Seed
   )
@@ -164,7 +164,7 @@ chainTransition
   :: forall crypto
    . ( Crypto crypto
      , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-     , DSignable crypto (TxBody crypto)
+     , DSignable crypto (Hash crypto (TxBody crypto))
      , KESignable crypto (BHBody crypto)
      , VRF.Signable (VRF crypto) Seed
      )
@@ -206,7 +206,7 @@ chainTransition = judgmentContext >>=
 instance
   ( Crypto crypto
   , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   , KESignable crypto (BHBody crypto)
   , VRF.Signable (VRF crypto) Seed
   )
@@ -217,7 +217,7 @@ instance
 instance
   ( Crypto crypto
   , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   , KESignable crypto (BHBody crypto)
   , VRF.Signable (VRF crypto) Seed
   )
@@ -228,7 +228,7 @@ instance
 instance
   ( Crypto crypto
   , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   , KESignable crypto (BHBody crypto)
   , VRF.Signable (VRF crypto) Seed
   )

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -55,7 +55,7 @@ data LedgerEnv
 
 instance
   ( Crypto crypto
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   )
   => STS (LEDGER crypto)
  where
@@ -102,7 +102,7 @@ instance
 ledgerTransition
   :: forall crypto
    . ( Crypto crypto
-     , DSignable crypto (TxBody crypto)
+     , DSignable crypto (Hash crypto (TxBody crypto))
      )
   => TransitionRule (LEDGER crypto)
 ledgerTransition = do
@@ -126,7 +126,7 @@ ledgerTransition = do
 
 instance
   ( Crypto crypto
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   )
   => Embed (DELEGS crypto) (LEDGER crypto)
  where
@@ -134,7 +134,7 @@ instance
 
 instance
   ( Crypto crypto
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   )
   => Embed (UTXOW crypto) (LEDGER crypto)
  where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledgers.hs
@@ -26,7 +26,7 @@ import           GHC.Generics (Generic)
 import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
 import           Shelley.Spec.Ledger.Coin (Coin)
 import           Shelley.Spec.Ledger.Crypto (Crypto)
-import           Shelley.Spec.Ledger.Keys (DSignable)
+import           Shelley.Spec.Ledger.Keys (DSignable, Hash)
 import           Shelley.Spec.Ledger.LedgerState (LedgerState (..), emptyLedgerState,
                      _delegationState, _utxoState)
 import           Shelley.Spec.Ledger.PParams (PParams)
@@ -45,7 +45,7 @@ data LedgersEnv
 
 instance
   ( Crypto crypto
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   )
   => STS (LEDGERS crypto)
  where
@@ -77,7 +77,7 @@ instance
 ledgersTransition
   :: forall crypto
    . ( Crypto crypto
-     , DSignable crypto (TxBody crypto)
+     , DSignable crypto (Hash crypto (TxBody crypto))
      )
   => TransitionRule (LEDGERS crypto)
 ledgersTransition = do
@@ -96,7 +96,7 @@ ledgersTransition = do
 
 instance
   ( Crypto crypto
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   )
   => Embed (LEDGER crypto) (LEDGERS crypto)
  where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -46,7 +46,7 @@ data UTXOW crypto
 
 instance
   ( Crypto crypto
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   )
   => STS (UTXOW crypto)
  where
@@ -112,7 +112,7 @@ instance
 initialLedgerStateUTXOW
   :: forall crypto
    . ( Crypto crypto
-     , DSignable crypto (TxBody crypto)
+     , DSignable crypto (Hash crypto (TxBody crypto))
      )
    => InitialRule (UTXOW crypto)
 initialLedgerStateUTXOW = do
@@ -122,7 +122,7 @@ initialLedgerStateUTXOW = do
 utxoWitnessed
   :: forall crypto
    . ( Crypto crypto
-     , DSignable crypto (TxBody crypto)
+     , DSignable crypto (Hash crypto (TxBody crypto))
      )
    => TransitionRule (UTXOW crypto)
 utxoWitnessed = judgmentContext >>=
@@ -174,7 +174,7 @@ utxoWitnessed = judgmentContext >>=
 
 instance
   ( Crypto crypto
-  , DSignable crypto (TxBody crypto)
+  , DSignable crypto (Hash crypto (TxBody crypto))
   )
   => Embed (UTXO crypto) (UTXOW crypto)
  where

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -83,8 +83,8 @@ import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
 
 import           Byron.Spec.Ledger.Core (Relation (..))
-import           Shelley.Spec.Ledger.BaseTypes (DnsName, Port, StrictMaybe (..),
-                     UnitInterval, Url, invalidKey, maybeToStrictMaybe, strictMaybeToMaybe)
+import           Shelley.Spec.Ledger.BaseTypes (DnsName, Port, StrictMaybe (..), UnitInterval, Url,
+                     invalidKey, maybeToStrictMaybe, strictMaybeToMaybe)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Keys (HasKeyRole (..), Hash, KeyHash (..), KeyRole (..),
                      SignedDSIGN, VKey, VerKeyVRF, decodeSignedDSIGN, encodeSignedDSIGN, hashKey)
@@ -382,7 +382,7 @@ pattern TxBody
 data WitVKey crypto
   = WitVKey'
     { wvkKey' :: !(VKey 'Witness crypto)
-    , wvkSig' :: !(SignedDSIGN crypto (TxBody crypto))
+    , wvkSig' :: !(SignedDSIGN crypto (Hash crypto (TxBody crypto)))
     , wvkBytes :: LByteString
     }
   deriving (Show, Eq, Generic)
@@ -391,7 +391,7 @@ data WitVKey crypto
 pattern WitVKey
    :: Crypto crypto
    => VKey 'Witness crypto
-   -> SignedDSIGN crypto (TxBody crypto)
+   -> SignedDSIGN crypto (Hash crypto (TxBody crypto))
    -> WitVKey crypto
 pattern WitVKey k s <- WitVKey' k s _
   where

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -160,7 +160,7 @@ import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern DCertDeleg, p
                      _poolMDHash, _poolMDUrl, _poolMargin, _poolOwners, _poolPledge, _poolPubKey,
                      _poolRAcnt, _poolRelays, _poolVrf)
 import qualified Shelley.Spec.Ledger.TxData as TxData (TxBody (..))
-import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, makeWitnessesVKey, txid)
+import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, hashTxBody, makeWitnessesVKey, txid)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, Block, CHAIN, ChainState,
                      ConcreteCrypto, Credential, DState, EpochState, pattern GenDelegs, HashHeader,
@@ -497,7 +497,7 @@ txEx2A :: Tx
 txEx2A = Tx
           txbodyEx2A
           (makeWitnessesVKey
-            txbodyEx2A
+            (hashTxBody txbodyEx2A)
             ( (asWitness <$> [alicePay, carlPay])
             <> (asWitness <$> [aliceStake])
             <> (asWitness <$> [cold alicePool, cold $ coreNodeKeys 0])
@@ -506,7 +506,7 @@ txEx2A = Tx
             -- since it is an owner of the stake pool being registered,
             -- and *not* because of the stake key registration.
                      `Set.union`
-           makeWitnessesVKey txbodyEx2A [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
+           makeWitnessesVKey (hashTxBody txbodyEx2A) [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
              , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
              , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
              , KeyPair (coreNodeVKG 3) (coreNodeSKG 3)
@@ -671,7 +671,7 @@ txbodyEx2B = TxBody
 txEx2B :: Tx
 txEx2B = Tx
           txbodyEx2B -- Body of the transaction
-          (makeWitnessesVKey txbodyEx2B
+          (makeWitnessesVKey (hashTxBody txbodyEx2B)
             [asWitness alicePay, asWitness aliceStake, asWitness bobStake])
                      -- Witness verification key set
           Map.empty  -- Witness signature map
@@ -938,7 +938,7 @@ txbodyEx2D = TxBody
 txEx2D :: Tx
 txEx2D = Tx
           txbodyEx2D
-          (makeWitnessesVKey txbodyEx2D [asWitness alicePay, asWitness carlStake])
+          (makeWitnessesVKey (hashTxBody txbodyEx2D) [asWitness alicePay, asWitness carlStake])
           Map.empty
           SNothing
 
@@ -1436,7 +1436,7 @@ txbodyEx2J = TxBody
 txEx2J :: Tx
 txEx2J = Tx
           txbodyEx2J
-          (makeWitnessesVKey txbodyEx2J [asWitness bobPay, asWitness bobStake])
+          (makeWitnessesVKey (hashTxBody txbodyEx2J) [asWitness bobPay, asWitness bobStake])
           Map.empty
           SNothing
 
@@ -1532,7 +1532,7 @@ txbodyEx2K = TxBody
 txEx2K :: Tx
 txEx2K = Tx
           txbodyEx2K
-          (makeWitnessesVKey txbodyEx2K [asWitness $ cold alicePool, asWitness alicePay])
+          (makeWitnessesVKey (hashTxBody txbodyEx2K) [asWitness $ cold alicePool, asWitness alicePay])
           Map.empty
           SNothing
 
@@ -1743,7 +1743,7 @@ txEx3A :: Tx
 txEx3A = Tx
           txbodyEx3A
           (makeWitnessesVKey
-            txbodyEx3A
+            (hashTxBody txbodyEx3A)
             [ asWitness alicePay
             , asWitness . cold $ coreNodeKeys 0
             , asWitness . cold $ coreNodeKeys 3
@@ -1835,7 +1835,7 @@ txEx3B :: Tx
 txEx3B = Tx
           txbodyEx3B
           (makeWitnessesVKey
-            txbodyEx3B
+            (hashTxBody txbodyEx3B)
             [ asWitness alicePay
             , asWitness . cold $ coreNodeKeys 1
             , asWitness . cold $ coreNodeKeys 5
@@ -1994,7 +1994,10 @@ txbodyEx4A = TxBody
 txEx4A :: Tx
 txEx4A = Tx
            txbodyEx4A
-           (makeWitnessesVKey txbodyEx4A [ alicePay ] `Set.union` makeWitnessesVKey txbodyEx4A [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0) ])
+           (makeWitnessesVKey (hashTxBody txbodyEx4A) [ alicePay ]
+             `Set.union`
+              makeWitnessesVKey (hashTxBody txbodyEx4A)
+                [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0) ])
            Map.empty
            SNothing
 
@@ -2146,7 +2149,8 @@ txbodyEx5A = TxBody
 txEx5A :: Tx
 txEx5A = Tx
            txbodyEx5A
-           (makeWitnessesVKey txbodyEx5A [ alicePay ] `Set.union` makeWitnessesVKey txbodyEx5A
+           (makeWitnessesVKey (hashTxBody txbodyEx5A) [ alicePay ]
+             `Set.union` makeWitnessesVKey (hashTxBody txbodyEx5A)
              [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
              , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
              , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
@@ -2220,7 +2224,9 @@ ex5A = CHAINExample (SlotNo 10) initStEx2A blockEx5A (Right expectedStEx5A)
 txEx5B :: Tx
 txEx5B = Tx
            txbodyEx5A
-           (makeWitnessesVKey txbodyEx5A [ alicePay ] `Set.union` makeWitnessesVKey txbodyEx5A
+           (makeWitnessesVKey (hashTxBody txbodyEx5A) [ alicePay ]
+             `Set.union`
+             makeWitnessesVKey (hashTxBody txbodyEx5A)
              [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
              , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
              , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
@@ -2311,8 +2317,8 @@ txbodyEx5F = TxBody
 
 txEx5F :: Tx
 txEx5F = Tx txbodyEx5F
-            (makeWitnessesVKey txbodyEx5F [ asWitness alicePay, asWitness aliceStake ]
-            `Set.union` makeWitnessesVKey txbodyEx5F
+            (makeWitnessesVKey (hashTxBody txbodyEx5F) [ asWitness alicePay, asWitness aliceStake ]
+            `Set.union` makeWitnessesVKey (hashTxBody txbodyEx5F)
              [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
              , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
              , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
@@ -2356,7 +2362,7 @@ txbodyEx5F' = TxBody
                SNothing
 
 txEx5F' :: Tx
-txEx5F' = Tx txbodyEx5F' (makeWitnessesVKey txbodyEx5F' [ alicePay ]) Map.empty SNothing
+txEx5F' = Tx txbodyEx5F' (makeWitnessesVKey (hashTxBody txbodyEx5F') [ alicePay ]) Map.empty SNothing
 
 blockEx5F' :: Block
 blockEx5F' = mkBlock
@@ -2392,7 +2398,7 @@ txbodyEx5F'' = TxBody
                 SNothing
 
 txEx5F'' :: Tx
-txEx5F'' = Tx txbodyEx5F'' (makeWitnessesVKey txbodyEx5F'' [ alicePay ]) Map.empty SNothing
+txEx5F'' = Tx txbodyEx5F'' (makeWitnessesVKey (hashTxBody txbodyEx5F'') [ alicePay ]) Map.empty SNothing
 
 blockEx5F'' :: Block
 blockEx5F'' = mkBlock

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
@@ -38,7 +38,7 @@ import           Shelley.Spec.Ledger.TxData (pattern DCertDeleg, pattern DCertPo
                      _poolMD, _poolMDHash, _poolMDUrl, _poolMargin, _poolOwners, _poolPledge,
                      _poolPubKey, _poolRAcnt, _poolRelays, _poolVrf, _ttl, _txUpdate, _txfee,
                      _wdrls)
-import           Shelley.Spec.Ledger.UTxO (makeWitnessesVKey)
+import           Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessesVKey)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, ConcreteCrypto, Credential,
                      KeyHash, MultiSig, PoolParams, SignKeyVRF, Tx, TxBody, VerKeyVRF,
@@ -128,13 +128,13 @@ txbSimpleUTxO = TxBody
 txSimpleUTxO :: Tx
 txSimpleUTxO = Tx
   { _body           = txbSimpleUTxO
-  , _witnessVKeySet = makeWitnessesVKey txbSimpleUTxO [alicePay]
+  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbSimpleUTxO) [alicePay]
   , _witnessMSigMap = Map.empty
   , _metadata       = SNothing
   }
 
 txSimpleUTxOBytes16 :: BSL.ByteString
-txSimpleUTxOBytes16 = "83a4009f82446050074300ff0181840044aee84c70440acd1b520a02185e030aa10081821b303030303032313482447c5af1ef1b3030303030323134f6"
+txSimpleUTxOBytes16 = "83a4009f82446050074300ff0181840044aee84c70440acd1b520a02185e030aa10081821b30303030303231348244eb4659ba1b3030303030323134f6"
 
 -- | Transaction which consumes two UTxO and creates five UTxO
 -- | and has two witness
@@ -162,7 +162,7 @@ txbMutiUTxO = TxBody
 txMutiUTxO :: Tx
 txMutiUTxO = Tx
   { _body           = txbMutiUTxO
-  , _witnessVKeySet = makeWitnessesVKey txbMutiUTxO
+  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbMutiUTxO)
                       [ alicePay
                       , bobPay
                       ]
@@ -171,7 +171,7 @@ txMutiUTxO = Tx
   }
 
 txMutiUTxOBytes16 :: BSL.ByteString
-txMutiUTxOBytes16 = "83a4009f8244605007430082446050074301ff0185840044aee84c70440acd1b520a840044aee84c70440acd1b5214840044aee84c70440acd1b52181e840044d42eadb144d42eadb11828840044d42eadb144d42eadb118320218c7030aa10082821b30303030303231348244aac4968a1b3030303030323134821b31353438353836378244aac4968a1b3135343835383637f6"
+txMutiUTxOBytes16 = "83a4009f8244605007430082446050074301ff0185840044aee84c70440acd1b520a840044aee84c70440acd1b5214840044aee84c70440acd1b52181e840044d42eadb144d42eadb11828840044d42eadb144d42eadb118320218c7030aa10082821b30303030303231348244bbedc57a1b3030303030323134821b31353438353836378244bbedc57a1b3135343835383637f6"
 
 -- | Transaction which registers a stake key
 
@@ -190,13 +190,13 @@ txbRegisterStake = TxBody
 txRegisterStake :: Tx
 txRegisterStake = Tx
   { _body           = txbRegisterStake
-  , _witnessVKeySet = makeWitnessesVKey txbRegisterStake [alicePay]
+  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbRegisterStake) [alicePay]
   , _witnessMSigMap = Map.empty
   , _metadata       = SNothing
   }
 
 txRegisterStakeBytes16 :: BSL.ByteString
-txRegisterStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048182008200440acd1b52a10081821b303030303032313482446724004d1b3030303030323134f6"
+txRegisterStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048182008200440acd1b52a10081821b303030303032313482443dff0e3e1b3030303030323134f6"
 
 -- | Transaction which delegates a stake key
 
@@ -215,13 +215,15 @@ txbDelegateStake = TxBody
 txDelegateStake :: Tx
 txDelegateStake = Tx
   { _body           = txbDelegateStake
-  , _witnessVKeySet = makeWitnessesVKey txbDelegateStake [asWitness alicePay, asWitness bobStake]
+  , _witnessVKeySet = makeWitnessesVKey
+                        (hashTxBody txbDelegateStake)
+                        [asWitness alicePay, asWitness bobStake]
   , _witnessMSigMap = Map.empty
   , _metadata       = SNothing
   }
 
 txDelegateStakeBytes16 :: BSL.ByteString
-txDelegateStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a04818302820044d42eadb14450d474d0a10082821b303030303032313482448b8c22791b3030303030323134821b313534383538363782448b8c22791b3135343835383637f6"
+txDelegateStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a04818302820044d42eadb14450d474d0a10082821b303030303032313482446d2304911b3030303030323134821b313534383538363782446d2304911b3135343835383637f6"
 
 -- | Transaction which de-registers a stake key
 
@@ -240,14 +242,14 @@ txbDeregisterStake = TxBody
 txDeregisterStake :: Tx
 txDeregisterStake = Tx
   { _body           = txbDeregisterStake
-  , _witnessVKeySet = makeWitnessesVKey txbDeregisterStake [alicePay]
+  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbDeregisterStake) [alicePay]
   , _witnessMSigMap = Map.empty
   , _metadata       = SNothing
   }
 
 
 txDeregisterStakeBytes16 :: BSL.ByteString
-txDeregisterStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048182018200440acd1b52a10081821b303030303032313482446262964d1b3030303030323134f6"
+txDeregisterStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048182018200440acd1b52a10081821b30303030303231348244bd35013b1b3030303030323134f6"
 
 -- | Transaction which registers a stake pool
 
@@ -266,13 +268,13 @@ txbRegisterPool = TxBody
 txRegisterPool :: Tx
 txRegisterPool = Tx
   { _body           = txbRegisterPool
-  , _witnessVKeySet = makeWitnessesVKey txbRegisterPool [alicePay]
+  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbRegisterPool) [alicePay]
   , _witnessMSigMap = Map.empty
   , _metadata       = SNothing
   }
 
 txRegisterPoolBytes16 :: BSL.ByteString
-txRegisterPoolBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a04818a034450d474d04495286b7b0105d81e82010a8200440acd1b5281440acd1b52818301f66872656c61792e696f826a616c6963652e706f6f6c427b7da10081821b303030303032313482444a0fe82d1b3030303030323134f6"
+txRegisterPoolBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a04818a034450d474d04495286b7b0105d81e82010a8200440acd1b5281440acd1b52818301f66872656c61792e696f826a616c6963652e706f6f6c427b7da10081821b30303030303231348244b9f105371b3030303030323134f6"
 
 -- | Transaction which retires a stake pool
 
@@ -291,13 +293,13 @@ txbRetirePool = TxBody
 txRetirePool :: Tx
 txRetirePool = Tx
   { _body           = txbRetirePool
-  , _witnessVKeySet = makeWitnessesVKey txbRetirePool [alicePay]
+  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbRetirePool) [alicePay]
   , _witnessMSigMap = Map.empty
   , _metadata       = SNothing
   }
 
 txRetirePoolBytes16 :: BSL.ByteString
-txRetirePoolBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048183044450d474d005a10081821b30303030303231348244acbec7831b3030303030323134f6"
+txRetirePoolBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048183044450d474d005a10081821b303030303032313482443267fcc41b3030303030323134f6"
 
 -- | Simple Transaction which consumes one UTxO and creates one UTxO
 -- | and has one witness
@@ -320,13 +322,13 @@ txbWithMD = TxBody
 txWithMD :: Tx
 txWithMD = Tx
   { _body           = txbWithMD
-  , _witnessVKeySet = makeWitnessesVKey txbWithMD [alicePay]
+  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbWithMD) [alicePay]
   , _witnessMSigMap = Map.empty
   , _metadata       = SJust md
   }
 
 txWithMDBytes16 :: BSL.ByteString
-txWithMDBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a07444eece652a10081821b303030303032313482444731ea781b3030303030323134a10082056568656c6c6f"
+txWithMDBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a07444eece652a10081821b3030303030323134824469e542f81b3030303030323134a10082056568656c6c6f"
 
 -- | Spending from a multi-sig address
 
@@ -352,13 +354,13 @@ txbWithMultiSig = TxBody
 txWithMultiSig :: Tx
 txWithMultiSig = Tx
   { _body           = txbWithMultiSig
-  , _witnessVKeySet = makeWitnessesVKey txbWithMultiSig [alicePay, bobPay]
+  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbWithMultiSig) [alicePay, bobPay]
   , _witnessMSigMap = Map.singleton (hashScript msig) msig
   , _metadata       = SNothing
   }
 
 txWithMultiSigBytes16 :: BSL.ByteString
-txWithMultiSigBytes16 = "83a4009f82446050074300ff0181840044aee84c70440acd1b520a02185e030aa20082821b303030303032313482447c5af1ef1b3030303030323134821b313534383538363782447c5af1ef1b3135343835383637018183030283820044aee84c70820044d42eadb1820044ae010e05f6"
+txWithMultiSigBytes16 = "83a4009f82446050074300ff0181840044aee84c70440acd1b520a02185e030aa20082821b30303030303231348244eb4659ba1b3030303030323134821b31353438353836378244eb4659ba1b3135343835383637018183030283820044aee84c70820044d42eadb1820044ae010e05f6"
 
 -- | Transaction with a Reward Withdrawal
 
@@ -377,13 +379,15 @@ txbWithWithdrawal = TxBody
 txWithWithdrawal :: Tx
 txWithWithdrawal = Tx
   { _body           = txbWithWithdrawal
-  , _witnessVKeySet = makeWitnessesVKey txbWithWithdrawal [asWitness alicePay, asWitness aliceStake]
+  , _witnessVKeySet = makeWitnessesVKey
+                        (hashTxBody txbWithWithdrawal)
+                        [asWitness alicePay, asWitness aliceStake]
   , _witnessMSigMap = Map.empty
   , _metadata       = SNothing
   }
 
 txWithWithdrawalBytes16 :: BSL.ByteString
-txWithWithdrawalBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a05a18200440acd1b521864a10082821b303030303836303282444ce091651b3030303038363032821b303030303032313482444ce091651b3030303030323134f6"
+txWithWithdrawalBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a05a18200440acd1b521864a10082821b3030303038363032824442b5d6c41b3030303038363032821b3030303030323134824442b5d6c41b3030303030323134f6"
 
 -- NOTE the txsize function takes into account which actual crypto parameter is use.
 -- These tests are using ShortHash and MockDSIGN so that:

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
@@ -37,7 +37,7 @@ import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj,
                      pattern ScriptHashObj, pattern StakeCreds, pattern StakePools,
                      pattern StakeRefBase, pattern TxBody, pattern TxIn, pattern TxOut,
                      pattern Wdrl, unWdrl)
-import           Shelley.Spec.Ledger.UTxO (makeWitnessesVKey, txid)
+import           Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessesVKey, txid)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, KeyPair, LedgerState, MultiSig,
                      ScriptHash, Tx, TxBody, TxId, TxIn, UTXOW, UTxOState, Wdrl, pattern GenDelegs)
@@ -102,7 +102,7 @@ makeTxBody inp addrCs wdrl =
 
 makeTx :: TxBody -> [KeyPair 'Witness] -> Map ScriptHash MultiSig -> Maybe MetaData -> Tx
 makeTx txBody keyPairs msigs =
-  Tx txBody (makeWitnessesVKey txBody keyPairs) msigs . maybeToStrictMaybe
+  Tx txBody (makeWitnessesVKey (hashTxBody txBody) keyPairs) msigs . maybeToStrictMaybe
 
 aliceInitCoin :: Coin
 aliceInitCoin = 10000

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -40,7 +40,7 @@ import           Shelley.Spec.Ledger.Tx (pattern Tx, pattern TxBody, pattern TxO
 import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj,
                      pattern ScriptHashObj, pattern StakeRefBase, pattern StakeRefPtr, Wdrl (..),
                      getRwdCred, _outputs, _txfee)
-import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, makeWitnessesFromScriptKeys,
+import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, hashTxBody, makeWitnessesFromScriptKeys,
                      makeWitnessesVKey)
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, CoreKeyPair, Credential, DCert,
@@ -201,9 +201,9 @@ mkTxWits
   -> Set (KeyHash 'Witness)
   -> Set WitVKey
 mkTxWits txBody keyWits genesisWits keyHashMap msigs =
-  makeWitnessesVKey txBody keyWits
-  `Set.union` makeWitnessesVKey txBody genesisWits
-  `Set.union` makeWitnessesFromScriptKeys txBody keyHashMap msigs
+  makeWitnessesVKey (hashTxBody txBody) keyWits
+  `Set.union` makeWitnessesVKey (hashTxBody txBody) genesisWits
+  `Set.union` makeWitnessesFromScriptKeys (hashTxBody txBody) keyHashMap msigs
 
 -- | Generate a transaction body with the given inputs/outputs and certificates
 genTxBody

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSGenerator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSGenerator.hs
@@ -65,7 +65,7 @@ import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern DCertDeleg, p
                      pattern DeRegKey, pattern Delegate, pattern Delegation, pattern KeyHashObj,
                      pattern RegKey, pattern RetirePool, StakeCreds (..), pattern StakeRefBase,
                      Wdrl (..))
-import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, makeWitnessVKey)
+import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, hashTxBody, makeWitnessVKey)
 import           Shelley.Spec.Ledger.Validation (ValidationError (..), Validity (..))
 
 import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
@@ -188,7 +188,8 @@ genTx keyList (UTxO m) cslot = do
            (cslot + SlotNo txttl)
            SNothing
            SNothing
-  let !txwit = makeWitnessVKey txbody selectedKeyPair
+  let !txbHash = hashTxBody txbody
+  let !txwit = makeWitnessVKey txbHash selectedKeyPair
   pure (txfee', Tx txbody (Set.fromList [txwit]) Map.empty SNothing)
             where utxoInputs = Map.keys m
                   addr inp   = getTxOutAddr $ m Map.! inp

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -660,8 +660,9 @@ If the predicates are satisfied, the state is transitioned by the UTxO transitio
       \fun{validateScript}~\var{validator}~\var{tx}\\~\\
       \fun{scriptsNeeded}~\var{utxo}~\var{tx} = \dom (\fun{txwitsScript}~{tx})
       \\~\\
+      \var{txbodyHash}\leteq\fun{hash}~(\txbody{tx}) \\
       \forall \var{vk} \mapsto \sigma \in \txwitsVKey{tx},
-      \mathcal{V}_{\var{vk}}{\serialised{\txbody{tx}}}_{\sigma} \\
+      \mathcal{V}_{\var{vk}}{\serialised{txbodyHash}}_{\sigma} \\
       \fun{witsVKeyNeeded}~{utxo}~{tx}~{genDelegs} \subseteq witsKeyHashes
       \\~\\
       genSig \leteq


### PR DESCRIPTION
The signatures are now of the transaction body _hashes_, not the transaction bodies.

closes #1417 