### PR TITLE
Format everything with Ormolu

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -22,5 +22,17 @@
         "type": "tarball",
         "url": "https://github.com/input-output-hk/iohk-nix/archive/50eb9c4ececf383309ada328545b788c3493cd42.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "ormolu": {
+        "branch": "master",
+        "description": "A formatter for Haskell source code",
+        "homepage": null,
+        "owner": "tweag",
+        "repo": "ormolu",
+        "rev": "194da3a19f501247fc76af842b6aa5794d82c2eb",
+        "sha256": "0h86ihsddzap30iivm1fyy5l16ab99hlljb9wl7157ia598af06j",
+        "type": "tarball",
+        "url": "https://github.com/tweag/ormolu/archive/194da3a19f501247fc76af842b6aa5794d82c2eb.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/scripts/ormolise.sh
+++ b/scripts/ormolise.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env nix-shell
+#! nix-shell ../shell.nix -i bash
+
+set -euo pipefail
+
+ormolu -m inplace $(git ls-files -- 'shelley/chain-and-ledger/executable-spec/*.hs' | grep -v Setup.hs)

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@
 }:
 with pkgs;
 let
+  ormolu = import pkgs.commonLib.sources.ormolu {};
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
   shell = cardanoLedgerSpecsHaskellPackages.shellFor {
@@ -30,6 +31,7 @@ let
       hlint
       stylish-haskell
       weeder
+      ormolu.ormolu
     ];
 
     # Prevents cabal from choosing alternate plans, so that

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API.hs
@@ -4,7 +4,7 @@ module Shelley.Spec.Ledger.API
   )
 where
 
-import           Shelley.Spec.Ledger.API.Mempool as X
-import           Shelley.Spec.Ledger.API.Protocol as X
-import           Shelley.Spec.Ledger.API.Validation as X
-import           Shelley.Spec.Ledger.API.Wallet as X
+import Shelley.Spec.Ledger.API.Mempool as X
+import Shelley.Spec.Ledger.API.Protocol as X
+import Shelley.Spec.Ledger.API.Validation as X
+import Shelley.Spec.Ledger.API.Wallet as X

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Mempool.hs
@@ -17,22 +17,22 @@ module Shelley.Spec.Ledger.API.Mempool
   )
 where
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import           Shelley.Spec.Ledger.API.Validation
-import           Shelley.Spec.Ledger.Crypto
-import           Control.Arrow (left)
-import           Control.Monad.Except
-import           Control.Monad.Trans.Reader (runReader)
-import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
-import           Data.Sequence (Seq)
-import           Data.Typeable (Typeable)
-import           Shelley.Spec.Ledger.BaseTypes (Globals)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Control.Arrow (left)
+import Control.Monad.Except
+import Control.Monad.Trans.Reader (runReader)
+import Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
+import Data.Sequence (Seq)
+import Data.Typeable (Typeable)
+import Shelley.Spec.Ledger.API.Validation
+import Shelley.Spec.Ledger.BaseTypes (Globals)
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Keys
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
-import           Shelley.Spec.Ledger.Keys
-import           Shelley.Spec.Ledger.Slot (SlotNo)
-import           Shelley.Spec.Ledger.STS.Ledgers (LEDGERS)
+import Shelley.Spec.Ledger.STS.Ledgers (LEDGERS)
 import qualified Shelley.Spec.Ledger.STS.Ledgers as Ledgers
-import           Shelley.Spec.Ledger.Tx (Tx)
+import Shelley.Spec.Ledger.Slot (SlotNo)
+import Shelley.Spec.Ledger.Tx (Tx)
 import qualified Shelley.Spec.Ledger.Tx as Tx
 
 type MempoolEnv = Ledgers.LedgersEnv
@@ -82,17 +82,16 @@ data ApplyTxError crypto = ApplyTxError [PredicateFailure (LEDGERS crypto)]
   deriving (Eq, Show)
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBOR (ApplyTxError crypto)
- where
-   toCBOR (ApplyTxError es) = toCBOR es
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (ApplyTxError crypto)
+  where
+  toCBOR (ApplyTxError es) = toCBOR es
 
 instance
-  (Crypto crypto)
-  => FromCBOR (ApplyTxError crypto)
- where
+  (Crypto crypto) =>
+  FromCBOR (ApplyTxError crypto)
+  where
   fromCBOR = ApplyTxError <$> fromCBOR
-
 
 applyTxs ::
   forall crypto m.

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -20,25 +20,32 @@ module Shelley.Spec.Ledger.API.Protocol
   )
 where
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLenOf, encodeListLen)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.Arrow (left, right)
-import           Control.Monad.Except
-import           Control.Monad.Trans.Reader (runReader)
-import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
-import           Data.Map.Strict (Map)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.API.Validation
-import           Shelley.Spec.Ledger.BaseTypes (Globals)
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr)
-import           Shelley.Spec.Ledger.Keys (GenDelegs)
-import           Shelley.Spec.Ledger.LedgerState (EpochState (..), NewEpochState (..), OBftSlot,
-                     getGKeys, _delegationState, _dstate, _genDelegs)
-import           Shelley.Spec.Ledger.PParams (PParams)
-import           Shelley.Spec.Ledger.Slot (SlotNo)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLenOf, encodeListLen)
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.Arrow (left, right)
+import Control.Monad.Except
+import Control.Monad.Trans.Reader (runReader)
+import Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
+import Data.Map.Strict (Map)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.API.Validation
+import Shelley.Spec.Ledger.BaseTypes (Globals)
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr)
+import Shelley.Spec.Ledger.Keys (GenDelegs)
+import Shelley.Spec.Ledger.LedgerState
+  ( EpochState (..),
+    NewEpochState (..),
+    OBftSlot,
+    _delegationState,
+    _dstate,
+    _genDelegs,
+    getGKeys,
+  )
+import Shelley.Spec.Ledger.PParams (PParams)
 import qualified Shelley.Spec.Ledger.STS.Prtcl as STS.Prtcl
-import           Shelley.Spec.Ledger.STS.Tick (TICK, TickEnv (..))
+import Shelley.Spec.Ledger.STS.Tick (TICK, TickEnv (..))
+import Shelley.Spec.Ledger.Slot (SlotNo)
 
 -- | Data required by the Transitional Praos protocol from the Shelley ledger.
 data LedgerView crypto = LedgerView
@@ -158,7 +165,6 @@ newtype FutureLedgerViewError crypto
 --   Given a slot within the future stability window from our current slot (the
 --   slot corresponding to the passed-in 'ShelleyState'), return a 'LedgerView'
 --   appropriate to that slot.
---
 futureLedgerView ::
   forall crypto m.
   ( Crypto crypto,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Validation.hs
@@ -8,32 +8,32 @@
 -- API.
 module Shelley.Spec.Ledger.API.Validation
   ( ShelleyState,
-    TickTransitionError(..),
-    BlockTransitionError(..),
+    TickTransitionError (..),
+    BlockTransitionError (..),
     chainChecks,
     applyTickTransition,
     applyBlockTransition,
   )
 where
 
-import           Byron.Spec.Ledger.Core (Relation (..))
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.Arrow (left, right)
-import           Control.Monad.Except
-import           Control.Monad.Trans.Reader (runReader)
-import           Control.State.Transition.Extended (TRC (..), applySTS)
-import           Data.Either (fromRight)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes (Globals (..))
-import           Shelley.Spec.Ledger.BlockChain
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Keys
+import Byron.Spec.Ledger.Core (Relation (..))
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.Arrow (left, right)
+import Control.Monad.Except
+import Control.Monad.Trans.Reader (runReader)
+import Control.State.Transition.Extended (TRC (..), applySTS)
+import Data.Either (fromRight)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes (Globals (..))
+import Shelley.Spec.Ledger.BlockChain
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Keys
 import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
-import           Shelley.Spec.Ledger.PParams (PParams)
-import           Shelley.Spec.Ledger.Slot (SlotNo)
+import Shelley.Spec.Ledger.PParams (PParams)
 import qualified Shelley.Spec.Ledger.STS.Bbody as STS
 import qualified Shelley.Spec.Ledger.STS.Chain as STS
 import qualified Shelley.Spec.Ledger.STS.Tick as STS
+import Shelley.Spec.Ledger.Slot (SlotNo)
 import qualified Shelley.Spec.Ledger.TxData as Tx
 
 -- | Type alias for the state updated by TICK and BBODY rules
@@ -67,14 +67,15 @@ mkBbodyEnv
   LedgerState.NewEpochState
     { LedgerState.nesOsched,
       LedgerState.nesEs
-    } = STS.BbodyEnv
-    { STS.bbodySlots = dom nesOsched,
-      STS.bbodyPp = LedgerState.esPp nesEs,
-      STS.bbodyReserves =
-        LedgerState._reserves
-          . LedgerState.esAccountState
-          $ nesEs
-    }
+    } =
+    STS.BbodyEnv
+      { STS.bbodySlots = dom nesOsched,
+        STS.bbodyPp = LedgerState.esPp nesEs,
+        STS.bbodyReserves =
+          LedgerState._reserves
+            . LedgerState.esAccountState
+            $ nesEs
+      }
 
 newtype TickTransitionError crypto
   = TickTransitionError [STS.PredicateFailure (STS.TICK crypto)]

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Wallet.hs
@@ -1,80 +1,93 @@
 {-# LANGUAGE DataKinds #-}
+
 module Shelley.Spec.Ledger.API.Wallet
-  ( getNonMyopicMemberRewards
-  , getUTxO
-  , getFilteredUTxO
+  ( getNonMyopicMemberRewards,
+    getUTxO,
+    getFilteredUTxO,
   )
 where
 
-import           Data.Map (Map)
+import Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.Ratio ((%))
-import           Data.Set (Set)
+import Data.Ratio ((%))
+import Data.Set (Set)
 import qualified Data.Set as Set
-
-import           Shelley.Spec.Ledger.API.Validation (ShelleyState)
-import           Shelley.Spec.Ledger.BaseTypes (Globals (..))
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.EpochBoundary (SnapShot (..), Stake (..), poolStake)
-import           Shelley.Spec.Ledger.Keys (KeyHash, KeyRole(..))
-import           Shelley.Spec.Ledger.LedgerState (esLState, esNonMyopic, esPp, nesEs, _utxo,
-                     _utxoState)
-import           Shelley.Spec.Ledger.Rewards (NonMyopic (..), StakeShare (..), getTopRankedPools,
-                     nonMyopicMemberRew, nonMyopicStake)
-import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), PoolParams (..),
-                     TxOut (..))
-import           Shelley.Spec.Ledger.UTxO (UTxO (..))
-
+import Shelley.Spec.Ledger.API.Validation (ShelleyState)
+import Shelley.Spec.Ledger.BaseTypes (Globals (..))
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.EpochBoundary (SnapShot (..), Stake (..), poolStake)
+import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
+import Shelley.Spec.Ledger.LedgerState
+  ( _utxo,
+    _utxoState,
+    esLState,
+    esNonMyopic,
+    esPp,
+    nesEs,
+  )
+import Shelley.Spec.Ledger.Rewards
+  ( NonMyopic (..),
+    StakeShare (..),
+    getTopRankedPools,
+    nonMyopicMemberRew,
+    nonMyopicStake,
+  )
+import Shelley.Spec.Ledger.TxData
+  ( Addr (..),
+    Credential (..),
+    PoolParams (..),
+    TxOut (..),
+  )
+import Shelley.Spec.Ledger.UTxO (UTxO (..))
 
 -- | Calculate the Non-Myopic Pool Member Rewards for a set of credentials.
 -- For each given credential, this function returns a map from each stake
 -- pool (identified by the key hash of the pool operator) to the
 -- non-myopic pool member reward for that stake pool.
-getNonMyopicMemberRewards
-  :: Globals
-  -> ShelleyState crypto
-  -> Set (Credential 'Staking crypto)
-  -> Map (Credential 'Staking crypto) (Map (KeyHash 'StakePool crypto) Coin)
-getNonMyopicMemberRewards globals ss creds = Map.fromList $
-  fmap
-    (\cred -> (cred, Map.mapWithKey (mkNMMRewards $ memShare cred) poolData))
-    (Set.toList creds)
+getNonMyopicMemberRewards ::
+  Globals ->
+  ShelleyState crypto ->
+  Set (Credential 'Staking crypto) ->
+  Map (Credential 'Staking crypto) (Map (KeyHash 'StakePool crypto) Coin)
+getNonMyopicMemberRewards globals ss creds =
+  Map.fromList $
+    fmap
+      (\cred -> (cred, Map.mapWithKey (mkNMMRewards $ memShare cred) poolData))
+      (Set.toList creds)
   where
     total = fromIntegral $ maxLovelaceSupply globals
     toShare (Coin x) = StakeShare (x % total)
     memShare cred = toShare $ Map.findWithDefault (Coin 0) cred (unStake stake)
-
     es = nesEs ss
     pp = esPp es
     NonMyopic
-      { apparentPerformances = aps
-      , rewardPot = rPot
-      , snap = (SnapShot stake delegs poolParams)
+      { apparentPerformances = aps,
+        rewardPot = rPot,
+        snap = (SnapShot stake delegs poolParams)
       } = esNonMyopic es
-
-    poolData = Map.intersectionWithKey
-                 (\k a p -> (a, p, toShare . sum . unStake $ poolStake k delegs stake))
-                 aps
-                 poolParams
+    poolData =
+      Map.intersectionWithKey
+        (\k a p -> (a, p, toShare . sum . unStake $ poolStake k delegs stake))
+        aps
+        poolParams
     topPools = getTopRankedPools rPot (Coin total) pp poolParams aps
-
     mkNMMRewards ms k (ap, poolp, sigma) = nonMyopicMemberRew pp poolp rPot s ms nmps ap
       where
         s = (toShare . _poolPledge) poolp
         nmps = nonMyopicStake k sigma s pp topPools
 
 -- | Get the full UTxO.
-getUTxO
-  :: ShelleyState crypto
-  -> UTxO crypto
+getUTxO ::
+  ShelleyState crypto ->
+  UTxO crypto
 getUTxO = _utxo . _utxoState . esLState . nesEs
 
 -- | Get the UTxO filtered by address.
-getFilteredUTxO
-  :: ShelleyState crypto
-  -> Set (Addr crypto)
-  -> UTxO crypto
+getFilteredUTxO ::
+  ShelleyState crypto ->
+  Set (Addr crypto) ->
+  UTxO crypto
 getFilteredUTxO ss addrs =
-    UTxO $ Map.filter (\(TxOut addr _) -> addr `Set.member` addrs) fullUTxO
+  UTxO $ Map.filter (\(TxOut addr _) -> addr `Set.member` addrs) fullUTxO
   where
     UTxO fullUTxO = getUTxO ss

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -16,156 +16,209 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.BlockChain
-  ( HashHeader(..)
-  , PrevHash(..)
-  , LastAppliedBlock(..)
-  , lastAppliedHash
-  , BHBody(..)
-  , BHeader(BHeader)
-  , Block(Block)
-  , LaxBlock(..)
-  , TxSeq(TxSeq)
-  , bhHash
-  , bbHash
-  , hashHeaderToNonce
-  , bHeaderSize
-  , bBodySize
-  , slotToNonce
-  , hBbsize
+  ( HashHeader (..),
+    PrevHash (..),
+    LastAppliedBlock (..),
+    lastAppliedHash,
+    BHBody (..),
+    BHeader (BHeader),
+    Block (Block),
+    LaxBlock (..),
+    TxSeq (TxSeq),
+    bhHash,
+    bbHash,
+    hashHeaderToNonce,
+    bHeaderSize,
+    bBodySize,
+    slotToNonce,
+    hBbsize,
     -- accessor functions
-  , bheader
-  , bhbody
-  , bbody
-  , hsig
+    bheader,
+    bhbody,
+    bbody,
+    hsig,
     --
-  , seedEta
-  , seedL
-  , vrfChecks
-  , incrBlocks
-  , mkSeed
-  , checkVRFValue
+    seedEta,
+    seedL,
+    vrfChecks,
+    incrBlocks,
+    mkSeed,
+    checkVRFValue,
   )
 where
 
-
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.ByteString.Lazy as BSL
-import           Data.Coerce (coerce)
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           Data.Sequence (Seq)
-import qualified Data.Sequence as Seq
-import           Data.Sequence.Strict (StrictSeq)
-import qualified Data.Sequence.Strict as StrictSeq
-import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
-
-import           Cardano.Binary (Annotator (..), Decoder, FromCBOR (fromCBOR), ToCBOR (toCBOR),
-                     TokenType (TypeNull), annotatorSlice, decodeListLen, decodeListLenOf,
-                     decodeNull, encodeListLen, encodeNull, encodePreEncoded, matchSize,
-                     peekTokenType, serialize', serializeEncoding, serializeEncoding', withSlice)
-import           Cardano.Crypto.Hash (SHA256)
+import Cardano.Binary
+  ( Annotator (..),
+    Decoder,
+    FromCBOR (fromCBOR),
+    ToCBOR (toCBOR),
+    TokenType (TypeNull),
+    annotatorSlice,
+    decodeListLen,
+    decodeListLenOf,
+    decodeNull,
+    encodeListLen,
+    encodeNull,
+    encodePreEncoded,
+    matchSize,
+    peekTokenType,
+    serialize',
+    serializeEncoding,
+    serializeEncoding',
+    withSlice,
+  )
+import Cardano.Crypto.Hash (SHA256)
 import qualified Cardano.Crypto.Hash.Class as Hash
 import qualified Cardano.Crypto.VRF as VRF
-import           Cardano.Prelude (AllowThunksIn (..), ByteString, LByteString,
-                     NoUnexpectedThunks (..))
-import           Cardano.Slotting.Slot (WithOrigin (..))
-import           Control.Monad (unless)
-import           Shelley.Spec.Ledger.BaseTypes (ActiveSlotCoeff, Nonce (..), Seed (..),
-                     UnitInterval, activeSlotLog, activeSlotVal, intervalValue, mkNonce,
-                     strictMaybeToMaybe)
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
-import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
-import           Shelley.Spec.Ledger.Keys (CertifiedVRF, Hash, KeyHash, KeyRole (..), SignedKES,
-                     VKey, VRFValue (..), VerKeyVRF, coerceKeyRole, decodeSignedKES,
-                     decodeVerKeyVRF, encodeSignedKES, encodeVerKeyVRF, hash, hashKey,
-                     hashVerKeyVRF)
-import           Shelley.Spec.Ledger.OCert (OCert (..))
-import           Shelley.Spec.Ledger.PParams (ProtVer (..))
-import           Shelley.Spec.Ledger.Serialization (FromCBORGroup (..), ToCBORGroup (..), decodeMap,
-                     decodeSeq, encodeFoldableEncoder, encodeFoldableMapEncoder)
-import           Shelley.Spec.Ledger.Slot (BlockNo (..), SlotNo (..))
-import           Shelley.Spec.Ledger.Tx (Tx (..), decodeWits, segwitTx)
-import           Shelley.Spec.NonIntegral (CompareResult (..), taylorExpCmp)
+import Cardano.Prelude
+  ( AllowThunksIn (..),
+    ByteString,
+    LByteString,
+    NoUnexpectedThunks (..),
+  )
+import Cardano.Slotting.Slot (WithOrigin (..))
+import Control.Monad (unless)
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Coerce (coerce)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes
+  ( ActiveSlotCoeff,
+    Nonce (..),
+    Seed (..),
+    UnitInterval,
+    activeSlotLog,
+    activeSlotVal,
+    intervalValue,
+    mkNonce,
+    strictMaybeToMaybe,
+  )
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
+import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..))
+import Shelley.Spec.Ledger.Keys
+  ( CertifiedVRF,
+    Hash,
+    KeyHash,
+    KeyRole (..),
+    SignedKES,
+    VKey,
+    VRFValue (..),
+    VerKeyVRF,
+    coerceKeyRole,
+    decodeSignedKES,
+    decodeVerKeyVRF,
+    encodeSignedKES,
+    encodeVerKeyVRF,
+    hash,
+    hashKey,
+    hashVerKeyVRF,
+  )
+import Shelley.Spec.Ledger.OCert (OCert (..))
+import Shelley.Spec.Ledger.PParams (ProtVer (..))
+import Shelley.Spec.Ledger.Serialization
+  ( FromCBORGroup (..),
+    ToCBORGroup (..),
+    decodeMap,
+    decodeSeq,
+    encodeFoldableEncoder,
+    encodeFoldableMapEncoder,
+  )
+import Shelley.Spec.Ledger.Slot (BlockNo (..), SlotNo (..))
+import Shelley.Spec.Ledger.Tx (Tx (..), decodeWits, segwitTx)
+import Shelley.Spec.NonIntegral (CompareResult (..), taylorExpCmp)
 
 -- | The hash of a Block Header
-newtype HashHeader crypto =
-  HashHeader { unHashHeader :: (Hash crypto (BHeader crypto)) }
+newtype HashHeader crypto = HashHeader {unHashHeader :: (Hash crypto (BHeader crypto))}
   deriving (Show, Eq, Generic, Ord)
 
 deriving instance Crypto crypto => ToCBOR (HashHeader crypto)
+
 deriving instance Crypto crypto => FromCBOR (HashHeader crypto)
 
 instance NoUnexpectedThunks (HashHeader crypto)
 
-data TxSeq crypto
-    = TxSeq'
-    { txSeqTxns' :: !(StrictSeq (Tx crypto))
-    , txSeqBodyBytes :: LByteString
-    , txSeqWitsBytes :: LByteString
-    , txSeqMetadataBytes :: LByteString
-    }
+data TxSeq crypto = TxSeq'
+  { txSeqTxns' :: !(StrictSeq (Tx crypto)),
+    txSeqBodyBytes :: LByteString,
+    txSeqWitsBytes :: LByteString,
+    txSeqMetadataBytes :: LByteString
+  }
   deriving (Eq, Show, Generic)
-  deriving NoUnexpectedThunks via
-    AllowThunksIn
-    '[ "txSeqBodyBytes"
-    , "txSeqWitsBytes"
-    , "txSeqMetadataBytes"
-    ] (TxSeq crypto)
-
+  deriving
+    (NoUnexpectedThunks)
+    via AllowThunksIn
+          '[ "txSeqBodyBytes",
+             "txSeqWitsBytes",
+             "txSeqMetadataBytes"
+           ]
+          (TxSeq crypto)
 
 pattern TxSeq :: Crypto crypto => StrictSeq (Tx crypto) -> TxSeq crypto
-pattern TxSeq xs <- TxSeq' xs _ _ _
+pattern TxSeq xs <-
+  TxSeq' xs _ _ _
   where
-  TxSeq txns =
-     let serializeFoldable x = serializeEncoding $
-           encodeFoldableEncoder (encodePreEncoded . BSL.toStrict) x
-         metaChunk index m = (\metadata ->
-           toCBOR index <> toCBOR metadata) <$> strictMaybeToMaybe m
-     in  TxSeq'
-         { txSeqTxns' = txns
-         , txSeqBodyBytes =
-             serializeEncoding . encodeFoldableEncoder (toCBOR . _body) $ txns
-         , txSeqWitsBytes = serializeFoldable $ txWitsBytes <$> txns
-         , txSeqMetadataBytes =
-            serializeEncoding . encodeFoldableMapEncoder metaChunk $
-             _metadata <$> txns
-         }
+    TxSeq txns =
+      let serializeFoldable x =
+            serializeEncoding $
+              encodeFoldableEncoder (encodePreEncoded . BSL.toStrict) x
+          metaChunk index m =
+            ( \metadata ->
+                toCBOR index <> toCBOR metadata
+            )
+              <$> strictMaybeToMaybe m
+       in TxSeq'
+            { txSeqTxns' = txns,
+              txSeqBodyBytes =
+                serializeEncoding . encodeFoldableEncoder (toCBOR . _body) $ txns,
+              txSeqWitsBytes = serializeFoldable $ txWitsBytes <$> txns,
+              txSeqMetadataBytes =
+                serializeEncoding . encodeFoldableMapEncoder metaChunk $
+                  _metadata <$> txns
+            }
 
 {-# COMPLETE TxSeq #-}
 
-instance Crypto crypto
-  => ToCBORGroup (TxSeq crypto)
- where
+instance
+  Crypto crypto =>
+  ToCBORGroup (TxSeq crypto)
+  where
   toCBORGroup (TxSeq' _ bodyBytes witsBytes metadataBytes) =
-     encodePreEncoded $ BSL.toStrict $
-     bodyBytes <> witsBytes <> metadataBytes
+    encodePreEncoded $ BSL.toStrict $
+      bodyBytes <> witsBytes <> metadataBytes
   listLen _ = 3
 
 -- | Hash of block body
-newtype HashBBody crypto =
-  HashBBody { unHashBody :: (Hash crypto (TxSeq crypto)) }
+newtype HashBBody crypto = HashBBody {unHashBody :: (Hash crypto (TxSeq crypto))}
   deriving (Show, Eq, Ord, NoUnexpectedThunks)
 
 deriving instance Crypto crypto => ToCBOR (HashBBody crypto)
+
 deriving instance Crypto crypto => FromCBOR (HashBBody crypto)
 
--- |Hash a given block header
-bhHash
-  :: Crypto crypto
-  => BHeader crypto
-  -> HashHeader crypto
+-- | Hash a given block header
+bhHash ::
+  Crypto crypto =>
+  BHeader crypto ->
+  HashHeader crypto
 bhHash = HashHeader . Hash.hashWithSerialiser toCBOR
 
--- |Hash a given block body
-bbHash
-  :: forall crypto
-   . Crypto crypto
-  => TxSeq crypto
-  -> HashBBody crypto
-bbHash (TxSeq' _ bodies wits md) = (HashBBody . coerce) $
-  hashStrict (hashPart bodies <> hashPart wits <> hashPart md)
+-- | Hash a given block body
+bbHash ::
+  forall crypto.
+  Crypto crypto =>
+  TxSeq crypto ->
+  HashBBody crypto
+bbHash (TxSeq' _ bodies wits md) =
+  (HashBBody . coerce) $
+    hashStrict (hashPart bodies <> hashPart wits <> hashPart md)
   where
     -- FIXME: hash this with less indirection
     -- This should be directly hashing the provided bytes with no funny business.
@@ -173,129 +226,140 @@ bbHash (TxSeq' _ bodies wits md) = (HashBBody . coerce) $
     hashStrict = Hash.hashWithSerialiser encodePreEncoded
     hashPart = Hash.getHash . hashStrict . BSL.toStrict
 
--- |HashHeader to Nonce
+-- | HashHeader to Nonce
 hashHeaderToNonce :: HashHeader crypto -> Nonce
 hashHeaderToNonce = Nonce . coerce
 
-data BHeader crypto
-  = BHeader' {
-      bHeaderBody' :: !(BHBody crypto)
-    , bHeaderSig' :: !(SignedKES crypto (BHBody crypto))
-    , bHeaderBytes :: !LByteString
-    }
+data BHeader crypto = BHeader'
+  { bHeaderBody' :: !(BHBody crypto),
+    bHeaderSig' :: !(SignedKES crypto (BHBody crypto)),
+    bHeaderBytes :: !LByteString
+  }
   deriving (Generic)
-  deriving NoUnexpectedThunks via
-             AllowThunksIn '["bHeaderBytes"] (BHeader crypto)
+  deriving
+    (NoUnexpectedThunks)
+    via AllowThunksIn '["bHeaderBytes"] (BHeader crypto)
 
 deriving instance Crypto crypto => Eq (BHeader crypto)
+
 deriving instance Crypto crypto => Show (BHeader crypto)
 
 pattern BHeader :: Crypto crypto => BHBody crypto -> SignedKES crypto (BHBody crypto) -> BHeader crypto
-pattern BHeader bHeaderBody' bHeaderSig' <- BHeader' { bHeaderBody', bHeaderSig' }
+pattern BHeader bHeaderBody' bHeaderSig' <-
+  BHeader' {bHeaderBody', bHeaderSig'}
   where
-  BHeader body sig =
-    let mkBytes bhBody kESig = serializeEncoding $
-          encodeListLen 2
-          <> toCBOR bhBody
-          <> encodeSignedKES kESig
-     in BHeader' body sig (mkBytes body sig)
+    BHeader body sig =
+      let mkBytes bhBody kESig =
+            serializeEncoding $
+              encodeListLen 2
+                <> toCBOR bhBody
+                <> encodeSignedKES kESig
+       in BHeader' body sig (mkBytes body sig)
 
 {-# COMPLETE BHeader #-}
 
-instance Crypto crypto
-  => ToCBOR (BHeader crypto)
+instance
+  Crypto crypto =>
+  ToCBOR (BHeader crypto)
   where
-    toCBOR (BHeader' _ _ bytes) = encodePreEncoded (BSL.toStrict bytes)
+  toCBOR (BHeader' _ _ bytes) = encodePreEncoded (BSL.toStrict bytes)
 
-instance Crypto crypto
-  => FromCBOR (Annotator (BHeader crypto))
- where
-   fromCBOR = annotatorSlice $ do
-     n <- decodeListLen
-     bhb <- fromCBOR
-     sig <- decodeSignedKES
-     matchSize "Header" 2 n
-     pure $ BHeader' <$> pure bhb <*> pure sig
+instance
+  Crypto crypto =>
+  FromCBOR (Annotator (BHeader crypto))
+  where
+  fromCBOR = annotatorSlice $ do
+    n <- decodeListLen
+    bhb <- fromCBOR
+    sig <- decodeSignedKES
+    matchSize "Header" 2 n
+    pure $ BHeader' <$> pure bhb <*> pure sig
 
--- |The previous hash of a block
+-- | The previous hash of a block
 data PrevHash crypto = GenesisHash | BlockHash !(HashHeader crypto)
   deriving (Show, Eq, Generic, Ord)
 
 instance Crypto crypto => NoUnexpectedThunks (PrevHash crypto)
 
-instance Crypto crypto
-  => ToCBOR (PrevHash crypto)
+instance
+  Crypto crypto =>
+  ToCBOR (PrevHash crypto)
   where
-    toCBOR GenesisHash = encodeNull
-    toCBOR (BlockHash h) = toCBOR h
+  toCBOR GenesisHash = encodeNull
+  toCBOR (BlockHash h) = toCBOR h
 
-instance Crypto crypto
-  => FromCBOR (PrevHash crypto)
- where
-   fromCBOR = do
-     peekTokenType >>= \case
-       TypeNull -> do
-         decodeNull
-         pure GenesisHash
-       _ -> BlockHash <$> fromCBOR
+instance
+  Crypto crypto =>
+  FromCBOR (PrevHash crypto)
+  where
+  fromCBOR = do
+    peekTokenType >>= \case
+      TypeNull -> do
+        decodeNull
+        pure GenesisHash
+      _ -> BlockHash <$> fromCBOR
 
-data LastAppliedBlock crypto = LastAppliedBlock {
-     labBlockNo :: !BlockNo
-   , labSlotNo  :: !SlotNo
-   , labHash    :: !(HashHeader crypto)
-   }
+data LastAppliedBlock crypto = LastAppliedBlock
+  { labBlockNo :: !BlockNo,
+    labSlotNo :: !SlotNo,
+    labHash :: !(HashHeader crypto)
+  }
   deriving (Show, Eq, Generic)
 
 instance Crypto crypto => NoUnexpectedThunks (LastAppliedBlock crypto)
 
 instance Crypto crypto => ToCBOR (LastAppliedBlock crypto) where
   toCBOR (LastAppliedBlock b s h) =
-      encodeListLen 3 <> toCBOR b <> toCBOR s <> toCBOR h
+    encodeListLen 3 <> toCBOR b <> toCBOR s <> toCBOR h
 
 instance Crypto crypto => FromCBOR (LastAppliedBlock crypto) where
-  fromCBOR = decodeListLenOf 3 >>
-    LastAppliedBlock
+  fromCBOR =
+    decodeListLenOf 3
+      >> LastAppliedBlock
       <$> fromCBOR
       <*> fromCBOR
       <*> fromCBOR
 
 lastAppliedHash :: WithOrigin (LastAppliedBlock crypto) -> PrevHash crypto
-lastAppliedHash Origin   = GenesisHash
+lastAppliedHash Origin = GenesisHash
 lastAppliedHash (At lab) = BlockHash $ labHash lab
 
 data BHBody crypto = BHBody
   { -- | block number
-    bheaderBlockNo        :: !BlockNo
+    bheaderBlockNo :: !BlockNo,
     -- | block slot
-  , bheaderSlotNo         :: !SlotNo
-  , -- | Hash of the previous block header
-    bheaderPrev           :: !(PrevHash crypto)
+    bheaderSlotNo :: !SlotNo,
+    -- | Hash of the previous block header
+    bheaderPrev :: !(PrevHash crypto),
     -- | verification key of block issuer
-  , bheaderVk             :: !(VKey 'BlockIssuer crypto)
+    bheaderVk :: !(VKey 'BlockIssuer crypto),
     -- | VRF verification key for block issuer
-  , bheaderVrfVk          :: !(VerKeyVRF crypto)
+    bheaderVrfVk :: !(VerKeyVRF crypto),
     -- | block nonce
-  , bheaderEta            :: !(CertifiedVRF crypto Nonce)
+    bheaderEta :: !(CertifiedVRF crypto Nonce),
     -- | leader election value
-  , bheaderL              :: !(CertifiedVRF crypto UnitInterval)
+    bheaderL :: !(CertifiedVRF crypto UnitInterval),
     -- | Size of the block body
-  , bsize                 :: !Natural
+    bsize :: !Natural,
     -- | Hash of block body
-  , bhash                 :: !(HashBBody crypto)
+    bhash :: !(HashBBody crypto),
     -- | operational certificate
-  , bheaderOCert          :: !(OCert crypto)
+    bheaderOCert :: !(OCert crypto),
     -- | protocol version
-  , bprotver              :: !ProtVer
-  } deriving (Show, Eq, Generic)
+    bprotver :: !ProtVer
+  }
+  deriving (Show, Eq, Generic)
 
-instance Crypto crypto
-  => NoUnexpectedThunks (BHBody crypto)
+instance
+  Crypto crypto =>
+  NoUnexpectedThunks (BHBody crypto)
 
-instance Crypto crypto
-  => ToCBOR (BHBody crypto)
- where
+instance
+  Crypto crypto =>
+  ToCBOR (BHBody crypto)
+  where
   toCBOR bhBody =
-         encodeListLen (9 + listLen oc + listLen pv)
+    encodeListLen (9 + listLen oc + listLen pv)
       <> toCBOR (bheaderBlockNo bhBody)
       <> toCBOR (bheaderSlotNo bhBody)
       <> toCBOR (bheaderPrev bhBody)
@@ -311,10 +375,10 @@ instance Crypto crypto
       oc = bheaderOCert bhBody
       pv = bprotver bhBody
 
-
-instance Crypto crypto
-  => FromCBOR (BHBody crypto)
- where
+instance
+  Crypto crypto =>
+  FromCBOR (BHBody crypto)
+  where
   fromCBOR = do
     n <- decodeListLen
     bheaderBlockNo <- fromCBOR
@@ -323,49 +387,53 @@ instance Crypto crypto
     bheaderVk <- fromCBOR
     bheaderVrfVk <- decodeVerKeyVRF
     bheaderEta <- fromCBOR
-    bheaderL  <- fromCBOR
+    bheaderL <- fromCBOR
     bsize <- fromCBOR
     bhash <- fromCBOR
     bheaderOCert <- fromCBORGroup
     bprotver <- fromCBORGroup
     matchSize "BHBody" (fromIntegral $ 9 + listLen bheaderOCert + listLen bprotver) n
-    pure $ BHBody
-           { bheaderBlockNo
-           , bheaderSlotNo
-           , bheaderPrev
-           , bheaderVk
-           , bheaderVrfVk
-           , bheaderEta
-           , bheaderL
-           , bsize
-           , bhash
-           , bheaderOCert
-           , bprotver
-           }
+    pure $
+      BHBody
+        { bheaderBlockNo,
+          bheaderSlotNo,
+          bheaderPrev,
+          bheaderVk,
+          bheaderVrfVk,
+          bheaderEta,
+          bheaderL,
+          bsize,
+          bhash,
+          bheaderOCert,
+          bprotver
+        }
 
 data Block crypto
   = Block' !(BHeader crypto) !(TxSeq crypto) LByteString
-    deriving (Eq, Show)
+  deriving (Eq, Show)
 
 pattern Block :: Crypto crypto => BHeader crypto -> TxSeq crypto -> Block crypto
-pattern Block h txns <- Block' h txns _
+pattern Block h txns <-
+  Block' h txns _
   where
-  Block h txns =
-    let bytes = serializeEncoding $
-          encodeListLen (1 + listLen txns) <> toCBOR h <> toCBORGroup txns
-    in Block' h txns bytes
+    Block h txns =
+      let bytes =
+            serializeEncoding $
+              encodeListLen (1 + listLen txns) <> toCBOR h <> toCBORGroup txns
+       in Block' h txns bytes
 
 {-# COMPLETE Block #-}
 
--- |Given a size and a mapping from indices to maybe metadata,
--- return a sequence whose size is the size paramater and
--- whose non-Nothing values correspond no the values in the mapping.
+-- | Given a size and a mapping from indices to maybe metadata,
+--  return a sequence whose size is the size paramater and
+--  whose non-Nothing values correspond no the values in the mapping.
 constructMetaData :: Int -> Map Int a -> Seq (Maybe a)
-constructMetaData n md = fmap (`Map.lookup` md) (Seq.fromList [0 .. n-1])
+constructMetaData n md = fmap (`Map.lookup` md) (Seq.fromList [0 .. n -1])
 
-instance Crypto crypto
-  => ToCBOR (Block crypto)
- where
+instance
+  Crypto crypto =>
+  ToCBOR (Block crypto)
+  where
   toCBOR (Block' _ _ blockBytes) = encodePreEncoded $ BSL.toStrict blockBytes
 
 blockDecoder :: Crypto crypto => Bool -> forall s. Decoder s (Annotator (Block crypto))
@@ -383,110 +451,133 @@ txSeqDecoder lax = do
   let b = length bodies
       w = length wits
 
-  (metadata, metadataAnn) <- withSlice $ constructMetaData b <$>
-    decodeMap fromCBOR fromCBOR
+  (metadata, metadataAnn) <-
+    withSlice $
+      constructMetaData b
+        <$> decodeMap fromCBOR fromCBOR
   let m = length metadata
 
-  unless (lax || b == w)
-      (fail $ "different number of transaction bodies ("
-        <> show b <> ") and witness sets ("
-        <> show w <> ")"
-      )
-  unless (lax || b == m)
-      (fail $ "mismatch between transaction bodies ("
-        <> show b <> ") and metadata ("
-        <> show w <> ")"
-      )
+  unless
+    (lax || b == w)
+    ( fail $
+        "different number of transaction bodies ("
+          <> show b
+          <> ") and witness sets ("
+          <> show w
+          <> ")"
+    )
+  unless
+    (lax || b == m)
+    ( fail $
+        "mismatch between transaction bodies ("
+          <> show b
+          <> ") and metadata ("
+          <> show w
+          <> ")"
+    )
   let txns = sequenceA $ StrictSeq.toStrict $ Seq.zipWith3 segwitTx bodies wits metadata
   pure $ TxSeq' <$> txns <*> bodiesAnn <*> witsAnn <*> metadataAnn
 
-instance Crypto crypto
-  => FromCBOR (Annotator (Block crypto))
- where
+instance
+  Crypto crypto =>
+  FromCBOR (Annotator (Block crypto))
+  where
   fromCBOR = blockDecoder False
 
 newtype LaxBlock crypto
   = LaxBlock (Block crypto)
   deriving (Show, Eq)
-  deriving ToCBOR via (Block crypto)
+  deriving (ToCBOR) via (Block crypto)
 
-instance Crypto crypto
-  => FromCBOR (Annotator (LaxBlock crypto))
- where
+instance
+  Crypto crypto =>
+  FromCBOR (Annotator (LaxBlock crypto))
+  where
   fromCBOR = fmap LaxBlock <$> blockDecoder True
 
-bHeaderSize
-  :: forall crypto. (Crypto crypto)
-  => BHeader crypto
-  -> Int
+bHeaderSize ::
+  forall crypto.
+  (Crypto crypto) =>
+  BHeader crypto ->
+  Int
 bHeaderSize = BS.length . serialize'
 
-bBodySize
-  :: forall crypto. (Crypto crypto)
-  => TxSeq crypto
-  -> Int
+bBodySize ::
+  forall crypto.
+  (Crypto crypto) =>
+  TxSeq crypto ->
+  Int
 bBodySize = BS.length . serializeEncoding' . toCBORGroup
 
 slotToNonce :: SlotNo -> Nonce
 slotToNonce (SlotNo s) = mkNonce (fromIntegral s)
 
-bheader
-  :: Crypto crypto => Block crypto
-  -> BHeader crypto
+bheader ::
+  Crypto crypto =>
+  Block crypto ->
+  BHeader crypto
 bheader (Block bh _) = bh
 
 bbody :: Crypto crypto => Block crypto -> TxSeq crypto
 bbody (Block _ txs) = txs
 
-bhbody
-  :: Crypto crypto => BHeader crypto
-  -> BHBody crypto
+bhbody ::
+  Crypto crypto =>
+  BHeader crypto ->
+  BHBody crypto
 bhbody (BHeader b _) = b
 
-hsig
-  :: Crypto crypto => BHeader crypto
-  -> SignedKES crypto (BHBody crypto)
+hsig ::
+  Crypto crypto =>
+  BHeader crypto ->
+  SignedKES crypto (BHBody crypto)
 hsig (BHeader _ s) = s
 
 -- | Construct a seed to use in the VRF computation.
-mkSeed
-  :: Nonce -- ^ Universal constant
-  -> SlotNo
-  -> Nonce -- ^ Epoch nonce
-  -> Seed
+mkSeed ::
+  -- | Universal constant
+  Nonce ->
+  SlotNo ->
+  -- | Epoch nonce
+  Nonce ->
+  Seed
 mkSeed (Nonce uc) slot nonce =
   Seed . coerce $ uc `Hash.xor` coerce (hash @SHA256 (slot, nonce))
 mkSeed NeutralNonce slot nonce =
   Seed . coerce $ hash @SHA256 (slot, nonce)
 
-vrfChecks
-  ::  forall crypto
-  . ( Crypto crypto
-    , VRF.Signable (VRF crypto) Seed
-    , VRF.ContextVRF (VRF crypto) ~ ()
-    )
-  => Nonce
-  -> PoolDistr crypto
-  -> ActiveSlotCoeff
-  -> BHBody crypto
-  -> Bool
+vrfChecks ::
+  forall crypto.
+  ( Crypto crypto,
+    VRF.Signable (VRF crypto) Seed,
+    VRF.ContextVRF (VRF crypto) ~ ()
+  ) =>
+  Nonce ->
+  PoolDistr crypto ->
+  ActiveSlotCoeff ->
+  BHBody crypto ->
+  Bool
 vrfChecks eta0 (PoolDistr pd) f bhb =
   let sigma' = Map.lookup hk pd
-  in  case sigma' of
+   in case sigma' of
         Nothing -> False
         Just (sigma, vrfHK) ->
           vrfHK == hashVerKeyVRF vrfK
-            && VRF.verifyCertified () vrfK
-                         (mkSeed seedEta slot eta0)
-                         (coerce $ bheaderEta bhb)
-            && VRF.verifyCertified () vrfK
-                         (mkSeed seedL slot eta0)
-                         (coerce $ bheaderL bhb)
+            && VRF.verifyCertified
+              ()
+              vrfK
+              (mkSeed seedEta slot eta0)
+              (coerce $ bheaderEta bhb)
+            && VRF.verifyCertified
+              ()
+              vrfK
+              (mkSeed seedL slot eta0)
+              (coerce $ bheaderL bhb)
             && checkVRFValue (VRF.certifiedNatural $ bheaderL bhb) sigma f
- where
-  hk = coerceKeyRole . hashKey $ bheaderVk bhb
-  vrfK = bheaderVrfVk bhb
-  slot = bheaderSlotNo bhb
+  where
+    hk = coerceKeyRole . hashKey $ bheaderVk bhb
+    vrfK = bheaderVrfVk bhb
+    slot = bheaderSlotNo bhb
 
 -- | Check that the certified input natural is valid for being slot leader. This
 -- means we check that
@@ -508,22 +599,22 @@ vrfChecks eta0 (PoolDistr pd) f bhb =
 checkVRFValue :: Natural -> Rational -> ActiveSlotCoeff -> Bool
 checkVRFValue certNat σ f =
   if (intervalValue $ activeSlotVal f) == 1
-    -- If the active slot coefficient is equal to one,
+    then-- If the active slot coefficient is equal to one,
     -- then nearly every stake pool can produce a block every slot.
     -- In this degenerate case, where ln (1-f) is not defined,
     -- we let the VRF leader check always succeed.
     -- This is a testing convenience, the active slot coefficient should not
     -- bet set above one half otherwise.
-  then True
-  else if leaderVal == 1
-    -- Having a VRF value of one is always a failure.
-    -- Moreover, it would cause division by zero.
-  then False
-  else
-    case taylorExpCmp 3 (1 / q) x of
-      ABOVE _ _    -> False
-      BELOW _ _    -> True
-      MaxReached _ -> False
+      True
+    else
+      if leaderVal == 1
+        then-- Having a VRF value of one is always a failure.
+        -- Moreover, it would cause division by zero.
+          False
+        else case taylorExpCmp 3 (1 / q) x of
+          ABOVE _ _ -> False
+          BELOW _ _ -> True
+          MaxReached _ -> False
   where
     leaderVal = (intervalValue . fromNatural) certNat
     c = activeSlotLog f
@@ -539,14 +630,15 @@ seedL = mkNonce 1
 hBbsize :: BHBody crypto -> Natural
 hBbsize = bsize
 
-incrBlocks
-  :: Bool
-  -> KeyHash 'StakePool crypto
-  -> BlocksMade crypto
-  -> BlocksMade crypto
+incrBlocks ::
+  Bool ->
+  KeyHash 'StakePool crypto ->
+  BlocksMade crypto ->
+  BlocksMade crypto
 incrBlocks isOverlay hk b'@(BlocksMade b)
   | isOverlay = b'
   | otherwise = BlocksMade $ case hkVal of
     Nothing -> Map.insert hk 1 b
-    Just n  -> Map.insert hk (n + 1) b
-  where hkVal = Map.lookup hk b
+    Just n -> Map.insert hk (n + 1) b
+  where
+    hkVal = Map.lookup hk b

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Coin.hs
@@ -3,17 +3,17 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Shelley.Spec.Ledger.Coin
-    (
-     Coin(..)
-    , splitCoin
-    ) where
+  ( Coin (..),
+    splitCoin,
+  )
+where
 
-import           Cardano.Binary (DecoderError (..), FromCBOR (..), ToCBOR (..))
-import           Cardano.Prelude (NoUnexpectedThunks (..), cborError)
-import           Data.Text (pack)
-import           Data.Word (Word64)
+import Cardano.Binary (DecoderError (..), FromCBOR (..), ToCBOR (..))
+import Cardano.Prelude (NoUnexpectedThunks (..), cborError)
+import Data.Text (pack)
+import Data.Word (Word64)
 
--- |The amount of value held by a transaction output.
+-- | The amount of value held by a transaction output.
 newtype Coin = Coin Integer
   deriving (Show, Eq, Ord, Num, Integral, Real, Enum, NoUnexpectedThunks)
 
@@ -33,5 +33,5 @@ instance FromCBOR Coin where
 splitCoin :: Coin -> Integer -> (Coin, Coin)
 splitCoin (Coin n) 0 = (Coin 0, Coin n)
 splitCoin (Coin n) m
- | m <= 0     = error "must split coins into positive parts"
- | otherwise = (Coin $ n `div` m, Coin $ n `rem` m)
+  | m <= 0 = error "must split coins into positive parts"
+  | otherwise = (Coin $ n `div` m, Coin $ n `rem` m)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Crypto.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Crypto.hs
@@ -21,8 +21,8 @@ class
     ContextVRF (VRF c) ~ (),
     Typeable c
   ) =>
-  Crypto c where
-
+  Crypto c
+  where
   type HASH c :: Type
 
   type DSIGN c :: Type

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/Certificates.hs
@@ -2,103 +2,117 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Shelley.Spec.Ledger.Delegation.Certificates
-  ( DCert(..)
-  , DelegCert(..)
-  , PoolCert(..)
-  , GenesisDelegCert(..)
-  , MIRCert(..)
-  , StakeCreds(..)
-  , StakePools(..)
-  , PoolDistr(..)
-  , delegCWitness
-  , poolCWitness
-  , genesisCWitness
-  , dvalue
-  , refund
-  , decayKey
-  , decayPool
-  , isRegKey
-  , isDeRegKey
-  , isDelegation
-  , isGenesisDelegation
-  , isRegPool
-  , isRetirePool
-  , isInstantaneousRewards
-  , requiresVKeyWitness
-  ) where
+  ( DCert (..),
+    DelegCert (..),
+    PoolCert (..),
+    GenesisDelegCert (..),
+    MIRCert (..),
+    StakeCreds (..),
+    StakePools (..),
+    PoolDistr (..),
+    delegCWitness,
+    poolCWitness,
+    genesisCWitness,
+    dvalue,
+    refund,
+    decayKey,
+    decayPool,
+    isRegKey,
+    isDeRegKey,
+    isDelegation,
+    isGenesisDelegation,
+    isRegPool,
+    isRetirePool,
+    isInstantaneousRewards,
+    requiresVKeyWitness,
+  )
+where
 
-import           Byron.Spec.Ledger.Core (Relation (..))
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import           Shelley.Spec.Ledger.BaseTypes (FixedPoint, UnitInterval, fpEpsilon, intervalValue)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), Hash, KeyHash, VerKeyVRF)
-import           Shelley.Spec.Ledger.PParams (PParams, _keyDecayRate, _keyDeposit, _keyMinRefund,
-                     _poolDecayRate, _poolDeposit, _poolMinRefund)
-import           Shelley.Spec.Ledger.Slot (Duration (..))
-import           Shelley.Spec.Ledger.TxData (Credential (..), DCert (..), DelegCert (..),
-                     Delegation (..), GenesisDelegCert (..), MIRCert (..), PoolCert (..),
-                     PoolParams (..), StakeCreds (..), StakePools (..))
-import           Shelley.Spec.NonIntegral (exp')
+import Byron.Spec.Ledger.Core (Relation (..))
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Data.Map.Strict (Map)
+import Data.Ratio (approxRational)
+import Shelley.Spec.Ledger.BaseTypes (FixedPoint, UnitInterval, fpEpsilon, intervalValue)
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Keys (Hash, KeyHash, KeyRole (..), VerKeyVRF)
+import Shelley.Spec.Ledger.PParams
+  ( PParams,
+    _keyDecayRate,
+    _keyDeposit,
+    _keyMinRefund,
+    _poolDecayRate,
+    _poolDeposit,
+    _poolMinRefund,
+  )
+import Shelley.Spec.Ledger.Slot (Duration (..))
+import Shelley.Spec.Ledger.TxData
+  ( Credential (..),
+    DCert (..),
+    DelegCert (..),
+    Delegation (..),
+    GenesisDelegCert (..),
+    MIRCert (..),
+    PoolCert (..),
+    PoolParams (..),
+    StakeCreds (..),
+    StakePools (..),
+  )
+import Shelley.Spec.NonIntegral (exp')
 
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Data.Map.Strict (Map)
-import           Data.Ratio (approxRational)
-
-
--- |Determine the certificate author
-delegCWitness :: DelegCert crypto-> Credential 'Staking crypto
-delegCWitness (RegKey _)            = error "no witness in key registration certificate"
-delegCWitness (DeRegKey hk)         = hk
+-- | Determine the certificate author
+delegCWitness :: DelegCert crypto -> Credential 'Staking crypto
+delegCWitness (RegKey _) = error "no witness in key registration certificate"
+delegCWitness (DeRegKey hk) = hk
 delegCWitness (Delegate delegation) = _delegator delegation
 
 poolCWitness :: PoolCert crypto -> Credential 'StakePool crypto
-poolCWitness (RegPool pool)            = KeyHashObj $ _poolPubKey pool
-poolCWitness (RetirePool k _)          = KeyHashObj k
+poolCWitness (RegPool pool) = KeyHashObj $ _poolPubKey pool
+poolCWitness (RetirePool k _) = KeyHashObj k
 
 genesisCWitness :: GenesisDelegCert crypto -> KeyHash 'Genesis crypto
 genesisCWitness (GenesisDelegCert gk _) = gk
 
--- |Retrieve the deposit amount for a certificate
-dvalue :: DCert crypto-> PParams -> Coin
-dvalue (DCertDeleg (RegKey _))  = _keyDeposit
+-- | Retrieve the deposit amount for a certificate
+dvalue :: DCert crypto -> PParams -> Coin
+dvalue (DCertDeleg (RegKey _)) = _keyDeposit
 dvalue (DCertPool (RegPool _)) = _poolDeposit
 dvalue _ = const $ Coin 0
 
--- |Compute a refund on a deposit
+-- | Compute a refund on a deposit
 refund :: Coin -> UnitInterval -> Rational -> Duration -> Coin
 refund (Coin dval) dmin lambda delta = floor refund'
   where
-    pow     = fromRational (-lambda * fromIntegral delta) :: FixedPoint
+    pow = fromRational (- lambda * fromIntegral delta) :: FixedPoint
     refund' = fromIntegral dval * (dmin' + (1 - dmin') * dCay)
-    dmin'   = intervalValue dmin
-    dCay    = approxRational (exp' pow) fpEpsilon
+    dmin' = intervalValue dmin
+    dCay = approxRational (exp' pow) fpEpsilon
 
 -- | Check for `RegKey` constructor
-isRegKey :: DCert crypto-> Bool
+isRegKey :: DCert crypto -> Bool
 isRegKey (DCertDeleg (RegKey _)) = True
 isRegKey _ = False
 
 -- | Check for `DeRegKey` constructor
-isDeRegKey :: DCert crypto-> Bool
+isDeRegKey :: DCert crypto -> Bool
 isDeRegKey (DCertDeleg (DeRegKey _)) = True
 isDeRegKey _ = False
 
 -- | Check for `Delegation` constructor
-isDelegation :: DCert crypto-> Bool
+isDelegation :: DCert crypto -> Bool
 isDelegation (DCertDeleg (Delegate _)) = True
 isDelegation _ = False
 
 -- | Check for `GenesisDelegate` constructor
-isGenesisDelegation :: DCert crypto-> Bool
+isGenesisDelegation :: DCert crypto -> Bool
 isGenesisDelegation (DCertGenesis (GenesisDelegCert {})) = True
 isGenesisDelegation _ = False
 
 -- | Check for `RegPool` constructor
-isRegPool :: DCert crypto-> Bool
+isRegPool :: DCert crypto -> Bool
 isRegPool (DCertPool (RegPool _)) = True
 isRegPool _ = False
 
@@ -109,29 +123,35 @@ isRetirePool _ = False
 
 decayKey :: PParams -> (Coin, UnitInterval, Rational)
 decayKey pc = (dval, dmin, lambdad)
-    where dval    = fromIntegral $ _keyDeposit pc
-          dmin    = _keyMinRefund pc
-          lambdad = _keyDecayRate pc
+  where
+    dval = fromIntegral $ _keyDeposit pc
+    dmin = _keyMinRefund pc
+    lambdad = _keyDecayRate pc
 
 decayPool :: PParams -> (Coin, UnitInterval, Rational)
 decayPool pc = (pval, pmin, lambdap)
-    where pval    = fromIntegral $ _poolDeposit pc
-          pmin    = _poolMinRefund pc
-          lambdap = _poolDecayRate pc
+  where
+    pval = fromIntegral $ _poolDeposit pc
+    pmin = _poolMinRefund pc
+    lambdap = _poolDecayRate pc
 
 newtype PoolDistr crypto = PoolDistr
-  { unPoolDistr :: (Map (KeyHash 'StakePool crypto)
-                        (Rational, Hash crypto (VerKeyVRF crypto)))
-  } deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks, Relation)
+  { unPoolDistr ::
+      ( Map
+          (KeyHash 'StakePool crypto)
+          (Rational, Hash crypto (VerKeyVRF crypto))
+      )
+  }
+  deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks, Relation)
 
-isInstantaneousRewards :: DCert crypto-> Bool
+isInstantaneousRewards :: DCert crypto -> Bool
 isInstantaneousRewards (DCertMir _) = True
-isInstantaneousRewards _       = False
+isInstantaneousRewards _ = False
 
 -- | Returns True for delegation certificates that require at least
 -- one witness, and False otherwise. It is mainly used to ensure
 -- that calling a variant of `cwitness` is safe.
-requiresVKeyWitness :: DCert crypto-> Bool
+requiresVKeyWitness :: DCert crypto -> Bool
 requiresVKeyWitness (DCertMir (MIRCert _)) = False
 requiresVKeyWitness (DCertDeleg (RegKey _)) = False
 requiresVKeyWitness _ = True

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/PoolParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Delegation/PoolParams.hs
@@ -1,10 +1,11 @@
 module Shelley.Spec.Ledger.Delegation.PoolParams
-  ( poolSpec
-  ) where
+  ( poolSpec,
+  )
+where
 
-import           Shelley.Spec.Ledger.BaseTypes (UnitInterval)
-import           Shelley.Spec.Ledger.Coin (Coin)
-import           Shelley.Spec.Ledger.TxData (PoolParams (..))
+import Shelley.Spec.Ledger.BaseTypes (UnitInterval)
+import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.TxData (PoolParams (..))
 
 poolSpec :: PoolParams crypto -> (Coin, UnitInterval, Coin)
 poolSpec pool = (_poolCost pool, _poolMargin pool, _poolPledge pool)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/EpochBoundary.hs
@@ -6,54 +6,64 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 
-{-|
-Module      : EpochBoundary
-Description : Functions and definitions for rules at epoch boundary.
-
-This modules implements the necessary functions for the changes that can happen at epoch boundaries.
--}
+-- |
+-- Module      : EpochBoundary
+-- Description : Functions and definitions for rules at epoch boundary.
+--
+-- This modules implements the necessary functions for the changes that can happen at epoch boundaries.
 module Shelley.Spec.Ledger.EpochBoundary
-  ( Stake(..)
-  , BlocksMade(..)
-  , SnapShot(..)
-  , SnapShots(..)
-  , emptySnapShot
-  , emptySnapShots
-  , rewardStake
-  , aggregateOuts
-  , baseStake
-  , ptrStake
-  , poolStake
-  , obligation
-  , poolRefunds
-  , maxPool
-  , groupByPool
-  , (⊎)
-  ) where
+  ( Stake (..),
+    BlocksMade (..),
+    SnapShot (..),
+    SnapShots (..),
+    emptySnapShot,
+    emptySnapShots,
+    rewardStake,
+    aggregateOuts,
+    baseStake,
+    ptrStake,
+    poolStake,
+    obligation,
+    poolRefunds,
+    maxPool,
+    groupByPool,
+    (⊎),
+  )
+where
 
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Delegation.Certificates (StakeCreds (..), StakePools (..),
-                     decayKey, decayPool, refund)
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), KeyHash)
-import           Shelley.Spec.Ledger.PParams (PParams, _a0, _nOpt)
-import           Shelley.Spec.Ledger.Slot (SlotNo, (-*))
-import           Shelley.Spec.Ledger.TxData (Addr (..), Credential, PoolParams, Ptr, RewardAcnt,
-                     StakeReference (..), TxOut (..), getRwdCred)
-import           Shelley.Spec.Ledger.UTxO (UTxO (..))
-
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Data.Map.Strict (Map)
+import Byron.Spec.Ledger.Core (dom, (▷), (◁))
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), encodeListLen, enforceSize)
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (mapMaybe)
-import           Data.Ratio ((%))
+import Data.Maybe (mapMaybe)
+import Data.Ratio ((%))
 import qualified Data.Set as Set
-import           Shelley.Spec.Ledger.Crypto
-
-import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
-
-import           Byron.Spec.Ledger.Core (dom, (▷), (◁))
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( StakeCreds (..),
+    StakePools (..),
+    decayKey,
+    decayPool,
+    refund,
+  )
+import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
+import Shelley.Spec.Ledger.PParams (PParams, _a0, _nOpt)
+import Shelley.Spec.Ledger.Slot ((-*), SlotNo)
+import Shelley.Spec.Ledger.TxData
+  ( Addr (..),
+    Credential,
+    PoolParams,
+    Ptr,
+    RewardAcnt,
+    StakeReference (..),
+    TxOut (..),
+    getRwdCred,
+  )
+import Shelley.Spec.Ledger.UTxO (UTxO (..))
 
 -- | Blocks made
 newtype BlocksMade crypto
@@ -61,103 +71,103 @@ newtype BlocksMade crypto
   deriving (Show, Eq, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
 -- | Type of stake as map from hash key to coins associated.
-newtype Stake crypto
-  = Stake { unStake :: (Map (Credential 'Staking crypto) Coin) }
+newtype Stake crypto = Stake {unStake :: (Map (Credential 'Staking crypto) Coin)}
   deriving (Show, Eq, Ord, ToCBOR, FromCBOR, NoUnexpectedThunks)
 
 -- | Add two stake distributions
-(⊎)
-  :: Stake crypto
-  -> Stake crypto
-  -> Stake crypto
+(⊎) ::
+  Stake crypto ->
+  Stake crypto ->
+  Stake crypto
 (Stake lhs) ⊎ (Stake rhs) = Stake $ Map.unionWith (+) lhs rhs
 
 -- | Extract hash of staking key from base address.
 getStakeHK :: Addr crypto -> Maybe (Credential 'Staking crypto)
 getStakeHK (Addr _ (StakeRefBase hk)) = Just hk
-getStakeHK _                          = Nothing
+getStakeHK _ = Nothing
 
 aggregateOuts :: UTxO crypto -> Map (Addr crypto) Coin
 aggregateOuts (UTxO u) =
   Map.fromListWith (+) (map (\(_, TxOut a c) -> (a, c)) $ Map.toList u)
 
 -- | Get Stake of base addresses in TxOut set.
-baseStake
-  :: Map (Addr crypto) Coin
-  -> [(Credential 'Staking crypto, Coin)]
+baseStake ::
+  Map (Addr crypto) Coin ->
+  [(Credential 'Staking crypto, Coin)]
 baseStake vals =
   mapMaybe convert $ Map.toList vals
   where
-   convert
-     :: (Addr crypto, Coin)
-     -> Maybe (Credential 'Staking crypto, Coin)
-   convert (a, c) =
-     (,c) <$> getStakeHK a
+    convert ::
+      (Addr crypto, Coin) ->
+      Maybe (Credential 'Staking crypto, Coin)
+    convert (a, c) =
+      (,c) <$> getStakeHK a
 
 -- | Extract pointer from pointer address.
 getStakePtr :: Addr crypto -> Maybe Ptr
 getStakePtr (Addr _ (StakeRefPtr ptr)) = Just ptr
-getStakePtr _               = Nothing
+getStakePtr _ = Nothing
 
 -- | Calculate stake of pointer addresses in TxOut set.
-ptrStake
-  :: forall crypto
-   . Map (Addr crypto) Coin
-  -> Map Ptr (Credential 'Staking crypto)
-  -> [(Credential 'Staking crypto, Coin)]
+ptrStake ::
+  forall crypto.
+  Map (Addr crypto) Coin ->
+  Map Ptr (Credential 'Staking crypto) ->
+  [(Credential 'Staking crypto, Coin)]
 ptrStake vals pointers =
   mapMaybe convert $ Map.toList vals
   where
-    convert
-      :: (Addr crypto, Coin)
-      -> Maybe (Credential 'Staking crypto, Coin)
+    convert ::
+      (Addr crypto, Coin) ->
+      Maybe (Credential 'Staking crypto, Coin)
     convert (a, c) =
       case getStakePtr a of
         Nothing -> Nothing
         Just s -> (,c) <$> Map.lookup s pointers
 
-rewardStake
-  :: forall crypto
-   . Map (RewardAcnt crypto) Coin
-  -> [(Credential 'Staking crypto, Coin)]
+rewardStake ::
+  forall crypto.
+  Map (RewardAcnt crypto) Coin ->
+  [(Credential 'Staking crypto, Coin)]
 rewardStake rewards =
   map convert $ Map.toList rewards
   where
     convert (rwdKey, c) = (getRwdCred rwdKey, c)
 
 -- | Get stake of one pool
-poolStake
-  :: KeyHash 'StakePool crypto
-  -> Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto)
-  -> Stake crypto
-  -> Stake crypto
+poolStake ::
+  KeyHash 'StakePool crypto ->
+  Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto) ->
+  Stake crypto ->
+  Stake crypto
 poolStake hk delegs (Stake stake) =
   Stake $ dom (delegs ▷ Set.singleton hk) ◁ stake
 
 -- | Calculate pool refunds
-poolRefunds
-  :: PParams
-  -> Map (KeyHash 'StakePool crypto) SlotNo
-  -> SlotNo
-  -> Map (KeyHash 'StakePool crypto) Coin
+poolRefunds ::
+  PParams ->
+  Map (KeyHash 'StakePool crypto) SlotNo ->
+  SlotNo ->
+  Map (KeyHash 'StakePool crypto) Coin
 poolRefunds pp retirees cslot =
   Map.map
-    (\s ->
-       refund pval pmin lambda (cslot -* s))
+    ( \s ->
+        refund pval pmin lambda (cslot -* s)
+    )
     retirees
   where
     (pval, pmin, lambda) = decayPool pp
 
 -- | Calculate total possible refunds.
-obligation
-  :: PParams
-  -> StakeCreds crypto
-  -> StakePools crypto
-  -> SlotNo
-  -> Coin
+obligation ::
+  PParams ->
+  StakeCreds crypto ->
+  StakePools crypto ->
+  SlotNo ->
+  Coin
 obligation pc (StakeCreds stakeKeys) (StakePools stakePools) cslot =
-  sum (map (\s -> refund dval dmin lambdad (cslot -* s)) $ Map.elems stakeKeys) +
-  sum (map (\s -> refund pval pmin lambdap (cslot -* s)) $ Map.elems stakePools)
+  sum (map (\s -> refund dval dmin lambdad (cslot -* s)) $ Map.elems stakeKeys)
+    + sum (map (\s -> refund pval pmin lambdap (cslot -* s)) $ Map.elems stakePools)
   where
     (dval, dmin, lambdad) = decayKey pc
     (pval, pmin, lambdap) = decayPool pc
@@ -177,87 +187,89 @@ maxPool pc (Coin r) sigma pR = floor $ factor1 * factor2
     factor4 = (z0 - sigma') / z0
 
 -- | Pool individual reward
-groupByPool
-  :: Map (KeyHash 'Staking crypto) Coin
-  -> Map (KeyHash 'Staking crypto) (KeyHash 'StakePool crypto)
-  -> Map
-       (KeyHash 'StakePool crypto)
-       (Map (KeyHash 'Staking crypto) Coin)
+groupByPool ::
+  Map (KeyHash 'Staking crypto) Coin ->
+  Map (KeyHash 'Staking crypto) (KeyHash 'StakePool crypto) ->
+  Map
+    (KeyHash 'StakePool crypto)
+    (Map (KeyHash 'Staking crypto) Coin)
 groupByPool active delegs =
   Map.fromListWith
     Map.union
     [ (delegs Map.! hk, Set.singleton hk ◁ active)
-    | hk <- Map.keys delegs
+      | hk <- Map.keys delegs
     ]
 
 -- | Snapshot of the stake distribution.
-data SnapShot crypto
-  = SnapShot
-    { _stake       :: !(Stake crypto)
-    , _delegations :: !(Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto))
-    , _poolParams  :: !(Map (KeyHash 'StakePool crypto) (PoolParams crypto))
-    } deriving (Show, Eq, Generic)
+data SnapShot crypto = SnapShot
+  { _stake :: !(Stake crypto),
+    _delegations :: !(Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto)),
+    _poolParams :: !(Map (KeyHash 'StakePool crypto) (PoolParams crypto))
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (SnapShot crypto)
 
 instance
-  Crypto crypto
-  => ToCBOR (SnapShot crypto)
+  Crypto crypto =>
+  ToCBOR (SnapShot crypto)
   where
-    toCBOR (SnapShot
-      { _stake = s
-      , _delegations = d
-      , _poolParams = p
-      }) =
+  toCBOR
+    ( SnapShot
+        { _stake = s,
+          _delegations = d,
+          _poolParams = p
+        }
+      ) =
       encodeListLen 3
         <> toCBOR s
         <> toCBOR d
         <> toCBOR p
 
 instance
-  Crypto crypto
-  => FromCBOR (SnapShot crypto)
+  Crypto crypto =>
+  FromCBOR (SnapShot crypto)
   where
-    fromCBOR = do
-      enforceSize "SnapShot" 3
-      s <- fromCBOR
-      d <- fromCBOR
-      p <- fromCBOR
-      pure $ SnapShot s d p
+  fromCBOR = do
+    enforceSize "SnapShot" 3
+    s <- fromCBOR
+    d <- fromCBOR
+    p <- fromCBOR
+    pure $ SnapShot s d p
 
 -- | Snapshots of the stake distribution.
-data SnapShots crypto
-  = SnapShots
-    { _pstakeMark :: !(SnapShot crypto)
-    , _pstakeSet  :: !(SnapShot crypto)
-    , _pstakeGo   :: !(SnapShot crypto)
-    , _feeSS      :: !Coin
-    } deriving (Show, Eq, Generic)
+data SnapShots crypto = SnapShots
+  { _pstakeMark :: !(SnapShot crypto),
+    _pstakeSet :: !(SnapShot crypto),
+    _pstakeGo :: !(SnapShot crypto),
+    _feeSS :: !Coin
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (SnapShots crypto)
 
 instance
-  Crypto crypto
-  => ToCBOR (SnapShots crypto)
+  Crypto crypto =>
+  ToCBOR (SnapShots crypto)
   where
-    toCBOR (SnapShots mark set go fs) =
-      encodeListLen 4
+  toCBOR (SnapShots mark set go fs) =
+    encodeListLen 4
       <> toCBOR mark
       <> toCBOR set
       <> toCBOR go
       <> toCBOR fs
 
 instance
-  Crypto crypto
-  => FromCBOR (SnapShots crypto)
+  Crypto crypto =>
+  FromCBOR (SnapShots crypto)
   where
-    fromCBOR = do
-      enforceSize "SnapShots" 4
-      mark <- fromCBOR
-      set <- fromCBOR
-      go <- fromCBOR
-      f <- fromCBOR
-      pure $ SnapShots mark set go f
+  fromCBOR = do
+    enforceSize "SnapShots" 4
+    mark <- fromCBOR
+    set <- fromCBOR
+    go <- fromCBOR
+    f <- fromCBOR
+    pure $ SnapShots mark set go f
 
 emptySnapShot :: SnapShot crypto
 emptySnapShot = SnapShot (Stake Map.empty) Map.empty Map.empty

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -11,116 +11,202 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-{-|
-Module      : LedgerState
-Description : Operational Rules
-
-This module implements the operation rules for treating UTxO transactions ('Tx')
-as state transformations on a ledger state ('LedgerState'),
-as specified in /A Simplified Formal Specification of a UTxO Ledger/.
--}
-
+-- |
+-- Module      : LedgerState
+-- Description : Operational Rules
+--
+-- This module implements the operation rules for treating UTxO transactions ('Tx')
+-- as state transformations on a ledger state ('LedgerState'),
+-- as specified in /A Simplified Formal Specification of a UTxO Ledger/.
 module Shelley.Spec.Ledger.LedgerState
-  ( LedgerState(..)
-  , Ix
-  , DPState(..)
-  , DState(..)
-  , AccountState(..)
-  , RewardUpdate(..)
-  , RewardAccounts
-  , emptyRewardUpdate
-  , FutureGenDeleg(..)
-  , EpochState(..)
-  , emptyEpochState
-  , getIR
-  , emptyLedgerState
-  , emptyUTxOState
-  , clearPpup
-  , PState(..)
-  , KeyPairs
-  , UTxOState(..)
-  , OBftSlot(..)
-  , emptyAccount
-  , emptyPState
-  , emptyDState
-  -- * state transitions
-  , emptyDelegation
-  , applyTxBody
-  -- * Genesis State
-  , genesisId
-  , genesisCoins
-  , genesisState
-  -- * Validation
-  , LedgerValidation(..)
-  , minfee
-  , txsize
-  , validTx
-  , produced
-  , consumed
-  , verifiedWits
-  , witsVKeyNeeded
-  -- DelegationState
-  -- refunds
-  , keyRefunds
-  , keyRefund
-  , decayedTx
-  -- epoch boundary
-  , stakeDistr
-  , applyRUpd
-  , createRUpd
-  --
-  , NewEpochState(..)
-  , NewEpochEnv(..)
-  , overlaySchedule
-  , getGKeys
-  , updateNES
-  ) where
+  ( LedgerState (..),
+    Ix,
+    DPState (..),
+    DState (..),
+    AccountState (..),
+    RewardUpdate (..),
+    RewardAccounts,
+    emptyRewardUpdate,
+    FutureGenDeleg (..),
+    EpochState (..),
+    emptyEpochState,
+    getIR,
+    emptyLedgerState,
+    emptyUTxOState,
+    clearPpup,
+    PState (..),
+    KeyPairs,
+    UTxOState (..),
+    OBftSlot (..),
+    emptyAccount,
+    emptyPState,
+    emptyDState,
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), TokenType (TypeNull), decodeNull,
-                     encodeListLen, encodeNull, enforceSize, peekTokenType, serialize)
-import           Cardano.Crypto.Hash (hashWithSerialiser)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.Monad.Trans.Reader (ReaderT (..), asks)
+    -- * state transitions
+    emptyDelegation,
+    applyTxBody,
+
+    -- * Genesis State
+    genesisId,
+    genesisCoins,
+    genesisState,
+
+    -- * Validation
+    LedgerValidation (..),
+    minfee,
+    txsize,
+    validTx,
+    produced,
+    consumed,
+    verifiedWits,
+    witsVKeyNeeded,
+    -- DelegationState
+    -- refunds
+    keyRefunds,
+    keyRefund,
+    decayedTx,
+    -- epoch boundary
+    stakeDistr,
+    applyRUpd,
+    createRUpd,
+    --
+    NewEpochState (..),
+    NewEpochEnv (..),
+    overlaySchedule,
+    getGKeys,
+    updateNES,
+  )
+where
+
+import Byron.Spec.Ledger.Core (dom, (∪), (∪+), (⋪), (▷), (◁))
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    TokenType (TypeNull),
+    decodeNull,
+    encodeListLen,
+    encodeNull,
+    enforceSize,
+    peekTokenType,
+    serialize,
+  )
+import Cardano.Crypto.Hash (hashWithSerialiser)
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.Monad.Trans.Reader (ReaderT (..), asks)
 import qualified Data.ByteString.Lazy as BSL (length)
-import           Data.Foldable (toList)
-import           Data.List (foldl')
-import           Data.List.NonEmpty (NonEmpty)
+import Data.Foldable (toList)
+import Data.List (foldl')
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NonEmpty
-import           Data.Map.Strict (Map)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Set (Set)
+import Data.Set (Set)
 import qualified Data.Set as Set
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Crypto (Crypto)
-import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), SnapShot (..), SnapShots (..),
-                     Stake (..), aggregateOuts, baseStake, emptySnapShots, ptrStake, rewardStake)
-import           Shelley.Spec.Ledger.Keys (DSignable, GenDelegs (..), Hash, KeyHash, KeyPair,
-                     KeyRole (..), asWitness, hash)
-import           Shelley.Spec.Ledger.PParams (PParams, ProposedPPUpdates (..), Update (..),
-                     emptyPPPUpdates, emptyPParams, _d, _keyDecayRate, _keyDeposit, _keyMinRefund,
-                     _minfeeA, _minfeeB, _rho, _tau)
-import           Shelley.Spec.Ledger.Slot (Duration (..), EpochNo (..), SlotNo (..), epochInfoEpoch,
-                     epochInfoFirst, epochInfoSize, (+*), (-*))
-import           Shelley.Spec.Ledger.Tx (Tx (..), extractKeyHash)
-import           Shelley.Spec.Ledger.TxData (Addr (..), Credential (..), DelegCert (..), Ix,
-                     PoolCert (..), PoolParams (..), Ptr (..), RewardAcnt (..), TxBody (..),
-                     TxId (..), TxIn (..), TxOut (..), Wdrl (..), getRwdCred, witKeyHash)
-import           Shelley.Spec.Ledger.UTxO (UTxO (..), balance, totalDeposits, txinLookup, txins,
-                     txouts, txup, verifyWitVKey)
-import           Shelley.Spec.Ledger.Validation (ValidationError (..), Validity (..))
-
-import           Shelley.Spec.Ledger.Delegation.Certificates (DCert (..), PoolDistr (..),
-                     StakeCreds (..), StakePools (..), decayKey, delegCWitness, genesisCWitness,
-                     poolCWitness, refund, requiresVKeyWitness)
-import           Shelley.Spec.Ledger.Rewards (ApparentPerformance (..), NonMyopic (..),
-                     emptyNonMyopic, reward)
-
-import           Byron.Spec.Ledger.Core (dom, (∪), (∪+), (⋪), (▷), (◁))
-import           Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase, StrictMaybe (..),
-                     UnitInterval, activeSlotVal, intervalValue)
-
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Globals (..),
+    ShelleyBase,
+    StrictMaybe (..),
+    UnitInterval,
+    activeSlotVal,
+    intervalValue,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Crypto (Crypto)
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( DCert (..),
+    PoolDistr (..),
+    StakeCreds (..),
+    StakePools (..),
+    decayKey,
+    delegCWitness,
+    genesisCWitness,
+    poolCWitness,
+    refund,
+    requiresVKeyWitness,
+  )
+import Shelley.Spec.Ledger.EpochBoundary
+  ( BlocksMade (..),
+    SnapShot (..),
+    SnapShots (..),
+    Stake (..),
+    aggregateOuts,
+    baseStake,
+    emptySnapShots,
+    ptrStake,
+    rewardStake,
+  )
+import Shelley.Spec.Ledger.Keys
+  ( DSignable,
+    GenDelegs (..),
+    Hash,
+    KeyHash,
+    KeyPair,
+    KeyRole (..),
+    asWitness,
+    hash,
+  )
+import Shelley.Spec.Ledger.PParams
+  ( PParams,
+    ProposedPPUpdates (..),
+    Update (..),
+    _d,
+    _keyDecayRate,
+    _keyDeposit,
+    _keyMinRefund,
+    _minfeeA,
+    _minfeeB,
+    _rho,
+    _tau,
+    emptyPPPUpdates,
+    emptyPParams,
+  )
+import Shelley.Spec.Ledger.Rewards
+  ( ApparentPerformance (..),
+    NonMyopic (..),
+    emptyNonMyopic,
+    reward,
+  )
+import Shelley.Spec.Ledger.Slot
+  ( (+*),
+    (-*),
+    Duration (..),
+    EpochNo (..),
+    SlotNo (..),
+    epochInfoEpoch,
+    epochInfoFirst,
+    epochInfoSize,
+  )
+import Shelley.Spec.Ledger.Tx (Tx (..), extractKeyHash)
+import Shelley.Spec.Ledger.TxData
+  ( Addr (..),
+    Credential (..),
+    DelegCert (..),
+    Ix,
+    PoolCert (..),
+    PoolParams (..),
+    Ptr (..),
+    RewardAcnt (..),
+    TxBody (..),
+    TxId (..),
+    TxIn (..),
+    TxOut (..),
+    Wdrl (..),
+    getRwdCred,
+    witKeyHash,
+  )
+import Shelley.Spec.Ledger.UTxO
+  ( UTxO (..),
+    balance,
+    totalDeposits,
+    txinLookup,
+    txins,
+    txouts,
+    txup,
+    verifyWitVKey,
+  )
+import Shelley.Spec.Ledger.Validation (ValidationError (..), Validity (..))
 
 -- | Representation of a list of pairs of key pairs, e.g., pay and stake keys
 type KeyPairs crypto = [(KeyPair 'Payment crypto, KeyPair 'Staking crypto)]
@@ -133,23 +219,22 @@ data LedgerValidation crypto
 
 instance NoUnexpectedThunks (LedgerValidation crypto)
 
-type RewardAccounts crypto
-  = Map (RewardAcnt crypto) Coin
+type RewardAccounts crypto =
+  Map (RewardAcnt crypto) Coin
 
 data FutureGenDeleg crypto = FutureGenDeleg
-    { fGenDelegSlot       :: !SlotNo
-    , fGenDelegGenKeyHash :: !(KeyHash 'Genesis crypto)
-    } deriving (Show, Eq, Ord, Generic)
+  { fGenDelegSlot :: !SlotNo,
+    fGenDelegGenKeyHash :: !(KeyHash 'Genesis crypto)
+  }
+  deriving (Show, Eq, Ord, Generic)
 
 instance NoUnexpectedThunks (FutureGenDeleg crypto)
 
-instance Crypto crypto => ToCBOR (FutureGenDeleg crypto)
- where
+instance Crypto crypto => ToCBOR (FutureGenDeleg crypto) where
   toCBOR (FutureGenDeleg a b) =
     encodeListLen 2 <> toCBOR a <> toCBOR b
 
-instance Crypto crypto => FromCBOR (FutureGenDeleg crypto)
- where
+instance Crypto crypto => FromCBOR (FutureGenDeleg crypto) where
   fromCBOR = do
     enforceSize "FutureGenDeleg" 2
     a <- fromCBOR
@@ -158,32 +243,33 @@ instance Crypto crypto => FromCBOR (FutureGenDeleg crypto)
 
 -- | State of staking pool delegations and rewards
 data DState crypto = DState
-    {  -- |The active stake keys.
-      _stkCreds    :: !(StakeCreds           crypto)
-      -- |The active reward accounts.
-    ,  _rewards    :: !(RewardAccounts       crypto)
-      -- |The current delegations.
-    , _delegations :: !(Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto))
-      -- |The pointed to hash keys.
-    , _ptrs        :: !(Map Ptr (Credential 'Staking crypto))
-      -- | future genesis key delegations
-    , _fGenDelegs  :: !(Map (FutureGenDeleg crypto) (KeyHash 'GenesisDelegate crypto))
-      -- |Genesis key delegations
-    , _genDelegs   :: !(GenDelegs crypto)
-      -- | Instantaneous Rewards
-    , _irwd        :: !(Map (Credential 'Staking crypto) Coin)
-    } deriving (Show, Eq, Generic)
+  { -- | The active stake keys.
+    _stkCreds :: !(StakeCreds crypto),
+    -- | The active reward accounts.
+    _rewards :: !(RewardAccounts crypto),
+    -- | The current delegations.
+    _delegations :: !(Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto)),
+    -- | The pointed to hash keys.
+    _ptrs :: !(Map Ptr (Credential 'Staking crypto)),
+    -- | future genesis key delegations
+    _fGenDelegs :: !(Map (FutureGenDeleg crypto) (KeyHash 'GenesisDelegate crypto)),
+    -- | Genesis key delegations
+    _genDelegs :: !(GenDelegs crypto),
+    -- | Instantaneous Rewards
+    _irwd :: !(Map (Credential 'Staking crypto) Coin)
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (DState crypto)
 
-instance Crypto crypto => ToCBOR (DState crypto)
- where
+instance Crypto crypto => ToCBOR (DState crypto) where
   toCBOR (DState sc rw dlg p fgs gs ir) =
     encodeListLen 7 <> toCBOR sc <> toCBOR rw <> toCBOR dlg <> toCBOR p
-      <> toCBOR fgs <> toCBOR gs <> toCBOR ir
+      <> toCBOR fgs
+      <> toCBOR gs
+      <> toCBOR ir
 
-instance Crypto crypto => FromCBOR (DState crypto)
- where
+instance Crypto crypto => FromCBOR (DState crypto) where
   fromCBOR = do
     enforceSize "DState" 7
     sc <- fromCBOR
@@ -197,23 +283,22 @@ instance Crypto crypto => FromCBOR (DState crypto)
 
 -- | Current state of staking pools and their certificate counters.
 data PState crypto = PState
-    { -- |The active stake pools.
-      _stPools     :: !(StakePools crypto)
-      -- |The pool parameters.
-    , _pParams     :: !(Map (KeyHash 'StakePool crypto) (PoolParams crypto))
-      -- |A map of retiring stake pools to the epoch when they retire.
-    , _retiring    :: !(Map (KeyHash 'StakePool crypto) EpochNo)
-    } deriving (Show, Eq, Generic)
+  { -- | The active stake pools.
+    _stPools :: !(StakePools crypto),
+    -- | The pool parameters.
+    _pParams :: !(Map (KeyHash 'StakePool crypto) (PoolParams crypto)),
+    -- | A map of retiring stake pools to the epoch when they retire.
+    _retiring :: !(Map (KeyHash 'StakePool crypto) EpochNo)
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (PState crypto)
 
-instance Crypto crypto => ToCBOR (PState crypto)
- where
+instance Crypto crypto => ToCBOR (PState crypto) where
   toCBOR (PState a b c) =
     encodeListLen 3 <> toCBOR a <> toCBOR b <> toCBOR c
 
-instance Crypto crypto => FromCBOR (PState crypto)
- where
+instance Crypto crypto => FromCBOR (PState crypto) where
   fromCBOR = do
     enforceSize "PState" 3
     a <- fromCBOR
@@ -222,50 +307,46 @@ instance Crypto crypto => FromCBOR (PState crypto)
     pure $ PState a b c
 
 -- | The state associated with the current stake delegation.
-data DPState crypto =
-    DPState
-    {
-      _dstate :: !(DState crypto)
-    , _pstate :: !(PState crypto)
-    } deriving (Show, Eq, Generic)
+data DPState crypto = DPState
+  { _dstate :: !(DState crypto),
+    _pstate :: !(PState crypto)
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (DPState crypto)
 
-instance Crypto crypto => ToCBOR (DPState crypto)
- where
+instance Crypto crypto => ToCBOR (DPState crypto) where
   toCBOR (DPState ds ps) =
     encodeListLen 2 <> toCBOR ds <> toCBOR ps
 
-instance Crypto crypto => FromCBOR (DPState crypto)
- where
+instance Crypto crypto => FromCBOR (DPState crypto) where
   fromCBOR = do
     enforceSize "DPState" 2
     ds <- fromCBOR
     ps <- fromCBOR
     pure $ DPState ds ps
 
-data RewardUpdate crypto= RewardUpdate
-  { deltaT        :: !Coin
-  , deltaR        :: !Coin
-  , rs            :: !(Map (RewardAcnt crypto) Coin)
-  , deltaF        :: !Coin
-  , nonMyopic     :: !(NonMyopic crypto)
-  } deriving (Show, Eq, Generic)
+data RewardUpdate crypto = RewardUpdate
+  { deltaT :: !Coin,
+    deltaR :: !Coin,
+    rs :: !(Map (RewardAcnt crypto) Coin),
+    deltaF :: !Coin,
+    nonMyopic :: !(NonMyopic crypto)
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (RewardUpdate crypto)
 
-instance Crypto crypto => ToCBOR (RewardUpdate crypto)
- where
+instance Crypto crypto => ToCBOR (RewardUpdate crypto) where
   toCBOR (RewardUpdate dt dr rw df nm) =
     encodeListLen 5
       <> toCBOR dt
-      <> toCBOR (-dr) -- TODO change Coin serialization to use integers?
+      <> toCBOR (- dr) -- TODO change Coin serialization to use integers?
       <> toCBOR rw
-      <> toCBOR (-df) -- TODO change Coin serialization to use integers?
+      <> toCBOR (- df) -- TODO change Coin serialization to use integers?
       <> toCBOR nm
 
-instance Crypto crypto => FromCBOR (RewardUpdate crypto)
- where
+instance Crypto crypto => FromCBOR (RewardUpdate crypto) where
   fromCBOR = do
     enforceSize "RewardUpdate" 5
     dt <- fromCBOR
@@ -273,23 +354,22 @@ instance Crypto crypto => FromCBOR (RewardUpdate crypto)
     rw <- fromCBOR
     df <- fromCBOR -- TODO change Coin serialization to use integers?
     nm <- fromCBOR
-    pure $ RewardUpdate dt (-dr) rw (-df) nm
+    pure $ RewardUpdate dt (- dr) rw (- df) nm
 
 emptyRewardUpdate :: RewardUpdate crypto
 emptyRewardUpdate = RewardUpdate (Coin 0) (Coin 0) Map.empty (Coin 0) emptyNonMyopic
 
 data AccountState = AccountState
-  { _treasury  :: !Coin
-  , _reserves  :: !Coin
-  } deriving (Show, Eq, Generic)
+  { _treasury :: !Coin,
+    _reserves :: !Coin
+  }
+  deriving (Show, Eq, Generic)
 
-instance ToCBOR AccountState
- where
+instance ToCBOR AccountState where
   toCBOR (AccountState t r) =
     encodeListLen 2 <> toCBOR t <> toCBOR r
 
-instance FromCBOR AccountState
- where
+instance FromCBOR AccountState where
   fromCBOR = do
     enforceSize "AccountState" 2
     t <- fromCBOR
@@ -298,26 +378,23 @@ instance FromCBOR AccountState
 
 instance NoUnexpectedThunks AccountState
 
-data EpochState crypto
-  = EpochState
-    { esAccountState :: !AccountState
-    , esSnapshots :: !(SnapShots crypto)
-    , esLState :: !(LedgerState crypto)
-    , esPrevPp :: !PParams
-    , esPp :: !PParams
-    , esNonMyopic :: !(NonMyopic crypto)
-    }
+data EpochState crypto = EpochState
+  { esAccountState :: !AccountState,
+    esSnapshots :: !(SnapShots crypto),
+    esLState :: !(LedgerState crypto),
+    esPrevPp :: !PParams,
+    esPp :: !PParams,
+    esNonMyopic :: !(NonMyopic crypto)
+  }
   deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (EpochState crypto)
 
-instance Crypto crypto => ToCBOR (EpochState crypto)
- where
+instance Crypto crypto => ToCBOR (EpochState crypto) where
   toCBOR (EpochState a s l r p n) =
     encodeListLen 6 <> toCBOR a <> toCBOR s <> toCBOR l <> toCBOR r <> toCBOR p <> toCBOR n
 
-instance Crypto crypto => FromCBOR (EpochState crypto)
- where
+instance Crypto crypto => FromCBOR (EpochState crypto) where
   fromCBOR = do
     enforceSize "EpochState" 6
     a <- fromCBOR
@@ -341,15 +418,15 @@ getIR = _irwd . _dstate . _delegationState . esLState
 emptyLedgerState :: LedgerState crypto
 emptyLedgerState =
   LedgerState
-  emptyUTxOState
-  emptyDelegation
+    emptyUTxOState
+    emptyDelegation
 
 emptyAccount :: AccountState
 emptyAccount = AccountState (Coin 0) (Coin 0)
 
 emptyDelegation :: DPState crypto
 emptyDelegation =
-    DPState emptyDState emptyPState
+  DPState emptyDState emptyPState
 
 emptyDState :: DState crypto
 emptyDState =
@@ -359,29 +436,27 @@ emptyPState :: PState crypto
 emptyPState =
   PState (StakePools Map.empty) Map.empty Map.empty
 
--- |Clear the protocol parameter updates
-clearPpup
-  :: UTxOState crypto
-  -> UTxOState crypto
+-- | Clear the protocol parameter updates
+clearPpup ::
+  UTxOState crypto ->
+  UTxOState crypto
 clearPpup utxoSt = utxoSt {_ppups = emptyPPPUpdates}
 
-data UTxOState crypto=
-    UTxOState
-    { _utxo      :: !(UTxO crypto)
-    , _deposited :: !Coin
-    , _fees      :: !Coin
-    , _ppups     :: !(ProposedPPUpdates crypto)
-    } deriving (Show, Eq, Generic)
+data UTxOState crypto = UTxOState
+  { _utxo :: !(UTxO crypto),
+    _deposited :: !Coin,
+    _fees :: !Coin,
+    _ppups :: !(ProposedPPUpdates crypto)
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (UTxOState crypto)
 
-instance Crypto crypto => ToCBOR (UTxOState crypto)
- where
+instance Crypto crypto => ToCBOR (UTxOState crypto) where
   toCBOR (UTxOState ut dp fs us) =
     encodeListLen 4 <> toCBOR ut <> toCBOR dp <> toCBOR fs <> toCBOR us
 
-instance Crypto crypto => FromCBOR (UTxOState crypto)
- where
+instance Crypto crypto => FromCBOR (UTxOState crypto) where
   fromCBOR = do
     enforceSize "UTxOState" 4
     ut <- fromCBOR
@@ -390,51 +465,60 @@ instance Crypto crypto => FromCBOR (UTxOState crypto)
     us <- fromCBOR
     pure $ UTxOState ut dp fs us
 
-data OBftSlot crypto =
-    NonActiveSlot
+data OBftSlot crypto
+  = NonActiveSlot
   | ActiveSlot !(KeyHash 'Genesis crypto)
   deriving (Show, Eq, Ord, Generic)
 
-instance Crypto crypto
-  => ToCBOR (OBftSlot crypto)
+instance
+  Crypto crypto =>
+  ToCBOR (OBftSlot crypto)
   where
-    toCBOR NonActiveSlot  = encodeNull
-    toCBOR (ActiveSlot k) = toCBOR k
+  toCBOR NonActiveSlot = encodeNull
+  toCBOR (ActiveSlot k) = toCBOR k
 
-instance Crypto crypto
-  => FromCBOR (OBftSlot crypto)
- where
-   fromCBOR = do
-     peekTokenType >>= \case
-       TypeNull -> do
-         decodeNull
-         pure NonActiveSlot
-       _ -> ActiveSlot <$> fromCBOR
+instance
+  Crypto crypto =>
+  FromCBOR (OBftSlot crypto)
+  where
+  fromCBOR = do
+    peekTokenType >>= \case
+      TypeNull -> do
+        decodeNull
+        pure NonActiveSlot
+      _ -> ActiveSlot <$> fromCBOR
 
 instance NoUnexpectedThunks (OBftSlot crypto)
 
 -- | New Epoch state and environment
-data NewEpochState crypto=
-  NewEpochState {
-    nesEL     :: !EpochNo                              -- ^ Last epoch
-  , nesBprev  :: !(BlocksMade                crypto)   -- ^ Blocks made before current epoch
-  , nesBcur   :: !(BlocksMade                crypto)   -- ^ Blocks made in current epoch
-  , nesEs     :: !(EpochState                crypto)   -- ^ Epoch state before current
-  , nesRu     :: !(StrictMaybe (RewardUpdate crypto))  -- ^ Possible reward update
-  , nesPd     :: !(PoolDistr                 crypto)   -- ^ Stake distribution within the stake pool
-  , nesOsched :: !(Map SlotNo (OBftSlot      crypto))  -- ^ Overlay schedule for PBFT vs Praos
-  } deriving (Show, Eq, Generic)
+data NewEpochState crypto = NewEpochState
+  { -- | Last epoch
+    nesEL :: !EpochNo,
+    -- | Blocks made before current epoch
+    nesBprev :: !(BlocksMade crypto),
+    -- | Blocks made in current epoch
+    nesBcur :: !(BlocksMade crypto),
+    -- | Epoch state before current
+    nesEs :: !(EpochState crypto),
+    -- | Possible reward update
+    nesRu :: !(StrictMaybe (RewardUpdate crypto)),
+    -- | Stake distribution within the stake pool
+    nesPd :: !(PoolDistr crypto),
+    -- | Overlay schedule for PBFT vs Praos
+    nesOsched :: !(Map SlotNo (OBftSlot crypto))
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (NewEpochState crypto)
 
-instance Crypto crypto => ToCBOR (NewEpochState crypto)
- where
+instance Crypto crypto => ToCBOR (NewEpochState crypto) where
   toCBOR (NewEpochState e bp bc es ru pd os) =
     encodeListLen 7 <> toCBOR e <> toCBOR bp <> toCBOR bc <> toCBOR es
-      <> toCBOR ru <> toCBOR pd <> toCBOR (compactOverlaySchedule os)
+      <> toCBOR ru
+      <> toCBOR pd
+      <> toCBOR (compactOverlaySchedule os)
 
-instance Crypto crypto => FromCBOR (NewEpochState crypto)
- where
+instance Crypto crypto => FromCBOR (NewEpochState crypto) where
   fromCBOR = do
     enforceSize "NewEpochState" 7
     e <- fromCBOR
@@ -451,109 +535,115 @@ instance Crypto crypto => FromCBOR (NewEpochState crypto)
 --
 -- Each genesis key hash will only be stored once, instead of each time it is
 -- assigned to a slot.
-compactOverlaySchedule
-  :: Map SlotNo (OBftSlot crypto)
-  -> Map (OBftSlot crypto) (NonEmpty SlotNo)
+compactOverlaySchedule ::
+  Map SlotNo (OBftSlot crypto) ->
+  Map (OBftSlot crypto) (NonEmpty SlotNo)
 compactOverlaySchedule =
-    Map.foldrWithKey'
-      (\slot obftSlot ->
-        Map.insertWith (<>) obftSlot (pure slot))
-      Map.empty
+  Map.foldrWithKey'
+    ( \slot obftSlot ->
+        Map.insertWith (<>) obftSlot (pure slot)
+    )
+    Map.empty
 
 -- | Inverse of 'compactOverlaySchedule'
-decompactOverlaySchedule
-  :: Map (OBftSlot crypto) (NonEmpty SlotNo)
-  -> Map SlotNo (OBftSlot crypto)
-decompactOverlaySchedule compact = Map.fromList
+decompactOverlaySchedule ::
+  Map (OBftSlot crypto) (NonEmpty SlotNo) ->
+  Map SlotNo (OBftSlot crypto)
+decompactOverlaySchedule compact =
+  Map.fromList
     [ (slot, obftSlot)
-    | (obftSlot, slots) <- Map.toList compact
-    , slot <- NonEmpty.toList slots
+      | (obftSlot, slots) <- Map.toList compact,
+        slot <- NonEmpty.toList slots
     ]
 
-getGKeys
-  :: NewEpochState crypto
-  -> Set (KeyHash 'Genesis crypto)
+getGKeys ::
+  NewEpochState crypto ->
+  Set (KeyHash 'Genesis crypto)
 getGKeys nes = Map.keysSet genDelegs
-  where NewEpochState _ _ _ es _ _ _ = nes
-        EpochState _ _ ls _ _ _ = es
-        LedgerState _ (DPState (DState _ _ _ _ _ (GenDelegs genDelegs) _) _) = ls
+  where
+    NewEpochState _ _ _ es _ _ _ = nes
+    EpochState _ _ ls _ _ _ = es
+    LedgerState _ (DPState (DState _ _ _ _ _ (GenDelegs genDelegs) _) _) = ls
 
-data NewEpochEnv crypto=
-  NewEpochEnv {
-    neeS     :: SlotNo
-  , neeGkeys :: Set (KeyHash 'Genesis crypto)
-  } deriving (Show, Eq, Generic)
+data NewEpochEnv crypto = NewEpochEnv
+  { neeS :: SlotNo,
+    neeGkeys :: Set (KeyHash 'Genesis crypto)
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (NewEpochEnv crypto)
 
--- |The state associated with a 'Ledger'.
-data LedgerState crypto=
-  LedgerState
-  { -- |The current unspent transaction outputs.
-    _utxoState         :: !(UTxOState crypto)
-    -- |The current delegation state
-  , _delegationState   :: !(DPState crypto)
-  } deriving (Show, Eq, Generic)
+-- | The state associated with a 'Ledger'.
+data LedgerState crypto = LedgerState
+  { -- | The current unspent transaction outputs.
+    _utxoState :: !(UTxOState crypto),
+    -- | The current delegation state
+    _delegationState :: !(DPState crypto)
+  }
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks (LedgerState crypto)
 
-instance Crypto crypto => ToCBOR (LedgerState crypto)
- where
+instance Crypto crypto => ToCBOR (LedgerState crypto) where
   toCBOR (LedgerState u dp) =
     encodeListLen 2 <> toCBOR u <> toCBOR dp
 
-instance Crypto crypto => FromCBOR (LedgerState crypto)
- where
+instance Crypto crypto => FromCBOR (LedgerState crypto) where
   fromCBOR = do
     enforceSize "LedgerState" 2
     u <- fromCBOR
     dp <- fromCBOR
     pure $ LedgerState u dp
 
--- |The transaction Id for 'UTxO' included at the beginning of a new ledger.
-genesisId
-  :: (Crypto crypto)
-  => TxId crypto
+-- | The transaction Id for 'UTxO' included at the beginning of a new ledger.
+genesisId ::
+  (Crypto crypto) =>
+  TxId crypto
 genesisId =
-  TxId $ hash
-  (TxBody
-   Set.empty
-   StrictSeq.Empty
-   StrictSeq.Empty
-   (Wdrl Map.empty)
-   (Coin 0)
-   (SlotNo 0)
-   SNothing
-   SNothing)
+  TxId $
+    hash
+      ( TxBody
+          Set.empty
+          StrictSeq.Empty
+          StrictSeq.Empty
+          (Wdrl Map.empty)
+          (Coin 0)
+          (SlotNo 0)
+          SNothing
+          SNothing
+      )
 
--- |Creates the UTxO for a new ledger with the specified transaction outputs.
-genesisCoins
-  :: (Crypto crypto)
-  => [TxOut crypto]
-  -> UTxO crypto
-genesisCoins outs = UTxO $
-  Map.fromList [(TxIn genesisId idx, out) | (idx, out) <- zip [0..] outs]
+-- | Creates the UTxO for a new ledger with the specified transaction outputs.
+genesisCoins ::
+  (Crypto crypto) =>
+  [TxOut crypto] ->
+  UTxO crypto
+genesisCoins outs =
+  UTxO $
+    Map.fromList [(TxIn genesisId idx, out) | (idx, out) <- zip [0 ..] outs]
 
--- |Creates the ledger state for an empty ledger which
--- contains the specified transaction outputs.
-genesisState
-  :: Map (KeyHash 'Genesis crypto) (KeyHash 'GenesisDelegate crypto)
-  -> UTxO crypto
-  -> LedgerState crypto
-genesisState genDelegs0 utxo0 = LedgerState
-  (UTxOState
-    utxo0
-    (Coin 0)
-    (Coin 0)
-    emptyPPPUpdates)
-  (DPState dState emptyPState)
+-- | Creates the ledger state for an empty ledger which
+--  contains the specified transaction outputs.
+genesisState ::
+  Map (KeyHash 'Genesis crypto) (KeyHash 'GenesisDelegate crypto) ->
+  UTxO crypto ->
+  LedgerState crypto
+genesisState genDelegs0 utxo0 =
+  LedgerState
+    ( UTxOState
+        utxo0
+        (Coin 0)
+        (Coin 0)
+        emptyPPPUpdates
+    )
+    (DPState dState emptyPState)
   where
     dState = emptyDState {_genDelegs = GenDelegs genDelegs0}
 
 -- | Determine if the transaction has expired
 current :: Crypto crypto => TxBody crypto -> SlotNo -> Validity
 current tx slot =
-    if _ttl tx < slot
+  if _ttl tx < slot
     then Invalid [Expired (_ttl tx) slot]
     else Valid
 
@@ -561,23 +651,23 @@ current tx slot =
 -- else it would be possible to do a replay attack using this transaction.
 validNoReplay :: Crypto crypto => TxBody crypto -> Validity
 validNoReplay tx =
-    if txins tx == Set.empty
+  if txins tx == Set.empty
     then Invalid [InputSetEmpty]
     else Valid
 
--- |Determine if the inputs in a transaction are valid for a given ledger state.
-validInputs
-  :: Crypto crypto
-  => TxBody crypto
-  -> UTxOState crypto
-  -> Validity
+-- | Determine if the inputs in a transaction are valid for a given ledger state.
+validInputs ::
+  Crypto crypto =>
+  TxBody crypto ->
+  UTxOState crypto ->
+  Validity
 validInputs tx u =
   if txins tx `Set.isSubsetOf` dom (_utxo u)
     then Valid
     else Invalid [BadInputs]
 
--- |Implementation of abstract transaction size
-txsize :: forall crypto . (Crypto crypto) => Tx crypto-> Integer
+-- | Implementation of abstract transaction size
+txsize :: forall crypto. (Crypto crypto) => Tx crypto -> Integer
 txsize tx = numInputs * inputSize + numOutputs * outputSize + rest
   where
     uint = 5
@@ -587,136 +677,136 @@ txsize tx = numInputs * inputSize + numOutputs * outputSize + rest
     addrHashLen = 28
     addrHeader = 1
     address = 2 + addrHeader + 2 * addrHashLen
-
     txbody = _body tx
-
-    numInputs  = toInteger . length .  _inputs $ txbody
-    inputSize  = smallArray + uint + hashObj
-
+    numInputs = toInteger . length . _inputs $ txbody
+    inputSize = smallArray + uint + hashObj
     numOutputs = toInteger . length . _outputs $ txbody
     outputSize = smallArray + uint + address
+    rest =
+      toInteger . BSL.length . serialize $
+        tx
+          { _body =
+              txbody
+                { _outputs = StrictSeq.empty,
+                  _inputs = Set.empty,
+                  _txfee = 0
+                }
+          }
 
-    rest  = toInteger . BSL.length . serialize $
-              tx { _body = txbody { _outputs = StrictSeq.empty
-                                  , _inputs  = Set.empty
-                                  , _txfee   = 0
-                                  }
-                 }
-
-
--- |Minimum fee calculation
-minfee :: forall crypto . (Crypto crypto) => PParams -> Tx crypto-> Coin
+-- | Minimum fee calculation
+minfee :: forall crypto. (Crypto crypto) => PParams -> Tx crypto -> Coin
 minfee pp tx = Coin $ fromIntegral (_minfeeA pp) * txsize tx + fromIntegral (_minfeeB pp)
 
--- |Determine if the fee is large enough
-validFee :: forall crypto . (Crypto crypto) => PParams -> Tx crypto-> Validity
+-- | Determine if the fee is large enough
+validFee :: forall crypto. (Crypto crypto) => PParams -> Tx crypto -> Validity
 validFee pc tx =
   if needed <= given
     then Valid
     else Invalid [FeeTooSmall needed given]
-      where
-        needed = minfee pc tx
-        given  = (_txfee . _body) tx
+  where
+    needed = minfee pc tx
+    given = (_txfee . _body) tx
 
--- |Compute the lovelace which are created by the transaction
-produced
-  :: (Crypto crypto)
-  => PParams
-  -> StakePools crypto
-  -> TxBody crypto
-  -> Coin
+-- | Compute the lovelace which are created by the transaction
+produced ::
+  (Crypto crypto) =>
+  PParams ->
+  StakePools crypto ->
+  TxBody crypto ->
+  Coin
 produced pp stakePools tx =
-    balance (txouts tx) + _txfee tx + totalDeposits pp stakePools (toList $ _certs tx)
+  balance (txouts tx) + _txfee tx + totalDeposits pp stakePools (toList $ _certs tx)
 
--- |Compute the key deregistration refunds in a transaction
-keyRefunds
-  :: Crypto crypto
-  => PParams
-  -> StakeCreds crypto
-  -> TxBody crypto
-  -> Coin
+-- | Compute the key deregistration refunds in a transaction
+keyRefunds ::
+  Crypto crypto =>
+  PParams ->
+  StakeCreds crypto ->
+  TxBody crypto ->
+  Coin
 keyRefunds pp stk tx =
   sum [keyRefund dval dmin lambda stk (_ttl tx) c | c@(DCertDeleg (DeRegKey _)) <- toList $ _certs tx]
-  where (dval, dmin, lambda) = decayKey pp
+  where
+    (dval, dmin, lambda) = decayKey pp
 
 -- | Key refund for a deregistration certificate.
-keyRefund
-  :: Coin
-  -> UnitInterval
-  -> Rational
-  -> StakeCreds crypto
-  -> SlotNo
-  -> DCert crypto
-  -> Coin
+keyRefund ::
+  Coin ->
+  UnitInterval ->
+  Rational ->
+  StakeCreds crypto ->
+  SlotNo ->
+  DCert crypto ->
+  Coin
 keyRefund dval dmin lambda (StakeCreds stkcreds) slot c =
-    case c of
-      DCertDeleg (DeRegKey key) -> case Map.lookup key stkcreds of
-                                     Nothing -> Coin 0
-                                     Just  s -> refund dval dmin lambda $ slot -* s
-      _ -> Coin 0
+  case c of
+    DCertDeleg (DeRegKey key) -> case Map.lookup key stkcreds of
+      Nothing -> Coin 0
+      Just s -> refund dval dmin lambda $ slot -* s
+    _ -> Coin 0
 
 -- | Functions to calculate decayed deposits
-decayedKey
-  :: PParams
-  -> StakeCreds crypto
-  -> SlotNo
-  -> DCert crypto
-  -> ShelleyBase Coin
+decayedKey ::
+  PParams ->
+  StakeCreds crypto ->
+  SlotNo ->
+  DCert crypto ->
+  ShelleyBase Coin
 decayedKey pp stk@(StakeCreds stkcreds) cslot cert =
-    case cert of
-      DCertDeleg (DeRegKey key) ->
-          if Map.notMember key stkcreds
-          then pure 0
-          else do
-            let created'      = stkcreds Map.! key
-            start <- do
-              ei <- asks epochInfo
-              fs <- epochInfoFirst ei =<< epochInfoEpoch ei cslot
-              pure $ max fs created'
-            let dval          = _keyDeposit pp
-                dmin          = _keyMinRefund pp
-                lambda        = _keyDecayRate pp
-                epochRefund   = keyRefund dval dmin lambda stk start cert
-                currentRefund = keyRefund dval dmin lambda stk cslot cert
-            pure $ epochRefund - currentRefund
-      _ -> pure 0
+  case cert of
+    DCertDeleg (DeRegKey key) ->
+      if Map.notMember key stkcreds
+        then pure 0
+        else do
+          let created' = stkcreds Map.! key
+          start <- do
+            ei <- asks epochInfo
+            fs <- epochInfoFirst ei =<< epochInfoEpoch ei cslot
+            pure $ max fs created'
+          let dval = _keyDeposit pp
+              dmin = _keyMinRefund pp
+              lambda = _keyDecayRate pp
+              epochRefund = keyRefund dval dmin lambda stk start cert
+              currentRefund = keyRefund dval dmin lambda stk cslot cert
+          pure $ epochRefund - currentRefund
+    _ -> pure 0
 
 -- | Decayed deposit portions
-decayedTx
-  :: Crypto crypto
-  => PParams
-  -> StakeCreds crypto
-  -> TxBody crypto
-  -> ShelleyBase Coin
+decayedTx ::
+  Crypto crypto =>
+  PParams ->
+  StakeCreds crypto ->
+  TxBody crypto ->
+  ShelleyBase Coin
 decayedTx pp stk tx =
-      lsum [decayedKey pp stk (_ttl tx) c | c@(DCertDeleg (DeRegKey _)) <- toList $ _certs tx]
-    where
-      lsum xs = ReaderT $ \s -> sum $ fmap (flip runReaderT s) xs
+  lsum [decayedKey pp stk (_ttl tx) c | c@(DCertDeleg (DeRegKey _)) <- toList $ _certs tx]
+  where
+    lsum xs = ReaderT $ \s -> sum $ fmap (flip runReaderT s) xs
 
--- |Compute the lovelace which are destroyed by the transaction
-consumed
-  :: Crypto crypto
-  => PParams
-  -> UTxO crypto
-  -> StakeCreds crypto
-  -> TxBody crypto
-  -> Coin
+-- | Compute the lovelace which are destroyed by the transaction
+consumed ::
+  Crypto crypto =>
+  PParams ->
+  UTxO crypto ->
+  StakeCreds crypto ->
+  TxBody crypto ->
+  Coin
 consumed pp u stakeKeys tx =
-    balance (txins tx ◁ u) + refunds + withdrawals
+  balance (txins tx ◁ u) + refunds + withdrawals
   where
     refunds = keyRefunds pp stakeKeys tx
     withdrawals = sum . unWdrl $ _wdrls tx
 
--- |Determine if the balance of the ledger state would be effected
--- in an acceptable way by a transaction.
-preserveBalance
-  :: (Crypto crypto)
-  => StakePools crypto
-  -> StakeCreds crypto
-  -> PParams
-  -> TxBody crypto
-  -> UTxOState crypto
-  -> Validity
+-- | Determine if the balance of the ledger state would be effected
+--  in an acceptable way by a transaction.
+preserveBalance ::
+  (Crypto crypto) =>
+  StakePools crypto ->
+  StakeCreds crypto ->
+  PParams ->
+  TxBody crypto ->
+  UTxOState crypto ->
+  Validity
 preserveBalance stakePools stakeKeys pp tx u =
   if destroyed' == created'
     then Valid
@@ -725,85 +815,85 @@ preserveBalance stakePools stakeKeys pp tx u =
     destroyed' = consumed pp (_utxo u) stakeKeys tx
     created' = produced pp stakePools tx
 
--- |Determine if the reward witdrawals correspond
--- to the rewards in the ledger state
-correctWithdrawals
-  :: RewardAccounts crypto
-  -> RewardAccounts crypto
-  -> Validity
+-- | Determine if the reward witdrawals correspond
+--  to the rewards in the ledger state
+correctWithdrawals ::
+  RewardAccounts crypto ->
+  RewardAccounts crypto ->
+  Validity
 correctWithdrawals accs withdrawals =
   if withdrawals `Map.isSubmapOf` accs
     then Valid
     else Invalid [IncorrectRewards]
 
--- |Collect the set of hashes of keys that needs to sign a
--- given transaction. This set consists of the txin owners,
--- certificate authors, and withdrawal reward accounts.
-witsVKeyNeeded
-  :: Crypto crypto
-  => UTxO crypto
-  -> Tx crypto
-  -> GenDelegs crypto
-  -> Set (KeyHash 'Witness crypto)
+-- | Collect the set of hashes of keys that needs to sign a
+--  given transaction. This set consists of the txin owners,
+--  certificate authors, and withdrawal reward accounts.
+witsVKeyNeeded ::
+  Crypto crypto =>
+  UTxO crypto ->
+  Tx crypto ->
+  GenDelegs crypto ->
+  Set (KeyHash 'Witness crypto)
 witsVKeyNeeded utxo' tx@(Tx txbody _ _ _) _genDelegs =
-    inputAuthors `Set.union`
-    wdrlAuthors  `Set.union`
-    certAuthors  `Set.union`
-    updateKeys   `Set.union`
-    owners
+  inputAuthors
+    `Set.union` wdrlAuthors
+    `Set.union` certAuthors
+    `Set.union` updateKeys
+    `Set.union` owners
   where
     inputAuthors = asWitness `Set.map` Set.foldr insertHK Set.empty (_inputs txbody)
     insertHK txin hkeys =
       case txinLookup txin utxo' of
         Just (TxOut (Addr (KeyHashObj pay) _) _) -> Set.insert pay hkeys
-        _                                        -> hkeys
-
-    wdrlAuthors
-      = Set.map asWitness
-      . Set.fromList
-      . extractKeyHash
-      $ map getRwdCred (Map.keys (unWdrl $ _wdrls txbody))
-    owners = foldl' Set.union Set.empty
-               [ ((Set.map asWitness) . _poolOwners) pool
-               | DCertPool (RegPool pool) <- toList $ _certs txbody
-               ]
+        _ -> hkeys
+    wdrlAuthors =
+      Set.map asWitness
+        . Set.fromList
+        . extractKeyHash
+        $ map getRwdCred (Map.keys (unWdrl $ _wdrls txbody))
+    owners =
+      foldl'
+        Set.union
+        Set.empty
+        [ ((Set.map asWitness) . _poolOwners) pool
+          | DCertPool (RegPool pool) <- toList $ _certs txbody
+        ]
     certAuthors = Set.map asWitness . Set.fromList $ foldl (++) [] $ fmap getCertHK certificates
     getCertHK = cwitness
-
     -- key reg requires no witness but this is already filtered out before the
     -- call to `cwitness`
     cwitness (DCertDeleg dc) = asWitness <$> extractKeyHash [delegCWitness dc]
     cwitness (DCertPool pc) = asWitness <$> extractKeyHash [poolCWitness pc]
     cwitness (DCertGenesis gc) = [asWitness $ genesisCWitness gc]
     cwitness c = error $ show c ++ " does not have a witness"
-
     certificates = filter requiresVKeyWitness (toList $ _certs txbody)
     updateKeys = asWitness `Set.map` propWits (txup tx) _genDelegs
 
--- |Given a ledger state, determine if the UTxO witnesses in a given
--- transaction are correct.
-verifiedWits
-  :: ( Crypto crypto
-     , DSignable crypto (Hash crypto (TxBody crypto))
-     )
-  => Tx crypto
-  -> Validity
+-- | Given a ledger state, determine if the UTxO witnesses in a given
+--  transaction are correct.
+verifiedWits ::
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  Tx crypto ->
+  Validity
 verifiedWits (Tx txbody wits _ _) =
   if all (verifyWitVKey $ hashWithSerialiser toCBOR txbody) wits
     then Valid
     else Invalid [InvalidWitness]
 
--- |Given a ledger state, determine if the UTxO witnesses in a given
--- transaction are sufficient.
--- We check that there are not more witnesses than inputs, if several inputs
--- from the same address are used, it is not strictly necessary to include more
--- than one witness.
-enoughWits
-  :: Crypto crypto
-  => Tx crypto
-  -> GenDelegs crypto
-  -> UTxOState crypto
-  -> Validity
+-- | Given a ledger state, determine if the UTxO witnesses in a given
+--  transaction are sufficient.
+--  We check that there are not more witnesses than inputs, if several inputs
+--  from the same address are used, it is not strictly necessary to include more
+--  than one witness.
+enoughWits ::
+  Crypto crypto =>
+  Tx crypto ->
+  GenDelegs crypto ->
+  UTxOState crypto ->
+  Validity
 enoughWits tx@(Tx _ wits _ _) d' u =
   if witsVKeyNeeded (_utxo u) tx d' `Set.isSubsetOf` signers
     then Valid
@@ -811,182 +901,199 @@ enoughWits tx@(Tx _ wits _ _) d' u =
   where
     signers = Set.map witKeyHash wits
 
-validRuleUTXO
-  :: (Crypto crypto)
-  => RewardAccounts crypto
-  -> StakePools crypto
-  -> StakeCreds crypto
-  -> PParams
-  -> SlotNo
-  -> Tx crypto
-  -> UTxOState crypto
-  -> Validity
+validRuleUTXO ::
+  (Crypto crypto) =>
+  RewardAccounts crypto ->
+  StakePools crypto ->
+  StakeCreds crypto ->
+  PParams ->
+  SlotNo ->
+  Tx crypto ->
+  UTxOState crypto ->
+  Validity
 validRuleUTXO accs stakePools stakeKeys pc slot tx u =
-                          validInputs txb u
-                       <> current txb slot
-                       <> validNoReplay txb
-                       <> validFee pc tx
-                       <> preserveBalance stakePools stakeKeys pc txb u
-                       <> correctWithdrawals accs (unWdrl $ _wdrls txb)
-  where txb = _body tx
+  validInputs txb u
+    <> current txb slot
+    <> validNoReplay txb
+    <> validFee pc tx
+    <> preserveBalance stakePools stakeKeys pc txb u
+    <> correctWithdrawals accs (unWdrl $ _wdrls txb)
+  where
+    txb = _body tx
 
-validRuleUTXOW
-  :: ( Crypto crypto
-     , DSignable crypto (Hash crypto (TxBody crypto))
-     )
-  => Tx crypto
-  -> GenDelegs crypto
-  -> LedgerState crypto
-  -> Validity
-validRuleUTXOW tx d' l = verifiedWits tx
-                   <> enoughWits tx d' (_utxoState l)
+validRuleUTXOW ::
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  Tx crypto ->
+  GenDelegs crypto ->
+  LedgerState crypto ->
+  Validity
+validRuleUTXOW tx d' l =
+  verifiedWits tx
+    <> enoughWits tx d' (_utxoState l)
 
 -- | Calculate the set of hash keys of the required witnesses for update
 -- proposals.
-propWits
-  :: Maybe (Update crypto)
-  -> GenDelegs crypto
-  -> Set (KeyHash 'Witness crypto)
+propWits ::
+  Maybe (Update crypto) ->
+  GenDelegs crypto ->
+  Set (KeyHash 'Witness crypto)
 propWits Nothing _ = Set.empty
 propWits (Just (Update (ProposedPPUpdates pup) _)) (GenDelegs _genDelegs) =
   Set.map asWitness . Set.fromList $ Map.elems updateKeys
-  where updateKeys = Map.keysSet pup ◁ _genDelegs
+  where
+    updateKeys = Map.keysSet pup ◁ _genDelegs
 
-validTx
-  :: ( Crypto crypto
-     , DSignable crypto (Hash crypto (TxBody crypto))
-     )
-  => Tx crypto
-  -> GenDelegs crypto
-  -> SlotNo
-  -> PParams
-  -> LedgerState crypto
-  -> Validity
+validTx ::
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  Tx crypto ->
+  GenDelegs crypto ->
+  SlotNo ->
+  PParams ->
+  LedgerState crypto ->
+  Validity
 validTx tx d' slot pp l =
-    validRuleUTXO  ((_rewards  . _dstate . _delegationState ) l)
-                   ((_stPools  . _pstate . _delegationState ) l)
-                   ((_stkCreds . _dstate . _delegationState ) l)
-                   pp
-                   slot
-                   tx
-                   (_utxoState l)
- <> validRuleUTXOW tx d' l
+  validRuleUTXO
+    ((_rewards . _dstate . _delegationState) l)
+    ((_stPools . _pstate . _delegationState) l)
+    ((_stkCreds . _dstate . _delegationState) l)
+    pp
+    slot
+    tx
+    (_utxoState l)
+    <> validRuleUTXOW tx d' l
 
 -- Functions for stake delegation model
 
--- |Calculate the change to the deposit pool for a given transaction.
-depositPoolChange
-  :: Crypto crypto
-  => LedgerState crypto
-  -> PParams
-  -> TxBody crypto
-  -> Coin
+-- | Calculate the change to the deposit pool for a given transaction.
+depositPoolChange ::
+  Crypto crypto =>
+  LedgerState crypto ->
+  PParams ->
+  TxBody crypto ->
+  Coin
 depositPoolChange ls pp tx = (currentPool + txDeposits) - txRefunds
-  -- Note that while (currentPool + txDeposits) >= txRefunds,
-  -- it could be that txDeposits < txRefunds. We keep the parenthesis above
-  -- to emphasize this point.
   where
+    -- Note that while (currentPool + txDeposits) >= txRefunds,
+    -- it could be that txDeposits < txRefunds. We keep the parenthesis above
+    -- to emphasize this point.
+
     currentPool = (_deposited . _utxoState) ls
     txDeposits =
       totalDeposits pp ((_stPools . _pstate . _delegationState) ls) (toList $ _certs tx)
     txRefunds = keyRefunds pp ((_stkCreds . _dstate . _delegationState) ls) tx
 
--- |Apply a transaction body as a state transition function on the ledger state.
-applyTxBody
-  :: (Crypto crypto)
-  => LedgerState crypto
-  -> PParams
-  -> TxBody crypto
-  -> LedgerState crypto
-applyTxBody ls pp tx = ls
-  {
-    _utxoState = us
-      { _utxo = txins tx ⋪ (_utxo us) ∪ txouts tx
-      , _deposited = depositPoolChange ls pp tx
-      , _fees = (_txfee tx) + (_fees . _utxoState $ ls)
-      }
-  , _delegationState = dels
-      { _dstate = dst {_rewards = newAccounts}}
-  }
+-- | Apply a transaction body as a state transition function on the ledger state.
+applyTxBody ::
+  (Crypto crypto) =>
+  LedgerState crypto ->
+  PParams ->
+  TxBody crypto ->
+  LedgerState crypto
+applyTxBody ls pp tx =
+  ls
+    { _utxoState =
+        us
+          { _utxo = txins tx ⋪ (_utxo us) ∪ txouts tx,
+            _deposited = depositPoolChange ls pp tx,
+            _fees = (_txfee tx) + (_fees . _utxoState $ ls)
+          },
+      _delegationState =
+        dels
+          { _dstate = dst {_rewards = newAccounts}
+          }
+    }
   where
     dels = _delegationState ls
     dst = _dstate dels
     us = _utxoState ls
-    newAccounts = reapRewards
-      ((_rewards . _dstate . _delegationState) ls)
-      (unWdrl $ _wdrls tx)
+    newAccounts =
+      reapRewards
+        ((_rewards . _dstate . _delegationState) ls)
+        (unWdrl $ _wdrls tx)
 
-reapRewards
-  :: RewardAccounts crypto
-  -> RewardAccounts crypto
-  -> RewardAccounts crypto
+reapRewards ::
+  RewardAccounts crypto ->
+  RewardAccounts crypto ->
+  RewardAccounts crypto
 reapRewards dStateRewards withdrawals =
-    Map.mapWithKey removeRewards dStateRewards
-    where removeRewards k v = if k `Map.member` withdrawals then Coin 0 else v
+  Map.mapWithKey removeRewards dStateRewards
+  where
+    removeRewards k v = if k `Map.member` withdrawals then Coin 0 else v
 
 ---------------------------------
 -- epoch boundary calculations --
 ---------------------------------
 
 -- | Stake distribution
-stakeDistr
-  :: forall crypto
-   . UTxO crypto
-  -> DState crypto
-  -> PState crypto
-  -> SnapShot crypto
-stakeDistr u ds ps = SnapShot
-  (Stake $ dom activeDelegs ◁ aggregatePlus stakeRelation)
-  delegs
-  poolParams
-    where
-      DState (StakeCreds stkcreds) rewards' delegs ptrs' _ _ _ = ds
-      PState (StakePools stpools) poolParams _                 = ps
-      outs = aggregateOuts u
-
-      stakeRelation :: [(Credential 'Staking crypto, Coin)]
-      stakeRelation = baseStake outs ∪ ptrStake outs ptrs' ∪ rewardStake rewards'
-
-      activeDelegs = dom stkcreds ◁ delegs ▷ dom stpools
-
-      aggregatePlus = Map.fromListWith (+)
+stakeDistr ::
+  forall crypto.
+  UTxO crypto ->
+  DState crypto ->
+  PState crypto ->
+  SnapShot crypto
+stakeDistr u ds ps =
+  SnapShot
+    (Stake $ dom activeDelegs ◁ aggregatePlus stakeRelation)
+    delegs
+    poolParams
+  where
+    DState (StakeCreds stkcreds) rewards' delegs ptrs' _ _ _ = ds
+    PState (StakePools stpools) poolParams _ = ps
+    outs = aggregateOuts u
+    stakeRelation :: [(Credential 'Staking crypto, Coin)]
+    stakeRelation = baseStake outs ∪ ptrStake outs ptrs' ∪ rewardStake rewards'
+    activeDelegs = dom stkcreds ◁ delegs ▷ dom stpools
+    aggregatePlus = Map.fromListWith (+)
 
 -- | Apply a reward update
-applyRUpd
-  :: RewardUpdate crypto
-  -> EpochState crypto
-  -> EpochState crypto
+applyRUpd ::
+  RewardUpdate crypto ->
+  EpochState crypto ->
+  EpochState crypto
 applyRUpd ru (EpochState as ss ls pr pp nm) = EpochState as' ss ls' pr pp nm
-  where utxoState_ = _utxoState ls
-        delegState = _delegationState ls
-        dState = _dstate delegState
+  where
+    utxoState_ = _utxoState ls
+    delegState = _delegationState ls
+    dState = _dstate delegState
+    as' =
+      as
+        { _treasury = _treasury as + deltaT ru,
+          _reserves = _reserves as + deltaR ru
+        }
+    ls' =
+      ls
+        { _utxoState =
+            utxoState_ {_fees = _fees utxoState_ + deltaF ru},
+          _delegationState =
+            delegState
+              { _dstate =
+                  dState
+                    { _rewards = _rewards dState ∪+ rs ru
+                    }
+              }
+        }
 
-        as' = as { _treasury = _treasury as + deltaT ru
-                 , _reserves = _reserves as + deltaR ru
-                 }
-        ls' = ls { _utxoState =
-                     utxoState_ { _fees = _fees utxoState_ + deltaF ru }
-                 , _delegationState =
-                     delegState
-                     {_dstate = dState
-                                { _rewards = _rewards dState ∪+ rs ru
-                                }}}
-
-updateNonMypopic
-  :: NonMyopic crypto
-  -> Coin
-  -> Map (KeyHash 'StakePool crypto) Rational
-  -> SnapShot crypto
-  -> NonMyopic crypto
-updateNonMypopic nm rPot aps ss = nm
-  { apparentPerformances = aps'
-  , rewardPot = rPot
-  , snap = ss
-  }
+updateNonMypopic ::
+  NonMyopic crypto ->
+  Coin ->
+  Map (KeyHash 'StakePool crypto) Rational ->
+  SnapShot crypto ->
+  NonMyopic crypto
+updateNonMypopic nm rPot aps ss =
+  nm
+    { apparentPerformances = aps',
+      rewardPot = rPot,
+      snap = ss
+    }
   where
     SnapShot _ _ poolParams = ss
-    absentPools = Set.toList $
-      (Map.keysSet poolParams) `Set.difference` (Map.keysSet aps)
+    absentPools =
+      Set.toList $
+        (Map.keysSet poolParams) `Set.difference` (Map.keysSet aps)
     performanceZero = Map.fromList $ fmap (\p -> (p, 0)) absentPools
     -- TODO how to handle pools with near zero stake?
 
@@ -994,95 +1101,98 @@ updateNonMypopic nm rPot aps ss = nm
     prev = apparentPerformances nm
     performance kh ap = case Map.lookup kh prev of
       Nothing -> ApparentPerformance $ fromRational ap -- TODO give new pools the average performance?
-      Just (ApparentPerformance p) -> ApparentPerformance $
-        expMovAvgWeight * p + (1 - expMovAvgWeight) * (fromRational ap)
+      Just (ApparentPerformance p) ->
+        ApparentPerformance $
+          expMovAvgWeight * p + (1 - expMovAvgWeight) * (fromRational ap)
     aps' = Map.mapWithKey performance (aps `Map.union` performanceZero)
 
-
 -- | Create a reward update
-createRUpd
-  :: EpochNo
-  -> BlocksMade crypto
-  -> EpochState crypto
-  -> Coin
-  -> ShelleyBase (RewardUpdate crypto)
+createRUpd ::
+  EpochNo ->
+  BlocksMade crypto ->
+  EpochState crypto ->
+  Coin ->
+  ShelleyBase (RewardUpdate crypto)
 createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total = do
-    ei <- asks epochInfo
-    slotsPerEpoch <- epochInfoSize ei e
-    asc <- asks activeSlotCoeff
-    let SnapShot stake' delegs' poolParams = _pstakeGo ss
-        Coin reserves = _reserves acnt
-        ds = _dstate $ _delegationState ls
-
-        -- reserves and rewards change
-        deltaR_ = (floor $ min 1 eta * intervalValue (_rho pr) * fromIntegral reserves)
-        expectedBlocks =
-          intervalValue (activeSlotVal asc) * fromIntegral slotsPerEpoch
-        eta = fromIntegral blocksMade / expectedBlocks
-
-        Coin rPot = _feeSS ss + deltaR_
-        deltaT1 = floor $ intervalValue (_tau pr) * fromIntegral rPot
-        _R = Coin $ rPot - deltaT1
-
-        (rs_, aps) = reward pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' total
-        deltaT2 = _R - (Map.foldr (+) (Coin 0) rs_)
-
-        blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
-    pure $ RewardUpdate
-             (Coin deltaT1 + deltaT2)
-             (-deltaR_)
-             rs_
-             (-(_feeSS ss))
-             (updateNonMypopic nm _R aps (_pstakeGo ss))
+  ei <- asks epochInfo
+  slotsPerEpoch <- epochInfoSize ei e
+  asc <- asks activeSlotCoeff
+  let SnapShot stake' delegs' poolParams = _pstakeGo ss
+      Coin reserves = _reserves acnt
+      ds = _dstate $ _delegationState ls
+      -- reserves and rewards change
+      deltaR_ = (floor $ min 1 eta * intervalValue (_rho pr) * fromIntegral reserves)
+      expectedBlocks =
+        intervalValue (activeSlotVal asc) * fromIntegral slotsPerEpoch
+      eta = fromIntegral blocksMade / expectedBlocks
+      Coin rPot = _feeSS ss + deltaR_
+      deltaT1 = floor $ intervalValue (_tau pr) * fromIntegral rPot
+      _R = Coin $ rPot - deltaT1
+      (rs_, aps) = reward pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' total
+      deltaT2 = _R - (Map.foldr (+) (Coin 0) rs_)
+      blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer
+  pure $
+    RewardUpdate
+      (Coin deltaT1 + deltaT2)
+      (- deltaR_)
+      rs_
+      (- (_feeSS ss))
+      (updateNonMypopic nm _R aps (_pstakeGo ss))
 
 -- | Overlay schedule
 -- This is just a very simple round-robin, evenly spaced schedule.
-overlaySchedule
-  :: EpochNo
-  -> Set (KeyHash 'Genesis crypto)
-  -> PParams
-  -> ShelleyBase (Map SlotNo (OBftSlot crypto))
+overlaySchedule ::
+  EpochNo ->
+  Set (KeyHash 'Genesis crypto) ->
+  PParams ->
+  ShelleyBase (Map SlotNo (OBftSlot crypto))
 overlaySchedule e gkeys pp = do
   let dval = intervalValue $ _d pp
   if dval == 0
-    then
-      pure Map.empty
+    then pure Map.empty
     else do
       ei <- asks epochInfo
       slotsPerEpoch <- epochInfoSize ei e
       firstSlotNo <- epochInfoFirst ei e
       asc <- asks activeSlotCoeff
-      let
-        numActive = dval * fromIntegral slotsPerEpoch
-        dInv = 1 / dval
-        ascValue = (intervalValue . activeSlotVal) asc
-
-        toRelativeSlotNo x = (Duration . floor) (dInv * fromInteger x)
-        toSlotNo x = firstSlotNo +* toRelativeSlotNo x
-
-        genesisSlots = [ toSlotNo x | x <-[0..(floor numActive - 1)] ]
-
-        numInactivePerActive = floor (1 / ascValue) - 1
-        activitySchedule = cycle (True:replicate numInactivePerActive False)
-        unassignedSched = zip activitySchedule genesisSlots
-        genesisCycle = if Set.null gkeys then [] else cycle (Set.toList gkeys)
-
-        active =
-          Map.fromList $ fmap
-            (\(gk,(_,s))->(s, ActiveSlot gk))
-            (zip genesisCycle (filter fst unassignedSched))
-        inactive =
-          Map.fromList $ fmap
-            (\x -> (snd x, NonActiveSlot))
-            (filter (not . fst) unassignedSched)
+      let numActive = dval * fromIntegral slotsPerEpoch
+          dInv = 1 / dval
+          ascValue = (intervalValue . activeSlotVal) asc
+          toRelativeSlotNo x = (Duration . floor) (dInv * fromInteger x)
+          toSlotNo x = firstSlotNo +* toRelativeSlotNo x
+          genesisSlots = [toSlotNo x | x <- [0 .. (floor numActive - 1)]]
+          numInactivePerActive = floor (1 / ascValue) - 1
+          activitySchedule = cycle (True : replicate numInactivePerActive False)
+          unassignedSched = zip activitySchedule genesisSlots
+          genesisCycle = if Set.null gkeys then [] else cycle (Set.toList gkeys)
+          active =
+            Map.fromList $
+              fmap
+                (\(gk, (_, s)) -> (s, ActiveSlot gk))
+                (zip genesisCycle (filter fst unassignedSched))
+          inactive =
+            Map.fromList $
+              fmap
+                (\x -> (snd x, NonActiveSlot))
+                (filter (not . fst) unassignedSched)
       pure $ Map.union active inactive
 
 -- | Update new epoch state
+updateNES ::
+  NewEpochState crypto ->
+  BlocksMade crypto ->
+  LedgerState crypto ->
+  NewEpochState crypto
 updateNES
-  :: NewEpochState crypto
-  -> BlocksMade crypto
-  -> LedgerState crypto
-  -> NewEpochState crypto
-updateNES (NewEpochState eL bprev _
-           (EpochState acnt ss _ pr pp nm) ru pd osched) bcur ls =
-  NewEpochState eL bprev bcur (EpochState acnt ss ls pr pp nm) ru pd osched
+  ( NewEpochState
+      eL
+      bprev
+      _
+      (EpochState acnt ss _ pr pp nm)
+      ru
+      pd
+      osched
+    )
+  bcur
+  ls =
+    NewEpochState eL bprev bcur (EpochState acnt ss ls pr pp nm) ru pd osched

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/MetaData.hs
@@ -10,55 +10,63 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Shelley.Spec.Ledger.MetaData
-  ( MetaDatum (..)
-  , MetaData (MetaData)
-  , MetaDataHash (..)
-  , hashMetaData
-) where
+  ( MetaDatum (..),
+    MetaData (MetaData),
+    MetaDataHash (..),
+    hashMetaData,
+  )
+where
 
-import           Cardano.Binary (Annotator (..), DecoderError (..), FromCBOR (fromCBOR),
-                     ToCBOR (toCBOR), encodePreEncoded, serializeEncoding, withSlice)
-import           Cardano.Prelude (AllowThunksIn(..), LByteString, NoUnexpectedThunks (..), Word64, cborError)
-import           Data.Bifunctor (bimap)
-import           Data.Bitraversable (bitraverse)
-import           Data.ByteString as B
-import           Data.ByteString.Lazy as BL
-import           Data.Map.Strict (Map)
+import Cardano.Binary
+  ( Annotator (..),
+    DecoderError (..),
+    FromCBOR (fromCBOR),
+    ToCBOR (toCBOR),
+    encodePreEncoded,
+    serializeEncoding,
+    withSlice,
+  )
+import Cardano.Prelude (AllowThunksIn (..), LByteString, NoUnexpectedThunks (..), Word64, cborError)
+import qualified Codec.CBOR.Term as CBOR
+import Data.Bifunctor (bimap)
+import Data.Bitraversable (bitraverse)
+import Data.ByteString as B
+import Data.ByteString.Lazy as BL
+import Data.Map.Strict (Map)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
-import           Shelley.Spec.Ledger.Crypto (Crypto)
-import           Shelley.Spec.Ledger.Keys (Hash, hash)
-
-import qualified Codec.CBOR.Term as CBOR
-
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.Crypto (Crypto)
+import Shelley.Spec.Ledger.Keys (Hash, hash)
+import Shelley.Spec.Ledger.Serialization (mapFromCBOR, mapToCBOR)
 
 -- | A generic metadatum type.
 --
 -- TODO make strict
 data MetaDatum
-    = Map [(MetaDatum, MetaDatum)]
-    | List [MetaDatum]
-    | I Integer
-    | B B.ByteString
-    | S T.Text
-    deriving stock (Show, Eq, Ord, Generic)
+  = Map [(MetaDatum, MetaDatum)]
+  | List [MetaDatum]
+  | I Integer
+  | B B.ByteString
+  | S T.Text
+  deriving stock (Show, Eq, Ord, Generic)
 
 instance NoUnexpectedThunks MetaDatum
 
-data MetaData =
-  MetaData'
-  { mdMap :: Map Word64 MetaDatum
-  , mdBytes :: LByteString
-  } deriving (Eq, Show, Generic)
-    deriving NoUnexpectedThunks via AllowThunksIn '["mdBytes"] MetaData
+data MetaData = MetaData'
+  { mdMap :: Map Word64 MetaDatum,
+    mdBytes :: LByteString
+  }
+  deriving (Eq, Show, Generic)
+  deriving (NoUnexpectedThunks) via AllowThunksIn '["mdBytes"] MetaData
 
 pattern MetaData :: Map Word64 MetaDatum -> MetaData
-pattern MetaData m <- MetaData' m _
+pattern MetaData m <-
+  MetaData' m _
   where
-  MetaData m = let bytes = serializeEncoding $ mapToCBOR m
-                in MetaData' m bytes
+    MetaData m =
+      let bytes = serializeEncoding $ mapToCBOR m
+       in MetaData' m bytes
 
 {-# COMPLETE MetaData #-}
 
@@ -87,7 +95,7 @@ fromTerm t =
     CBOR.TInteger i -> Right $ I i
     CBOR.TBytes b -> Right $ B b
     CBOR.TBytesI b -> Right $ B (BL.toStrict b)
-    CBOR.TString  s -> Right $ S s
+    CBOR.TString s -> Right $ S s
     CBOR.TStringI s -> Right $ S (TL.toStrict s)
     CBOR.TMap m -> Map <$> traverse (bitraverse fromTerm fromTerm) m
     CBOR.TMapI m -> Map <$> traverse (bitraverse fromTerm fromTerm) m
@@ -97,33 +105,31 @@ fromTerm t =
 
 toTerm :: MetaDatum -> CBOR.Term
 toTerm = \case
-    I i -> CBOR.TInteger i
-    B b -> CBOR.TBytes b
-    S s -> CBOR.TString s
-    Map entries -> CBOR.TMap (fmap (bimap toTerm toTerm) entries)
-    List ts -> CBOR.TList (fmap toTerm ts)
+  I i -> CBOR.TInteger i
+  B b -> CBOR.TBytes b
+  S s -> CBOR.TString s
+  Map entries -> CBOR.TMap (fmap (bimap toTerm toTerm) entries)
+  List ts -> CBOR.TList (fmap toTerm ts)
 
-instance ToCBOR MetaDatum
- where
-   toCBOR = CBOR.encodeTerm . toTerm
+instance ToCBOR MetaDatum where
+  toCBOR = CBOR.encodeTerm . toTerm
 
-instance FromCBOR MetaDatum
- where
-   fromCBOR = do
-     t <- CBOR.decodeTerm
-     case fromTerm t of
-       Right d -> pure d
-       Left e   -> (cborError . DecoderErrorCustom "metadata" . T.pack) e
+instance FromCBOR MetaDatum where
+  fromCBOR = do
+    t <- CBOR.decodeTerm
+    case fromTerm t of
+      Right d -> pure d
+      Left e -> (cborError . DecoderErrorCustom "metadata" . T.pack) e
 
-newtype MetaDataHash crypto
-  = MetaDataHash { unsafeMetaDataHash :: Hash crypto MetaData }
+newtype MetaDataHash crypto = MetaDataHash {unsafeMetaDataHash :: Hash crypto MetaData}
   deriving (Show, Eq, Ord, NoUnexpectedThunks)
 
 deriving instance Crypto crypto => ToCBOR (MetaDataHash crypto)
+
 deriving instance Crypto crypto => FromCBOR (MetaDataHash crypto)
 
-hashMetaData
-  :: Crypto crypto
-  => MetaData
-  -> MetaDataHash crypto
+hashMetaData ::
+  Crypto crypto =>
+  MetaData ->
+  MetaDataHash crypto
 hashMetaData = MetaDataHash . hash

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Orphans.hs
@@ -2,8 +2,9 @@
 
 module Shelley.Spec.Ledger.Orphans where
 
-import           Cardano.Prelude (NoUnexpectedThunks)
-import           Data.IP (IPv4, IPv6)
+import Cardano.Prelude (NoUnexpectedThunks)
+import Data.IP (IPv4, IPv6)
 
 instance NoUnexpectedThunks IPv4
+
 instance NoUnexpectedThunks IPv6

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/PParams.hs
@@ -13,96 +13,118 @@
 
 -- | This module contains just the type of protocol parameters.
 module Shelley.Spec.Ledger.PParams
-  ( PParams'(..)
-  , PParams
-  , emptyPParams
-  , ProtVer(..)
-  , PPUpdateEnv(..)
-  , ProposedPPUpdates(..)
-  , emptyPPPUpdates
-  , PParamsUpdate
-  , Update(..)
-  , updatePParams
-  ) where
+  ( PParams' (..),
+    PParams,
+    emptyPParams,
+    ProtVer (..),
+    PPUpdateEnv (..),
+    ProposedPPUpdates (..),
+    emptyPPPUpdates,
+    PParamsUpdate,
+    Update (..),
+    updatePParams,
+  )
+where
 
-import           Control.Monad (unless)
-import           Data.Foldable (fold)
-import           Data.Functor.Identity (Identity)
-import           Data.List (nub)
-import           Data.Map.Strict (Map)
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    decodeWord,
+    encodeListLen,
+    encodeMapLen,
+    encodeWord,
+    enforceSize,
+  )
+import Cardano.Prelude (NoUnexpectedThunks (..), mapMaybe)
+import Control.Monad (unless)
+import Data.Foldable (fold)
+import Data.Functor.Identity (Identity)
+import Data.List (nub)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe)
-import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
-
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord, encodeListLen,
-                     encodeMapLen, encodeWord, enforceSize)
-import           Cardano.Prelude (NoUnexpectedThunks (..), mapMaybe)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (NeutralNonce), StrictMaybe (..),
-                     UnitInterval, interval0, invalidKey, strictMaybeToMaybe)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Keys (GenDelegs, KeyHash, KeyRole(..))
-import           Shelley.Spec.Ledger.Serialization (CBORGroup (..), FromCBORGroup (..),
-                     ToCBORGroup (..), decodeMapContents, mapFromCBOR, mapToCBOR, rationalFromCBOR,
-                     rationalToCBOR)
-import           Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
-
+import Data.Maybe (fromMaybe)
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Nonce (NeutralNonce),
+    StrictMaybe (..),
+    UnitInterval,
+    interval0,
+    invalidKey,
+    strictMaybeToMaybe,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Keys (GenDelegs, KeyHash, KeyRole (..))
+import Shelley.Spec.Ledger.Serialization
+  ( CBORGroup (..),
+    FromCBORGroup (..),
+    ToCBORGroup (..),
+    decodeMapContents,
+    mapFromCBOR,
+    mapToCBOR,
+    rationalFromCBOR,
+    rationalToCBOR,
+  )
+import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
 
 type family HKD f a where
   HKD Identity a = a
-  HKD f        a = f a
+  HKD f a = f a
 
 -- | Protocol parameters
 data PParams' f = PParams
-  { -- |The linear factor for the minimum fee calculation
-    _minfeeA         :: !(HKD f Natural)
-    -- |The constant factor for the minimum fee calculation
-  , _minfeeB         :: !(HKD f Natural)
+  { -- | The linear factor for the minimum fee calculation
+    _minfeeA :: !(HKD f Natural),
+    -- | The constant factor for the minimum fee calculation
+    _minfeeB :: !(HKD f Natural),
     -- | Maximal block body size
-  , _maxBBSize       :: !(HKD f Natural)
+    _maxBBSize :: !(HKD f Natural),
     -- | Maximal transaction size
-  , _maxTxSize       :: !(HKD f Natural)
+    _maxTxSize :: !(HKD f Natural),
     -- | Maximal block header size
-  , _maxBHSize       :: !(HKD f Natural)
-    -- |The amount of a key registration deposit
-  , _keyDeposit      :: !(HKD f Coin)
-    -- |The minimum percent refund guarantee
-  , _keyMinRefund    :: !(HKD f UnitInterval)
-    -- |The deposit decay rate
-  , _keyDecayRate    :: !(HKD f Rational)
-    -- |The amount of a pool registration deposit
-  , _poolDeposit     :: !(HKD f Coin)
+    _maxBHSize :: !(HKD f Natural),
+    -- | The amount of a key registration deposit
+    _keyDeposit :: !(HKD f Coin),
+    -- | The minimum percent refund guarantee
+    _keyMinRefund :: !(HKD f UnitInterval),
+    -- | The deposit decay rate
+    _keyDecayRate :: !(HKD f Rational),
+    -- | The amount of a pool registration deposit
+    _poolDeposit :: !(HKD f Coin),
     -- | The minimum percent pool refund
-  , _poolMinRefund   :: !(HKD f UnitInterval)
+    _poolMinRefund :: !(HKD f UnitInterval),
     -- | Decay rate for pool deposits
-  , _poolDecayRate   :: !(HKD f Rational)
+    _poolDecayRate :: !(HKD f Rational),
     -- | epoch bound on pool retirement
-  , _eMax            :: !(HKD f EpochNo)
+    _eMax :: !(HKD f EpochNo),
     -- | Desired number of pools
-  , _nOpt            :: !(HKD f Natural)
+    _nOpt :: !(HKD f Natural),
     -- | Pool influence
-  , _a0              :: !(HKD f Rational)
+    _a0 :: !(HKD f Rational),
     -- | Treasury expansion
-  , _rho             :: !(HKD f UnitInterval)
+    _rho :: !(HKD f UnitInterval),
     -- | Monetary expansion
-  , _tau             :: !(HKD f UnitInterval)
+    _tau :: !(HKD f UnitInterval),
     -- | Decentralization parameter
-  , _d               :: !(HKD f UnitInterval)
+    _d :: !(HKD f UnitInterval),
     -- | Extra entropy
-  , _extraEntropy    :: !(HKD f Nonce)
+    _extraEntropy :: !(HKD f Nonce),
     -- | Protocol version
-  , _protocolVersion :: !(HKD f ProtVer)
-  } deriving (Generic)
+    _protocolVersion :: !(HKD f ProtVer)
+  }
+  deriving (Generic)
 
 type PParams = PParams' Identity
+
 deriving instance Eq (PParams' Identity)
+
 deriving instance Show (PParams' Identity)
 
 data ProtVer = ProtVer !Natural !Natural
   deriving (Show, Eq, Generic, Ord)
-  deriving ToCBOR via (CBORGroup ProtVer)
-  deriving FromCBOR via (CBORGroup ProtVer)
+  deriving (ToCBOR) via (CBORGroup ProtVer)
+  deriving (FromCBOR) via (CBORGroup ProtVer)
 
 instance NoUnexpectedThunks ProtVer
 
@@ -118,29 +140,30 @@ instance FromCBORGroup ProtVer where
 
 instance NoUnexpectedThunks PParams
 
-instance ToCBOR PParams
- where
-  toCBOR (PParams
-    { _minfeeA         = minfeeA'
-    , _minfeeB         = minfeeB'
-    , _maxBBSize       = maxBBSize'
-    , _maxTxSize       = maxTxSize'
-    , _maxBHSize       = maxBHSize'
-    , _keyDeposit      = keyDeposit'
-    , _keyMinRefund    = keyMinRefund'
-    , _keyDecayRate    = keyDecayRate'
-    , _poolDeposit     = poolDeposit'
-    , _poolMinRefund   = poolMinRefund'
-    , _poolDecayRate   = poolDecayRate'
-    , _eMax            = eMax'
-    , _nOpt            = nOpt'
-    , _a0              = a0'
-    , _rho             = rho'
-    , _tau             = tau'
-    , _d               = d'
-    , _extraEntropy    = extraEntropy'
-    , _protocolVersion = protocolVersion'
-    }) =
+instance ToCBOR PParams where
+  toCBOR
+    ( PParams
+        { _minfeeA = minfeeA',
+          _minfeeB = minfeeB',
+          _maxBBSize = maxBBSize',
+          _maxTxSize = maxTxSize',
+          _maxBHSize = maxBHSize',
+          _keyDeposit = keyDeposit',
+          _keyMinRefund = keyMinRefund',
+          _keyDecayRate = keyDecayRate',
+          _poolDeposit = poolDeposit',
+          _poolMinRefund = poolMinRefund',
+          _poolDecayRate = poolDecayRate',
+          _eMax = eMax',
+          _nOpt = nOpt',
+          _a0 = a0',
+          _rho = rho',
+          _tau = tau',
+          _d = d',
+          _extraEntropy = extraEntropy',
+          _protocolVersion = protocolVersion'
+        }
+      ) =
       encodeListLen 20
         <> toCBOR minfeeA'
         <> toCBOR minfeeB'
@@ -162,55 +185,54 @@ instance ToCBOR PParams
         <> toCBOR extraEntropy'
         <> toCBORGroup protocolVersion'
 
-instance FromCBOR PParams
- where
+instance FromCBOR PParams where
   fromCBOR = do
     enforceSize "PParams" 20
     PParams
-      <$> fromCBOR         -- _minfeeA         :: Integer
-      <*> fromCBOR         -- _minfeeB         :: Natural
-      <*> fromCBOR         -- _maxBBSize       :: Natural
-      <*> fromCBOR         -- _maxTxSize       :: Natural
-      <*> fromCBOR         -- _maxBHSize       :: Natural
-      <*> fromCBOR         -- _keyDeposit      :: Coin
-      <*> fromCBOR         -- _keyMinRefund    :: UnitInterval
+      <$> fromCBOR -- _minfeeA         :: Integer
+      <*> fromCBOR -- _minfeeB         :: Natural
+      <*> fromCBOR -- _maxBBSize       :: Natural
+      <*> fromCBOR -- _maxTxSize       :: Natural
+      <*> fromCBOR -- _maxBHSize       :: Natural
+      <*> fromCBOR -- _keyDeposit      :: Coin
+      <*> fromCBOR -- _keyMinRefund    :: UnitInterval
       <*> rationalFromCBOR -- _keyDecayRate    :: Rational
-      <*> fromCBOR         -- _poolDeposit     :: Coin
-      <*> fromCBOR         -- _poolMinRefund   :: UnitInterval
+      <*> fromCBOR -- _poolDeposit     :: Coin
+      <*> fromCBOR -- _poolMinRefund   :: UnitInterval
       <*> rationalFromCBOR -- _poolDecayRate   :: Rational
-      <*> fromCBOR         -- _eMax            :: EpochNo
-      <*> fromCBOR         -- _nOpt            :: Natural
+      <*> fromCBOR -- _eMax            :: EpochNo
+      <*> fromCBOR -- _nOpt            :: Natural
       <*> rationalFromCBOR -- _a0              :: Rational
-      <*> fromCBOR         -- _rho             :: UnitInterval
-      <*> fromCBOR         -- _tau             :: UnitInterval
-      <*> fromCBOR         -- _d               :: UnitInterval
-      <*> fromCBOR         -- _extraEntropy    :: Nonce
-      <*> fromCBORGroup    -- _protocolVersion :: ProtVer
+      <*> fromCBOR -- _rho             :: UnitInterval
+      <*> fromCBOR -- _tau             :: UnitInterval
+      <*> fromCBOR -- _d               :: UnitInterval
+      <*> fromCBOR -- _extraEntropy    :: Nonce
+      <*> fromCBORGroup -- _protocolVersion :: ProtVer
 
 -- | Returns a basic "empty" `PParams` structure with all zero values.
 emptyPParams :: PParams
 emptyPParams =
-    PParams {
-       _minfeeA = 0
-     , _minfeeB = 0
-     , _maxBBSize = 0
-     , _maxTxSize = 2048
-     , _maxBHSize = 0
-     , _keyDeposit = Coin 0
-     , _keyMinRefund = interval0
-     , _keyDecayRate = 0
-     , _poolDeposit = Coin 0
-     , _poolMinRefund = interval0
-     , _poolDecayRate = 0
-     , _eMax = EpochNo 0
-     , _nOpt = 100
-     , _a0 = 0
-     , _rho = interval0
-     , _tau = interval0
-     , _d = interval0
-     , _extraEntropy = NeutralNonce
-     , _protocolVersion = ProtVer 0 0
-     }
+  PParams
+    { _minfeeA = 0,
+      _minfeeB = 0,
+      _maxBBSize = 0,
+      _maxTxSize = 2048,
+      _maxBHSize = 0,
+      _keyDeposit = Coin 0,
+      _keyMinRefund = interval0,
+      _keyDecayRate = 0,
+      _poolDeposit = Coin 0,
+      _poolMinRefund = interval0,
+      _poolDecayRate = 0,
+      _eMax = EpochNo 0,
+      _nOpt = 100,
+      _a0 = 0,
+      _rho = interval0,
+      _tau = interval0,
+      _d = interval0,
+      _extraEntropy = NeutralNonce,
+      _protocolVersion = ProtVer 0 0
+    }
 
 -- | Update Proposal
 data Update crypto
@@ -235,91 +257,98 @@ data PPUpdateEnv crypto = PPUpdateEnv SlotNo (GenDelegs crypto)
 instance NoUnexpectedThunks (PPUpdateEnv crypto)
 
 type PParamsUpdate = PParams' StrictMaybe
+
 deriving instance Eq (PParams' StrictMaybe)
+
 deriving instance Show (PParams' StrictMaybe)
+
 deriving instance Ord (PParams' StrictMaybe)
 
-instance NoUnexpectedThunks PParamsUpdate where
+instance NoUnexpectedThunks PParamsUpdate
 
 instance ToCBOR PParamsUpdate where
   toCBOR ppup =
-    let l = mapMaybe strictMaybeToMaybe
-          [ encodeMapElement  0 toCBOR         =<< _minfeeA         ppup
-          , encodeMapElement  1 toCBOR         =<< _minfeeB         ppup
-          , encodeMapElement  2 toCBOR         =<< _maxBBSize       ppup
-          , encodeMapElement  3 toCBOR         =<< _maxTxSize       ppup
-          , encodeMapElement  4 toCBOR         =<< _maxBHSize       ppup
-          , encodeMapElement  5 toCBOR         =<< _keyDeposit      ppup
-          , encodeMapElement  6 toCBOR         =<< _keyMinRefund    ppup
-          , encodeMapElement  7 rationalToCBOR =<< _keyDecayRate    ppup
-          , encodeMapElement  8 toCBOR         =<< _poolDeposit     ppup
-          , encodeMapElement  9 toCBOR         =<< _poolMinRefund   ppup
-          , encodeMapElement 10 rationalToCBOR =<< _poolDecayRate   ppup
-          , encodeMapElement 11 toCBOR         =<< _eMax            ppup
-          , encodeMapElement 12 toCBOR         =<< _nOpt            ppup
-          , encodeMapElement 13 rationalToCBOR =<< _a0              ppup
-          , encodeMapElement 14 toCBOR         =<< _rho             ppup
-          , encodeMapElement 15 toCBOR         =<< _tau             ppup
-          , encodeMapElement 16 toCBOR         =<< _d               ppup
-          , encodeMapElement 17 toCBOR         =<< _extraEntropy    ppup
-          , encodeMapElement 18 toCBOR         =<< _protocolVersion ppup
-          ]
+    let l =
+          mapMaybe
+            strictMaybeToMaybe
+            [ encodeMapElement 0 toCBOR =<< _minfeeA ppup,
+              encodeMapElement 1 toCBOR =<< _minfeeB ppup,
+              encodeMapElement 2 toCBOR =<< _maxBBSize ppup,
+              encodeMapElement 3 toCBOR =<< _maxTxSize ppup,
+              encodeMapElement 4 toCBOR =<< _maxBHSize ppup,
+              encodeMapElement 5 toCBOR =<< _keyDeposit ppup,
+              encodeMapElement 6 toCBOR =<< _keyMinRefund ppup,
+              encodeMapElement 7 rationalToCBOR =<< _keyDecayRate ppup,
+              encodeMapElement 8 toCBOR =<< _poolDeposit ppup,
+              encodeMapElement 9 toCBOR =<< _poolMinRefund ppup,
+              encodeMapElement 10 rationalToCBOR =<< _poolDecayRate ppup,
+              encodeMapElement 11 toCBOR =<< _eMax ppup,
+              encodeMapElement 12 toCBOR =<< _nOpt ppup,
+              encodeMapElement 13 rationalToCBOR =<< _a0 ppup,
+              encodeMapElement 14 toCBOR =<< _rho ppup,
+              encodeMapElement 15 toCBOR =<< _tau ppup,
+              encodeMapElement 16 toCBOR =<< _d ppup,
+              encodeMapElement 17 toCBOR =<< _extraEntropy ppup,
+              encodeMapElement 18 toCBOR =<< _protocolVersion ppup
+            ]
         n = fromIntegral $ length l
-    in encodeMapLen n <> fold l
+     in encodeMapLen n <> fold l
     where
       encodeMapElement ix encoder x = SJust (encodeWord ix <> encoder x)
 
 emptyPParamsUpdate :: PParamsUpdate
-emptyPParamsUpdate   = PParams
-  { _minfeeA         = SNothing
-  , _minfeeB         = SNothing
-  , _maxBBSize       = SNothing
-  , _maxTxSize       = SNothing
-  , _maxBHSize       = SNothing
-  , _keyDeposit      = SNothing
-  , _keyMinRefund    = SNothing
-  , _keyDecayRate    = SNothing
-  , _poolDeposit     = SNothing
-  , _poolMinRefund   = SNothing
-  , _poolDecayRate   = SNothing
-  , _eMax            = SNothing
-  , _nOpt            = SNothing
-  , _a0              = SNothing
-  , _rho             = SNothing
-  , _tau             = SNothing
-  , _d               = SNothing
-  , _extraEntropy    = SNothing
-  , _protocolVersion = SNothing
-  }
+emptyPParamsUpdate =
+  PParams
+    { _minfeeA = SNothing,
+      _minfeeB = SNothing,
+      _maxBBSize = SNothing,
+      _maxTxSize = SNothing,
+      _maxBHSize = SNothing,
+      _keyDeposit = SNothing,
+      _keyMinRefund = SNothing,
+      _keyDecayRate = SNothing,
+      _poolDeposit = SNothing,
+      _poolMinRefund = SNothing,
+      _poolDecayRate = SNothing,
+      _eMax = SNothing,
+      _nOpt = SNothing,
+      _a0 = SNothing,
+      _rho = SNothing,
+      _tau = SNothing,
+      _d = SNothing,
+      _extraEntropy = SNothing,
+      _protocolVersion = SNothing
+    }
 
 instance FromCBOR PParamsUpdate where
-   fromCBOR = do
-     mapParts <- decodeMapContents $
-       decodeWord >>= \case
-         0  -> fromCBOR         >>= \x -> pure ( 0, \up -> up { _minfeeA         = SJust x })
-         1  -> fromCBOR         >>= \x -> pure ( 1, \up -> up { _minfeeB         = SJust x })
-         2  -> fromCBOR         >>= \x -> pure ( 2, \up -> up { _maxBBSize       = SJust x })
-         3  -> fromCBOR         >>= \x -> pure ( 3, \up -> up { _maxTxSize       = SJust x })
-         4  -> fromCBOR         >>= \x -> pure ( 4, \up -> up { _maxBHSize       = SJust x })
-         5  -> fromCBOR         >>= \x -> pure ( 5, \up -> up { _keyDeposit      = SJust x })
-         6  -> fromCBOR         >>= \x -> pure ( 6, \up -> up { _keyMinRefund    = SJust x })
-         7  -> rationalFromCBOR >>= \x -> pure ( 7, \up -> up { _keyDecayRate    = SJust x })
-         8  -> fromCBOR         >>= \x -> pure ( 8, \up -> up { _poolDeposit     = SJust x })
-         9  -> fromCBOR         >>= \x -> pure ( 9, \up -> up { _poolMinRefund   = SJust x })
-         10 -> rationalFromCBOR >>= \x -> pure (10, \up -> up { _poolDecayRate   = SJust x })
-         11 -> fromCBOR         >>= \x -> pure (11, \up -> up { _eMax            = SJust x })
-         12 -> fromCBOR         >>= \x -> pure (12, \up -> up { _nOpt            = SJust x })
-         13 -> rationalFromCBOR >>= \x -> pure (13, \up -> up { _a0              = SJust x })
-         14 -> fromCBOR         >>= \x -> pure (14, \up -> up { _rho             = SJust x })
-         15 -> fromCBOR         >>= \x -> pure (15, \up -> up { _tau             = SJust x })
-         16 -> fromCBOR         >>= \x -> pure (17, \up -> up { _d               = SJust x })
-         17 -> fromCBOR         >>= \x -> pure (18, \up -> up { _extraEntropy    = SJust x })
-         18 -> fromCBOR         >>= \x -> pure (19, \up -> up { _protocolVersion = SJust x })
-         k -> invalidKey k
-     let fields = fst <$> mapParts :: [Int]
-     unless (nub fields == fields)
-       (fail $ "duplicate keys: " <> show fields)
-     pure $ foldr ($) emptyPParamsUpdate (snd <$> mapParts)
+  fromCBOR = do
+    mapParts <- decodeMapContents $
+      decodeWord >>= \case
+        0 -> fromCBOR >>= \x -> pure (0, \up -> up {_minfeeA = SJust x})
+        1 -> fromCBOR >>= \x -> pure (1, \up -> up {_minfeeB = SJust x})
+        2 -> fromCBOR >>= \x -> pure (2, \up -> up {_maxBBSize = SJust x})
+        3 -> fromCBOR >>= \x -> pure (3, \up -> up {_maxTxSize = SJust x})
+        4 -> fromCBOR >>= \x -> pure (4, \up -> up {_maxBHSize = SJust x})
+        5 -> fromCBOR >>= \x -> pure (5, \up -> up {_keyDeposit = SJust x})
+        6 -> fromCBOR >>= \x -> pure (6, \up -> up {_keyMinRefund = SJust x})
+        7 -> rationalFromCBOR >>= \x -> pure (7, \up -> up {_keyDecayRate = SJust x})
+        8 -> fromCBOR >>= \x -> pure (8, \up -> up {_poolDeposit = SJust x})
+        9 -> fromCBOR >>= \x -> pure (9, \up -> up {_poolMinRefund = SJust x})
+        10 -> rationalFromCBOR >>= \x -> pure (10, \up -> up {_poolDecayRate = SJust x})
+        11 -> fromCBOR >>= \x -> pure (11, \up -> up {_eMax = SJust x})
+        12 -> fromCBOR >>= \x -> pure (12, \up -> up {_nOpt = SJust x})
+        13 -> rationalFromCBOR >>= \x -> pure (13, \up -> up {_a0 = SJust x})
+        14 -> fromCBOR >>= \x -> pure (14, \up -> up {_rho = SJust x})
+        15 -> fromCBOR >>= \x -> pure (15, \up -> up {_tau = SJust x})
+        16 -> fromCBOR >>= \x -> pure (17, \up -> up {_d = SJust x})
+        17 -> fromCBOR >>= \x -> pure (18, \up -> up {_extraEntropy = SJust x})
+        18 -> fromCBOR >>= \x -> pure (19, \up -> up {_protocolVersion = SJust x})
+        k -> invalidKey k
+    let fields = fst <$> mapParts :: [Int]
+    unless
+      (nub fields == fields)
+      (fail $ "duplicate keys: " <> show fields)
+    pure $ foldr ($) emptyPParamsUpdate (snd <$> mapParts)
 
 -- | Update operation for protocol parameters structure @PParams
 newtype ProposedPPUpdates crypto
@@ -338,27 +367,28 @@ emptyPPPUpdates :: ProposedPPUpdates crypto
 emptyPPPUpdates = ProposedPPUpdates Map.empty
 
 updatePParams :: PParams -> PParamsUpdate -> PParams
-updatePParams pp ppup = PParams
-  { _minfeeA = fromMaybe' (_minfeeA pp) (_minfeeA ppup)
-  , _minfeeB = fromMaybe' (_minfeeB pp) (_minfeeB ppup)
-  , _maxBBSize = fromMaybe' (_maxBBSize pp) (_maxBBSize ppup)
-  , _maxTxSize = fromMaybe' (_maxTxSize pp) (_maxTxSize ppup)
-  , _maxBHSize = fromMaybe' (_maxBHSize pp) (_maxBHSize ppup)
-  , _keyDeposit = fromMaybe' (_keyDeposit pp) (_keyDeposit ppup)
-  , _keyMinRefund = fromMaybe' (_keyMinRefund pp) (_keyMinRefund ppup)
-  , _keyDecayRate = fromMaybe' (_keyDecayRate pp) (_keyDecayRate ppup)
-  , _poolDeposit = fromMaybe' (_poolDeposit pp) (_poolDeposit ppup)
-  , _poolMinRefund = fromMaybe' (_poolMinRefund pp) (_poolMinRefund ppup)
-  , _poolDecayRate = fromMaybe' (_poolDecayRate pp) (_poolDecayRate ppup)
-  , _eMax = fromMaybe' (_eMax pp) (_eMax ppup)
-  , _nOpt = fromMaybe' (_nOpt pp) (_nOpt ppup)
-  , _a0 = fromMaybe' (_a0 pp) (_a0 ppup)
-  , _rho = fromMaybe' (_rho pp) (_rho ppup)
-  , _tau = fromMaybe' (_tau pp) (_tau ppup)
-  , _d = fromMaybe' (_d pp) (_d ppup)
-  , _extraEntropy = fromMaybe' (_extraEntropy pp) (_extraEntropy ppup)
-  , _protocolVersion = fromMaybe' (_protocolVersion pp) (_protocolVersion ppup)
-  }
+updatePParams pp ppup =
+  PParams
+    { _minfeeA = fromMaybe' (_minfeeA pp) (_minfeeA ppup),
+      _minfeeB = fromMaybe' (_minfeeB pp) (_minfeeB ppup),
+      _maxBBSize = fromMaybe' (_maxBBSize pp) (_maxBBSize ppup),
+      _maxTxSize = fromMaybe' (_maxTxSize pp) (_maxTxSize ppup),
+      _maxBHSize = fromMaybe' (_maxBHSize pp) (_maxBHSize ppup),
+      _keyDeposit = fromMaybe' (_keyDeposit pp) (_keyDeposit ppup),
+      _keyMinRefund = fromMaybe' (_keyMinRefund pp) (_keyMinRefund ppup),
+      _keyDecayRate = fromMaybe' (_keyDecayRate pp) (_keyDecayRate ppup),
+      _poolDeposit = fromMaybe' (_poolDeposit pp) (_poolDeposit ppup),
+      _poolMinRefund = fromMaybe' (_poolMinRefund pp) (_poolMinRefund ppup),
+      _poolDecayRate = fromMaybe' (_poolDecayRate pp) (_poolDecayRate ppup),
+      _eMax = fromMaybe' (_eMax pp) (_eMax ppup),
+      _nOpt = fromMaybe' (_nOpt pp) (_nOpt ppup),
+      _a0 = fromMaybe' (_a0 pp) (_a0 ppup),
+      _rho = fromMaybe' (_rho pp) (_rho ppup),
+      _tau = fromMaybe' (_tau pp) (_tau ppup),
+      _d = fromMaybe' (_d pp) (_d ppup),
+      _extraEntropy = fromMaybe' (_extraEntropy pp) (_extraEntropy ppup),
+      _protocolVersion = fromMaybe' (_protocolVersion pp) (_protocolVersion ppup)
+    }
   where
     fromMaybe' :: a -> StrictMaybe a -> a
     fromMaybe' x = fromMaybe x . strictMaybeToMaybe

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Rewards.hs
@@ -4,112 +4,122 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Shelley.Spec.Ledger.Rewards
-  ( desirability
-  , ApparentPerformance (..)
-  , NonMyopic (..)
-  , emptyNonMyopic
-  , getTopRankedPools
-  , StakeShare(..)
-  , mkApparentPerformance
-  , reward
-  , nonMyopicStake
-  , nonMyopicMemberRew
-  ) where
+  ( desirability,
+    ApparentPerformance (..),
+    NonMyopic (..),
+    emptyNonMyopic,
+    getTopRankedPools,
+    StakeShare (..),
+    mkApparentPerformance,
+    reward,
+    nonMyopicStake,
+    nonMyopicMemberRew,
+  )
+where
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeDouble, encodeDouble,
-                     encodeListLen, enforceSize)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Shelley.Spec.Ledger.Crypto (Crypto)
-
-import           Data.Function (on)
-import           Data.List (foldl', sortBy)
-import           Data.Map.Strict (Map)
+import Byron.Spec.Ledger.Core ((◁))
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    decodeDouble,
+    encodeDouble,
+    encodeListLen,
+    enforceSize,
+  )
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Data.Function (on)
+import Data.List (foldl', sortBy)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe)
-import           Data.Ratio ((%))
-import           Data.Set (Set)
+import Data.Maybe (fromMaybe)
+import Data.Ratio ((%))
+import Data.Set (Set)
 import qualified Data.Set as Set
-import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes (UnitInterval (..), intervalValue, mkUnitInterval)
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Crypto (Crypto)
+import Shelley.Spec.Ledger.Delegation.PoolParams (poolSpec)
+import Shelley.Spec.Ledger.EpochBoundary
+  ( BlocksMade (..),
+    SnapShot (..),
+    Stake (..),
+    emptySnapShot,
+    maxPool,
+    poolStake,
+  )
+import Shelley.Spec.Ledger.Keys (KeyHash, KeyRole (..))
+import Shelley.Spec.Ledger.PParams (PParams, _a0, _d, _nOpt)
+import Shelley.Spec.Ledger.TxData (Credential (..), PoolParams (..), RewardAcnt (..))
 
-import           Byron.Spec.Ledger.Core ((◁))
-import           Shelley.Spec.Ledger.BaseTypes (UnitInterval (..), intervalValue, mkUnitInterval)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Delegation.PoolParams (poolSpec)
-import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), SnapShot (..), Stake (..),
-                     emptySnapShot, maxPool, poolStake)
-import           Shelley.Spec.Ledger.Keys (KeyHash, KeyRole(..))
-import           Shelley.Spec.Ledger.PParams (PParams, _a0, _d, _nOpt)
-import           Shelley.Spec.Ledger.TxData (Credential (..), PoolParams (..), RewardAcnt (..))
-
-
-newtype ApparentPerformance = ApparentPerformance { unApparentPerformance :: Double }
+newtype ApparentPerformance = ApparentPerformance {unApparentPerformance :: Double}
   deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
-instance ToCBOR ApparentPerformance
- where toCBOR = encodeDouble . unApparentPerformance
+instance ToCBOR ApparentPerformance where
+  toCBOR = encodeDouble . unApparentPerformance
 
-instance FromCBOR ApparentPerformance
- where fromCBOR = ApparentPerformance <$> decodeDouble
+instance FromCBOR ApparentPerformance where
+  fromCBOR = ApparentPerformance <$> decodeDouble
 
-data NonMyopic crypto= NonMyopic
-  { apparentPerformances :: !(Map (KeyHash 'StakePool crypto) ApparentPerformance)
-  , rewardPot :: !Coin
-  , snap :: !(SnapShot crypto)
-  } deriving (Show, Eq, Generic)
+data NonMyopic crypto = NonMyopic
+  { apparentPerformances :: !(Map (KeyHash 'StakePool crypto) ApparentPerformance),
+    rewardPot :: !Coin,
+    snap :: !(SnapShot crypto)
+  }
+  deriving (Show, Eq, Generic)
 
 emptyNonMyopic :: NonMyopic crypto
 emptyNonMyopic = NonMyopic Map.empty (Coin 0) emptySnapShot
 
 instance NoUnexpectedThunks (NonMyopic crypto)
 
-instance Crypto crypto => ToCBOR (NonMyopic crypto)
- where
-  toCBOR NonMyopic
-           { apparentPerformances = aps
-           , rewardPot = rp
-           , snap = s
-           } =
-    encodeListLen 3
-      <> toCBOR aps
-      <> toCBOR rp
-      <> toCBOR s
+instance Crypto crypto => ToCBOR (NonMyopic crypto) where
+  toCBOR
+    NonMyopic
+      { apparentPerformances = aps,
+        rewardPot = rp,
+        snap = s
+      } =
+      encodeListLen 3
+        <> toCBOR aps
+        <> toCBOR rp
+        <> toCBOR s
 
-instance Crypto crypto => FromCBOR (NonMyopic crypto)
- where
+instance Crypto crypto => FromCBOR (NonMyopic crypto) where
   fromCBOR = do
     enforceSize "NonMyopic" 3
     aps <- fromCBOR
     rp <- fromCBOR
     s <- fromCBOR
-    pure $ NonMyopic { apparentPerformances = aps
-                     , rewardPot = rp
-                     , snap = s
-                     }
+    pure $
+      NonMyopic
+        { apparentPerformances = aps,
+          rewardPot = rp,
+          snap = s
+        }
 
 -- | Desirability calculation for non-myopic utily,
 -- corresponding to f^~ in section 5.6.1 of
 -- "Design Specification for Delegation and Incentives in Cardano"
-desirability
-  :: PParams
-  -> Coin
-  -> PoolParams crypto
-  -> ApparentPerformance
-  -> Coin
-  -> Double
+desirability ::
+  PParams ->
+  Coin ->
+  PoolParams crypto ->
+  ApparentPerformance ->
+  Coin ->
+  Double
 desirability pp r pool (ApparentPerformance p) (Coin total) =
   if fTilde <= cost
     then 0
-    else (fTilde - cost)*(1 - margin)
+    else (fTilde - cost) * (1 - margin)
   where
-    fTilde      = fTildeNumer / fTildeDenom
+    fTilde = fTildeNumer / fTildeDenom
     fTildeNumer = p * fromRational (fromIntegral r * (z0 + min s z0 * a0))
     fTildeDenom = fromRational $ 1 + a0
-
-    cost   = (fromIntegral . _poolCost) pool
+    cost = (fromIntegral . _poolCost) pool
     margin = (fromRational . intervalValue . _poolMargin) pool
     tot = max 1 (fromIntegral total)
-
     Coin pledge = _poolPledge pool
     s = fromIntegral pledge % tot
     a0 = _a0 pp
@@ -118,42 +128,45 @@ desirability pp r pool (ApparentPerformance p) (Coin total) =
 -- | Computes the top ranked stake pools
 -- corresponding to section 5.6.1 of
 -- "Design Specification for Delegation and Incentives in Cardano"
-getTopRankedPools
-  :: Coin
-  -> Coin
-  -> PParams
-  -> Map (KeyHash 'StakePool crypto) (PoolParams crypto)
-  -> Map (KeyHash 'StakePool crypto) ApparentPerformance
-  -> Set (KeyHash 'StakePool crypto)
+getTopRankedPools ::
+  Coin ->
+  Coin ->
+  PParams ->
+  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
+  Map (KeyHash 'StakePool crypto) ApparentPerformance ->
+  Set (KeyHash 'StakePool crypto)
 getTopRankedPools rPot total pp poolParams aps =
   Set.fromList $ fmap fst $
     take (fromIntegral $ _nOpt pp) (sortBy (flip compare `on` snd) rankings)
   where
     pdata =
-      [ ( hk
-        , ( poolParams Map.! hk
-          , aps Map.! hk))
-      | hk <-
-          Set.toList $ Map.keysSet poolParams `Set.intersection` Map.keysSet aps
+      [ ( hk,
+          ( poolParams Map.! hk,
+            aps Map.! hk
+          )
+        )
+        | hk <-
+            Set.toList $ Map.keysSet poolParams `Set.intersection` Map.keysSet aps
       ]
     rankings =
-      [ ( hk
-        , desirability pp rPot pool ap total)
-      | (hk, (pool, ap)) <- pdata
+      [ ( hk,
+          desirability pp rPot pool ap total
+        )
+        | (hk, (pool, ap)) <- pdata
       ]
 
 -- | StakeShare type
-newtype StakeShare =
-  StakeShare Rational
+newtype StakeShare
+  = StakeShare Rational
   deriving (Show, Ord, Eq, NoUnexpectedThunks)
 
 -- | Calculate pool reward
-mkApparentPerformance
-  :: UnitInterval
-  -> UnitInterval
-  -> Natural
-  -> Natural
-  -> Rational
+mkApparentPerformance ::
+  UnitInterval ->
+  UnitInterval ->
+  Natural ->
+  Natural ->
+  Rational
 mkApparentPerformance d_ sigma blocksN blocksTotal
   | sigma' == 0 = 0
   | intervalValue d_ < 0.8 = beta / sigma'
@@ -163,12 +176,12 @@ mkApparentPerformance d_ sigma blocksN blocksTotal
     sigma' = intervalValue sigma
 
 -- | Calculate pool leader reward
-leaderRew
-  :: Coin
-  -> PoolParams crypto
-  -> StakeShare
-  -> StakeShare
-  -> Coin
+leaderRew ::
+  Coin ->
+  PoolParams crypto ->
+  StakeShare ->
+  StakeShare ->
+  Coin
 leaderRew f@(Coin f') pool (StakeShare s) (StakeShare sigma)
   | f' <= c = f
   | otherwise =
@@ -178,12 +191,12 @@ leaderRew f@(Coin f') pool (StakeShare s) (StakeShare sigma)
     m' = intervalValue m
 
 -- | Calculate pool member reward
-memberRew
-  :: Coin
-  -> PoolParams crypto
-  -> StakeShare
-  -> StakeShare
-  -> Coin
+memberRew ::
+  Coin ->
+  PoolParams crypto ->
+  StakeShare ->
+  StakeShare ->
+  Coin
 memberRew (Coin f') pool (StakeShare t) (StakeShare sigma)
   | f' <= c = 0
   | otherwise = floor $ fromIntegral (f' - c) * (1 - m') * t / sigma
@@ -192,24 +205,25 @@ memberRew (Coin f') pool (StakeShare t) (StakeShare sigma)
     m' = intervalValue m
 
 -- | Reward one pool
-rewardOnePool
-  :: PParams
-  -> Coin
-  -> Natural
-  -> Natural
-  -> PoolParams crypto
-  -> Stake crypto
-  -> Coin
-  -> Set (RewardAcnt crypto)
-  -> (Map (RewardAcnt crypto) Coin, Rational)
+rewardOnePool ::
+  PParams ->
+  Coin ->
+  Natural ->
+  Natural ->
+  PoolParams crypto ->
+  Stake crypto ->
+  Coin ->
+  Set (RewardAcnt crypto) ->
+  (Map (RewardAcnt crypto) Coin, Rational)
 rewardOnePool pp r blocksN blocksTotal pool (Stake stake) (Coin total) addrsRew =
   (rewards', appPerf)
   where
     Coin pstake = sum stake
-    Coin ostake = Set.foldl'
-                    (\c o -> c + (stake Map.! KeyHashObj o))
-                    (Coin 0)
-                    (_poolOwners pool)
+    Coin ostake =
+      Set.foldl'
+        (\c o -> c + (stake Map.! KeyHashObj o))
+        (Coin 0)
+        (_poolOwners pool)
     sigma = fromIntegral pstake % fromIntegral total
     Coin pledge = _poolPledge pool
     pr = fromIntegral pledge % fromIntegral total
@@ -221,68 +235,73 @@ rewardOnePool pp r blocksN blocksTotal pool (Stake stake) (Coin total) addrsRew 
     appPerf = mkApparentPerformance (_d pp) s' blocksN blocksTotal
     poolR = floor (appPerf * fromIntegral maxP)
     tot = fromIntegral total
-    mRewards = Map.fromList
-     [(RewardAcnt hk,
-       memberRew poolR pool (StakeShare (fromIntegral c % tot)) (StakeShare sigma))
-     | (hk, Coin c) <- Map.toList stake, hk `Set.notMember` (KeyHashObj `Set.map` _poolOwners pool)]
-    iReward  = leaderRew poolR pool (StakeShare $ fromIntegral ostake % tot) (StakeShare sigma)
+    mRewards =
+      Map.fromList
+        [ ( RewardAcnt hk,
+            memberRew poolR pool (StakeShare (fromIntegral c % tot)) (StakeShare sigma)
+          )
+          | (hk, Coin c) <- Map.toList stake,
+            hk `Set.notMember` (KeyHashObj `Set.map` _poolOwners pool)
+        ]
+    iReward = leaderRew poolR pool (StakeShare $ fromIntegral ostake % tot) (StakeShare sigma)
     potentialRewards = Map.insert (_poolRAcnt pool) iReward mRewards
     rewards' = Map.filter (/= Coin 0) $ addrsRew ◁ potentialRewards
 
-reward
-  :: PParams
-  -> BlocksMade crypto
-  -> Coin
-  -> Set (RewardAcnt crypto)
-  -> Map (KeyHash 'StakePool crypto) (PoolParams crypto)
-  -> Stake crypto
-  -> Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto)
-  -> Coin
-  -> (Map (RewardAcnt crypto) Coin, Map (KeyHash 'StakePool crypto) Rational)
+reward ::
+  PParams ->
+  BlocksMade crypto ->
+  Coin ->
+  Set (RewardAcnt crypto) ->
+  Map (KeyHash 'StakePool crypto) (PoolParams crypto) ->
+  Stake crypto ->
+  Map (Credential 'Staking crypto) (KeyHash 'StakePool crypto) ->
+  Coin ->
+  (Map (RewardAcnt crypto) Coin, Map (KeyHash 'StakePool crypto) Rational)
 reward pp (BlocksMade b) r addrsRew poolParams stake delegs total =
   (rewards', appPerformances)
   where
     pdata =
-      [ ( hk
-        , ( poolParams Map.! hk
-          , b Map.! hk
-          , poolStake hk delegs stake))
-      | hk <-
-          Set.toList $ Map.keysSet poolParams `Set.intersection` Map.keysSet b
+      [ ( hk,
+          ( poolParams Map.! hk,
+            b Map.! hk,
+            poolStake hk delegs stake
+          )
+        )
+        | hk <-
+            Set.toList $ Map.keysSet poolParams `Set.intersection` Map.keysSet b
       ]
     results =
-      [ ( hk
-        , rewardOnePool pp r n totalBlocks pool actgr total addrsRew)
-      | (hk, (pool, n, actgr)) <- pdata
+      [ ( hk,
+          rewardOnePool pp r n totalBlocks pool actgr total addrsRew
+        )
+        | (hk, (pool, n, actgr)) <- pdata
       ]
     rewards' = foldl' (\m (_, r') -> Map.union m (fst r')) Map.empty results
     appPerformances = Map.fromList $ fmap (\(hk, r') -> (hk, snd r')) results
     totalBlocks = sum b
 
-nonMyopicStake
-  :: KeyHash 'StakePool crypto
-  -> StakeShare
-  -> StakeShare
-  -> PParams
-  -> Set (KeyHash 'StakePool crypto)
-  -> StakeShare
+nonMyopicStake ::
+  KeyHash 'StakePool crypto ->
+  StakeShare ->
+  StakeShare ->
+  PParams ->
+  Set (KeyHash 'StakePool crypto) ->
+  StakeShare
 nonMyopicStake kh (StakeShare sigma) (StakeShare s) pp topPools =
-  let
-    z0 = 1 % max 1 (fromIntegral (_nOpt pp))
-  in
-    if kh `Set.member` topPools
-      then StakeShare (max sigma z0)
-      else StakeShare s
+  let z0 = 1 % max 1 (fromIntegral (_nOpt pp))
+   in if kh `Set.member` topPools
+        then StakeShare (max sigma z0)
+        else StakeShare s
 
-nonMyopicMemberRew
-  :: PParams
-  -> PoolParams crypto
-  -> Coin
-  -> StakeShare
-  -> StakeShare
-  -> StakeShare
-  -> ApparentPerformance
-  -> Coin
+nonMyopicMemberRew ::
+  PParams ->
+  PoolParams crypto ->
+  Coin ->
+  StakeShare ->
+  StakeShare ->
+  StakeShare ->
+  ApparentPerformance ->
+  Coin
 nonMyopicMemberRew
   pp
   pool
@@ -291,10 +310,7 @@ nonMyopicMemberRew
   (StakeShare t)
   (StakeShare nm)
   (ApparentPerformance p) =
-
-  let
-    nm' = max t nm -- TODO check with researchers that this is how to handle t > nm
-    (Coin f) = maxPool pp rPot nm' s
-    fHat = floor (p * fromIntegral f)
-  in
-    memberRew (Coin fHat) pool (StakeShare s) (StakeShare nm')
+    let nm' = max t nm -- TODO check with researchers that this is how to handle t > nm
+        (Coin f) = maxPool pp rPot nm' s
+        fHat = floor (p * fromIntegral f)
+     in memberRew (Coin fHat) pool (StakeShare s) (StakeShare nm')

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Bbody.hs
@@ -9,31 +9,31 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Bbody
-  ( BBODY
-  , BbodyState (..)
-  , BbodyEnv (..)
-  , PredicateFailure (..)
-  , State
+  ( BBODY,
+    BbodyState (..),
+    BbodyEnv (..),
+    PredicateFailure (..),
+    State,
   )
 where
 
-import           Byron.Spec.Ledger.Core ((∈))
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.State.Transition
+import Byron.Spec.Ledger.Core ((∈))
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.State.Transition
 import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Set (Set)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.BlockChain
-import           Shelley.Spec.Ledger.Coin (Coin)
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.EpochBoundary
-import           Shelley.Spec.Ledger.Keys
-import           Shelley.Spec.Ledger.LedgerState
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.STS.Ledgers
-import           Shelley.Spec.Ledger.Tx
+import Data.Set (Set)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.BlockChain
+import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.EpochBoundary
+import Shelley.Spec.Ledger.Keys
+import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.STS.Ledgers
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.Tx
 
 data BBODY crypto
 
@@ -41,24 +41,25 @@ data BbodyState crypto
   = BbodyState (LedgerState crypto) (BlocksMade crypto)
   deriving (Eq, Show)
 
-data BbodyEnv
-  = BbodyEnv
-    { bbodySlots    :: (Set SlotNo)
-    , bbodyPp       :: PParams
-    , bbodyReserves :: Coin
-    }
+data BbodyEnv = BbodyEnv
+  { bbodySlots :: (Set SlotNo),
+    bbodyPp :: PParams,
+    bbodyReserves :: Coin
+  }
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  )
-  => STS (BBODY crypto)
- where
-  type State (BBODY crypto)
-    = BbodyState crypto
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  STS (BBODY crypto)
+  where
+  type
+    State (BBODY crypto) =
+      BbodyState crypto
 
-  type Signal (BBODY crypto)
-    = Block crypto
+  type
+    Signal (BBODY crypto) =
+      Block crypto
 
   type Environment (BBODY crypto) = BbodyEnv
 
@@ -75,37 +76,41 @@ instance
 
 instance NoUnexpectedThunks (PredicateFailure (BBODY crypto))
 
-bbodyTransition
-  :: forall crypto
-   . ( Crypto crypto
-     , DSignable crypto (Hash crypto (TxBody crypto))
-     )
-  => TransitionRule (BBODY crypto)
-bbodyTransition = judgmentContext >>=
-  \(TRC ( BbodyEnv oslots pp _reserves
-          , BbodyState ls b
-          , Block (BHeader bhb _) txsSeq)
-   ) -> do
-  let hk = hashKey $ bheaderVk bhb
-      TxSeq txs = txsSeq
+bbodyTransition ::
+  forall crypto.
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  TransitionRule (BBODY crypto)
+bbodyTransition =
+  judgmentContext
+    >>= \( TRC
+             ( BbodyEnv oslots pp _reserves,
+               BbodyState ls b,
+               Block (BHeader bhb _) txsSeq
+               )
+           ) -> do
+        let hk = hashKey $ bheaderVk bhb
+            TxSeq txs = txsSeq
 
-  bBodySize txsSeq == fromIntegral (hBbsize bhb) ?! WrongBlockBodySizeBBODY
+        bBodySize txsSeq == fromIntegral (hBbsize bhb) ?! WrongBlockBodySizeBBODY
 
-  bbHash txsSeq == bhash bhb ?! InvalidBodyHashBBODY
+        bbHash txsSeq == bhash bhb ?! InvalidBodyHashBBODY
 
-  ls' <- trans @(LEDGERS crypto)
-         $ TRC (LedgersEnv (bheaderSlotNo bhb) pp _reserves, ls, StrictSeq.getSeq txs)
+        ls' <-
+          trans @(LEDGERS crypto) $
+            TRC (LedgersEnv (bheaderSlotNo bhb) pp _reserves, ls, StrictSeq.getSeq txs)
 
-  -- Note that this may not actually be a stake pool - it could be a genesis key
-  -- delegate. However, this would only entail an overhead of 7 counts, and it's
-  -- easier than differentiating here.
-  let hkAsStakePool = coerceKeyRole hk
-  pure $ BbodyState ls' (incrBlocks (bheaderSlotNo bhb ∈ oslots) hkAsStakePool b)
+        -- Note that this may not actually be a stake pool - it could be a genesis key
+        -- delegate. However, this would only entail an overhead of 7 counts, and it's
+        -- easier than differentiating here.
+        let hkAsStakePool = coerceKeyRole hk
+        pure $ BbodyState ls' (incrBlocks (bheaderSlotNo bhb ∈ oslots) hkAsStakePool b)
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  )
-  => Embed (LEDGERS crypto) (BBODY crypto)
- where
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  Embed (LEDGERS crypto) (BBODY crypto)
+  where
   wrapFailed = LedgersFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -10,100 +10,136 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Chain
-  ( CHAIN
-  , ChainState (..)
-  , PredicateFailure(..)
-  , initialShelleyState
-  , totalAda
-  , chainChecks
+  ( CHAIN,
+    ChainState (..),
+    PredicateFailure (..),
+    initialShelleyState,
+    totalAda,
+    chainChecks,
   )
 where
 
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
-
-import           Cardano.Prelude (MonadError (..), NoUnexpectedThunks, asks, unless)
-import           Cardano.Slotting.Slot (WithOrigin (..))
-import           Shelley.Spec.Ledger.BaseTypes (Globals (..), Nonce (..), Seed (..), ShelleyBase,
-                     StrictMaybe (..))
-import           Shelley.Spec.Ledger.BlockChain (BHBody, BHeader, Block (..), LastAppliedBlock (..),
-                     bHeaderSize, bhbody, bheaderSlotNo, hBbsize)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
-import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
-import           Shelley.Spec.Ledger.Keys (DSignable, GenDelegs (..), Hash, KESignable, KeyHash,
-                     KeyRole (..), VerKeyKES, coerceKeyRole)
-import           Shelley.Spec.Ledger.LedgerState (AccountState (..), DPState (..), DState (..),
-                     EpochState (..), LedgerState (..), NewEpochState (..), OBftSlot, PState (..),
-                     UTxOState (..), emptyDState, emptyPState, getGKeys, updateNES, _genDelegs)
-import           Shelley.Spec.Ledger.OCert (KESPeriod)
-import           Shelley.Spec.Ledger.PParams (PParams, ProposedPPUpdates (..), ProtVer (..),
-                     _maxBBSize, _maxBHSize, _protocolVersion)
-import           Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
-import           Shelley.Spec.Ledger.Slot (EpochNo, SlotNo)
-import           Shelley.Spec.Ledger.Tx (TxBody)
-import           Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
-
 import qualified Cardano.Crypto.VRF as VRF
-import           Control.State.Transition
-import           Shelley.Spec.Ledger.Crypto
-
-import           Shelley.Spec.Ledger.STS.Bbody
-import           Shelley.Spec.Ledger.STS.Prtcl
-import           Shelley.Spec.Ledger.STS.Tick
+import Cardano.Prelude (MonadError (..), NoUnexpectedThunks, asks, unless)
+import Cardano.Slotting.Slot (WithOrigin (..))
+import Control.State.Transition
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Globals (..),
+    Nonce (..),
+    Seed (..),
+    ShelleyBase,
+    StrictMaybe (..),
+  )
+import Shelley.Spec.Ledger.BlockChain
+  ( BHBody,
+    BHeader,
+    Block (..),
+    LastAppliedBlock (..),
+    bHeaderSize,
+    bhbody,
+    bheaderSlotNo,
+    hBbsize,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
+import Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), emptySnapShots)
+import Shelley.Spec.Ledger.Keys
+  ( DSignable,
+    GenDelegs (..),
+    Hash,
+    KESignable,
+    KeyHash,
+    KeyRole (..),
+    VerKeyKES,
+    coerceKeyRole,
+  )
+import Shelley.Spec.Ledger.LedgerState
+  ( AccountState (..),
+    DPState (..),
+    DState (..),
+    EpochState (..),
+    LedgerState (..),
+    NewEpochState (..),
+    OBftSlot,
+    PState (..),
+    UTxOState (..),
+    _genDelegs,
+    emptyDState,
+    emptyPState,
+    getGKeys,
+    updateNES,
+  )
+import Shelley.Spec.Ledger.OCert (KESPeriod)
+import Shelley.Spec.Ledger.PParams
+  ( PParams,
+    ProposedPPUpdates (..),
+    ProtVer (..),
+    _maxBBSize,
+    _maxBHSize,
+    _protocolVersion,
+  )
+import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
+import Shelley.Spec.Ledger.STS.Bbody
+import Shelley.Spec.Ledger.STS.Prtcl
+import Shelley.Spec.Ledger.STS.Tick
+import Shelley.Spec.Ledger.Slot (EpochNo, SlotNo)
+import Shelley.Spec.Ledger.Tx (TxBody)
+import Shelley.Spec.Ledger.UTxO (UTxO (..), balance)
 
 data CHAIN crypto
 
-data ChainState crypto
-  = ChainState
-    { chainNes              :: NewEpochState crypto
-    , chainOCertIssue       :: Map.Map (KeyHash 'BlockIssuer crypto) Natural
-    , chainEpochNonce       :: Nonce
-    , chainEvolvingNonce    :: Nonce
-    , chainCandidateNonce   :: Nonce
-    , chainPrevEpochNonce   :: Nonce
-    , chainLastAppliedBlock :: WithOrigin (LastAppliedBlock crypto)
-    }
+data ChainState crypto = ChainState
+  { chainNes :: NewEpochState crypto,
+    chainOCertIssue :: Map.Map (KeyHash 'BlockIssuer crypto) Natural,
+    chainEpochNonce :: Nonce,
+    chainEvolvingNonce :: Nonce,
+    chainCandidateNonce :: Nonce,
+    chainPrevEpochNonce :: Nonce,
+    chainLastAppliedBlock :: WithOrigin (LastAppliedBlock crypto)
+  }
   deriving (Show, Eq)
 
--- |Creates a valid initial chain state
-initialShelleyState
-  :: WithOrigin (LastAppliedBlock crypto)
-  -> EpochNo
-  -> UTxO crypto
-  -> Coin
-  -> Map (KeyHash 'Genesis crypto) (KeyHash 'GenesisDelegate crypto)
-  -> Map SlotNo (OBftSlot crypto)
-  -> PParams
-  -> Nonce
-  -> ChainState crypto
+-- | Creates a valid initial chain state
+initialShelleyState ::
+  WithOrigin (LastAppliedBlock crypto) ->
+  EpochNo ->
+  UTxO crypto ->
+  Coin ->
+  Map (KeyHash 'Genesis crypto) (KeyHash 'GenesisDelegate crypto) ->
+  Map SlotNo (OBftSlot crypto) ->
+  PParams ->
+  Nonce ->
+  ChainState crypto
 initialShelleyState lab e utxo reserves genDelegs os pp initNonce =
   ChainState
-    (NewEpochState
-       e
-       (BlocksMade Map.empty)
-       (BlocksMade Map.empty)
-       (EpochState
-         (AccountState (Coin 0) reserves)
-         emptySnapShots
-         (LedgerState
-           (UTxOState
-             utxo
-             (Coin 0)
-             (Coin 0)
-             (ProposedPPUpdates Map.empty)
-           )
-           (DPState (emptyDState {_genDelegs = (GenDelegs genDelegs)}) emptyPState)
-         )
-         pp
-         pp
-         emptyNonMyopic
-       )
-       SNothing
-       (PoolDistr Map.empty)
-       os
+    ( NewEpochState
+        e
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        ( EpochState
+            (AccountState (Coin 0) reserves)
+            emptySnapShots
+            ( LedgerState
+                ( UTxOState
+                    utxo
+                    (Coin 0)
+                    (Coin 0)
+                    (ProposedPPUpdates Map.empty)
+                )
+                (DPState (emptyDState {_genDelegs = (GenDelegs genDelegs)}) emptyPState)
+            )
+            pp
+            pp
+            emptyNonMyopic
+        )
+        SNothing
+        (PoolDistr Map.empty)
+        os
     )
     cs
     initNonce
@@ -112,22 +148,24 @@ initialShelleyState lab e utxo reserves genDelegs os pp initNonce =
     NeutralNonce
     lab
   where
-    cs = Map.fromList (fmap (\hk -> (coerceKeyRole hk,0)) (Map.elems genDelegs))
+    cs = Map.fromList (fmap (\hk -> (coerceKeyRole hk, 0)) (Map.elems genDelegs))
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  , KESignable crypto (BHBody crypto)
-  , VRF.Signable (VRF crypto) Seed
-  )
-  => STS (CHAIN crypto)
- where
-  type State (CHAIN crypto)
-    = ChainState crypto
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    DSignable crypto (Hash crypto (TxBody crypto)),
+    KESignable crypto (BHBody crypto),
+    VRF.Signable (VRF crypto) Seed
+  ) =>
+  STS (CHAIN crypto)
+  where
+  type
+    State (CHAIN crypto) =
+      ChainState crypto
 
-  type Signal (CHAIN crypto)
-    = Block crypto
+  type
+    Signal (CHAIN crypto) =
+      Block crypto
 
   type Environment (CHAIN crypto) = SlotNo
   type BaseM (CHAIN crypto) = ShelleyBase
@@ -146,97 +184,99 @@ instance
 
 instance Crypto crypto => NoUnexpectedThunks (PredicateFailure (CHAIN crypto))
 
-chainChecks
-  :: (Crypto crypto, MonadError (PredicateFailure (CHAIN crypto)) m)
-  => Natural
-  -> PParams
-  -> BHeader crypto
-  -> m ()
+chainChecks ::
+  (Crypto crypto, MonadError (PredicateFailure (CHAIN crypto)) m) =>
+  Natural ->
+  PParams ->
+  BHeader crypto ->
+  m ()
 chainChecks maxpv pp bh = do
-  unless (m <= maxpv)                                     $ throwError (ObsoleteNodeCHAIN m maxpv)
+  unless (m <= maxpv) $ throwError (ObsoleteNodeCHAIN m maxpv)
   unless (fromIntegral (bHeaderSize bh) <= _maxBHSize pp) $ throwError HeaderSizeTooLargeCHAIN
-  unless (hBbsize (bhbody bh) <= _maxBBSize pp)           $ throwError BlockSizeTooLargeCHAIN
+  unless (hBbsize (bhbody bh) <= _maxBBSize pp) $ throwError BlockSizeTooLargeCHAIN
   where
     (ProtVer m _) = _protocolVersion pp
 
+chainTransition ::
+  forall crypto.
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    DSignable crypto (Hash crypto (TxBody crypto)),
+    KESignable crypto (BHBody crypto),
+    VRF.Signable (VRF crypto) Seed
+  ) =>
+  TransitionRule (CHAIN crypto)
+chainTransition =
+  judgmentContext
+    >>= \(TRC (sNow, ChainState nes cs eta0 etaV etaC etaH lab, block@(Block bh _))) -> do
+      let NewEpochState _ _ _ (EpochState _ _ _ _ pp _) _ _ _ = nes
 
-chainTransition
-  :: forall crypto
-   . ( Crypto crypto
-     , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-     , DSignable crypto (Hash crypto (TxBody crypto))
-     , KESignable crypto (BHBody crypto)
-     , VRF.Signable (VRF crypto) Seed
-     )
-  => TransitionRule (CHAIN crypto)
-chainTransition = judgmentContext >>=
-  \( TRC (sNow, ChainState nes cs eta0 etaV etaC etaH lab, block@(Block bh _))
-  ) -> do
+      maxpv <- liftSTS $ asks maxMajorPV
+      case chainChecks maxpv pp bh of
+        Right () -> pure ()
+        Left e -> failBecause e
 
-  let NewEpochState _ _ _ (EpochState _ _ _ _ pp _) _ _ _ = nes
+      let s = bheaderSlotNo $ bhbody bh
+      let gkeys = getGKeys nes
 
-  maxpv <- liftSTS $ asks maxMajorPV
-  case chainChecks maxpv pp bh of
-    Right () -> pure ()
-    Left e -> failBecause e
+      nes' <-
+        trans @(TICK crypto) $ TRC (TickEnv gkeys, nes, s)
 
-  let s = bheaderSlotNo $ bhbody bh
-  let gkeys = getGKeys nes
+      let NewEpochState e1 _ _ _ _ _ _ = nes
+          NewEpochState e2 _ bcur es _ _pd osched = nes'
+      let EpochState (AccountState _ _reserves) _ ls _ pp' _ = es
+      let LedgerState _ (DPState (DState _ _ _ _ _ _genDelegs _) (PState _ _ _)) = ls
 
-  nes' <-
-    trans @(TICK crypto) $ TRC (TickEnv gkeys, nes, s)
+      PrtclState cs' lab' eta0' etaV' etaC' etaH' <-
+        trans @(PRTCL crypto) $
+          TRC
+            ( PrtclEnv pp' osched _pd _genDelegs sNow (e1 /= e2),
+              PrtclState cs lab eta0 etaV etaC etaH,
+              bh
+            )
 
-  let NewEpochState e1 _ _ _ _ _ _ = nes
-      NewEpochState e2 _ bcur es _ _pd osched = nes'
-  let EpochState (AccountState _ _reserves) _ ls _ pp' _                     = es
-  let LedgerState _ (DPState (DState _ _ _ _ _ _genDelegs _) (PState _ _ _)) = ls
+      BbodyState ls' bcur' <-
+        trans @(BBODY crypto) $
+          TRC (BbodyEnv (Map.keysSet osched) pp' _reserves, BbodyState ls bcur, block)
 
-  PrtclState cs' lab' eta0' etaV' etaC' etaH' <- trans @(PRTCL crypto)
-    $ TRC ( PrtclEnv pp' osched _pd _genDelegs sNow (e1 /= e2)
-          , PrtclState cs lab eta0 etaV etaC etaH
-          , bh)
+      let nes'' = updateNES nes' bcur' ls'
 
-  BbodyState ls' bcur' <- trans @(BBODY crypto)
-    $ TRC (BbodyEnv (Map.keysSet osched) pp' _reserves, BbodyState ls bcur, block)
-
-  let nes'' = updateNES nes' bcur' ls'
-
-  pure $ ChainState nes'' cs' eta0' etaV' etaC' etaH' lab'
+      pure $ ChainState nes'' cs' eta0' etaV' etaC' etaH' lab'
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  , KESignable crypto (BHBody crypto)
-  , VRF.Signable (VRF crypto) Seed
-  )
-  => Embed (BBODY crypto) (CHAIN crypto)
- where
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    DSignable crypto (Hash crypto (TxBody crypto)),
+    KESignable crypto (BHBody crypto),
+    VRF.Signable (VRF crypto) Seed
+  ) =>
+  Embed (BBODY crypto) (CHAIN crypto)
+  where
   wrapFailed = BbodyFailure
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  , KESignable crypto (BHBody crypto)
-  , VRF.Signable (VRF crypto) Seed
-  )
-  => Embed (TICK crypto) (CHAIN crypto)
- where
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    DSignable crypto (Hash crypto (TxBody crypto)),
+    KESignable crypto (BHBody crypto),
+    VRF.Signable (VRF crypto) Seed
+  ) =>
+  Embed (TICK crypto) (CHAIN crypto)
+  where
   wrapFailed = TickFailure
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  , KESignable crypto (BHBody crypto)
-  , VRF.Signable (VRF crypto) Seed
-  )
-  => Embed (PRTCL crypto) (CHAIN crypto)
- where
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    DSignable crypto (Hash crypto (TxBody crypto)),
+    KESignable crypto (BHBody crypto),
+    VRF.Signable (VRF crypto) Seed
+  ) =>
+  Embed (PRTCL crypto) (CHAIN crypto)
+  where
   wrapFailed = PrtclFailure
 
--- |Calculate the total ada in the chain state
+-- | Calculate the total ada in the chain state
 totalAda :: ChainState crypto -> Coin
 totalAda (ChainState nes _ _ _ _ _ _) =
   treasury_ + reserves_ + rewards_ + circulation + deposits + fees_

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -6,45 +6,53 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Deleg
-  ( DELEG
-  , DelegEnv (..)
-  , PredicateFailure(..)
+  ( DELEG,
+    DelegEnv (..),
+    PredicateFailure (..),
   )
 where
 
-import           Byron.Spec.Ledger.Core (dom, range, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.Monad.Trans.Reader (asks)
-import           Control.State.Transition
-import           Data.List (foldl')
+import Byron.Spec.Ledger.Core (dom, range, singleton, (∈), (∉), (∪), (⋪), (⋫), (⨃))
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord)
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition
+import Data.List (foldl')
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import           Data.Typeable (Typeable)
-import           Data.Word (Word8)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Delegation.Certificates
-import           Shelley.Spec.Ledger.Keys
-import           Shelley.Spec.Ledger.LedgerState (DState, FutureGenDeleg (..), emptyDState,
-                     _delegations, _fGenDelegs, _genDelegs, _irwd, _ptrs, _rewards, _stkCreds)
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.TxData
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates
+import Shelley.Spec.Ledger.Keys
+import Shelley.Spec.Ledger.LedgerState
+  ( DState,
+    FutureGenDeleg (..),
+    _delegations,
+    _fGenDelegs,
+    _genDelegs,
+    _irwd,
+    _ptrs,
+    _rewards,
+    _stkCreds,
+    emptyDState,
+  )
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.TxData
 
 data DELEG crypto
 
-data DelegEnv
-  = DelegEnv
-  { slotNo    :: SlotNo
-  , ptr_      :: Ptr
-  , reserves_ :: Coin
+data DelegEnv = DelegEnv
+  { slotNo :: SlotNo,
+    ptr_ :: Ptr,
+    reserves_ :: Coin
   }
   deriving (Show, Eq)
 
-instance STS (DELEG crypto)
- where
+instance STS (DELEG crypto) where
   type State (DELEG crypto) = DState crypto
   type Signal (DELEG crypto) = DCert crypto
   type Environment (DELEG crypto) = DelegEnv
@@ -67,24 +75,24 @@ instance STS (DELEG crypto)
 instance NoUnexpectedThunks (PredicateFailure (DELEG crypto))
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBOR (PredicateFailure (DELEG crypto))
- where
-   toCBOR = \case
-      StakeKeyAlreadyRegisteredDELEG           -> toCBOR (0 :: Word8)
-      StakeKeyNotRegisteredDELEG               -> toCBOR (1 :: Word8)
-      StakeKeyNonZeroAccountBalanceDELEG       -> toCBOR (2 :: Word8)
-      StakeDelegationImpossibleDELEG           -> toCBOR (3 :: Word8)
-      WrongCertificateTypeDELEG                -> toCBOR (4 :: Word8)
-      GenesisKeyNotInpMappingDELEG             -> toCBOR (5 :: Word8)
-      DuplicateGenesisDelegateDELEG            -> toCBOR (6 :: Word8)
-      InsufficientForInstantaneousRewardsDELEG -> toCBOR (7 :: Word8)
-      MIRCertificateTooLateinEpochDELEG        -> toCBOR (8 :: Word8)
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (PredicateFailure (DELEG crypto))
+  where
+  toCBOR = \case
+    StakeKeyAlreadyRegisteredDELEG -> toCBOR (0 :: Word8)
+    StakeKeyNotRegisteredDELEG -> toCBOR (1 :: Word8)
+    StakeKeyNonZeroAccountBalanceDELEG -> toCBOR (2 :: Word8)
+    StakeDelegationImpossibleDELEG -> toCBOR (3 :: Word8)
+    WrongCertificateTypeDELEG -> toCBOR (4 :: Word8)
+    GenesisKeyNotInpMappingDELEG -> toCBOR (5 :: Word8)
+    DuplicateGenesisDelegateDELEG -> toCBOR (6 :: Word8)
+    InsufficientForInstantaneousRewardsDELEG -> toCBOR (7 :: Word8)
+    MIRCertificateTooLateinEpochDELEG -> toCBOR (8 :: Word8)
 
 instance
-  (Crypto crypto)
-  => FromCBOR (PredicateFailure (DELEG crypto))
- where
+  (Crypto crypto) =>
+  FromCBOR (PredicateFailure (DELEG crypto))
+  where
   fromCBOR = do
     decodeWord >>= \case
       0 -> pure StakeKeyAlreadyRegisteredDELEG
@@ -98,8 +106,8 @@ instance
       8 -> pure MIRCertificateTooLateinEpochDELEG
       k -> invalidKey k
 
-delegationTransition
-  :: TransitionRule (DELEG crypto)
+delegationTransition ::
+  TransitionRule (DELEG crypto)
 delegationTransition = do
   TRC (DelegEnv slot ptr reserves, ds, c) <- judgmentContext
 
@@ -108,12 +116,12 @@ delegationTransition = do
       -- note that pattern match is used instead of regCred, as in the spec
       hk ∉ dom (_stkCreds ds) ?! StakeKeyAlreadyRegisteredDELEG
 
-      pure $ ds
-        { _stkCreds  = _stkCreds ds  ∪ singleton hk slot
-        , _rewards = _rewards ds ∪ Map.singleton (RewardAcnt hk) (Coin 0) -- ∪ is override left
-        , _ptrs    = _ptrs ds    ∪ Map.singleton ptr hk
-        }
-
+      pure $
+        ds
+          { _stkCreds = _stkCreds ds ∪ singleton hk slot,
+            _rewards = _rewards ds ∪ Map.singleton (RewardAcnt hk) (Coin 0), -- ∪ is override left
+            _ptrs = _ptrs ds ∪ Map.singleton ptr hk
+          }
     DCertDeleg (DeRegKey hk) -> do
       -- note that pattern match is used instead of cwitness, as in the spec
       hk ∈ dom (_stkCreds ds) ?! StakeKeyNotRegisteredDELEG
@@ -121,20 +129,21 @@ delegationTransition = do
       let rewardCoin = Map.lookup (RewardAcnt hk) (_rewards ds)
       rewardCoin == Just 0 ?! StakeKeyNonZeroAccountBalanceDELEG
 
-      pure $ ds
-        { _stkCreds    = Set.singleton hk              ⋪ _stkCreds ds
-        , _rewards     = Set.singleton (RewardAcnt hk) ⋪ _rewards ds
-        , _delegations = Set.singleton hk              ⋪ _delegations ds
-        , _ptrs        = _ptrs ds                      ⋫ Set.singleton hk
-        }
-
+      pure $
+        ds
+          { _stkCreds = Set.singleton hk ⋪ _stkCreds ds,
+            _rewards = Set.singleton (RewardAcnt hk) ⋪ _rewards ds,
+            _delegations = Set.singleton hk ⋪ _delegations ds,
+            _ptrs = _ptrs ds ⋫ Set.singleton hk
+          }
     DCertDeleg (Delegate (Delegation hk dpool)) -> do
       -- note that pattern match is used instead of cwitness and dpool, as in the spec
       hk ∈ dom (_stkCreds ds) ?! StakeDelegationImpossibleDELEG
 
-      pure $ ds
-        { _delegations = _delegations ds ⨃ [(hk, dpool)] }
-
+      pure $
+        ds
+          { _delegations = _delegations ds ⨃ [(hk, dpool)]
+          }
     DCertGenesis (GenesisDelegCert gkh vkh) -> do
       sp <- liftSTS $ asks slotsPrior
       -- note that pattern match is used instead of genesisDeleg, as in the spec
@@ -143,9 +152,10 @@ delegationTransition = do
 
       gkh ∈ dom genDelegs ?! GenesisKeyNotInpMappingDELEG
       vkh ∉ range genDelegs ?! DuplicateGenesisDelegateDELEG
-      pure $ ds
-        { _fGenDelegs = _fGenDelegs ds ⨃ [(FutureGenDeleg s' gkh, vkh)]}
-
+      pure $
+        ds
+          { _fGenDelegs = _fGenDelegs ds ⨃ [(FutureGenDeleg s' gkh, vkh)]
+          }
     DCertMir (MIRCert credCoinMap) -> do
       sp <- liftSTS $ asks slotsPrior
       firstSlot <- liftSTS $ do
@@ -159,8 +169,7 @@ delegationTransition = do
           requiredForRewards = foldl' (+) (Coin 0) (range combinedMap)
       requiredForRewards <= reserves ?! InsufficientForInstantaneousRewardsDELEG
 
-      pure $ ds { _irwd = combinedMap }
-
+      pure $ ds {_irwd = combinedMap}
     _ -> do
       failBecause WrongCertificateTypeDELEG -- this always fails
       pure ds

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delegs.hs
@@ -9,50 +9,60 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Delegs
-  ( DELEGS
-  , DelegsEnv (..)
-  , PredicateFailure(..)
+  ( DELEGS,
+    DelegsEnv (..),
+    PredicateFailure (..),
   )
 where
 
-import           Byron.Spec.Ledger.Core (dom, (∈), (⊆), (⨃))
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLen, decodeWord,
-                     encodeListLen, matchSize)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.State.Transition
-import           Data.Sequence (Seq (..))
+import Byron.Spec.Ledger.Core (dom, (∈), (⊆), (⨃))
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    decodeListLen,
+    decodeWord,
+    encodeListLen,
+    matchSize,
+  )
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.State.Transition
+import Data.Sequence (Seq (..))
 import qualified Data.Set as Set
-import           Data.Typeable (Typeable)
-import           Data.Word (Word8)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.Coin (Coin)
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Delegation.Certificates
-import           Shelley.Spec.Ledger.LedgerState (DPState (..), emptyDelegation, _dstate, _rewards,
-                     _stPools)
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.STS.Delpl
-import           Shelley.Spec.Ledger.Tx
-import           Shelley.Spec.Ledger.TxData
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates
+import Shelley.Spec.Ledger.LedgerState
+  ( DPState (..),
+    _dstate,
+    _rewards,
+    _stPools,
+    emptyDelegation,
+  )
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.STS.Delpl
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.Tx
+import Shelley.Spec.Ledger.TxData
 
 data DELEGS crypto
 
-data DelegsEnv crypto
-  = DelegsEnv
-    { delegsSlotNo   :: SlotNo
-    , delegsIx       :: Ix
-    , delegspp       :: PParams
-    , delegsTx       :: (Tx crypto)
-    , delegsReserves :: Coin
-    }
-  deriving Show
+data DelegsEnv crypto = DelegsEnv
+  { delegsSlotNo :: SlotNo,
+    delegsIx :: Ix,
+    delegspp :: PParams,
+    delegsTx :: (Tx crypto),
+    delegsReserves :: Coin
+  }
+  deriving (Show)
 
 instance
-  Crypto crypto
-  => STS (DELEGS crypto)
- where
+  Crypto crypto =>
+  STS (DELEGS crypto)
+  where
   type State (DELEGS crypto) = DPState crypto
   type Signal (DELEGS crypto) = Seq (DCert crypto)
   type Environment (DELEGS crypto) = DelegsEnv crypto
@@ -63,74 +73,76 @@ instance
     | DelplFailure (PredicateFailure (DELPL crypto))
     deriving (Show, Eq, Generic)
 
-  initialRules    = [ pure emptyDelegation ]
-  transitionRules = [ delegsTransition     ]
+  initialRules = [pure emptyDelegation]
+  transitionRules = [delegsTransition]
 
 instance NoUnexpectedThunks (PredicateFailure (DELEGS crypto))
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBOR (PredicateFailure (DELEGS crypto))
- where
-   toCBOR = \case
-      DelegateeNotRegisteredDELEG   -> encodeListLen 1 <> toCBOR (0 :: Word8)
-      WithdrawalsNotInRewardsDELEGS -> encodeListLen 1 <> toCBOR (1 :: Word8)
-      (DelplFailure a)              -> encodeListLen 2 <> toCBOR (2 :: Word8)
-                                        <> toCBOR a
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (PredicateFailure (DELEGS crypto))
+  where
+  toCBOR = \case
+    DelegateeNotRegisteredDELEG -> encodeListLen 1 <> toCBOR (0 :: Word8)
+    WithdrawalsNotInRewardsDELEGS -> encodeListLen 1 <> toCBOR (1 :: Word8)
+    (DelplFailure a) ->
+      encodeListLen 2 <> toCBOR (2 :: Word8)
+        <> toCBOR a
 
 instance
-  (Crypto crypto)
-  => FromCBOR (PredicateFailure (DELEGS crypto))
- where
+  (Crypto crypto) =>
+  FromCBOR (PredicateFailure (DELEGS crypto))
+  where
   fromCBOR = do
     n <- decodeListLen
     decodeWord >>= \case
-      0 -> matchSize "DelegateeNotRegisteredDELEG" 1 n >>
-             pure DelegateeNotRegisteredDELEG
-      1 -> matchSize "WithdrawalsNotInRewardsDELEGS" 1 n >>
-             pure WithdrawalsNotInRewardsDELEGS
+      0 ->
+        matchSize "DelegateeNotRegisteredDELEG" 1 n
+          >> pure DelegateeNotRegisteredDELEG
+      1 ->
+        matchSize "WithdrawalsNotInRewardsDELEGS" 1 n
+          >> pure WithdrawalsNotInRewardsDELEGS
       2 -> do
         matchSize "DelplFailure" 2 n
         a <- fromCBOR
         pure $ DelplFailure a
       k -> invalidKey k
 
-delegsTransition
-  :: forall crypto
-   . Crypto crypto
-  => TransitionRule (DELEGS crypto)
+delegsTransition ::
+  forall crypto.
+  Crypto crypto =>
+  TransitionRule (DELEGS crypto)
 delegsTransition = do
   TRC (env@(DelegsEnv slot txIx pp tx reserves), dpstate, certificates) <- judgmentContext
 
   case certificates of
     Empty -> do
-      let ds       = _dstate dpstate
-          wdrls_   = unWdrl $ _wdrls (_body tx)
+      let ds = _dstate dpstate
+          wdrls_ = unWdrl $ _wdrls (_body tx)
           rewards = _rewards ds
 
       wdrls_ ⊆ rewards ?! WithdrawalsNotInRewardsDELEGS
 
       let rewards' = rewards ⨃ [(w, 0) | w <- Set.toList (dom wdrls_)]
 
-      pure $ dpstate { _dstate = ds { _rewards = rewards' } }
-
+      pure $ dpstate {_dstate = ds {_rewards = rewards'}}
     gamma :|> c -> do
       dpstate' <-
         trans @(DELEGS crypto) $ TRC (env, dpstate, gamma)
 
       let isDelegationRegistered = case c of
             DCertDeleg (Delegate deleg) ->
-              let StakePools stPools_ = _stPools $ _pstate dpstate' in
-              _delegatee deleg ∈ dom stPools_
+              let StakePools stPools_ = _stPools $ _pstate dpstate'
+               in _delegatee deleg ∈ dom stPools_
             _ -> True
       isDelegationRegistered ?! DelegateeNotRegisteredDELEG
 
       let ptr = Ptr slot txIx (fromIntegral $ length gamma)
-      trans @(DELPL crypto)
-        $ TRC (DelplEnv slot ptr pp reserves, dpstate', c)
+      trans @(DELPL crypto) $
+        TRC (DelplEnv slot ptr pp reserves, dpstate', c)
 
 instance
-  Crypto crypto
-  => Embed (DELPL crypto) (DELEGS crypto)
- where
+  Crypto crypto =>
+  Embed (DELPL crypto) (DELEGS crypto)
+  where
   wrapFailed = DelplFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Delpl.hs
@@ -9,46 +9,51 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Delpl
-  ( DELPL
-  , DelplEnv (..)
-  , PredicateFailure(..)
+  ( DELPL,
+    DelplEnv (..),
+    PredicateFailure (..),
   )
 where
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLen, decodeWord,
-                     encodeListLen, matchSize)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.State.Transition
-import           Data.Typeable (Typeable)
-import           Data.Word (Word8)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.Coin (Coin)
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Delegation.Certificates
-import           Shelley.Spec.Ledger.LedgerState (DPState, emptyDelegation, _dstate, _pstate)
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.STS.Deleg (DELEG, DelegEnv (..))
-import           Shelley.Spec.Ledger.STS.Pool
-import           Shelley.Spec.Ledger.TxData
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    decodeListLen,
+    decodeWord,
+    encodeListLen,
+    matchSize,
+  )
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.State.Transition
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates
+import Shelley.Spec.Ledger.LedgerState (DPState, _dstate, _pstate, emptyDelegation)
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.STS.Deleg (DELEG, DelegEnv (..))
+import Shelley.Spec.Ledger.STS.Pool
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.TxData
 
 data DELPL crypto
 
-data DelplEnv
-  = DelplEnv
-    { delplSlotNo   :: SlotNo
-    , delPlPtr      :: Ptr
-    , delPlPp       :: PParams
-    , delPlReserves :: Coin
-    }
+data DelplEnv = DelplEnv
+  { delplSlotNo :: SlotNo,
+    delPlPtr :: Ptr,
+    delPlPp :: PParams,
+    delPlReserves :: Coin
+  }
 
 instance
-  Crypto crypto
-  => STS (DELPL crypto)
- where
-  type State (DELPL crypto)       = DPState crypto
-  type Signal (DELPL crypto)      = DCert crypto
+  Crypto crypto =>
+  STS (DELPL crypto)
+  where
+  type State (DELPL crypto) = DPState crypto
+  type Signal (DELPL crypto) = DCert crypto
   type Environment (DELPL crypto) = DelplEnv
   type BaseM (DELPL crypto) = ShelleyBase
   data PredicateFailure (DELPL crypto)
@@ -59,28 +64,30 @@ instance
     | ScriptDoesNotValidateDELPL
     deriving (Show, Eq, Generic)
 
-  initialRules    = [ pure emptyDelegation ]
-  transitionRules = [ delplTransition      ]
+  initialRules = [pure emptyDelegation]
+  transitionRules = [delplTransition]
 
 instance NoUnexpectedThunks (PredicateFailure (DELPL crypto))
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBOR (PredicateFailure (DELPL crypto))
- where
-   toCBOR = \case
-      (PoolFailure a)            -> encodeListLen 2 <> toCBOR (0 :: Word8)
-                                      <> toCBOR a
-      (DelegFailure a)           -> encodeListLen 2 <> toCBOR (1 :: Word8)
-                                      <> toCBOR a
-      ScriptNotInWitnessDELPL    -> encodeListLen 1 <> toCBOR (2 :: Word8)
-      ScriptHashNotMatchDELPL    -> encodeListLen 1 <> toCBOR (3 :: Word8)
-      ScriptDoesNotValidateDELPL -> encodeListLen 1 <> toCBOR (4 :: Word8)
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (PredicateFailure (DELPL crypto))
+  where
+  toCBOR = \case
+    (PoolFailure a) ->
+      encodeListLen 2 <> toCBOR (0 :: Word8)
+        <> toCBOR a
+    (DelegFailure a) ->
+      encodeListLen 2 <> toCBOR (1 :: Word8)
+        <> toCBOR a
+    ScriptNotInWitnessDELPL -> encodeListLen 1 <> toCBOR (2 :: Word8)
+    ScriptHashNotMatchDELPL -> encodeListLen 1 <> toCBOR (3 :: Word8)
+    ScriptDoesNotValidateDELPL -> encodeListLen 1 <> toCBOR (4 :: Word8)
 
 instance
-  (Crypto crypto)
-  => FromCBOR (PredicateFailure (DELPL crypto))
- where
+  (Crypto crypto) =>
+  FromCBOR (PredicateFailure (DELPL crypto))
+  where
   fromCBOR = do
     n <- decodeListLen
     decodeWord >>= \case
@@ -92,63 +99,60 @@ instance
         matchSize "DelegFailure" 2 n
         a <- fromCBOR
         pure $ DelegFailure a
-      2 -> matchSize "ScriptNotInWitnessDELPL" 1 n >>
-             pure ScriptNotInWitnessDELPL
-      3 -> matchSize "ScriptHashNotMatchDELPL" 1 n >>
-             pure ScriptHashNotMatchDELPL
-      4 -> matchSize "ScriptDoesNotValidateDELPL" 1 n >>
-             pure ScriptDoesNotValidateDELPL
+      2 ->
+        matchSize "ScriptNotInWitnessDELPL" 1 n
+          >> pure ScriptNotInWitnessDELPL
+      3 ->
+        matchSize "ScriptHashNotMatchDELPL" 1 n
+          >> pure ScriptHashNotMatchDELPL
+      4 ->
+        matchSize "ScriptDoesNotValidateDELPL" 1 n
+          >> pure ScriptDoesNotValidateDELPL
       k -> invalidKey k
 
-
-delplTransition
-  :: forall crypto
-   . Crypto crypto
-  => TransitionRule (DELPL crypto)
+delplTransition ::
+  forall crypto.
+  Crypto crypto =>
+  TransitionRule (DELPL crypto)
 delplTransition = do
   TRC (DelplEnv slot ptr pp reserves, d, c) <- judgmentContext
   case c of
     DCertPool (RegPool _) -> do
       ps <-
         trans @(POOL crypto) $ TRC (PoolEnv slot pp, _pstate d, c)
-      pure $ d { _pstate = ps }
+      pure $ d {_pstate = ps}
     DCertPool (RetirePool _ _) -> do
       ps <-
         trans @(POOL crypto) $ TRC (PoolEnv slot pp, _pstate d, c)
-      pure $ d { _pstate = ps }
+      pure $ d {_pstate = ps}
     DCertGenesis (GenesisDelegCert {}) -> do
       ds <-
         trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
-      pure $ d { _dstate = ds }
-
+      pure $ d {_dstate = ds}
     DCertDeleg (RegKey _) -> do
       ds <-
         trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
-      pure $ d { _dstate = ds }
-
+      pure $ d {_dstate = ds}
     DCertDeleg (DeRegKey _) -> do
       ds <-
         trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
-      pure $ d { _dstate = ds }
-
+      pure $ d {_dstate = ds}
     DCertDeleg (Delegate _) -> do
       ds <-
-        trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves , _dstate d, c)
-      pure $ d { _dstate = ds }
-
+        trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
+      pure $ d {_dstate = ds}
     DCertMir _ -> do
-      ds <- trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves , _dstate d, c)
-      pure $ d { _dstate = ds }
-
+      ds <- trans @(DELEG crypto) $ TRC (DelegEnv slot ptr reserves, _dstate d, c)
+      pure $ d {_dstate = ds}
 
 instance
-  Crypto crypto
-  => Embed (POOL crypto) (DELPL crypto)
- where
+  Crypto crypto =>
+  Embed (POOL crypto) (DELPL crypto)
+  where
   wrapFailed = PoolFailure
 
 instance
-  Crypto crypto
-  => Embed (DELEG crypto) (DELPL crypto)
- where
+  Crypto crypto =>
+  Embed (DELEG crypto) (DELPL crypto)
+  where
   wrapFailed = DelegFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Epoch.hs
@@ -8,84 +8,102 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Epoch
-  ( EPOCH
-  , PredicateFailure(..)
+  ( EPOCH,
+    PredicateFailure (..),
   )
 where
 
-import           Cardano.Prelude (NoUnexpectedThunks (..), asks)
-import           Data.Map.Strict (Map)
+import Cardano.Prelude (NoUnexpectedThunks (..), asks)
+import Control.State.Transition
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.EpochBoundary
-import           Shelley.Spec.Ledger.LedgerState (pattern DPState, EpochState, pattern EpochState,
-                     emptyAccount, emptyLedgerState, esAccountState, esLState, esNonMyopic, esPp,
-                     esPrevPp, esSnapshots, _delegationState, _ppups, _utxoState)
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
-import           Shelley.Spec.Ledger.Slot
-
-import           Control.State.Transition
-
-import           Shelley.Spec.Ledger.STS.Newpp
-import           Shelley.Spec.Ledger.STS.PoolReap
-import           Shelley.Spec.Ledger.STS.Snap
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.EpochBoundary
+import Shelley.Spec.Ledger.LedgerState
+  ( EpochState,
+    _delegationState,
+    _ppups,
+    _utxoState,
+    emptyAccount,
+    emptyLedgerState,
+    esAccountState,
+    esLState,
+    esNonMyopic,
+    esPp,
+    esPrevPp,
+    esSnapshots,
+    pattern DPState,
+    pattern EpochState,
+  )
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
+import Shelley.Spec.Ledger.STS.Newpp
+import Shelley.Spec.Ledger.STS.PoolReap
+import Shelley.Spec.Ledger.STS.Snap
+import Shelley.Spec.Ledger.Slot
 
 data EPOCH crypto
 
 instance STS (EPOCH crypto) where
-    type State (EPOCH crypto) = EpochState crypto
-    type Signal (EPOCH crypto) = EpochNo
-    type Environment (EPOCH crypto) = ()
-    type BaseM (EPOCH crypto) = ShelleyBase
-    data PredicateFailure (EPOCH crypto)
-      = PoolReapFailure (PredicateFailure (POOLREAP crypto))
-      | SnapFailure (PredicateFailure (SNAP crypto))
-      | NewPpFailure (PredicateFailure (NEWPP crypto))
-      deriving (Show, Generic, Eq)
+  type State (EPOCH crypto) = EpochState crypto
+  type Signal (EPOCH crypto) = EpochNo
+  type Environment (EPOCH crypto) = ()
+  type BaseM (EPOCH crypto) = ShelleyBase
+  data PredicateFailure (EPOCH crypto)
+    = PoolReapFailure (PredicateFailure (POOLREAP crypto))
+    | SnapFailure (PredicateFailure (SNAP crypto))
+    | NewPpFailure (PredicateFailure (NEWPP crypto))
+    deriving (Show, Generic, Eq)
 
-    initialRules = [ initialEpoch ]
-    transitionRules = [ epochTransition ]
+  initialRules = [initialEpoch]
+  transitionRules = [epochTransition]
 
 instance NoUnexpectedThunks (PredicateFailure (EPOCH crypto))
 
 initialEpoch :: InitialRule (EPOCH crypto)
 initialEpoch =
-  pure $ EpochState
-           emptyAccount
-           emptySnapShots
-           emptyLedgerState
-           emptyPParams
-           emptyPParams
-           emptyNonMyopic
+  pure $
+    EpochState
+      emptyAccount
+      emptySnapShots
+      emptyLedgerState
+      emptyPParams
+      emptyPParams
+      emptyNonMyopic
 
-votedValuePParams
-  :: ProposedPPUpdates crypto
-  -> PParams
-  -> Int
-  -> Maybe PParams
+votedValuePParams ::
+  ProposedPPUpdates crypto ->
+  PParams ->
+  Int ->
+  Maybe PParams
 votedValuePParams (ProposedPPUpdates ppup) pps quorumN =
-  let
-    incrTally vote tally = 1 + Map.findWithDefault 0 vote tally
-    votes = Map.foldr
-              (\vote tally -> Map.insert vote (incrTally vote tally) tally)
-              (Map.empty :: Map PParamsUpdate Int)
-              ppup
-    consensus = Map.filter (>= quorumN) votes
-  in
-    case length consensus of
-      1 -> (Just . updatePParams pps . fst . head . Map.toList) consensus
-      _ -> Nothing
+  let incrTally vote tally = 1 + Map.findWithDefault 0 vote tally
+      votes =
+        Map.foldr
+          (\vote tally -> Map.insert vote (incrTally vote tally) tally)
+          (Map.empty :: Map PParamsUpdate Int)
+          ppup
+      consensus = Map.filter (>= quorumN) votes
+   in case length consensus of
+        1 -> (Just . updatePParams pps . fst . head . Map.toList) consensus
+        _ -> Nothing
 
-epochTransition :: forall crypto . TransitionRule (EPOCH crypto)
+epochTransition :: forall crypto. TransitionRule (EPOCH crypto)
 epochTransition = do
-  TRC (_, EpochState { esAccountState = acnt
-                     , esSnapshots = ss
-                     , esLState = ls
-                     , esPrevPp = _pr
-                     , esPp = pp
-                     , esNonMyopic = nm}, e) <- judgmentContext
+  TRC
+    ( _,
+      EpochState
+        { esAccountState = acnt,
+          esSnapshots = ss,
+          esLState = ls,
+          esPrevPp = _pr,
+          esPp = pp,
+          esNonMyopic = nm
+        },
+      e
+      ) <-
+    judgmentContext
   let utxoSt = _utxoState ls
   let DPState dstate pstate = _delegationState ls
   SnapState ss' utxoSt' <-
@@ -98,21 +116,22 @@ epochTransition = do
   let ppup = _ppups utxoSt
   let ppNew = votedValuePParams ppup pp (fromIntegral coreNodeQuorum)
   NewppState utxoSt''' acnt'' pp' <-
-    trans @(NEWPP crypto)
-      $ TRC (NewppEnv ppNew dstate' pstate', NewppState utxoSt'' acnt' pp, e)
-  pure $ EpochState
-    acnt''
-    ss'
-    (ls { _utxoState = utxoSt''', _delegationState = DPState dstate' pstate' })
-    pp
-    pp'
-    nm
+    trans @(NEWPP crypto) $
+      TRC (NewppEnv ppNew dstate' pstate', NewppState utxoSt'' acnt' pp, e)
+  pure $
+    EpochState
+      acnt''
+      ss'
+      (ls {_utxoState = utxoSt''', _delegationState = DPState dstate' pstate'})
+      pp
+      pp'
+      nm
 
 instance Embed (SNAP crypto) (EPOCH crypto) where
-    wrapFailed = SnapFailure
+  wrapFailed = SnapFailure
 
 instance Embed (POOLREAP crypto) (EPOCH crypto) where
-    wrapFailed = PoolReapFailure
+  wrapFailed = PoolReapFailure
 
 instance Embed (NEWPP crypto) (EPOCH crypto) where
-    wrapFailed = NewPpFailure
+  wrapFailed = NewPpFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -12,55 +12,73 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Ledger
-  ( LEDGER
-  , LedgerEnv (..)
-  , PredicateFailure(..)
+  ( LEDGER,
+    LedgerEnv (..),
+    PredicateFailure (..),
   )
 where
 
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLen, decodeWord,
-                     encodeListLen, matchSize)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.State.Transition
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    decodeListLen,
+    decodeWord,
+    encodeListLen,
+    matchSize,
+  )
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.State.Transition
 import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Typeable (Typeable)
-import           Data.Word (Word8)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.Coin (Coin)
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Keys
-import           Shelley.Spec.Ledger.LedgerState (DPState (..), DState (..), Ix, PState (..),
-                     UTxOState)
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.STS.Delegs
-import           Shelley.Spec.Ledger.STS.Utxo (pattern BadInputsUTxO, pattern ExpiredUTxO,
-                     pattern FeeTooSmallUTxO, pattern InputSetEmptyUTxO, pattern MaxTxSizeUTxO,
-                     pattern NegativeOutputsUTxO, pattern UpdateFailure, UtxoEnv (..),
-                     pattern ValueNotConservedUTxO)
-import           Shelley.Spec.Ledger.STS.Utxow
-import           Shelley.Spec.Ledger.Tx
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Keys
+import Shelley.Spec.Ledger.LedgerState
+  ( DPState (..),
+    DState (..),
+    Ix,
+    PState (..),
+    UTxOState,
+  )
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.STS.Delegs
+import Shelley.Spec.Ledger.STS.Utxo
+  ( UtxoEnv (..),
+    pattern BadInputsUTxO,
+    pattern ExpiredUTxO,
+    pattern FeeTooSmallUTxO,
+    pattern InputSetEmptyUTxO,
+    pattern MaxTxSizeUTxO,
+    pattern NegativeOutputsUTxO,
+    pattern UpdateFailure,
+    pattern ValueNotConservedUTxO,
+  )
+import Shelley.Spec.Ledger.STS.Utxow
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.Tx
 
 data LEDGER crypto
 
-data LedgerEnv
-  = LedgerEnv
-    { ledgerSlotNo   :: SlotNo
-    , ledgerIx       :: Ix
-    , ledgerPp       :: PParams
-    , ledgerReserves :: Coin
-    }
+data LedgerEnv = LedgerEnv
+  { ledgerSlotNo :: SlotNo,
+    ledgerIx :: Ix,
+    ledgerPp :: PParams,
+    ledgerReserves :: Coin
+  }
   deriving (Show)
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  )
-  => STS (LEDGER crypto)
- where
-  type State (LEDGER crypto)
-    = (UTxOState crypto, DPState crypto)
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  STS (LEDGER crypto)
+  where
+  type
+    State (LEDGER crypto) =
+      (UTxOState crypto, DPState crypto)
   type Signal (LEDGER crypto) = Tx crypto
   type Environment (LEDGER crypto) = LedgerEnv
   type BaseM (LEDGER crypto) = ShelleyBase
@@ -75,17 +93,17 @@ instance
 instance NoUnexpectedThunks (PredicateFailure (LEDGER crypto))
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBOR (PredicateFailure (LEDGER crypto))
- where
-   toCBOR = \case
-      (UtxowFailure a)  -> encodeListLen 2 <> toCBOR (0 :: Word8) <> toCBOR a
-      (DelegsFailure a) -> encodeListLen 2 <> toCBOR (1 :: Word8) <> toCBOR a
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (PredicateFailure (LEDGER crypto))
+  where
+  toCBOR = \case
+    (UtxowFailure a) -> encodeListLen 2 <> toCBOR (0 :: Word8) <> toCBOR a
+    (DelegsFailure a) -> encodeListLen 2 <> toCBOR (1 :: Word8) <> toCBOR a
 
 instance
-  (Crypto crypto)
-  => FromCBOR (PredicateFailure (LEDGER crypto))
- where
+  (Crypto crypto) =>
+  FromCBOR (PredicateFailure (LEDGER crypto))
+  where
   fromCBOR = do
     n <- decodeListLen
     decodeWord >>= \case
@@ -99,43 +117,44 @@ instance
         pure $ DelegsFailure a
       k -> invalidKey k
 
-ledgerTransition
-  :: forall crypto
-   . ( Crypto crypto
-     , DSignable crypto (Hash crypto (TxBody crypto))
-     )
-  => TransitionRule (LEDGER crypto)
+ledgerTransition ::
+  forall crypto.
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  TransitionRule (LEDGER crypto)
 ledgerTransition = do
   TRC (LedgerEnv slot txIx pp reserves, (utxoSt, dpstate), tx) <- judgmentContext
 
   dpstate' <-
-    trans @(DELEGS crypto)
-      $ TRC (DelegsEnv slot txIx pp tx reserves, dpstate, StrictSeq.getSeq $ _certs $ _body tx)
+    trans @(DELEGS crypto) $
+      TRC (DelegsEnv slot txIx pp tx reserves, dpstate, StrictSeq.getSeq $ _certs $ _body tx)
 
-  let
-    DPState dstate pstate = dpstate
-    DState stkCreds _ _ _ _ genDelegs _ = dstate
-    PState stpools _ _ = pstate
+  let DPState dstate pstate = dpstate
+      DState stkCreds _ _ _ _ genDelegs _ = dstate
+      PState stpools _ _ = pstate
 
-  utxoSt' <- trans @(UTXOW crypto) $ TRC
-    ( UtxoEnv slot pp stkCreds stpools genDelegs
-    , utxoSt
-    , tx
-    )
+  utxoSt' <-
+    trans @(UTXOW crypto) $
+      TRC
+        ( UtxoEnv slot pp stkCreds stpools genDelegs,
+          utxoSt,
+          tx
+        )
   pure (utxoSt', dpstate')
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  )
-  => Embed (DELEGS crypto) (LEDGER crypto)
- where
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  Embed (DELEGS crypto) (LEDGER crypto)
+  where
   wrapFailed = DelegsFailure
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  )
-  => Embed (UTXOW crypto) (LEDGER crypto)
- where
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  Embed (UTXOW crypto) (LEDGER crypto)
+  where
   wrapFailed = UtxowFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Mir.hs
@@ -9,59 +9,82 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Mir
-  ( MIR
-  , PredicateFailure
+  ( MIR,
+    PredicateFailure,
   )
 where
 
-import           Byron.Spec.Ledger.Core (dom, (∪+), (◁))
-import           Cardano.Prelude (NoUnexpectedThunks (..))
+import Byron.Spec.Ledger.Core (dom, (∪+), (◁))
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.State.Transition
 import qualified Data.Map.Strict as Map
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.Address (mkRwdAcnt)
-import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
-import           Shelley.Spec.Ledger.Delegation.Certificates (StakeCreds (..))
-import           Shelley.Spec.Ledger.EpochBoundary (emptySnapShots)
-import           Shelley.Spec.Ledger.LedgerState (EpochState, pattern EpochState, emptyAccount,
-                     emptyLedgerState, esAccountState, esLState, esNonMyopic, esPp, esPrevPp,
-                     esSnapshots, _delegationState, _dstate, _irwd, _reserves, _rewards, _stkCreds)
-import           Shelley.Spec.Ledger.PParams (emptyPParams)
-import           Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
-
-import           Control.State.Transition
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.Address (mkRwdAcnt)
+import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
+import Shelley.Spec.Ledger.Delegation.Certificates (StakeCreds (..))
+import Shelley.Spec.Ledger.EpochBoundary (emptySnapShots)
+import Shelley.Spec.Ledger.LedgerState
+  ( EpochState,
+    _delegationState,
+    _dstate,
+    _irwd,
+    _reserves,
+    _rewards,
+    _stkCreds,
+    emptyAccount,
+    emptyLedgerState,
+    esAccountState,
+    esLState,
+    esNonMyopic,
+    esPp,
+    esPrevPp,
+    esSnapshots,
+    pattern EpochState,
+  )
+import Shelley.Spec.Ledger.PParams (emptyPParams)
+import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
 
 data MIR crypto
 
 instance STS (MIR crypto) where
-    type State (MIR crypto) = EpochState crypto
-    type Signal (MIR crypto) = ()
-    type Environment (MIR crypto) = ()
-    type BaseM (MIR crypto) = ShelleyBase
-    data PredicateFailure (MIR crypto)
-      deriving (Show, Generic, Eq)
+  type State (MIR crypto) = EpochState crypto
+  type Signal (MIR crypto) = ()
+  type Environment (MIR crypto) = ()
+  type BaseM (MIR crypto) = ShelleyBase
+  data PredicateFailure (MIR crypto)
+    deriving (Show, Generic, Eq)
 
-    initialRules = [ initialMir ]
-    transitionRules = [ mirTransition ]
+  initialRules = [initialMir]
+  transitionRules = [mirTransition]
 
 instance NoUnexpectedThunks (PredicateFailure (MIR crypto))
 
 initialMir :: InitialRule (MIR crypto)
-initialMir = pure $ EpochState
-                      emptyAccount
-                      emptySnapShots
-                      emptyLedgerState
-                      emptyPParams
-                      emptyPParams
-                      emptyNonMyopic
+initialMir =
+  pure $
+    EpochState
+      emptyAccount
+      emptySnapShots
+      emptyLedgerState
+      emptyPParams
+      emptyPParams
+      emptyNonMyopic
 
-mirTransition :: forall crypto . TransitionRule (MIR crypto)
+mirTransition :: forall crypto. TransitionRule (MIR crypto)
 mirTransition = do
-  TRC (_, EpochState { esAccountState = acnt
-                     , esSnapshots = ss
-                     , esLState = ls
-                     , esPrevPp = pr
-                     , esPp = pp
-                     , esNonMyopic = nm}, ()) <- judgmentContext
+  TRC
+    ( _,
+      EpochState
+        { esAccountState = acnt,
+          esSnapshots = ss,
+          esLState = ls,
+          esPrevPp = pr,
+          esPp = pp,
+          esNonMyopic = nm
+        },
+      ()
+      ) <-
+    judgmentContext
   let dpState = _delegationState ls
       dState = _dstate dpState
       StakeCreds stkcreds = _stkCreds dState
@@ -70,22 +93,36 @@ mirTransition = do
       reserves = _reserves acnt
       update = Map.mapKeys mkRwdAcnt irwd'
   if tot <= reserves
-    then pure $ EpochState
-                  acnt { _reserves = reserves - tot }
-                  ss
-                  ls { _delegationState =
-                         dpState {  _dstate =
-                           dState  { _rewards = (_rewards dState) ∪+ update
-                                   , _irwd = Map.empty } } }
-                  pr
-                  pp
-                  nm
-    else pure $ EpochState
-                  acnt
-                  ss
-                  ls { _delegationState =
-                         dpState {  _dstate =
-                           dState  { _irwd = Map.empty } } }
-                  pr
-                  pp
-                  nm
+    then
+      pure $
+        EpochState
+          acnt {_reserves = reserves - tot}
+          ss
+          ls
+            { _delegationState =
+                dpState
+                  { _dstate =
+                      dState
+                        { _rewards = (_rewards dState) ∪+ update,
+                          _irwd = Map.empty
+                        }
+                  }
+            }
+          pr
+          pp
+          nm
+    else
+      pure $
+        EpochState
+          acnt
+          ss
+          ls
+            { _delegationState =
+                dpState
+                  { _dstate =
+                      dState {_irwd = Map.empty}
+                  }
+            }
+          pr
+          pp
+          nm

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/NewEpoch.hs
@@ -8,27 +8,27 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.NewEpoch
-  ( NEWEPOCH
-  , PredicateFailure(..)
-  , calculatePoolDistr
+  ( NEWEPOCH,
+    PredicateFailure (..),
+    calculatePoolDistr,
   )
 where
 
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.State.Transition
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.State.Transition
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.Coin
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Delegation.Certificates
-import           Shelley.Spec.Ledger.EpochBoundary
-import           Shelley.Spec.Ledger.LedgerState
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.STS.Epoch
-import           Shelley.Spec.Ledger.STS.Mir
-import           Shelley.Spec.Ledger.TxData
+import Data.Maybe (catMaybes)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates
+import Shelley.Spec.Ledger.EpochBoundary
+import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.STS.Epoch
+import Shelley.Spec.Ledger.STS.Mir
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.TxData
 
 data NEWEPOCH crypto
 
@@ -36,7 +36,6 @@ instance
   Crypto crypto =>
   STS (NEWEPOCH crypto)
   where
-
   type State (NEWEPOCH crypto) = NewEpochState crypto
 
   type Signal (NEWEPOCH crypto) = EpochNo
@@ -82,11 +81,11 @@ newEpochTransition = do
     then pure src
     else do
       es' <- case ru of
-               SNothing  -> pure es
-               SJust ru' -> do
-                 let RewardUpdate dt dr rs_ df _ = ru'
-                 dt + dr + (sum rs_) + df == 0 ?! CorruptRewardUpdate ru'
-                 pure $ applyRUpd ru' es
+        SNothing -> pure es
+        SJust ru' -> do
+          let RewardUpdate dt dr rs_ df _ = ru'
+          dt + dr + (sum rs_) + df == 0 ?! CorruptRewardUpdate ru'
+          pure $ applyRUpd ru' es
 
       es'' <- trans @(MIR crypto) $ TRC ((), es', ())
       es''' <- trans @(EPOCH crypto) $ TRC ((), es'', e)
@@ -104,18 +103,17 @@ newEpochTransition = do
           osched'
 
 calculatePoolDistr :: SnapShot crypto -> PoolDistr crypto
-calculatePoolDistr (SnapShot (Stake stake) delegs poolParams)
-  = let
-      Coin total = Map.foldl' (+) (Coin 0) stake
+calculatePoolDistr (SnapShot (Stake stake) delegs poolParams) =
+  let Coin total = Map.foldl' (+) (Coin 0) stake
       sd =
-            Map.fromListWith (+) $
-              catMaybes
-                [ (,fromIntegral c / fromIntegral (if total == 0 then 1 else total)) <$>
-                  Map.lookup hk delegs -- TODO mgudemann total could be zero (in
-                                       -- particular when shrinking)
-                  | (hk, Coin c) <- Map.toList stake
-                ]
-    in PoolDistr $ Map.intersectionWith (,) sd (Map.map _poolVrf poolParams)
+        Map.fromListWith (+) $
+          catMaybes
+            [ (,fromIntegral c / fromIntegral (if total == 0 then 1 else total))
+                <$> Map.lookup hk delegs -- TODO mgudemann total could be zero (in
+                  -- particular when shrinking)
+              | (hk, Coin c) <- Map.toList stake
+            ]
+   in PoolDistr $ Map.intersectionWith (,) sd (Map.map _poolVrf poolParams)
 
 instance
   Crypto crypto =>

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ocert.hs
@@ -7,38 +7,40 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Ocert
-  ( OCERT
-  , PredicateFailure(..)
-  , OCertEnv(..)
+  ( OCERT,
+    PredicateFailure (..),
+    OCertEnv (..),
   )
 where
 
-import           Byron.Spec.Ledger.Core ((⨃))
-import           Cardano.Prelude (NoUnexpectedThunks, asks)
-import           Control.State.Transition
-import           Data.Map.Strict (Map)
+import Byron.Spec.Ledger.Core ((⨃))
+import Cardano.Prelude (NoUnexpectedThunks, asks)
+import Control.State.Transition
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.BlockChain
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Keys
-import           Shelley.Spec.Ledger.OCert
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.BlockChain
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Keys
+import Shelley.Spec.Ledger.OCert
 
 data OCERT crypto
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , KESignable crypto (BHBody crypto)
-  )
-  => STS (OCERT crypto)
- where
-  type State (OCERT crypto)
-    = Map (KeyHash 'BlockIssuer crypto) Natural
-  type Signal (OCERT crypto)
-    = BHeader crypto
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    KESignable crypto (BHBody crypto)
+  ) =>
+  STS (OCERT crypto)
+  where
+  type
+    State (OCERT crypto) =
+      Map (KeyHash 'BlockIssuer crypto) Natural
+  type
+    Signal (OCERT crypto) =
+      BHeader crypto
   type Environment (OCERT crypto) = OCertEnv crypto
   type BaseM (OCERT crypto) = ShelleyBase
   data PredicateFailure (OCERT crypto)
@@ -55,12 +57,12 @@ instance
 
 instance NoUnexpectedThunks (PredicateFailure (OCERT crypto))
 
-ocertTransition
-  :: ( Crypto crypto
-     , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-     , KESignable crypto (BHBody crypto)
-     )
-  => TransitionRule (OCERT crypto)
+ocertTransition ::
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    KESignable crypto (BHBody crypto)
+  ) =>
+  TransitionRule (OCERT crypto)
 ocertTransition = judgmentContext >>= \(TRC (env, cs, BHeader bhb sigma)) -> do
   let OCert vk_hot n c0@(KESPeriod c0_) tau = bheaderOCert bhb
       vkey = bheaderVk bhb
@@ -74,12 +76,11 @@ ocertTransition = judgmentContext >>= \(TRC (env, cs, BHeader bhb sigma)) -> do
   kp_ < c0_ + (fromIntegral maxKESiterations) ?! KESAfterEndOCERT
 
   let t = if kp_ >= c0_ then kp_ - c0_ else 0 -- this is required to prevent an
-                                              -- arithmetic underflow, in the
-                                              -- case of kp_ < c0_ we get the
-                                              -- above `KESBeforeStartOCERT`
-                                              -- predicate failure in the
-                                              -- transition.
-
+      -- arithmetic underflow, in the
+      -- case of kp_ < c0_ we get the
+      -- above `KESBeforeStartOCERT`
+      -- predicate failure in the
+      -- transition.
   verifySignedDSIGN vkey (vk_hot, n, c0) tau ?! InvalidSignatureOCERT
   verifySignedKES () vk_hot t bhb sigma ?!: InvalidKesSignatureOCERT
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Overlay.hs
@@ -10,33 +10,39 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Overlay
-  ( OVERLAY
-  , PredicateFailure(..)
-  , OverlayEnv(..)
+  ( OVERLAY,
+    PredicateFailure (..),
+    OverlayEnv (..),
   )
 where
 
-import           Byron.Spec.Ledger.Core (dom, range)
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
-import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
-
-import           Cardano.Prelude (asks)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce, Seed, ShelleyBase, activeSlotCoeff)
-import           Shelley.Spec.Ledger.BlockChain (BHBody (..), BHeader (..), vrfChecks)
-import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr)
-import           Shelley.Spec.Ledger.Keys (DSignable, GenDelegs (..), KESignable, KeyHash,
-                     KeyRole (..), VerKeyKES, coerceKeyRole, hashKey)
-import           Shelley.Spec.Ledger.LedgerState (OBftSlot (..))
-import           Shelley.Spec.Ledger.OCert (KESPeriod)
-import           Shelley.Spec.Ledger.Slot (SlotNo)
-import           Shelley.Spec.Ledger.STS.Ocert (OCERT, OCertEnv (..))
-
+import Byron.Spec.Ledger.Core (dom, range)
 import qualified Cardano.Crypto.VRF as VRF
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.State.Transition
-import           Shelley.Spec.Ledger.Crypto
+import Cardano.Prelude (asks)
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.State.Transition
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes (Nonce, Seed, ShelleyBase, activeSlotCoeff)
+import Shelley.Spec.Ledger.BlockChain (BHBody (..), BHeader (..), vrfChecks)
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr)
+import Shelley.Spec.Ledger.Keys
+  ( DSignable,
+    GenDelegs (..),
+    KESignable,
+    KeyHash,
+    KeyRole (..),
+    VerKeyKES,
+    coerceKeyRole,
+    hashKey,
+  )
+import Shelley.Spec.Ledger.LedgerState (OBftSlot (..))
+import Shelley.Spec.Ledger.OCert (KESPeriod)
+import Shelley.Spec.Ledger.STS.Ocert (OCERT, OCertEnv (..))
+import Shelley.Spec.Ledger.Slot (SlotNo)
 
 data OVERLAY crypto
 
@@ -46,23 +52,25 @@ data OverlayEnv crypto
       Nonce
       (PoolDistr crypto)
       (GenDelegs crypto)
-  deriving Generic
+  deriving (Generic)
 
 instance NoUnexpectedThunks (OverlayEnv crypto)
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , KESignable crypto (BHBody crypto)
-  , VRF.Signable (VRF crypto) Seed
-  )
-  => STS (OVERLAY crypto)
- where
-  type State (OVERLAY crypto)
-    = Map (KeyHash 'BlockIssuer crypto) Natural
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    KESignable crypto (BHBody crypto),
+    VRF.Signable (VRF crypto) Seed
+  ) =>
+  STS (OVERLAY crypto)
+  where
+  type
+    State (OVERLAY crypto) =
+      Map (KeyHash 'BlockIssuer crypto) Natural
 
-  type Signal (OVERLAY crypto)
-    = BHeader crypto
+  type
+    Signal (OVERLAY crypto) =
+      BHeader crypto
 
   type Environment (OVERLAY crypto) = OverlayEnv crypto
   type BaseM (OVERLAY crypto) = ShelleyBase
@@ -79,50 +87,55 @@ instance
 
   transitionRules = [overlayTransition]
 
-overlayTransition
-  :: forall crypto
-   . ( Crypto crypto
-     , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-     , KESignable crypto (BHBody crypto)
-     , VRF.Signable (VRF crypto) Seed
-     )
-  => TransitionRule (OVERLAY crypto)
-overlayTransition = judgmentContext >>=
-  \( TRC ( OverlayEnv osched eta0 pd (GenDelegs genDelegs)
-      , cs
-      , bh@(BHeader bhb _))
-   ) -> do
-  let vk = bheaderVk bhb
-      vkh = hashKey vk
+overlayTransition ::
+  forall crypto.
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    KESignable crypto (BHBody crypto),
+    VRF.Signable (VRF crypto) Seed
+  ) =>
+  TransitionRule (OVERLAY crypto)
+overlayTransition =
+  judgmentContext
+    >>= \( TRC
+             ( OverlayEnv osched eta0 pd (GenDelegs genDelegs),
+               cs,
+               bh@(BHeader bhb _)
+               )
+           ) -> do
+        let vk = bheaderVk bhb
+            vkh = hashKey vk
 
-  asc <- liftSTS $ asks activeSlotCoeff
+        asc <- liftSTS $ asks activeSlotCoeff
 
-  case Map.lookup (bheaderSlotNo bhb) osched of
-    Nothing ->
-      vrfChecks eta0 pd asc bhb ?! NotPraosLeaderOVERLAY
-    Just NonActiveSlot ->
-      failBecause NotActiveSlotOVERLAY
-    Just (ActiveSlot gkey) ->
-      case Map.lookup gkey genDelegs of
-        Nothing ->
-          failBecause NoGenesisStakingOVERLAY
-        Just genDelegsKey ->
-          vkh == coerceKeyRole genDelegsKey ?! WrongGenesisColdKeyOVERLAY vkh genDelegsKey
+        case Map.lookup (bheaderSlotNo bhb) osched of
+          Nothing ->
+            vrfChecks eta0 pd asc bhb ?! NotPraosLeaderOVERLAY
+          Just NonActiveSlot ->
+            failBecause NotActiveSlotOVERLAY
+          Just (ActiveSlot gkey) ->
+            case Map.lookup gkey genDelegs of
+              Nothing ->
+                failBecause NoGenesisStakingOVERLAY
+              Just genDelegsKey ->
+                vkh == coerceKeyRole genDelegsKey ?! WrongGenesisColdKeyOVERLAY vkh genDelegsKey
 
-  let
-    oce = OCertEnv
-      { ocertEnvStPools = dom pd, ocertEnvGenDelegs = range genDelegs }
+        let oce =
+              OCertEnv
+                { ocertEnvStPools = dom pd,
+                  ocertEnvGenDelegs = range genDelegs
+                }
 
-  trans @(OCERT crypto) $ TRC (oce, cs, bh)
+        trans @(OCERT crypto) $ TRC (oce, cs, bh)
 
 instance NoUnexpectedThunks (PredicateFailure (OVERLAY crypto))
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (VerKeyKES crypto, Natural, KESPeriod)
-  , KESignable crypto (BHBody crypto)
-  , VRF.Signable (VRF crypto) Seed
-  )
-  => Embed (OCERT crypto) (OVERLAY crypto)
- where
+  ( Crypto crypto,
+    DSignable crypto (VerKeyKES crypto, Natural, KESPeriod),
+    KESignable crypto (BHBody crypto),
+    VRF.Signable (VRF crypto) Seed
+  ) =>
+  Embed (OCERT crypto) (OVERLAY crypto)
+  where
   wrapFailed = OcertFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Pool.hs
@@ -6,31 +6,31 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Pool
-  ( POOL
-  , PoolEnv(..)
-  , PredicateFailure(..)
+  ( POOL,
+    PoolEnv (..),
+    PredicateFailure (..),
   )
 where
 
-import           Byron.Spec.Ledger.Core (dom, (∈), (∉), (⋪))
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord)
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.Monad.Trans.Reader (asks)
-import           Control.State.Transition
-import           Data.Map.Strict (Map)
+import Byron.Spec.Ledger.Core (dom, (∈), (∉), (⋪))
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeWord)
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import           Data.Typeable (Typeable)
-import           Data.Word (Word8)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Delegation.Certificates
-import           Shelley.Spec.Ledger.Keys
-import           Shelley.Spec.Ledger.LedgerState
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.TxData
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates
+import Shelley.Spec.Ledger.Keys
+import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.TxData
 
 data POOL crypto
 
@@ -39,7 +39,6 @@ data PoolEnv
   deriving (Show, Eq)
 
 instance STS (POOL crypto) where
-
   type State (POOL crypto) = PState crypto
 
   type Signal (POOL crypto) = DCert crypto
@@ -61,18 +60,18 @@ instance STS (POOL crypto) where
 instance NoUnexpectedThunks (PredicateFailure (POOL crypto))
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBOR (PredicateFailure (POOL crypto))
- where
-   toCBOR = \case
-      StakePoolNotRegisteredOnKeyPOOL   -> toCBOR (0 :: Word8)
-      StakePoolRetirementWrongEpochPOOL -> toCBOR (1 :: Word8)
-      WrongCertificateTypePOOL          -> toCBOR (2 :: Word8)
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (PredicateFailure (POOL crypto))
+  where
+  toCBOR = \case
+    StakePoolNotRegisteredOnKeyPOOL -> toCBOR (0 :: Word8)
+    StakePoolRetirementWrongEpochPOOL -> toCBOR (1 :: Word8)
+    WrongCertificateTypePOOL -> toCBOR (2 :: Word8)
 
 instance
-  (Crypto crypto)
-  => FromCBOR (PredicateFailure (POOL crypto))
- where
+  (Crypto crypto) =>
+  FromCBOR (PredicateFailure (POOL crypto))
+  where
   fromCBOR = do
     decodeWord >>= \case
       0 -> pure StakePoolNotRegisteredOnKeyPOOL

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
@@ -5,25 +5,40 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Rupd
-  ( RUPD
-  , RupdEnv(..)
-  , PredicateFailure
+  ( RUPD,
+    RupdEnv (..),
+    PredicateFailure,
   )
 where
 
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.Monad.Trans.Reader (asks)
-import           Control.State.Transition (STS (..), TRC (..), TransitionRule, judgmentContext,
-                     liftSTS)
-import           Data.Functor ((<&>))
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), epochInfo,
-                     maxLovelaceSupply, startRewards)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade)
-import           Shelley.Spec.Ledger.LedgerState (EpochState, RewardUpdate, createRUpd)
-import           Shelley.Spec.Ledger.Slot (Duration (..), SlotNo, epochInfoEpoch, epochInfoFirst,
-                     (+*))
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition
+  ( STS (..),
+    TRC (..),
+    TransitionRule,
+    judgmentContext,
+    liftSTS,
+  )
+import Data.Functor ((<&>))
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+  ( ShelleyBase,
+    StrictMaybe (..),
+    epochInfo,
+    maxLovelaceSupply,
+    startRewards,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.EpochBoundary (BlocksMade)
+import Shelley.Spec.Ledger.LedgerState (EpochState, RewardUpdate, createRUpd)
+import Shelley.Spec.Ledger.Slot
+  ( (+*),
+    Duration (..),
+    SlotNo,
+    epochInfoEpoch,
+    epochInfoFirst,
+  )
 
 data RUPD crypto
 
@@ -57,4 +72,4 @@ rupdTransition = do
     then pure ru
     else case ru of
       SNothing -> SJust <$> (liftSTS $ createRUpd epoch b es (Coin $ fromIntegral maxLL))
-      SJust _  -> pure ru
+      SJust _ -> pure ru

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -5,26 +5,32 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Snap
-  ( SNAP
-  , SnapState (..)
-  , SnapEnv (..)
-  , PredicateFailure
+  ( SNAP,
+    SnapState (..),
+    SnapEnv (..),
+    PredicateFailure,
   )
 where
 
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.Monad.Trans.Reader (asks)
-import           Control.State.Transition
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition
 import qualified Data.Map.Strict as Map
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.Coin
-import           Shelley.Spec.Ledger.EpochBoundary
-import           Shelley.Spec.Ledger.LedgerState (DState (..), PState (..), UTxOState (..),
-                     stakeDistr, _deposited, _fees)
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.UTxO
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.EpochBoundary
+import Shelley.Spec.Ledger.LedgerState
+  ( DState (..),
+    PState (..),
+    UTxOState (..),
+    _deposited,
+    _fees,
+    stakeDistr,
+  )
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.UTxO
 
 data SNAP crypto
 
@@ -59,17 +65,22 @@ snapTransition = do
 
   let UTxOState utxo deposits' fees _ = u
   let DState stkCreds _ _ _ _ _ _ = dstate
-  let PState stpools _ _          = pstate
+  let PState stpools _ _ = pstate
   let stake = stakeDistr utxo dstate pstate
   _slot <- liftSTS $ do
     ei <- asks epochInfo
     epochInfoFirst ei eNew
   let oblg = obligation pp stkCreds stpools _slot
   let decayed = deposits' - oblg
-  pure $ SnapState
-    s { _pstakeMark = stake
-      , _pstakeSet = _pstakeMark s
-      , _pstakeGo = _pstakeSet s
-      , _feeSS = fees + decayed}
-    u { _deposited = oblg
-      , _fees = fees + decayed}
+  pure $
+    SnapState
+      s
+        { _pstakeMark = stake,
+          _pstakeSet = _pstakeMark s,
+          _pstakeGo = _pstakeSet s,
+          _feeSS = fees + decayed
+        }
+      u
+        { _deposited = oblg,
+          _fees = fees + decayed
+        }

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Tick.hs
@@ -8,41 +8,51 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Tick
-  ( TICK
-  , TickEnv (..)
-  , State
-  , PredicateFailure (..)
+  ( TICK,
+    TickEnv (..),
+    State,
+    PredicateFailure (..),
   )
 where
 
-import           Byron.Spec.Ledger.Core ((⨃))
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Control.Monad.Trans.Reader (asks)
-import           Control.State.Transition
+import Byron.Spec.Ledger.Core ((⨃))
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition
 import qualified Data.Map.Strict as Map
-import           Data.Set (Set)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase, epochInfo)
-import           Shelley.Spec.Ledger.Crypto (Crypto)
-import           Shelley.Spec.Ledger.Keys (KeyHash, KeyRole(..), GenDelegs (..))
-import           Shelley.Spec.Ledger.LedgerState (DPState (..), DState (..), EpochState (..),
-                     FutureGenDeleg (..), LedgerState (..), NewEpochEnv (..), NewEpochState (..))
-import           Shelley.Spec.Ledger.Slot (SlotNo, epochInfoEpoch)
-import           Shelley.Spec.Ledger.STS.NewEpoch (NEWEPOCH)
-import           Shelley.Spec.Ledger.STS.Rupd (RUPD, RupdEnv (..))
+import Data.Set (Set)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes (ShelleyBase, epochInfo)
+import Shelley.Spec.Ledger.Crypto (Crypto)
+import Shelley.Spec.Ledger.Keys (GenDelegs (..), KeyHash, KeyRole (..))
+import Shelley.Spec.Ledger.LedgerState
+  ( DPState (..),
+    DState (..),
+    EpochState (..),
+    FutureGenDeleg (..),
+    LedgerState (..),
+    NewEpochEnv (..),
+    NewEpochState (..),
+  )
+import Shelley.Spec.Ledger.STS.NewEpoch (NEWEPOCH)
+import Shelley.Spec.Ledger.STS.Rupd (RUPD, RupdEnv (..))
+import Shelley.Spec.Ledger.Slot (SlotNo, epochInfoEpoch)
 
 data TICK crypto
 
 data TickEnv crypto
   = TickEnv (Set (KeyHash 'Genesis crypto))
 
-instance Crypto crypto
-  => STS (TICK crypto)
- where
-  type State (TICK crypto)
-    = NewEpochState crypto
-  type Signal (TICK crypto)
-    = SlotNo
+instance
+  Crypto crypto =>
+  STS (TICK crypto)
+  where
+  type
+    State (TICK crypto) =
+      NewEpochState crypto
+  type
+    Signal (TICK crypto) =
+      SlotNo
   type Environment (TICK crypto) = TickEnv crypto
   type BaseM (TICK crypto) = ShelleyBase
   data PredicateFailure (TICK crypto)
@@ -55,39 +65,39 @@ instance Crypto crypto
 
 instance NoUnexpectedThunks (PredicateFailure (TICK crypto))
 
-adoptGenesisDelegs
-  :: EpochState crypto
-  -> SlotNo
-  -> EpochState crypto
+adoptGenesisDelegs ::
+  EpochState crypto ->
+  SlotNo ->
+  EpochState crypto
 adoptGenesisDelegs es slot = es'
   where
     ls = esLState es
     dp = _delegationState ls
     ds = _dstate dp
-
     fGenDelegs = _fGenDelegs ds
     GenDelegs genDelegs = _genDelegs ds
     (curr, fGenDelegs') = Map.partitionWithKey (\(FutureGenDeleg s _) _ -> s <= slot) fGenDelegs
-
     latestPerGKey (FutureGenDeleg s genKeyHash) delegate latest =
       case Map.lookup genKeyHash latest of
         Nothing -> Map.insert genKeyHash (s, delegate) latest
-        Just (t, _) -> if s > t
-                         then Map.insert genKeyHash (s, delegate) latest
-                         else latest
+        Just (t, _) ->
+          if s > t
+            then Map.insert genKeyHash (s, delegate) latest
+            else latest
     genDelegs' = Map.map snd $ Map.foldrWithKey latestPerGKey Map.empty curr
-
-    ds' = ds { _fGenDelegs = fGenDelegs'
-             , _genDelegs = GenDelegs $ genDelegs ⨃ Map.toList genDelegs'
-             }
+    ds' =
+      ds
+        { _fGenDelegs = fGenDelegs',
+          _genDelegs = GenDelegs $ genDelegs ⨃ Map.toList genDelegs'
+        }
     dp' = dp {_dstate = ds'}
     ls' = ls {_delegationState = dp'}
     es' = es {esLState = ls'}
 
-bheadTransition
-  :: forall crypto
-   . ( Crypto crypto)
-  => TransitionRule (TICK crypto)
+bheadTransition ::
+  forall crypto.
+  (Crypto crypto) =>
+  TransitionRule (TICK crypto)
 bheadTransition = do
   TRC (TickEnv gkeys, nes@(NewEpochState _ bprev _ es _ _ _), slot) <-
     judgmentContext
@@ -96,23 +106,28 @@ bheadTransition = do
     ei <- asks epochInfo
     epochInfoEpoch ei slot
 
-  nes' <- trans @(NEWEPOCH crypto)
-    $ TRC (NewEpochEnv slot gkeys, nes, epoch)
+  nes' <-
+    trans @(NEWEPOCH crypto) $
+      TRC (NewEpochEnv slot gkeys, nes, epoch)
 
   ru' <- trans @(RUPD crypto) $ TRC (RupdEnv bprev es, nesRu nes', slot)
 
   let es' = adoptGenesisDelegs (nesEs nes') slot
-      nes'' = nes' { nesRu = ru'
-                   , nesEs = es'
-                   }
+      nes'' =
+        nes'
+          { nesRu = ru',
+            nesEs = es'
+          }
   pure nes''
 
-instance Crypto crypto
-  => Embed (NEWEPOCH crypto) (TICK crypto)
- where
+instance
+  Crypto crypto =>
+  Embed (NEWEPOCH crypto) (TICK crypto)
+  where
   wrapFailed = NewEpochFailure
 
-instance Crypto crypto
-  => Embed (RUPD crypto) (TICK crypto)
- where
+instance
+  Crypto crypto =>
+  Embed (RUPD crypto) (TICK crypto)
+  where
   wrapFailed = RupdFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
@@ -7,32 +7,34 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Shelley.Spec.Ledger.STS.Updn
-  ( UPDN
-  , UpdnEnv(..)
-  , UpdnState(..)
-  , PredicateFailure
+  ( UPDN,
+    UpdnEnv (..),
+    UpdnState (..),
+    PredicateFailure,
   )
 where
 
-import           Cardano.Prelude (NoUnexpectedThunks)
-import           Control.Monad.Trans.Reader (asks)
-import           Control.State.Transition
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.BlockChain
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Slot
+import Cardano.Prelude (NoUnexpectedThunks)
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.BlockChain
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.Slot
 
 data UPDN crypto
 
 data UpdnEnv crypto = UpdnEnv Nonce PParams (PrevHash crypto) Bool
+
 data UpdnState = UpdnState Nonce Nonce Nonce Nonce
   deriving (Show, Eq)
 
 instance
-  (Crypto crypto)
-  => STS (UPDN crypto) where
+  (Crypto crypto) =>
+  STS (UPDN crypto)
+  where
   type State (UPDN crypto) = UpdnState
   type Signal (UPDN crypto) = SlotNo
   type Environment (UPDN crypto) = UpdnEnv crypto
@@ -44,16 +46,16 @@ instance
 
 instance NoUnexpectedThunks (PredicateFailure (UPDN crypto))
 
-prevHashToNonce
-  :: PrevHash crypto
-  -> Nonce
+prevHashToNonce ::
+  PrevHash crypto ->
+  Nonce
 prevHashToNonce = \case
   GenesisHash -> NeutralNonce -- This case can only happen when starting Shelley from genesis,
-                              -- setting the intial chain state to some epoch e,
-                              -- and having the first block be in epoch e+1.
-                              -- In this edge case there is no need to add any extra
-                              -- entropy via the previous header hash to the next epoch nonce,
-                              -- so using the neutral nonce is appropriate.
+    -- setting the intial chain state to some epoch e,
+    -- and having the first block be in epoch e+1.
+    -- In this edge case there is no need to add any extra
+    -- entropy via the previous header hash to the next epoch nonce,
+    -- so using the neutral nonce is appropriate.
   BlockHash ph -> hashHeaderToNonce ph
 
 updTransition :: Crypto crypto => TransitionRule (UPDN crypto)
@@ -63,11 +65,12 @@ updTransition = do
   sp <- liftSTS $ asks slotsPrior
   EpochNo e <- liftSTS $ epochInfoEpoch ei s
   firstSlotNextEpoch <- liftSTS $ epochInfoFirst ei (EpochNo (e + 1))
-  pure $ UpdnState
-    (if ne then eta_c ⭒ eta_h ⭒ _extraEntropy pp else eta_0)
-    (eta_v ⭒ eta)
-    (if s +* Duration sp < firstSlotNextEpoch
-      then eta_v ⭒ eta
-      else eta_c
-    )
-    (if ne then (prevHashToNonce ph) else eta_h)
+  pure $
+    UpdnState
+      (if ne then eta_c ⭒ eta_h ⭒ _extraEntropy pp else eta_0)
+      (eta_v ⭒ eta)
+      ( if s +* Duration sp < firstSlotNextEpoch
+          then eta_v ⭒ eta
+          else eta_c
+      )
+      (if ne then (prevHashToNonce ph) else eta_h)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Utxow.hs
@@ -11,45 +11,57 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Shelley.Spec.Ledger.STS.Utxow
-  ( UTXOW
-  , PredicateFailure(..)
+  ( UTXOW,
+    PredicateFailure (..),
   )
 where
 
-import           Byron.Spec.Ledger.Core (dom, (∩))
-import           Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLen, decodeWord,
-                     encodeListLen, matchSize)
-import           Cardano.Prelude (NoUnexpectedThunks (..), asks)
-import           Control.State.Transition
+import Byron.Spec.Ledger.Core (dom, (∩))
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    decodeListLen,
+    decodeWord,
+    encodeListLen,
+    matchSize,
+  )
+import Cardano.Prelude (NoUnexpectedThunks (..), asks)
+import Control.State.Transition
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq (filter)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-import           Data.Typeable (Typeable)
-import           Data.Word (Word8)
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), intervalValue,
-                     invalidKey, quorum, (==>))
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.Delegation.Certificates (isInstantaneousRewards)
-import           Shelley.Spec.Ledger.Keys
-import           Shelley.Spec.Ledger.LedgerState (UTxOState (..), verifiedWits, witsVKeyNeeded)
-import           Shelley.Spec.Ledger.MetaData (hashMetaData)
-import           Shelley.Spec.Ledger.PParams (_d)
-import           Shelley.Spec.Ledger.STS.Utxo
-import           Shelley.Spec.Ledger.Tx
-import           Shelley.Spec.Ledger.TxData
-import           Shelley.Spec.Ledger.UTxO
-import           Shelley.Spec.Ledger.Validation (Validity (..))
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+  ( (==>),
+    ShelleyBase,
+    StrictMaybe (..),
+    intervalValue,
+    invalidKey,
+    quorum,
+  )
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Delegation.Certificates (isInstantaneousRewards)
+import Shelley.Spec.Ledger.Keys
+import Shelley.Spec.Ledger.LedgerState (UTxOState (..), verifiedWits, witsVKeyNeeded)
+import Shelley.Spec.Ledger.MetaData (hashMetaData)
+import Shelley.Spec.Ledger.PParams (_d)
+import Shelley.Spec.Ledger.STS.Utxo
+import Shelley.Spec.Ledger.Tx
+import Shelley.Spec.Ledger.TxData
+import Shelley.Spec.Ledger.UTxO
+import Shelley.Spec.Ledger.Validation (Validity (..))
 
 data UTXOW crypto
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  )
-  => STS (UTXOW crypto)
- where
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  STS (UTXOW crypto)
+  where
   type State (UTXOW crypto) = UTxOState crypto
   type Signal (UTXOW crypto) = Tx crypto
   type Environment (UTXOW crypto) = UtxoEnv crypto
@@ -71,111 +83,122 @@ instance
 instance NoUnexpectedThunks (PredicateFailure (UTXOW crypto))
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBOR (PredicateFailure (UTXOW crypto))
- where
-   toCBOR = \case
-      InvalidWitnessesUTXOW                -> encodeListLen 1 <> toCBOR (0 :: Word8)
-      MissingVKeyWitnessesUTXOW            -> encodeListLen 1 <> toCBOR (1 :: Word8)
-      MissingScriptWitnessesUTXOW          -> encodeListLen 1 <> toCBOR (2 :: Word8)
-      ScriptWitnessNotValidatingUTXOW      -> encodeListLen 1 <> toCBOR (3 :: Word8)
-      (UtxoFailure a)                      -> encodeListLen 2 <> toCBOR (4 :: Word8)
-                                                <> toCBOR a
-      MIRInsufficientGenesisSigsUTXOW      -> encodeListLen 1 <> toCBOR (5 :: Word8)
-      MIRImpossibleInDecentralizedNetUTXOW -> encodeListLen 1 <> toCBOR (6 :: Word8)
-      BadMetaDataHashUTXOW                 -> encodeListLen 1 <> toCBOR (7 :: Word8)
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (PredicateFailure (UTXOW crypto))
+  where
+  toCBOR = \case
+    InvalidWitnessesUTXOW -> encodeListLen 1 <> toCBOR (0 :: Word8)
+    MissingVKeyWitnessesUTXOW -> encodeListLen 1 <> toCBOR (1 :: Word8)
+    MissingScriptWitnessesUTXOW -> encodeListLen 1 <> toCBOR (2 :: Word8)
+    ScriptWitnessNotValidatingUTXOW -> encodeListLen 1 <> toCBOR (3 :: Word8)
+    (UtxoFailure a) ->
+      encodeListLen 2 <> toCBOR (4 :: Word8)
+        <> toCBOR a
+    MIRInsufficientGenesisSigsUTXOW -> encodeListLen 1 <> toCBOR (5 :: Word8)
+    MIRImpossibleInDecentralizedNetUTXOW -> encodeListLen 1 <> toCBOR (6 :: Word8)
+    BadMetaDataHashUTXOW -> encodeListLen 1 <> toCBOR (7 :: Word8)
 
 instance
-  (Crypto crypto)
-  => FromCBOR (PredicateFailure (UTXOW crypto))
- where
+  (Crypto crypto) =>
+  FromCBOR (PredicateFailure (UTXOW crypto))
+  where
   fromCBOR = do
     n <- decodeListLen
     decodeWord >>= \case
       0 -> matchSize "InvalidWitnessesUTXOW" 1 n >> pure InvalidWitnessesUTXOW
       1 -> matchSize "MissingVKeyWitnessesUTXOW" 1 n >> pure MissingVKeyWitnessesUTXOW
       2 -> matchSize "MissingScriptWitnessesUTXOW" 1 n >> pure MissingScriptWitnessesUTXOW
-      3 -> matchSize "ScriptWitnessNotValidatingUTXOW" 1 n >>
-             pure ScriptWitnessNotValidatingUTXOW
+      3 ->
+        matchSize "ScriptWitnessNotValidatingUTXOW" 1 n
+          >> pure ScriptWitnessNotValidatingUTXOW
       4 -> do
         matchSize "UtxoFailure" 2 n
         a <- fromCBOR
         pure $ UtxoFailure a
-      5 -> matchSize "MIRInsufficientGenesisSigsUTXOW" 1 n >>
-             pure MIRInsufficientGenesisSigsUTXOW
-      6 -> matchSize "MIRImpossibleInDecentralizedNetUTXOW" 1 n >>
-             pure MIRImpossibleInDecentralizedNetUTXOW
-      7 -> matchSize "BadMetaDataHashUTXOW" 1 n >>
-             pure BadMetaDataHashUTXOW
+      5 ->
+        matchSize "MIRInsufficientGenesisSigsUTXOW" 1 n
+          >> pure MIRInsufficientGenesisSigsUTXOW
+      6 ->
+        matchSize "MIRImpossibleInDecentralizedNetUTXOW" 1 n
+          >> pure MIRImpossibleInDecentralizedNetUTXOW
+      7 ->
+        matchSize "BadMetaDataHashUTXOW" 1 n
+          >> pure BadMetaDataHashUTXOW
       k -> invalidKey k
 
-initialLedgerStateUTXOW
-  :: forall crypto
-   . ( Crypto crypto
-     , DSignable crypto (Hash crypto (TxBody crypto))
-     )
-   => InitialRule (UTXOW crypto)
+initialLedgerStateUTXOW ::
+  forall crypto.
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  InitialRule (UTXOW crypto)
 initialLedgerStateUTXOW = do
   IRC (UtxoEnv slots pp stakeCreds stakepools genDelegs) <- judgmentContext
   trans @(UTXO crypto) $ IRC (UtxoEnv slots pp stakeCreds stakepools genDelegs)
 
-utxoWitnessed
-  :: forall crypto
-   . ( Crypto crypto
-     , DSignable crypto (Hash crypto (TxBody crypto))
-     )
-   => TransitionRule (UTXOW crypto)
-utxoWitnessed = judgmentContext >>=
-  \( TRC (UtxoEnv slot pp stakeCreds stakepools genDelegs, u, tx@(Tx txbody wits _ md))
-   ) -> do
-  let utxo = _utxo u
-  let witsKeyHashes = Set.map witKeyHash wits
+utxoWitnessed ::
+  forall crypto.
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  TransitionRule (UTXOW crypto)
+utxoWitnessed =
+  judgmentContext
+    >>= \(TRC (UtxoEnv slot pp stakeCreds stakepools genDelegs, u, tx@(Tx txbody wits _ md))) -> do
+      let utxo = _utxo u
+      let witsKeyHashes = Set.map witKeyHash wits
 
-  -- check multi-signature scripts
-  all (\(hs, validator) -> hashScript validator == hs
-      && validateScript validator tx) (Map.toList $ txwitsScript tx)
-    ?! ScriptWitnessNotValidatingUTXOW
+      -- check multi-signature scripts
+      all
+        ( \(hs, validator) ->
+            hashScript validator == hs
+              && validateScript validator tx
+        )
+        (Map.toList $ txwitsScript tx)
+        ?! ScriptWitnessNotValidatingUTXOW
 
-  scriptsNeeded utxo tx == Map.keysSet (txwitsScript tx)
-    ?! MissingScriptWitnessesUTXOW
+      scriptsNeeded utxo tx == Map.keysSet (txwitsScript tx)
+        ?! MissingScriptWitnessesUTXOW
 
-  -- check VKey witnesses
-  verifiedWits tx == Valid ?! InvalidWitnessesUTXOW
+      -- check VKey witnesses
+      verifiedWits tx == Valid ?! InvalidWitnessesUTXOW
 
-  let needed = witsVKeyNeeded utxo tx genDelegs
-  needed `Set.isSubsetOf` witsKeyHashes  ?! MissingVKeyWitnessesUTXOW
+      let needed = witsVKeyNeeded utxo tx genDelegs
+      needed `Set.isSubsetOf` witsKeyHashes ?! MissingVKeyWitnessesUTXOW
 
-  -- check metadata hash
-  case (_mdHash txbody) of
-    SNothing  -> md == SNothing ?! BadMetaDataHashUTXOW
-    SJust mdh -> case md of
-                  SNothing  -> failBecause BadMetaDataHashUTXOW
-                  SJust md' -> hashMetaData md' == mdh ?! BadMetaDataHashUTXOW
+      -- check metadata hash
+      case (_mdHash txbody) of
+        SNothing -> md == SNothing ?! BadMetaDataHashUTXOW
+        SJust mdh -> case md of
+          SNothing -> failBecause BadMetaDataHashUTXOW
+          SJust md' -> hashMetaData md' == mdh ?! BadMetaDataHashUTXOW
 
-  -- check genesis keys signatures for instantaneous rewards certificates
-  let genSig = (Set.map asWitness $ dom genMapping) ∩ Set.map witKeyHash wits
-      mirCerts =
-          StrictSeq.toStrict
-        . Seq.filter isInstantaneousRewards
-        . StrictSeq.getSeq
-        $ _certs txbody
-      GenDelegs genMapping = genDelegs
+      -- check genesis keys signatures for instantaneous rewards certificates
+      let genSig = (Set.map asWitness $ dom genMapping) ∩ Set.map witKeyHash wits
+          mirCerts =
+            StrictSeq.toStrict
+              . Seq.filter isInstantaneousRewards
+              . StrictSeq.getSeq
+              $ _certs txbody
+          GenDelegs genMapping = genDelegs
 
-  coreNodeQuorum <- liftSTS $ asks quorum
-  (    (not $ null mirCerts)
-   ==> Set.size genSig >= fromIntegral coreNodeQuorum)
-      ?! MIRInsufficientGenesisSigsUTXOW
-  (    (not $ null mirCerts)
-   ==> (0 < intervalValue (_d pp)))
-    ?! MIRImpossibleInDecentralizedNetUTXOW
+      coreNodeQuorum <- liftSTS $ asks quorum
+      ( (not $ null mirCerts)
+          ==> Set.size genSig >= fromIntegral coreNodeQuorum
+        )
+        ?! MIRInsufficientGenesisSigsUTXOW
+      ( (not $ null mirCerts)
+          ==> (0 < intervalValue (_d pp))
+        )
+        ?! MIRImpossibleInDecentralizedNetUTXOW
 
-  trans @(UTXO crypto)
-    $ TRC (UtxoEnv slot pp stakeCreds stakepools genDelegs, u, tx)
+      trans @(UTXO crypto) $
+        TRC (UtxoEnv slot pp stakeCreds stakepools genDelegs, u, tx)
 
 instance
-  ( Crypto crypto
-  , DSignable crypto (Hash crypto (TxBody crypto))
-  )
-  => Embed (UTXO crypto) (UTXOW crypto)
- where
+  ( Crypto crypto,
+    DSignable crypto (Hash crypto (TxBody crypto))
+  ) =>
+  Embed (UTXO crypto) (UTXOW crypto)
+  where
   wrapFailed = UtxoFailure

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Scripts.hs
@@ -1,63 +1,62 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Shelley.Spec.Ledger.Scripts
   ( MultiSig
-    ( RequireAllOf
-    , RequireAnyOf
-    , RequireSignature
-    , RequireMOf
-    , multiSigBytes
-    )
-  , Script (..)
-  , ScriptHash (..)
-  , countMSigNodes
-  , getKeyCombination
-  , getKeyCombinations
-  , hashAnyScript
-  ) where
-
-import           Cardano.Binary
-  ( Annotator (..)
-  , annotatorSlice
-  , FromCBOR (fromCBOR)
-  , ToCBOR (toCBOR)
-  , decodeListLen
-  , decodeWord
-  , encodeListLen
-  , encodePreEncoded
-  , encodeWord
-  , encodeWord8
-  , matchSize
-  , serializeEncoding
+      ( RequireAllOf,
+        RequireAnyOf,
+        RequireSignature,
+        RequireMOf,
+        multiSigBytes
+      ),
+    Script (..),
+    ScriptHash (..),
+    countMSigNodes,
+    getKeyCombination,
+    getKeyCombinations,
+    hashAnyScript,
   )
-import           Cardano.Prelude (AllowThunksIn (..), LByteString, NFData)
-import           Cardano.Crypto.Hash (hashWithSerialiser)
-import           Cardano.Prelude (Generic, NoUnexpectedThunks (..))
+where
+
+import Cardano.Binary
+  ( Annotator (..),
+    FromCBOR (fromCBOR),
+    ToCBOR (toCBOR),
+    annotatorSlice,
+    decodeListLen,
+    decodeWord,
+    encodeListLen,
+    encodePreEncoded,
+    encodeWord,
+    encodeWord8,
+    matchSize,
+    serializeEncoding,
+  )
+import Cardano.Crypto.Hash (hashWithSerialiser)
+import Cardano.Prelude (AllowThunksIn (..), LByteString, NFData)
+import Cardano.Prelude (Generic, NoUnexpectedThunks (..))
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.List as List (concat, concatMap, permutations)
-import           Data.Word (Word8)
-import           Shelley.Spec.Ledger.BaseTypes (invalidKey)
-import           Shelley.Spec.Ledger.Crypto (Crypto (..))
-import           Shelley.Spec.Ledger.Keys (KeyHash(..), KeyRole(Witness), Hash)
-import           Shelley.Spec.Ledger.Serialization (decodeList, encodeFoldable, decodeRecordNamed)
-
+import Data.Word (Word8)
+import Shelley.Spec.Ledger.BaseTypes (invalidKey)
+import Shelley.Spec.Ledger.Crypto (Crypto (..))
+import Shelley.Spec.Ledger.Keys (Hash, KeyHash (..), KeyRole (Witness))
+import Shelley.Spec.Ledger.Serialization (decodeList, decodeRecordNamed, encodeFoldable)
 
 -- | Magic number representing the tag of the native multi-signature script
 -- language. For each script language included, a new tag is chosen and the tag
 -- is included in the script hash for a script.
 nativeMultiSigTag :: Word8
 nativeMultiSigTag = 0
-
 
 -- | A simple language for expressing conditions under which it is valid to
 -- withdraw from a normal UTxO payment address or to use a stake address.
@@ -73,76 +72,76 @@ nativeMultiSigTag = 0
 -- This makes it easy to express multi-signature addresses, and provides an
 -- extension point to express other validity conditions, e.g., as needed for
 -- locking funds used with lightning.
---
-data MultiSig' crypto =
-       -- | Require the redeeming transaction be witnessed by the spending key
-       --   corresponding to the given verification key hash.
-       RequireSignature'  !(KeyHash 'Witness crypto)
-
-       -- | Require all the sub-terms to be satisfied.
-     | RequireAllOf'      ![MultiSig crypto]
-
-       -- | Require any one of the sub-terms to be satisfied.
-     | RequireAnyOf'      ![MultiSig crypto]
-
-       -- | Require M of the given sub-terms to be satisfied.
-     | RequireMOf'   !Int ![MultiSig crypto]
+data MultiSig' crypto
+  = -- | Require the redeeming transaction be witnessed by the spending key
+    --   corresponding to the given verification key hash.
+    RequireSignature' !(KeyHash 'Witness crypto)
+  | -- | Require all the sub-terms to be satisfied.
+    RequireAllOf' ![MultiSig crypto]
+  | -- | Require any one of the sub-terms to be satisfied.
+    RequireAnyOf' ![MultiSig crypto]
+  | -- | Require M of the given sub-terms to be satisfied.
+    RequireMOf' !Int ![MultiSig crypto]
   deriving (Show, Eq, Ord, Generic)
-  deriving anyclass NoUnexpectedThunks
+  deriving anyclass (NoUnexpectedThunks)
 
 data MultiSig crypto = MultiSig'
-  { multiSig :: !(MultiSig' crypto)
-  , multiSigBytes :: LByteString
+  { multiSig :: !(MultiSig' crypto),
+    multiSigBytes :: LByteString
   }
   deriving (Show, Eq, Ord, Generic)
-  deriving NoUnexpectedThunks via AllowThunksIn '["multiSigBytes"] (MultiSig crypto)
+  deriving (NoUnexpectedThunks) via AllowThunksIn '["multiSigBytes"] (MultiSig crypto)
 
 pattern RequireSignature :: Crypto crypto => KeyHash 'Witness crypto -> MultiSig crypto
-pattern RequireSignature akh <- MultiSig' (RequireSignature' akh) _
+pattern RequireSignature akh <-
+  MultiSig' (RequireSignature' akh) _
   where
     RequireSignature akh =
       let bytes = serializeEncoding $ encodeListLen 2 <> encodeWord 0 <> toCBOR akh
        in MultiSig' (RequireSignature' akh) bytes
 
 pattern RequireAllOf :: Crypto crypto => [MultiSig crypto] -> MultiSig crypto
-pattern RequireAllOf ms <- MultiSig' (RequireAllOf' ms) _
+pattern RequireAllOf ms <-
+  MultiSig' (RequireAllOf' ms) _
   where
     RequireAllOf ms =
       let bytes = serializeEncoding $ encodeListLen 2 <> encodeWord 1 <> encodeFoldable ms
        in MultiSig' (RequireAllOf' ms) bytes
 
 pattern RequireAnyOf :: Crypto crypto => [MultiSig crypto] -> MultiSig crypto
-pattern RequireAnyOf ms <- MultiSig' (RequireAnyOf' ms) _
+pattern RequireAnyOf ms <-
+  MultiSig' (RequireAnyOf' ms) _
   where
     RequireAnyOf ms =
       let bytes = serializeEncoding $ encodeListLen 2 <> encodeWord 2 <> encodeFoldable ms
        in MultiSig' (RequireAnyOf' ms) bytes
 
 pattern RequireMOf :: Crypto crypto => Int -> [MultiSig crypto] -> MultiSig crypto
-pattern RequireMOf n ms <- MultiSig' (RequireMOf' n ms) _
+pattern RequireMOf n ms <-
+  MultiSig' (RequireMOf' n ms) _
   where
     RequireMOf n ms =
-      let bytes = serializeEncoding $
-             encodeListLen 3 <> encodeWord 3 <> toCBOR n <> encodeFoldable ms
+      let bytes =
+            serializeEncoding $
+              encodeListLen 3 <> encodeWord 3 <> toCBOR n <> encodeFoldable ms
        in MultiSig' (RequireMOf' n ms) bytes
 
 {-# COMPLETE RequireSignature, RequireAllOf, RequireAnyOf, RequireMOf #-}
 
-newtype ScriptHash crypto =
-  ScriptHash (Hash crypto (Script crypto))
+newtype ScriptHash crypto
+  = ScriptHash (Hash crypto (Script crypto))
   deriving (Show, Eq, Ord, Generic)
   deriving newtype (NFData, NoUnexpectedThunks)
 
 deriving newtype instance Crypto crypto => ToCBOR (ScriptHash crypto)
+
 deriving newtype instance Crypto crypto => FromCBOR (ScriptHash crypto)
 
 data Script crypto = MultiSigScript (MultiSig crypto)
-                     -- new languages go here
+  -- new languages go here
   deriving (Show, Eq, Ord, Generic)
 
 instance Crypto crypto => NoUnexpectedThunks (Script crypto)
-
-
 
 -- | Count nodes and leaves of multi signature script
 countMSigNodes :: Crypto crypto => MultiSig crypto -> Int
@@ -151,17 +150,20 @@ countMSigNodes (RequireAllOf msigs) = 1 + sum (map countMSigNodes msigs)
 countMSigNodes (RequireAnyOf msigs) = 1 + sum (map countMSigNodes msigs)
 countMSigNodes (RequireMOf _ msigs) = 1 + sum (map countMSigNodes msigs)
 
-
-
 -- | Hashes native multi-signature script, appending the 'nativeMultiSigTag' in
 -- front and then calling the script CBOR function.
-hashAnyScript
-  :: Crypto crypto
-  => Script crypto
-  -> ScriptHash crypto
+hashAnyScript ::
+  Crypto crypto =>
+  Script crypto ->
+  ScriptHash crypto
 hashAnyScript (MultiSigScript msig) =
-  ScriptHash $ hashWithSerialiser (\x -> encodeWord8 nativeMultiSigTag
-                                          <> toCBOR x) (MultiSigScript msig)
+  ScriptHash $
+    hashWithSerialiser
+      ( \x ->
+          encodeWord8 nativeMultiSigTag
+            <> toCBOR x
+      )
+      (MultiSigScript msig)
 
 -- | Get one possible combination of keys for multi signature script
 getKeyCombination :: Crypto crypto => MultiSig crypto -> [KeyHash 'Witness crypto]
@@ -170,33 +172,36 @@ getKeyCombination (RequireAllOf msigs) =
   List.concatMap getKeyCombination msigs
 getKeyCombination (RequireAnyOf msigs) =
   case msigs of
-    []  -> []
-    x:_ -> getKeyCombination x
+    [] -> []
+    x : _ -> getKeyCombination x
 getKeyCombination (RequireMOf m msigs) =
   List.concatMap getKeyCombination (take m msigs)
-
 
 -- | Get all valid combinations of keys for given multi signature. This is
 -- mainly useful for testing.
 getKeyCombinations :: Crypto crypto => MultiSig crypto -> [[KeyHash 'Witness crypto]]
 getKeyCombinations (RequireSignature hk) = [[hk]]
-getKeyCombinations (RequireAllOf msigs) = [List.concat $
-  List.concatMap getKeyCombinations msigs]
+getKeyCombinations (RequireAllOf msigs) =
+  [ List.concat $
+      List.concatMap getKeyCombinations msigs
+  ]
 getKeyCombinations (RequireAnyOf msigs) = List.concatMap getKeyCombinations msigs
 getKeyCombinations (RequireMOf m msigs) =
-  let perms = map (take m) $ List.permutations msigs in
-    map (concat . List.concatMap getKeyCombinations) perms
-
-
+  let perms = map (take m) $ List.permutations msigs
+   in map (concat . List.concatMap getKeyCombinations) perms
 
 -- CBOR
 
-instance (Crypto crypto) =>
-  ToCBOR (MultiSig crypto) where
+instance
+  (Crypto crypto) =>
+  ToCBOR (MultiSig crypto)
+  where
   toCBOR (MultiSig' _ bytes) = encodePreEncoded $ BSL.toStrict bytes
 
-instance (Crypto crypto) =>
-  FromCBOR (MultiSig crypto) where
+instance
+  (Crypto crypto) =>
+  FromCBOR (MultiSig crypto)
+  where
   fromCBOR = do
     n <- decodeListLen
     decodeWord >>= \case
@@ -205,39 +210,48 @@ instance (Crypto crypto) =>
       2 -> matchSize "RequireAnyOf" 2 n >> RequireAnyOf <$> decodeList fromCBOR
       3 -> do
         matchSize "RequireMOf" 3 n
-        m     <- fromCBOR
+        m <- fromCBOR
         msigs <- decodeList fromCBOR
         pure $ RequireMOf m msigs
       k -> invalidKey k
 
-instance Crypto crypto =>
-  FromCBOR (Annotator (MultiSig crypto)) where
+instance
+  Crypto crypto =>
+  FromCBOR (Annotator (MultiSig crypto))
+  where
   fromCBOR = annotatorSlice $ fmap MultiSig' <$> fromCBOR
 
-instance Crypto crypto =>
-  FromCBOR (Annotator (MultiSig' crypto)) where
-  fromCBOR = fmap snd $ decodeRecordNamed "MultiSig" fst $ decodeWord >>= \case
-    0 -> (,) 2 . pure . RequireSignature' . KeyHash <$> fromCBOR
-    1 -> do
-      multiSigs <- sequence <$> decodeList fromCBOR
-      pure (2, RequireAllOf' <$> multiSigs)
-    2 -> do
-      multiSigs <- sequence <$> decodeList fromCBOR
-      pure (2, RequireAnyOf' <$> multiSigs)
-    3 -> do
-      m <- fromCBOR
-      multiSigs <- sequence <$> decodeList fromCBOR
-      pure $ (3, RequireMOf' m <$> multiSigs)
-    k -> invalidKey k
+instance
+  Crypto crypto =>
+  FromCBOR (Annotator (MultiSig' crypto))
+  where
+  fromCBOR = fmap snd $ decodeRecordNamed "MultiSig" fst $
+    decodeWord >>= \case
+      0 -> (,) 2 . pure . RequireSignature' . KeyHash <$> fromCBOR
+      1 -> do
+        multiSigs <- sequence <$> decodeList fromCBOR
+        pure (2, RequireAllOf' <$> multiSigs)
+      2 -> do
+        multiSigs <- sequence <$> decodeList fromCBOR
+        pure (2, RequireAnyOf' <$> multiSigs)
+      3 -> do
+        m <- fromCBOR
+        multiSigs <- sequence <$> decodeList fromCBOR
+        pure $ (3, RequireMOf' m <$> multiSigs)
+      k -> invalidKey k
 
-instance (Crypto crypto) =>
-  ToCBOR (Script crypto) where
+instance
+  (Crypto crypto) =>
+  ToCBOR (Script crypto)
+  where
   toCBOR (MultiSigScript msig) =
     --TODO make valid encoding or use CBORGroup
     toCBOR nativeMultiSigTag <> toCBOR msig
 
-instance (Crypto crypto) =>
-  FromCBOR (Script crypto) where
+instance
+  (Crypto crypto) =>
+  FromCBOR (Script crypto)
+  where
   fromCBOR = do
     decodeWord >>= \case
       0 -> MultiSigScript <$> fromCBOR

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Slot.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Slot.hs
@@ -4,35 +4,35 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Shelley.Spec.Ledger.Slot
-  ( SlotNo(..)
-  , Duration(..)
-  , (-*)
-  , (+*)
-  , (*-)
-  , EpochNo(..)
-  , EpochSize(..)
-  , EpochInfo
-  -- conversion between Byron / Shelley
-  , slotByronToShelley
-  , slotShelleyToByron
-  -- Block number
-  , BlockNo(..)
-  , epochInfoEpoch
-  , epochInfoFirst
-  , epochInfoSize
+  ( SlotNo (..),
+    Duration (..),
+    (-*),
+    (+*),
+    (*-),
+    EpochNo (..),
+    EpochSize (..),
+    EpochInfo,
+    -- conversion between Byron / Shelley
+    slotByronToShelley,
+    slotShelleyToByron,
+    -- Block number
+    BlockNo (..),
+    epochInfoEpoch,
+    epochInfoFirst,
+    epochInfoSize,
   )
 where
 
 import qualified Byron.Spec.Ledger.Core as Byron (Slot (..))
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Cardano.Slotting.Block (BlockNo (..))
-import           Cardano.Slotting.EpochInfo (EpochInfo)
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import Cardano.Slotting.Block (BlockNo (..))
+import Cardano.Slotting.EpochInfo (EpochInfo)
 import qualified Cardano.Slotting.EpochInfo as EI
-import           Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
-import           Control.Monad.Trans (lift)
-import           Data.Functor.Identity (Identity)
-import           Data.Word (Word64)
-import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
+import Control.Monad.Trans (lift)
+import Data.Functor.Identity (Identity)
+import Data.Word (Word64)
+import Shelley.Spec.Ledger.BaseTypes (ShelleyBase)
 
 newtype Duration = Duration Word64
   deriving (Show, Eq, Ord, NoUnexpectedThunks, Num, Integral, Real, Enum)
@@ -41,7 +41,7 @@ instance Semigroup Duration where
   (Duration x) <> (Duration y) = Duration $ x + y
 
 instance Monoid Duration where
-  mempty  = Duration 0
+  mempty = Duration 0
   mappend = (<>)
 
 (-*) :: SlotNo -> SlotNo -> Duration

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -10,124 +10,163 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-
 module Shelley.Spec.Ledger.Tx
   ( -- transaction
-    Tx(Tx
-      , _body
-      , _witnessVKeySet
-      , _witnessMSigMap
-      , _metadata
-      , txWitsBytes
-      )
-  , TxBody(..)
-  , TxOut(..)
-  , TxIn(..)
-  , TxId(..)
-  , Wits(..)
-  , decodeWits
-  , segwitTx
+    Tx
+      ( Tx,
+        _body,
+        _witnessVKeySet,
+        _witnessMSigMap,
+        _metadata,
+        txWitsBytes
+      ),
+    TxBody (..),
+    TxOut (..),
+    TxIn (..),
+    TxId (..),
+    Wits (..),
+    decodeWits,
+    segwitTx,
     -- witness data
-  , WitVKey(..)
-  , MultiSignatureScript
-  , validateScript
-  , hashScript
-  , txwitsScript
-  , extractKeyHash
-  , extractScriptHash
-  , getKeyCombinations
-  , getKeyCombination
+    WitVKey (..),
+    MultiSignatureScript,
+    validateScript,
+    hashScript,
+    txwitsScript,
+    extractKeyHash,
+    extractScriptHash,
+    getKeyCombinations,
+    getKeyCombination,
   )
 where
 
-
-import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe, invalidKey, maybeToStrictMaybe,
-                     strictMaybeToMaybe)
-import           Shelley.Spec.Ledger.Keys
-
-import           Cardano.Binary (Annotator (..), Decoder, FromCBOR (fromCBOR), ToCBOR (toCBOR),
-                     annotatorSlice, decodeWord, encodeListLen, encodeMapLen, encodeNull,
-                     encodePreEncoded, encodeWord, serialize, serializeEncoding, withSlice)
-import           Cardano.Prelude (AllowThunksIn (..), LByteString, NoUnexpectedThunks (..),
-                     catMaybes)
+import Cardano.Binary
+  ( Annotator (..),
+    Decoder,
+    FromCBOR (fromCBOR),
+    ToCBOR (toCBOR),
+    annotatorSlice,
+    decodeWord,
+    encodeListLen,
+    encodeMapLen,
+    encodeNull,
+    encodePreEncoded,
+    encodeWord,
+    serialize,
+    serializeEncoding,
+    withSlice,
+  )
+import Cardano.Prelude
+  ( AllowThunksIn (..),
+    LByteString,
+    NoUnexpectedThunks (..),
+    catMaybes,
+  )
 import qualified Data.ByteString.Lazy as BSL
-import           Data.Foldable (fold)
-import           Data.Map.Strict (Map)
+import Data.Foldable (fold)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (mapMaybe)
-import           Data.Set (Set)
+import Data.Maybe (mapMaybe)
+import Data.Set (Set)
 import qualified Data.Set as Set
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.Crypto
-import           Shelley.Spec.Ledger.MetaData (MetaData)
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.BaseTypes
+  ( StrictMaybe,
+    invalidKey,
+    maybeToStrictMaybe,
+    strictMaybeToMaybe,
+  )
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Keys
+import Shelley.Spec.Ledger.MetaData (MetaData)
+import Shelley.Spec.Ledger.Scripts
+import Shelley.Spec.Ledger.Serialization
+  ( decodeList,
+    decodeMapContents,
+    decodeNullMaybe,
+    decodeRecordNamed,
+    encodeFoldable,
+    encodeNullMaybe,
+  )
+import Shelley.Spec.Ledger.TxData
+  ( Credential (..),
+    TxBody (..),
+    TxId (..),
+    TxIn (..),
+    TxOut (..),
+    WitVKey (..),
+    witKeyHash,
+  )
 
-import           Shelley.Spec.Ledger.Scripts
-import           Shelley.Spec.Ledger.Serialization (decodeList, decodeMapContents, decodeNullMaybe,
-                     decodeRecordNamed, encodeFoldable, encodeNullMaybe)
-import           Shelley.Spec.Ledger.TxData (Credential (..), TxBody (..), TxId (..), TxIn (..),
-                     TxOut (..), WitVKey (..), witKeyHash)
+-- | A fully formed transaction.
+data Tx crypto = Tx'
+  { _body' :: !(TxBody crypto),
+    _witnessVKeySet' :: !(Set (WitVKey crypto)),
+    _witnessMSigMap' :: !(Map (ScriptHash crypto) (MultiSig crypto)),
+    _metadata' :: !(StrictMaybe MetaData),
+    txWitsBytes :: LByteString,
+    txFullBytes :: LByteString
+  }
+  deriving (Show, Eq, Generic)
+  deriving
+    (NoUnexpectedThunks)
+    via AllowThunksIn
+          '[ "txWitsBytes",
+             "txFullBytes"
+           ]
+          (Tx crypto)
 
--- |A fully formed transaction.
-data Tx crypto
-  = Tx'
-      { _body'           :: !(TxBody crypto)
-      , _witnessVKeySet' :: !(Set (WitVKey crypto))
-      , _witnessMSigMap' :: !(Map (ScriptHash crypto) (MultiSig crypto))
-      , _metadata'       :: !(StrictMaybe MetaData)
-      , txWitsBytes      :: LByteString
-      , txFullBytes      :: LByteString
-      } deriving (Show, Eq, Generic)
-        deriving NoUnexpectedThunks via
-          AllowThunksIn
-            '[ "txWitsBytes"
-            , "txFullBytes"
-            ] (Tx crypto)
-
-pattern Tx :: Crypto crypto
-  => TxBody crypto
-  -> Set (WitVKey crypto)
-  -> Map (ScriptHash crypto) (MultiSig crypto)
-  -> StrictMaybe MetaData
-  -> Tx crypto
-pattern Tx { _body, _witnessVKeySet, _witnessMSigMap, _metadata } <-
+pattern Tx ::
+  Crypto crypto =>
+  TxBody crypto ->
+  Set (WitVKey crypto) ->
+  Map (ScriptHash crypto) (MultiSig crypto) ->
+  StrictMaybe MetaData ->
+  Tx crypto
+pattern Tx {_body, _witnessVKeySet, _witnessMSigMap, _metadata} <-
   Tx' _body _witnessVKeySet _witnessMSigMap _metadata _ _
   where
-  Tx body witnessVKeySet witnessMSigMap metadata =
-    let encodeMapElement ix enc x =
-          if null x then Nothing else Just (encodeWord ix <> enc x)
-        l = catMaybes $
-              [ encodeMapElement 0 encodeFoldable witnessVKeySet
-              , encodeMapElement 1 encodeFoldable witnessMSigMap
+    Tx body witnessVKeySet witnessMSigMap metadata =
+      let encodeMapElement ix enc x =
+            if null x then Nothing else Just (encodeWord ix <> enc x)
+          l =
+            catMaybes $
+              [ encodeMapElement 0 encodeFoldable witnessVKeySet,
+                encodeMapElement 1 encodeFoldable witnessMSigMap
               ]
-        n = fromIntegral $ length l
-        bodyBytes = serialize body
-        witsBytes = serializeEncoding $ encodeMapLen n <> fold l
-        wrappedMetadataBytes = serializeEncoding $
-          encodeNullMaybe toCBOR (strictMaybeToMaybe metadata)
-        fullBytes = (serializeEncoding $ encodeListLen 3)
-          <> bodyBytes <> witsBytes <> wrappedMetadataBytes
-     in Tx'
-        { _body'           = body
-        , _witnessVKeySet' = witnessVKeySet
-        , _witnessMSigMap' = witnessMSigMap
-        , _metadata'       = metadata
-        , txWitsBytes      = witsBytes
-        , txFullBytes      = fullBytes
-        }
+          n = fromIntegral $ length l
+          bodyBytes = serialize body
+          witsBytes = serializeEncoding $ encodeMapLen n <> fold l
+          wrappedMetadataBytes =
+            serializeEncoding $
+              encodeNullMaybe toCBOR (strictMaybeToMaybe metadata)
+          fullBytes =
+            (serializeEncoding $ encodeListLen 3)
+              <> bodyBytes
+              <> witsBytes
+              <> wrappedMetadataBytes
+       in Tx'
+            { _body' = body,
+              _witnessVKeySet' = witnessVKeySet,
+              _witnessMSigMap' = witnessMSigMap,
+              _metadata' = metadata,
+              txWitsBytes = witsBytes,
+              txFullBytes = fullBytes
+            }
 
 {-# COMPLETE Tx #-}
 
-segwitTx
-  :: Crypto crypto
-  => Annotator (TxBody crypto)
-  -> (Annotator (Wits crypto), Annotator LByteString)
-  -> Maybe (Annotator MetaData)
-  -> Annotator (Tx crypto)
+segwitTx ::
+  Crypto crypto =>
+  Annotator (TxBody crypto) ->
+  (Annotator (Wits crypto), Annotator LByteString) ->
+  Maybe (Annotator MetaData) ->
+  Annotator (Tx crypto)
 segwitTx
   bodyAnn
   (wits, witsAnn)
-  metaAnn
-  = Annotator $ \bytes ->
+  metaAnn =
+    Annotator $ \bytes ->
       let body = runAnnotator bodyAnn bytes
           Wits witnessVKeySet witnessMSigMap = runAnnotator wits bytes
           witsBytes = runAnnotator witsAnn bytes
@@ -135,28 +174,33 @@ segwitTx
           wrappedMetadataBytes = case metadata of
             Nothing -> serializeEncoding encodeNull
             Just b -> serialize b
-          fullBytes = (serializeEncoding $ encodeListLen 3)
-            <> serialize body <> witsBytes <> wrappedMetadataBytes
+          fullBytes =
+            (serializeEncoding $ encodeListLen 3)
+              <> serialize body
+              <> witsBytes
+              <> wrappedMetadataBytes
        in Tx'
-          { _body'           = body
-          , _witnessVKeySet' = witnessVKeySet
-          , _witnessMSigMap' = witnessMSigMap
-          , _metadata'       = maybeToStrictMaybe metadata
-          , txWitsBytes      = witsBytes
-          , txFullBytes      = fullBytes
-          }
+            { _body' = body,
+              _witnessVKeySet' = witnessVKeySet,
+              _witnessMSigMap' = witnessMSigMap,
+              _metadata' = maybeToStrictMaybe metadata,
+              txWitsBytes = witsBytes,
+              txFullBytes = fullBytes
+            }
 
 type MultiSigMap crypto = Map (ScriptHash crypto) (MultiSig crypto)
-data Wits crypto = Wits
-  (Set (WitVKey crypto))
-  (MultiSigMap crypto)
+
+data Wits crypto
+  = Wits
+      (Set (WitVKey crypto))
+      (MultiSigMap crypto)
 
 decodeWits :: Crypto crypto => Decoder s (Annotator (Wits crypto))
 decodeWits = do
   mapParts <- decodeMapContents $
     decodeWord >>= \case
-      0 -> decodeList fromCBOR >>= \x -> pure (\(_,b) -> (x,b))
-      1 -> decodeList fromCBOR >>= \x -> pure (\(a,_) -> (a,x))
+      0 -> decodeList fromCBOR >>= \x -> pure (\(_, b) -> (x, b))
+      1 -> decodeList fromCBOR >>= \x -> pure (\(a, _) -> (a, x))
       k -> invalidKey k
   let (witsVKeys, witsScripts) = foldr ($) ([], []) mapParts
       keysSet = Set.fromList <$> sequence witsVKeys
@@ -167,9 +211,9 @@ keyBy :: Ord k => (a -> k) -> [a] -> Map k a
 keyBy f xs = Map.fromList $ (\x -> (f x, x)) <$> xs
 
 instance
-  (Crypto crypto)
-  => ToCBOR (Tx crypto)
- where
+  (Crypto crypto) =>
+  ToCBOR (Tx crypto)
+  where
   toCBOR tx = encodePreEncoded . BSL.toStrict $ txFullBytes tx
 
 instance Crypto crypto => FromCBOR (Annotator (Tx crypto)) where
@@ -179,33 +223,38 @@ instance Crypto crypto => FromCBOR (Annotator (Tx crypto)) where
     meta <- decodeNullMaybe fromCBOR
     pure $ Annotator $ \fullbytes bytes ->
       let (Wits witsVKeys witsScripts) = runAnnotator wits fullbytes
-       in Tx' (runAnnotator body fullbytes)
-              witsVKeys
-              witsScripts
-              (maybeToStrictMaybe $ flip runAnnotator fullbytes <$> meta)
-              (runAnnotator witsAnn fullbytes)
-              bytes
+       in Tx'
+            (runAnnotator body fullbytes)
+            witsVKeys
+            witsScripts
+            (maybeToStrictMaybe $ flip runAnnotator fullbytes <$> meta)
+            (runAnnotator witsAnn fullbytes)
+            bytes
 
 -- | Typeclass for multis-signature script data types. Allows for script
 -- validation and hashing.
-class (Crypto crypto, ToCBOR a) =>
-  MultiSignatureScript a crypto where
+class
+  (Crypto crypto, ToCBOR a) =>
+  MultiSignatureScript a crypto
+  where
   validateScript :: a -> Tx crypto -> Bool
   hashScript :: a -> ScriptHash crypto
 
 -- | instance of MultiSignatureScript type class
-instance Crypto crypto =>
-  MultiSignatureScript (MultiSig crypto) crypto where
+instance
+  Crypto crypto =>
+  MultiSignatureScript (MultiSig crypto) crypto
+  where
   validateScript = validateNativeMultiSigScript
   hashScript = \x -> hashAnyScript (MultiSigScript x)
 
 -- | Script evaluator for native multi-signature scheme. 'vhks' is the set of
 -- key hashes that signed the transaction to be validated.
-evalNativeMultiSigScript
-  :: Crypto crypto
-  => MultiSig crypto
-  -> Set (KeyHash 'Witness crypto)
-  -> Bool
+evalNativeMultiSigScript ::
+  Crypto crypto =>
+  MultiSig crypto ->
+  Set (KeyHash 'Witness crypto) ->
+  Bool
 evalNativeMultiSigScript (RequireSignature hk) vhks = Set.member hk vhks
 evalNativeMultiSigScript (RequireAllOf msigs) vhks =
   all (`evalNativeMultiSigScript` vhks) msigs
@@ -215,35 +264,40 @@ evalNativeMultiSigScript (RequireMOf m msigs) vhks =
   m <= sum [if evalNativeMultiSigScript msig vhks then 1 else 0 | msig <- msigs]
 
 -- | Script validator for native multi-signature scheme.
-validateNativeMultiSigScript
-  :: (Crypto crypto)
-  => MultiSig crypto
-  -> Tx crypto
-  -> Bool
+validateNativeMultiSigScript ::
+  (Crypto crypto) =>
+  MultiSig crypto ->
+  Tx crypto ->
+  Bool
 validateNativeMultiSigScript msig tx =
   evalNativeMultiSigScript msig (coerceKeyRole `Set.map` vhks)
-  where witsSet = _witnessVKeySet tx
-        vhks    = Set.map witKeyHash witsSet
-
+  where
+    witsSet = _witnessVKeySet tx
+    vhks = Set.map witKeyHash witsSet
 
 -- | Multi-signature script witness accessor function for Transactions
-txwitsScript
-  :: Crypto crypto => Tx crypto
-  -> Map (ScriptHash crypto) (MultiSig crypto)
+txwitsScript ::
+  Crypto crypto =>
+  Tx crypto ->
+  Map (ScriptHash crypto) (MultiSig crypto)
 txwitsScript = _witnessMSigMap
 
-extractKeyHash
-  :: [Credential kr crypto]
-  -> [KeyHash kr crypto]
+extractKeyHash ::
+  [Credential kr crypto] ->
+  [KeyHash kr crypto]
 extractKeyHash =
-  mapMaybe (\case
-                KeyHashObj hk -> Just hk
-                _ -> Nothing)
+  mapMaybe
+    ( \case
+        KeyHashObj hk -> Just hk
+        _ -> Nothing
+    )
 
-extractScriptHash
-  :: [Credential 'Payment crypto]
-  -> [ScriptHash crypto]
+extractScriptHash ::
+  [Credential 'Payment crypto] ->
+  [ScriptHash crypto]
 extractScriptHash =
-  mapMaybe (\case
-                ScriptHashObj hk -> Just hk
-                _ -> Nothing)
+  mapMaybe
+    ( \case
+        ScriptHashObj hk -> Just hk
+        _ -> Nothing
+    )

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -16,134 +16,181 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
-
 module Shelley.Spec.Ledger.TxData
-  ( Addr (..)
-  , Credential (..)
-  , DCert (..)
-  , DelegCert (..)
-  , Delegation (..)
-  , GenesisDelegCert (..)
-  , Ix
-  , MIRCert (..)
-  , PoolCert (..)
-  , PoolMetaData (..)
-  , PoolParams (..)
-  , Ptr (..)
-  , RewardAcnt (..)
-  , StakeCreds (..)
-  , StakePools (..)
-  , StakePoolRelay (..)
-  , StakeReference (..)
-  , TxBody
-    ( TxBody
-    , _inputs
-    , _outputs
-    , _certs
-    , _wdrls
-    , _txfee
-    , _ttl
-    , _txUpdate
-    , _mdHash
-    )
-  , TxId (..)
-  , TxIn (..)
-  , TxOut (..)
-  , Url
-  , Wdrl (..)
-  , WitVKey (WitVKey, wvkBytes)
-  --
-  , witKeyHash
-  , addStakeCreds
-)
-  where
+  ( Addr (..),
+    Credential (..),
+    DCert (..),
+    DelegCert (..),
+    Delegation (..),
+    GenesisDelegCert (..),
+    Ix,
+    MIRCert (..),
+    PoolCert (..),
+    PoolMetaData (..),
+    PoolParams (..),
+    Ptr (..),
+    RewardAcnt (..),
+    StakeCreds (..),
+    StakePools (..),
+    StakePoolRelay (..),
+    StakeReference (..),
+    TxBody
+      ( TxBody,
+        _inputs,
+        _outputs,
+        _certs,
+        _wdrls,
+        _txfee,
+        _ttl,
+        _txUpdate,
+        _mdHash
+      ),
+    TxId (..),
+    TxIn (..),
+    TxOut (..),
+    Url,
+    Wdrl (..),
+    WitVKey (WitVKey, wvkBytes),
+    --
+    witKeyHash,
+    addStakeCreds,
+  )
+where
 
-import           Cardano.Binary (Annotator (..), FromCBOR (fromCBOR), ToCBOR (toCBOR),
-                     annotatorSlice, decodeListLen, decodeWord, encodeListLen, encodeMapLen,
-                     encodePreEncoded, encodeWord, enforceSize, matchSize, serializeEncoding)
-import           Cardano.Prelude (AllowThunksIn (..), LByteString, NFData, NoUnexpectedThunks (..),
-                     Word64, catMaybes)
-import           Control.Monad (unless)
-import           Shelley.Spec.Ledger.Crypto
-
-import           Data.ByteString (ByteString)
+import Byron.Spec.Ledger.Core (Relation (..))
+import Cardano.Binary
+  ( Annotator (..),
+    FromCBOR (fromCBOR),
+    ToCBOR (toCBOR),
+    annotatorSlice,
+    decodeListLen,
+    decodeWord,
+    encodeListLen,
+    encodeMapLen,
+    encodePreEncoded,
+    encodeWord,
+    enforceSize,
+    matchSize,
+    serializeEncoding,
+  )
+import Cardano.Prelude
+  ( AllowThunksIn (..),
+    LByteString,
+    NFData,
+    NoUnexpectedThunks (..),
+    Word64,
+    catMaybes,
+  )
+import Control.Monad (unless)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BSL
-import           Data.Foldable (fold)
-import           Data.IP (IPv4, IPv6)
-import           Data.Map.Strict (Map)
+import Data.Foldable (fold)
+import Data.IP (IPv4, IPv6)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Ord (comparing)
-import           Data.Sequence.Strict (StrictSeq)
+import Data.Ord (comparing)
+import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Set (Set)
+import Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Typeable (Typeable)
-import           Data.Word (Word8)
-import           GHC.Generics (Generic)
-import           Numeric.Natural (Natural)
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes
+  ( DnsName,
+    Port,
+    StrictMaybe (..),
+    UnitInterval,
+    Url,
+    invalidKey,
+    maybeToStrictMaybe,
+    strictMaybeToMaybe,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Keys
+  ( HasKeyRole (..),
+    Hash,
+    KeyHash (..),
+    KeyRole (..),
+    SignedDSIGN,
+    VKey,
+    VerKeyVRF,
+    decodeSignedDSIGN,
+    encodeSignedDSIGN,
+    hashKey,
+  )
+import Shelley.Spec.Ledger.MetaData (MetaDataHash)
+import Shelley.Spec.Ledger.Orphans ()
+import Shelley.Spec.Ledger.PParams (Update)
+import Shelley.Spec.Ledger.Scripts
+import Shelley.Spec.Ledger.Serialization
+  ( CBORGroup (..),
+    CborSeq (..),
+    FromCBORGroup (..),
+    ToCBORGroup (..),
+    decodeMapContents,
+    decodeNullMaybe,
+    decodeRecordNamed,
+    decodeSet,
+    encodeFoldable,
+    encodeNullMaybe,
+    ipv4FromCBOR,
+    ipv4ToCBOR,
+    ipv6FromCBOR,
+    ipv6ToCBOR,
+    mapFromCBOR,
+    mapToCBOR,
+    unwrapCborStrictSeq,
+  )
+import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
 
-import           Byron.Spec.Ledger.Core (Relation (..))
-import           Shelley.Spec.Ledger.BaseTypes (DnsName, Port, StrictMaybe (..), UnitInterval, Url,
-                     invalidKey, maybeToStrictMaybe, strictMaybeToMaybe)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Keys (HasKeyRole (..), Hash, KeyHash (..), KeyRole (..),
-                     SignedDSIGN, VKey, VerKeyVRF, decodeSignedDSIGN, encodeSignedDSIGN, hashKey)
-import           Shelley.Spec.Ledger.MetaData (MetaDataHash)
-import           Shelley.Spec.Ledger.Orphans ()
-import           Shelley.Spec.Ledger.PParams (Update)
-import           Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
-
-import           Shelley.Spec.Ledger.Serialization (CBORGroup (..), CborSeq (..),
-                     FromCBORGroup (..), ToCBORGroup (..), decodeMapContents, decodeNullMaybe,
-                     decodeRecordNamed, decodeSet, encodeFoldable, encodeNullMaybe, ipv4FromCBOR,
-                     ipv4ToCBOR, ipv6FromCBOR, ipv6ToCBOR, mapFromCBOR, mapToCBOR,
-                     unwrapCborStrictSeq)
-
-import           Shelley.Spec.Ledger.Scripts
-
--- |The delegation of one stake key to another.
+-- | The delegation of one stake key to another.
 data Delegation crypto = Delegation
-  { _delegator :: !(StakeCredential crypto)
-  , _delegatee :: !(KeyHash 'StakePool crypto)
-  } deriving (Eq, Generic, Show)
+  { _delegator :: !(StakeCredential crypto),
+    _delegatee :: !(KeyHash 'StakePool crypto)
+  }
+  deriving (Eq, Generic, Show)
 
 instance NoUnexpectedThunks (Delegation crypto)
 
 data PoolMetaData = PoolMetaData
-  { _poolMDUrl  :: !Url
-  , _poolMDHash :: !ByteString
-  } deriving (Eq, Generic, Show)
+  { _poolMDUrl :: !Url,
+    _poolMDHash :: !ByteString
+  }
+  deriving (Eq, Generic, Show)
 
 instance NoUnexpectedThunks PoolMetaData
 
-data StakePoolRelay =
-     SingleHostAddr !(StrictMaybe Port) !(StrictMaybe IPv4) !(StrictMaybe IPv6)
-     -- ^ One or both of IPv4 & IPv6
-   | SingleHostName !(StrictMaybe Port) !DnsName
-     -- ^ An @A@ or @AAAA@ DNS record
-   | MultiHostName  !(StrictMaybe Port) !DnsName
-     -- ^ A @SRV@ DNS record
+data StakePoolRelay
+  = -- | One or both of IPv4 & IPv6
+    SingleHostAddr !(StrictMaybe Port) !(StrictMaybe IPv4) !(StrictMaybe IPv6)
+  | -- | An @A@ or @AAAA@ DNS record
+    SingleHostName !(StrictMaybe Port) !DnsName
+  | -- | A @SRV@ DNS record
+    MultiHostName !(StrictMaybe Port) !DnsName
   deriving (Eq, Generic, Show)
 
 instance NoUnexpectedThunks StakePoolRelay
 
 instance ToCBOR StakePoolRelay where
-  toCBOR (SingleHostAddr p ipv4 ipv6)
-    = encodeListLen 4
-        <> toCBOR (0 :: Word8)
-        <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
-        <> encodeNullMaybe ipv4ToCBOR (strictMaybeToMaybe ipv4)
-        <> encodeNullMaybe ipv6ToCBOR (strictMaybeToMaybe ipv6)
-  toCBOR (SingleHostName p n)
-    = encodeListLen 3
-        <> toCBOR (1 :: Word8)
-        <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
-        <> toCBOR n
-  toCBOR (MultiHostName p n)
-    = encodeListLen 3
-        <> toCBOR (2 :: Word8)
-        <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
-        <> toCBOR n
+  toCBOR (SingleHostAddr p ipv4 ipv6) =
+    encodeListLen 4
+      <> toCBOR (0 :: Word8)
+      <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
+      <> encodeNullMaybe ipv4ToCBOR (strictMaybeToMaybe ipv4)
+      <> encodeNullMaybe ipv6ToCBOR (strictMaybeToMaybe ipv6)
+  toCBOR (SingleHostName p n) =
+    encodeListLen 3
+      <> toCBOR (1 :: Word8)
+      <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
+      <> toCBOR n
+  toCBOR (MultiHostName p n) =
+    encodeListLen 3
+      <> toCBOR (2 :: Word8)
+      <> encodeNullMaybe toCBOR (strictMaybeToMaybe p)
+      <> toCBOR n
 
 instance FromCBOR StakePoolRelay where
   fromCBOR = do
@@ -151,46 +198,48 @@ instance FromCBOR StakePoolRelay where
     w <- decodeWord
     p <- maybeToStrictMaybe <$> decodeNullMaybe fromCBOR
     case w of
-      0 -> matchSize "SingleHostAddr" 4 n >>
-             SingleHostAddr p
-               <$> (maybeToStrictMaybe <$> decodeNullMaybe ipv4FromCBOR)
-               <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv6FromCBOR)
+      0 ->
+        matchSize "SingleHostAddr" 4 n
+          >> SingleHostAddr p
+          <$> (maybeToStrictMaybe <$> decodeNullMaybe ipv4FromCBOR)
+          <*> (maybeToStrictMaybe <$> decodeNullMaybe ipv6FromCBOR)
       1 -> matchSize "SingleHostName" 3 n >> SingleHostName p <$> fromCBOR
-      2 -> matchSize "MultiHostName"  3 n >> MultiHostName p <$> fromCBOR
+      2 -> matchSize "MultiHostName" 3 n >> MultiHostName p <$> fromCBOR
       k -> invalidKey k
 
--- |A stake pool.
-data PoolParams crypto =
-  PoolParams
-    { _poolPubKey  :: !(KeyHash 'StakePool crypto)
-    , _poolVrf     :: !(Hash crypto (VerKeyVRF crypto))
-    , _poolPledge  :: !Coin
-    , _poolCost    :: !Coin
-    , _poolMargin  :: !UnitInterval
-    , _poolRAcnt   :: !(RewardAcnt crypto)
-    , _poolOwners  :: !(Set (KeyHash 'Staking crypto))
-    , _poolRelays  :: !(StrictSeq StakePoolRelay)
-    , _poolMD      :: !(StrictMaybe PoolMetaData)
-    } deriving (Show, Generic, Eq)
-      deriving ToCBOR via CBORGroup (PoolParams crypto)
-      deriving FromCBOR via CBORGroup (PoolParams crypto)
+-- | A stake pool.
+data PoolParams crypto = PoolParams
+  { _poolPubKey :: !(KeyHash 'StakePool crypto),
+    _poolVrf :: !(Hash crypto (VerKeyVRF crypto)),
+    _poolPledge :: !Coin,
+    _poolCost :: !Coin,
+    _poolMargin :: !UnitInterval,
+    _poolRAcnt :: !(RewardAcnt crypto),
+    _poolOwners :: !(Set (KeyHash 'Staking crypto)),
+    _poolRelays :: !(StrictSeq StakePoolRelay),
+    _poolMD :: !(StrictMaybe PoolMetaData)
+  }
+  deriving (Show, Generic, Eq)
+  deriving (ToCBOR) via CBORGroup (PoolParams crypto)
+  deriving (FromCBOR) via CBORGroup (PoolParams crypto)
 
 instance NoUnexpectedThunks (PoolParams crypto)
 
--- |An account based address for rewards
+-- | An account based address for rewards
 --
--- A reward account uses the staking credential
+--  A reward account uses the staking credential
 newtype RewardAcnt crypto = RewardAcnt
   { getRwdCred :: Credential 'Staking crypto
-  } deriving (Show, Eq, Generic, Ord)
-    deriving newtype (FromCBOR, NFData, NoUnexpectedThunks, ToCBOR)
+  }
+  deriving (Show, Eq, Generic, Ord)
+  deriving newtype (FromCBOR, NFData, NoUnexpectedThunks, ToCBOR)
 
 -- | Script hash or key hash for a payment or a staking object.
-data Credential (kr :: KeyRole) crypto =
-    ScriptHashObj !(ScriptHash crypto)
-  | KeyHashObj    !(KeyHash kr crypto)
-    deriving (Show, Eq, Generic, NFData, Ord)
-    deriving ToCBOR via (CBORGroup (Credential kr crypto))
+data Credential (kr :: KeyRole) crypto
+  = ScriptHashObj !(ScriptHash crypto)
+  | KeyHashObj !(KeyHash kr crypto)
+  deriving (Show, Eq, Generic, NFData, Ord)
+  deriving (ToCBOR) via (CBORGroup (Credential kr crypto))
 
 instance HasKeyRole Credential where
   coerceKeyRole (ScriptHashObj x) = ScriptHashObj x
@@ -199,15 +248,16 @@ instance HasKeyRole Credential where
 newtype GenesisCredential crypto = GenesisCredential (KeyHash 'Genesis crypto)
   deriving (Show, Generic)
 
-instance Ord (GenesisCredential crypto)
-  where compare (GenesisCredential gh) (GenesisCredential gh')  = compare gh gh'
+instance Ord (GenesisCredential crypto) where
+  compare (GenesisCredential gh) (GenesisCredential gh') = compare gh gh'
 
-instance Eq (GenesisCredential crypto)
-  where (==) (GenesisCredential gh) (GenesisCredential gh') = gh == gh'
+instance Eq (GenesisCredential crypto) where
+  (==) (GenesisCredential gh) (GenesisCredential gh') = gh == gh'
 
 instance NoUnexpectedThunks (Credential kr crypto)
 
 type PaymentCredential crypto = Credential 'Payment crypto
+
 type StakeCredential crypto = Credential 'Staking crypto
 
 data StakeReference crypto
@@ -218,7 +268,7 @@ data StakeReference crypto
 
 instance NoUnexpectedThunks (StakeReference crypto)
 
--- |An address for UTxO.
+-- | An address for UTxO.
 data Addr crypto
   = Addr !(PaymentCredential crypto) !(StakeReference crypto)
   | AddrBootstrap !(KeyHash 'Payment crypto)
@@ -227,7 +277,7 @@ data Addr crypto
 
 instance NoUnexpectedThunks (Addr crypto)
 
-type Ix  = Natural
+type Ix = Natural
 
 -- | Pointer to a slot, transaction index and index in certificate list.
 data Ptr
@@ -236,11 +286,12 @@ data Ptr
   deriving (ToCBOR, FromCBOR) via CBORGroup Ptr
 
 instance NFData Ptr
+
 instance NoUnexpectedThunks Ptr
 
-newtype Wdrl crypto = Wdrl { unWdrl :: Map (RewardAcnt crypto) Coin }
+newtype Wdrl crypto = Wdrl {unWdrl :: Map (RewardAcnt crypto) Coin}
   deriving (Show, Eq, Generic)
-  deriving newtype NoUnexpectedThunks
+  deriving newtype (NoUnexpectedThunks)
 
 instance Crypto crypto => ToCBOR (Wdrl crypto) where
   toCBOR = mapToCBOR . unWdrl
@@ -248,49 +299,48 @@ instance Crypto crypto => ToCBOR (Wdrl crypto) where
 instance Crypto crypto => FromCBOR (Wdrl crypto) where
   fromCBOR = Wdrl <$> mapFromCBOR
 
-
--- |A unique ID of a transaction, which is computable from the transaction.
-newtype TxId crypto
-  = TxId { _TxId :: Hash crypto (TxBody crypto) }
+-- | A unique ID of a transaction, which is computable from the transaction.
+newtype TxId crypto = TxId {_TxId :: Hash crypto (TxBody crypto)}
   deriving (Show, Eq, Ord, Generic)
   deriving newtype (NFData, NoUnexpectedThunks)
 
 deriving newtype instance Crypto crypto => ToCBOR (TxId crypto)
+
 deriving newtype instance Crypto crypto => FromCBOR (TxId crypto)
 
--- |The input of a UTxO.
+-- | The input of a UTxO.
 data TxIn crypto
   = TxIn !(TxId crypto) !Natural -- TODO use our own Natural type
   deriving (Show, Eq, Generic, Ord)
 
 instance NoUnexpectedThunks (TxIn crypto)
 
--- |The output of a UTxO.
+-- | The output of a UTxO.
 data TxOut crypto
   = TxOut !(Addr crypto) !Coin
   deriving (Show, Eq, Generic, Ord)
 
 instance NoUnexpectedThunks (TxOut crypto)
 
-data DelegCert crypto =
-    -- | A stake key registration certificate.
+data DelegCert crypto
+  = -- | A stake key registration certificate.
     RegKey !(StakeCredential crypto)
-    -- | A stake key deregistration certificate.
-  | DeRegKey !(StakeCredential crypto)
-    -- | A stake delegation certificate.
-  | Delegate !(Delegation crypto)
+  | -- | A stake key deregistration certificate.
+    DeRegKey !(StakeCredential crypto)
+  | -- | A stake delegation certificate.
+    Delegate !(Delegation crypto)
   deriving (Show, Generic, Eq)
 
-data PoolCert crypto =
-    -- | A stake pool registration certificate.
+data PoolCert crypto
+  = -- | A stake pool registration certificate.
     RegPool !(PoolParams crypto)
-    -- | A stake pool retirement certificate.
-  | RetirePool !(KeyHash 'StakePool crypto) !EpochNo
+  | -- | A stake pool retirement certificate.
+    RetirePool !(KeyHash 'StakePool crypto) !EpochNo
   deriving (Show, Generic, Eq)
 
 -- | Genesis key delegation certificate
-data GenesisDelegCert crypto =
-    GenesisDelegCert !(KeyHash 'Genesis crypto) !(KeyHash 'GenesisDelegate crypto)
+data GenesisDelegCert crypto
+  = GenesisDelegCert !(KeyHash 'Genesis crypto) !(KeyHash 'GenesisDelegate crypto)
   deriving (Show, Generic, Eq)
 
 -- | Move instantaneous rewards certificate
@@ -304,181 +354,186 @@ instance Crypto crypto => ToCBOR (MIRCert crypto) where
   toCBOR (MIRCert c) = mapToCBOR c
 
 -- | A heavyweight certificate.
-data DCert crypto =
-    DCertDeleg !(DelegCert crypto)
+data DCert crypto
+  = DCertDeleg !(DelegCert crypto)
   | DCertPool !(PoolCert crypto)
   | DCertGenesis !(GenesisDelegCert crypto)
   | DCertMir !(MIRCert crypto)
   deriving (Show, Generic, Eq)
 
 instance NoUnexpectedThunks (DelegCert crypto)
+
 instance NoUnexpectedThunks (PoolCert crypto)
+
 instance NoUnexpectedThunks (GenesisDelegCert crypto)
+
 instance NoUnexpectedThunks (MIRCert crypto)
+
 instance NoUnexpectedThunks (DCert crypto)
 
--- |A raw transaction
-data TxBody crypto
-  = TxBody'
-      { _inputs'   :: !(Set (TxIn crypto))
-      , _outputs'  :: !(StrictSeq (TxOut crypto))
-      , _certs'    :: !(StrictSeq (DCert crypto))
-      , _wdrls'    :: !(Wdrl crypto)
-      , _txfee'    :: !Coin
-      , _ttl'      :: !SlotNo
-      , _txUpdate' :: !(StrictMaybe (Update crypto))
-      , _mdHash'   :: !(StrictMaybe (MetaDataHash crypto))
-      , bodyBytes  :: LByteString
-      } deriving (Show, Eq, Generic)
-        deriving NoUnexpectedThunks via
-          AllowThunksIn '["bodyBytes"] (TxBody crypto)
+-- | A raw transaction
+data TxBody crypto = TxBody'
+  { _inputs' :: !(Set (TxIn crypto)),
+    _outputs' :: !(StrictSeq (TxOut crypto)),
+    _certs' :: !(StrictSeq (DCert crypto)),
+    _wdrls' :: !(Wdrl crypto),
+    _txfee' :: !Coin,
+    _ttl' :: !SlotNo,
+    _txUpdate' :: !(StrictMaybe (Update crypto)),
+    _mdHash' :: !(StrictMaybe (MetaDataHash crypto)),
+    bodyBytes :: LByteString
+  }
+  deriving (Show, Eq, Generic)
+  deriving
+    (NoUnexpectedThunks)
+    via AllowThunksIn '["bodyBytes"] (TxBody crypto)
 
-pattern TxBody
-  :: Crypto crypto
-  => Set (TxIn crypto)
-  -> StrictSeq (TxOut crypto)
-  -> StrictSeq (DCert crypto)
-  -> Wdrl crypto
-  -> Coin
-  -> SlotNo
-  -> StrictMaybe (Update crypto)
-  -> StrictMaybe (MetaDataHash crypto)
-  -> TxBody crypto
-pattern TxBody
- { _inputs, _outputs, _certs, _wdrls, _txfee, _ttl, _txUpdate, _mdHash } <-
- TxBody'
-   { _inputs'   = _inputs
-   , _outputs'  = _outputs
-   , _certs'    =  _certs
-   , _wdrls'    = _wdrls
-   , _txfee'    = _txfee
-   , _ttl'      = _ttl
-   , _txUpdate' = _txUpdate
-   , _mdHash'   = _mdHash
-   }
+pattern TxBody ::
+  Crypto crypto =>
+  Set (TxIn crypto) ->
+  StrictSeq (TxOut crypto) ->
+  StrictSeq (DCert crypto) ->
+  Wdrl crypto ->
+  Coin ->
+  SlotNo ->
+  StrictMaybe (Update crypto) ->
+  StrictMaybe (MetaDataHash crypto) ->
+  TxBody crypto
+pattern TxBody {_inputs, _outputs, _certs, _wdrls, _txfee, _ttl, _txUpdate, _mdHash} <-
+  TxBody'
+    { _inputs' = _inputs,
+      _outputs' = _outputs,
+      _certs' = _certs,
+      _wdrls' = _wdrls,
+      _txfee' = _txfee,
+      _ttl' = _ttl,
+      _txUpdate' = _txUpdate,
+      _mdHash' = _mdHash
+    }
   where
-  TxBody _inputs _outputs _certs _wdrls _txfee _ttl _txUpdate _mdHash =
-    let encodeMapElement ix x = Just (encodeWord ix <> toCBOR x)
-        encodeMapElementUnless condition ix x = if condition x
-          then Nothing
-          else encodeMapElement ix x
-        l = catMaybes
-          [ encodeMapElement 0 $ Set.toList _inputs
-          , encodeMapElement 1 $ CborSeq $ StrictSeq.getSeq _outputs
-          , encodeMapElement 2 _txfee
-          , encodeMapElement 3 _ttl
-          , encodeMapElementUnless null 4 $ CborSeq $ StrictSeq.getSeq _certs
-          , encodeMapElementUnless (null . unWdrl) 5 _wdrls
-          , encodeMapElement 6 =<< strictMaybeToMaybe _txUpdate
-          , encodeMapElement 7 =<< strictMaybeToMaybe _mdHash
-          ]
-        n = fromIntegral $ length l
-        bytes = serializeEncoding $ encodeMapLen n <> fold l
-     in TxBody' _inputs _outputs _certs _wdrls _txfee _ttl _txUpdate _mdHash bytes
+    TxBody _inputs _outputs _certs _wdrls _txfee _ttl _txUpdate _mdHash =
+      let encodeMapElement ix x = Just (encodeWord ix <> toCBOR x)
+          encodeMapElementUnless condition ix x =
+            if condition x
+              then Nothing
+              else encodeMapElement ix x
+          l =
+            catMaybes
+              [ encodeMapElement 0 $ Set.toList _inputs,
+                encodeMapElement 1 $ CborSeq $ StrictSeq.getSeq _outputs,
+                encodeMapElement 2 _txfee,
+                encodeMapElement 3 _ttl,
+                encodeMapElementUnless null 4 $ CborSeq $ StrictSeq.getSeq _certs,
+                encodeMapElementUnless (null . unWdrl) 5 _wdrls,
+                encodeMapElement 6 =<< strictMaybeToMaybe _txUpdate,
+                encodeMapElement 7 =<< strictMaybeToMaybe _mdHash
+              ]
+          n = fromIntegral $ length l
+          bytes = serializeEncoding $ encodeMapLen n <> fold l
+       in TxBody' _inputs _outputs _certs _wdrls _txfee _ttl _txUpdate _mdHash bytes
 
 {-# COMPLETE TxBody #-}
 
--- |Proof/Witness that a transaction is authorized by the given key holder.
-data WitVKey crypto
-  = WitVKey'
-    { wvkKey' :: !(VKey 'Witness crypto)
-    , wvkSig' :: !(SignedDSIGN crypto (Hash crypto (TxBody crypto)))
-    , wvkBytes :: LByteString
-    }
+-- | Proof/Witness that a transaction is authorized by the given key holder.
+data WitVKey crypto = WitVKey'
+  { wvkKey' :: !(VKey 'Witness crypto),
+    wvkSig' :: !(SignedDSIGN crypto (Hash crypto (TxBody crypto))),
+    wvkBytes :: LByteString
+  }
   deriving (Show, Eq, Generic)
-  deriving NoUnexpectedThunks via AllowThunksIn '["wvkBytes"] (WitVKey crypto)
+  deriving (NoUnexpectedThunks) via AllowThunksIn '["wvkBytes"] (WitVKey crypto)
 
-pattern WitVKey
-   :: Crypto crypto
-   => VKey 'Witness crypto
-   -> SignedDSIGN crypto (Hash crypto (TxBody crypto))
-   -> WitVKey crypto
-pattern WitVKey k s <- WitVKey' k s _
+pattern WitVKey ::
+  Crypto crypto =>
+  VKey 'Witness crypto ->
+  SignedDSIGN crypto (Hash crypto (TxBody crypto)) ->
+  WitVKey crypto
+pattern WitVKey k s <-
+  WitVKey' k s _
   where
-  WitVKey k s =
-    let bytes = serializeEncoding $ encodeListLen 2 <> toCBOR k <> encodeSignedDSIGN s
-     in WitVKey' k s bytes
+    WitVKey k s =
+      let bytes = serializeEncoding $ encodeListLen 2 <> toCBOR k <> encodeSignedDSIGN s
+       in WitVKey' k s bytes
 
 {-# COMPLETE WitVKey #-}
 
-witKeyHash
-  :: forall crypto. ( Crypto crypto)
-  => WitVKey crypto
-  -> KeyHash 'Witness crypto
+witKeyHash ::
+  forall crypto.
+  (Crypto crypto) =>
+  WitVKey crypto ->
+  KeyHash 'Witness crypto
 witKeyHash (WitVKey key _) = hashKey key
 
-instance forall crypto
-  . ( Crypto crypto)
-  => Ord (WitVKey crypto) where
-    compare = comparing witKeyHash
+instance
+  forall crypto.
+  (Crypto crypto) =>
+  Ord (WitVKey crypto)
+  where
+  compare = comparing witKeyHash
 
-newtype StakeCreds crypto =
-  StakeCreds (Map (Credential 'Staking crypto) SlotNo)
+newtype StakeCreds crypto
+  = StakeCreds (Map (Credential 'Staking crypto) SlotNo)
   deriving (Show, Eq, Generic)
   deriving newtype (FromCBOR, NFData, NoUnexpectedThunks, ToCBOR)
 
-addStakeCreds
-  :: (Credential 'Staking crypto)
-  -> SlotNo
-  -> (StakeCreds crypto)
-  -> StakeCreds crypto
+addStakeCreds ::
+  (Credential 'Staking crypto) ->
+  SlotNo ->
+  (StakeCreds crypto) ->
+  StakeCreds crypto
 addStakeCreds newCred s (StakeCreds creds) = StakeCreds $ Map.insert newCred s creds
 
-newtype StakePools crypto =
-  StakePools { unStakePools :: (Map (KeyHash 'StakePool crypto) SlotNo) }
+newtype StakePools crypto = StakePools {unStakePools :: (Map (KeyHash 'StakePool crypto) SlotNo)}
   deriving (Show, Eq, Generic)
   deriving newtype (FromCBOR, NFData, NoUnexpectedThunks, ToCBOR)
 
 -- CBOR
 
 instance
-  (Crypto crypto)
-  => ToCBOR (DCert crypto)
- where
-   toCBOR = \case
-           -- DCertDeleg
-     DCertDeleg (RegKey cred) ->
-           encodeListLen 2
-           <> toCBOR (0 :: Word8)
-           <> toCBOR cred
-     DCertDeleg (DeRegKey cred) ->
-           encodeListLen 2
-           <> toCBOR (1 :: Word8)
-           <> toCBOR cred
-     DCertDeleg (Delegate (Delegation cred poolkh)) ->
-           encodeListLen 3
-           <> toCBOR (2 :: Word8)
-           <> toCBOR cred
-           <> toCBOR poolkh
-
-           -- DCertPool
-     DCertPool (RegPool poolParams) ->
-           encodeListLen (1 + listLen poolParams)
-           <> toCBOR (3 :: Word8)
-           <> toCBORGroup poolParams
-     DCertPool (RetirePool vk epoch) ->
-           encodeListLen 3
-           <> toCBOR (4 :: Word8)
-           <> toCBOR vk
-           <> toCBOR epoch
-
-           -- DCertGenesis
-     DCertGenesis (GenesisDelegCert gk kh) ->
-           encodeListLen 3
-           <> toCBOR (5 :: Word8)
-           <> toCBOR gk
-           <> toCBOR kh
-
-           -- DCertMIR
-     DCertMir mir ->
-           encodeListLen 2
-           <> toCBOR (6 :: Word8)
-           <> toCBOR mir
+  (Crypto crypto) =>
+  ToCBOR (DCert crypto)
+  where
+  toCBOR = \case
+    -- DCertDeleg
+    DCertDeleg (RegKey cred) ->
+      encodeListLen 2
+        <> toCBOR (0 :: Word8)
+        <> toCBOR cred
+    DCertDeleg (DeRegKey cred) ->
+      encodeListLen 2
+        <> toCBOR (1 :: Word8)
+        <> toCBOR cred
+    DCertDeleg (Delegate (Delegation cred poolkh)) ->
+      encodeListLen 3
+        <> toCBOR (2 :: Word8)
+        <> toCBOR cred
+        <> toCBOR poolkh
+    -- DCertPool
+    DCertPool (RegPool poolParams) ->
+      encodeListLen (1 + listLen poolParams)
+        <> toCBOR (3 :: Word8)
+        <> toCBORGroup poolParams
+    DCertPool (RetirePool vk epoch) ->
+      encodeListLen 3
+        <> toCBOR (4 :: Word8)
+        <> toCBOR vk
+        <> toCBOR epoch
+    -- DCertGenesis
+    DCertGenesis (GenesisDelegCert gk kh) ->
+      encodeListLen 3
+        <> toCBOR (5 :: Word8)
+        <> toCBOR gk
+        <> toCBOR kh
+    -- DCertMIR
+    DCertMir mir ->
+      encodeListLen 2
+        <> toCBOR (6 :: Word8)
+        <> toCBOR mir
 
 instance
-  (Crypto crypto)
-  => FromCBOR (DCert crypto)
- where
+  (Crypto crypto) =>
+  FromCBOR (DCert crypto)
+  where
   fromCBOR = do
     n <- decodeListLen
     decodeWord >>= \case
@@ -507,16 +562,18 @@ instance
       k -> invalidKey k
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBOR (TxIn crypto)
- where
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (TxIn crypto)
+  where
   toCBOR (TxIn txId index) =
     encodeListLen 2
       <> toCBOR txId
       <> toCBOR (fromIntegral index :: Word64)
 
-instance (Crypto crypto) =>
-  FromCBOR (TxIn crypto) where
+instance
+  (Crypto crypto) =>
+  FromCBOR (TxIn crypto)
+  where
   fromCBOR = do
     enforceSize "TxIn" 2
     a <- fromCBOR
@@ -524,16 +581,18 @@ instance (Crypto crypto) =>
     pure $ TxIn a (fromInteger $ toInteger b)
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBOR (TxOut crypto)
- where
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (TxOut crypto)
+  where
   toCBOR (TxOut addr coin) =
     encodeListLen (listLen addr + 1)
       <> toCBORGroup addr
       <> toCBOR coin
 
-instance (Crypto crypto) =>
-  FromCBOR (TxOut crypto) where
+instance
+  (Crypto crypto) =>
+  FromCBOR (TxOut crypto)
+  where
   fromCBOR = do
     n <- decodeListLen
     addr <- fromCBORGroup
@@ -542,81 +601,91 @@ instance (Crypto crypto) =>
     pure $ TxOut addr (Coin $ toInteger b)
 
 instance
-  Crypto crypto
-  => ToCBOR (WitVKey crypto)
- where
+  Crypto crypto =>
+  ToCBOR (WitVKey crypto)
+  where
   toCBOR = encodePreEncoded . BSL.toStrict . wvkBytes
 
 instance
-  Crypto crypto
-  => FromCBOR (Annotator (WitVKey crypto))
- where
-  fromCBOR = annotatorSlice $ decodeRecordNamed "WitVKey" (const 2) $
-    fmap pure $ WitVKey' <$> fromCBOR <*> decodeSignedDSIGN
+  Crypto crypto =>
+  FromCBOR (Annotator (WitVKey crypto))
+  where
+  fromCBOR =
+    annotatorSlice $ decodeRecordNamed "WitVKey" (const 2)
+      $ fmap pure
+      $ WitVKey' <$> fromCBOR <*> decodeSignedDSIGN
 
 instance
-  (Crypto crypto)
-  => ToCBOR (TxBody crypto)
- where
+  (Crypto crypto) =>
+  ToCBOR (TxBody crypto)
+  where
   toCBOR = encodePreEncoded . BSL.toStrict . bodyBytes
 
 instance
-  (Crypto crypto)
-  => FromCBOR (Annotator (TxBody crypto))
+  (Crypto crypto) =>
+  FromCBOR (Annotator (TxBody crypto))
   where
-   fromCBOR = annotatorSlice $ do
-     mapParts <- decodeMapContents $
-       decodeWord >>= \case
-         0 -> decodeSet fromCBOR                 >>= \x -> pure (0, \t -> t { _inputs   = x })
-         1 -> (unwrapCborStrictSeq <$> fromCBOR) >>= \x -> pure (1, \t -> t { _outputs'  = x })
-         2 -> fromCBOR                           >>= \x -> pure (2, \t -> t { _txfee'    = x })
-         3 -> fromCBOR                           >>= \x -> pure (3, \t -> t { _ttl'      = x })
-         4 -> (unwrapCborStrictSeq <$> fromCBOR) >>= \x -> pure (4, \t -> t { _certs'    = x })
-         5 -> fromCBOR                           >>= \x -> pure (5, \t -> t { _wdrls'    = x })
-         6 -> fromCBOR                           >>= \x -> pure (6, \t -> t { _txUpdate' = SJust x })
-         7 -> fromCBOR                           >>= \x -> pure (7, \t -> t { _mdHash'   = SJust x })
-         k -> invalidKey k
-     let requiredFields :: Map Int String
-         requiredFields = Map.fromList $
-           [ (0, "inputs")
-           , (1, "outputs")
-           , (2, "fee")
-           , (3, "ttl")
-           ]
-         fields = fst <$> mapParts
-         missingFields = Map.filterWithKey (\k _ -> notElem k fields) requiredFields
-     unless (null missingFields)
-       (fail $ "missing required transaction component(s): " <> show missingFields)
-     pure $ Annotator $ \_fullbytes bytes ->
-       (foldr ($) basebody (snd <$> mapParts)) { bodyBytes = bytes }
-     where
-       basebody = TxBody'
-          { _inputs'  = Set.empty
-          , _outputs' = StrictSeq.empty
-          , _txfee'   = Coin 0
-          , _ttl'     = SlotNo 0
-          , _certs'   = StrictSeq.empty
-          , _wdrls'   = Wdrl Map.empty
-          , _txUpdate'= SNothing
-          , _mdHash'  = SNothing
-          , bodyBytes = mempty
+  fromCBOR = annotatorSlice $ do
+    mapParts <- decodeMapContents $
+      decodeWord >>= \case
+        0 -> decodeSet fromCBOR >>= \x -> pure (0, \t -> t {_inputs = x})
+        1 -> (unwrapCborStrictSeq <$> fromCBOR) >>= \x -> pure (1, \t -> t {_outputs' = x})
+        2 -> fromCBOR >>= \x -> pure (2, \t -> t {_txfee' = x})
+        3 -> fromCBOR >>= \x -> pure (3, \t -> t {_ttl' = x})
+        4 -> (unwrapCborStrictSeq <$> fromCBOR) >>= \x -> pure (4, \t -> t {_certs' = x})
+        5 -> fromCBOR >>= \x -> pure (5, \t -> t {_wdrls' = x})
+        6 -> fromCBOR >>= \x -> pure (6, \t -> t {_txUpdate' = SJust x})
+        7 -> fromCBOR >>= \x -> pure (7, \t -> t {_mdHash' = SJust x})
+        k -> invalidKey k
+    let requiredFields :: Map Int String
+        requiredFields =
+          Map.fromList $
+            [ (0, "inputs"),
+              (1, "outputs"),
+              (2, "fee"),
+              (3, "ttl")
+            ]
+        fields = fst <$> mapParts
+        missingFields = Map.filterWithKey (\k _ -> notElem k fields) requiredFields
+    unless
+      (null missingFields)
+      (fail $ "missing required transaction component(s): " <> show missingFields)
+    pure $ Annotator $ \_fullbytes bytes ->
+      (foldr ($) basebody (snd <$> mapParts)) {bodyBytes = bytes}
+    where
+      basebody =
+        TxBody'
+          { _inputs' = Set.empty,
+            _outputs' = StrictSeq.empty,
+            _txfee' = Coin 0,
+            _ttl' = SlotNo 0,
+            _certs' = StrictSeq.empty,
+            _wdrls' = Wdrl Map.empty,
+            _txUpdate' = SNothing,
+            _mdHash' = SNothing,
+            bodyBytes = mempty
           }
 
-
-instance (Typeable kr, Typeable crypto, Crypto crypto)
-  => ToCBORGroup (Credential kr crypto) where
+instance
+  (Typeable kr, Typeable crypto, Crypto crypto) =>
+  ToCBORGroup (Credential kr crypto)
+  where
   listLen _ = 2
   toCBORGroup = \case
-    KeyHashObj     kh -> toCBOR (0 :: Word8) <> toCBOR kh
-    ScriptHashObj  hs -> toCBOR (1 :: Word8) <> toCBOR hs
+    KeyHashObj kh -> toCBOR (0 :: Word8) <> toCBOR kh
+    ScriptHashObj hs -> toCBOR (1 :: Word8) <> toCBOR hs
 
-instance (Typeable crypto, Crypto crypto)
-  => ToCBOR (GenesisCredential crypto)
-  where toCBOR (GenesisCredential kh) =
-          toCBOR kh
+instance
+  (Typeable crypto, Crypto crypto) =>
+  ToCBOR (GenesisCredential crypto)
+  where
+  toCBOR (GenesisCredential kh) =
+    toCBOR kh
 
-instance (Crypto crypto, Typeable kr) =>
-  FromCBOR (Credential kr crypto) where
+instance
+  (Crypto crypto, Typeable kr) =>
+  FromCBOR (Credential kr crypto)
+  where
   fromCBOR = do
     enforceSize "Credential" 2
     decodeWord >>= \case
@@ -625,13 +694,13 @@ instance (Crypto crypto, Typeable kr) =>
       k -> invalidKey k
 
 instance
-  (Typeable crypto, Crypto crypto)
-  => ToCBORGroup (Addr crypto)
- where
+  (Typeable crypto, Crypto crypto) =>
+  ToCBORGroup (Addr crypto)
+  where
   listLen (Addr _ (StakeRefBase _)) = 3
   listLen (Addr _ (StakeRefPtr p)) = 2 + listLen p
   listLen (Addr _ (StakeRefNull)) = 2
-  listLen (AddrBootstrap  _) = 2
+  listLen (AddrBootstrap _) = 2
 
   toCBORGroup (Addr (KeyHashObj a) (StakeRefBase (KeyHashObj b))) =
     toCBOR (0 :: Word8) <> toCBOR a <> toCBOR b
@@ -652,8 +721,10 @@ instance
   toCBORGroup (AddrBootstrap a) =
     toCBOR (8 :: Word8) <> toCBOR a
 
-instance (Crypto crypto) =>
-  FromCBORGroup (Addr crypto) where
+instance
+  (Crypto crypto) =>
+  FromCBORGroup (Addr crypto)
+  where
   fromCBORGroup = do
     decodeWord >>= \case
       0 -> do
@@ -697,7 +768,7 @@ instance (Crypto crypto) =>
 
 instance ToCBORGroup Ptr where
   toCBORGroup (Ptr sl txIx certIx) =
-         toCBOR sl
+    toCBOR sl
       <> toCBOR (fromInteger (toInteger txIx) :: Word)
       <> toCBOR (fromInteger (toInteger certIx) :: Word)
   listLen _ = 3
@@ -705,15 +776,13 @@ instance ToCBORGroup Ptr where
 instance FromCBORGroup Ptr where
   fromCBORGroup = Ptr <$> fromCBOR <*> fromCBOR <*> fromCBOR
 
-instance ToCBOR PoolMetaData
- where
+instance ToCBOR PoolMetaData where
   toCBOR (PoolMetaData u h) =
     encodeListLen 2
       <> toCBOR u
       <> toCBOR h
 
-instance FromCBOR PoolMetaData
-  where
+instance FromCBOR PoolMetaData where
   fromCBOR = do
     enforceSize "PoolMetaData" 2
     u <- fromCBOR
@@ -721,11 +790,11 @@ instance FromCBOR PoolMetaData
     pure $ PoolMetaData u h
 
 instance
-  (Crypto crypto)
-  => ToCBORGroup (PoolParams crypto)
- where
+  (Crypto crypto) =>
+  ToCBORGroup (PoolParams crypto)
+  where
   toCBORGroup poolParams =
-         toCBOR (_poolPubKey poolParams)
+    toCBOR (_poolPubKey poolParams)
       <> toCBOR (_poolVrf poolParams)
       <> toCBOR (_poolPledge poolParams)
       <> toCBOR (_poolCost poolParams)
@@ -737,9 +806,9 @@ instance
   listLen _ = 9
 
 instance
-  (Crypto crypto)
-  => FromCBORGroup (PoolParams crypto)
- where
+  (Crypto crypto) =>
+  FromCBORGroup (PoolParams crypto)
+  where
   fromCBORGroup = do
     vk <- fromCBOR
     vrf <- fromCBOR
@@ -750,21 +819,22 @@ instance
     owners <- decodeSet fromCBOR
     relays <- fromCBOR
     md <- decodeNullMaybe fromCBOR
-    pure $ PoolParams
-            { _poolPubKey = vk
-            , _poolVrf    = vrf
-            , _poolPledge = pledge
-            , _poolCost   = cost
-            , _poolMargin = margin
-            , _poolRAcnt  = ra
-            , _poolOwners = owners
-            , _poolRelays = unwrapCborStrictSeq relays
-            , _poolMD     = maybeToStrictMaybe md
-            }
+    pure $
+      PoolParams
+        { _poolPubKey = vk,
+          _poolVrf = vrf,
+          _poolPledge = pledge,
+          _poolCost = cost,
+          _poolMargin = margin,
+          _poolRAcnt = ra,
+          _poolOwners = owners,
+          _poolRelays = unwrapCborStrictSeq relays,
+          _poolMD = maybeToStrictMaybe md
+        }
 
 instance Relation (StakeCreds crypto) where
   type Domain (StakeCreds crypto) = Credential 'Staking crypto
-  type Range (StakeCreds crypto)  = SlotNo
+  type Range (StakeCreds crypto) = SlotNo
 
   singleton k v = StakeCreds $ Map.singleton k v
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Validation.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Validation.hs
@@ -2,54 +2,53 @@
 
 module Shelley.Spec.Ledger.Validation where
 
-import           GHC.Generics (Generic)
+import Cardano.Prelude (NoUnexpectedThunks (..))
+import GHC.Generics (Generic)
+import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.Slot (SlotNo)
 
-import           Cardano.Prelude (NoUnexpectedThunks (..))
-import           Shelley.Spec.Ledger.Coin (Coin)
-import           Shelley.Spec.Ledger.Slot (SlotNo)
-
--- |Validation errors represent the failures of a transaction to be valid
--- for a given ledger state.
-data ValidationError =
-  -- | The transaction inputs are not valid.
+-- | Validation errors represent the failures of a transaction to be valid
+--  for a given ledger state.
+data ValidationError
+  = -- | The transaction inputs are not valid.
     BadInputs
-  -- | The transaction has expired
-  | Expired SlotNo SlotNo
-  -- | Pool Retirement Certificate expired
-  | RetirementCertExpired SlotNo SlotNo
-  -- | The transaction fee is too small
-  | FeeTooSmall Coin Coin
-  -- | Value is not conserved
-  | ValueNotConserved Coin Coin
-  -- | Unknown reward account
-  | IncorrectRewards
-  -- | One of the transaction witnesses is invalid.
-  | InvalidWitness
-  -- | The transaction does not have the required witnesses.
-  | MissingWitnesses
-  -- | Missing Replay Attack Protection, at least one input must be spent.
-  | InputSetEmpty
-  -- | A stake key cannot be registered again.
-  | StakeKeyAlreadyRegistered
-  -- | A stake key must be registered to be used or deregistered.
-  | StakeKeyNotRegistered
-  -- | The stake key to which is delegated is not known.
-  | StakeDelegationImpossible
-  -- | Stake pool not registered for key, cannot be retired.
-  | StakePoolNotRegisteredOnKey
-  -- | Other error (for conversion from STS errors that have no correspondance here)
-  | UnknownValidationError
-    deriving (Show, Eq, Generic)
+  | -- | The transaction has expired
+    Expired SlotNo SlotNo
+  | -- | Pool Retirement Certificate expired
+    RetirementCertExpired SlotNo SlotNo
+  | -- | The transaction fee is too small
+    FeeTooSmall Coin Coin
+  | -- | Value is not conserved
+    ValueNotConserved Coin Coin
+  | -- | Unknown reward account
+    IncorrectRewards
+  | -- | One of the transaction witnesses is invalid.
+    InvalidWitness
+  | -- | The transaction does not have the required witnesses.
+    MissingWitnesses
+  | -- | Missing Replay Attack Protection, at least one input must be spent.
+    InputSetEmpty
+  | -- | A stake key cannot be registered again.
+    StakeKeyAlreadyRegistered
+  | -- | A stake key must be registered to be used or deregistered.
+    StakeKeyNotRegistered
+  | -- | The stake key to which is delegated is not known.
+    StakeDelegationImpossible
+  | -- | Stake pool not registered for key, cannot be retired.
+    StakePoolNotRegisteredOnKey
+  | -- | Other error (for conversion from STS errors that have no correspondance here)
+    UnknownValidationError
+  deriving (Show, Eq, Generic)
 
 instance NoUnexpectedThunks ValidationError
 
--- |The validity of a transaction, where an invalid transaction
--- is represented by list of errors.
+-- | The validity of a transaction, where an invalid transaction
+--  is represented by list of errors.
 data Validity = Valid | Invalid [ValidationError] deriving (Show, Eq)
 
 instance Semigroup Validity where
-  Valid <> b                 = b
-  a <> Valid                 = a
+  Valid <> b = b
+  a <> Valid = a
   (Invalid a) <> (Invalid b) = Invalid (a ++ b)
 
 instance Monoid Validity where

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/ConcreteCryptoTypes.hs
@@ -6,14 +6,12 @@
 
 module Test.Shelley.Spec.Ledger.ConcreteCryptoTypes where
 
-import           Cardano.Crypto.DSIGN (MockDSIGN, VerKeyDSIGN)
-import           Cardano.Crypto.Hash (ShortHash)
-import           Cardano.Crypto.KES (MockKES)
-import           Data.Map (Map)
-import           Test.Cardano.Crypto.VRF.Fake (FakeVRF)
-
+import Cardano.Crypto.DSIGN (MockDSIGN, VerKeyDSIGN)
+import Cardano.Crypto.Hash (ShortHash)
+import Cardano.Crypto.KES (MockKES)
+import Data.Map (Map)
 import qualified Shelley.Spec.Ledger.BlockChain as BlockChain
-import           Shelley.Spec.Ledger.Crypto
+import Shelley.Spec.Ledger.Crypto
 import qualified Shelley.Spec.Ledger.Delegation.Certificates as Delegation.Certificates
 import qualified Shelley.Spec.Ledger.EpochBoundary as EpochBoundary
 import qualified Shelley.Spec.Ledger.Keys as Keys
@@ -21,7 +19,6 @@ import qualified Shelley.Spec.Ledger.LedgerState as LedgerState
 import qualified Shelley.Spec.Ledger.OCert as OCert
 import qualified Shelley.Spec.Ledger.PParams as PParams
 import qualified Shelley.Spec.Ledger.Rewards as Rewards
-import qualified Shelley.Spec.Ledger.Scripts as Scripts
 import qualified Shelley.Spec.Ledger.STS.Chain as STS.Chain
 import qualified Shelley.Spec.Ledger.STS.Deleg as STS.Deleg
 import qualified Shelley.Spec.Ledger.STS.Delegs as STS.Delegs
@@ -35,9 +32,11 @@ import qualified Shelley.Spec.Ledger.STS.PoolReap as STS.PoolReap
 import qualified Shelley.Spec.Ledger.STS.Tick as STS.Tick
 import qualified Shelley.Spec.Ledger.STS.Utxo as STS.Utxo
 import qualified Shelley.Spec.Ledger.STS.Utxow as STS.Utxow
+import qualified Shelley.Spec.Ledger.Scripts as Scripts
 import qualified Shelley.Spec.Ledger.Tx as Tx
 import qualified Shelley.Spec.Ledger.TxData as TxData
 import qualified Shelley.Spec.Ledger.UTxO as UTxO
+import Test.Cardano.Crypto.VRF.Fake (FakeVRF)
 
 data ConcreteCrypto
 
@@ -60,22 +59,28 @@ type RewardAcnt = TxData.RewardAcnt ConcreteCrypto
 type StakePools = TxData.StakePools ConcreteCrypto
 
 type KeyHash kr = Keys.KeyHash kr ConcreteCrypto
-pattern KeyHash
-  :: Keys.Hash ConcreteCrypto (VerKeyDSIGN (DSIGN ConcreteCrypto))
-  -> KeyHash kr
+
+pattern KeyHash ::
+  Keys.Hash ConcreteCrypto (VerKeyDSIGN (DSIGN ConcreteCrypto)) ->
+  KeyHash kr
 pattern KeyHash h = Keys.KeyHash h
+
 {-# COMPLETE KeyHash #-}
 
 type GenDelegs = Keys.GenDelegs ConcreteCrypto
-pattern GenDelegs
-  :: (Map (KeyHash 'Keys.Genesis) (KeyHash 'Keys.GenesisDelegate))
-  -> GenDelegs
+
+pattern GenDelegs ::
+  (Map (KeyHash 'Keys.Genesis) (KeyHash 'Keys.GenesisDelegate)) ->
+  GenDelegs
 pattern GenDelegs m = Keys.GenDelegs m
+
 {-# COMPLETE GenDelegs #-}
 
 type KeyPair kr = Keys.KeyPair kr ConcreteCrypto
+
 pattern KeyPair :: VKey kr -> SignKeyDSIGN -> KeyPair kr
 pattern KeyPair vk sk = Keys.KeyPair vk sk
+
 {-# COMPLETE KeyPair #-}
 
 type CoreKeyPair = Keys.KeyPair 'Keys.Genesis ConcreteCrypto
@@ -85,8 +90,10 @@ type SignedDSIGN = Keys.SignedDSIGN ConcreteCrypto
 type SignKeyDSIGN = Keys.SignKeyDSIGN ConcreteCrypto
 
 type VKey kr = Keys.VKey kr ConcreteCrypto
+
 pattern VKey :: VerKeyDSIGN (DSIGN ConcreteCrypto) -> VKey kr
 pattern VKey x = Keys.VKey x
+
 {-# COMPLETE VKey #-}
 
 type KeyPairs = LedgerState.KeyPairs ConcreteCrypto
@@ -217,7 +224,7 @@ type ProposedPPUpdates = PParams.ProposedPPUpdates ConcreteCrypto
 
 type VRFKeyHash = Keys.Hash ConcreteCrypto (Keys.VerKeyVRF ConcreteCrypto)
 
-hashKeyVRF
-  :: Keys.VerKeyVRF ConcreteCrypto
-  -> VRFKeyHash
+hashKeyVRF ::
+  Keys.VerKeyVRF ConcreteCrypto ->
+  VRFKeyHash
 hashKeyVRF = Keys.hashVerKeyVRF

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/CDDL.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/CDDL.hs
@@ -2,69 +2,85 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 
 module Test.Shelley.Spec.Ledger.Examples.CDDL
-  ( cddlTests
+  ( cddlTests,
   )
- where
+where
 
-import           Prelude (String)
-import qualified Prelude
-
-import           Cardano.Binary (Annotator, DecoderError, FromCBOR (..), ToCBOR (..),
-                     decodeAnnotator, decodeFullDecoder, encodeListLen, serialize,
-                     serializeEncoding)
-import           Cardano.Prelude
-import           Control.Exception (bracket)
+import Cardano.Binary
+  ( Annotator,
+    DecoderError,
+    FromCBOR (..),
+    ToCBOR (..),
+    decodeAnnotator,
+    decodeFullDecoder,
+    encodeListLen,
+    serialize,
+    serializeEncoding,
+  )
+import Cardano.Prelude
+import Control.Exception (bracket)
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Lazy as BSL
-import           Data.ByteString.Lazy.Char8 as Char8 (lines, unpack)
+import Data.ByteString.Lazy.Char8 as Char8 (lines, unpack)
+import Shelley.Spec.Ledger.Keys (KeyRole (Staking))
+import Shelley.Spec.Ledger.MetaData (MetaData)
+import Shelley.Spec.Ledger.PParams (PParamsUpdate)
+import Shelley.Spec.Ledger.Serialization
+import Shelley.Spec.Ledger.TxData (StakePoolRelay)
 import qualified System.Directory as Sys
 import qualified System.IO as Sys
 import qualified System.IO.Error as Sys
-import           System.Process.ByteString.Lazy
-
-
-import           Test.Tasty
-import           Test.Tasty.HUnit
-
-import           Shelley.Spec.Ledger.Keys (KeyRole(Staking))
-import           Shelley.Spec.Ledger.MetaData (MetaData)
-import           Shelley.Spec.Ledger.PParams (PParamsUpdate)
-import           Shelley.Spec.Ledger.Serialization
-import           Shelley.Spec.Ledger.TxData (StakePoolRelay)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, BHBody, BHeader, Credential,
-                     DCert, LaxBlock, MultiSig, OCert, ProposedPPUpdates, Tx, TxBody, TxIn, TxOut,
-                     Update)
+import System.Process.ByteString.Lazy
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Addr,
+    BHBody,
+    BHeader,
+    Credential,
+    DCert,
+    LaxBlock,
+    MultiSig,
+    OCert,
+    ProposedPPUpdates,
+    Tx,
+    TxBody,
+    TxIn,
+    TxOut,
+    Update,
+  )
+import Test.Tasty
+import Test.Tasty.HUnit
+import qualified Prelude
+import Prelude (String)
 
 cddlTests :: Int -> TestTree
 cddlTests n = withResource combinedCDDL (const (pure ())) $ \cddl ->
   testGroup "CDDL roundtrip tests" $
-    [
-      cddlTest' @BHeader          n "header"
-    , cddlTest @BHBody            n "header_body"
-    , cddlGroupTest @OCert        n "operational_cert"
-    , cddlGroupTest @Addr         n "address"
-    , cddlTest @(Credential 'Staking)   n "stake_credential"
-    , cddlTest' @TxBody           n "transaction_body"
-    , cddlTest @TxOut             n "transaction_output"
-    , cddlTest @StakePoolRelay    n "relay"
-    , cddlTest @DCert             n "certificate"
-    , cddlTest @TxIn              n "transaction_input"
-    , cddlTest' @MetaData         n "transaction_metadata"
-    , cddlTest @MultiSig          n "multisig_script"
-    , cddlTest @Update            n "update"
-    , cddlTest @ProposedPPUpdates n "proposed_protocol_parameter_updates"
-    , cddlTest @PParamsUpdate     n "protocol_param_update"
-    , cddlTest' @Tx               n "transaction"
-    , cddlTest' @LaxBlock         n "block"
-    ] <*> pure cddl
+    [ cddlTest' @BHeader n "header",
+      cddlTest @BHBody n "header_body",
+      cddlGroupTest @OCert n "operational_cert",
+      cddlGroupTest @Addr n "address",
+      cddlTest @(Credential 'Staking) n "stake_credential",
+      cddlTest' @TxBody n "transaction_body",
+      cddlTest @TxOut n "transaction_output",
+      cddlTest @StakePoolRelay n "relay",
+      cddlTest @DCert n "certificate",
+      cddlTest @TxIn n "transaction_input",
+      cddlTest' @MetaData n "transaction_metadata",
+      cddlTest @MultiSig n "multisig_script",
+      cddlTest @Update n "update",
+      cddlTest @ProposedPPUpdates n "proposed_protocol_parameter_updates",
+      cddlTest @PParamsUpdate n "protocol_param_update",
+      cddlTest' @Tx n "transaction",
+      cddlTest' @LaxBlock n "block"
+    ]
+      <*> pure cddl
 
 combinedCDDL :: IO BSL.ByteString
 combinedCDDL = do
@@ -73,38 +89,41 @@ combinedCDDL = do
   extras <- BSL.readFile "cddl-files/mock/extras.cddl"
   pure $ base <> crypto <> extras
 
-cddlTest
-  :: forall a. (ToCBOR a, FromCBOR a, Show a)
-  => Int
-  -> BSL.ByteString
-  -> IO BSL.ByteString
-  -> TestTree
+cddlTest ::
+  forall a.
+  (ToCBOR a, FromCBOR a, Show a) =>
+  Int ->
+  BSL.ByteString ->
+  IO BSL.ByteString ->
+  TestTree
 cddlTest n entryName cddlRes = testCase
   ("cddl roundtrip " <> show (typeRep (Proxy @a)))
   $ do
-  basecddl <- cddlRes
-  let cddl = "output = " <> entryName <> "\n" <> basecddl
-  cddlTestCommon @a serialize (decodeFullDecoder "cbor test" fromCBOR) n cddl
+    basecddl <- cddlRes
+    let cddl = "output = " <> entryName <> "\n" <> basecddl
+    cddlTestCommon @a serialize (decodeFullDecoder "cbor test" fromCBOR) n cddl
 
-cddlTest'
-  :: forall a. (ToCBOR a, FromCBOR (Annotator a), Show a)
-  => Int
-  -> BSL.ByteString
-  -> IO BSL.ByteString
-  -> TestTree
+cddlTest' ::
+  forall a.
+  (ToCBOR a, FromCBOR (Annotator a), Show a) =>
+  Int ->
+  BSL.ByteString ->
+  IO BSL.ByteString ->
+  TestTree
 cddlTest' n entryName cddlRes = testCase
   ("cddl roundtrip " <> show (typeRep (Proxy @a)))
   $ do
-  basecddl <- cddlRes
-  let cddl = "output = " <> entryName <> "\n" <> basecddl
-  cddlTestCommon @a serialize (decodeAnnotator "cbor test" fromCBOR) n cddl
+    basecddl <- cddlRes
+    let cddl = "output = " <> entryName <> "\n" <> basecddl
+    cddlTestCommon @a serialize (decodeAnnotator "cbor test" fromCBOR) n cddl
 
-cddlGroupTest
-  :: forall a. (ToCBORGroup a, FromCBORGroup a, Show a)
-  => Int
-  -> BSL.ByteString
-  -> IO BSL.ByteString
-  -> TestTree
+cddlGroupTest ::
+  forall a.
+  (ToCBORGroup a, FromCBORGroup a, Show a) =>
+  Int ->
+  BSL.ByteString ->
+  IO BSL.ByteString ->
+  TestTree
 cddlGroupTest n entryName cddlRes = testCase ("cddl roundtrip " <> show (typeRep (Proxy @a))) $ do
   basecddl <- cddlRes
   let cddl = "output = [" <> entryName <> "]\n" <> basecddl
@@ -114,12 +133,13 @@ cddlGroupTest n entryName cddlRes = testCase ("cddl roundtrip " <> show (typeRep
     n
     cddl
 
-cddlTestCommon
-  :: Show a => (a -> BSL.ByteString)
-  -> (BSL.ByteString -> Either DecoderError a)
-  -> Int
-  -> BSL.ByteString
-  -> IO ()
+cddlTestCommon ::
+  Show a =>
+  (a -> BSL.ByteString) ->
+  (BSL.ByteString -> Either DecoderError a) ->
+  Int ->
+  BSL.ByteString ->
+  IO ()
 cddlTestCommon serializer decoder n cddlData = do
   usingFile cddlData $ \cddl -> do
     examples <- Char8.lines <$> generateCBORDiagStdIn n cddlData :: IO [BSL.ByteString]
@@ -127,50 +147,52 @@ cddlTestCommon serializer decoder n cddlData = do
       exampleBytes <- diagToBytes exampleDiag
       decoded <- case decoder exampleBytes of
         Right x -> pure x
-        Left e  ->
-          assertFailure $ Prelude.unlines
-            [ "Failed to deserialize"
-            , "Error: " <> show e
-            , "Generated diag: " <> Char8.unpack exampleDiag
-            ]
+        Left e ->
+          assertFailure $
+            Prelude.unlines
+              [ "Failed to deserialize",
+                "Error: " <> show e,
+                "Generated diag: " <> Char8.unpack exampleDiag
+              ]
       let reencoded = serializer decoded
       verifyConforming reencoded cddl >>= \case
         True -> pure ()
         False ->
-          assertFailure $ Prelude.unlines
-            [ "Serialized data did not conform to the spec"
-            , "Generated diag: " <> Char8.unpack exampleDiag
-            , "Generated base16: " <> Char8.unpack (Base16.encode exampleBytes)
-            , "Decoded value: " <> show decoded
-            , "Reencoded base16: " <> Char8.unpack (Base16.encode reencoded)
-            ]
+          assertFailure $
+            Prelude.unlines
+              [ "Serialized data did not conform to the spec",
+                "Generated diag: " <> Char8.unpack exampleDiag,
+                "Generated base16: " <> Char8.unpack (Base16.encode exampleBytes),
+                "Decoded value: " <> show decoded,
+                "Reencoded base16: " <> Char8.unpack (Base16.encode reencoded)
+              ]
 
 data StdErr = StdErr Prelude.String BSL.ByteString
 
 instance Show StdErr where
-  show (StdErr message stdErr) = Prelude.unlines
-    [ message
-    , Char8.unpack stdErr
-    ]
+  show (StdErr message stdErr) =
+    Prelude.unlines
+      [ message,
+        Char8.unpack stdErr
+      ]
 
 instance Exception StdErr
 
 throwStdErr :: forall a. Prelude.String -> BSL.ByteString -> IO a
 throwStdErr message stdErr = throwIO $ StdErr message stdErr
 
-
 generateCBORDiagStdIn :: Int -> BSL.ByteString -> IO BSL.ByteString
 generateCBORDiagStdIn rounds cddl =
-  readProcessWithExitCode2 "cddl" ["-", "generate", Prelude.show rounds] cddl >>=
-    \case
+  readProcessWithExitCode2 "cddl" ["-", "generate", Prelude.show rounds] cddl
+    >>= \case
       Right result -> pure result
       Left stdErr -> throwStdErr "Got failing exit code when generating examples" stdErr
 
 diagToBytes :: BSL.ByteString -> IO BSL.ByteString
-diagToBytes diag = readProcessWithExitCode2 "diag2cbor.rb" ["-"] diag >>=
-    \case
-      Right result -> pure result
-      Left stdErr -> throwStdErr "Got failing exit code when converting cbor diagnostic notation to bytes" stdErr
+diagToBytes diag = readProcessWithExitCode2 "diag2cbor.rb" ["-"] diag
+  >>= \case
+    Right result -> pure result
+    Left stdErr -> throwStdErr "Got failing exit code when converting cbor diagnostic notation to bytes" stdErr
 
 readProcessWithExitCode2 :: FilePath -> [String] -> BSL.ByteString -> IO (Either BSL.ByteString BSL.ByteString)
 readProcessWithExitCode2 exec args stdIn = do
@@ -182,10 +204,10 @@ readProcessWithExitCode2 exec args stdIn = do
 withTempFile :: FilePath -> String -> (FilePath -> Handle -> IO a) -> IO a
 withTempFile dir nameTemplate k = bracket (Sys.openBinaryTempFile dir nameTemplate) cleanup (uncurry k)
   where
-  cleanup (fileName, h) = do
-    Sys.hClose h
-    catch (Sys.removeFile fileName) $ \err ->
-      if Sys.isDoesNotExistError err then return () else throwIO err
+    cleanup (fileName, h) = do
+      Sys.hClose h
+      catch (Sys.removeFile fileName) $ \err ->
+        if Sys.isDoesNotExistError err then return () else throwIO err
 
 usingFile :: BSL.ByteString -> (FilePath -> IO a) -> IO a
 usingFile bytes k = withTempFile "." "tmp" $ \fileName h -> do
@@ -194,7 +216,7 @@ usingFile bytes k = withTempFile "." "tmp" $ \fileName h -> do
   k fileName
 
 verifyConforming :: BSL.ByteString -> FilePath -> IO Bool
-verifyConforming value cddl = readProcessWithExitCode2 "cddl" [cddl, "validate", "-"] value >>=
-    \case
-      Right _ -> pure True
-      Left _ -> pure False
+verifyConforming value cddl = readProcessWithExitCode2 "cddl" [cddl, "validate", "-"] value
+  >>= \case
+    Right _ -> pure True
+    Left _ -> pure False

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -6,193 +6,364 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Shelley.Spec.Ledger.Examples.Examples
-  ( CHAINExample(..)
-  , ex1
-  , ex2A
-  , ex2B
-  , ex2C
-  , ex2Cbis
-  , ex2Cter
-  , ex2Cquater
-  , ex2D
-  , ex2E
-  , ex2F
-  , ex2G
-  , ex2H
-  , ex2I
-  , ex2J
-  , ex2K
-  , ex2L
-  , ex3A
-  , ex3B
-  , ex3C
-  , ex4A
-  , ex4B
-  , ex5A
-  , ex5B
-  , ex5C
-  , ex5D
-  , ex5E
-  , ex5F'
-  , test5F
-  -- key pairs and example addresses
-  , alicePay
-  , aliceStake
-  , aliceAddr
-  , bobPay
-  , bobStake
-  , bobAddr
-  , carlPay
-  , carlStake
-  , carlAddr
-  , dariaPay
-  , dariaStake
-  , dariaAddr
-  , coreNodeSKG -- TODO remove
-  -- blocks
-  , blockEx1
-  , blockEx2A
-  , blockEx2B
-  , blockEx2C
-  , blockEx2D
-  , blockEx2E
-  , blockEx2F
-  , blockEx2G
-  , blockEx2H
-  , blockEx2I
-  , blockEx2J
-  , blockEx2K
-  , blockEx2L
-  , blockEx3A
-  , blockEx3B
-  , blockEx3C
-  , blockEx4A
-  , blockEx4B
-  , blockEx5A
-  , blockEx5B
-  , blockEx5F
-  , blockEx5F'
-  , blockEx5F''
-  -- transactions
-  , txEx2A
-  , txEx2B
-  , txEx2D
-  , txEx2J
-  , txEx2K
-  , txEx3A
-  , txEx3B
-  , txEx4A
-  , txEx5A
-  , txEx5B
-  , txEx5F
-  , txEx5F'
-  , txEx5F''
-  -- helpers
-  , unsafeMkUnitInterval
+  ( CHAINExample (..),
+    ex1,
+    ex2A,
+    ex2B,
+    ex2C,
+    ex2Cbis,
+    ex2Cter,
+    ex2Cquater,
+    ex2D,
+    ex2E,
+    ex2F,
+    ex2G,
+    ex2H,
+    ex2I,
+    ex2J,
+    ex2K,
+    ex2L,
+    ex3A,
+    ex3B,
+    ex3C,
+    ex4A,
+    ex4B,
+    ex5A,
+    ex5B,
+    ex5C,
+    ex5D,
+    ex5E,
+    ex5F',
+    test5F,
+    -- key pairs and example addresses
+    alicePay,
+    aliceStake,
+    aliceAddr,
+    bobPay,
+    bobStake,
+    bobAddr,
+    carlPay,
+    carlStake,
+    carlAddr,
+    dariaPay,
+    dariaStake,
+    dariaAddr,
+    coreNodeSKG, -- TODO remove
+    -- blocks
+    blockEx1,
+    blockEx2A,
+    blockEx2B,
+    blockEx2C,
+    blockEx2D,
+    blockEx2E,
+    blockEx2F,
+    blockEx2G,
+    blockEx2H,
+    blockEx2I,
+    blockEx2J,
+    blockEx2K,
+    blockEx2L,
+    blockEx3A,
+    blockEx3B,
+    blockEx3C,
+    blockEx4A,
+    blockEx4B,
+    blockEx5A,
+    blockEx5B,
+    blockEx5F,
+    blockEx5F',
+    blockEx5F'',
+    -- transactions
+    txEx2A,
+    txEx2B,
+    txEx2D,
+    txEx2J,
+    txEx2K,
+    txEx3A,
+    txEx3B,
+    txEx4A,
+    txEx5A,
+    txEx5B,
+    txEx5F,
+    txEx5F',
+    txEx5F'',
+    -- helpers
+    unsafeMkUnitInterval,
   )
 where
 
-import           Test.Tasty.HUnit (Assertion, assertBool, assertFailure)
-
+import Cardano.Slotting.Slot (WithOrigin (..))
+import Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
 import qualified Data.ByteString.Char8 as BS (pack)
-import           Data.Coerce (coerce)
-import           Data.List (foldl')
-import           Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map (elems, empty, fromList, insert, keysSet, member, singleton,
-                     (!?))
-import           Data.Maybe (fromJust, isJust, maybe)
-import           Data.Ratio ((%))
+import Data.Coerce (coerce)
+import Data.List (foldl')
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+  ( (!?),
+    elems,
+    empty,
+    fromList,
+    insert,
+    keysSet,
+    member,
+    singleton,
+  )
+import Data.Maybe (fromJust, isJust, maybe)
+import Data.Ratio ((%))
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-import           Data.Word (Word64)
-import           Numeric.Natural (Natural)
-
-import           Cardano.Slotting.Slot (WithOrigin (..))
-import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
-import           Shelley.Spec.Ledger.Address (mkRwdAcnt)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), mkNonce, startRewards,
-                     textToUrl, (⭒))
-import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader, LastAppliedBlock (..), bhHash,
-                     bheader, hashHeaderToNonce)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, pattern Delegate,
-                     pattern GenesisDelegCert, pattern MIRCert, pattern PoolDistr, pattern RegKey,
-                     pattern RegPool, pattern RetirePool)
-import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), pattern SnapShot,
-                     pattern SnapShots, pattern Stake, emptySnapShots, _feeSS, _pstakeGo,
-                     _pstakeMark, _pstakeSet)
-import           Shelley.Spec.Ledger.Keys (Hash, KeyRole (..), asWitness, coerceKeyRole, hash,
-                     hashKey, vKey)
-import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern ActiveSlot,
-                     pattern DPState, pattern EpochState, FutureGenDeleg (..), pattern LedgerState,
-                     pattern NewEpochState, pattern RewardUpdate, pattern UTxOState, deltaF,
-                     deltaR, deltaT, emptyDState, emptyPState, esAccountState, esLState, esPp,
-                     genesisCoins, genesisId, nesEs, nonMyopic, overlaySchedule, rs,
-                     _delegationState, _delegations, _dstate, _fGenDelegs, _genDelegs, _irwd,
-                     _pParams, _ptrs, _reserves, _retiring, _rewards, _stPools, _stkCreds,
-                     _treasury)
-import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
-import           Shelley.Spec.Ledger.PParams (PParams, PParams' (PParams), PParamsUpdate,
-                     pattern ProposedPPUpdates, pattern Update, emptyPPPUpdates, emptyPParams, _a0,
-                     _d, _eMax, _extraEntropy, _keyDecayRate, _keyDeposit, _keyMinRefund,
-                     _maxBBSize, _maxBHSize, _maxTxSize, _minfeeA, _minfeeB, _nOpt, _poolDecayRate,
-                     _poolDeposit, _poolMinRefund, _protocolVersion, _rho, _tau)
-import           Shelley.Spec.Ledger.Rewards (ApparentPerformance (..), pattern NonMyopic,
-                     emptyNonMyopic, rewardPot)
-import           Shelley.Spec.Ledger.Slot (BlockNo (..), Duration (..), EpochNo (..), SlotNo (..),
-                     (+*))
-import           Shelley.Spec.Ledger.STS.Bbody (pattern LedgersFailure)
-import           Shelley.Spec.Ledger.STS.Chain (pattern BbodyFailure, pattern ChainState, chainNes,
-                     initialShelleyState, totalAda)
-import           Shelley.Spec.Ledger.STS.Deleg (pattern InsufficientForInstantaneousRewardsDELEG)
-import           Shelley.Spec.Ledger.STS.Delegs (pattern DelplFailure)
-import           Shelley.Spec.Ledger.STS.Delpl (pattern DelegFailure)
-import           Shelley.Spec.Ledger.STS.Ledger (pattern DelegsFailure, pattern UtxowFailure)
-import           Shelley.Spec.Ledger.STS.Ledgers (pattern LedgerFailure)
-import           Shelley.Spec.Ledger.STS.Utxow (pattern MIRImpossibleInDecentralizedNetUTXOW,
-                     pattern MIRInsufficientGenesisSigsUTXOW)
-import           Shelley.Spec.Ledger.Tx (pattern Tx)
-import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern DCertDeleg, pattern DCertGenesis,
-                     pattern DCertMir, pattern DCertPool, pattern Delegation, pattern KeyHashObj,
-                     PoolMetaData (..), pattern PoolParams, Ptr (..), pattern RewardAcnt,
-                     pattern StakeCreds, pattern StakePools, pattern StakeRefPtr, pattern TxBody,
-                     pattern TxIn, pattern TxOut, Wdrl (..), addStakeCreds, _poolCost, _poolMD,
-                     _poolMDHash, _poolMDUrl, _poolMargin, _poolOwners, _poolPledge, _poolPubKey,
-                     _poolRAcnt, _poolRelays, _poolVrf)
+import Data.Word (Word64)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.Address (mkRwdAcnt)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Nonce (..),
+    StrictMaybe (..),
+    mkNonce,
+    startRewards,
+    textToUrl,
+    (⭒),
+  )
+import Shelley.Spec.Ledger.BlockChain
+  ( LastAppliedBlock (..),
+    bhHash,
+    bheader,
+    hashHeaderToNonce,
+    pattern HashHeader,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( pattern DeRegKey,
+    pattern Delegate,
+    pattern GenesisDelegCert,
+    pattern MIRCert,
+    pattern PoolDistr,
+    pattern RegKey,
+    pattern RegPool,
+    pattern RetirePool,
+  )
+import Shelley.Spec.Ledger.EpochBoundary
+  ( BlocksMade (..),
+    _feeSS,
+    _pstakeGo,
+    _pstakeMark,
+    _pstakeSet,
+    emptySnapShots,
+    pattern SnapShot,
+    pattern SnapShots,
+    pattern Stake,
+  )
+import Shelley.Spec.Ledger.Keys
+  ( Hash,
+    KeyRole (..),
+    asWitness,
+    coerceKeyRole,
+    hash,
+    hashKey,
+    vKey,
+  )
+import Shelley.Spec.Ledger.LedgerState
+  ( AccountState (..),
+    FutureGenDeleg (..),
+    _delegationState,
+    _delegations,
+    _dstate,
+    _fGenDelegs,
+    _genDelegs,
+    _irwd,
+    _pParams,
+    _ptrs,
+    _reserves,
+    _retiring,
+    _rewards,
+    _stPools,
+    _stkCreds,
+    _treasury,
+    deltaF,
+    deltaR,
+    deltaT,
+    emptyDState,
+    emptyPState,
+    esAccountState,
+    esLState,
+    esPp,
+    genesisCoins,
+    genesisId,
+    nesEs,
+    nonMyopic,
+    overlaySchedule,
+    rs,
+    pattern ActiveSlot,
+    pattern DPState,
+    pattern EpochState,
+    pattern LedgerState,
+    pattern NewEpochState,
+    pattern RewardUpdate,
+    pattern UTxOState,
+  )
+import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Shelley.Spec.Ledger.PParams
+  ( PParams,
+    PParams' (PParams),
+    PParamsUpdate,
+    _a0,
+    _d,
+    _eMax,
+    _extraEntropy,
+    _keyDecayRate,
+    _keyDeposit,
+    _keyMinRefund,
+    _maxBBSize,
+    _maxBHSize,
+    _maxTxSize,
+    _minfeeA,
+    _minfeeB,
+    _nOpt,
+    _poolDecayRate,
+    _poolDeposit,
+    _poolMinRefund,
+    _protocolVersion,
+    _rho,
+    _tau,
+    emptyPPPUpdates,
+    emptyPParams,
+    pattern ProposedPPUpdates,
+    pattern Update,
+  )
+import Shelley.Spec.Ledger.Rewards
+  ( ApparentPerformance (..),
+    emptyNonMyopic,
+    rewardPot,
+    pattern NonMyopic,
+  )
+import Shelley.Spec.Ledger.STS.Bbody (pattern LedgersFailure)
+import Shelley.Spec.Ledger.STS.Chain
+  ( chainNes,
+    initialShelleyState,
+    totalAda,
+    pattern BbodyFailure,
+    pattern ChainState,
+  )
+import Shelley.Spec.Ledger.STS.Deleg (pattern InsufficientForInstantaneousRewardsDELEG)
+import Shelley.Spec.Ledger.STS.Delegs (pattern DelplFailure)
+import Shelley.Spec.Ledger.STS.Delpl (pattern DelegFailure)
+import Shelley.Spec.Ledger.STS.Ledger (pattern DelegsFailure, pattern UtxowFailure)
+import Shelley.Spec.Ledger.STS.Ledgers (pattern LedgerFailure)
+import Shelley.Spec.Ledger.STS.Utxow
+  ( pattern MIRImpossibleInDecentralizedNetUTXOW,
+    pattern MIRInsufficientGenesisSigsUTXOW,
+  )
+import Shelley.Spec.Ledger.Slot
+  ( (+*),
+    BlockNo (..),
+    Duration (..),
+    EpochNo (..),
+    SlotNo (..),
+  )
+import Shelley.Spec.Ledger.Tx (pattern Tx)
+import Shelley.Spec.Ledger.TxData
+  ( PoolMetaData (..),
+    Ptr (..),
+    Wdrl (..),
+    _poolCost,
+    _poolMD,
+    _poolMDHash,
+    _poolMDUrl,
+    _poolMargin,
+    _poolOwners,
+    _poolPledge,
+    _poolPubKey,
+    _poolRAcnt,
+    _poolRelays,
+    _poolVrf,
+    addStakeCreds,
+    pattern Addr,
+    pattern DCertDeleg,
+    pattern DCertGenesis,
+    pattern DCertMir,
+    pattern DCertPool,
+    pattern Delegation,
+    pattern KeyHashObj,
+    pattern PoolParams,
+    pattern RewardAcnt,
+    pattern StakeCreds,
+    pattern StakePools,
+    pattern StakeRefPtr,
+    pattern TxBody,
+    pattern TxIn,
+    pattern TxOut,
+  )
 import qualified Shelley.Spec.Ledger.TxData as TxData (TxBody (..))
-import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, hashTxBody, makeWitnessesVKey, txid)
+import Shelley.Spec.Ledger.UTxO (balance, hashTxBody, makeWitnessesVKey, txid, pattern UTxO)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Addr,
+    Block,
+    CHAIN,
+    ChainState,
+    ConcreteCrypto,
+    Credential,
+    DState,
+    EpochState,
+    HashHeader,
+    KeyHash,
+    KeyPair,
+    LedgerState,
+    NewEpochState,
+    OBftSlot,
+    PState,
+    PoolDistr,
+    PoolParams,
+    ProposedPPUpdates,
+    RewardAcnt,
+    SignKeyDSIGN,
+    SnapShot,
+    SnapShots,
+    Tx,
+    TxBody,
+    UTxO,
+    UTxOState,
+    Update,
+    VKeyGenesis,
+    hashKeyVRF,
+    pattern GenDelegs,
+    pattern KeyPair,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( AllPoolKeys (..),
+    NatNonce (..),
+    genesisAccountState,
+    mkBlock,
+    mkOCert,
+    zero,
+  )
+import Test.Shelley.Spec.Ledger.Utils
+import Test.Tasty.HUnit (Assertion, assertBool, assertFailure)
 
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, Block, CHAIN, ChainState,
-                     ConcreteCrypto, Credential, DState, EpochState, pattern GenDelegs, HashHeader,
-                     KeyHash, KeyPair, pattern KeyPair, LedgerState, NewEpochState, OBftSlot,
-                     PState, PoolDistr, PoolParams, ProposedPPUpdates, RewardAcnt, SignKeyDSIGN,
-                     SnapShot, SnapShots, Tx, TxBody, UTxO, UTxOState, Update, VKeyGenesis,
-                     hashKeyVRF)
-import           Test.Shelley.Spec.Ledger.Generator.Core (AllPoolKeys (..), NatNonce (..),
-                     genesisAccountState, mkBlock, mkOCert, zero)
-import           Test.Shelley.Spec.Ledger.Utils
+data CHAINExample = CHAINExample
+  { -- | Current slot
+    currentSlotNo :: SlotNo,
+    -- | State to start testing with
+    startState :: ChainState,
+    -- | Block to run chain state transition system on
+    newBlock :: Block,
+    -- | type of fatal error, if failure expected and final chain state if success expected
+    intendedResult :: Either [[PredicateFailure CHAIN]] ChainState
+  }
 
-data CHAINExample =
-  CHAINExample { currentSlotNo    :: SlotNo       -- ^ Current slot
-               , startState     :: ChainState -- ^ State to start testing with
-               , newBlock       :: Block      -- ^ Block to run chain state transition system on
-               , intendedResult :: Either [[PredicateFailure CHAIN]] ChainState
-                  -- ^ type of fatal error, if failure expected and final chain state if success expected
-               }
-
-data MIRExample =
-  MIRExample
-  { mirStkCred :: Credential 'Staking
-  , mirRewards :: Coin
-  , target     :: Either [[PredicateFailure CHAIN]] ChainState
-  } deriving (Show, Eq)
+data MIRExample = MIRExample
+  { mirStkCred :: Credential 'Staking,
+    mirRewards :: Coin,
+    target :: Either [[PredicateFailure CHAIN]] ChainState
+  }
+  deriving (Show, Eq)
 
 mkAllPoolKeys :: Word64 -> AllPoolKeys
-mkAllPoolKeys w = AllPoolKeys (KeyPair vkCold skCold)
-                              (mkVRFKeyPair (w, 0, 0, 0, 2))
-                              [(KESPeriod 0, mkKESKeyPair (w, 0, 0, 0, 3))]
-                  -- TODO mgudemann
-                              (hashKey vkCold)
+mkAllPoolKeys w =
+  AllPoolKeys
+    (KeyPair vkCold skCold)
+    (mkVRFKeyPair (w, 0, 0, 0, 2))
+    [(KESPeriod 0, mkKESKeyPair (w, 0, 0, 0, 3))]
+    -- TODO mgudemann
+    (hashKey vkCold)
   where
     (skCold, vkCold) = mkKeyPair (w, 0, 0, 0, 1)
 
@@ -200,7 +371,7 @@ numCoreNodes :: Word64
 numCoreNodes = 7
 
 coreNodes :: [((SignKeyDSIGN, VKeyGenesis), AllPoolKeys)]
-coreNodes = [(mkGenKey (x, 0, 0, 0, 0), mkAllPoolKeys x) | x <-[101..100+numCoreNodes]]
+coreNodes = [(mkGenKey (x, 0, 0, 0, 0), mkAllPoolKeys x) | x <- [101 .. 100 + numCoreNodes]]
 
 coreNodeSKG :: Int -> SignKeyDSIGN
 coreNodeSKG = fst . fst . (coreNodes !!)
@@ -212,18 +383,23 @@ coreNodeKeys :: Int -> AllPoolKeys
 coreNodeKeys = snd . (coreNodes !!)
 
 genDelegs :: Map (KeyHash 'Genesis) (KeyHash 'GenesisDelegate)
-genDelegs = Map.fromList
-  [ ( hashKey $ snd gkey
-    , coerceKeyRole . hashKey . vKey $ cold pkeys)
-  | (gkey, pkeys) <- coreNodes]
+genDelegs =
+  Map.fromList
+    [ ( hashKey $ snd gkey,
+        coerceKeyRole . hashKey . vKey $ cold pkeys
+      )
+      | (gkey, pkeys) <- coreNodes
+    ]
 
 alicePay :: KeyPair 'Payment
 alicePay = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (0, 0, 0, 0, 0)
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 0)
 
 aliceStake :: KeyPair 'Staking
 aliceStake = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (1, 1, 1, 1, 1)
+  where
+    (sk, vk) = mkKeyPair (1, 1, 1, 1, 1)
 
 alicePool :: AllPoolKeys
 alicePool = mkAllPoolKeys 1
@@ -236,11 +412,13 @@ aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
 
 bobPay :: KeyPair 'Payment
 bobPay = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (2, 2, 2, 2, 2)
+  where
+    (sk, vk) = mkKeyPair (2, 2, 2, 2, 2)
 
 bobStake :: KeyPair 'Staking
 bobStake = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (3, 3, 3, 3, 3)
+  where
+    (sk, vk) = mkKeyPair (3, 3, 3, 3, 3)
 
 bobAddr :: Addr
 bobAddr = mkAddr (bobPay, bobStake)
@@ -249,35 +427,36 @@ bobSHK :: Credential 'Staking
 bobSHK = (KeyHashObj . hashKey . vKey) bobStake
 
 aliceInitCoin :: Coin
-aliceInitCoin = 10*1000*1000*1000*1000*1000
+aliceInitCoin = 10 * 1000 * 1000 * 1000 * 1000 * 1000
 
 bobInitCoin :: Coin
-bobInitCoin = 1*1000*1000*1000*1000*1000
+bobInitCoin = 1 * 1000 * 1000 * 1000 * 1000 * 1000
 
 alicePoolParams :: PoolParams
 alicePoolParams =
   PoolParams
-    { _poolPubKey = (hashKey . vKey . cold) alicePool
-    , _poolVrf = hashKeyVRF . snd $ vrf alicePool
-    , _poolPledge = Coin 1
-    , _poolCost = Coin 5
-    , _poolMargin = unsafeMkUnitInterval 0.1
-    , _poolRAcnt = RewardAcnt aliceSHK
-    , _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake
-    , _poolRelays = StrictSeq.empty
-    , _poolMD = SJust $ PoolMetaData
-                  { _poolMDUrl  = fromJust $ textToUrl "alice.pool"
-                  , _poolMDHash = BS.pack "{}"
-                  }
+    { _poolPubKey = (hashKey . vKey . cold) alicePool,
+      _poolVrf = hashKeyVRF . snd $ vrf alicePool,
+      _poolPledge = Coin 1,
+      _poolCost = Coin 5,
+      _poolMargin = unsafeMkUnitInterval 0.1,
+      _poolRAcnt = RewardAcnt aliceSHK,
+      _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake,
+      _poolRelays = StrictSeq.empty,
+      _poolMD =
+        SJust $
+          PoolMetaData
+            { _poolMDUrl = fromJust $ textToUrl "alice.pool",
+              _poolMDHash = BS.pack "{}"
+            }
     }
-
 
 -- | Helper Functions
 
--- |The first block of the Shelley era will point back to the last block of the Byron era.
--- For our purposes in this test we can bootstrap the chain by just coercing the value.
--- When this transition actually occurs, the consensus layer will do the work of making
--- sure that the hash gets translated across the fork
+-- | The first block of the Shelley era will point back to the last block of the Byron era.
+--  For our purposes in this test we can bootstrap the chain by just coercing the value.
+--  When this transition actually occurs, the consensus layer will do the work of making
+--  sure that the hash gets translated across the fork
 lastByronHeaderHash :: HashHeader
 lastByronHeaderHash = HashHeader $ coerce (hash 0 :: Hash ConcreteCrypto Int)
 
@@ -285,15 +464,17 @@ nonce0 :: Nonce
 nonce0 = hashHeaderToNonce lastByronHeaderHash
 
 mkSeqNonce :: Natural -> Nonce
-mkSeqNonce m = foldl' (\c x -> c ⭒ mkNonce x) nonce0 [1.. m]
+mkSeqNonce m = foldl' (\c x -> c ⭒ mkNonce x) nonce0 [1 .. m]
 
 carlPay :: KeyPair 'Payment
 carlPay = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (4, 4, 4, 4, 4)
+  where
+    (sk, vk) = mkKeyPair (4, 4, 4, 4, 4)
 
 carlStake :: KeyPair 'Staking
 carlStake = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (5, 5, 5, 5, 5)
+  where
+    (sk, vk) = mkKeyPair (5, 5, 5, 5, 5)
 
 carlAddr :: Addr
 carlAddr = mkAddr (carlPay, carlStake)
@@ -301,14 +482,15 @@ carlAddr = mkAddr (carlPay, carlStake)
 carlSHK :: Credential 'Staking
 carlSHK = (KeyHashObj . hashKey . vKey) carlStake
 
-
 dariaPay :: KeyPair 'Payment
 dariaPay = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (6, 6, 6, 6, 6)
+  where
+    (sk, vk) = mkKeyPair (6, 6, 6, 6, 6)
 
 dariaStake :: KeyPair 'Staking
 dariaStake = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (7, 7, 7, 7, 7)
+  where
+    (sk, vk) = mkKeyPair (7, 7, 7, 7, 7)
 
 dariaAddr :: Addr
 dariaAddr = mkAddr (dariaPay, dariaStake)
@@ -323,11 +505,12 @@ utxostEx1 :: UTxOState
 utxostEx1 = UTxOState (UTxO Map.empty) (Coin 0) (Coin 0) emptyPPPUpdates
 
 dsEx1 :: DState
-dsEx1 = emptyDState { _genDelegs = GenDelegs genDelegs }
+dsEx1 = emptyDState {_genDelegs = GenDelegs genDelegs}
 
 oCertIssueNosEx1 :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx1 = Map.fromList (fmap f (Map.elems genDelegs))
-  where f vk = (coerceKeyRole vk, 0)
+  where
+    f vk = (coerceKeyRole vk, 0)
 
 psEx1 :: PState
 psEx1 = emptyPState
@@ -337,36 +520,46 @@ lsEx1 :: LedgerState
 lsEx1 = LedgerState utxostEx1 (DPState dsEx1 psEx1)
 
 ppsEx1 :: PParams
-ppsEx1 = emptyPParams { _maxBBSize       =       50000
-                      , _maxBHSize       =       10000
-                      , _maxTxSize       =       10000
-                      , _eMax            = EpochNo 10000
-                      , _keyDeposit      = Coin      7
-                      , _poolDeposit     = Coin    250
-                      , _d               = unsafeMkUnitInterval 0.5
-                      , _tau             = unsafeMkUnitInterval 0.2
-                      , _rho             = unsafeMkUnitInterval 0.0021
-                      , _keyDecayRate    =                      0.002
-                      , _keyMinRefund    = unsafeMkUnitInterval 0.5
-                      , _poolDecayRate   =                      0.001
-                      , _poolMinRefund   = unsafeMkUnitInterval 0.5
-                      }
+ppsEx1 =
+  emptyPParams
+    { _maxBBSize = 50000,
+      _maxBHSize = 10000,
+      _maxTxSize = 10000,
+      _eMax = EpochNo 10000,
+      _keyDeposit = Coin 7,
+      _poolDeposit = Coin 250,
+      _d = unsafeMkUnitInterval 0.5,
+      _tau = unsafeMkUnitInterval 0.2,
+      _rho = unsafeMkUnitInterval 0.0021,
+      _keyDecayRate = 0.002,
+      _keyMinRefund = unsafeMkUnitInterval 0.5,
+      _poolDecayRate = 0.001,
+      _poolMinRefund = unsafeMkUnitInterval 0.5
+    }
 
 -- | Never decay.
 ppsExNoDecay :: PParams
-ppsExNoDecay = ppsEx1 { _keyDecayRate  = 0
-                      , _poolDecayRate = 0 }
+ppsExNoDecay =
+  ppsEx1
+    { _keyDecayRate = 0,
+      _poolDecayRate = 0
+    }
 
 -- | Refund everything.
 ppsExFullRefund :: PParams
-ppsExFullRefund = ppsEx1 { _keyMinRefund  = unsafeMkUnitInterval 1
-                         , _poolMinRefund = unsafeMkUnitInterval 1 }
+ppsExFullRefund =
+  ppsEx1
+    { _keyMinRefund = unsafeMkUnitInterval 1,
+      _poolMinRefund = unsafeMkUnitInterval 1
+    }
 
 -- | Decay instantly within one cycle.
 ppsExInstantDecay :: PParams
-ppsExInstantDecay = ppsEx1 { _keyDecayRate  = 1000
-                           , _poolDecayRate = 1000 }
-
+ppsExInstantDecay =
+  ppsEx1
+    { _keyDecayRate = 1000,
+      _poolDecayRate = 1000
+    }
 
 -- | Account with empty treasury.
 acntEx1 :: AccountState
@@ -379,141 +572,164 @@ esEx1 = EpochState acntEx1 emptySnapShots lsEx1 ppsEx1 ppsEx1 emptyNonMyopic
 -- | Empty initial Shelley state with fake Byron hash and no blocks at all.
 --   No blocks of Shelley have been processed yet.
 initStEx1 :: ChainState
-initStEx1 = initialShelleyState
-  (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
-  (EpochNo 0)
-  (UTxO Map.empty)
-  maxLLSupply
-  genDelegs
-  (Map.singleton (SlotNo 1) (ActiveSlot . hashKey $ coreNodeVKG 0))
-  ppsEx1
-  (hashHeaderToNonce lastByronHeaderHash)
+initStEx1 =
+  initialShelleyState
+    (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
+    (EpochNo 0)
+    (UTxO Map.empty)
+    maxLLSupply
+    genDelegs
+    (Map.singleton (SlotNo 1) (ActiveSlot . hashKey $ coreNodeVKG 0))
+    ppsEx1
+    (hashHeaderToNonce lastByronHeaderHash)
 
 -- | Null initial block. Just records the Byron hash, and contains no transactions.
 blockEx1 :: Block
-blockEx1 = mkBlock
-             lastByronHeaderHash
-             (coreNodeKeys 0)
-             []
-             (SlotNo 1)
-             (BlockNo 1)
-             (mkNonce 0)
-             (NatNonce 1)
-             zero
-             0
-             0
-             (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+blockEx1 =
+  mkBlock
+    lastByronHeaderHash
+    (coreNodeKeys 0)
+    []
+    (SlotNo 1)
+    (BlockNo 1)
+    (mkNonce 0)
+    (NatNonce 1)
+    zero
+    0
+    0
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 -- | Expected chain state after successful processing of null block.
 expectedStEx1 :: ChainState
-expectedStEx1 = ChainState
-  (NewEpochState
-     (EpochNo 0)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     -- Note that blocks in the overlay schedule do not add to this count.
-     esEx1
-     SNothing
-     (PoolDistr Map.empty)
-     (Map.singleton (SlotNo 1) (ActiveSlot . hashKey $ coreNodeVKG 0)))
-  oCertIssueNosEx1
-  nonce0
-  (nonce0 ⭒ mkNonce 1)
-  (nonce0 ⭒ mkNonce 1)
-  NeutralNonce
-  (At $ LastAppliedBlock
-    (BlockNo 1)
-    (SlotNo 1)
-    (bhHash . bheader $ blockEx1))
+expectedStEx1 =
+  ChainState
+    ( NewEpochState
+        (EpochNo 0)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        -- Note that blocks in the overlay schedule do not add to this count.
+        esEx1
+        SNothing
+        (PoolDistr Map.empty)
+        (Map.singleton (SlotNo 1) (ActiveSlot . hashKey $ coreNodeVKG 0))
+    )
+    oCertIssueNosEx1
+    nonce0
+    (nonce0 ⭒ mkNonce 1)
+    (nonce0 ⭒ mkNonce 1)
+    NeutralNonce
+    ( At $
+        LastAppliedBlock
+          (BlockNo 1)
+          (SlotNo 1)
+          (bhHash . bheader $ blockEx1)
+    )
 
 -- | Wraps example all together.
 ex1 :: CHAINExample
 ex1 = CHAINExample (SlotNo 1) initStEx1 blockEx1 (Right expectedStEx1)
-
 
 -- * Example 2A - apply CHAIN transition to register stake keys and a pool
 
 -- | Unspent transaction output for example 2A,
 --   so that users actually have coins to spend.
 utxoEx2A :: UTxO
-utxoEx2A = genesisCoins
-       [ TxOut aliceAddr aliceInitCoin
-       , TxOut bobAddr   bobInitCoin
-       ]
+utxoEx2A =
+  genesisCoins
+    [ TxOut aliceAddr aliceInitCoin,
+      TxOut bobAddr bobInitCoin
+    ]
 
 -- | Register a single pool with 255 coins of deposit
 ppupEx2A :: ProposedPPUpdates
-ppupEx2A = ProposedPPUpdates $ Map.singleton
-             (hashKey $ coreNodeVKG 0) -- stake key
-             (PParams
-                { _minfeeA = SNothing
-                , _minfeeB = SNothing
-                , _maxBBSize = SNothing
-                , _maxTxSize = SNothing
-                , _maxBHSize = SNothing
-                , _keyDeposit = SJust 255
-                , _keyMinRefund = SNothing
-                , _keyDecayRate = SNothing
-                , _poolDeposit = SNothing
-                , _poolMinRefund = SNothing
-                , _poolDecayRate = SNothing
-                , _eMax = SNothing
-                , _nOpt = SNothing
-                , _a0 = SNothing
-                , _rho = SNothing
-                , _tau = SNothing
-                , _d = SNothing
-                , _extraEntropy = SNothing
-                , _protocolVersion = SNothing
-                })
+ppupEx2A =
+  ProposedPPUpdates $
+    Map.singleton
+      (hashKey $ coreNodeVKG 0) -- stake key
+      ( PParams
+          { _minfeeA = SNothing,
+            _minfeeB = SNothing,
+            _maxBBSize = SNothing,
+            _maxTxSize = SNothing,
+            _maxBHSize = SNothing,
+            _keyDeposit = SJust 255,
+            _keyMinRefund = SNothing,
+            _keyDecayRate = SNothing,
+            _poolDeposit = SNothing,
+            _poolMinRefund = SNothing,
+            _poolDecayRate = SNothing,
+            _eMax = SNothing,
+            _nOpt = SNothing,
+            _a0 = SNothing,
+            _rho = SNothing,
+            _tau = SNothing,
+            _d = SNothing,
+            _extraEntropy = SNothing,
+            _protocolVersion = SNothing
+          }
+      )
 
 -- | Update proposal that just changes protocol parameters,
 --   and does not change applications.
 updateEx2A :: Update
 updateEx2A = Update ppupEx2A (EpochNo 0)
 
-
 aliceCoinEx2A :: Coin
 aliceCoinEx2A = aliceInitCoin - (_poolDeposit ppsEx1) - 3 * (_keyDeposit ppsEx1) - 3
 
 -- | Transaction body to be processed.
 txbodyEx2A :: TxBody
-txbodyEx2A = TxBody
-           (Set.fromList [TxIn genesisId 0])
-           (StrictSeq.fromList [TxOut aliceAddr aliceCoinEx2A])
-           (StrictSeq.fromList ([ DCertDeleg (RegKey aliceSHK)
-           , DCertDeleg (RegKey bobSHK)
-           , DCertDeleg (RegKey carlSHK)
-           , DCertPool (RegPool alicePoolParams)
-           ] ++ [DCertMir (MIRCert (Map.fromList [ (carlSHK, 110)
-                                                 , (dariaSHK, 99)]))]))
-           (Wdrl Map.empty)
-           (Coin 3)
-           (SlotNo 10)
-           (SJust updateEx2A)
-           SNothing
+txbodyEx2A =
+  TxBody
+    (Set.fromList [TxIn genesisId 0])
+    (StrictSeq.fromList [TxOut aliceAddr aliceCoinEx2A])
+    ( StrictSeq.fromList
+        ( [ DCertDeleg (RegKey aliceSHK),
+            DCertDeleg (RegKey bobSHK),
+            DCertDeleg (RegKey carlSHK),
+            DCertPool (RegPool alicePoolParams)
+          ]
+            ++ [ DCertMir
+                   ( MIRCert
+                       ( Map.fromList
+                           [ (carlSHK, 110),
+                             (dariaSHK, 99)
+                           ]
+                       )
+                   )
+               ]
+        )
+    )
+    (Wdrl Map.empty)
+    (Coin 3)
+    (SlotNo 10)
+    (SJust updateEx2A)
+    SNothing
 
 txEx2A :: Tx
-txEx2A = Tx
-          txbodyEx2A
-          (makeWitnessesVKey
-            (hashTxBody txbodyEx2A)
-            ( (asWitness <$> [alicePay, carlPay])
+txEx2A =
+  Tx
+    txbodyEx2A
+    ( makeWitnessesVKey
+        (hashTxBody txbodyEx2A)
+        ( (asWitness <$> [alicePay, carlPay])
             <> (asWitness <$> [aliceStake])
             <> (asWitness <$> [cold alicePool, cold $ coreNodeKeys 0])
-            )
-            -- Note that Alice's stake key needs to sign this transaction
-            -- since it is an owner of the stake pool being registered,
-            -- and *not* because of the stake key registration.
-                     `Set.union`
-           makeWitnessesVKey (hashTxBody txbodyEx2A) [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
-             , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
-             , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
-             , KeyPair (coreNodeVKG 3) (coreNodeSKG 3)
-             , KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
-             ])
-          Map.empty
-          SNothing
+        )
+        -- Note that Alice's stake key needs to sign this transaction
+        -- since it is an owner of the stake pool being registered,
+        -- and *not* because of the stake key registration.
+        `Set.union` makeWitnessesVKey
+          (hashTxBody txbodyEx2A)
+          [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0),
+            KeyPair (coreNodeVKG 1) (coreNodeSKG 1),
+            KeyPair (coreNodeVKG 2) (coreNodeSKG 2),
+            KeyPair (coreNodeVKG 3) (coreNodeSKG 3),
+            KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
+          ]
+    )
+    Map.empty
+    SNothing
 
 -- | Pointer address to address of Alice address.
 alicePtrAddr :: Addr
@@ -526,126 +742,151 @@ lsEx2A :: LedgerState
 lsEx2A = LedgerState utxostEx2A (DPState dsEx1 psEx1)
 
 acntEx2A :: AccountState
-acntEx2A = AccountState
-            { _treasury = Coin 0
-            , _reserves = maxLLSupply - balance utxoEx2A
-            }
+acntEx2A =
+  AccountState
+    { _treasury = Coin 0,
+      _reserves = maxLLSupply - balance utxoEx2A
+    }
 
 esEx2A :: EpochState
 esEx2A = EpochState acntEx2A emptySnapShots lsEx2A ppsEx1 ppsEx1 emptyNonMyopic
 
 overlayEx2A :: Map SlotNo OBftSlot
-overlayEx2A = runShelleyBase
-  $ overlaySchedule
-    (EpochNo 0)
-    (Map.keysSet genDelegs)
-    ppsEx1
+overlayEx2A =
+  runShelleyBase $
+    overlaySchedule
+      (EpochNo 0)
+      (Map.keysSet genDelegs)
+      ppsEx1
 
 initNesEx2A :: NewEpochState
-initNesEx2A = NewEpochState
-               (EpochNo 0)
-               (BlocksMade Map.empty)
-               (BlocksMade Map.empty)
-               esEx2A
-               SNothing
-               (PoolDistr Map.empty)
-               overlayEx2A
-
+initNesEx2A =
+  NewEpochState
+    (EpochNo 0)
+    (BlocksMade Map.empty)
+    (BlocksMade Map.empty)
+    esEx2A
+    SNothing
+    (PoolDistr Map.empty)
+    overlayEx2A
 
 initStEx2A :: ChainState
-initStEx2A = initialShelleyState
-  (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
-  (EpochNo 0)
-  utxoEx2A
-  (maxLLSupply - balance utxoEx2A)
-  genDelegs
-  overlayEx2A
-  ppsEx1
-  (hashHeaderToNonce lastByronHeaderHash)
+initStEx2A =
+  initialShelleyState
+    (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
+    (EpochNo 0)
+    utxoEx2A
+    (maxLLSupply - balance utxoEx2A)
+    genDelegs
+    overlayEx2A
+    ppsEx1
+    (hashHeaderToNonce lastByronHeaderHash)
 
 blockEx2A :: Block
-blockEx2A = mkBlock
-             lastByronHeaderHash
-             (coreNodeKeys 0)
-             [txEx2A]
-             (SlotNo 10)
-             (BlockNo 1)
-             (mkNonce 0)
-             (NatNonce 1)
-             zero
-             0
-             0
-             (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+blockEx2A =
+  mkBlock
+    lastByronHeaderHash
+    (coreNodeKeys 0)
+    [txEx2A]
+    (SlotNo 10)
+    (BlockNo 1)
+    (mkNonce 0)
+    (NatNonce 1)
+    zero
+    0
+    0
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 dsEx2A :: DState
-dsEx2A = dsEx1
-          { _ptrs = Map.fromList [ (Ptr (SlotNo 10) 0 0, aliceSHK)
-                                 , (Ptr (SlotNo 10) 0 1, bobSHK)
-                                 , (Ptr (SlotNo 10) 0 2, carlSHK)]
-          , _stkCreds = StakeCreds $ Map.fromList [ (aliceSHK, SlotNo 10)
-                                                  , (bobSHK, SlotNo 10)
-                                                  , (carlSHK, SlotNo 10)]
-          , _rewards = Map.fromList [ (RewardAcnt aliceSHK, Coin 0)
-                                    , (RewardAcnt bobSHK, Coin 0)
-                                    , (RewardAcnt carlSHK, Coin 0)]
-          , _irwd = Map.fromList [ (carlSHK, 110)
-                                 , (dariaSHK, 99)]
-          }
+dsEx2A =
+  dsEx1
+    { _ptrs =
+        Map.fromList
+          [ (Ptr (SlotNo 10) 0 0, aliceSHK),
+            (Ptr (SlotNo 10) 0 1, bobSHK),
+            (Ptr (SlotNo 10) 0 2, carlSHK)
+          ],
+      _stkCreds =
+        StakeCreds $
+          Map.fromList
+            [ (aliceSHK, SlotNo 10),
+              (bobSHK, SlotNo 10),
+              (carlSHK, SlotNo 10)
+            ],
+      _rewards =
+        Map.fromList
+          [ (RewardAcnt aliceSHK, Coin 0),
+            (RewardAcnt bobSHK, Coin 0),
+            (RewardAcnt carlSHK, Coin 0)
+          ],
+      _irwd =
+        Map.fromList
+          [ (carlSHK, 110),
+            (dariaSHK, 99)
+          ]
+    }
 
 psEx2A :: PState
-psEx2A = psEx1
-          { _stPools = StakePools $ Map.singleton (hk alicePool) (SlotNo 10)
-          , _pParams = Map.singleton (hk alicePool) alicePoolParams
-          }
+psEx2A =
+  psEx1
+    { _stPools = StakePools $ Map.singleton (hk alicePool) (SlotNo 10),
+      _pParams = Map.singleton (hk alicePool) alicePoolParams
+    }
 
 expectedLSEx2A :: LedgerState
-expectedLSEx2A = LedgerState
-               (UTxOState
-                 (UTxO . Map.fromList $
-                   [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin)
-                   , (TxIn (txid txbodyEx2A) 0, TxOut aliceAddr aliceCoinEx2A)
-                   ])
-                 (Coin 271)
-                 (Coin 3)
-                 ppupEx2A)
-               (DPState dsEx2A psEx2A)
+expectedLSEx2A =
+  LedgerState
+    ( UTxOState
+        ( UTxO . Map.fromList $
+            [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin),
+              (TxIn (txid txbodyEx2A) 0, TxOut aliceAddr aliceCoinEx2A)
+            ]
+        )
+        (Coin 271)
+        (Coin 3)
+        ppupEx2A
+    )
+    (DPState dsEx2A psEx2A)
 
 blockEx2AHash :: HashHeader
 blockEx2AHash = bhHash (bheader blockEx2A)
 
 -- | Expected state after update is processed and STS applied.
 expectedStEx2A :: ChainState
-expectedStEx2A = ChainState
-  (NewEpochState
-     (EpochNo   0)
-     (BlocksMade Map.empty) -- Still no blocks
-     (BlocksMade Map.empty) -- Still no blocks
-     (EpochState acntEx2A emptySnapShots expectedLSEx2A ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     (PoolDistr Map.empty)
-     overlayEx2A)
-  -- Operational certificate issue numbers are now only updated during block
-  -- header processing (in the OCERT rule). As such, we will not see the
-  -- operational certificate issue number appear until the first time a block is
-  -- issued using the corresponding hot key.
-  oCertIssueNosEx1
-  nonce0
-  (nonce0 ⭒ mkNonce 1)
-  (nonce0 ⭒ mkNonce 1)
-  NeutralNonce
-  (At $ LastAppliedBlock
-    (BlockNo 1)
-    (SlotNo 10)
-    blockEx2AHash)
+expectedStEx2A =
+  ChainState
+    ( NewEpochState
+        (EpochNo 0)
+        (BlocksMade Map.empty) -- Still no blocks
+        (BlocksMade Map.empty) -- Still no blocks
+        (EpochState acntEx2A emptySnapShots expectedLSEx2A ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        (PoolDistr Map.empty)
+        overlayEx2A
+    )
+    -- Operational certificate issue numbers are now only updated during block
+    -- header processing (in the OCERT rule). As such, we will not see the
+    -- operational certificate issue number appear until the first time a block is
+    -- issued using the corresponding hot key.
+    oCertIssueNosEx1
+    nonce0
+    (nonce0 ⭒ mkNonce 1)
+    (nonce0 ⭒ mkNonce 1)
+    NeutralNonce
+    ( At $
+        LastAppliedBlock
+          (BlockNo 1)
+          (SlotNo 10)
+          blockEx2AHash
+    )
 
 ex2A :: CHAINExample
 ex2A = CHAINExample (SlotNo 10) initStEx2A blockEx2A (Right expectedStEx2A)
 
-
 -- * Example 2B - process a block late enough in the epoch in order to create a reward update.
 
 aliceCoinEx2BBase :: Coin
-aliceCoinEx2BBase = 5*1000*1000*1000*1000*1000
+aliceCoinEx2BBase = 5 * 1000 * 1000 * 1000 * 1000 * 1000
 
 aliceCoinEx2BPtr :: Coin
 aliceCoinEx2BPtr = aliceCoinEx2A - (aliceCoinEx2BBase + 4)
@@ -653,60 +894,72 @@ aliceCoinEx2BPtr = aliceCoinEx2A - (aliceCoinEx2BBase + 4)
 -- | The transaction delegates Alice's and Bob's stake to Alice's pool.
 --   Additionally, we split Alice's ADA between a base address and a pointer address.
 txbodyEx2B :: TxBody
-txbodyEx2B = TxBody
-      { TxData._inputs   = Set.fromList [TxIn (txid txbodyEx2A) 0]
-      , TxData._outputs  = StrictSeq.fromList [ TxOut aliceAddr    aliceCoinEx2BBase
-                                              , TxOut alicePtrAddr aliceCoinEx2BPtr ]
+txbodyEx2B =
+  TxBody
+    { TxData._inputs = Set.fromList [TxIn (txid txbodyEx2A) 0],
+      TxData._outputs =
+        StrictSeq.fromList
+          [ TxOut aliceAddr aliceCoinEx2BBase,
+            TxOut alicePtrAddr aliceCoinEx2BPtr
+          ],
       --  Delegation certificates
-      , TxData._certs    =
-        StrictSeq.fromList [ DCertDeleg (Delegate $ Delegation aliceSHK (hk alicePool))
-                           , DCertDeleg (Delegate $ Delegation bobSHK   (hk alicePool))]
-      , TxData._wdrls    = Wdrl Map.empty
-      , TxData._txfee    = Coin 4
-      , TxData._ttl      = SlotNo 90
-      , TxData._txUpdate = SNothing
-      , TxData._mdHash   = SNothing
-      }
+      TxData._certs =
+        StrictSeq.fromList
+          [ DCertDeleg (Delegate $ Delegation aliceSHK (hk alicePool)),
+            DCertDeleg (Delegate $ Delegation bobSHK (hk alicePool))
+          ],
+      TxData._wdrls = Wdrl Map.empty,
+      TxData._txfee = Coin 4,
+      TxData._ttl = SlotNo 90,
+      TxData._txUpdate = SNothing,
+      TxData._mdHash = SNothing
+    }
 
 txEx2B :: Tx
-txEx2B = Tx
-          txbodyEx2B -- Body of the transaction
-          (makeWitnessesVKey (hashTxBody txbodyEx2B)
-            [asWitness alicePay, asWitness aliceStake, asWitness bobStake])
-                     -- Witness verification key set
-          Map.empty  -- Witness signature map
-          SNothing
+txEx2B =
+  Tx
+    txbodyEx2B -- Body of the transaction
+    ( makeWitnessesVKey
+        (hashTxBody txbodyEx2B)
+        [asWitness alicePay, asWitness aliceStake, asWitness bobStake]
+    )
+    -- Witness verification key set
+    Map.empty -- Witness signature map
+    SNothing
 
 blockEx2B :: Block
-blockEx2B = mkBlock
-             blockEx2AHash    -- Hash of previous block
-             (coreNodeKeys 3)
-             [txEx2B]         -- Single transaction to record
-             (SlotNo 90)      -- Current slot
-             (BlockNo 2)
-             (mkNonce 0)      -- Epoch nonce
-             (NatNonce 2)     -- Block nonce
-             zero             -- Praos leader value
-             4                -- Period of KES (key evolving signature scheme)
-             0
-             (mkOCert (coreNodeKeys 3) 0 (KESPeriod 0))
+blockEx2B =
+  mkBlock
+    blockEx2AHash -- Hash of previous block
+    (coreNodeKeys 3)
+    [txEx2B] -- Single transaction to record
+    (SlotNo 90) -- Current slot
+    (BlockNo 2)
+    (mkNonce 0) -- Epoch nonce
+    (NatNonce 2) -- Block nonce
+    zero -- Praos leader value
+    4 -- Period of KES (key evolving signature scheme)
+    0
+    (mkOCert (coreNodeKeys 3) 0 (KESPeriod 0))
 
 blockEx2BHash :: HashHeader
 blockEx2BHash = bhHash (bheader blockEx2B)
 
 utxoEx2B :: UTxO
-utxoEx2B = UTxO . Map.fromList $
-                   [ (TxIn genesisId 1,         TxOut bobAddr      bobInitCoin)
-                   , (TxIn (txid txbodyEx2B) 0, TxOut aliceAddr    aliceCoinEx2BBase)
-                   , (TxIn (txid txbodyEx2B) 1, TxOut alicePtrAddr aliceCoinEx2BPtr)
-                   ]
+utxoEx2B =
+  UTxO . Map.fromList $
+    [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin),
+      (TxIn (txid txbodyEx2B) 0, TxOut aliceAddr aliceCoinEx2BBase),
+      (TxIn (txid txbodyEx2B) 1, TxOut alicePtrAddr aliceCoinEx2BPtr)
+    ]
 
 -- | Both Alice and Bob delegate to the Alice pool
 delegsEx2B :: Map (Credential 'Staking) (KeyHash 'StakePool)
-delegsEx2B = Map.fromList
-              [ (aliceSHK, hk alicePool)
-              , (bobSHK,   hk alicePool)
-              ]
+delegsEx2B =
+  Map.fromList
+    [ (aliceSHK, hk alicePool),
+      (bobSHK, hk alicePool)
+    ]
 
 carlMIR :: Coin
 carlMIR = Coin 110
@@ -715,45 +968,60 @@ dariaMIR :: Coin
 dariaMIR = Coin 99
 
 dsEx2B :: DState
-dsEx2B = dsEx2A { _delegations = delegsEx2B
-                , _irwd = Map.fromList [ (carlSHK, carlMIR)
-                                       , (dariaSHK, dariaMIR)] }
+dsEx2B =
+  dsEx2A
+    { _delegations = delegsEx2B,
+      _irwd =
+        Map.fromList
+          [ (carlSHK, carlMIR),
+            (dariaSHK, dariaMIR)
+          ]
+    }
 
 expectedLSEx2B :: LedgerState
-expectedLSEx2B = LedgerState
-               (UTxOState
-                 utxoEx2B
-                 (Coin 271)
-                 (Coin 7)
-                 ppupEx2A)
-               (DPState dsEx2B psEx2A)
+expectedLSEx2B =
+  LedgerState
+    ( UTxOState
+        utxoEx2B
+        (Coin 271)
+        (Coin 7)
+        ppupEx2A
+    )
+    (DPState dsEx2B psEx2A)
 
 expectedStEx2Bgeneric :: PParams -> ChainState
-expectedStEx2Bgeneric pp = ChainState
-  -- New state of the epoch
-  (NewEpochState
-     (EpochNo 0)            -- First epoch
-     (BlocksMade Map.empty) -- Blocks made before current
-     (BlocksMade Map.empty) -- Blocks made before current
-     (EpochState acntEx2A emptySnapShots expectedLSEx2B pp pp emptyNonMyopic)
-                            -- Previous epoch state
-     (SJust RewardUpdate { deltaT        = Coin 0
-                         , deltaR        = Coin 0
-                         , rs            = Map.empty
-                         , deltaF        = Coin 0
-                         , nonMyopic     = emptyNonMyopic
-                         })  -- Update reward
-     (PoolDistr Map.empty)
-     overlayEx2A)
-  oCertIssueNosEx1
-  nonce0
-  (nonce0 ⭒ mkNonce 1 ⭒ mkNonce 2) -- Evolving nonce
-  (nonce0 ⭒ mkNonce 1)             -- Candidate nonce
-  NeutralNonce
-  (At $ LastAppliedBlock
-    (BlockNo 2)                    -- Current block no
-    (SlotNo 90)                    -- Current slot
-    blockEx2BHash)                 -- Hash header of the chain
+expectedStEx2Bgeneric pp =
+  ChainState
+    -- New state of the epoch
+    ( NewEpochState
+        (EpochNo 0) -- First epoch
+        (BlocksMade Map.empty) -- Blocks made before current
+        (BlocksMade Map.empty) -- Blocks made before current
+        (EpochState acntEx2A emptySnapShots expectedLSEx2B pp pp emptyNonMyopic)
+        -- Previous epoch state
+        ( SJust
+            RewardUpdate
+              { deltaT = Coin 0,
+                deltaR = Coin 0,
+                rs = Map.empty,
+                deltaF = Coin 0,
+                nonMyopic = emptyNonMyopic
+              } -- Update reward
+        )
+        (PoolDistr Map.empty)
+        overlayEx2A
+    )
+    oCertIssueNosEx1
+    nonce0
+    (nonce0 ⭒ mkNonce 1 ⭒ mkNonce 2) -- Evolving nonce
+    (nonce0 ⭒ mkNonce 1) -- Candidate nonce
+    NeutralNonce
+    ( At $
+        LastAppliedBlock
+          (BlockNo 2) -- Current block no
+          (SlotNo 90) -- Current slot
+          blockEx2BHash -- Hash header of the chain
+    )
 
 -- | Expected state after transition
 expectedStEx2B :: ChainState
@@ -777,42 +1045,50 @@ ex2B = CHAINExample (SlotNo 90) expectedStEx2A blockEx2B (Right expectedStEx2B)
 
 -- | Example 2C - process an empty block in the next epoch
 -- so that the (empty) reward update is applied and a stake snapshot is made.
-
-
 blockEx2C :: Block
-blockEx2C = mkBlock
-             blockEx2BHash    -- Hash of previous block
-             (coreNodeKeys 0)
-             []               -- No transactions at all (empty block)
-             (SlotNo 110)     -- Current slot
-             (BlockNo 3)      -- Second block within the epoch
-             (mkNonce 0)      -- Epoch nonce
-             (NatNonce 3)     -- Block nonce
-             zero             -- Praos leader value
-             5                -- Period of KES (key evolving signature scheme)
-             0
-             (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+blockEx2C =
+  mkBlock
+    blockEx2BHash -- Hash of previous block
+    (coreNodeKeys 0)
+    [] -- No transactions at all (empty block)
+    (SlotNo 110) -- Current slot
+    (BlockNo 3) -- Second block within the epoch
+    (mkNonce 0) -- Epoch nonce
+    (NatNonce 3) -- Block nonce
+    zero -- Praos leader value
+    5 -- Period of KES (key evolving signature scheme)
+    0
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 epoch1OSchedEx2C :: Map SlotNo OBftSlot
-epoch1OSchedEx2C = runShelleyBase $ overlaySchedule
-                    (EpochNo 1)
-                    (Map.keysSet genDelegs)
-                    ppsEx1
+epoch1OSchedEx2C =
+  runShelleyBase $
+    overlaySchedule
+      (EpochNo 1)
+      (Map.keysSet genDelegs)
+      ppsEx1
 
 -- | Snapshot of stakes for Alice and Bob
 snapEx2C :: SnapShot
-snapEx2C = SnapShot
-  (Stake ( Map.fromList [ (aliceSHK, aliceCoinEx2BBase + aliceCoinEx2BPtr)
-                        , (bobSHK, bobInitCoin)]))
-  delegsEx2B
-  (Map.singleton (hk alicePool) alicePoolParams)
+snapEx2C =
+  SnapShot
+    ( Stake
+        ( Map.fromList
+            [ (aliceSHK, aliceCoinEx2BBase + aliceCoinEx2BPtr),
+              (bobSHK, bobInitCoin)
+            ]
+        )
+    )
+    delegsEx2B
+    (Map.singleton (hk alicePool) alicePoolParams)
 
 -- | Make a snapshot for a given fee.
 snapsEx2Cgeneric :: Coin -> SnapShots
-snapsEx2Cgeneric feeSnapShot = emptySnapShots {
-    _pstakeMark = snapEx2C -- snapshot of stake pools and parameters
-  , _feeSS      = feeSnapShot
-  }
+snapsEx2Cgeneric feeSnapShot =
+  emptySnapShots
+    { _pstakeMark = snapEx2C, -- snapshot of stake pools and parameters
+      _feeSS = feeSnapShot
+    }
 
 -- | Snapshots with given fees.
 snapsEx2C :: SnapShots
@@ -830,17 +1106,20 @@ snapsEx2Cquater = snapsEx2Cgeneric 144
 expectedLSEx2Cgeneric :: Coin -> Coin -> LedgerState
 expectedLSEx2Cgeneric lsDeposits lsFees =
   LedgerState
-  (UTxOState
-    utxoEx2B
-    lsDeposits
-    lsFees
-    emptyPPPUpdates) -- Note that the ppup is gone now
-  (DPState
-    dsEx2B { _irwd     = Map.empty
-           , _stkCreds = addStakeCreds carlSHK (SlotNo 10)   $ _stkCreds dsEx2B
-           , _rewards  = Map.insert (mkRwdAcnt carlSHK) 110 $ _rewards dsEx2B
-           }
-    psEx2A)
+    ( UTxOState
+        utxoEx2B
+        lsDeposits
+        lsFees
+        emptyPPPUpdates -- Note that the ppup is gone now
+    )
+    ( DPState
+        dsEx2B
+          { _irwd = Map.empty,
+            _stkCreds = addStakeCreds carlSHK (SlotNo 10) $ _stkCreds dsEx2B,
+            _rewards = Map.insert (mkRwdAcnt carlSHK) 110 $ _rewards dsEx2B
+          }
+        psEx2A
+    )
 
 expectedLSEx2C :: LedgerState
 expectedLSEx2C = expectedLSEx2Cgeneric 257 21
@@ -858,26 +1137,31 @@ blockEx2CHash :: HashHeader
 blockEx2CHash = bhHash (bheader blockEx2C)
 
 expectedStEx2Cgeneric :: SnapShots -> LedgerState -> PParams -> ChainState
-expectedStEx2Cgeneric ss ls pp = ChainState
-  (NewEpochState
-     (EpochNo 1)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2A { _reserves = _reserves acntEx2A - carlMIR } ss ls pp pp emptyNonMyopic)
-     SNothing
-     (PoolDistr Map.empty)
-     epoch1OSchedEx2C)
-  oCertIssueNosEx1
-  (nonce0 ⭒ mkNonce 1)
-  (mkSeqNonce 3)
-  (mkSeqNonce 3)
-  (hashHeaderToNonce blockEx2BHash)
-  (At $ LastAppliedBlock
-    (BlockNo 3)
-    (SlotNo 110)
-    blockEx2CHash)
+expectedStEx2Cgeneric ss ls pp =
+  ChainState
+    ( NewEpochState
+        (EpochNo 1)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2A {_reserves = _reserves acntEx2A - carlMIR} ss ls pp pp emptyNonMyopic)
+        SNothing
+        (PoolDistr Map.empty)
+        epoch1OSchedEx2C
+    )
+    oCertIssueNosEx1
+    (nonce0 ⭒ mkNonce 1)
+    (mkSeqNonce 3)
+    (mkSeqNonce 3)
+    (hashHeaderToNonce blockEx2BHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 3)
+          (SlotNo 110)
+          blockEx2CHash
+    )
 
 -- ** Expected chain state after STS
+
 expectedStEx2C :: ChainState
 expectedStEx2C = expectedStEx2Cgeneric snapsEx2C expectedLSEx2C ppsEx1
 
@@ -909,179 +1193,204 @@ ex2Cquater :: CHAINExample
 ex2Cquater =
   CHAINExample (SlotNo 110) expectedStEx2Bquater blockEx2C (Right expectedStEx2Cquater)
 
-
 -- | Example 2D - process a block late enough
 -- in the epoch in order to create a second reward update, preparing the way for
 -- the first non-empty pool distribution in this running example.
 -- Additionally, in order to have the stake distribution change,
 -- Carl delegates his stake.
 
-
 -- | The transaction delegates Carl's stake to Alice's pool.
-
 aliceCoinEx2DBase :: Coin
 aliceCoinEx2DBase = aliceCoinEx2BBase - 5
 
 txbodyEx2D :: TxBody
-txbodyEx2D = TxBody
-      { TxData._inputs   = Set.fromList [TxIn (txid txbodyEx2B) 0]
-      , TxData._outputs  = StrictSeq.fromList [ TxOut aliceAddr aliceCoinEx2DBase ]
-      , TxData._certs    =
-        StrictSeq.fromList [ DCertDeleg (Delegate $ Delegation carlSHK (hk alicePool)) ]
-      , TxData._wdrls    = Wdrl Map.empty
-      , TxData._txfee    = Coin 5
-      , TxData._ttl      = SlotNo 500
-      , TxData._txUpdate = SNothing
-      , TxData._mdHash   = SNothing
-      }
+txbodyEx2D =
+  TxBody
+    { TxData._inputs = Set.fromList [TxIn (txid txbodyEx2B) 0],
+      TxData._outputs = StrictSeq.fromList [TxOut aliceAddr aliceCoinEx2DBase],
+      TxData._certs =
+        StrictSeq.fromList [DCertDeleg (Delegate $ Delegation carlSHK (hk alicePool))],
+      TxData._wdrls = Wdrl Map.empty,
+      TxData._txfee = Coin 5,
+      TxData._ttl = SlotNo 500,
+      TxData._txUpdate = SNothing,
+      TxData._mdHash = SNothing
+    }
 
 txEx2D :: Tx
-txEx2D = Tx
-          txbodyEx2D
-          (makeWitnessesVKey (hashTxBody txbodyEx2D) [asWitness alicePay, asWitness carlStake])
-          Map.empty
-          SNothing
+txEx2D =
+  Tx
+    txbodyEx2D
+    (makeWitnessesVKey (hashTxBody txbodyEx2D) [asWitness alicePay, asWitness carlStake])
+    Map.empty
+    SNothing
 
 blockEx2D :: Block
-blockEx2D = mkBlock
-             blockEx2CHash
-             (coreNodeKeys 3)
-             [txEx2D]
-             (SlotNo 190)
-             (BlockNo 4)
-             (mkNonce 0 ⭒ mkNonce 1)
-             (NatNonce 4)
-             zero
-             9
-             0
-             (mkOCert (coreNodeKeys 3) 0 (KESPeriod 0))
+blockEx2D =
+  mkBlock
+    blockEx2CHash
+    (coreNodeKeys 3)
+    [txEx2D]
+    (SlotNo 190)
+    (BlockNo 4)
+    (mkNonce 0 ⭒ mkNonce 1)
+    (NatNonce 4)
+    zero
+    9
+    0
+    (mkOCert (coreNodeKeys 3) 0 (KESPeriod 0))
 
 blockEx2DHash :: HashHeader
 blockEx2DHash = bhHash (bheader blockEx2D)
 
 utxoEx2D :: UTxO
-utxoEx2D = UTxO . Map.fromList $
-                   [ (TxIn genesisId 1,         TxOut bobAddr      bobInitCoin)
-                   , (TxIn (txid txbodyEx2D) 0, TxOut aliceAddr    aliceCoinEx2DBase)
-                   , (TxIn (txid txbodyEx2B) 1, TxOut alicePtrAddr aliceCoinEx2BPtr)
-                   ]
+utxoEx2D =
+  UTxO . Map.fromList $
+    [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin),
+      (TxIn (txid txbodyEx2D) 0, TxOut aliceAddr aliceCoinEx2DBase),
+      (TxIn (txid txbodyEx2B) 1, TxOut alicePtrAddr aliceCoinEx2BPtr)
+    ]
 
 delegsEx2D :: Map (Credential 'Staking) (KeyHash 'StakePool)
-delegsEx2D = Map.fromList
-              [ (aliceSHK, hk alicePool)
-              , (bobSHK,   hk alicePool)
-              , (carlSHK,   hk alicePool)
-              ]
+delegsEx2D =
+  Map.fromList
+    [ (aliceSHK, hk alicePool),
+      (bobSHK, hk alicePool),
+      (carlSHK, hk alicePool)
+    ]
 
 dsEx2D :: DState
-dsEx2D = (dsEx2C) { _delegations = delegsEx2D }
+dsEx2D = (dsEx2C) {_delegations = delegsEx2D}
   where
     dsEx2C = (_dstate . _delegationState) expectedLSEx2C
 
 expectedLSEx2D :: LedgerState
-expectedLSEx2D = LedgerState
-               (UTxOState
-                 utxoEx2D
-                 (Coin 257)
-                 (Coin 26)
-                 emptyPPPUpdates)
-               (DPState dsEx2D psEx2A)
+expectedLSEx2D =
+  LedgerState
+    ( UTxOState
+        utxoEx2D
+        (Coin 257)
+        (Coin 26)
+        emptyPPPUpdates
+    )
+    (DPState dsEx2D psEx2A)
 
 expectedStEx2D :: ChainState
-expectedStEx2D = ChainState
-  (NewEpochState
-     (EpochNo 1)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState
-        acntEx2A { _reserves = _reserves acntEx2A - carlMIR}
-        snapsEx2C
-        expectedLSEx2D
-        ppsEx1
-        ppsEx1
-        emptyNonMyopic)
-     (SJust RewardUpdate { deltaT        = Coin 21
-                         , deltaR        = Coin 0
-                         , rs            = Map.empty
-                         , deltaF        = Coin (-21)
-                         , nonMyopic     = emptyNonMyopic { rewardPot = Coin 17 }
-                         })
-     (PoolDistr Map.empty)
-     epoch1OSchedEx2C)
-  oCertIssueNosEx1
-  (nonce0 ⭒ mkNonce 1)
-  (mkSeqNonce 4)
-  (mkSeqNonce 3)
-  (hashHeaderToNonce blockEx2BHash)
-  (At $ LastAppliedBlock
-    (BlockNo 4)
-    (SlotNo 190)
-    blockEx2DHash)
+expectedStEx2D =
+  ChainState
+    ( NewEpochState
+        (EpochNo 1)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        ( EpochState
+            acntEx2A {_reserves = _reserves acntEx2A - carlMIR}
+            snapsEx2C
+            expectedLSEx2D
+            ppsEx1
+            ppsEx1
+            emptyNonMyopic
+        )
+        ( SJust
+            RewardUpdate
+              { deltaT = Coin 21,
+                deltaR = Coin 0,
+                rs = Map.empty,
+                deltaF = Coin (-21),
+                nonMyopic = emptyNonMyopic {rewardPot = Coin 17}
+              }
+        )
+        (PoolDistr Map.empty)
+        epoch1OSchedEx2C
+    )
+    oCertIssueNosEx1
+    (nonce0 ⭒ mkNonce 1)
+    (mkSeqNonce 4)
+    (mkSeqNonce 3)
+    (hashHeaderToNonce blockEx2BHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 4)
+          (SlotNo 190)
+          blockEx2DHash
+    )
 
 ex2D :: CHAINExample
 ex2D = CHAINExample (SlotNo 190) expectedStEx2C blockEx2D (Right expectedStEx2D)
 
-
 -- | Example 2E - create the first non-empty pool distribution
 -- by creating a block in the third epoch of this running example.
-
-
 blockEx2E :: Block
-blockEx2E = mkBlock
-             blockEx2DHash
-             (coreNodeKeys 3)
-             []
-             (SlotNo 220)
-             (BlockNo 5)
-             ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
-             (NatNonce 5)
-             zero
-             11
-             10
-             (mkOCert (coreNodeKeys 3) 1 (KESPeriod 10))
+blockEx2E =
+  mkBlock
+    blockEx2DHash
+    (coreNodeKeys 3)
+    []
+    (SlotNo 220)
+    (BlockNo 5)
+    ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
+    (NatNonce 5)
+    zero
+    11
+    10
+    (mkOCert (coreNodeKeys 3) 1 (KESPeriod 10))
 
 epoch1OSchedEx2E :: Map SlotNo OBftSlot
-epoch1OSchedEx2E = runShelleyBase $ overlaySchedule
-                    (EpochNo 2)
-                    (Map.keysSet genDelegs)
-                    ppsEx1
+epoch1OSchedEx2E =
+  runShelleyBase $
+    overlaySchedule
+      (EpochNo 2)
+      (Map.keysSet genDelegs)
+      ppsEx1
 
 snapEx2E :: SnapShot
-snapEx2E = SnapShot
-  (Stake ( Map.fromList [ (aliceSHK, aliceCoinEx2DBase + aliceCoinEx2BPtr)
-                        , (carlSHK, carlMIR)
-                        , (bobSHK, bobInitCoin)]))
-  delegsEx2D
-  (Map.singleton (hk alicePool) alicePoolParams)
+snapEx2E =
+  SnapShot
+    ( Stake
+        ( Map.fromList
+            [ (aliceSHK, aliceCoinEx2DBase + aliceCoinEx2BPtr),
+              (carlSHK, carlMIR),
+              (bobSHK, bobInitCoin)
+            ]
+        )
+    )
+    delegsEx2D
+    (Map.singleton (hk alicePool) alicePoolParams)
 
 snapsEx2E :: SnapShots
-snapsEx2E = emptySnapShots { _pstakeMark = snapEx2E
-                           , _pstakeSet = snapEx2C
-                           , _feeSS = Coin 19
-                           }
+snapsEx2E =
+  emptySnapShots
+    { _pstakeMark = snapEx2E,
+      _pstakeSet = snapEx2C,
+      _feeSS = Coin 19
+    }
 
 expectedLSEx2E :: LedgerState
-expectedLSEx2E = LedgerState
-               (UTxOState
-                 utxoEx2D
-                 (Coin 243)
-                 (Coin 19)
-                 emptyPPPUpdates)
-               (DPState
-                dsEx2D { _irwd = Map.empty
-                       , _stkCreds = addStakeCreds carlSHK (SlotNo 10) $ _stkCreds dsEx2B
-                       , _rewards = Map.insert (mkRwdAcnt carlSHK) 110 $ _rewards dsEx2B
-                       }
-                 psEx2A)
+expectedLSEx2E =
+  LedgerState
+    ( UTxOState
+        utxoEx2D
+        (Coin 243)
+        (Coin 19)
+        emptyPPPUpdates
+    )
+    ( DPState
+        dsEx2D
+          { _irwd = Map.empty,
+            _stkCreds = addStakeCreds carlSHK (SlotNo 10) $ _stkCreds dsEx2B,
+            _rewards = Map.insert (mkRwdAcnt carlSHK) 110 $ _rewards dsEx2B
+          }
+        psEx2A
+    )
 
 blockEx2EHash :: HashHeader
 blockEx2EHash = bhHash (bheader blockEx2E)
 
 acntEx2E :: AccountState
-acntEx2E = AccountState
-            { _treasury = Coin 21
-            , _reserves = maxLLSupply - balance utxoEx2A - carlMIR
-            }
+acntEx2E =
+  AccountState
+    { _treasury = Coin 21,
+      _reserves = maxLLSupply - balance utxoEx2A - carlMIR
+    }
 
 oCertIssueNosEx2 :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2 =
@@ -1091,50 +1400,55 @@ oCertIssueNosEx2 =
     oCertIssueNosEx1
 
 expectedStEx2E :: ChainState
-expectedStEx2E = ChainState
-  (NewEpochState
-     (EpochNo 2)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     (PoolDistr
-       (Map.singleton
-          (hk alicePool)
-          (1, hashKeyVRF (snd $ vrf alicePool))))
-     epoch1OSchedEx2E)
-  oCertIssueNosEx2
-  ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
-  (mkSeqNonce 5)
-  (mkSeqNonce 5)
-  (hashHeaderToNonce blockEx2DHash)
-  (At $ LastAppliedBlock
-    (BlockNo 5)
-    (SlotNo 220)
-    blockEx2EHash)
+expectedStEx2E =
+  ChainState
+    ( NewEpochState
+        (EpochNo 2)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        ( PoolDistr
+            ( Map.singleton
+                (hk alicePool)
+                (1, hashKeyVRF (snd $ vrf alicePool))
+            )
+        )
+        epoch1OSchedEx2E
+    )
+    oCertIssueNosEx2
+    ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
+    (mkSeqNonce 5)
+    (mkSeqNonce 5)
+    (hashHeaderToNonce blockEx2DHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 5)
+          (SlotNo 220)
+          blockEx2EHash
+    )
 
 ex2E :: CHAINExample
 ex2E = CHAINExample (SlotNo 220) expectedStEx2D blockEx2E (Right expectedStEx2E)
 
-
 -- | Example 2F - create a decentralized Praos block (ie one not in the overlay schedule)
-
 oCertIssueNosEx2F :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2F = Map.insert (coerceKeyRole $ hk alicePool) 0 oCertIssueNosEx2
 
 blockEx2F :: Block
-blockEx2F = mkBlock
-             blockEx2EHash
-             alicePool
-             []
-             (SlotNo 295) -- odd slots open for decentralization in epoch1OSchedEx2E
-             (BlockNo 6)
-             ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
-             (NatNonce 6)
-             zero
-             14
-             14
-             (mkOCert alicePool 0 (KESPeriod 14))
+blockEx2F =
+  mkBlock
+    blockEx2EHash
+    alicePool
+    []
+    (SlotNo 295) -- odd slots open for decentralization in epoch1OSchedEx2E
+    (BlockNo 6)
+    ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
+    (NatNonce 6)
+    zero
+    14
+    14
+    (mkOCert alicePool 0 (KESPeriod 14))
 
 blockEx2FHash :: HashHeader
 blockEx2FHash = bhHash (bheader blockEx2F)
@@ -1143,77 +1457,90 @@ pdEx2F :: PoolDistr
 pdEx2F = PoolDistr $ Map.singleton (hk alicePool) (1, hashKeyVRF $ snd $ vrf alicePool)
 
 expectedStEx2F :: ChainState
-expectedStEx2F = ChainState
-  (NewEpochState
-     (EpochNo 2)
-     (BlocksMade Map.empty)
-     (BlocksMade $ Map.singleton (hk alicePool) 1)
-     (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1 ppsEx1 emptyNonMyopic)
-     (SJust RewardUpdate { deltaT        = Coin 19
-                         , deltaR        = Coin 0
-                         , rs            = Map.empty
-                         , deltaF        = Coin (-19)
-                         , nonMyopic     = emptyNonMyopic { rewardPot = Coin 16 }
-                         })
-     pdEx2F
-     epoch1OSchedEx2E)
-  oCertIssueNosEx2F
-  ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
-  (mkSeqNonce 6)
-  (mkSeqNonce 5)
-  (hashHeaderToNonce blockEx2DHash)
-  (At $ LastAppliedBlock
-    (BlockNo 6)
-    (SlotNo 295)
-    blockEx2FHash)
+expectedStEx2F =
+  ChainState
+    ( NewEpochState
+        (EpochNo 2)
+        (BlocksMade Map.empty)
+        (BlocksMade $ Map.singleton (hk alicePool) 1)
+        (EpochState acntEx2E snapsEx2E expectedLSEx2E ppsEx1 ppsEx1 emptyNonMyopic)
+        ( SJust
+            RewardUpdate
+              { deltaT = Coin 19,
+                deltaR = Coin 0,
+                rs = Map.empty,
+                deltaF = Coin (-19),
+                nonMyopic = emptyNonMyopic {rewardPot = Coin 16}
+              }
+        )
+        pdEx2F
+        epoch1OSchedEx2E
+    )
+    oCertIssueNosEx2F
+    ((mkSeqNonce 3) ⭒ (hashHeaderToNonce blockEx2BHash))
+    (mkSeqNonce 6)
+    (mkSeqNonce 5)
+    (hashHeaderToNonce blockEx2DHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 6)
+          (SlotNo 295)
+          blockEx2FHash
+    )
 
 ex2F :: CHAINExample
 ex2F = CHAINExample (SlotNo 295) expectedStEx2E blockEx2F (Right expectedStEx2F)
 
-
 -- | Example 2G - create an empty block in the next epoch
 -- to prepare the way for the first non-trivial reward update
-
-
 blockEx2G :: Block
-blockEx2G = mkBlock
-             blockEx2FHash
-             (coreNodeKeys 0)
-             []
-             (SlotNo 310)
-             (BlockNo 7)
-             (mkSeqNonce 5)
-             (NatNonce 7)
-             zero
-             15
-             15
-             (mkOCert (coreNodeKeys 0) 1 (KESPeriod 15))
+blockEx2G =
+  mkBlock
+    blockEx2FHash
+    (coreNodeKeys 0)
+    []
+    (SlotNo 310)
+    (BlockNo 7)
+    (mkSeqNonce 5)
+    (NatNonce 7)
+    zero
+    15
+    15
+    (mkOCert (coreNodeKeys 0) 1 (KESPeriod 15))
 
 blockEx2GHash :: HashHeader
 blockEx2GHash = bhHash (bheader blockEx2G)
 
 epoch1OSchedEx2G :: Map SlotNo OBftSlot
-epoch1OSchedEx2G = runShelleyBase $ overlaySchedule
-                    (EpochNo 3)
-                    (Map.keysSet genDelegs)
-                    ppsEx1
+epoch1OSchedEx2G =
+  runShelleyBase $
+    overlaySchedule
+      (EpochNo 3)
+      (Map.keysSet genDelegs)
+      ppsEx1
 
 snapsEx2G :: SnapShots
-snapsEx2G = snapsEx2E { _pstakeMark = snapEx2E
-                      , _pstakeSet = snapEx2E
-                      , _pstakeGo = snapEx2C
-                      , _feeSS = 10}
+snapsEx2G =
+  snapsEx2E
+    { _pstakeMark = snapEx2E,
+      _pstakeSet = snapEx2E,
+      _pstakeGo = snapEx2C,
+      _feeSS = 10
+    }
 
 expectedLSEx2G :: LedgerState
-expectedLSEx2G = LedgerState
-               (UTxOState
-                 utxoEx2D
-                 (Coin 233)
-                 (Coin 10)
-                 emptyPPPUpdates)
-               (DPState
-                 dsEx2D
-                 psEx2A)
+expectedLSEx2G =
+  LedgerState
+    ( UTxOState
+        utxoEx2D
+        (Coin 233)
+        (Coin 10)
+        emptyPPPUpdates
+    )
+    ( DPState
+        dsEx2D
+        psEx2A
+    )
 
 oCertIssueNosEx2G :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2G =
@@ -1223,48 +1550,50 @@ oCertIssueNosEx2G =
     oCertIssueNosEx2F
 
 acntEx2G :: AccountState
-acntEx2G = acntEx2E { _treasury = Coin 40 }
+acntEx2G = acntEx2E {_treasury = Coin 40}
 
 expectedStEx2G :: ChainState
-expectedStEx2G = ChainState
-  (NewEpochState
-     (EpochNo 3)
-     (BlocksMade $ Map.singleton (hk alicePool) 1)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2G snapsEx2G expectedLSEx2G ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     pdEx2F
-     epoch1OSchedEx2G)
-  oCertIssueNosEx2G
-  ((mkSeqNonce 5) ⭒ (hashHeaderToNonce blockEx2DHash))
-  (mkSeqNonce 7)
-  (mkSeqNonce 7)
-  (hashHeaderToNonce blockEx2FHash)
-  (At $ LastAppliedBlock
-    (BlockNo 7)
-    (SlotNo 310)
-    blockEx2GHash)
+expectedStEx2G =
+  ChainState
+    ( NewEpochState
+        (EpochNo 3)
+        (BlocksMade $ Map.singleton (hk alicePool) 1)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2G snapsEx2G expectedLSEx2G ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        pdEx2F
+        epoch1OSchedEx2G
+    )
+    oCertIssueNosEx2G
+    ((mkSeqNonce 5) ⭒ (hashHeaderToNonce blockEx2DHash))
+    (mkSeqNonce 7)
+    (mkSeqNonce 7)
+    (hashHeaderToNonce blockEx2FHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 7)
+          (SlotNo 310)
+          blockEx2GHash
+    )
 
 ex2G :: CHAINExample
 ex2G = CHAINExample (SlotNo 310) expectedStEx2F blockEx2G (Right expectedStEx2G)
 
-
 -- | Example 2H - create the first non-trivial reward update
-
-
 blockEx2H :: Block
-blockEx2H = mkBlock
-             blockEx2GHash
-             (coreNodeKeys 3)
-             []
-             (SlotNo 390)
-             (BlockNo 8)
-             (mkSeqNonce 5)
-             (NatNonce 8)
-             zero
-             19
-             19
-             (mkOCert (coreNodeKeys 3) 2 (KESPeriod 19))
+blockEx2H =
+  mkBlock
+    blockEx2GHash
+    (coreNodeKeys 3)
+    []
+    (SlotNo 390)
+    (BlockNo 8)
+    (mkSeqNonce 5)
+    (NatNonce 8)
+    zero
+    19
+    19
+    (mkOCert (coreNodeKeys 3) 2 (KESPeriod 19))
 
 blockEx2HHash :: HashHeader
 blockEx2HHash = bhHash (bheader blockEx2H)
@@ -1276,8 +1605,11 @@ bobRAcnt2H :: Coin
 bobRAcnt2H = Coin 2124297519
 
 rewardsEx2H :: Map RewardAcnt Coin
-rewardsEx2H = Map.fromList [ (RewardAcnt aliceSHK, aliceRAcnt2H)
-                          , (RewardAcnt bobSHK, bobRAcnt2H) ]
+rewardsEx2H =
+  Map.fromList
+    [ (RewardAcnt aliceSHK, aliceRAcnt2H),
+      (RewardAcnt bobSHK, bobRAcnt2H)
+    ]
 
 oCertIssueNosEx2H :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2H =
@@ -1294,94 +1626,112 @@ alicePerfEx2H = ApparentPerformance (beta / sigma)
     stake = aliceCoinEx2BBase + aliceCoinEx2BPtr + bobInitCoin
 
 expectedStEx2H :: ChainState
-expectedStEx2H = ChainState
-  (NewEpochState
-     (EpochNo 3)
-     (BlocksMade $ Map.singleton (hk alicePool) 1)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2G snapsEx2G expectedLSEx2G ppsEx1 ppsEx1 emptyNonMyopic)
-     (SJust RewardUpdate { deltaT        = Coin 767369696984
-                         , deltaR        = Coin (-793333333333)
-                         , rs            = rewardsEx2H
-                         , deltaF        = Coin (-10)
-                         , nonMyopic     = NonMyopic
-                             (Map.singleton (hk alicePool) alicePerfEx2H)
-                             (Coin 634666666675)
-                             snapEx2C
-                         })
-     pdEx2F
-     epoch1OSchedEx2G)
-  oCertIssueNosEx2H
-  ((mkSeqNonce 5) ⭒ (hashHeaderToNonce blockEx2DHash))
-  (mkSeqNonce 8)
-  (mkSeqNonce 7)
-  (hashHeaderToNonce blockEx2FHash)
-  (At $ LastAppliedBlock
-    (BlockNo 8)
-    (SlotNo 390)
-    blockEx2HHash)
+expectedStEx2H =
+  ChainState
+    ( NewEpochState
+        (EpochNo 3)
+        (BlocksMade $ Map.singleton (hk alicePool) 1)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2G snapsEx2G expectedLSEx2G ppsEx1 ppsEx1 emptyNonMyopic)
+        ( SJust
+            RewardUpdate
+              { deltaT = Coin 767369696984,
+                deltaR = Coin (-793333333333),
+                rs = rewardsEx2H,
+                deltaF = Coin (-10),
+                nonMyopic =
+                  NonMyopic
+                    (Map.singleton (hk alicePool) alicePerfEx2H)
+                    (Coin 634666666675)
+                    snapEx2C
+              }
+        )
+        pdEx2F
+        epoch1OSchedEx2G
+    )
+    oCertIssueNosEx2H
+    ((mkSeqNonce 5) ⭒ (hashHeaderToNonce blockEx2DHash))
+    (mkSeqNonce 8)
+    (mkSeqNonce 7)
+    (hashHeaderToNonce blockEx2FHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 8)
+          (SlotNo 390)
+          blockEx2HHash
+    )
 
 ex2H :: CHAINExample
 ex2H = CHAINExample (SlotNo 390) expectedStEx2G blockEx2H (Right expectedStEx2H)
 
-
 -- | Example 2I - apply the first non-trivial reward update
-
-
 blockEx2I :: Block
-blockEx2I = mkBlock
-              blockEx2HHash
-              (coreNodeKeys 0)
-              []
-              (SlotNo 410)
-              (BlockNo 9)
-              (mkSeqNonce 7)
-              (NatNonce 9)
-              zero
-              20
-              20
-              (mkOCert (coreNodeKeys 0) 2 (KESPeriod 20))
+blockEx2I =
+  mkBlock
+    blockEx2HHash
+    (coreNodeKeys 0)
+    []
+    (SlotNo 410)
+    (BlockNo 9)
+    (mkSeqNonce 7)
+    (NatNonce 9)
+    zero
+    20
+    20
+    (mkOCert (coreNodeKeys 0) 2 (KESPeriod 20))
 
 blockEx2IHash :: HashHeader
 blockEx2IHash = bhHash (bheader blockEx2I)
 
 epoch1OSchedEx2I :: Map SlotNo OBftSlot
-epoch1OSchedEx2I = runShelleyBase $ overlaySchedule
-                     (EpochNo 4)
-                     (Map.keysSet genDelegs)
-                     ppsEx1
+epoch1OSchedEx2I =
+  runShelleyBase $
+    overlaySchedule
+      (EpochNo 4)
+      (Map.keysSet genDelegs)
+      ppsEx1
 
 acntEx2I :: AccountState
-acntEx2I = AccountState
-            { _treasury = Coin 767369697024
-            , _reserves = Coin 33999206666666557
-            }
+acntEx2I =
+  AccountState
+    { _treasury = Coin 767369697024,
+      _reserves = Coin 33999206666666557
+    }
 
 dsEx2I :: DState
-dsEx2I = dsEx2D { _rewards = Map.insert (mkRwdAcnt carlSHK) 110 rewardsEx2H }
+dsEx2I = dsEx2D {_rewards = Map.insert (mkRwdAcnt carlSHK) 110 rewardsEx2H}
 
 expectedLSEx2I :: LedgerState
-expectedLSEx2I = LedgerState
-               (UTxOState
-                 utxoEx2D
-                 (Coin 224)
-                 (Coin 9)
-                 emptyPPPUpdates)
-               (DPState dsEx2I psEx2A)
+expectedLSEx2I =
+  LedgerState
+    ( UTxOState
+        utxoEx2D
+        (Coin 224)
+        (Coin 9)
+        emptyPPPUpdates
+    )
+    (DPState dsEx2I psEx2A)
 
 snapsEx2I :: SnapShots
-snapsEx2I = snapsEx2G { _pstakeMark = SnapShot
-                          (Stake ( Map.fromList
-                            [ (bobSHK, bobInitCoin + bobRAcnt2H)
-                            , (aliceSHK, aliceCoinEx2DBase + aliceCoinEx2BPtr + aliceRAcnt2H)
-                            , (carlSHK, carlMIR) ]))
-                          delegsEx2D
-                          (Map.singleton (hk alicePool) alicePoolParams)
-                        -- The stake snapshots have bigger values now, due to the new rewards
-                      , _pstakeSet = snapEx2E
-                      , _pstakeGo = snapEx2E
-                      , _feeSS = Coin 9
-                      }
+snapsEx2I =
+  snapsEx2G
+    { _pstakeMark =
+        SnapShot
+          ( Stake
+              ( Map.fromList
+                  [ (bobSHK, bobInitCoin + bobRAcnt2H),
+                    (aliceSHK, aliceCoinEx2DBase + aliceCoinEx2BPtr + aliceRAcnt2H),
+                    (carlSHK, carlMIR)
+                  ]
+              )
+          )
+          delegsEx2D
+          (Map.singleton (hk alicePool) alicePoolParams),
+      -- The stake snapshots have bigger values now, due to the new rewards
+      _pstakeSet = snapEx2E,
+      _pstakeGo = snapEx2E,
+      _feeSS = Coin 9
+    }
 
 oCertIssueNosEx2I :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2I =
@@ -1391,96 +1741,109 @@ oCertIssueNosEx2I =
     oCertIssueNosEx2H
 
 expectedStEx2I :: ChainState
-expectedStEx2I = ChainState
-  (NewEpochState
-     (EpochNo 4)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2I snapsEx2I expectedLSEx2I ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     pdEx2F
-     epoch1OSchedEx2I)
-  oCertIssueNosEx2I
-  ((mkSeqNonce 7) ⭒ (hashHeaderToNonce blockEx2FHash))
-  (mkSeqNonce 9)
-  (mkSeqNonce 9)
-  (hashHeaderToNonce blockEx2HHash)
-  (At $ LastAppliedBlock
-    (BlockNo 9)
-    (SlotNo 410)
-    blockEx2IHash)
+expectedStEx2I =
+  ChainState
+    ( NewEpochState
+        (EpochNo 4)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2I snapsEx2I expectedLSEx2I ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        pdEx2F
+        epoch1OSchedEx2I
+    )
+    oCertIssueNosEx2I
+    ((mkSeqNonce 7) ⭒ (hashHeaderToNonce blockEx2FHash))
+    (mkSeqNonce 9)
+    (mkSeqNonce 9)
+    (hashHeaderToNonce blockEx2HHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 9)
+          (SlotNo 410)
+          blockEx2IHash
+    )
 
 ex2I :: CHAINExample
 ex2I = CHAINExample (SlotNo 410) expectedStEx2H blockEx2I (Right expectedStEx2I)
 
-
 -- | Example 2J - drain reward account and de-register stake key
-
 bobAda2J :: Coin
-bobAda2J = bobRAcnt2H -- reward account
-                   + bobInitCoin -- txin we will consume (must spend at least one)
-                   + Coin 4 -- stake registration refund
-                   - Coin 9 -- tx fee
+bobAda2J =
+  bobRAcnt2H -- reward account
+    + bobInitCoin -- txin we will consume (must spend at least one)
+    + Coin 4 -- stake registration refund
+    - Coin 9 -- tx fee
 
 txbodyEx2J :: TxBody
-txbodyEx2J = TxBody
-           (Set.fromList [TxIn genesisId 1])
-           (StrictSeq.singleton $ TxOut bobAddr bobAda2J)
-           (StrictSeq.fromList [DCertDeleg (DeRegKey bobSHK)])
-           (Wdrl $ Map.singleton (RewardAcnt bobSHK) bobRAcnt2H)
-           (Coin 9)
-           (SlotNo 500)
-           SNothing
-           SNothing
+txbodyEx2J =
+  TxBody
+    (Set.fromList [TxIn genesisId 1])
+    (StrictSeq.singleton $ TxOut bobAddr bobAda2J)
+    (StrictSeq.fromList [DCertDeleg (DeRegKey bobSHK)])
+    (Wdrl $ Map.singleton (RewardAcnt bobSHK) bobRAcnt2H)
+    (Coin 9)
+    (SlotNo 500)
+    SNothing
+    SNothing
 
 txEx2J :: Tx
-txEx2J = Tx
-          txbodyEx2J
-          (makeWitnessesVKey (hashTxBody txbodyEx2J) [asWitness bobPay, asWitness bobStake])
-          Map.empty
-          SNothing
+txEx2J =
+  Tx
+    txbodyEx2J
+    (makeWitnessesVKey (hashTxBody txbodyEx2J) [asWitness bobPay, asWitness bobStake])
+    Map.empty
+    SNothing
 
 blockEx2J :: Block
-blockEx2J = mkBlock
-              blockEx2IHash
-              (coreNodeKeys 3)
-              [txEx2J]
-              (SlotNo 420)
-              (BlockNo 10)
-              (mkSeqNonce 7)
-              (NatNonce 10)
-              zero
-              21
-              19
-              (mkOCert (coreNodeKeys 3) 2 (KESPeriod 19))
+blockEx2J =
+  mkBlock
+    blockEx2IHash
+    (coreNodeKeys 3)
+    [txEx2J]
+    (SlotNo 420)
+    (BlockNo 10)
+    (mkSeqNonce 7)
+    (NatNonce 10)
+    zero
+    21
+    19
+    (mkOCert (coreNodeKeys 3) 2 (KESPeriod 19))
 
 blockEx2JHash :: HashHeader
 blockEx2JHash = bhHash (bheader blockEx2J)
 
 utxoEx2J :: UTxO
-utxoEx2J = UTxO . Map.fromList $
-                   [ (TxIn (txid txbodyEx2J) 0, TxOut bobAddr bobAda2J)
-                   , (TxIn (txid txbodyEx2D) 0, TxOut aliceAddr aliceCoinEx2DBase)
-                   , (TxIn (txid txbodyEx2B) 1, TxOut alicePtrAddr aliceCoinEx2BPtr)
-                   ]
+utxoEx2J =
+  UTxO . Map.fromList $
+    [ (TxIn (txid txbodyEx2J) 0, TxOut bobAddr bobAda2J),
+      (TxIn (txid txbodyEx2D) 0, TxOut aliceAddr aliceCoinEx2DBase),
+      (TxIn (txid txbodyEx2B) 1, TxOut alicePtrAddr aliceCoinEx2BPtr)
+    ]
 
 dsEx2J :: DState
-dsEx2J = dsEx1
-          { _ptrs = Map.fromList [ (Ptr (SlotNo 10) 0 0, aliceSHK)
-                                 , (Ptr (SlotNo 10) 0 2, carlSHK)]
-          , _stkCreds = StakeCreds $ Map.fromList [(aliceSHK, SlotNo 10), (carlSHK, SlotNo 10)]
-          , _delegations = Map.fromList [(aliceSHK, hk alicePool), (carlSHK, hk alicePool)]
-          , _rewards = Map.fromList [(RewardAcnt aliceSHK, aliceRAcnt2H), (RewardAcnt carlSHK, carlMIR)]
-          }
+dsEx2J =
+  dsEx1
+    { _ptrs =
+        Map.fromList
+          [ (Ptr (SlotNo 10) 0 0, aliceSHK),
+            (Ptr (SlotNo 10) 0 2, carlSHK)
+          ],
+      _stkCreds = StakeCreds $ Map.fromList [(aliceSHK, SlotNo 10), (carlSHK, SlotNo 10)],
+      _delegations = Map.fromList [(aliceSHK, hk alicePool), (carlSHK, hk alicePool)],
+      _rewards = Map.fromList [(RewardAcnt aliceSHK, aliceRAcnt2H), (RewardAcnt carlSHK, carlMIR)]
+    }
 
 expectedLSEx2J :: LedgerState
-expectedLSEx2J = LedgerState
-               (UTxOState
-                 utxoEx2J
-                 (Coin (219 - 4) + 5)
-                 (Coin 18)
-                 emptyPPPUpdates)
-               (DPState dsEx2J psEx2A)
+expectedLSEx2J =
+  LedgerState
+    ( UTxOState
+        utxoEx2J
+        (Coin (219 - 4) + 5)
+        (Coin 18)
+        emptyPPPUpdates
+    )
+    (DPState dsEx2J psEx2A)
 
 oCertIssueNosEx2J :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2J =
@@ -1490,237 +1853,274 @@ oCertIssueNosEx2J =
     oCertIssueNosEx2H
 
 expectedStEx2J :: ChainState
-expectedStEx2J = ChainState
-  (NewEpochState
-     (EpochNo 4)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2I snapsEx2I expectedLSEx2J ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     pdEx2F
-     epoch1OSchedEx2I)
-  oCertIssueNosEx2J
-  ((mkSeqNonce 7) ⭒ (hashHeaderToNonce blockEx2FHash))
-  (mkSeqNonce 10)
-  (mkSeqNonce 10)
-  (hashHeaderToNonce blockEx2HHash)
-  (At $ LastAppliedBlock
-    (BlockNo 10)
-    (SlotNo 420)
-    blockEx2JHash)
+expectedStEx2J =
+  ChainState
+    ( NewEpochState
+        (EpochNo 4)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2I snapsEx2I expectedLSEx2J ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        pdEx2F
+        epoch1OSchedEx2I
+    )
+    oCertIssueNosEx2J
+    ((mkSeqNonce 7) ⭒ (hashHeaderToNonce blockEx2FHash))
+    (mkSeqNonce 10)
+    (mkSeqNonce 10)
+    (hashHeaderToNonce blockEx2HHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 10)
+          (SlotNo 420)
+          blockEx2JHash
+    )
 
 ex2J :: CHAINExample
 ex2J = CHAINExample (SlotNo 420) expectedStEx2I blockEx2J (Right expectedStEx2J)
 
-
 -- | Example 2K - start stake pool retirement
-
 aliceCoinEx2KPtr :: Coin
 aliceCoinEx2KPtr = aliceCoinEx2DBase - 2
 
 txbodyEx2K :: TxBody
-txbodyEx2K = TxBody
-           (Set.fromList [TxIn (txid txbodyEx2D) 0])
-           (StrictSeq.singleton $ TxOut alicePtrAddr aliceCoinEx2KPtr)
-           (StrictSeq.fromList [DCertPool (RetirePool (hk alicePool) (EpochNo 5))])
-           (Wdrl Map.empty)
-           (Coin 2)
-           (SlotNo 500)
-           SNothing
-           SNothing
+txbodyEx2K =
+  TxBody
+    (Set.fromList [TxIn (txid txbodyEx2D) 0])
+    (StrictSeq.singleton $ TxOut alicePtrAddr aliceCoinEx2KPtr)
+    (StrictSeq.fromList [DCertPool (RetirePool (hk alicePool) (EpochNo 5))])
+    (Wdrl Map.empty)
+    (Coin 2)
+    (SlotNo 500)
+    SNothing
+    SNothing
 
 txEx2K :: Tx
-txEx2K = Tx
-          txbodyEx2K
-          (makeWitnessesVKey (hashTxBody txbodyEx2K) [asWitness $ cold alicePool, asWitness alicePay])
-          Map.empty
-          SNothing
+txEx2K =
+  Tx
+    txbodyEx2K
+    (makeWitnessesVKey (hashTxBody txbodyEx2K) [asWitness $ cold alicePool, asWitness alicePay])
+    Map.empty
+    SNothing
 
 blockEx2K :: Block
-blockEx2K = mkBlock
-              blockEx2JHash
-              (coreNodeKeys 3)
-              [txEx2K]
-              (SlotNo 490)
-              (BlockNo 11)
-              (mkSeqNonce 7)
-              (NatNonce 11)
-              zero
-              24
-              19
-              (mkOCert (coreNodeKeys 3) 2 (KESPeriod 19))
+blockEx2K =
+  mkBlock
+    blockEx2JHash
+    (coreNodeKeys 3)
+    [txEx2K]
+    (SlotNo 490)
+    (BlockNo 11)
+    (mkSeqNonce 7)
+    (NatNonce 11)
+    zero
+    24
+    19
+    (mkOCert (coreNodeKeys 3) 2 (KESPeriod 19))
 
 blockEx2KHash :: HashHeader
 blockEx2KHash = bhHash (bheader blockEx2K)
 
 utxoEx2K :: UTxO
-utxoEx2K = UTxO . Map.fromList $
-                   [ (TxIn (txid txbodyEx2J) 0, TxOut bobAddr bobAda2J)
-                   , (TxIn (txid txbodyEx2K) 0, TxOut alicePtrAddr aliceCoinEx2KPtr)
-                   , (TxIn (txid txbodyEx2B) 1, TxOut alicePtrAddr aliceCoinEx2BPtr)
-                   ]
+utxoEx2K =
+  UTxO . Map.fromList $
+    [ (TxIn (txid txbodyEx2J) 0, TxOut bobAddr bobAda2J),
+      (TxIn (txid txbodyEx2K) 0, TxOut alicePtrAddr aliceCoinEx2KPtr),
+      (TxIn (txid txbodyEx2B) 1, TxOut alicePtrAddr aliceCoinEx2BPtr)
+    ]
 
 psEx2K :: PState
-psEx2K = psEx2A { _retiring = Map.singleton (hk alicePool) (EpochNo 5) }
+psEx2K = psEx2A {_retiring = Map.singleton (hk alicePool) (EpochNo 5)}
 
 expectedLSEx2K :: LedgerState
-expectedLSEx2K = LedgerState
-               (UTxOState
-                 utxoEx2K
-                 (Coin 220)
-                 (Coin 20)
-                 emptyPPPUpdates)
-               (DPState dsEx2J psEx2K)
+expectedLSEx2K =
+  LedgerState
+    ( UTxOState
+        utxoEx2K
+        (Coin 220)
+        (Coin 20)
+        emptyPPPUpdates
+    )
+    (DPState dsEx2J psEx2K)
 
 expectedStEx2K :: ChainState
-expectedStEx2K = ChainState
-  (NewEpochState
-     (EpochNo 4)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2I snapsEx2I expectedLSEx2K ppsEx1 ppsEx1 emptyNonMyopic)
-     (SJust RewardUpdate { deltaT        = Coin 9
-                         , deltaR        = Coin 0
-                         , rs            = Map.empty
-                         , deltaF        = Coin (-9)
-                         , nonMyopic     = NonMyopic
-                             (Map.singleton (hk alicePool) (ApparentPerformance 0))
-                             (Coin 8)
-                             snapEx2E
-                         })
-     pdEx2F
-     epoch1OSchedEx2I)
-  oCertIssueNosEx2J
-  ((mkSeqNonce 7) ⭒ (hashHeaderToNonce blockEx2FHash))
-  (mkSeqNonce 11)
-  (mkSeqNonce 10)
-  (hashHeaderToNonce blockEx2HHash)
-  (At $ LastAppliedBlock
-    (BlockNo 11)
-    (SlotNo 490)
-    blockEx2KHash)
+expectedStEx2K =
+  ChainState
+    ( NewEpochState
+        (EpochNo 4)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2I snapsEx2I expectedLSEx2K ppsEx1 ppsEx1 emptyNonMyopic)
+        ( SJust
+            RewardUpdate
+              { deltaT = Coin 9,
+                deltaR = Coin 0,
+                rs = Map.empty,
+                deltaF = Coin (-9),
+                nonMyopic =
+                  NonMyopic
+                    (Map.singleton (hk alicePool) (ApparentPerformance 0))
+                    (Coin 8)
+                    snapEx2E
+              }
+        )
+        pdEx2F
+        epoch1OSchedEx2I
+    )
+    oCertIssueNosEx2J
+    ((mkSeqNonce 7) ⭒ (hashHeaderToNonce blockEx2FHash))
+    (mkSeqNonce 11)
+    (mkSeqNonce 10)
+    (hashHeaderToNonce blockEx2HHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 11)
+          (SlotNo 490)
+          blockEx2KHash
+    )
 
 ex2K :: CHAINExample
 ex2K = CHAINExample (SlotNo 490) expectedStEx2J blockEx2K (Right expectedStEx2K)
 
-
 -- | Example 2L - reap a stake pool
-
-
 blockEx2L :: Block
-blockEx2L = mkBlock
-              blockEx2KHash
-              (coreNodeKeys 0)
-              []
-              (SlotNo 510)
-              (BlockNo 12)
-              (mkSeqNonce 10)
-              (NatNonce 12)
-              zero
-              25
-              25
-              (mkOCert (coreNodeKeys 0) 3 (KESPeriod 25))
+blockEx2L =
+  mkBlock
+    blockEx2KHash
+    (coreNodeKeys 0)
+    []
+    (SlotNo 510)
+    (BlockNo 12)
+    (mkSeqNonce 10)
+    (NatNonce 12)
+    zero
+    25
+    25
+    (mkOCert (coreNodeKeys 0) 3 (KESPeriod 25))
 
 blockEx2LHash :: HashHeader
 blockEx2LHash = bhHash (bheader blockEx2L)
 
 acntEx2L :: AccountState
-acntEx2L = acntEx2I { _treasury =  _treasury acntEx2I --previous amount
-                                  + Coin 9 } -- from the reward update
+acntEx2L =
+  acntEx2I
+    { _treasury =
+        _treasury acntEx2I --previous amount
+          + Coin 9 -- from the reward update
+    }
 
 snapsEx2L :: SnapShots
-snapsEx2L = SnapShots { _pstakeMark = SnapShot
-                          (Stake (
-                            Map.fromList [ (aliceSHK, aliceRAcnt2H + aliceCoinEx2BPtr + aliceCoinEx2KPtr)
-                                         , (carlSHK, carlMIR)]))
-                          (Map.fromList [ (aliceSHK, hk alicePool), (carlSHK, hk alicePool) ])
-                          (Map.singleton (hk alicePool) alicePoolParams)
-                      , _pstakeSet = _pstakeMark snapsEx2I
-                      , _pstakeGo = _pstakeSet snapsEx2I
-                      , _feeSS = Coin 22
-                      }
+snapsEx2L =
+  SnapShots
+    { _pstakeMark =
+        SnapShot
+          ( Stake
+              ( Map.fromList
+                  [ (aliceSHK, aliceRAcnt2H + aliceCoinEx2BPtr + aliceCoinEx2KPtr),
+                    (carlSHK, carlMIR)
+                  ]
+              )
+          )
+          (Map.fromList [(aliceSHK, hk alicePool), (carlSHK, hk alicePool)])
+          (Map.singleton (hk alicePool) alicePoolParams),
+      _pstakeSet = _pstakeMark snapsEx2I,
+      _pstakeGo = _pstakeSet snapsEx2I,
+      _feeSS = Coin 22
+    }
+
 dsEx2L :: DState
-dsEx2L = dsEx1
-          { _ptrs = Map.fromList [ (Ptr (SlotNo 10) 0 0, aliceSHK)
-                                 , (Ptr (SlotNo 10) 0 2, carlSHK)
-                                 ]
-          , _stkCreds = StakeCreds $ Map.fromList [(aliceSHK, SlotNo 10), (carlSHK, SlotNo 10)]
-          , _rewards = Map.fromList [ (RewardAcnt aliceSHK, aliceRAcnt2H + Coin 201)
-                                    , (RewardAcnt carlSHK, carlMIR) ]
-                       -- Note the pool cert refund of 201
-          }
+dsEx2L =
+  dsEx1
+    { _ptrs =
+        Map.fromList
+          [ (Ptr (SlotNo 10) 0 0, aliceSHK),
+            (Ptr (SlotNo 10) 0 2, carlSHK)
+          ],
+      _stkCreds = StakeCreds $ Map.fromList [(aliceSHK, SlotNo 10), (carlSHK, SlotNo 10)],
+      _rewards =
+        Map.fromList
+          [ (RewardAcnt aliceSHK, aliceRAcnt2H + Coin 201),
+            (RewardAcnt carlSHK, carlMIR)
+          ]
+      -- Note the pool cert refund of 201
+    }
 
 expectedLSEx2L :: LedgerState
-expectedLSEx2L = LedgerState
-               (UTxOState
-                 utxoEx2K
-                 (Coin 4 + 4)
-                 (Coin 22)
-                 emptyPPPUpdates)
-               (DPState dsEx2L psEx1) -- Note the stake pool is reaped
-
+expectedLSEx2L =
+  LedgerState
+    ( UTxOState
+        utxoEx2K
+        (Coin 4 + 4)
+        (Coin 22)
+        emptyPPPUpdates
+    )
+    (DPState dsEx2L psEx1) -- Note the stake pool is reaped
 
 oCertIssueNosEx2L :: Map (KeyHash 'BlockIssuer) Natural
 oCertIssueNosEx2L =
   Map.insert (coerceKeyRole . hashKey $ vKey $ cold $ coreNodeKeys 0) 3 oCertIssueNosEx2J
 
 expectedStEx2L :: ChainState
-expectedStEx2L = ChainState
-  (NewEpochState
-     (EpochNo 5)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2L snapsEx2L expectedLSEx2L ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     pdEx2F
-     (runShelleyBase $ overlaySchedule (EpochNo 5) (Map.keysSet genDelegs) ppsEx1))
-  oCertIssueNosEx2L
-  ((mkSeqNonce 10) ⭒ (hashHeaderToNonce blockEx2HHash))
-  (mkSeqNonce 12)
-  (mkSeqNonce 12)
-  (hashHeaderToNonce blockEx2KHash)
-  (At $ LastAppliedBlock
-    (BlockNo 12)
-    (SlotNo 510)
-    blockEx2LHash)
+expectedStEx2L =
+  ChainState
+    ( NewEpochState
+        (EpochNo 5)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2L snapsEx2L expectedLSEx2L ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        pdEx2F
+        (runShelleyBase $ overlaySchedule (EpochNo 5) (Map.keysSet genDelegs) ppsEx1)
+    )
+    oCertIssueNosEx2L
+    ((mkSeqNonce 10) ⭒ (hashHeaderToNonce blockEx2HHash))
+    (mkSeqNonce 12)
+    (mkSeqNonce 12)
+    (hashHeaderToNonce blockEx2KHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 12)
+          (SlotNo 510)
+          blockEx2LHash
+    )
 
 ex2L :: CHAINExample
 ex2L = CHAINExample (SlotNo 510) expectedStEx2K blockEx2L (Right expectedStEx2L)
 
-
 -- | Example 3A - Setting up for a successful protocol parameter update,
 -- have three genesis keys vote on the same new parameters
-
-
 ppVote3A :: PParamsUpdate
-ppVote3A = PParams
-             { _minfeeA = SNothing
-             , _minfeeB = SNothing
-             , _maxBBSize = SNothing
-             , _maxTxSize = SNothing
-             , _maxBHSize = SNothing
-             , _keyDeposit = SNothing
-             , _keyMinRefund = SNothing
-             , _keyDecayRate = SNothing
-             , _poolDeposit = SJust 200
-             , _poolMinRefund = SNothing
-             , _poolDecayRate = SNothing
-             , _eMax = SNothing
-             , _nOpt = SNothing
-             , _a0 = SNothing
-             , _rho = SNothing
-             , _tau = SNothing
-             , _d = SNothing
-             , _extraEntropy = SJust (mkNonce 123)
-             , _protocolVersion = SNothing
-             }
+ppVote3A =
+  PParams
+    { _minfeeA = SNothing,
+      _minfeeB = SNothing,
+      _maxBBSize = SNothing,
+      _maxTxSize = SNothing,
+      _maxBHSize = SNothing,
+      _keyDeposit = SNothing,
+      _keyMinRefund = SNothing,
+      _keyDecayRate = SNothing,
+      _poolDeposit = SJust 200,
+      _poolMinRefund = SNothing,
+      _poolDecayRate = SNothing,
+      _eMax = SNothing,
+      _nOpt = SNothing,
+      _a0 = SNothing,
+      _rho = SNothing,
+      _tau = SNothing,
+      _d = SNothing,
+      _extraEntropy = SJust (mkNonce 123),
+      _protocolVersion = SNothing
+    }
 
 ppupEx3A :: ProposedPPUpdates
-ppupEx3A = ProposedPPUpdates $ Map.fromList
-             [ (hashKey $ coreNodeVKG 0, ppVote3A)
-             , (hashKey $ coreNodeVKG 3, ppVote3A)
-             , (hashKey $ coreNodeVKG 4, ppVote3A)
-                                   ]
+ppupEx3A =
+  ProposedPPUpdates $
+    Map.fromList
+      [ (hashKey $ coreNodeVKG 0, ppVote3A),
+        (hashKey $ coreNodeVKG 3, ppVote3A),
+        (hashKey $ coreNodeVKG 4, ppVote3A)
+      ]
 
 updateEx3A :: Update
 updateEx3A = Update ppupEx3A (EpochNo 0)
@@ -1729,90 +2129,100 @@ aliceCoinEx3A :: Coin
 aliceCoinEx3A = aliceInitCoin - 1
 
 txbodyEx3A :: TxBody
-txbodyEx3A = TxBody
-           (Set.fromList [TxIn genesisId 0])
-           (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx3A)
-           StrictSeq.empty
-           (Wdrl Map.empty)
-           (Coin 1)
-           (SlotNo 10)
-           (SJust updateEx3A)
-           SNothing
+txbodyEx3A =
+  TxBody
+    (Set.fromList [TxIn genesisId 0])
+    (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx3A)
+    StrictSeq.empty
+    (Wdrl Map.empty)
+    (Coin 1)
+    (SlotNo 10)
+    (SJust updateEx3A)
+    SNothing
 
 txEx3A :: Tx
-txEx3A = Tx
-          txbodyEx3A
-          (makeWitnessesVKey
-            (hashTxBody txbodyEx3A)
-            [ asWitness alicePay
-            , asWitness . cold $ coreNodeKeys 0
-            , asWitness . cold $ coreNodeKeys 3
-            , asWitness . cold $ coreNodeKeys 4
-            ])
-          Map.empty
-          SNothing
+txEx3A =
+  Tx
+    txbodyEx3A
+    ( makeWitnessesVKey
+        (hashTxBody txbodyEx3A)
+        [ asWitness alicePay,
+          asWitness . cold $ coreNodeKeys 0,
+          asWitness . cold $ coreNodeKeys 3,
+          asWitness . cold $ coreNodeKeys 4
+        ]
+    )
+    Map.empty
+    SNothing
 
 blockEx3A :: Block
-blockEx3A = mkBlock
-             lastByronHeaderHash
-             (coreNodeKeys 0)
-             [txEx3A]
-             (SlotNo 10)
-             (BlockNo 1)
-             (mkNonce 0)
-             (NatNonce 1)
-             zero
-             0
-             0
-             (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+blockEx3A =
+  mkBlock
+    lastByronHeaderHash
+    (coreNodeKeys 0)
+    [txEx3A]
+    (SlotNo 10)
+    (BlockNo 1)
+    (mkNonce 0)
+    (NatNonce 1)
+    zero
+    0
+    0
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 expectedLSEx3A :: LedgerState
-expectedLSEx3A = LedgerState
-               (UTxOState
-                 (UTxO . Map.fromList $
-                   [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin)
-                   , (TxIn (txid txbodyEx3A) 0, TxOut aliceAddr aliceCoinEx3A)
-                   ])
-                 (Coin 0)
-                 (Coin 1)
-                 ppupEx3A)
-               (DPState dsEx1 psEx1)
+expectedLSEx3A =
+  LedgerState
+    ( UTxOState
+        ( UTxO . Map.fromList $
+            [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin),
+              (TxIn (txid txbodyEx3A) 0, TxOut aliceAddr aliceCoinEx3A)
+            ]
+        )
+        (Coin 0)
+        (Coin 1)
+        ppupEx3A
+    )
+    (DPState dsEx1 psEx1)
 
 blockEx3AHash :: HashHeader
 blockEx3AHash = bhHash (bheader blockEx3A)
 
 expectedStEx3A :: ChainState
-expectedStEx3A = ChainState
-  (NewEpochState
-     (EpochNo 0)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2A emptySnapShots expectedLSEx3A ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     (PoolDistr Map.empty)
-     overlayEx2A)
-  oCertIssueNosEx1
-  nonce0
-  (nonce0 ⭒ mkNonce 1)
-  (nonce0 ⭒ mkNonce 1)
-  NeutralNonce
-  (At $ LastAppliedBlock
-    (BlockNo 1)
-    (SlotNo 10)
-    blockEx3AHash)
+expectedStEx3A =
+  ChainState
+    ( NewEpochState
+        (EpochNo 0)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2A emptySnapShots expectedLSEx3A ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        (PoolDistr Map.empty)
+        overlayEx2A
+    )
+    oCertIssueNosEx1
+    nonce0
+    (nonce0 ⭒ mkNonce 1)
+    (nonce0 ⭒ mkNonce 1)
+    NeutralNonce
+    ( At $
+        LastAppliedBlock
+          (BlockNo 1)
+          (SlotNo 10)
+          blockEx3AHash
+    )
 
 ex3A :: CHAINExample
 ex3A = CHAINExample (SlotNo 10) initStEx2A blockEx3A (Right expectedStEx3A)
 
-
 -- | Example 3B - Finish getting enough votes for the protocol parameter update.
-
-
 ppupEx3B :: ProposedPPUpdates
-ppupEx3B = ProposedPPUpdates $ Map.fromList
-             [ (hashKey $ coreNodeVKG 1, ppVote3A)
-             , (hashKey $ coreNodeVKG 5, ppVote3A)
-             ]
+ppupEx3B =
+  ProposedPPUpdates $
+    Map.fromList
+      [ (hashKey $ coreNodeVKG 1, ppVote3A),
+        (hashKey $ coreNodeVKG 5, ppVote3A)
+      ]
 
 updateEx3B :: Update
 updateEx3B = Update ppupEx3B (EpochNo 0)
@@ -1821,314 +2231,360 @@ aliceCoinEx3B :: Coin
 aliceCoinEx3B = aliceCoinEx3A - 1
 
 txbodyEx3B :: TxBody
-txbodyEx3B = TxBody
-           (Set.fromList [TxIn (txid txbodyEx3A) 0])
-           (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx3B)
-           StrictSeq.empty
-           (Wdrl Map.empty)
-           (Coin 1)
-           (SlotNo 31)
-           (SJust updateEx3B)
-           SNothing
+txbodyEx3B =
+  TxBody
+    (Set.fromList [TxIn (txid txbodyEx3A) 0])
+    (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx3B)
+    StrictSeq.empty
+    (Wdrl Map.empty)
+    (Coin 1)
+    (SlotNo 31)
+    (SJust updateEx3B)
+    SNothing
 
 txEx3B :: Tx
-txEx3B = Tx
-          txbodyEx3B
-          (makeWitnessesVKey
-            (hashTxBody txbodyEx3B)
-            [ asWitness alicePay
-            , asWitness . cold $ coreNodeKeys 1
-            , asWitness . cold $ coreNodeKeys 5
-            ])
-          Map.empty
-          SNothing
+txEx3B =
+  Tx
+    txbodyEx3B
+    ( makeWitnessesVKey
+        (hashTxBody txbodyEx3B)
+        [ asWitness alicePay,
+          asWitness . cold $ coreNodeKeys 1,
+          asWitness . cold $ coreNodeKeys 5
+        ]
+    )
+    Map.empty
+    SNothing
 
 blockEx3B :: Block
-blockEx3B = mkBlock
-             blockEx3AHash
-             (coreNodeKeys 3)
-             [txEx3B]
-             (SlotNo 20)
-             (BlockNo 2)
-             (mkNonce 0)
-             (NatNonce 2)
-             zero
-             1
-             0
-             (mkOCert (coreNodeKeys 3) 0 (KESPeriod 0))
+blockEx3B =
+  mkBlock
+    blockEx3AHash
+    (coreNodeKeys 3)
+    [txEx3B]
+    (SlotNo 20)
+    (BlockNo 2)
+    (mkNonce 0)
+    (NatNonce 2)
+    zero
+    1
+    0
+    (mkOCert (coreNodeKeys 3) 0 (KESPeriod 0))
 
 utxoEx3B :: UTxO
-utxoEx3B = UTxO . Map.fromList $
-             [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin)
-             , (TxIn (txid txbodyEx3B) 0, TxOut aliceAddr aliceCoinEx3B)
-             ]
+utxoEx3B =
+  UTxO . Map.fromList $
+    [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin),
+      (TxIn (txid txbodyEx3B) 0, TxOut aliceAddr aliceCoinEx3B)
+    ]
 
 ppupEx3B' :: ProposedPPUpdates
-ppupEx3B' = ProposedPPUpdates $ Map.fromList $
-  fmap (\n -> (hashKey $ coreNodeVKG n, ppVote3A)) [0, 1, 3, 4, 5]
+ppupEx3B' =
+  ProposedPPUpdates $ Map.fromList $
+    fmap (\n -> (hashKey $ coreNodeVKG n, ppVote3A)) [0, 1, 3, 4, 5]
 
 expectedLSEx3B :: LedgerState
-expectedLSEx3B = LedgerState
-               (UTxOState
-                 utxoEx3B
-                 (Coin 0)
-                 (Coin 2)
-                 ppupEx3B')
-               (DPState dsEx1 psEx1)
+expectedLSEx3B =
+  LedgerState
+    ( UTxOState
+        utxoEx3B
+        (Coin 0)
+        (Coin 2)
+        ppupEx3B'
+    )
+    (DPState dsEx1 psEx1)
 
 blockEx3BHash :: HashHeader
 blockEx3BHash = bhHash (bheader blockEx3B)
 
 expectedStEx3B :: ChainState
-expectedStEx3B = ChainState
-  (NewEpochState
-     (EpochNo 0)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2A emptySnapShots expectedLSEx3B ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     (PoolDistr Map.empty)
-     overlayEx2A)
-  oCertIssueNosEx1
-  nonce0
-  (mkSeqNonce 2)
-  (mkSeqNonce 2)
-  NeutralNonce
-  (At $ LastAppliedBlock
-    (BlockNo 2)
-    (SlotNo 20)
-    blockEx3BHash)
+expectedStEx3B =
+  ChainState
+    ( NewEpochState
+        (EpochNo 0)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2A emptySnapShots expectedLSEx3B ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        (PoolDistr Map.empty)
+        overlayEx2A
+    )
+    oCertIssueNosEx1
+    nonce0
+    (mkSeqNonce 2)
+    (mkSeqNonce 2)
+    NeutralNonce
+    ( At $
+        LastAppliedBlock
+          (BlockNo 2)
+          (SlotNo 20)
+          blockEx3BHash
+    )
 
 ex3B :: CHAINExample
 ex3B = CHAINExample (SlotNo 20) expectedStEx3A blockEx3B (Right expectedStEx3B)
 
-
 -- | Example 3C - Adopt protocol parameter update
-
-
 blockEx3C :: Block
-blockEx3C = mkBlock
-             blockEx3BHash
-             (coreNodeKeys 0)
-             []
-             (SlotNo 110)
-             (BlockNo 3)
-             (mkSeqNonce 2)
-             (NatNonce 3)
-             zero
-             5
-             0
-             (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+blockEx3C =
+  mkBlock
+    blockEx3BHash
+    (coreNodeKeys 0)
+    []
+    (SlotNo 110)
+    (BlockNo 3)
+    (mkSeqNonce 2)
+    (NatNonce 3)
+    zero
+    5
+    0
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 blockEx3CHash :: HashHeader
 blockEx3CHash = bhHash (bheader blockEx3C)
 
 overlayEx3C :: Map SlotNo OBftSlot
-overlayEx3C = runShelleyBase $ overlaySchedule
-                    (EpochNo 1)
-                    (Map.keysSet genDelegs)
-                    ppsEx1
+overlayEx3C =
+  runShelleyBase $
+    overlaySchedule
+      (EpochNo 1)
+      (Map.keysSet genDelegs)
+      ppsEx1
 
 snapsEx3C :: SnapShots
-snapsEx3C = emptySnapShots { _feeSS = Coin 2 }
+snapsEx3C = emptySnapShots {_feeSS = Coin 2}
 
 expectedLSEx3C :: LedgerState
-expectedLSEx3C = LedgerState
-               (UTxOState
-                 utxoEx3B
-                 (Coin 0)
-                 (Coin 2)
-                 emptyPPPUpdates)
-               (DPState dsEx1 psEx1)
+expectedLSEx3C =
+  LedgerState
+    ( UTxOState
+        utxoEx3B
+        (Coin 0)
+        (Coin 2)
+        emptyPPPUpdates
+    )
+    (DPState dsEx1 psEx1)
 
 ppsEx3C :: PParams
-ppsEx3C = ppsEx1 { _poolDeposit = Coin 200, _extraEntropy = mkNonce 123 }
+ppsEx3C = ppsEx1 {_poolDeposit = Coin 200, _extraEntropy = mkNonce 123}
 
 expectedStEx3C :: ChainState
-expectedStEx3C = ChainState
-  (NewEpochState
-     (EpochNo 1)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2A snapsEx3C expectedLSEx3C ppsEx1 ppsEx3C emptyNonMyopic)
-     SNothing
-     (PoolDistr Map.empty)
-     overlayEx3C)
-  oCertIssueNosEx1
-  (mkSeqNonce 2 ⭒ mkNonce 123)
-  (mkSeqNonce 3)
-  (mkSeqNonce 3)
-  (hashHeaderToNonce blockEx3BHash)
-  (At $ LastAppliedBlock
-    (BlockNo 3)
-    (SlotNo 110)
-    blockEx3CHash)
+expectedStEx3C =
+  ChainState
+    ( NewEpochState
+        (EpochNo 1)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2A snapsEx3C expectedLSEx3C ppsEx1 ppsEx3C emptyNonMyopic)
+        SNothing
+        (PoolDistr Map.empty)
+        overlayEx3C
+    )
+    oCertIssueNosEx1
+    (mkSeqNonce 2 ⭒ mkNonce 123)
+    (mkSeqNonce 3)
+    (mkSeqNonce 3)
+    (hashHeaderToNonce blockEx3BHash)
+    ( At $
+        LastAppliedBlock
+          (BlockNo 3)
+          (SlotNo 110)
+          blockEx3CHash
+    )
 
 ex3C :: CHAINExample
 ex3C = CHAINExample (SlotNo 110) expectedStEx3B blockEx3C (Right expectedStEx3C)
 
-
 -- | Example 4A - Genesis key delegation
-
-
 newGenDelegate :: KeyPair 'GenesisDelegate
-newGenDelegate  = KeyPair vkCold skCold
-  where (skCold, vkCold) = mkKeyPair (108, 0, 0, 0, 1)
+newGenDelegate = KeyPair vkCold skCold
+  where
+    (skCold, vkCold) = mkKeyPair (108, 0, 0, 0, 1)
 
 aliceCoinEx4A :: Coin
 aliceCoinEx4A = aliceInitCoin - 1
 
 txbodyEx4A :: TxBody
-txbodyEx4A = TxBody
-              (Set.fromList [TxIn genesisId 0])
-              (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx4A)
-              (StrictSeq.fromList [DCertGenesis (GenesisDelegCert
-                                       (hashKey (coreNodeVKG 0))
-                                       (hashKey (vKey newGenDelegate)))])
-              (Wdrl Map.empty)
-              (Coin 1)
-              (SlotNo 10)
-              SNothing
-              SNothing
+txbodyEx4A =
+  TxBody
+    (Set.fromList [TxIn genesisId 0])
+    (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx4A)
+    ( StrictSeq.fromList
+        [ DCertGenesis
+            ( GenesisDelegCert
+                (hashKey (coreNodeVKG 0))
+                (hashKey (vKey newGenDelegate))
+            )
+        ]
+    )
+    (Wdrl Map.empty)
+    (Coin 1)
+    (SlotNo 10)
+    SNothing
+    SNothing
 
 txEx4A :: Tx
-txEx4A = Tx
-           txbodyEx4A
-           (makeWitnessesVKey (hashTxBody txbodyEx4A) [ alicePay ]
-             `Set.union`
-              makeWitnessesVKey (hashTxBody txbodyEx4A)
-                [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0) ])
-           Map.empty
-           SNothing
+txEx4A =
+  Tx
+    txbodyEx4A
+    ( makeWitnessesVKey (hashTxBody txbodyEx4A) [alicePay]
+        `Set.union` makeWitnessesVKey
+          (hashTxBody txbodyEx4A)
+          [KeyPair (coreNodeVKG 0) (coreNodeSKG 0)]
+    )
+    Map.empty
+    SNothing
 
 blockEx4A :: Block
-blockEx4A = mkBlock
-              lastByronHeaderHash
-              (coreNodeKeys 0)
-              [txEx4A]
-              (SlotNo 10)
-              (BlockNo 1)
-              (mkNonce 0)
-              (NatNonce 1)
-              zero
-              0
-              0
-              (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+blockEx4A =
+  mkBlock
+    lastByronHeaderHash
+    (coreNodeKeys 0)
+    [txEx4A]
+    (SlotNo 10)
+    (BlockNo 1)
+    (mkNonce 0)
+    (NatNonce 1)
+    zero
+    0
+    0
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 blockEx4AHash :: HashHeader
 blockEx4AHash = bhHash (bheader blockEx4A)
 
 dsEx4A :: DState
-dsEx4A = dsEx1 { _fGenDelegs = Map.singleton
-                          ( FutureGenDeleg (SlotNo 43) (hashKey $ coreNodeVKG 0) )
-                          ( (hashKey . vKey) newGenDelegate ) }
+dsEx4A =
+  dsEx1
+    { _fGenDelegs =
+        Map.singleton
+          (FutureGenDeleg (SlotNo 43) (hashKey $ coreNodeVKG 0))
+          ((hashKey . vKey) newGenDelegate)
+    }
 
 utxoEx4A :: UTxO
-utxoEx4A = UTxO . Map.fromList $
-                    [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin)
-                    , (TxIn (txid txbodyEx4A) 0, TxOut aliceAddr aliceCoinEx4A)
-                    ]
+utxoEx4A =
+  UTxO . Map.fromList $
+    [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin),
+      (TxIn (txid txbodyEx4A) 0, TxOut aliceAddr aliceCoinEx4A)
+    ]
 
 expectedLSEx4A :: LedgerState
-expectedLSEx4A = LedgerState
-               (UTxOState
-                 utxoEx4A
-                 (Coin 0)
-                 (Coin 1)
-                 emptyPPPUpdates)
-               (DPState dsEx4A psEx1)
+expectedLSEx4A =
+  LedgerState
+    ( UTxOState
+        utxoEx4A
+        (Coin 0)
+        (Coin 1)
+        emptyPPPUpdates
+    )
+    (DPState dsEx4A psEx1)
 
 expectedStEx4A :: ChainState
-expectedStEx4A = ChainState
-  (NewEpochState
-     (EpochNo 0)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2A emptySnapShots expectedLSEx4A ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     (PoolDistr Map.empty)
-     overlayEx2A)
-  oCertIssueNosEx1
-  nonce0
-  (nonce0 ⭒ mkNonce 1)
-  (nonce0 ⭒ mkNonce 1)
-  NeutralNonce
-  (At $ LastAppliedBlock
-    (BlockNo 1)
-    (SlotNo 10)
-    blockEx4AHash)
+expectedStEx4A =
+  ChainState
+    ( NewEpochState
+        (EpochNo 0)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2A emptySnapShots expectedLSEx4A ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        (PoolDistr Map.empty)
+        overlayEx2A
+    )
+    oCertIssueNosEx1
+    nonce0
+    (nonce0 ⭒ mkNonce 1)
+    (nonce0 ⭒ mkNonce 1)
+    NeutralNonce
+    ( At $
+        LastAppliedBlock
+          (BlockNo 1)
+          (SlotNo 10)
+          blockEx4AHash
+    )
 
 ex4A :: CHAINExample
 ex4A = CHAINExample (SlotNo 10) initStEx2A blockEx4A (Right expectedStEx4A)
 
-
 -- | Example 4B - New genesis key delegation updated from future delegations
-
 blockEx4B :: Block
-blockEx4B = mkBlock
-             blockEx4AHash
-             (coreNodeKeys 6)
-             []
-             (SlotNo 50)
-             (BlockNo 2)
-             (mkNonce 0)
-             (NatNonce 2)
-             zero
-             2
-             0
-             (mkOCert (coreNodeKeys 6) 0 (KESPeriod 0))
+blockEx4B =
+  mkBlock
+    blockEx4AHash
+    (coreNodeKeys 6)
+    []
+    (SlotNo 50)
+    (BlockNo 2)
+    (mkNonce 0)
+    (NatNonce 2)
+    zero
+    2
+    0
+    (mkOCert (coreNodeKeys 6) 0 (KESPeriod 0))
 
 blockEx4BHash :: HashHeader
 blockEx4BHash = bhHash (bheader blockEx4B)
 
 dsEx4B :: DState
-dsEx4B = dsEx4A { _fGenDelegs = Map.empty
-                , _genDelegs = GenDelegs $ Map.insert
-                                 ((hashKey . coreNodeVKG) 0)
-                                 ((hashKey . vKey) newGenDelegate)
-                                 genDelegs }
+dsEx4B =
+  dsEx4A
+    { _fGenDelegs = Map.empty,
+      _genDelegs =
+        GenDelegs $
+          Map.insert
+            ((hashKey . coreNodeVKG) 0)
+            ((hashKey . vKey) newGenDelegate)
+            genDelegs
+    }
 
 expectedLSEx4B :: LedgerState
-expectedLSEx4B = LedgerState
-               (UTxOState
-                 utxoEx4A
-                 (Coin 0)
-                 (Coin 1)
-                 emptyPPPUpdates)
-               (DPState dsEx4B psEx1)
+expectedLSEx4B =
+  LedgerState
+    ( UTxOState
+        utxoEx4A
+        (Coin 0)
+        (Coin 1)
+        emptyPPPUpdates
+    )
+    (DPState dsEx4B psEx1)
 
 expectedStEx4B :: ChainState
-expectedStEx4B = ChainState
-  (NewEpochState
-     (EpochNo 0)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2A emptySnapShots expectedLSEx4B ppsEx1 ppsEx1 emptyNonMyopic)
-     (SJust RewardUpdate { deltaT        = Coin 0
-                         , deltaR        = Coin 0
-                         , rs            = Map.empty
-                         , deltaF        = Coin 0
-                         , nonMyopic     = emptyNonMyopic
-                         })
-     (PoolDistr Map.empty)
-     overlayEx2A)
-  oCertIssueNosEx1
-  nonce0
-  (mkSeqNonce 2)
-  (mkSeqNonce 2)
-  NeutralNonce
-  (At $ LastAppliedBlock
-    (BlockNo 2)
-    (SlotNo 50)
-    blockEx4BHash)
+expectedStEx4B =
+  ChainState
+    ( NewEpochState
+        (EpochNo 0)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2A emptySnapShots expectedLSEx4B ppsEx1 ppsEx1 emptyNonMyopic)
+        ( SJust
+            RewardUpdate
+              { deltaT = Coin 0,
+                deltaR = Coin 0,
+                rs = Map.empty,
+                deltaF = Coin 0,
+                nonMyopic = emptyNonMyopic
+              }
+        )
+        (PoolDistr Map.empty)
+        overlayEx2A
+    )
+    oCertIssueNosEx1
+    nonce0
+    (mkSeqNonce 2)
+    (mkSeqNonce 2)
+    NeutralNonce
+    ( At $
+        LastAppliedBlock
+          (BlockNo 2)
+          (SlotNo 50)
+          blockEx4BHash
+    )
 
 ex4B :: CHAINExample
 ex4B = CHAINExample (SlotNo 50) expectedStEx4A blockEx4B (Right expectedStEx4B)
 
-
 -- | Example 5A - Genesis key delegation
-
-
 ir :: Map (Credential 'Staking) Coin
 ir = Map.fromList [(aliceSHK, Coin 100)]
 
@@ -2136,118 +2592,131 @@ aliceCoinEx5A :: Coin
 aliceCoinEx5A = aliceInitCoin - 1
 
 txbodyEx5A :: TxBody
-txbodyEx5A = TxBody
-              (Set.fromList [TxIn genesisId 0])
-              (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5A)
-              (StrictSeq.fromList [DCertMir (MIRCert ir)])
-              (Wdrl Map.empty)
-              (Coin 1)
-              (SlotNo 10)
-              SNothing
-              SNothing
+txbodyEx5A =
+  TxBody
+    (Set.fromList [TxIn genesisId 0])
+    (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5A)
+    (StrictSeq.fromList [DCertMir (MIRCert ir)])
+    (Wdrl Map.empty)
+    (Coin 1)
+    (SlotNo 10)
+    SNothing
+    SNothing
 
 txEx5A :: Tx
-txEx5A = Tx
-           txbodyEx5A
-           (makeWitnessesVKey (hashTxBody txbodyEx5A) [ alicePay ]
-             `Set.union` makeWitnessesVKey (hashTxBody txbodyEx5A)
-             [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
-             , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
-             , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
-             , KeyPair (coreNodeVKG 3) (coreNodeSKG 3)
-             , KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
-           ])
-           Map.empty
-           SNothing
+txEx5A =
+  Tx
+    txbodyEx5A
+    ( makeWitnessesVKey (hashTxBody txbodyEx5A) [alicePay]
+        `Set.union` makeWitnessesVKey
+          (hashTxBody txbodyEx5A)
+          [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0),
+            KeyPair (coreNodeVKG 1) (coreNodeSKG 1),
+            KeyPair (coreNodeVKG 2) (coreNodeSKG 2),
+            KeyPair (coreNodeVKG 3) (coreNodeSKG 3),
+            KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
+          ]
+    )
+    Map.empty
+    SNothing
 
 blockEx5A :: Block
-blockEx5A = mkBlock
-              lastByronHeaderHash
-              (coreNodeKeys 0)
-              [txEx5A]
-              (SlotNo 10)
-              (BlockNo 1)
-              (mkNonce 0)
-              (NatNonce 1)
-              zero
-              0
-              0
-              (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+blockEx5A =
+  mkBlock
+    lastByronHeaderHash
+    (coreNodeKeys 0)
+    [txEx5A]
+    (SlotNo 10)
+    (BlockNo 1)
+    (mkNonce 0)
+    (NatNonce 1)
+    zero
+    0
+    0
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 blockEx5AHash :: HashHeader
 blockEx5AHash = bhHash (bheader blockEx5A)
 
 utxoEx5A :: UTxO
-utxoEx5A = UTxO . Map.fromList $
-                    [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin)
-                    , (TxIn (txid txbodyEx5A) 0, TxOut aliceAddr aliceCoinEx5A)
-                    ]
+utxoEx5A =
+  UTxO . Map.fromList $
+    [ (TxIn genesisId 1, TxOut bobAddr bobInitCoin),
+      (TxIn (txid txbodyEx5A) 0, TxOut aliceAddr aliceCoinEx5A)
+    ]
 
 dsEx5A :: DState
-dsEx5A = dsEx1 { _irwd = Map.fromList [(aliceSHK, Coin 100)] }
+dsEx5A = dsEx1 {_irwd = Map.fromList [(aliceSHK, Coin 100)]}
 
 expectedLSEx5A :: LedgerState
-expectedLSEx5A = LedgerState
-               (UTxOState
-                 utxoEx5A
-                 (Coin 0)
-                 (Coin 1)
-                 emptyPPPUpdates)
-               (DPState dsEx5A psEx1)
+expectedLSEx5A =
+  LedgerState
+    ( UTxOState
+        utxoEx5A
+        (Coin 0)
+        (Coin 1)
+        emptyPPPUpdates
+    )
+    (DPState dsEx5A psEx1)
 
 expectedStEx5A :: ChainState
-expectedStEx5A = ChainState
-  (NewEpochState
-     (EpochNo 0)
-     (BlocksMade Map.empty)
-     (BlocksMade Map.empty)
-     (EpochState acntEx2A emptySnapShots expectedLSEx5A ppsEx1 ppsEx1 emptyNonMyopic)
-     SNothing
-     (PoolDistr Map.empty)
-     overlayEx2A)
-  oCertIssueNosEx1
-  nonce0
-  (nonce0 ⭒ mkNonce 1)
-  (nonce0 ⭒ mkNonce 1)
-  NeutralNonce
-  (At $ LastAppliedBlock
-    (BlockNo 1)
-    (SlotNo 10)
-    blockEx5AHash)
+expectedStEx5A =
+  ChainState
+    ( NewEpochState
+        (EpochNo 0)
+        (BlocksMade Map.empty)
+        (BlocksMade Map.empty)
+        (EpochState acntEx2A emptySnapShots expectedLSEx5A ppsEx1 ppsEx1 emptyNonMyopic)
+        SNothing
+        (PoolDistr Map.empty)
+        overlayEx2A
+    )
+    oCertIssueNosEx1
+    nonce0
+    (nonce0 ⭒ mkNonce 1)
+    (nonce0 ⭒ mkNonce 1)
+    NeutralNonce
+    ( At $
+        LastAppliedBlock
+          (BlockNo 1)
+          (SlotNo 10)
+          blockEx5AHash
+    )
 
 ex5A :: CHAINExample
 ex5A = CHAINExample (SlotNo 10) initStEx2A blockEx5A (Right expectedStEx5A)
 
-
 -- | Example 5B - Instantaneous rewards with insufficient core node signatures
-
 txEx5B :: Tx
-txEx5B = Tx
-           txbodyEx5A
-           (makeWitnessesVKey (hashTxBody txbodyEx5A) [ alicePay ]
-             `Set.union`
-             makeWitnessesVKey (hashTxBody txbodyEx5A)
-             [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
-             , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
-             , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
-             , KeyPair (coreNodeVKG 3) (coreNodeSKG 3)
-           ])
-           Map.empty
-           SNothing
+txEx5B =
+  Tx
+    txbodyEx5A
+    ( makeWitnessesVKey (hashTxBody txbodyEx5A) [alicePay]
+        `Set.union` makeWitnessesVKey
+          (hashTxBody txbodyEx5A)
+          [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0),
+            KeyPair (coreNodeVKG 1) (coreNodeSKG 1),
+            KeyPair (coreNodeVKG 2) (coreNodeSKG 2),
+            KeyPair (coreNodeVKG 3) (coreNodeSKG 3)
+          ]
+    )
+    Map.empty
+    SNothing
 
 blockEx5B :: Block
-blockEx5B = mkBlock
-              lastByronHeaderHash
-              (coreNodeKeys 0)
-              [txEx5B]
-              (SlotNo 10)
-              (BlockNo 1)
-              (mkNonce 0)
-              (NatNonce 1)
-              zero
-              0
-              0
-              (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+blockEx5B =
+  mkBlock
+    lastByronHeaderHash
+    (coreNodeKeys 0)
+    [txEx5B]
+    (SlotNo 10)
+    (BlockNo 1)
+    (mkNonce 0)
+    (NatNonce 1)
+    zero
+    0
+    0
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 expectedStEx5B :: PredicateFailure CHAIN
 expectedStEx5B = BbodyFailure (LedgersFailure (LedgerFailure (UtxowFailure MIRInsufficientGenesisSigsUTXOW)))
@@ -2256,173 +2725,188 @@ ex5B :: CHAINExample
 ex5B = CHAINExample (SlotNo 10) initStEx2A blockEx5B (Left [[expectedStEx5B]])
 
 -- | Example 5C - Instantaneous rewards in decentralized era
-
 expectedStEx5C :: PredicateFailure CHAIN
 expectedStEx5C = BbodyFailure (LedgersFailure (LedgerFailure (UtxowFailure MIRImpossibleInDecentralizedNetUTXOW)))
 
 ex5C :: CHAINExample
 ex5C =
   CHAINExample
-   (SlotNo 10)
-   (initStEx2A { chainNes = initNesEx2A { nesEs = esEx2A { esPp = ppsEx1 { _d = unsafeMkUnitInterval 0 }}}})
-   blockEx5A
-   (Left [[expectedStEx5C]])
-
+    (SlotNo 10)
+    (initStEx2A {chainNes = initNesEx2A {nesEs = esEx2A {esPp = ppsEx1 {_d = unsafeMkUnitInterval 0}}}})
+    blockEx5A
+    (Left [[expectedStEx5C]])
 
 -- | Example 5D - Instantaneous rewards in decentralized era and not enough core
 -- signatures
-
 ex5D :: CHAINExample
 ex5D =
   CHAINExample
-   (SlotNo 10)
-   (initStEx2A { chainNes = initNesEx2A { nesEs = esEx2A { esPp = ppsEx1 { _d = unsafeMkUnitInterval 0 }}}})
-   blockEx5B
-   (Left [[expectedStEx5C, expectedStEx5B]])
+    (SlotNo 10)
+    (initStEx2A {chainNes = initNesEx2A {nesEs = esEx2A {esPp = ppsEx1 {_d = unsafeMkUnitInterval 0}}}})
+    blockEx5B
+    (Left [[expectedStEx5C, expectedStEx5B]])
 
 -- | Example 5E - Instantaneous rewards that overrun the available reserves
-
 ex5E :: CHAINExample
 ex5E =
   CHAINExample
-   (SlotNo 10)
-   (initStEx2A { chainNes = initNesEx2A { nesEs = esEx2A { esAccountState = acntEx2A { _reserves = 99 }}}})
-   blockEx5A
-   (Left [[BbodyFailure
-           (LedgersFailure
-            (LedgerFailure
-             (DelegsFailure
-              (DelplFailure
-               (DelegFailure InsufficientForInstantaneousRewardsDELEG)))))]])
+    (SlotNo 10)
+    (initStEx2A {chainNes = initNesEx2A {nesEs = esEx2A {esAccountState = acntEx2A {_reserves = 99}}}})
+    blockEx5A
+    ( Left
+        [ [ BbodyFailure
+              ( LedgersFailure
+                  ( LedgerFailure
+                      ( DelegsFailure
+                          ( DelplFailure
+                              (DelegFailure InsufficientForInstantaneousRewardsDELEG)
+                          )
+                      )
+                  )
+              )
+          ]
+        ]
+    )
 
 -- | Example 5F - Apply instantaneous rewards at epoch boundary
 
-
 -- | The first transaction adds the MIR certificate that transfers a value of
 -- 100 to Alice.
-
 aliceCoinEx5F :: Coin
 aliceCoinEx5F = aliceInitCoin - (_keyDeposit ppsEx1) - 1
 
 txbodyEx5F :: TxBody
-txbodyEx5F = TxBody
-              (Set.fromList [TxIn genesisId 0])
-              (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5F)
-              (StrictSeq.fromList [DCertDeleg (RegKey aliceSHK), DCertMir (MIRCert ir)])
-              (Wdrl Map.empty)
-              (Coin 1)
-              (SlotNo 99)
-              SNothing
-              SNothing
+txbodyEx5F =
+  TxBody
+    (Set.fromList [TxIn genesisId 0])
+    (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5F)
+    (StrictSeq.fromList [DCertDeleg (RegKey aliceSHK), DCertMir (MIRCert ir)])
+    (Wdrl Map.empty)
+    (Coin 1)
+    (SlotNo 99)
+    SNothing
+    SNothing
 
 txEx5F :: Tx
-txEx5F = Tx txbodyEx5F
-            (makeWitnessesVKey (hashTxBody txbodyEx5F) [ asWitness alicePay, asWitness aliceStake ]
-            `Set.union` makeWitnessesVKey (hashTxBody txbodyEx5F)
-             [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0)
-             , KeyPair (coreNodeVKG 1) (coreNodeSKG 1)
-             , KeyPair (coreNodeVKG 2) (coreNodeSKG 2)
-             , KeyPair (coreNodeVKG 3) (coreNodeSKG 3)
-             , KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
-             ])
-            Map.empty
-            SNothing
+txEx5F =
+  Tx
+    txbodyEx5F
+    ( makeWitnessesVKey (hashTxBody txbodyEx5F) [asWitness alicePay, asWitness aliceStake]
+        `Set.union` makeWitnessesVKey
+          (hashTxBody txbodyEx5F)
+          [ KeyPair (coreNodeVKG 0) (coreNodeSKG 0),
+            KeyPair (coreNodeVKG 1) (coreNodeSKG 1),
+            KeyPair (coreNodeVKG 2) (coreNodeSKG 2),
+            KeyPair (coreNodeVKG 3) (coreNodeSKG 3),
+            KeyPair (coreNodeVKG 4) (coreNodeSKG 4)
+          ]
+    )
+    Map.empty
+    SNothing
 
 blockEx5F :: Block
-blockEx5F = mkBlock
-              lastByronHeaderHash
-              (coreNodeKeys 0)
-              [txEx5F]
-              (SlotNo 10)
-              (BlockNo 1)
-              (mkNonce 0)
-              (NatNonce 1)
-              zero
-              0
-              0
-              (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
+blockEx5F =
+  mkBlock
+    lastByronHeaderHash
+    (coreNodeKeys 0)
+    [txEx5F]
+    (SlotNo 10)
+    (BlockNo 1)
+    (mkNonce 0)
+    (NatNonce 1)
+    zero
+    0
+    0
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
 -- | The second transaction in the next epoch and at least `startRewards` slots
 -- after the transaction carrying the MIR certificate, then creates the rewards
 -- update that contains the transfer of `100` to Alice.
-
 aliceCoinEx5F' :: Coin
 aliceCoinEx5F' = aliceCoinEx5F - 1
 
 txbodyEx5F' :: TxBody
-txbodyEx5F' = TxBody
-               (Set.fromList [TxIn (txid txbodyEx5F) 0])
-               (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5F')
-               StrictSeq.empty
-               (Wdrl Map.empty)
-               (Coin 1)
-               ((slotFromEpoch $ EpochNo 1)
-                +* Duration (startRewards testGlobals) + SlotNo 7)
-               SNothing
-               SNothing
+txbodyEx5F' =
+  TxBody
+    (Set.fromList [TxIn (txid txbodyEx5F) 0])
+    (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5F')
+    StrictSeq.empty
+    (Wdrl Map.empty)
+    (Coin 1)
+    ( (slotFromEpoch $ EpochNo 1)
+        +* Duration (startRewards testGlobals) + SlotNo 7
+    )
+    SNothing
+    SNothing
 
 txEx5F' :: Tx
-txEx5F' = Tx txbodyEx5F' (makeWitnessesVKey (hashTxBody txbodyEx5F') [ alicePay ]) Map.empty SNothing
+txEx5F' = Tx txbodyEx5F' (makeWitnessesVKey (hashTxBody txbodyEx5F') [alicePay]) Map.empty SNothing
 
 blockEx5F' :: Block
-blockEx5F' = mkBlock
-              (bhHash (bheader blockEx5F))
-              (coreNodeKeys 5)
-              [txEx5F']
-              ((slotFromEpoch $ EpochNo 1)
-                +* Duration (startRewards testGlobals) + SlotNo 7)
-              (BlockNo 2)
-              (mkNonce 0)
-              (NatNonce 1)
-              zero
-              7
-              0
-              (mkOCert (coreNodeKeys 5) 0 (KESPeriod 0))
+blockEx5F' =
+  mkBlock
+    (bhHash (bheader blockEx5F))
+    (coreNodeKeys 5)
+    [txEx5F']
+    ( (slotFromEpoch $ EpochNo 1)
+        +* Duration (startRewards testGlobals) + SlotNo 7
+    )
+    (BlockNo 2)
+    (mkNonce 0)
+    (NatNonce 1)
+    zero
+    7
+    0
+    (mkOCert (coreNodeKeys 5) 0 (KESPeriod 0))
 
 -- | The third transaction in the next epoch applies the reward update to 1)
 -- register a staking credential for Alice, 2) deducing the key deposit from the
 -- 100 and to 3) create the reward account with an initial amount of 93.
-
 aliceCoinEx5F'' :: Coin
 aliceCoinEx5F'' = aliceCoinEx5F' - 1
 
 txbodyEx5F'' :: TxBody
-txbodyEx5F'' = TxBody
-                (Set.fromList [TxIn (txid txbodyEx5F') 0])
-                (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5F'')
-                StrictSeq.empty
-                (Wdrl Map.empty)
-                (Coin 1)
-                ((slotFromEpoch $ EpochNo 2) + SlotNo 10)
-                SNothing
-                SNothing
+txbodyEx5F'' =
+  TxBody
+    (Set.fromList [TxIn (txid txbodyEx5F') 0])
+    (StrictSeq.singleton $ TxOut aliceAddr aliceCoinEx5F'')
+    StrictSeq.empty
+    (Wdrl Map.empty)
+    (Coin 1)
+    ((slotFromEpoch $ EpochNo 2) + SlotNo 10)
+    SNothing
+    SNothing
 
 txEx5F'' :: Tx
-txEx5F'' = Tx txbodyEx5F'' (makeWitnessesVKey (hashTxBody txbodyEx5F'') [ alicePay ]) Map.empty SNothing
+txEx5F'' = Tx txbodyEx5F'' (makeWitnessesVKey (hashTxBody txbodyEx5F'') [alicePay]) Map.empty SNothing
 
 blockEx5F'' :: Block
-blockEx5F'' = mkBlock
-               (bhHash (bheader blockEx5F'))
-               (coreNodeKeys 0)
-               [txEx5F'']
-               ((slotFromEpoch $ EpochNo 2) + SlotNo 10)
-               (BlockNo 3)
-               (mkNonce 0)
-               (NatNonce 1)
-               zero
-               10
-               10
-               (mkOCert (coreNodeKeys 0) 0 (KESPeriod 10))
+blockEx5F'' =
+  mkBlock
+    (bhHash (bheader blockEx5F'))
+    (coreNodeKeys 0)
+    [txEx5F'']
+    ((slotFromEpoch $ EpochNo 2) + SlotNo 10)
+    (BlockNo 3)
+    (mkNonce 0)
+    (NatNonce 1)
+    zero
+    10
+    10
+    (mkOCert (coreNodeKeys 0) 0 (KESPeriod 10))
 
 ex5F' :: Either [[PredicateFailure CHAIN]] ChainState
 ex5F' = do
   nextState <- runShelleyBase $ applySTS @CHAIN (TRC (SlotNo 90, initStEx2A, blockEx5F))
   midState <-
-    runShelleyBase $ applySTS @CHAIN
-      (TRC (((slotFromEpoch $ EpochNo 1) + SlotNo 7) +* Duration (startRewards testGlobals)
-           , nextState
-           , blockEx5F')
-      )
+    runShelleyBase $
+      applySTS @CHAIN
+        ( TRC
+            ( ((slotFromEpoch $ EpochNo 1) + SlotNo 7) +* Duration (startRewards testGlobals),
+              nextState,
+              blockEx5F'
+            )
+        )
   finalState <-
     runShelleyBase $ applySTS @CHAIN (TRC (((slotFromEpoch $ EpochNo 2) + SlotNo 10), midState, blockEx5F''))
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Fees.hs
@@ -4,47 +4,92 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Shelley.Spec.Ledger.Examples.Fees
-  ( sizeTests
+  ( sizeTests,
   )
 where
 
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.HUnit (Assertion, testCase, (@?=))
-
+import Cardano.Binary (serialize)
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Char8 as BS (pack)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.Map.Strict as Map (empty, singleton)
-import           Data.Maybe (fromJust)
+import Data.Maybe (fromJust)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-
-import           Cardano.Binary (serialize)
-import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), textToDns, textToUrl)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, pattern Delegate,
-                     pattern RegKey, pattern RegPool, pattern RetirePool)
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), asWitness, hashKey, vKey)
-import           Shelley.Spec.Ledger.LedgerState (genesisId, txsize)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), textToDns, textToUrl)
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( pattern DeRegKey,
+    pattern Delegate,
+    pattern RegKey,
+    pattern RegPool,
+    pattern RetirePool,
+  )
+import Shelley.Spec.Ledger.Keys (KeyRole (..), asWitness, hashKey, vKey)
+import Shelley.Spec.Ledger.LedgerState (genesisId, txsize)
 import qualified Shelley.Spec.Ledger.MetaData as MD
-import           Shelley.Spec.Ledger.Scripts (pattern RequireMOf, pattern RequireSignature)
-import           Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
-import           Shelley.Spec.Ledger.Tx (pattern Tx, hashScript, _body, _metadata, _witnessMSigMap,
-                     _witnessVKeySet)
-import           Shelley.Spec.Ledger.TxData (pattern DCertDeleg, pattern DCertPool,
-                     pattern Delegation, pattern KeyHashObj, PoolMetaData (..), pattern PoolParams,
-                     pattern RewardAcnt, StakePoolRelay (..), pattern TxBody, pattern TxIn,
-                     pattern TxOut, Wdrl (..), _certs, _inputs, _mdHash, _outputs, _poolCost,
-                     _poolMD, _poolMDHash, _poolMDUrl, _poolMargin, _poolOwners, _poolPledge,
-                     _poolPubKey, _poolRAcnt, _poolRelays, _poolVrf, _ttl, _txUpdate, _txfee,
-                     _wdrls)
-import           Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessesVKey)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, ConcreteCrypto, Credential,
-                     KeyHash, MultiSig, PoolParams, SignKeyVRF, Tx, TxBody, VerKeyVRF,
-                     hashKeyVRF, KeyPair, pattern KeyPair)
-import           Test.Shelley.Spec.Ledger.Utils
-
+import Shelley.Spec.Ledger.Scripts (pattern RequireMOf, pattern RequireSignature)
+import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
+import Shelley.Spec.Ledger.Tx
+  ( _body,
+    _metadata,
+    _witnessMSigMap,
+    _witnessVKeySet,
+    hashScript,
+    pattern Tx,
+  )
+import Shelley.Spec.Ledger.TxData
+  ( PoolMetaData (..),
+    StakePoolRelay (..),
+    Wdrl (..),
+    _certs,
+    _inputs,
+    _mdHash,
+    _outputs,
+    _poolCost,
+    _poolMD,
+    _poolMDHash,
+    _poolMDUrl,
+    _poolMargin,
+    _poolOwners,
+    _poolPledge,
+    _poolPubKey,
+    _poolRAcnt,
+    _poolRelays,
+    _poolVrf,
+    _ttl,
+    _txUpdate,
+    _txfee,
+    _wdrls,
+    pattern DCertDeleg,
+    pattern DCertPool,
+    pattern Delegation,
+    pattern KeyHashObj,
+    pattern PoolParams,
+    pattern RewardAcnt,
+    pattern TxBody,
+    pattern TxIn,
+    pattern TxOut,
+  )
+import Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessesVKey)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Addr,
+    ConcreteCrypto,
+    Credential,
+    KeyHash,
+    KeyPair,
+    MultiSig,
+    PoolParams,
+    SignKeyVRF,
+    Tx,
+    TxBody,
+    VerKeyVRF,
+    hashKeyVRF,
+    pattern KeyPair,
+  )
+import Test.Shelley.Spec.Ledger.Utils
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit ((@?=), Assertion, testCase)
 
 sizeTest :: BSL.ByteString -> Tx -> Integer -> Assertion
 sizeTest b16 tx s = do
@@ -52,40 +97,45 @@ sizeTest b16 tx s = do
 
 alicePay :: KeyPair 'Payment
 alicePay = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (0,0,0,0,0)
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 0)
 
 aliceStake :: KeyPair 'Staking
 aliceStake = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (0,0,0,0,1)
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 1)
 
 aliceSHK :: Credential 'Staking
 aliceSHK = (KeyHashObj . hashKey . vKey) aliceStake
 
 alicePool :: KeyPair 'StakePool
 alicePool = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (0,0,0,0,2)
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 2)
 
 alicePoolKH :: KeyHash 'StakePool
 alicePoolKH = (hashKey . vKey) alicePool
 
 aliceVRF :: (SignKeyVRF, VerKeyVRF)
-aliceVRF = mkVRFKeyPair (0,0,0,0,3)
+aliceVRF = mkVRFKeyPair (0, 0, 0, 0, 3)
 
 alicePoolParams :: PoolParams
 alicePoolParams =
   PoolParams
-    { _poolPubKey = alicePoolKH
-    , _poolVrf = hashKeyVRF . snd $ aliceVRF
-    , _poolPledge = Coin 1
-    , _poolCost = Coin 5
-    , _poolMargin = unsafeMkUnitInterval 0.1
-    , _poolRAcnt = RewardAcnt aliceSHK
-    , _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake
-    , _poolRelays = StrictSeq.singleton $ SingleHostName SNothing $ fromJust $ textToDns "relay.io"
-    , _poolMD = SJust $ PoolMetaData
-                  { _poolMDUrl  = fromJust $ textToUrl "alice.pool"
-                  , _poolMDHash = BS.pack "{}"
-                  }
+    { _poolPubKey = alicePoolKH,
+      _poolVrf = hashKeyVRF . snd $ aliceVRF,
+      _poolPledge = Coin 1,
+      _poolCost = Coin 5,
+      _poolMargin = unsafeMkUnitInterval 0.1,
+      _poolRAcnt = RewardAcnt aliceSHK,
+      _poolOwners = Set.singleton $ (hashKey . vKey) aliceStake,
+      _poolRelays = StrictSeq.singleton $ SingleHostName SNothing $ fromJust $ textToDns "relay.io",
+      _poolMD =
+        SJust $
+          PoolMetaData
+            { _poolMDUrl = fromJust $ textToUrl "alice.pool",
+              _poolMDHash = BS.pack "{}"
+            }
     }
 
 aliceAddr :: Addr
@@ -93,11 +143,13 @@ aliceAddr = mkAddr (alicePay, aliceStake)
 
 bobPay :: KeyPair 'Payment
 bobPay = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (1,0,0,0,0)
+  where
+    (sk, vk) = mkKeyPair (1, 0, 0, 0, 0)
 
 bobStake :: KeyPair 'Staking
 bobStake = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (1,0,0,0,1)
+  where
+    (sk, vk) = mkKeyPair (1, 0, 0, 0, 1)
 
 bobSHK :: Credential 'Staking
 bobSHK = (KeyHashObj . hashKey . vKey) bobStake
@@ -107,284 +159,302 @@ bobAddr = mkAddr (bobPay, bobStake)
 
 carlPay :: KeyPair 'Payment
 carlPay = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (2,0,0,0,0)
-
+  where
+    (sk, vk) = mkKeyPair (2, 0, 0, 0, 0)
 
 -- | Simple Transaction which consumes one UTxO and creates one UTxO
 -- | and has one witness
-
 txbSimpleUTxO :: TxBody
-txbSimpleUTxO = TxBody
-  { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = StrictSeq.empty
-  , _wdrls    = Wdrl Map.empty
-  , _txfee    = Coin 94
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SNothing
-  }
+txbSimpleUTxO =
+  TxBody
+    { _inputs = Set.fromList [TxIn genesisId 0],
+      _outputs = StrictSeq.fromList [TxOut aliceAddr (Coin 10)],
+      _certs = StrictSeq.empty,
+      _wdrls = Wdrl Map.empty,
+      _txfee = Coin 94,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SNothing
+    }
 
 txSimpleUTxO :: Tx
-txSimpleUTxO = Tx
-  { _body           = txbSimpleUTxO
-  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbSimpleUTxO) [alicePay]
-  , _witnessMSigMap = Map.empty
-  , _metadata       = SNothing
-  }
+txSimpleUTxO =
+  Tx
+    { _body = txbSimpleUTxO,
+      _witnessVKeySet = makeWitnessesVKey (hashTxBody txbSimpleUTxO) [alicePay],
+      _witnessMSigMap = Map.empty,
+      _metadata = SNothing
+    }
 
 txSimpleUTxOBytes16 :: BSL.ByteString
 txSimpleUTxOBytes16 = "83a4009f82446050074300ff0181840044aee84c70440acd1b520a02185e030aa10081821b30303030303231348244eb4659ba1b3030303030323134f6"
 
 -- | Transaction which consumes two UTxO and creates five UTxO
 -- | and has two witness
-
 txbMutiUTxO :: TxBody
-txbMutiUTxO = TxBody
-  { _inputs   = Set.fromList [ TxIn genesisId 0
-                             , TxIn genesisId 1
-                             ]
-  , _outputs  = StrictSeq.fromList
-                [ TxOut aliceAddr (Coin 10)
-                , TxOut aliceAddr (Coin 20)
-                , TxOut aliceAddr (Coin 30)
-                , TxOut bobAddr   (Coin 40)
-                , TxOut bobAddr   (Coin 50)
-                ]
-  , _certs    = StrictSeq.empty
-  , _wdrls    = Wdrl Map.empty
-  , _txfee    = Coin 199
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SNothing
-  }
+txbMutiUTxO =
+  TxBody
+    { _inputs =
+        Set.fromList
+          [ TxIn genesisId 0,
+            TxIn genesisId 1
+          ],
+      _outputs =
+        StrictSeq.fromList
+          [ TxOut aliceAddr (Coin 10),
+            TxOut aliceAddr (Coin 20),
+            TxOut aliceAddr (Coin 30),
+            TxOut bobAddr (Coin 40),
+            TxOut bobAddr (Coin 50)
+          ],
+      _certs = StrictSeq.empty,
+      _wdrls = Wdrl Map.empty,
+      _txfee = Coin 199,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SNothing
+    }
 
 txMutiUTxO :: Tx
-txMutiUTxO = Tx
-  { _body           = txbMutiUTxO
-  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbMutiUTxO)
-                      [ alicePay
-                      , bobPay
-                      ]
-  , _witnessMSigMap = Map.empty
-  , _metadata       = SNothing
-  }
+txMutiUTxO =
+  Tx
+    { _body = txbMutiUTxO,
+      _witnessVKeySet =
+        makeWitnessesVKey
+          (hashTxBody txbMutiUTxO)
+          [ alicePay,
+            bobPay
+          ],
+      _witnessMSigMap = Map.empty,
+      _metadata = SNothing
+    }
 
 txMutiUTxOBytes16 :: BSL.ByteString
 txMutiUTxOBytes16 = "83a4009f8244605007430082446050074301ff0185840044aee84c70440acd1b520a840044aee84c70440acd1b5214840044aee84c70440acd1b52181e840044d42eadb144d42eadb11828840044d42eadb144d42eadb118320218c7030aa10082821b30303030303231348244bbedc57a1b3030303030323134821b31353438353836378244bbedc57a1b3135343835383637f6"
 
 -- | Transaction which registers a stake key
-
 txbRegisterStake :: TxBody
-txbRegisterStake = TxBody
-  { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = StrictSeq.fromList [ DCertDeleg (RegKey aliceSHK) ]
-  , _wdrls    = Wdrl Map.empty
-  , _txfee    = Coin 94
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SNothing
-  }
+txbRegisterStake =
+  TxBody
+    { _inputs = Set.fromList [TxIn genesisId 0],
+      _outputs = StrictSeq.fromList [TxOut aliceAddr (Coin 10)],
+      _certs = StrictSeq.fromList [DCertDeleg (RegKey aliceSHK)],
+      _wdrls = Wdrl Map.empty,
+      _txfee = Coin 94,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SNothing
+    }
 
 txRegisterStake :: Tx
-txRegisterStake = Tx
-  { _body           = txbRegisterStake
-  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbRegisterStake) [alicePay]
-  , _witnessMSigMap = Map.empty
-  , _metadata       = SNothing
-  }
+txRegisterStake =
+  Tx
+    { _body = txbRegisterStake,
+      _witnessVKeySet = makeWitnessesVKey (hashTxBody txbRegisterStake) [alicePay],
+      _witnessMSigMap = Map.empty,
+      _metadata = SNothing
+    }
 
 txRegisterStakeBytes16 :: BSL.ByteString
 txRegisterStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048182008200440acd1b52a10081821b303030303032313482443dff0e3e1b3030303030323134f6"
 
 -- | Transaction which delegates a stake key
-
 txbDelegateStake :: TxBody
-txbDelegateStake = TxBody
-  { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = StrictSeq.fromList [ DCertDeleg (Delegate $ Delegation bobSHK alicePoolKH) ]
-  , _wdrls    = Wdrl Map.empty
-  , _txfee    = Coin 94
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SNothing
-  }
+txbDelegateStake =
+  TxBody
+    { _inputs = Set.fromList [TxIn genesisId 0],
+      _outputs = StrictSeq.fromList [TxOut aliceAddr (Coin 10)],
+      _certs = StrictSeq.fromList [DCertDeleg (Delegate $ Delegation bobSHK alicePoolKH)],
+      _wdrls = Wdrl Map.empty,
+      _txfee = Coin 94,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SNothing
+    }
 
 txDelegateStake :: Tx
-txDelegateStake = Tx
-  { _body           = txbDelegateStake
-  , _witnessVKeySet = makeWitnessesVKey
-                        (hashTxBody txbDelegateStake)
-                        [asWitness alicePay, asWitness bobStake]
-  , _witnessMSigMap = Map.empty
-  , _metadata       = SNothing
-  }
+txDelegateStake =
+  Tx
+    { _body = txbDelegateStake,
+      _witnessVKeySet =
+        makeWitnessesVKey
+          (hashTxBody txbDelegateStake)
+          [asWitness alicePay, asWitness bobStake],
+      _witnessMSigMap = Map.empty,
+      _metadata = SNothing
+    }
 
 txDelegateStakeBytes16 :: BSL.ByteString
 txDelegateStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a04818302820044d42eadb14450d474d0a10082821b303030303032313482446d2304911b3030303030323134821b313534383538363782446d2304911b3135343835383637f6"
 
 -- | Transaction which de-registers a stake key
-
 txbDeregisterStake :: TxBody
-txbDeregisterStake = TxBody
-  { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = StrictSeq.fromList [ DCertDeleg (DeRegKey aliceSHK) ]
-  , _wdrls    = Wdrl Map.empty
-  , _txfee    = Coin 94
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SNothing
-  }
+txbDeregisterStake =
+  TxBody
+    { _inputs = Set.fromList [TxIn genesisId 0],
+      _outputs = StrictSeq.fromList [TxOut aliceAddr (Coin 10)],
+      _certs = StrictSeq.fromList [DCertDeleg (DeRegKey aliceSHK)],
+      _wdrls = Wdrl Map.empty,
+      _txfee = Coin 94,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SNothing
+    }
 
 txDeregisterStake :: Tx
-txDeregisterStake = Tx
-  { _body           = txbDeregisterStake
-  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbDeregisterStake) [alicePay]
-  , _witnessMSigMap = Map.empty
-  , _metadata       = SNothing
-  }
-
+txDeregisterStake =
+  Tx
+    { _body = txbDeregisterStake,
+      _witnessVKeySet = makeWitnessesVKey (hashTxBody txbDeregisterStake) [alicePay],
+      _witnessMSigMap = Map.empty,
+      _metadata = SNothing
+    }
 
 txDeregisterStakeBytes16 :: BSL.ByteString
 txDeregisterStakeBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048182018200440acd1b52a10081821b30303030303231348244bd35013b1b3030303030323134f6"
 
 -- | Transaction which registers a stake pool
-
 txbRegisterPool :: TxBody
-txbRegisterPool = TxBody
-  { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = StrictSeq.fromList [ DCertPool (RegPool alicePoolParams) ]
-  , _wdrls    = Wdrl Map.empty
-  , _txfee    = Coin 94
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SNothing
-  }
+txbRegisterPool =
+  TxBody
+    { _inputs = Set.fromList [TxIn genesisId 0],
+      _outputs = StrictSeq.fromList [TxOut aliceAddr (Coin 10)],
+      _certs = StrictSeq.fromList [DCertPool (RegPool alicePoolParams)],
+      _wdrls = Wdrl Map.empty,
+      _txfee = Coin 94,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SNothing
+    }
 
 txRegisterPool :: Tx
-txRegisterPool = Tx
-  { _body           = txbRegisterPool
-  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbRegisterPool) [alicePay]
-  , _witnessMSigMap = Map.empty
-  , _metadata       = SNothing
-  }
+txRegisterPool =
+  Tx
+    { _body = txbRegisterPool,
+      _witnessVKeySet = makeWitnessesVKey (hashTxBody txbRegisterPool) [alicePay],
+      _witnessMSigMap = Map.empty,
+      _metadata = SNothing
+    }
 
 txRegisterPoolBytes16 :: BSL.ByteString
 txRegisterPoolBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a04818a034450d474d04495286b7b0105d81e82010a8200440acd1b5281440acd1b52818301f66872656c61792e696f826a616c6963652e706f6f6c427b7da10081821b30303030303231348244b9f105371b3030303030323134f6"
 
 -- | Transaction which retires a stake pool
-
 txbRetirePool :: TxBody
-txbRetirePool = TxBody
-  { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = StrictSeq.fromList [ DCertPool (RetirePool alicePoolKH (EpochNo 5)) ]
-  , _wdrls    = Wdrl Map.empty
-  , _txfee    = Coin 94
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SNothing
-  }
+txbRetirePool =
+  TxBody
+    { _inputs = Set.fromList [TxIn genesisId 0],
+      _outputs = StrictSeq.fromList [TxOut aliceAddr (Coin 10)],
+      _certs = StrictSeq.fromList [DCertPool (RetirePool alicePoolKH (EpochNo 5))],
+      _wdrls = Wdrl Map.empty,
+      _txfee = Coin 94,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SNothing
+    }
 
 txRetirePool :: Tx
-txRetirePool = Tx
-  { _body           = txbRetirePool
-  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbRetirePool) [alicePay]
-  , _witnessMSigMap = Map.empty
-  , _metadata       = SNothing
-  }
+txRetirePool =
+  Tx
+    { _body = txbRetirePool,
+      _witnessVKeySet = makeWitnessesVKey (hashTxBody txbRetirePool) [alicePay],
+      _witnessMSigMap = Map.empty,
+      _metadata = SNothing
+    }
 
 txRetirePoolBytes16 :: BSL.ByteString
 txRetirePoolBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a048183044450d474d005a10081821b303030303032313482443267fcc41b3030303030323134f6"
 
 -- | Simple Transaction which consumes one UTxO and creates one UTxO
 -- | and has one witness
-
 md :: MD.MetaData
-md = MD.MetaData $ Map.singleton 0 (MD.List [ MD.I 5, MD.S "hello"])
+md = MD.MetaData $ Map.singleton 0 (MD.List [MD.I 5, MD.S "hello"])
 
 txbWithMD :: TxBody
-txbWithMD = TxBody
-  { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = StrictSeq.empty
-  , _wdrls    = Wdrl Map.empty
-  , _txfee    = Coin 94
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SJust $ MD.hashMetaData @ConcreteCrypto md
-  }
+txbWithMD =
+  TxBody
+    { _inputs = Set.fromList [TxIn genesisId 0],
+      _outputs = StrictSeq.fromList [TxOut aliceAddr (Coin 10)],
+      _certs = StrictSeq.empty,
+      _wdrls = Wdrl Map.empty,
+      _txfee = Coin 94,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SJust $ MD.hashMetaData @ConcreteCrypto md
+    }
 
 txWithMD :: Tx
-txWithMD = Tx
-  { _body           = txbWithMD
-  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbWithMD) [alicePay]
-  , _witnessMSigMap = Map.empty
-  , _metadata       = SJust md
-  }
+txWithMD =
+  Tx
+    { _body = txbWithMD,
+      _witnessVKeySet = makeWitnessesVKey (hashTxBody txbWithMD) [alicePay],
+      _witnessMSigMap = Map.empty,
+      _metadata = SJust md
+    }
 
 txWithMDBytes16 :: BSL.ByteString
 txWithMDBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a07444eece652a10081821b3030303030323134824469e542f81b3030303030323134a10082056568656c6c6f"
 
 -- | Spending from a multi-sig address
-
 msig :: MultiSig
-msig = RequireMOf 2
-  [ (RequireSignature . asWitness . hashKey . vKey) alicePay
-  , (RequireSignature . asWitness . hashKey . vKey) bobPay
-  , (RequireSignature . asWitness . hashKey . vKey) carlPay
-  ]
+msig =
+  RequireMOf
+    2
+    [ (RequireSignature . asWitness . hashKey . vKey) alicePay,
+      (RequireSignature . asWitness . hashKey . vKey) bobPay,
+      (RequireSignature . asWitness . hashKey . vKey) carlPay
+    ]
 
 txbWithMultiSig :: TxBody
-txbWithMultiSig = TxBody
-  { _inputs   = Set.fromList [TxIn genesisId 0] -- acting as if this is multi-sig
-  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = StrictSeq.empty
-  , _wdrls    = Wdrl Map.empty
-  , _txfee    = Coin 94
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SNothing
-  }
+txbWithMultiSig =
+  TxBody
+    { _inputs = Set.fromList [TxIn genesisId 0], -- acting as if this is multi-sig
+      _outputs = StrictSeq.fromList [TxOut aliceAddr (Coin 10)],
+      _certs = StrictSeq.empty,
+      _wdrls = Wdrl Map.empty,
+      _txfee = Coin 94,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SNothing
+    }
 
 txWithMultiSig :: Tx
-txWithMultiSig = Tx
-  { _body           = txbWithMultiSig
-  , _witnessVKeySet = makeWitnessesVKey (hashTxBody txbWithMultiSig) [alicePay, bobPay]
-  , _witnessMSigMap = Map.singleton (hashScript msig) msig
-  , _metadata       = SNothing
-  }
+txWithMultiSig =
+  Tx
+    { _body = txbWithMultiSig,
+      _witnessVKeySet = makeWitnessesVKey (hashTxBody txbWithMultiSig) [alicePay, bobPay],
+      _witnessMSigMap = Map.singleton (hashScript msig) msig,
+      _metadata = SNothing
+    }
 
 txWithMultiSigBytes16 :: BSL.ByteString
 txWithMultiSigBytes16 = "83a4009f82446050074300ff0181840044aee84c70440acd1b520a02185e030aa20082821b30303030303231348244eb4659ba1b3030303030323134821b31353438353836378244eb4659ba1b3135343835383637018183030283820044aee84c70820044d42eadb1820044ae010e05f6"
 
 -- | Transaction with a Reward Withdrawal
-
 txbWithWithdrawal :: TxBody
-txbWithWithdrawal = TxBody
-  { _inputs   = Set.fromList [TxIn genesisId 0]
-  , _outputs  = StrictSeq.fromList [TxOut aliceAddr (Coin 10)]
-  , _certs    = StrictSeq.empty
-  , _wdrls    = Wdrl $ Map.singleton (RewardAcnt aliceSHK) 100
-  , _txfee    = Coin 94
-  , _ttl      = SlotNo 10
-  , _txUpdate = SNothing
-  , _mdHash   = SNothing
-  }
+txbWithWithdrawal =
+  TxBody
+    { _inputs = Set.fromList [TxIn genesisId 0],
+      _outputs = StrictSeq.fromList [TxOut aliceAddr (Coin 10)],
+      _certs = StrictSeq.empty,
+      _wdrls = Wdrl $ Map.singleton (RewardAcnt aliceSHK) 100,
+      _txfee = Coin 94,
+      _ttl = SlotNo 10,
+      _txUpdate = SNothing,
+      _mdHash = SNothing
+    }
 
 txWithWithdrawal :: Tx
-txWithWithdrawal = Tx
-  { _body           = txbWithWithdrawal
-  , _witnessVKeySet = makeWitnessesVKey
-                        (hashTxBody txbWithWithdrawal)
-                        [asWitness alicePay, asWitness aliceStake]
-  , _witnessMSigMap = Map.empty
-  , _metadata       = SNothing
-  }
+txWithWithdrawal =
+  Tx
+    { _body = txbWithWithdrawal,
+      _witnessVKeySet =
+        makeWitnessesVKey
+          (hashTxBody txbWithWithdrawal)
+          [asWitness alicePay, asWitness aliceStake],
+      _witnessMSigMap = Map.empty,
+      _metadata = SNothing
+    }
 
 txWithWithdrawalBytes16 :: BSL.ByteString
 txWithWithdrawalBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520a02185e030a05a18200440acd1b521864a10082821b3030303038363032824442b5d6c41b3030303038363032821b3030303030323134824442b5d6c41b3030303030323134f6"
@@ -396,15 +466,17 @@ txWithWithdrawalBytes16 = "83a5009f82446050074300ff0181840044aee84c70440acd1b520
 --       the signature size is ---------> 13
 
 sizeTests :: TestTree
-sizeTests = testGroup "Fee Tests"
-  [ testCase "simple utxo" $ sizeTest txSimpleUTxOBytes16 txSimpleUTxO 145
-  , testCase "multiple utxo" $ sizeTest txMutiUTxOBytes16 txMutiUTxO 470
-  , testCase "register stake key" $ sizeTest txRegisterStakeBytes16 txRegisterStake 156
-  , testCase "delegate stake key" $ sizeTest txDelegateStakeBytes16 txDelegateStake 186
-  , testCase "deregister stake key" $ sizeTest txDeregisterStakeBytes16 txDeregisterStake 156
-  , testCase "register stake pool" $ sizeTest txRegisterPoolBytes16 txRegisterPool 207
-  , testCase "retire stake pool" $ sizeTest txRetirePoolBytes16 txRetirePool 155
-  , testCase "metadata" $ sizeTest txWithMDBytes16 txWithMD 160
-  , testCase "multisig" $ sizeTest txWithMultiSigBytes16 txWithMultiSig 197
-  , testCase "reward withdrawal" $ sizeTest txWithWithdrawalBytes16 txWithWithdrawal 181
-  ]
+sizeTests =
+  testGroup
+    "Fee Tests"
+    [ testCase "simple utxo" $ sizeTest txSimpleUTxOBytes16 txSimpleUTxO 145,
+      testCase "multiple utxo" $ sizeTest txMutiUTxOBytes16 txMutiUTxO 470,
+      testCase "register stake key" $ sizeTest txRegisterStakeBytes16 txRegisterStake 156,
+      testCase "delegate stake key" $ sizeTest txDelegateStakeBytes16 txDelegateStake 186,
+      testCase "deregister stake key" $ sizeTest txDeregisterStakeBytes16 txDeregisterStake 156,
+      testCase "register stake pool" $ sizeTest txRegisterPoolBytes16 txRegisterPool 207,
+      testCase "retire stake pool" $ sizeTest txRetirePoolBytes16 txRetirePool 155,
+      testCase "metadata" $ sizeTest txWithMDBytes16 txWithMD 160,
+      testCase "multisig" $ sizeTest txWithMultiSigBytes16 txWithMultiSig 197,
+      testCase "reward withdrawal" $ sizeTest txWithWithdrawalBytes16 txWithWithdrawal 181
+    ]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/MultiSigExamples.hs
@@ -3,53 +3,82 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Shelley.Spec.Ledger.Examples.MultiSigExamples
-  ( applyTxWithScript
-  , aliceOnly
-  , bobOnly
-  , aliceAndBob
-  , aliceOrBob
-  , aliceAndBobOrCarl
-  , aliceAndBobOrCarlAndDaria
-  , aliceAndBobOrCarlOrDaria
+  ( applyTxWithScript,
+    aliceOnly,
+    bobOnly,
+    aliceAndBob,
+    aliceOrBob,
+    aliceAndBobOrCarl,
+    aliceAndBobOrCarlAndDaria,
+    aliceAndBobOrCarlOrDaria,
   )
-  where
+where
 
-import           Data.Map.Strict (Map)
+import Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (empty, fromList)
-import           Data.Sequence.Strict (StrictSeq (..))
+import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as StrictSeq
-
 import qualified Data.Set as Set (fromList)
-
-import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
-import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
-import           Shelley.Spec.Ledger.Coin
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), asWitness)
-import           Shelley.Spec.Ledger.LedgerState (genesisCoins, genesisId, genesisState, _utxoState)
-import           Shelley.Spec.Ledger.MetaData (MetaData)
-import           Shelley.Spec.Ledger.PParams (PParams, emptyPParams, _maxTxSize)
-import           Shelley.Spec.Ledger.Scripts (pattern RequireAllOf, pattern RequireAnyOf,
-                     pattern RequireMOf, pattern RequireSignature)
-import           Shelley.Spec.Ledger.Slot (SlotNo (..))
-import           Shelley.Spec.Ledger.STS.Utxo (UtxoEnv (..))
-import           Shelley.Spec.Ledger.Tx (pattern Tx, hashScript, _body)
-import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj,
-                     pattern ScriptHashObj, pattern StakeCreds, pattern StakePools,
-                     pattern StakeRefBase, pattern TxBody, pattern TxIn, pattern TxOut,
-                     pattern Wdrl, unWdrl)
-import           Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessesVKey, txid)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, KeyPair, LedgerState, MultiSig,
-                     ScriptHash, Tx, TxBody, TxId, TxIn, UTXOW, UTxOState, Wdrl, pattern GenDelegs)
-import           Test.Shelley.Spec.Ledger.Examples.Examples (aliceAddr, alicePay, bobAddr, bobPay,
-                     carlAddr, dariaAddr)
-import           Test.Shelley.Spec.Ledger.Utils
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
+import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.Keys (KeyRole (..), asWitness)
+import Shelley.Spec.Ledger.LedgerState (_utxoState, genesisCoins, genesisId, genesisState)
+import Shelley.Spec.Ledger.MetaData (MetaData)
+import Shelley.Spec.Ledger.PParams (PParams, _maxTxSize, emptyPParams)
+import Shelley.Spec.Ledger.STS.Utxo (UtxoEnv (..))
+import Shelley.Spec.Ledger.Scripts
+  ( pattern RequireAllOf,
+    pattern RequireAnyOf,
+    pattern RequireMOf,
+    pattern RequireSignature,
+  )
+import Shelley.Spec.Ledger.Slot (SlotNo (..))
+import Shelley.Spec.Ledger.Tx (_body, hashScript, pattern Tx)
+import Shelley.Spec.Ledger.TxData
+  ( unWdrl,
+    pattern Addr,
+    pattern KeyHashObj,
+    pattern ScriptHashObj,
+    pattern StakeCreds,
+    pattern StakePools,
+    pattern StakeRefBase,
+    pattern TxBody,
+    pattern TxIn,
+    pattern TxOut,
+    pattern Wdrl,
+  )
+import Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessesVKey, txid)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Addr,
+    KeyPair,
+    LedgerState,
+    MultiSig,
+    ScriptHash,
+    Tx,
+    TxBody,
+    TxId,
+    TxIn,
+    UTXOW,
+    UTxOState,
+    Wdrl,
+    pattern GenDelegs,
+  )
+import Test.Shelley.Spec.Ledger.Examples.Examples
+  ( aliceAddr,
+    alicePay,
+    bobAddr,
+    bobPay,
+    carlAddr,
+    dariaAddr,
+  )
+import Test.Shelley.Spec.Ledger.Utils
 
 -- Multi-Signature tests
 
 -- Multi-signature scripts
 singleKeyOnly :: Addr -> MultiSig
-singleKeyOnly (Addr (KeyHashObj pk) _ ) = RequireSignature $ asWitness pk
+singleKeyOnly (Addr (KeyHashObj pk) _) = RequireSignature $ asWitness pk
 singleKeyOnly _ = error "use VKey address"
 
 aliceOnly :: MultiSig
@@ -69,24 +98,30 @@ aliceAndBobOrCarl = RequireMOf 1 [aliceAndBob, singleKeyOnly carlAddr]
 
 aliceAndBobOrCarlAndDaria :: MultiSig
 aliceAndBobOrCarlAndDaria =
-  RequireAnyOf [aliceAndBob,
-                RequireAllOf [singleKeyOnly carlAddr, singleKeyOnly dariaAddr]]
+  RequireAnyOf
+    [ aliceAndBob,
+      RequireAllOf [singleKeyOnly carlAddr, singleKeyOnly dariaAddr]
+    ]
 
 aliceAndBobOrCarlOrDaria :: MultiSig
 aliceAndBobOrCarlOrDaria =
-  RequireMOf 1 [aliceAndBob,
-                RequireAnyOf [singleKeyOnly carlAddr, singleKeyOnly dariaAddr]]
+  RequireMOf
+    1
+    [ aliceAndBob,
+      RequireAnyOf [singleKeyOnly carlAddr, singleKeyOnly dariaAddr]
+    ]
 
 initTxBody :: [(Addr, Coin)] -> TxBody
-initTxBody addrs = TxBody
-        (Set.fromList [TxIn genesisId 0, TxIn genesisId 1])
-        (StrictSeq.fromList $ map (uncurry TxOut) addrs)
-        Empty
-        (Wdrl Map.empty)
-        (Coin 0)
-        (SlotNo 0)
-        SNothing
-        SNothing
+initTxBody addrs =
+  TxBody
+    (Set.fromList [TxIn genesisId 0, TxIn genesisId 1])
+    (StrictSeq.fromList $ map (uncurry TxOut) addrs)
+    Empty
+    (Wdrl Map.empty)
+    (Coin 0)
+    (SlotNo 0)
+    SNothing
+    SNothing
 
 makeTxBody :: [TxIn] -> [(Addr, Coin)] -> Wdrl -> TxBody
 makeTxBody inp addrCs wdrl =
@@ -114,9 +149,11 @@ genesis :: LedgerState
 genesis = genesisState genDelegs0 utxo0
   where
     genDelegs0 = Map.empty
-    utxo0 = genesisCoins
-              [ TxOut aliceAddr aliceInitCoin
-              , TxOut bobAddr bobInitCoin]
+    utxo0 =
+      genesisCoins
+        [ TxOut aliceAddr aliceInitCoin,
+          TxOut bobAddr bobInitCoin
+        ]
 
 initPParams :: PParams
 initPParams = emptyPParams {_maxTxSize = 1000}
@@ -125,29 +162,43 @@ initPParams = emptyPParams {_maxTxSize = 1000}
 -- 'bobInitCoin' to spend. Then create and apply a transaction which, if
 -- 'aliceKeep' is greater than 0, gives that amount to Alice and creates outputs
 -- locked by a script for each pair of script, coin value in 'msigs'.
-initialUTxOState
-  :: Coin
-  -> [(MultiSig, Coin)]
-  -> (TxId, Either [[PredicateFailure UTXOW]] UTxOState)
+initialUTxOState ::
+  Coin ->
+  [(MultiSig, Coin)] ->
+  (TxId, Either [[PredicateFailure UTXOW]] UTxOState)
 initialUTxOState aliceKeep msigs =
   let addresses =
-        [(aliceAddr, aliceKeep) | aliceKeep > 0] ++
-        map (\(msig, c) ->
-               (Addr
-                (ScriptHashObj $ hashScript msig)
-                (StakeRefBase $ ScriptHashObj $ hashScript msig), c)) msigs
-  in
-  let tx = makeTx (initTxBody addresses)
-                  (asWitness <$> [alicePay, bobPay])
-                  Map.empty Nothing in
-  (txid $ _body tx, runShelleyBase $ applySTS @UTXOW (TRC( UtxoEnv
-                                           (SlotNo 0)
-                                           initPParams
-                                           (StakeCreds Map.empty)
-                                           (StakePools Map.empty)
-                                           (GenDelegs Map.empty)
-                                         , _utxoState genesis
-                                         , tx)))
+        [(aliceAddr, aliceKeep) | aliceKeep > 0]
+          ++ map
+            ( \(msig, c) ->
+                ( Addr
+                    (ScriptHashObj $ hashScript msig)
+                    (StakeRefBase $ ScriptHashObj $ hashScript msig),
+                  c
+                )
+            )
+            msigs
+   in let tx =
+            makeTx
+              (initTxBody addresses)
+              (asWitness <$> [alicePay, bobPay])
+              Map.empty
+              Nothing
+       in ( txid $ _body tx,
+            runShelleyBase $
+              applySTS @UTXOW
+                ( TRC
+                    ( UtxoEnv
+                        (SlotNo 0)
+                        initPParams
+                        (StakeCreds Map.empty)
+                        (StakePools Map.empty)
+                        (GenDelegs Map.empty),
+                      _utxoState genesis,
+                      tx
+                    )
+                )
+          )
 
 -- | Start from genesis, consume Alice's and Bob's coins, create an output
 -- spendable by Alice if 'aliceKeep' is greater than 0. For each pair of script
@@ -156,34 +207,51 @@ initialUTxOState aliceKeep msigs =
 -- transaction that uses the scripts in 'unlockScripts' (and the output for
 -- 'aliceKeep' in the case of it being non-zero) to spend all funds back to
 -- Alice. Return resulting UTxO state or collected errors
-applyTxWithScript
-  :: [(MultiSig, Coin)]
-  -> [MultiSig]
-  -> Wdrl
-  -> Coin
-  -> [KeyPair 'Witness]
-  -> Either [[PredicateFailure UTXOW]] UTxOState
+applyTxWithScript ::
+  [(MultiSig, Coin)] ->
+  [MultiSig] ->
+  Wdrl ->
+  Coin ->
+  [KeyPair 'Witness] ->
+  Either [[PredicateFailure UTXOW]] UTxOState
 applyTxWithScript lockScripts unlockScripts wdrl aliceKeep signers = utxoSt'
-  where (txId, initUtxo) = initialUTxOState aliceKeep lockScripts
-        utxoSt = case initUtxo of
-                   Right utxoSt'' -> utxoSt''
-                   _                      -> error ("must fail test before: "
-                                                   ++ show initUtxo)
-        txbody = makeTxBody inputs
-          [(aliceAddr, aliceInitCoin + bobInitCoin + sum (unWdrl wdrl))] wdrl
-        inputs = [TxIn txId (fromIntegral n) | n <-
-                     [0..length lockScripts - (if aliceKeep > 0 then 0 else 1)]]
-                                 -- alice? + scripts
-        tx = makeTx
-              txbody
-              signers
-              (Map.fromList $ map (\scr -> (hashScript scr, scr)) unlockScripts)
-              Nothing
-        utxoSt' = runShelleyBase $ applySTS @UTXOW (TRC( UtxoEnv
-                                          (SlotNo 0)
-                                          initPParams
-                                          (StakeCreds Map.empty)
-                                          (StakePools Map.empty)
-                                          (GenDelegs Map.empty)
-                                      , utxoSt
-                                      , tx))
+  where
+    (txId, initUtxo) = initialUTxOState aliceKeep lockScripts
+    utxoSt = case initUtxo of
+      Right utxoSt'' -> utxoSt''
+      _ ->
+        error
+          ( "must fail test before: "
+              ++ show initUtxo
+          )
+    txbody =
+      makeTxBody
+        inputs
+        [(aliceAddr, aliceInitCoin + bobInitCoin + sum (unWdrl wdrl))]
+        wdrl
+    inputs =
+      [ TxIn txId (fromIntegral n)
+        | n <-
+            [0 .. length lockScripts - (if aliceKeep > 0 then 0 else 1)]
+      ]
+    -- alice? + scripts
+    tx =
+      makeTx
+        txbody
+        signers
+        (Map.fromList $ map (\scr -> (hashScript scr, scr)) unlockScripts)
+        Nothing
+    utxoSt' =
+      runShelleyBase $
+        applySTS @UTXOW
+          ( TRC
+              ( UtxoEnv
+                  (SlotNo 0)
+                  initPParams
+                  (StakeCreds Map.empty)
+                  (StakePools Map.empty)
+                  (GenDelegs Map.empty),
+                utxoSt,
+                tx
+              )
+          )

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/STSTests.hs
@@ -3,29 +3,64 @@
 
 module Test.Shelley.Spec.Ledger.Examples.STSTests (stsTests) where
 
-import           Data.Either (fromRight, isRight)
+import Control.State.Transition.Extended (TRC (..), applySTS)
+import Control.State.Transition.Trace ((.-), (.->), checkTrace)
+import Data.Either (fromRight, isRight)
 import qualified Data.Map.Strict as Map (empty, singleton)
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCase, (@?=))
-
-import           Control.State.Transition.Extended (TRC (..), applySTS)
-import           Control.State.Transition.Trace (checkTrace, (.-), (.->))
-import           Shelley.Spec.Ledger.Keys (asWitness)
-import           Shelley.Spec.Ledger.STS.Chain (totalAda)
-import           Shelley.Spec.Ledger.STS.Utxow (PredicateFailure (..))
-import           Shelley.Spec.Ledger.Tx (hashScript)
-import           Shelley.Spec.Ledger.TxData (pattern RewardAcnt, pattern ScriptHashObj, Wdrl (..))
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN)
-import           Test.Shelley.Spec.Ledger.Examples.Examples (CHAINExample (..), alicePay, bobPay,
-                     carlPay, dariaPay, ex1, ex2A, ex2B, ex2C, ex2Cbis, ex2Cquater, ex2Cter, ex2D,
-                     ex2E, ex2F, ex2G, ex2H, ex2I, ex2J, ex2K, ex2L, ex3A, ex3B, ex3C, ex4A, ex4B,
-                     ex5A, ex5B, ex5C, ex5D, ex5E, ex5F', test5F)
-import           Test.Shelley.Spec.Ledger.Examples.MultiSigExamples (aliceAndBob, aliceAndBobOrCarl,
-                     aliceAndBobOrCarlAndDaria, aliceAndBobOrCarlOrDaria, aliceOnly, aliceOrBob,
-                     applyTxWithScript, bobOnly)
-import           Test.Shelley.Spec.Ledger.Utils (maxLLSupply, runShelleyBase)
-
+import Shelley.Spec.Ledger.Keys (asWitness)
+import Shelley.Spec.Ledger.STS.Chain (totalAda)
+import Shelley.Spec.Ledger.STS.Utxow (PredicateFailure (..))
+import Shelley.Spec.Ledger.Tx (hashScript)
+import Shelley.Spec.Ledger.TxData (Wdrl (..), pattern RewardAcnt, pattern ScriptHashObj)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN)
+import Test.Shelley.Spec.Ledger.Examples.Examples
+  ( CHAINExample (..),
+    alicePay,
+    bobPay,
+    carlPay,
+    dariaPay,
+    ex1,
+    ex2A,
+    ex2B,
+    ex2C,
+    ex2Cbis,
+    ex2Cquater,
+    ex2Cter,
+    ex2D,
+    ex2E,
+    ex2F,
+    ex2G,
+    ex2H,
+    ex2I,
+    ex2J,
+    ex2K,
+    ex2L,
+    ex3A,
+    ex3B,
+    ex3C,
+    ex4A,
+    ex4B,
+    ex5A,
+    ex5B,
+    ex5C,
+    ex5D,
+    ex5E,
+    ex5F',
+    test5F,
+  )
+import Test.Shelley.Spec.Ledger.Examples.MultiSigExamples
+  ( aliceAndBob,
+    aliceAndBobOrCarl,
+    aliceAndBobOrCarlAndDaria,
+    aliceAndBobOrCarlOrDaria,
+    aliceOnly,
+    aliceOrBob,
+    applyTxWithScript,
+    bobOnly,
+  )
+import Test.Shelley.Spec.Ledger.Utils (maxLLSupply, runShelleyBase)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit ((@?=), Assertion, assertBool, assertFailure, testCase)
 
 -- | Runs example, applies chain state transition system rule (STS),
 --   and checks that trace ends with expected state or expected error.
@@ -33,8 +68,7 @@ testCHAINExample :: CHAINExample -> Assertion
 testCHAINExample (CHAINExample slotNow initSt block (Right expectedSt)) = do
   checkTrace @CHAIN runShelleyBase slotNow $ pure initSt .- block .-> expectedSt
 testCHAINExample (CHAINExample slotNow initSt block predicateFailure@(Left _)) = do
-  let
-    st = runShelleyBase $ applySTS @CHAIN (TRC (slotNow, initSt, block))
+  let st = runShelleyBase $ applySTS @CHAIN (TRC (slotNow, initSt, block))
   st @?= predicateFailure
 
 testPreservationOfAda :: CHAINExample -> Assertion
@@ -44,269 +78,325 @@ testPreservationOfAda (CHAINExample _ _ _ (Left predicateFailure)) =
   assertFailure $ "Ada not preserved " ++ show predicateFailure
 
 stsTests :: TestTree
-stsTests = testGroup "STS Tests"
-  [ testCase "CHAIN example 1 - empty block" $ testCHAINExample ex1
-  , testCase "CHAIN example 2A - register stake key" $ testCHAINExample ex2A
-  , testCase "CHAIN example 2B - delegate stake and create reward update" $ testCHAINExample ex2B
-  , testCase "CHAIN example 2C - new epoch changes" $ testCHAINExample ex2C
-  , testCase "CHAIN example 2Cbis - as 2C but no decay" $ testCHAINExample ex2Cbis
-  , testCase "CHAIN example 2Cter - as 2C but full refund" $ testCHAINExample ex2Cter
-  , testCase "CHAIN example 2Cquater - as 2C but with instant decay" $ testCHAINExample ex2Cquater
-  , testCase "CHAIN example 2D - second reward update" $ testCHAINExample ex2D
-  , testCase "CHAIN example 2E - nonempty pool distr" $ testCHAINExample ex2E
-  , testCase "CHAIN example 2F - decentralized block" $ testCHAINExample ex2F
-  , testCase "CHAIN example 2G - prelude to the first nontrivial rewards" $ testCHAINExample ex2G
-  , testCase "CHAIN example 2H - create a nontrivial rewards" $ testCHAINExample ex2H
-  , testCase "CHAIN example 2I - apply a nontrivial rewards" $ testCHAINExample ex2I
-  , testCase "CHAIN example 2J - drain reward account and deregister" $ testCHAINExample ex2J
-  , testCase "CHAIN example 2K - stage stake pool retirement" $ testCHAINExample ex2K
-  , testCase "CHAIN example 2L - reap stake pool" $ testCHAINExample ex2L
-  , testCase "CHAIN example 3A - get 3/7 votes for a pparam update" $ testCHAINExample ex3A
-  , testCase "CHAIN example 3B - get 5/7 votes for a pparam update" $ testCHAINExample ex3B
-  , testCase "CHAIN example 3C - processes a pparam update" $ testCHAINExample ex3C
-  , testCase "CHAIN example 4A - stage genesis key delegation" $ testCHAINExample ex4A
-  , testCase "CHAIN example 4B - adopt genesis key delegation" $ testCHAINExample ex4B
-  , testCase "CHAIN example 5A - create MIR cert" $ testCHAINExample ex5A
-  , testCase "CHAIN example 5B - FAIL: insufficient core node signatures" $ testCHAINExample ex5B
-  , testCase "CHAIN example 5C - FAIL: MIR impossible in decentralized network" $ testCHAINExample ex5C
-  , testCase "CHAIN example 5D - FAIL: MIR impossible (decentralized and insufficient sigs)" $ testCHAINExample ex5D
-  , testCase "CHAIN example 5E - FAIL: MIR insufficient reserves" $ testCHAINExample ex5E
-  , testCase "CHAIN example 5F - apply MIR at epoch boundary" test5F
-  , testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda ex1
-  , testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda ex2A
-  , testCase "CHAIN example 2B - Preservation of ADA" $ testPreservationOfAda ex2B
-  , testCase "CHAIN example 2C - Preservation of ADA" $ testPreservationOfAda ex2C
-  , testCase "CHAIN example 2D - Preservation of ADA" $ testPreservationOfAda ex2D
-  , testCase "CHAIN example 2E - Preservation of ADA" $ testPreservationOfAda ex2E
-  , testCase "CHAIN example 2F - Preservation of ADA" $ testPreservationOfAda ex2F
-  , testCase "CHAIN example 2G - Preservation of ADA" $ testPreservationOfAda ex2G
-  , testCase "CHAIN example 2H - Preservation of ADA" $ testPreservationOfAda ex2H
-  , testCase "CHAIN example 2I - Preservation of ADA" $ testPreservationOfAda ex2I
-  , testCase "CHAIN example 2J - Preservation of ADA" $ testPreservationOfAda ex2J
-  , testCase "CHAIN example 2K - Preservation of ADA" $ testPreservationOfAda ex2K
-  , testCase "CHAIN example 2L - Preservation of ADA" $ testPreservationOfAda ex2L
-  , testCase "CHAIN example 3A - Preservation of ADA" $ testPreservationOfAda ex3A
-  , testCase "CHAIN example 3B - Preservation of ADA" $ testPreservationOfAda ex3B
-  , testCase "CHAIN example 3C - Preservation of ADA" $ testPreservationOfAda ex3C
-  , testCase "CHAIN example 4A - Preservation of ADA" $ testPreservationOfAda ex4A
-  , testCase "CHAIN example 4B - Preservation of ADA" $ testPreservationOfAda ex4B
-  , testCase "CHAIN example 5A - Preservation of ADA" $ testPreservationOfAda ex5A
-  , testCase "CHAIN example 5F - Preservation of ADA" $
-      (totalAda (fromRight (error "CHAIN example 5F" ) ex5F') @?= maxLLSupply)
-  , testCase "Alice uses SingleSig script" testAliceSignsAlone
-  , testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign
-  , testCase "Everybody signs in multi-sig" testEverybodySigns
-  , testCase "FAIL: Wrong script for correct signatures" testWrongScript
-  , testCase "Alice || Bob, Alice signs" testAliceOrBob
-  , testCase "Alice || Bob, Bob signs" testAliceOrBob'
-  , testCase "Alice && Bob, both sign" testAliceAndBob
-  , testCase "FAIL: Alice && Bob, Alice signs" testAliceAndBob'
-  , testCase "FAIL: Alice && Bob, Bob signs" testAliceAndBob''
-  , testCase "Alice && Bob || Carl, Alice && Bob sign" testAliceAndBobOrCarl
-  , testCase "Alice && Bob || Carl, Carl signs" testAliceAndBobOrCarl'
-  , testCase "Alice && Bob || Carl && Daria, Alice && Bob sign" testAliceAndBobOrCarlAndDaria
-  , testCase "Alice && Bob || Carl && Daria, Carl && Daria sign" testAliceAndBobOrCarlAndDaria'
-  , testCase "Alice && Bob || Carl || Daria, Alice && Bob sign" testAliceAndBobOrCarlOrDaria
-  , testCase "Alice && Bob || Carl || Daria, Carl signs" testAliceAndBobOrCarlOrDaria'
-  , testCase "Alice && Bob || Carl || Daria, Daria signs" testAliceAndBobOrCarlOrDaria''
-  , testCase "two scripts: Alice Or Bob / alice And Bob Or Carl" testTwoScripts
-  , testCase "FAIL: two scripts: Alice Or Bob / alice And Bob Or Carl" testTwoScripts'
-  , testCase "script and Key: Alice And Bob and alicePay" testScriptAndSKey
-  , testCase "FAIL: script and Key: Alice And Bob and alicePay" testScriptAndSKey'
-  , testCase "script and Key: Alice Or Bob and alicePay, only Alice" testScriptAndSKey''
-  , testCase "script and Key: Alice And Bob Or Carl and alicePay, Alice and Carl sign" testScriptAndSKey'''
-  , testCase "withdraw from script locked account, same script" testRwdAliceSignsAlone
-  , testCase "FAIL: withdraw from script locked account" testRwdAliceSignsAlone'
-  , testCase "withdraw from script locked account, different script" testRwdAliceSignsAlone''
-  , testCase "FAIL: withdraw from script locked account, signed, missing script" testRwdAliceSignsAlone'''
-  ]
+stsTests =
+  testGroup
+    "STS Tests"
+    [ testCase "CHAIN example 1 - empty block" $ testCHAINExample ex1,
+      testCase "CHAIN example 2A - register stake key" $ testCHAINExample ex2A,
+      testCase "CHAIN example 2B - delegate stake and create reward update" $ testCHAINExample ex2B,
+      testCase "CHAIN example 2C - new epoch changes" $ testCHAINExample ex2C,
+      testCase "CHAIN example 2Cbis - as 2C but no decay" $ testCHAINExample ex2Cbis,
+      testCase "CHAIN example 2Cter - as 2C but full refund" $ testCHAINExample ex2Cter,
+      testCase "CHAIN example 2Cquater - as 2C but with instant decay" $ testCHAINExample ex2Cquater,
+      testCase "CHAIN example 2D - second reward update" $ testCHAINExample ex2D,
+      testCase "CHAIN example 2E - nonempty pool distr" $ testCHAINExample ex2E,
+      testCase "CHAIN example 2F - decentralized block" $ testCHAINExample ex2F,
+      testCase "CHAIN example 2G - prelude to the first nontrivial rewards" $ testCHAINExample ex2G,
+      testCase "CHAIN example 2H - create a nontrivial rewards" $ testCHAINExample ex2H,
+      testCase "CHAIN example 2I - apply a nontrivial rewards" $ testCHAINExample ex2I,
+      testCase "CHAIN example 2J - drain reward account and deregister" $ testCHAINExample ex2J,
+      testCase "CHAIN example 2K - stage stake pool retirement" $ testCHAINExample ex2K,
+      testCase "CHAIN example 2L - reap stake pool" $ testCHAINExample ex2L,
+      testCase "CHAIN example 3A - get 3/7 votes for a pparam update" $ testCHAINExample ex3A,
+      testCase "CHAIN example 3B - get 5/7 votes for a pparam update" $ testCHAINExample ex3B,
+      testCase "CHAIN example 3C - processes a pparam update" $ testCHAINExample ex3C,
+      testCase "CHAIN example 4A - stage genesis key delegation" $ testCHAINExample ex4A,
+      testCase "CHAIN example 4B - adopt genesis key delegation" $ testCHAINExample ex4B,
+      testCase "CHAIN example 5A - create MIR cert" $ testCHAINExample ex5A,
+      testCase "CHAIN example 5B - FAIL: insufficient core node signatures" $ testCHAINExample ex5B,
+      testCase "CHAIN example 5C - FAIL: MIR impossible in decentralized network" $ testCHAINExample ex5C,
+      testCase "CHAIN example 5D - FAIL: MIR impossible (decentralized and insufficient sigs)" $ testCHAINExample ex5D,
+      testCase "CHAIN example 5E - FAIL: MIR insufficient reserves" $ testCHAINExample ex5E,
+      testCase "CHAIN example 5F - apply MIR at epoch boundary" test5F,
+      testCase "CHAIN example 1 - Preservation of ADA" $ testPreservationOfAda ex1,
+      testCase "CHAIN example 2A - Preservation of ADA" $ testPreservationOfAda ex2A,
+      testCase "CHAIN example 2B - Preservation of ADA" $ testPreservationOfAda ex2B,
+      testCase "CHAIN example 2C - Preservation of ADA" $ testPreservationOfAda ex2C,
+      testCase "CHAIN example 2D - Preservation of ADA" $ testPreservationOfAda ex2D,
+      testCase "CHAIN example 2E - Preservation of ADA" $ testPreservationOfAda ex2E,
+      testCase "CHAIN example 2F - Preservation of ADA" $ testPreservationOfAda ex2F,
+      testCase "CHAIN example 2G - Preservation of ADA" $ testPreservationOfAda ex2G,
+      testCase "CHAIN example 2H - Preservation of ADA" $ testPreservationOfAda ex2H,
+      testCase "CHAIN example 2I - Preservation of ADA" $ testPreservationOfAda ex2I,
+      testCase "CHAIN example 2J - Preservation of ADA" $ testPreservationOfAda ex2J,
+      testCase "CHAIN example 2K - Preservation of ADA" $ testPreservationOfAda ex2K,
+      testCase "CHAIN example 2L - Preservation of ADA" $ testPreservationOfAda ex2L,
+      testCase "CHAIN example 3A - Preservation of ADA" $ testPreservationOfAda ex3A,
+      testCase "CHAIN example 3B - Preservation of ADA" $ testPreservationOfAda ex3B,
+      testCase "CHAIN example 3C - Preservation of ADA" $ testPreservationOfAda ex3C,
+      testCase "CHAIN example 4A - Preservation of ADA" $ testPreservationOfAda ex4A,
+      testCase "CHAIN example 4B - Preservation of ADA" $ testPreservationOfAda ex4B,
+      testCase "CHAIN example 5A - Preservation of ADA" $ testPreservationOfAda ex5A,
+      testCase "CHAIN example 5F - Preservation of ADA" $
+        (totalAda (fromRight (error "CHAIN example 5F") ex5F') @?= maxLLSupply),
+      testCase "Alice uses SingleSig script" testAliceSignsAlone,
+      testCase "FAIL: Alice doesn't sign in multi-sig" testAliceDoesntSign,
+      testCase "Everybody signs in multi-sig" testEverybodySigns,
+      testCase "FAIL: Wrong script for correct signatures" testWrongScript,
+      testCase "Alice || Bob, Alice signs" testAliceOrBob,
+      testCase "Alice || Bob, Bob signs" testAliceOrBob',
+      testCase "Alice && Bob, both sign" testAliceAndBob,
+      testCase "FAIL: Alice && Bob, Alice signs" testAliceAndBob',
+      testCase "FAIL: Alice && Bob, Bob signs" testAliceAndBob'',
+      testCase "Alice && Bob || Carl, Alice && Bob sign" testAliceAndBobOrCarl,
+      testCase "Alice && Bob || Carl, Carl signs" testAliceAndBobOrCarl',
+      testCase "Alice && Bob || Carl && Daria, Alice && Bob sign" testAliceAndBobOrCarlAndDaria,
+      testCase "Alice && Bob || Carl && Daria, Carl && Daria sign" testAliceAndBobOrCarlAndDaria',
+      testCase "Alice && Bob || Carl || Daria, Alice && Bob sign" testAliceAndBobOrCarlOrDaria,
+      testCase "Alice && Bob || Carl || Daria, Carl signs" testAliceAndBobOrCarlOrDaria',
+      testCase "Alice && Bob || Carl || Daria, Daria signs" testAliceAndBobOrCarlOrDaria'',
+      testCase "two scripts: Alice Or Bob / alice And Bob Or Carl" testTwoScripts,
+      testCase "FAIL: two scripts: Alice Or Bob / alice And Bob Or Carl" testTwoScripts',
+      testCase "script and Key: Alice And Bob and alicePay" testScriptAndSKey,
+      testCase "FAIL: script and Key: Alice And Bob and alicePay" testScriptAndSKey',
+      testCase "script and Key: Alice Or Bob and alicePay, only Alice" testScriptAndSKey'',
+      testCase "script and Key: Alice And Bob Or Carl and alicePay, Alice and Carl sign" testScriptAndSKey''',
+      testCase "withdraw from script locked account, same script" testRwdAliceSignsAlone,
+      testCase "FAIL: withdraw from script locked account" testRwdAliceSignsAlone',
+      testCase "withdraw from script locked account, different script" testRwdAliceSignsAlone'',
+      testCase "FAIL: withdraw from script locked account, signed, missing script" testRwdAliceSignsAlone'''
+    ]
 
 testAliceSignsAlone :: Assertion
 testAliceSignsAlone =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [asWitness alicePay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [asWitness alicePay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceDoesntSign :: Assertion
 testAliceDoesntSign =
   utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW]]
-  where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [asWitness bobPay, asWitness carlPay, asWitness dariaPay]
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [asWitness bobPay, asWitness carlPay, asWitness dariaPay]
 
 testEverybodySigns :: Assertion
 testEverybodySigns =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay, asWitness carlPay, asWitness dariaPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay, asWitness carlPay, asWitness dariaPay]
+    s = "problem: " ++ show utxoSt'
 
 testWrongScript :: Assertion
 testWrongScript =
   utxoSt' @?= Left [[MissingScriptWitnessesUTXOW]]
-  where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOnly, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
 
 testAliceOrBob :: Assertion
 testAliceOrBob =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceOrBob, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [asWitness alicePay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOrBob, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [asWitness alicePay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceOrBob' :: Assertion
 testAliceOrBob' =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceOrBob, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [asWitness bobPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOrBob, 11000)] [aliceOrBob] (Wdrl Map.empty) 0 [asWitness bobPay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceAndBob :: Assertion
 testAliceAndBob =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceAndBob' :: Assertion
 testAliceAndBob' =
   utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW]]
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [asWitness alicePay]
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [asWitness alicePay]
 
 testAliceAndBob'' :: Assertion
 testAliceAndBob'' =
   utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW]]
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [asWitness bobPay]
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBob, 11000)] [aliceAndBob] (Wdrl Map.empty) 0 [asWitness bobPay]
 
 testAliceAndBobOrCarl :: Assertion
 testAliceAndBobOrCarl =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarl, 11000)] [aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBobOrCarl, 11000)] [aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarl' :: Assertion
 testAliceAndBobOrCarl' =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarl, 11000)] [aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness carlPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBobOrCarl, 11000)] [aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness carlPay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlAndDaria :: Assertion
 testAliceAndBobOrCarlAndDaria =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlAndDaria, 11000)] [aliceAndBobOrCarlAndDaria] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBobOrCarlAndDaria, 11000)] [aliceAndBobOrCarlAndDaria] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlAndDaria' :: Assertion
 testAliceAndBobOrCarlAndDaria' =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlAndDaria, 11000)] [aliceAndBobOrCarlAndDaria] (Wdrl Map.empty) 0 [asWitness carlPay, asWitness dariaPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBobOrCarlAndDaria, 11000)] [aliceAndBobOrCarlAndDaria] (Wdrl Map.empty) 0 [asWitness carlPay, asWitness dariaPay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlOrDaria :: Assertion
 testAliceAndBobOrCarlOrDaria =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [asWitness alicePay, asWitness bobPay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlOrDaria' :: Assertion
 testAliceAndBobOrCarlOrDaria' =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [asWitness carlPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [asWitness carlPay]
+    s = "problem: " ++ show utxoSt'
 
 testAliceAndBobOrCarlOrDaria'' :: Assertion
 testAliceAndBobOrCarlOrDaria'' =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [asWitness dariaPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceAndBobOrCarlOrDaria, 11000)] [aliceAndBobOrCarlOrDaria] (Wdrl Map.empty) 0 [asWitness dariaPay]
+    s = "problem: " ++ show utxoSt'
 
 -- multiple script-locked outputs
 
 testTwoScripts :: Assertion
 testTwoScripts =
   assertBool s (isRight utxoSt')
-  where utxoSt' = applyTxWithScript
-                   [ (aliceOrBob, 10000)
-                   , (aliceAndBobOrCarl, 1000)]
-                   [ aliceOrBob
-                   , aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness bobPay, asWitness carlPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript
+        [ (aliceOrBob, 10000),
+          (aliceAndBobOrCarl, 1000)
+        ]
+        [ aliceOrBob,
+          aliceAndBobOrCarl
+        ]
+        (Wdrl Map.empty)
+        0
+        [asWitness bobPay, asWitness carlPay]
+    s = "problem: " ++ show utxoSt'
 
 testTwoScripts' :: Assertion
 testTwoScripts' =
   utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW]]
-  where utxoSt' = applyTxWithScript
-                   [ (aliceAndBob, 10000)
-                   , (aliceAndBobOrCarl, 1000)]
-                   [ aliceAndBob
-                   , aliceAndBobOrCarl] (Wdrl Map.empty) 0 [asWitness bobPay, asWitness carlPay]
+  where
+    utxoSt' =
+      applyTxWithScript
+        [ (aliceAndBob, 10000),
+          (aliceAndBobOrCarl, 1000)
+        ]
+        [ aliceAndBob,
+          aliceAndBobOrCarl
+        ]
+        (Wdrl Map.empty)
+        0
+        [asWitness bobPay, asWitness carlPay]
 
 -- script and skey locked
 
 testScriptAndSKey :: Assertion
 testScriptAndSKey =
   assertBool s (isRight utxoSt')
-  where utxoSt' = applyTxWithScript
-                   [(aliceAndBob, 10000)]
-                   [aliceAndBob] (Wdrl Map.empty) 1000 [asWitness alicePay, asWitness bobPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript
+        [(aliceAndBob, 10000)]
+        [aliceAndBob]
+        (Wdrl Map.empty)
+        1000
+        [asWitness alicePay, asWitness bobPay]
+    s = "problem: " ++ show utxoSt'
 
 testScriptAndSKey' :: Assertion
 testScriptAndSKey' =
   utxoSt' @?= Left [[MissingVKeyWitnessesUTXOW]]
-  where utxoSt' = applyTxWithScript
-                   [(aliceOrBob, 10000)]
-                   [aliceOrBob] (Wdrl Map.empty) 1000 [asWitness bobPay]
+  where
+    utxoSt' =
+      applyTxWithScript
+        [(aliceOrBob, 10000)]
+        [aliceOrBob]
+        (Wdrl Map.empty)
+        1000
+        [asWitness bobPay]
 
 testScriptAndSKey'' :: Assertion
 testScriptAndSKey'' =
   assertBool s (isRight utxoSt')
-  where utxoSt' = applyTxWithScript
-                   [(aliceOrBob, 10000)]
-                   [aliceOrBob] (Wdrl Map.empty) 1000 [asWitness alicePay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript
+        [(aliceOrBob, 10000)]
+        [aliceOrBob]
+        (Wdrl Map.empty)
+        1000
+        [asWitness alicePay]
+    s = "problem: " ++ show utxoSt'
 
 testScriptAndSKey''' :: Assertion
 testScriptAndSKey''' =
   assertBool s (isRight utxoSt')
-  where utxoSt' = applyTxWithScript
-                   [(aliceAndBobOrCarl, 10000)]
-                   [aliceAndBobOrCarl] (Wdrl Map.empty) 1000 [asWitness alicePay, asWitness carlPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript
+        [(aliceAndBobOrCarl, 10000)]
+        [aliceAndBobOrCarl]
+        (Wdrl Map.empty)
+        1000
+        [asWitness alicePay, asWitness carlPay]
+    s = "problem: " ++ show utxoSt'
 
 -- Withdrawals
 
 testRwdAliceSignsAlone :: Assertion
 testRwdAliceSignsAlone =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript aliceOnly)) 1000) 0 [asWitness alicePay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript aliceOnly)) 1000) 0 [asWitness alicePay]
+    s = "problem: " ++ show utxoSt'
 
 testRwdAliceSignsAlone' :: Assertion
 testRwdAliceSignsAlone' =
   utxoSt' @?= Left [[ScriptWitnessNotValidatingUTXOW]]
-  where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly, bobOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [asWitness alicePay]
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOnly, 11000)] [aliceOnly, bobOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [asWitness alicePay]
 
 testRwdAliceSignsAlone'' :: Assertion
 testRwdAliceSignsAlone'' =
   assertBool s (isRight utxoSt')
-  where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly, bobOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [asWitness alicePay, asWitness bobPay]
-        s = "problem: " ++ show utxoSt'
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOnly, 11000)] [aliceOnly, bobOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [asWitness alicePay, asWitness bobPay]
+    s = "problem: " ++ show utxoSt'
 
 testRwdAliceSignsAlone''' :: Assertion
 testRwdAliceSignsAlone''' =
   utxoSt' @?= Left [[MissingScriptWitnessesUTXOW]]
-  where utxoSt' =
-          applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [asWitness alicePay, asWitness bobPay]
+  where
+    utxoSt' =
+      applyTxWithScript [(aliceOnly, 11000)] [aliceOnly] (Wdrl $ Map.singleton (RewardAcnt (ScriptHashObj $ hashScript bobOnly)) 1000) 0 [asWitness alicePay, asWitness bobPay]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -8,136 +8,271 @@
 
 module Test.Shelley.Spec.Ledger.Examples.Serialization where
 
-import           Data.List.NonEmpty (NonEmpty ((:|)))
-import           Data.IP (toIPv4)
-import qualified Data.Maybe as Maybe (fromJust)
-import           Data.String (fromString)
-import qualified Shelley.Spec.Ledger.MetaData as MD
-
-import           Cardano.Binary (Annotator, DecoderError, FromCBOR (..), ToCBOR (..),
-                     decodeAnnotator, decodeFullDecoder, serialize', serializeEncoding, toCBOR)
-import           Cardano.Crypto.DSIGN (DSIGNAlgorithm (encodeVerKeyDSIGN), encodeSignedDSIGN)
-import           Cardano.Crypto.Hash (getHash)
-import           Cardano.Prelude (LByteString)
-import           Codec.CBOR.Encoding (Encoding (..), Tokens (..))
-import           Data.ByteString (ByteString)
+import Cardano.Binary
+  ( Annotator,
+    DecoderError,
+    FromCBOR (..),
+    ToCBOR (..),
+    decodeAnnotator,
+    decodeFullDecoder,
+    serialize',
+    serializeEncoding,
+    toCBOR,
+  )
+import Cardano.Crypto.DSIGN (DSIGNAlgorithm (encodeVerKeyDSIGN), encodeSignedDSIGN)
+import Cardano.Crypto.Hash (getHash)
+import Cardano.Prelude (LByteString)
+import Codec.CBOR.Encoding (Encoding (..), Tokens (..))
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS (pack)
-
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.HUnit (Assertion, assertEqual, assertFailure, testCase, (@?=))
-
-import           Data.Coerce (coerce)
-import           Data.Ratio ((%))
-import           Numeric.Natural (Natural)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), UnitInterval (..),
-                     mkNonce, textToDns, textToUrl)
-import           Shelley.Spec.Ledger.BlockChain (pattern BHBody, pattern BHeader, Block (..),
-                     pattern BlockHash, pattern HashHeader, TxSeq (..), bbHash, bhash,
-                     bheaderBlockNo, bheaderEta, bheaderL, bheaderOCert, bheaderPrev,
-                     bheaderSlotNo, bheaderVk, bheaderVrfVk, bprotver, bsize, mkSeed, seedEta,
-                     seedL)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, pattern Delegate,
-                     pattern GenesisDelegCert, pattern MIRCert, pattern PoolDistr, pattern RegKey,
-                     pattern RegPool, pattern RetirePool)
-import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), SnapShot (..), SnapShots (..),
-                     Stake (..))
-import           Shelley.Spec.Ledger.Keys (Hash, KeyRole (..), asWitness, coerceKeyRole, hash,
-                     hashKey, sKey, signedDSIGN, signedKES, vKey, encodeSignedKES)
-import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern ActiveSlot,
-                     EpochState (..), NewEpochState (..), pattern RewardUpdate, deltaF, deltaR,
-                     deltaT, emptyLedgerState, genesisId, nonMyopic, rs)
-import           Shelley.Spec.Ledger.OCert (KESPeriod (..), pattern OCert)
-import           Shelley.Spec.Ledger.PParams (PParams' (PParams), PParamsUpdate,
-                     pattern ProposedPPUpdates, ProtVer (..), pattern Update, emptyPParams, _a0,
-                     _d, _eMax, _extraEntropy, _keyDecayRate, _keyDeposit, _keyMinRefund,
-                     _maxBBSize, _maxBHSize, _maxTxSize, _minfeeA, _minfeeB, _nOpt, _poolDecayRate,
-                     _poolDeposit, _poolMinRefund, _protocolVersion, _rho, _tau)
-import           Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
-import           Shelley.Spec.Ledger.Scripts (pattern RequireSignature, pattern ScriptHash)
-import           Shelley.Spec.Ledger.Serialization (FromCBORGroup (..), ToCBORGroup (..), ipv4ToBytes)
-import           Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
-import           Shelley.Spec.Ledger.Tx (Tx (..), hashScript)
-import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern DCertDeleg, pattern DCertGenesis,
-                     pattern DCertMir, pattern DCertPool, pattern Delegation, pattern KeyHashObj,
-                     PoolMetaData (..), pattern PoolParams, Ptr (..), pattern RewardAcnt,
-                     pattern ScriptHashObj, StakePoolRelay (..), pattern StakeRefBase,
-                     pattern StakeRefNull, pattern StakeRefPtr, pattern TxBody, pattern TxIn,
-                     pattern TxOut, Wdrl (..), WitVKey (..), _TxId, _poolCost, _poolMD,
-                     _poolMDHash, _poolMDUrl, _poolMargin, _poolOwners, _poolPledge, _poolPubKey,
-                     _poolRAcnt, _poolRelays, _poolVrf)
-import           Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessVKey)
-
-import           Test.Cardano.Crypto.VRF.Fake (WithResult (..))
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, BHBody, ConcreteCrypto,
-                     CoreKeyPair, Credential, HashHeader, KeyHash, pattern KeyHash, KeyPair,
-                     KeyPair, pattern KeyPair, MultiSig, PoolDistr, RewardUpdate, ScriptHash,
-                     SignKeyKES, SignKeyVRF, SignedDSIGN, TxBody, TxId, TxIn, VKey, pattern VKey,
-                     VRFKeyHash, VerKeyKES, VerKeyVRF, hashKeyVRF)
-import           Test.Shelley.Spec.Ledger.Utils
-
+import Data.Coerce (coerce)
+import Data.IP (toIPv4)
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.Map.Strict as Map
+import qualified Data.Maybe as Maybe (fromJust)
+import Data.Ratio ((%))
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import Data.String (fromString)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Nonce (..),
+    StrictMaybe (..),
+    UnitInterval (..),
+    mkNonce,
+    textToDns,
+    textToUrl,
+  )
+import Shelley.Spec.Ledger.BlockChain
+  ( Block (..),
+    TxSeq (..),
+    bbHash,
+    bhash,
+    bheaderBlockNo,
+    bheaderEta,
+    bheaderL,
+    bheaderOCert,
+    bheaderPrev,
+    bheaderSlotNo,
+    bheaderVk,
+    bheaderVrfVk,
+    bprotver,
+    bsize,
+    mkSeed,
+    seedEta,
+    seedL,
+    pattern BHBody,
+    pattern BHeader,
+    pattern BlockHash,
+    pattern HashHeader,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( pattern DeRegKey,
+    pattern Delegate,
+    pattern GenesisDelegCert,
+    pattern MIRCert,
+    pattern PoolDistr,
+    pattern RegKey,
+    pattern RegPool,
+    pattern RetirePool,
+  )
+import Shelley.Spec.Ledger.EpochBoundary
+  ( BlocksMade (..),
+    SnapShot (..),
+    SnapShots (..),
+    Stake (..),
+  )
+import Shelley.Spec.Ledger.Keys
+  ( Hash,
+    KeyRole (..),
+    asWitness,
+    coerceKeyRole,
+    encodeSignedKES,
+    hash,
+    hashKey,
+    sKey,
+    signedDSIGN,
+    signedKES,
+    vKey,
+  )
+import Shelley.Spec.Ledger.LedgerState
+  ( AccountState (..),
+    EpochState (..),
+    NewEpochState (..),
+    deltaF,
+    deltaR,
+    deltaT,
+    emptyLedgerState,
+    genesisId,
+    nonMyopic,
+    rs,
+    pattern ActiveSlot,
+    pattern RewardUpdate,
+  )
+import qualified Shelley.Spec.Ledger.MetaData as MD
+import Shelley.Spec.Ledger.OCert (KESPeriod (..), pattern OCert)
+import Shelley.Spec.Ledger.PParams
+  ( PParams' (PParams),
+    PParamsUpdate,
+    ProtVer (..),
+    _a0,
+    _d,
+    _eMax,
+    _extraEntropy,
+    _keyDecayRate,
+    _keyDeposit,
+    _keyMinRefund,
+    _maxBBSize,
+    _maxBHSize,
+    _maxTxSize,
+    _minfeeA,
+    _minfeeB,
+    _nOpt,
+    _poolDecayRate,
+    _poolDeposit,
+    _poolMinRefund,
+    _protocolVersion,
+    _rho,
+    _tau,
+    emptyPParams,
+    pattern ProposedPPUpdates,
+    pattern Update,
+  )
+import Shelley.Spec.Ledger.Rewards (emptyNonMyopic)
+import Shelley.Spec.Ledger.Scripts (pattern RequireSignature, pattern ScriptHash)
+import Shelley.Spec.Ledger.Serialization (FromCBORGroup (..), ToCBORGroup (..), ipv4ToBytes)
+import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
+import Shelley.Spec.Ledger.Tx (Tx (..), hashScript)
+import Shelley.Spec.Ledger.TxData
+  ( PoolMetaData (..),
+    Ptr (..),
+    StakePoolRelay (..),
+    Wdrl (..),
+    WitVKey (..),
+    _TxId,
+    _poolCost,
+    _poolMD,
+    _poolMDHash,
+    _poolMDUrl,
+    _poolMargin,
+    _poolOwners,
+    _poolPledge,
+    _poolPubKey,
+    _poolRAcnt,
+    _poolRelays,
+    _poolVrf,
+    pattern Addr,
+    pattern DCertDeleg,
+    pattern DCertGenesis,
+    pattern DCertMir,
+    pattern DCertPool,
+    pattern Delegation,
+    pattern KeyHashObj,
+    pattern PoolParams,
+    pattern RewardAcnt,
+    pattern ScriptHashObj,
+    pattern StakeRefBase,
+    pattern StakeRefNull,
+    pattern StakeRefPtr,
+    pattern TxBody,
+    pattern TxIn,
+    pattern TxOut,
+  )
+import Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessVKey)
+import Test.Cardano.Crypto.VRF.Fake (WithResult (..))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Addr,
+    BHBody,
+    ConcreteCrypto,
+    CoreKeyPair,
+    Credential,
+    HashHeader,
+    KeyHash,
+    KeyPair,
+    KeyPair,
+    MultiSig,
+    PoolDistr,
+    RewardUpdate,
+    ScriptHash,
+    SignKeyKES,
+    SignKeyVRF,
+    SignedDSIGN,
+    TxBody,
+    TxId,
+    TxIn,
+    VKey,
+    VRFKeyHash,
+    VerKeyKES,
+    VerKeyVRF,
+    hashKeyVRF,
+    pattern KeyHash,
+    pattern KeyPair,
+    pattern VKey,
+  )
+import Test.Shelley.Spec.Ledger.Utils
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit ((@?=), Assertion, assertEqual, assertFailure, testCase)
 
-roundTrip :: (Show a, Eq a)
-   => (a -> Encoding)
-   -> (LByteString -> Either DecoderError a)
-   -> a
-   -> Assertion
+roundTrip ::
+  (Show a, Eq a) =>
+  (a -> Encoding) ->
+  (LByteString -> Either DecoderError a) ->
+  a ->
+  Assertion
 roundTrip encode decode x =
   case (decode . serializeEncoding . encode) x of
     Left e -> assertFailure $ "could not decode serialization of " ++ show x ++ ", " ++ show e
     Right y -> y @?= x
 
-checkEncoding
-  :: (Show a, Eq a)
-    => (a -> Encoding)
-    -> (LByteString -> Either DecoderError a)
-    -> String
-    -> a
-    -> ToTokens
-    -> TestTree
-checkEncoding encode decode name x t = testCase testName $
-  assertEqual testName (fromEncoding $ toCBOR t) (fromEncoding $ encode x)
-    >> roundTrip encode decode x
+checkEncoding ::
+  (Show a, Eq a) =>
+  (a -> Encoding) ->
+  (LByteString -> Either DecoderError a) ->
+  String ->
+  a ->
+  ToTokens ->
+  TestTree
+checkEncoding encode decode name x t =
+  testCase testName $
+    assertEqual testName (fromEncoding $ toCBOR t) (fromEncoding $ encode x)
+      >> roundTrip encode decode x
   where
-   testName = "prop_serialize_" <> name
-   fromEncoding :: Encoding -> Tokens
-   fromEncoding (Encoding e) = e TkEnd
+    testName = "prop_serialize_" <> name
+    fromEncoding :: Encoding -> Tokens
+    fromEncoding (Encoding e) = e TkEnd
 
-checkEncodingCBOR
-  :: (FromCBOR a, ToCBOR a, Show a, Eq a)
-  => String
-  -> a
-  -> ToTokens
-  -> TestTree
+checkEncodingCBOR ::
+  (FromCBOR a, ToCBOR a, Show a, Eq a) =>
+  String ->
+  a ->
+  ToTokens ->
+  TestTree
 checkEncodingCBOR name x t =
   let d = decodeFullDecoder (fromString name) fromCBOR
-  in checkEncoding toCBOR d name x t
+   in checkEncoding toCBOR d name x t
 
-checkEncodingCBORAnnotated
-  :: (FromCBOR (Annotator a), ToCBOR a, Show a, Eq a)
-  => String
-  -> a
-  -> ToTokens
-  -> TestTree
+checkEncodingCBORAnnotated ::
+  (FromCBOR (Annotator a), ToCBOR a, Show a, Eq a) =>
+  String ->
+  a ->
+  ToTokens ->
+  TestTree
 checkEncodingCBORAnnotated name x t =
   let d = decodeAnnotator (fromString name) fromCBOR
-  in checkEncoding toCBOR d name x annTokens
+   in checkEncoding toCBOR d name x annTokens
   where
     annTokens = T $ TkEncoded $ serialize' t
 
-checkEncodingCBORCBORGroup
-  :: (FromCBORGroup a, ToCBORGroup a, Show a, Eq a)
-  => String
-  -> a
-  -> ToTokens
-  -> TestTree
+checkEncodingCBORCBORGroup ::
+  (FromCBORGroup a, ToCBORGroup a, Show a, Eq a) =>
+  String ->
+  a ->
+  ToTokens ->
+  TestTree
 checkEncodingCBORCBORGroup name x t =
   let d = decodeFullDecoder (fromString name) fromCBORGroup
-  in checkEncoding toCBORGroup d name x t
-
+   in checkEncoding toCBORGroup d name x t
 
 getRawKeyHash :: KeyHash 'Payment -> ByteString
 getRawKeyHash (KeyHash hsh) = getHash hsh
@@ -157,13 +292,14 @@ getRawNonce NeutralNonce = error "The neutral nonce has no bytes"
 
 testGKey :: CoreKeyPair
 testGKey = KeyPair vk sk
-  where (sk, vk) = mkGenKey (0,0,0,0,0)
+  where
+    (sk, vk) = mkGenKey (0, 0, 0, 0, 0)
 
 testGKeyHash :: KeyHash 'Genesis
 testGKeyHash = (hashKey . vKey) testGKey
 
 testVRF :: (SignKeyVRF, VerKeyVRF)
-testVRF = mkVRFKeyPair (0,0,0,0,5)
+testVRF = mkVRFKeyPair (0, 0, 0, 0, 5)
 
 testVRFKH :: VRFKeyHash
 testVRFKH = hashKeyVRF $ snd testVRF
@@ -176,19 +312,23 @@ testTxbHash = hashTxBody testTxb
 
 testKey1 :: KeyPair 'Payment
 testKey1 = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (0,0,0,0,1)
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 1)
 
 testKey2 :: KeyPair kr
 testKey2 = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (0,0,0,0,2)
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 2)
 
 testKey3 :: KeyPair kr
 testKey3 = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (0,0,0,0,3)
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 3)
 
 testBlockIssuerKey :: KeyPair 'BlockIssuer
 testBlockIssuerKey = KeyPair vk sk
-  where (sk, vk) = mkKeyPair (0,0,0,0,4)
+  where
+    (sk, vk) = mkKeyPair (0, 0, 0, 0, 4)
 
 testKey1Token :: Tokens -> Tokens
 testKey1Token = e
@@ -205,8 +345,9 @@ testBlockIssuerKeyTokens = e
 testKey1SigToken :: Tokens -> Tokens
 testKey1SigToken = e
   where
-    s = signedDSIGN @ConcreteCrypto (sKey testKey1) testTxbHash
-          :: SignedDSIGN (Hash ConcreteCrypto TxBody)
+    s =
+      signedDSIGN @ConcreteCrypto (sKey testKey1) testTxbHash ::
+        SignedDSIGN (Hash ConcreteCrypto TxBody)
     Encoding e = encodeSignedDSIGN s
 
 testOpCertSigTokens :: Tokens -> Tokens
@@ -225,7 +366,8 @@ testKeyHash3 :: KeyHash 'Payment
 testKeyHash3 = (hashKey . vKey) testKey3
 
 testKESKeys :: (SignKeyKES, VerKeyKES)
-testKESKeys = mkKESKeyPair (0,0,0,0,3)
+testKESKeys = mkKESKeyPair (0, 0, 0, 0, 3)
+
 testAddrE :: Addr
 testAddrE = Addr (KeyHashObj testKeyHash1) StakeRefNull
 
@@ -251,22 +393,39 @@ testHeaderHash :: HashHeader
 testHeaderHash = HashHeader $ coerce (hash 0 :: Hash ConcreteCrypto Int)
 
 testBHB :: BHBody
-testBHB = BHBody
-          { bheaderBlockNo = BlockNo 44
-          , bheaderSlotNo  = SlotNo 33
-          , bheaderPrev    = BlockHash testHeaderHash
-          , bheaderVk      = coerceKeyRole $ vKey testKey1
-          , bheaderVrfVk   = snd testVRF
-          , bheaderEta     = coerce $ mkCertifiedVRF (WithResult
-            (mkSeed seedEta (SlotNo 33) (mkNonce 0)) 1) (fst testVRF)
-          , bheaderL       = coerce $ mkCertifiedVRF (WithResult
-            (mkSeed seedL (SlotNo 33) (mkNonce 0)) 1) (fst testVRF)
-          , bsize          = 0
-          , bhash          = bbHash $ TxSeq StrictSeq.empty
-          , bheaderOCert   = OCert (snd testKESKeys)
-            0 (KESPeriod 0) (signedDSIGN @ConcreteCrypto (sKey testKey1) (snd testKESKeys, 0, KESPeriod 0))
-          , bprotver       = ProtVer 0 0
-          }
+testBHB =
+  BHBody
+    { bheaderBlockNo = BlockNo 44,
+      bheaderSlotNo = SlotNo 33,
+      bheaderPrev = BlockHash testHeaderHash,
+      bheaderVk = coerceKeyRole $ vKey testKey1,
+      bheaderVrfVk = snd testVRF,
+      bheaderEta =
+        coerce $
+          mkCertifiedVRF
+            ( WithResult
+                (mkSeed seedEta (SlotNo 33) (mkNonce 0))
+                1
+            )
+            (fst testVRF),
+      bheaderL =
+        coerce $
+          mkCertifiedVRF
+            ( WithResult
+                (mkSeed seedL (SlotNo 33) (mkNonce 0))
+                1
+            )
+            (fst testVRF),
+      bsize = 0,
+      bhash = bbHash $ TxSeq StrictSeq.empty,
+      bheaderOCert =
+        OCert
+          (snd testKESKeys)
+          0
+          (KESPeriod 0)
+          (signedDSIGN @ConcreteCrypto (sKey testKey1) (snd testKESKeys, 0, KESPeriod 0)),
+      bprotver = ProtVer 0 0
+    }
 
 testBHBSigTokens :: Tokens -> Tokens
 testBHBSigTokens = e
@@ -281,10 +440,10 @@ data ToTokens where
   Plus :: ToTokens -> ToTokens -> ToTokens
 
 instance ToCBOR ToTokens where
-   toCBOR (T xs) = Encoding xs
-   toCBOR (S s) = toCBOR s
-   toCBOR (G g) = toCBORGroup g
-   toCBOR (Plus a b) = toCBOR a <> toCBOR b
+  toCBOR (T xs) = Encoding xs
+  toCBOR (S s) = toCBOR s
+  toCBOR (G g) = toCBORGroup g
+  toCBOR (Plus a b) = toCBOR a <> toCBOR b
 
 instance Semigroup ToTokens where
   (<>) = Plus
@@ -295,827 +454,913 @@ instance Monoid ToTokens where
 testNegativeCoin :: Assertion
 testNegativeCoin =
   let enc@(Encoding tokens) = toCBOR (Coin (-1))
-  in
-    (tokens TkEnd @?= (TkInteger (-1)) TkEnd)
-    >>
-    (case (decodeFullDecoder "negative_coin" (fromCBOR @Coin) . serializeEncoding) enc of
-      Left _ -> pure ()
-      Right _ -> assertFailure "should not deserialize negative coins"
-    )
+   in (tokens TkEnd @?= (TkInteger (-1)) TkEnd)
+        >> ( case (decodeFullDecoder "negative_coin" (fromCBOR @Coin) . serializeEncoding) enc of
+               Left _ -> pure ()
+               Right _ -> assertFailure "should not deserialize negative coins"
+           )
 
 serializationTests :: TestTree
-serializationTests = testGroup "Serialization Tests"
-
-  [ checkEncodingCBOR "list"
-    [1::Integer]
-    (T (TkListBegin . TkInteger 1 . TkBreak))
-  , checkEncodingCBOR "set"
-    (Set.singleton (1 :: Integer))
-    (T (TkTag 258 . TkListLen 1 . TkInteger 1))
-  , checkEncodingCBOR "map"
-    (Map.singleton (1 :: Integer) (1 :: Integer))
-    (T (TkMapLen 1 . TkInteger 1 . TkInteger 1))
-  , checkEncodingCBOR "coin"
-    (Coin 30)
-    (T (TkWord64 30))
-  , testCase "prop_serialize_negative-coin" testNegativeCoin
-  , checkEncodingCBOR "rational"
-    (UnsafeUnitInterval (1 % 2))
-    (T (TkTag 30 . TkListLen 2 . TkInteger 1 . TkInteger 2))
-  , checkEncodingCBOR "slot"
-    (SlotNo 7)
-    (T (TkWord64 7))
-  , checkEncodingCBOR "neutral_nonce"
-    NeutralNonce
-    (T (TkListLen 1 . TkWord 0))
-  , checkEncodingCBOR "nonce"
-    (mkNonce 99)
-    (T (TkListLen 2 . TkWord 1 . TkBytes (getRawNonce $ mkNonce 99)))
-  , checkEncodingCBOR "key_hash"
-    testKeyHash1
-    (T (TkBytes (getRawKeyHash testKeyHash1)))
-  , checkEncodingCBOR "credential_key_hash"
-    testPayCred
-    (T (TkListLen 2 . TkWord 0) <> S testKeyHash1)
-  , checkEncodingCBOR "base_address_key_key"
-    (Addr testPayCred (StakeRefBase $ KeyHashObj testKeyHash2))
-    ( (T $ TkListLen 3)
-        <> (T $ TkWord 0)
-        <> S testKeyHash1
-        <> S testKeyHash2
-    )
-  , checkEncodingCBOR "base_address_key_script"
-    (Addr testPayCred (StakeRefBase $ ScriptHashObj testScriptHash))
-    ( (T $ TkListLen 3)
-        <> (T $ TkWord 1)
-        <> S testKeyHash1
-        <> S testScriptHash
-    )
-  , checkEncodingCBOR "base_address_script_key"
-    (Addr (ScriptHashObj testScriptHash) (StakeRefBase $ KeyHashObj testKeyHash2))
-    ( (T $ TkListLen 3)
-        <> (T $ TkWord 2)
-        <> S testScriptHash
-        <> S testKeyHash2
-    )
-  , checkEncodingCBOR "base_address_script_script"
-    (Addr (ScriptHashObj testScriptHash) (StakeRefBase $ ScriptHashObj testScriptHash2))
-    ( (T $ TkListLen 3)
-        <> (T $ TkWord 3)
-        <> S testScriptHash
-        <> S testScriptHash2
-    )
-  , let ptr = Ptr (SlotNo 12) 0 3 in
-    checkEncodingCBOR "pointer_address_key"
-    (Addr testPayCred (StakeRefPtr ptr))
-    ( (T $ TkListLen (2 + fromIntegral (listLen ptr)))
-       <> T (TkWord 4)
-       <> S testKeyHash1
-       <> G ptr
-    )
-  , let ptr = Ptr (SlotNo 12) 0 3 in
-    checkEncodingCBOR "pointer_address_script"
-    (Addr (ScriptHashObj testScriptHash) (StakeRefPtr ptr))
-    ( (T $ TkListLen (2 + fromIntegral (listLen ptr)))
-       <> T (TkWord 5)
-       <> S testScriptHash
-       <> G ptr
-    )
-  , checkEncodingCBOR "enterprise_address_key"
-    (Addr testPayCred StakeRefNull)
-    (T (TkListLen 2) <> T (TkWord 6) <> S testKeyHash1)
-  , checkEncodingCBOR "enterprise_address_script"
-    (Addr (ScriptHashObj testScriptHash) StakeRefNull)
-    (T (TkListLen 2) <> T (TkWord 7) <> S testScriptHash)
-  , checkEncodingCBOR "txin"
-    (TxIn genesisId 0 :: TxIn)
-    (T (TkListLen 2) <> S (genesisId :: TxId) <> T (TkWord64 0))
-  , let a = Addr testPayCred StakeRefNull in
-    checkEncodingCBOR "txout"
-    (TxOut a (Coin 2))
-    (T (TkListLen 3)
-      <> G a
-      <> S (Coin 2)
-    )
-  , case makeWitnessVKey testTxbHash testKey1 of
-    w@(WitVKey vk _sig) ->
-      checkEncodingCBORAnnotated "vkey_witnesses"
-      w  -- Transaction _witnessVKeySet element
-      ( T (TkListLen 2)
-        <> S vk -- vkey
-        <> T testKey1SigToken -- signature
-      )
-  , checkEncodingCBOR "script_hash_to_scripts"
-    (Map.singleton (hashScript testScript :: ScriptHash) testScript)  -- Transaction _witnessMSigMap
-    ( T (TkMapLen 1)
-      <> S (hashScript testScript :: ScriptHash)
-      <> S testScript
-    )
-
-  -- checkEncodingCBOR "withdrawal_key"
-  , checkEncodingCBOR "withdrawal"
-    (Map.singleton (RewardAcnt testStakeCred) (Coin 123))
-    ( (T $ TkMapLen 1 . TkListLen 2)
-        <> (T $ TkWord 0)
-        <> S testKeyHash2
-        <> S (Coin 123)
-    )
-
-  -- checkEncodingCBOR "withdrawal_script"
-  , checkEncodingCBOR "withdrawal"
-    (Map.singleton (RewardAcnt (ScriptHashObj testScriptHash)) (Coin 123))
-    ( (T $ TkMapLen 1 . TkListLen 2)
-        <> (T $ TkWord 1)
-        <> S testScriptHash
-        <> S (Coin 123)
-    )
-
-  , checkEncodingCBOR "register_stake_reference"
-    (DCertDeleg (RegKey testStakeCred))
-    ( T (TkListLen 2)
-      <> T (TkWord 0) -- Reg cert
-      <> S testStakeCred -- keyhash
-    )
-
-  , checkEncodingCBOR "deregister_stake_reference"
-    (DCertDeleg (DeRegKey testStakeCred))
-    ( T (TkListLen 2)
-      <> T (TkWord 1) -- DeReg cert
-      <> S testStakeCred -- keyhash
-    )
-
-  , checkEncodingCBOR "stake_delegation"
-    (DCertDeleg (Delegate (Delegation testStakeCred (coerceKeyRole testKeyHash2))))
-    ( T (TkListLen 3
-      . TkWord 2) -- delegation cert with key
-      <> S testStakeCred
-      <> S testKeyHash2
-    )
-
-    -- checkEncodingCBOR "register-pool"
-  , let poolOwner = testKeyHash2
-        poolMargin = unsafeMkUnitInterval 0.7
-        poolRAcnt = RewardAcnt testStakeCred
-        poolPledge = Coin 11
-        poolCost = Coin 55
-        poolUrl = "pool.io"
-        poolMDHash = BS.pack "{}"
-        ipv4 = toIPv4 [127,0,0,1]
-        ipv4Bytes = ipv4ToBytes . toIPv4 $ [127,0,0,1]
-        poolRelays = StrictSeq.fromList
-          [ SingleHostAddr SNothing (SJust ipv4) SNothing
-          , SingleHostName SNothing $ Maybe.fromJust $ textToDns "singlehost.relay.com"
-          , MultiHostName (SJust 42) $ Maybe.fromJust $ textToDns "multihost.relay.com"
-          ]
-    in
-    checkEncodingCBOR "register_pool"
-    (DCertPool (RegPool (PoolParams
-               { _poolPubKey = coerceKeyRole testKeyHash1
-               , _poolVrf = testVRFKH
-               , _poolPledge = poolPledge
-               , _poolCost = poolCost
-               , _poolMargin = poolMargin
-               , _poolRAcnt = poolRAcnt
-               , _poolOwners = Set.singleton poolOwner
-               , _poolRelays = poolRelays
-               , _poolMD = SJust $ PoolMetaData
-                             { _poolMDUrl = Maybe.fromJust $ textToUrl poolUrl
-                             , _poolMDHash = poolMDHash
-                             }
-               })))
-    ( T (TkListLen 10)
-      <> T (TkWord 3) -- Reg Pool
-      <> S testKeyHash1 -- operator
-      <> S testVRFKH    -- vrf keyhash
-      <> S poolPledge   -- pledge
-      <> S poolCost     -- cost
-      <> S poolMargin   -- margin
-      <> S poolRAcnt    -- reward acct
-      <> T (TkListLen 1) <> S poolOwner   -- owners
-      <> T (TkListLen 3) -- relays
-        <> T (TkListLen 4 . TkWord 0 . TkNull . TkBytes ipv4Bytes . TkNull)
-        <> T (TkListLen 3 . TkWord 1 . TkNull . TkString ("singlehost.relay.com"))
-        <> T (TkListLen 3 . TkWord 2 . (TkWord 42) . TkString ("multihost.relay.com"))
-      <> T (TkListLen 2) -- metadata present
-      <> S poolUrl       -- metadata url
-      <> S poolMDHash    -- metadata hash
-    )
-
-  , checkEncodingCBOR "retire_pool"
-    (DCertPool (RetirePool (coerceKeyRole testKeyHash1) (EpochNo 1729)))
-    ( T (TkListLen 3
-      . TkWord 4) -- Pool Retire
-      <> S testKeyHash1 -- key hash
-      <> S (EpochNo 1729) -- epoch
-    )
-
-  , checkEncodingCBOR "genesis_delegation"
-    (DCertGenesis (GenesisDelegCert testGKeyHash (coerceKeyRole testKeyHash1)))
-    ( T (TkListLen 3
-      . TkWord 5) -- genesis delegation cert
-      <> S testGKeyHash -- delegator credential
-      <> S testKeyHash1 -- delegatee key hash
-    )
-
-    -- checkEncodingCBOR "mir"
-    , let rws = Map.singleton testStakeCred 77
-    in
-    checkEncodingCBOR "mir"
-    (DCertMir (MIRCert rws))
-    ( T (TkListLen 2
-       . TkWord 6) -- make instantaneous rewards cert
-      <> S rws
-    )
-
-  , checkEncodingCBOR "pparams_update_key_deposit_only"
-    (PParams
-       { _minfeeA = SNothing
-       , _minfeeB = SNothing
-       , _maxBBSize = SNothing
-       , _maxTxSize = SNothing
-       , _maxBHSize = SNothing
-       , _keyDeposit = SJust (Coin 5)
-       , _keyMinRefund = SNothing
-       , _keyDecayRate = SNothing
-       , _poolDeposit = SNothing
-       , _poolMinRefund = SNothing
-       , _poolDecayRate = SNothing
-       , _eMax = SNothing
-       , _nOpt = SNothing
-       , _a0 = SNothing
-       , _rho = SNothing
-       , _tau = SNothing
-       , _d = SNothing
-       , _extraEntropy = SNothing
-       , _protocolVersion = SNothing
-       } :: PParamsUpdate)
-    ((T $ TkMapLen 1 . TkWord 5) <> S (Coin 5))
-
-  -- checkEncodingCBOR "pparams_update_all"
-  , let minfeea               = 0
-        minfeeb               = 1
-        maxbbsize             = 2
-        maxtxsize             = 3
-        maxbhsize             = 4
-        keydeposit            = Coin 5
-        keyminrefund          = UnsafeUnitInterval $ 1 % 2
-        keydecayrate          = 1 % 3
-        pooldeposit           = Coin 6
-        poolminrefund         = UnsafeUnitInterval $ 1 % 4
-        pooldecayrate         = 1 % 5
-        emax                  = EpochNo 7
-        nopt                  = 8
-        a0                    = 1 % 6
-        rho                   = UnsafeUnitInterval $ 1 % 6
-        tau                   = UnsafeUnitInterval $ 1 % 7
-        d                     = UnsafeUnitInterval $ 1 % 9
-        extraEntropy          = NeutralNonce
-        protocolVersion       = ProtVer 0 1
-    in
-    checkEncodingCBOR "pparams_update_all"
-    (PParams
-       { _minfeeA         = SJust minfeea
-       , _minfeeB         = SJust minfeeb
-       , _maxBBSize       = SJust maxbbsize
-       , _maxTxSize       = SJust maxtxsize
-       , _maxBHSize       = SJust maxbhsize
-       , _keyDeposit      = SJust keydeposit
-       , _keyMinRefund    = SJust keyminrefund
-       , _keyDecayRate    = SJust keydecayrate
-       , _poolDeposit     = SJust pooldeposit
-       , _poolMinRefund   = SJust poolminrefund
-       , _poolDecayRate   = SJust pooldecayrate
-       , _eMax            = SJust emax
-       , _nOpt            = SJust nopt
-       , _a0              = SJust a0
-       , _rho             = SJust rho
-       , _tau             = SJust tau
-       , _d               = SJust d
-       , _extraEntropy    = SJust extraEntropy
-       , _protocolVersion = SJust protocolVersion
-       } :: PParamsUpdate)
-    ((T $ TkMapLen 19)
-      <> (T $ TkWord 0) <> S minfeea
-      <> (T $ TkWord 1) <> S minfeeb
-      <> (T $ TkWord 2) <> S maxbbsize
-      <> (T $ TkWord 3) <> S maxtxsize
-      <> (T $ TkWord 4) <> S maxbhsize
-      <> (T $ TkWord 5) <> S keydeposit
-      <> (T $ TkWord 6) <> S keyminrefund
-      <> (T $ TkWord 7 . TkTag 30) <> S keydecayrate
-      <> (T $ TkWord 8) <> S pooldeposit
-      <> (T $ TkWord 9) <> S poolminrefund
-      <> (T $ TkWord 10 . TkTag 30) <> S pooldecayrate
-      <> (T $ TkWord 11) <> S emax
-      <> (T $ TkWord 12) <> S nopt
-      <> (T $ TkWord 13 . TkTag 30) <> S a0
-      <> (T $ TkWord 14) <> S rho
-      <> (T $ TkWord 15) <> S tau
-      <> (T $ TkWord 16) <> S d
-      <> (T $ TkWord 17) <> S extraEntropy
-      <> (T $ TkWord 18) <> S protocolVersion)
-
-    -- checkEncodingCBOR "full_update"
-  , let
-      ppup = ProposedPPUpdates (Map.singleton
-               testGKeyHash
-               (PParams
-                  { _minfeeA = SNothing
-                  , _minfeeB = SNothing
-                  , _maxBBSize = SNothing
-                  , _maxTxSize = SNothing
-                  , _maxBHSize = SNothing
-                  , _keyDeposit = SNothing
-                  , _keyMinRefund = SNothing
-                  , _keyDecayRate = SNothing
-                  , _poolDeposit = SNothing
-                  , _poolMinRefund = SNothing
-                  , _poolDecayRate = SNothing
-                  , _eMax = SNothing
-                  , _nOpt = SJust 100
-                  , _a0 = SNothing
-                  , _rho = SNothing
-                  , _tau = SNothing
-                  , _d = SNothing
-                  , _extraEntropy = SNothing
-                  , _protocolVersion = SNothing
-                  }))
-      e = EpochNo 0
-    in checkEncodingCBOR "full_update"
-    (Update ppup e)
-    ( (T $ TkListLen 2)
-      <> S ppup
-      <> S e
-    )
-
-  -- checkEncodingCBOR "minimal_txn_body"
-  , let
-      tin = [TxIn genesisId 1]
-      tout = TxOut testAddrE (Coin 2)
-    in checkEncodingCBORAnnotated "txbody"
-    ( TxBody -- minimal transaction body
-      (Set.fromList tin)
-      (StrictSeq.singleton tout)
-      StrictSeq.empty
-      (Wdrl Map.empty)
-      (Coin 9)
-      (SlotNo 500)
-      SNothing
-      SNothing
-    )
-    ( T (TkMapLen 4)
-      <> T (TkWord 0) -- Tx Ins
-      <> S tin
-      <> T (TkWord 1) -- Tx Outs
-      <> T (TkListLen 1)
-      <> S tout
-      <> T (TkWord 2) -- Tx Fee
-      <> T (TkWord64 9)
-      <> T (TkWord 3) -- Tx TTL
-      <> T (TkWord64 500)
-    )
-
-  -- checkEncodingCBOR "transaction_mixed"
-  , let
-      tin = [TxIn genesisId 1]
-      tout = TxOut testAddrE (Coin 2)
-      ra = RewardAcnt (KeyHashObj testKeyHash2)
-      ras = Map.singleton ra (Coin 123)
-      up = Update (ProposedPPUpdates (Map.singleton
-             testGKeyHash
-             (PParams
-                { _minfeeA = SNothing
-                , _minfeeB = SNothing
-                , _maxBBSize = SNothing
-                , _maxTxSize = SNothing
-                , _maxBHSize = SNothing
-                , _keyDeposit = SNothing
-                , _keyMinRefund = SNothing
-                , _keyDecayRate = SNothing
-                , _poolDeposit = SNothing
-                , _poolMinRefund = SNothing
-                , _poolDecayRate = SNothing
-                , _eMax = SNothing
-                , _nOpt = SJust 100
-                , _a0 = SNothing
-                , _rho = SNothing
-                , _tau = SNothing
-                , _d = SNothing
-                , _extraEntropy = SNothing
-                , _protocolVersion = SNothing
-                })))
-             (EpochNo 0)
-    in checkEncodingCBORAnnotated "txbody_partial"
-    ( TxBody -- transaction body with some optional components
-        (Set.fromList tin)
-        (StrictSeq.singleton tout)
-        StrictSeq.Empty
-        (Wdrl ras)
-        (Coin 9)
-        (SlotNo 500)
-        (SJust up)
-        SNothing
-     )
-     ( T (TkMapLen 6)
-       <> T (TkWord 0) -- Tx Ins
-       <> S tin
-       <> T (TkWord 1) -- Tx Outs
-       <> T (TkListLen 1)
-       <> S tout
-       <> T (TkWord 2) -- Tx Fee
-       <> S (Coin 9)
-       <> T (TkWord 3) -- Tx TTL
-       <> S (SlotNo 500)
-       <> T (TkWord 5) -- Tx Reward Withdrawals
-       <> S ras
-       <> T (TkWord 6) -- Tx Update
-       <> S up
-      )
-
-  -- checkEncodingCBOR "full_txn_body"
-  , let
-      tin = [TxIn genesisId 1]
-      tout = TxOut testAddrE (Coin 2)
-      reg = DCertDeleg (RegKey testStakeCred)
-      ra = RewardAcnt (KeyHashObj testKeyHash2)
-      ras = Map.singleton ra (Coin 123)
-      up = Update
-             (ProposedPPUpdates (Map.singleton
-                         testGKeyHash
-                         (PParams
-                            { _minfeeA = SNothing
-                            , _minfeeB = SNothing
-                            , _maxBBSize = SNothing
-                            , _maxTxSize = SNothing
-                            , _maxBHSize = SNothing
-                            , _keyDeposit = SNothing
-                            , _keyMinRefund = SNothing
-                            , _keyDecayRate = SNothing
-                            , _poolDeposit = SNothing
-                            , _poolMinRefund = SNothing
-                            , _poolDecayRate = SNothing
-                            , _eMax = SNothing
-                            , _nOpt = SJust 100
-                            , _a0 = SNothing
-                            , _rho = SNothing
-                            , _tau = SNothing
-                            , _d = SNothing
-                            , _extraEntropy = SNothing
-                            , _protocolVersion = SNothing
-                            })))
-             (EpochNo 0)
-      mdh = MD.hashMetaData $ MD.MetaData $ Map.singleton 13 (MD.I 17)
-    in checkEncodingCBORAnnotated "txbody_full"
-    ( TxBody -- transaction body with all components
-        (Set.fromList tin)
-        (StrictSeq.singleton tout)
-        (StrictSeq.fromList [ reg ])
-        (Wdrl ras)
-        (Coin 9)
-        (SlotNo 500)
-        (SJust up)
-        (SJust mdh)
-     )
-     ( T (TkMapLen 8)
-       <> T (TkWord 0) -- Tx Ins
-       <> S tin
-       <> T (TkWord 1) -- Tx Outs
-       <> T (TkListLen 1)
-       <> S tout
-       <> T (TkWord 2) -- Tx Fee
-       <> S (Coin 9)
-       <> T (TkWord 3) -- Tx TTL
-       <> S (SlotNo 500)
-       <> T (TkWord 4) -- Tx Certs
-       <> T (TkListLen 1) -- Seq list begin
-       <> S reg
-       <> T (TkWord 5) -- Tx Reward Withdrawals
-       <> S ras
-       <> T (TkWord 6) -- Tx Update
-       <> S up
-       <> T (TkWord 7) -- Tx Metadata
-       <> S mdh
-      )
-
-  -- checkEncodingCBOR "minimal_txn"
-  , let txb = TxBody
-                (Set.fromList [TxIn genesisId 1])
-                (StrictSeq.singleton $ TxOut testAddrE (Coin 2))
-                StrictSeq.empty
-                (Wdrl Map.empty)
-                (Coin 9)
-                (SlotNo 500)
-                SNothing
-                SNothing
-        txbh = hashTxBody txb
-        w = makeWitnessVKey txbh testKey1
-    in
-    checkEncodingCBORAnnotated "tx_min"
-    ( Tx txb (Set.singleton w) Map.empty SNothing )
-    ( T (TkListLen 3)
-      <> S txb
-      <> T (TkMapLen 1)
-       <> T (TkWord 0)
-       <> T (TkListLen 1)
-         <> S w
-      <> T TkNull
-    )
-
-  -- checkEncodingCBOR "full_txn"
-  , let txb = TxBody
-                (Set.fromList [TxIn genesisId 1])
-                (StrictSeq.singleton $ TxOut testAddrE (Coin 2))
-                StrictSeq.empty
-                (Wdrl Map.empty)
-                (Coin 9)
-                (SlotNo 500)
-                SNothing
-                SNothing
-        txbh = hashTxBody txb
-        w = makeWitnessVKey txbh testKey1
-        s = Map.singleton (hashScript testScript) testScript
-        md = MD.MetaData $ Map.singleton 17 (MD.I 42)
-    in
-    checkEncodingCBORAnnotated "tx_full"
-    ( Tx txb (Set.singleton w) s (SJust md))
-    ( T (TkListLen 3)
-      <> S txb
-      <> T (TkMapLen 2)
-       <> T (TkWord 0)
-       <> T (TkListLen 1)
-         <> S w
-       <> T (TkWord 1)
-       <> T (TkListLen 1)
-         <> S testScript
-      <> S md
-    )
-
-
-  -- checkEncodingCBOR "block_header_body"
-  , let
-      prevhash = BlockHash testHeaderHash
-      vrfVkey = snd testVRF
-      slot = SlotNo 33
-      nonce = mkSeed seedEta (SlotNo 33) (mkNonce 0)
-      nonceProof = coerce $ mkCertifiedVRF (WithResult nonce 1) (fst testVRF)
-      leaderValue = mkSeed seedL (SlotNo 33) (mkNonce 0)
-      leaderProof = coerce $ mkCertifiedVRF (WithResult leaderValue 1) (fst testVRF)
-      size = 0
-      blockNo = BlockNo 44
-      bbhash = bbHash $ TxSeq StrictSeq.empty
-      ocert = OCert
-                (snd testKESKeys)
-                0
-                (KESPeriod 0)
-                (signedDSIGN @ConcreteCrypto (sKey testKey1) (snd testKESKeys, 0, KESPeriod 0))
-      protover = ProtVer 0 0
-    in
-    checkEncodingCBOR "block_header_body"
-    ( BHBody
-      { bheaderBlockNo = blockNo
-      , bheaderSlotNo  = slot
-      , bheaderPrev    = prevhash
-      , bheaderVk      = vKey testBlockIssuerKey
-      , bheaderVrfVk   = vrfVkey
-      , bheaderEta     = nonceProof
-      , bheaderL       = leaderProof
-      , bsize          = size
-      , bhash          = bbhash
-      , bheaderOCert   = ocert
-      , bprotver       = protover
-      }
-    )
-    ( T (TkListLen $ 9 + 4 + 2)
-      <> S blockNo
-      <> S slot
-      <> S prevhash
-      <> T testBlockIssuerKeyTokens
-      <> S vrfVkey
-      <> S nonceProof
-      <> S leaderProof
-      <> S size
-      <> S bbhash
-      <> G ocert    -- 5
-      <> G protover -- 3
-    )
-
-  -- checkEncodingCBOR "operational_cert"
-  , let vkHot     = snd testKESKeys
-        counter   = 0
-        kesperiod = KESPeriod 0
-        signature = signedDSIGN @ConcreteCrypto (sKey testKey1) (snd testKESKeys, 0, KESPeriod 0)
-    in
-    checkEncodingCBORCBORGroup "operational_cert"
-    (OCert @ConcreteCrypto vkHot counter kesperiod signature)
-    (    S vkHot
-      <> S counter
-      <> S kesperiod
-      <> T testOpCertSigTokens
-    )
-
-    -- checkEncodingCBOR "block_header"
-  , let sig = Maybe.fromJust $ signedKES () 0 testBHB (fst testKESKeys)
-    in
-    checkEncodingCBORAnnotated "block_header"
-    (BHeader testBHB sig)
-    ( (T $ TkListLen 2)
-        <> S testBHB
-        <> T testBHBSigTokens
-    )
-
-    -- checkEncodingCBOR "empty_block"
-  , let sig = Maybe.fromJust $ signedKES () 0 testBHB (fst testKESKeys)
-        bh = BHeader testBHB sig
-        txns = TxSeq StrictSeq.Empty
-    in
-    checkEncodingCBORAnnotated "empty_block"
-    (Block bh txns)
-    ( (T $ TkListLen 4)
-        <> S bh
-        <> T (TkListLen 0 . TkListLen 0 . TkMapLen 0)
-    )
-
-    -- checkEncodingCBOR "rich_block"
-  , let sig = Maybe.fromJust $ signedKES () 0 testBHB (fst testKESKeys)
-        bh = BHeader testBHB sig
-        tin = Set.fromList [TxIn genesisId 1]
-        tout = StrictSeq.singleton $ TxOut testAddrE (Coin 2)
-        txb s = TxBody tin tout StrictSeq.empty (Wdrl Map.empty) (Coin 9) (SlotNo s) SNothing SNothing
-        txb1 = txb 500
-        txb2 = txb 501
-        txb3 = txb 502
-        txb4 = txb 503
-        txb5 = txb 504
-        w1 = makeWitnessVKey (hashTxBody txb1) testKey1
-        w2 = makeWitnessVKey (hashTxBody txb1) testKey2
-        ws = Set.fromList [w1, w2]
-        tx1 = Tx txb1 (Set.singleton w1) mempty SNothing
-        tx2 = Tx txb2 ws mempty SNothing
-        tx3 = Tx txb3 mempty (Map.singleton (hashScript testScript) testScript) SNothing
-        ss = Map.fromList [ (hashScript testScript, testScript)
-                          , (hashScript testScript2, testScript2)]
-        tx4 = Tx txb4 mempty ss SNothing
-        tx5MD = MD.MetaData $ Map.singleton 17 (MD.I 42)
-        tx5 = Tx txb5 ws ss (SJust tx5MD)
-        txns = TxSeq $ StrictSeq.fromList [tx1, tx2, tx3, tx4, tx5]
-    in
-    checkEncodingCBORAnnotated "rich_block"
-    (Block bh txns)
-    ( (T $ TkListLen 4)
-        -- header
-        <> S bh
-
-        -- bodies
-        <> T (TkListLen 5)
-        <> S txb1 <> S txb2 <> S txb3 <> S txb4 <> S txb5
-
-        -- witnesses
-        <> T (TkListLen 5)
-          -- tx 1, one key
-          <> T (TkMapLen 1 . TkWord 0)
-          <> T (TkListLen 1)
-          <> S w1
-
-          -- tx 2, two keys
-          <> T (TkMapLen 1 . TkWord 0)
-          <> T (TkListLen 2)
-          <> S w1
-          <> S w2
-
-          -- tx 3, one script
-          <> T (TkMapLen 1 . TkWord 1)
-          <> T (TkListLen 1)
-          <> S testScript
-
-          -- tx 4, two scripts
-          <> T (TkMapLen 1 . TkWord 1)
-          <> T (TkListLen 2)
-          <> S testScript
-          <> S testScript2
-
-          -- tx 5, two keys and two scripts
-          <> T (TkMapLen 2)
-          <> T (TkWord 0)
-            <> T (TkListLen 2)
-            <> S w1
-            <> S w2
-          <> T (TkWord 1)
-            <> T (TkListLen 2)
+serializationTests =
+  testGroup
+    "Serialization Tests"
+    [ checkEncodingCBOR
+        "list"
+        [1 :: Integer]
+        (T (TkListBegin . TkInteger 1 . TkBreak)),
+      checkEncodingCBOR
+        "set"
+        (Set.singleton (1 :: Integer))
+        (T (TkTag 258 . TkListLen 1 . TkInteger 1)),
+      checkEncodingCBOR
+        "map"
+        (Map.singleton (1 :: Integer) (1 :: Integer))
+        (T (TkMapLen 1 . TkInteger 1 . TkInteger 1)),
+      checkEncodingCBOR
+        "coin"
+        (Coin 30)
+        (T (TkWord64 30)),
+      testCase "prop_serialize_negative-coin" testNegativeCoin,
+      checkEncodingCBOR
+        "rational"
+        (UnsafeUnitInterval (1 % 2))
+        (T (TkTag 30 . TkListLen 2 . TkInteger 1 . TkInteger 2)),
+      checkEncodingCBOR
+        "slot"
+        (SlotNo 7)
+        (T (TkWord64 7)),
+      checkEncodingCBOR
+        "neutral_nonce"
+        NeutralNonce
+        (T (TkListLen 1 . TkWord 0)),
+      checkEncodingCBOR
+        "nonce"
+        (mkNonce 99)
+        (T (TkListLen 2 . TkWord 1 . TkBytes (getRawNonce $ mkNonce 99))),
+      checkEncodingCBOR
+        "key_hash"
+        testKeyHash1
+        (T (TkBytes (getRawKeyHash testKeyHash1))),
+      checkEncodingCBOR
+        "credential_key_hash"
+        testPayCred
+        (T (TkListLen 2 . TkWord 0) <> S testKeyHash1),
+      checkEncodingCBOR
+        "base_address_key_key"
+        (Addr testPayCred (StakeRefBase $ KeyHashObj testKeyHash2))
+        ( (T $ TkListLen 3)
+            <> (T $ TkWord 0)
+            <> S testKeyHash1
+            <> S testKeyHash2
+        ),
+      checkEncodingCBOR
+        "base_address_key_script"
+        (Addr testPayCred (StakeRefBase $ ScriptHashObj testScriptHash))
+        ( (T $ TkListLen 3)
+            <> (T $ TkWord 1)
+            <> S testKeyHash1
+            <> S testScriptHash
+        ),
+      checkEncodingCBOR
+        "base_address_script_key"
+        (Addr (ScriptHashObj testScriptHash) (StakeRefBase $ KeyHashObj testKeyHash2))
+        ( (T $ TkListLen 3)
+            <> (T $ TkWord 2)
+            <> S testScriptHash
+            <> S testKeyHash2
+        ),
+      checkEncodingCBOR
+        "base_address_script_script"
+        (Addr (ScriptHashObj testScriptHash) (StakeRefBase $ ScriptHashObj testScriptHash2))
+        ( (T $ TkListLen 3)
+            <> (T $ TkWord 3)
+            <> S testScriptHash
+            <> S testScriptHash2
+        ),
+      let ptr = Ptr (SlotNo 12) 0 3
+       in checkEncodingCBOR
+            "pointer_address_key"
+            (Addr testPayCred (StakeRefPtr ptr))
+            ( (T $ TkListLen (2 + fromIntegral (listLen ptr)))
+                <> T (TkWord 4)
+                <> S testKeyHash1
+                <> G ptr
+            ),
+      let ptr = Ptr (SlotNo 12) 0 3
+       in checkEncodingCBOR
+            "pointer_address_script"
+            (Addr (ScriptHashObj testScriptHash) (StakeRefPtr ptr))
+            ( (T $ TkListLen (2 + fromIntegral (listLen ptr)))
+                <> T (TkWord 5)
+                <> S testScriptHash
+                <> G ptr
+            ),
+      checkEncodingCBOR
+        "enterprise_address_key"
+        (Addr testPayCred StakeRefNull)
+        (T (TkListLen 2) <> T (TkWord 6) <> S testKeyHash1),
+      checkEncodingCBOR
+        "enterprise_address_script"
+        (Addr (ScriptHashObj testScriptHash) StakeRefNull)
+        (T (TkListLen 2) <> T (TkWord 7) <> S testScriptHash),
+      checkEncodingCBOR
+        "txin"
+        (TxIn genesisId 0 :: TxIn)
+        (T (TkListLen 2) <> S (genesisId :: TxId) <> T (TkWord64 0)),
+      let a = Addr testPayCred StakeRefNull
+       in checkEncodingCBOR
+            "txout"
+            (TxOut a (Coin 2))
+            ( T (TkListLen 3)
+                <> G a
+                <> S (Coin 2)
+            ),
+      case makeWitnessVKey testTxbHash testKey1 of
+        w@(WitVKey vk _sig) ->
+          checkEncodingCBORAnnotated
+            "vkey_witnesses"
+            w -- Transaction _witnessVKeySet element
+            ( T (TkListLen 2)
+                <> S vk -- vkey
+                <> T testKey1SigToken -- signature
+            ),
+      checkEncodingCBOR
+        "script_hash_to_scripts"
+        (Map.singleton (hashScript testScript :: ScriptHash) testScript) -- Transaction _witnessMSigMap
+        ( T (TkMapLen 1)
+            <> S (hashScript testScript :: ScriptHash)
             <> S testScript
-            <> S testScript2
-
-        -- metadata
-        <> T (TkMapLen 1)
-          <> T (TkInt 4)
-          <> S tx5MD
-    )
-  , checkEncodingCBOR "epoch"
-    (EpochNo 13)
-    (T (TkWord64 13))
-  , let n = (17 :: Natural)
-        bs = Map.singleton (coerceKeyRole testKeyHash1) n
-    in
-    checkEncodingCBOR "blocks_made"
-    (BlocksMade bs)
-    ( T (TkMapLen 1)
-      <> S testKeyHash1
-      <> S n)
-  , checkEncodingCBOR "account_state"
-    (AccountState (Coin 1) (Coin 2))
-    ( T (TkListLen 2)
-      <> S (Coin 1)
-      <> S (Coin 2))
-  , let stk = Map.singleton testStakeCred (Coin 13)
-    in
-    checkEncodingCBOR "stake"
-    (Stake stk)
-    ( T (TkMapLen 1)
-      <> S testStakeCred
-      <> S (Coin 13))
-  , let mark = SnapShot
-                 (Stake $ Map.singleton testStakeCred (Coin 11))
-                 (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
-                 ps
-        set  = SnapShot
-                 (Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22))
-                 (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
-                 ps
-        go   = SnapShot
-                 (Stake $ Map.singleton testStakeCred (Coin 33))
-                 (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
-                 ps
-        p = PoolParams
-              { _poolPubKey = coerceKeyRole testKeyHash1
-              , _poolVrf = testVRFKH
-              , _poolPledge = Coin 5
-              , _poolCost = Coin 4
-              , _poolMargin = unsafeMkUnitInterval 0.7
-              , _poolRAcnt = RewardAcnt testStakeCred
-              , _poolOwners = Set.singleton testKeyHash2
-              , _poolRelays = StrictSeq.empty
-              , _poolMD = SJust $ PoolMetaData
-                            { _poolMDUrl  = Maybe.fromJust $ textToUrl "web.site"
-                            , _poolMDHash = BS.pack "{}"
-                            }
-              }
-        ps = Map.singleton (coerceKeyRole testKeyHash1) p
-        fs = Coin 123
-    in
-    checkEncodingCBOR "snapshots"
-    (SnapShots mark set go fs)
-    ( T (TkListLen 4)
-      <> S mark
-      <> S set
-      <> S go
-      <> S fs )
-  , let
-      e  = EpochNo 0
-      ac = AccountState (Coin 100) (Coin 100)
-      mark = SnapShot
-               (Stake $ Map.singleton testStakeCred (Coin 11))
-               (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
-               ps
-      set  = SnapShot
-               (Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22))
-               (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
-               ps
-      go   = SnapShot
-               (Stake $ Map.singleton testStakeCred (Coin 33))
-               (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
-               ps
-      p = PoolParams
-            { _poolPubKey = coerceKeyRole testKeyHash1
-            , _poolVrf = testVRFKH
-            , _poolPledge = Coin 5
-            , _poolCost = Coin 4
-            , _poolMargin = unsafeMkUnitInterval 0.7
-            , _poolRAcnt = RewardAcnt testStakeCred
-            , _poolOwners = Set.singleton testKeyHash2
-            , _poolRelays = StrictSeq.empty
-            , _poolMD = SJust $ PoolMetaData
-                          { _poolMDUrl  = Maybe.fromJust $ textToUrl "web.site"
-                          , _poolMDHash = BS.pack "{}"
+        ),
+      -- checkEncodingCBOR "withdrawal_key"
+      checkEncodingCBOR
+        "withdrawal"
+        (Map.singleton (RewardAcnt testStakeCred) (Coin 123))
+        ( (T $ TkMapLen 1 . TkListLen 2)
+            <> (T $ TkWord 0)
+            <> S testKeyHash2
+            <> S (Coin 123)
+        ),
+      -- checkEncodingCBOR "withdrawal_script"
+      checkEncodingCBOR
+        "withdrawal"
+        (Map.singleton (RewardAcnt (ScriptHashObj testScriptHash)) (Coin 123))
+        ( (T $ TkMapLen 1 . TkListLen 2)
+            <> (T $ TkWord 1)
+            <> S testScriptHash
+            <> S (Coin 123)
+        ),
+      checkEncodingCBOR
+        "register_stake_reference"
+        (DCertDeleg (RegKey testStakeCred))
+        ( T (TkListLen 2)
+            <> T (TkWord 0) -- Reg cert
+            <> S testStakeCred -- keyhash
+        ),
+      checkEncodingCBOR
+        "deregister_stake_reference"
+        (DCertDeleg (DeRegKey testStakeCred))
+        ( T (TkListLen 2)
+            <> T (TkWord 1) -- DeReg cert
+            <> S testStakeCred -- keyhash
+        ),
+      checkEncodingCBOR
+        "stake_delegation"
+        (DCertDeleg (Delegate (Delegation testStakeCred (coerceKeyRole testKeyHash2))))
+        ( T
+            ( TkListLen 3
+                . TkWord 2 -- delegation cert with key
+            )
+            <> S testStakeCred
+            <> S testKeyHash2
+        ),
+      -- checkEncodingCBOR "register-pool"
+      let poolOwner = testKeyHash2
+          poolMargin = unsafeMkUnitInterval 0.7
+          poolRAcnt = RewardAcnt testStakeCred
+          poolPledge = Coin 11
+          poolCost = Coin 55
+          poolUrl = "pool.io"
+          poolMDHash = BS.pack "{}"
+          ipv4 = toIPv4 [127, 0, 0, 1]
+          ipv4Bytes = ipv4ToBytes . toIPv4 $ [127, 0, 0, 1]
+          poolRelays =
+            StrictSeq.fromList
+              [ SingleHostAddr SNothing (SJust ipv4) SNothing,
+                SingleHostName SNothing $ Maybe.fromJust $ textToDns "singlehost.relay.com",
+                MultiHostName (SJust 42) $ Maybe.fromJust $ textToDns "multihost.relay.com"
+              ]
+       in checkEncodingCBOR
+            "register_pool"
+            ( DCertPool
+                ( RegPool
+                    ( PoolParams
+                        { _poolPubKey = coerceKeyRole testKeyHash1,
+                          _poolVrf = testVRFKH,
+                          _poolPledge = poolPledge,
+                          _poolCost = poolCost,
+                          _poolMargin = poolMargin,
+                          _poolRAcnt = poolRAcnt,
+                          _poolOwners = Set.singleton poolOwner,
+                          _poolRelays = poolRelays,
+                          _poolMD =
+                            SJust $
+                              PoolMetaData
+                                { _poolMDUrl = Maybe.fromJust $ textToUrl poolUrl,
+                                  _poolMDHash = poolMDHash
+                                }
+                        }
+                    )
+                )
+            )
+            ( T (TkListLen 10)
+                <> T (TkWord 3) -- Reg Pool
+                <> S testKeyHash1 -- operator
+                <> S testVRFKH -- vrf keyhash
+                <> S poolPledge -- pledge
+                <> S poolCost -- cost
+                <> S poolMargin -- margin
+                <> S poolRAcnt -- reward acct
+                <> T (TkListLen 1)
+                <> S poolOwner -- owners
+                <> T (TkListLen 3) -- relays
+                <> T (TkListLen 4 . TkWord 0 . TkNull . TkBytes ipv4Bytes . TkNull)
+                <> T (TkListLen 3 . TkWord 1 . TkNull . TkString ("singlehost.relay.com"))
+                <> T (TkListLen 3 . TkWord 2 . (TkWord 42) . TkString ("multihost.relay.com"))
+                <> T (TkListLen 2) -- metadata present
+                <> S poolUrl -- metadata url
+                <> S poolMDHash -- metadata hash
+            ),
+      checkEncodingCBOR
+        "retire_pool"
+        (DCertPool (RetirePool (coerceKeyRole testKeyHash1) (EpochNo 1729)))
+        ( T
+            ( TkListLen 3
+                . TkWord 4 -- Pool Retire
+            )
+            <> S testKeyHash1 -- key hash
+            <> S (EpochNo 1729) -- epoch
+        ),
+      checkEncodingCBOR
+        "genesis_delegation"
+        (DCertGenesis (GenesisDelegCert testGKeyHash (coerceKeyRole testKeyHash1)))
+        ( T
+            ( TkListLen 3
+                . TkWord 5 -- genesis delegation cert
+            )
+            <> S testGKeyHash -- delegator credential
+            <> S testKeyHash1 -- delegatee key hash
+        ),
+      -- checkEncodingCBOR "mir"
+      let rws = Map.singleton testStakeCred 77
+       in checkEncodingCBOR
+            "mir"
+            (DCertMir (MIRCert rws))
+            ( T
+                ( TkListLen 2
+                    . TkWord 6 -- make instantaneous rewards cert
+                )
+                <> S rws
+            ),
+      checkEncodingCBOR
+        "pparams_update_key_deposit_only"
+        ( PParams
+            { _minfeeA = SNothing,
+              _minfeeB = SNothing,
+              _maxBBSize = SNothing,
+              _maxTxSize = SNothing,
+              _maxBHSize = SNothing,
+              _keyDeposit = SJust (Coin 5),
+              _keyMinRefund = SNothing,
+              _keyDecayRate = SNothing,
+              _poolDeposit = SNothing,
+              _poolMinRefund = SNothing,
+              _poolDecayRate = SNothing,
+              _eMax = SNothing,
+              _nOpt = SNothing,
+              _a0 = SNothing,
+              _rho = SNothing,
+              _tau = SNothing,
+              _d = SNothing,
+              _extraEntropy = SNothing,
+              _protocolVersion = SNothing
+            } ::
+            PParamsUpdate
+        )
+        ((T $ TkMapLen 1 . TkWord 5) <> S (Coin 5)),
+      -- checkEncodingCBOR "pparams_update_all"
+      let minfeea = 0
+          minfeeb = 1
+          maxbbsize = 2
+          maxtxsize = 3
+          maxbhsize = 4
+          keydeposit = Coin 5
+          keyminrefund = UnsafeUnitInterval $ 1 % 2
+          keydecayrate = 1 % 3
+          pooldeposit = Coin 6
+          poolminrefund = UnsafeUnitInterval $ 1 % 4
+          pooldecayrate = 1 % 5
+          emax = EpochNo 7
+          nopt = 8
+          a0 = 1 % 6
+          rho = UnsafeUnitInterval $ 1 % 6
+          tau = UnsafeUnitInterval $ 1 % 7
+          d = UnsafeUnitInterval $ 1 % 9
+          extraEntropy = NeutralNonce
+          protocolVersion = ProtVer 0 1
+       in checkEncodingCBOR
+            "pparams_update_all"
+            ( PParams
+                { _minfeeA = SJust minfeea,
+                  _minfeeB = SJust minfeeb,
+                  _maxBBSize = SJust maxbbsize,
+                  _maxTxSize = SJust maxtxsize,
+                  _maxBHSize = SJust maxbhsize,
+                  _keyDeposit = SJust keydeposit,
+                  _keyMinRefund = SJust keyminrefund,
+                  _keyDecayRate = SJust keydecayrate,
+                  _poolDeposit = SJust pooldeposit,
+                  _poolMinRefund = SJust poolminrefund,
+                  _poolDecayRate = SJust pooldecayrate,
+                  _eMax = SJust emax,
+                  _nOpt = SJust nopt,
+                  _a0 = SJust a0,
+                  _rho = SJust rho,
+                  _tau = SJust tau,
+                  _d = SJust d,
+                  _extraEntropy = SJust extraEntropy,
+                  _protocolVersion = SJust protocolVersion
+                } ::
+                PParamsUpdate
+            )
+            ( (T $ TkMapLen 19)
+                <> (T $ TkWord 0)
+                <> S minfeea
+                <> (T $ TkWord 1)
+                <> S minfeeb
+                <> (T $ TkWord 2)
+                <> S maxbbsize
+                <> (T $ TkWord 3)
+                <> S maxtxsize
+                <> (T $ TkWord 4)
+                <> S maxbhsize
+                <> (T $ TkWord 5)
+                <> S keydeposit
+                <> (T $ TkWord 6)
+                <> S keyminrefund
+                <> (T $ TkWord 7 . TkTag 30)
+                <> S keydecayrate
+                <> (T $ TkWord 8)
+                <> S pooldeposit
+                <> (T $ TkWord 9)
+                <> S poolminrefund
+                <> (T $ TkWord 10 . TkTag 30)
+                <> S pooldecayrate
+                <> (T $ TkWord 11)
+                <> S emax
+                <> (T $ TkWord 12)
+                <> S nopt
+                <> (T $ TkWord 13 . TkTag 30)
+                <> S a0
+                <> (T $ TkWord 14)
+                <> S rho
+                <> (T $ TkWord 15)
+                <> S tau
+                <> (T $ TkWord 16)
+                <> S d
+                <> (T $ TkWord 17)
+                <> S extraEntropy
+                <> (T $ TkWord 18)
+                <> S protocolVersion
+            ),
+      -- checkEncodingCBOR "full_update"
+      let ppup =
+            ProposedPPUpdates
+              ( Map.singleton
+                  testGKeyHash
+                  ( PParams
+                      { _minfeeA = SNothing,
+                        _minfeeB = SNothing,
+                        _maxBBSize = SNothing,
+                        _maxTxSize = SNothing,
+                        _maxBHSize = SNothing,
+                        _keyDeposit = SNothing,
+                        _keyMinRefund = SNothing,
+                        _keyDecayRate = SNothing,
+                        _poolDeposit = SNothing,
+                        _poolMinRefund = SNothing,
+                        _poolDecayRate = SNothing,
+                        _eMax = SNothing,
+                        _nOpt = SJust 100,
+                        _a0 = SNothing,
+                        _rho = SNothing,
+                        _tau = SNothing,
+                        _d = SNothing,
+                        _extraEntropy = SNothing,
+                        _protocolVersion = SNothing
+                      }
+                  )
+              )
+          e = EpochNo 0
+       in checkEncodingCBOR
+            "full_update"
+            (Update ppup e)
+            ( (T $ TkListLen 2)
+                <> S ppup
+                <> S e
+            ),
+      -- checkEncodingCBOR "minimal_txn_body"
+      let tin = [TxIn genesisId 1]
+          tout = TxOut testAddrE (Coin 2)
+       in checkEncodingCBORAnnotated
+            "txbody"
+            ( TxBody -- minimal transaction body
+                (Set.fromList tin)
+                (StrictSeq.singleton tout)
+                StrictSeq.empty
+                (Wdrl Map.empty)
+                (Coin 9)
+                (SlotNo 500)
+                SNothing
+                SNothing
+            )
+            ( T (TkMapLen 4)
+                <> T (TkWord 0) -- Tx Ins
+                <> S tin
+                <> T (TkWord 1) -- Tx Outs
+                <> T (TkListLen 1)
+                <> S tout
+                <> T (TkWord 2) -- Tx Fee
+                <> T (TkWord64 9)
+                <> T (TkWord 3) -- Tx TTL
+                <> T (TkWord64 500)
+            ),
+      -- checkEncodingCBOR "transaction_mixed"
+      let tin = [TxIn genesisId 1]
+          tout = TxOut testAddrE (Coin 2)
+          ra = RewardAcnt (KeyHashObj testKeyHash2)
+          ras = Map.singleton ra (Coin 123)
+          up =
+            Update
+              ( ProposedPPUpdates
+                  ( Map.singleton
+                      testGKeyHash
+                      ( PParams
+                          { _minfeeA = SNothing,
+                            _minfeeB = SNothing,
+                            _maxBBSize = SNothing,
+                            _maxTxSize = SNothing,
+                            _maxBHSize = SNothing,
+                            _keyDeposit = SNothing,
+                            _keyMinRefund = SNothing,
+                            _keyDecayRate = SNothing,
+                            _poolDeposit = SNothing,
+                            _poolMinRefund = SNothing,
+                            _poolDecayRate = SNothing,
+                            _eMax = SNothing,
+                            _nOpt = SJust 100,
+                            _a0 = SNothing,
+                            _rho = SNothing,
+                            _tau = SNothing,
+                            _d = SNothing,
+                            _extraEntropy = SNothing,
+                            _protocolVersion = SNothing
                           }
-            }
-      ps = Map.singleton (coerceKeyRole testKeyHash1) p
-      fs = Coin 123
-      ss = SnapShots mark set go fs
-      ls = emptyLedgerState
-      pps = emptyPParams
-      bs = Map.singleton (coerceKeyRole testKeyHash1) 1
-      nm = emptyNonMyopic
-      es = EpochState ac ss ls pps pps nm
-      ru = (SJust RewardUpdate
-             { deltaT        = Coin 100
-             , deltaR        = Coin (-200)
-             , rs            = Map.empty
-             , deltaF        = Coin (-10)
-             , nonMyopic     = nm
-             }) :: StrictMaybe RewardUpdate
-      pd = (PoolDistr Map.empty) :: PoolDistr
-      os = Map.singleton (SlotNo 1) (ActiveSlot testGKeyHash)
-      compactOs = Map.singleton (ActiveSlot testGKeyHash) (SlotNo 1 :| [])
-      nes = NewEpochState
+                      )
+                  )
+              )
+              (EpochNo 0)
+       in checkEncodingCBORAnnotated
+            "txbody_partial"
+            ( TxBody -- transaction body with some optional components
+                (Set.fromList tin)
+                (StrictSeq.singleton tout)
+                StrictSeq.Empty
+                (Wdrl ras)
+                (Coin 9)
+                (SlotNo 500)
+                (SJust up)
+                SNothing
+            )
+            ( T (TkMapLen 6)
+                <> T (TkWord 0) -- Tx Ins
+                <> S tin
+                <> T (TkWord 1) -- Tx Outs
+                <> T (TkListLen 1)
+                <> S tout
+                <> T (TkWord 2) -- Tx Fee
+                <> S (Coin 9)
+                <> T (TkWord 3) -- Tx TTL
+                <> S (SlotNo 500)
+                <> T (TkWord 5) -- Tx Reward Withdrawals
+                <> S ras
+                <> T (TkWord 6) -- Tx Update
+                <> S up
+            ),
+      -- checkEncodingCBOR "full_txn_body"
+      let tin = [TxIn genesisId 1]
+          tout = TxOut testAddrE (Coin 2)
+          reg = DCertDeleg (RegKey testStakeCred)
+          ra = RewardAcnt (KeyHashObj testKeyHash2)
+          ras = Map.singleton ra (Coin 123)
+          up =
+            Update
+              ( ProposedPPUpdates
+                  ( Map.singleton
+                      testGKeyHash
+                      ( PParams
+                          { _minfeeA = SNothing,
+                            _minfeeB = SNothing,
+                            _maxBBSize = SNothing,
+                            _maxTxSize = SNothing,
+                            _maxBHSize = SNothing,
+                            _keyDeposit = SNothing,
+                            _keyMinRefund = SNothing,
+                            _keyDecayRate = SNothing,
+                            _poolDeposit = SNothing,
+                            _poolMinRefund = SNothing,
+                            _poolDecayRate = SNothing,
+                            _eMax = SNothing,
+                            _nOpt = SJust 100,
+                            _a0 = SNothing,
+                            _rho = SNothing,
+                            _tau = SNothing,
+                            _d = SNothing,
+                            _extraEntropy = SNothing,
+                            _protocolVersion = SNothing
+                          }
+                      )
+                  )
+              )
+              (EpochNo 0)
+          mdh = MD.hashMetaData $ MD.MetaData $ Map.singleton 13 (MD.I 17)
+       in checkEncodingCBORAnnotated
+            "txbody_full"
+            ( TxBody -- transaction body with all components
+                (Set.fromList tin)
+                (StrictSeq.singleton tout)
+                (StrictSeq.fromList [reg])
+                (Wdrl ras)
+                (Coin 9)
+                (SlotNo 500)
+                (SJust up)
+                (SJust mdh)
+            )
+            ( T (TkMapLen 8)
+                <> T (TkWord 0) -- Tx Ins
+                <> S tin
+                <> T (TkWord 1) -- Tx Outs
+                <> T (TkListLen 1)
+                <> S tout
+                <> T (TkWord 2) -- Tx Fee
+                <> S (Coin 9)
+                <> T (TkWord 3) -- Tx TTL
+                <> S (SlotNo 500)
+                <> T (TkWord 4) -- Tx Certs
+                <> T (TkListLen 1) -- Seq list begin
+                <> S reg
+                <> T (TkWord 5) -- Tx Reward Withdrawals
+                <> S ras
+                <> T (TkWord 6) -- Tx Update
+                <> S up
+                <> T (TkWord 7) -- Tx Metadata
+                <> S mdh
+            ),
+      -- checkEncodingCBOR "minimal_txn"
+      let txb =
+            TxBody
+              (Set.fromList [TxIn genesisId 1])
+              (StrictSeq.singleton $ TxOut testAddrE (Coin 2))
+              StrictSeq.empty
+              (Wdrl Map.empty)
+              (Coin 9)
+              (SlotNo 500)
+              SNothing
+              SNothing
+          txbh = hashTxBody txb
+          w = makeWitnessVKey txbh testKey1
+       in checkEncodingCBORAnnotated
+            "tx_min"
+            (Tx txb (Set.singleton w) Map.empty SNothing)
+            ( T (TkListLen 3)
+                <> S txb
+                <> T (TkMapLen 1)
+                <> T (TkWord 0)
+                <> T (TkListLen 1)
+                <> S w
+                <> T TkNull
+            ),
+      -- checkEncodingCBOR "full_txn"
+      let txb =
+            TxBody
+              (Set.fromList [TxIn genesisId 1])
+              (StrictSeq.singleton $ TxOut testAddrE (Coin 2))
+              StrictSeq.empty
+              (Wdrl Map.empty)
+              (Coin 9)
+              (SlotNo 500)
+              SNothing
+              SNothing
+          txbh = hashTxBody txb
+          w = makeWitnessVKey txbh testKey1
+          s = Map.singleton (hashScript testScript) testScript
+          md = MD.MetaData $ Map.singleton 17 (MD.I 42)
+       in checkEncodingCBORAnnotated
+            "tx_full"
+            (Tx txb (Set.singleton w) s (SJust md))
+            ( T (TkListLen 3)
+                <> S txb
+                <> T (TkMapLen 2)
+                <> T (TkWord 0)
+                <> T (TkListLen 1)
+                <> S w
+                <> T (TkWord 1)
+                <> T (TkListLen 1)
+                <> S testScript
+                <> S md
+            ),
+      -- checkEncodingCBOR "block_header_body"
+      let prevhash = BlockHash testHeaderHash
+          vrfVkey = snd testVRF
+          slot = SlotNo 33
+          nonce = mkSeed seedEta (SlotNo 33) (mkNonce 0)
+          nonceProof = coerce $ mkCertifiedVRF (WithResult nonce 1) (fst testVRF)
+          leaderValue = mkSeed seedL (SlotNo 33) (mkNonce 0)
+          leaderProof = coerce $ mkCertifiedVRF (WithResult leaderValue 1) (fst testVRF)
+          size = 0
+          blockNo = BlockNo 44
+          bbhash = bbHash $ TxSeq StrictSeq.empty
+          ocert =
+            OCert
+              (snd testKESKeys)
+              0
+              (KESPeriod 0)
+              (signedDSIGN @ConcreteCrypto (sKey testKey1) (snd testKESKeys, 0, KESPeriod 0))
+          protover = ProtVer 0 0
+       in checkEncodingCBOR
+            "block_header_body"
+            ( BHBody
+                { bheaderBlockNo = blockNo,
+                  bheaderSlotNo = slot,
+                  bheaderPrev = prevhash,
+                  bheaderVk = vKey testBlockIssuerKey,
+                  bheaderVrfVk = vrfVkey,
+                  bheaderEta = nonceProof,
+                  bheaderL = leaderProof,
+                  bsize = size,
+                  bhash = bbhash,
+                  bheaderOCert = ocert,
+                  bprotver = protover
+                }
+            )
+            ( T (TkListLen $ 9 + 4 + 2)
+                <> S blockNo
+                <> S slot
+                <> S prevhash
+                <> T testBlockIssuerKeyTokens
+                <> S vrfVkey
+                <> S nonceProof
+                <> S leaderProof
+                <> S size
+                <> S bbhash
+                <> G ocert -- 5
+                <> G protover -- 3
+            ),
+      -- checkEncodingCBOR "operational_cert"
+      let vkHot = snd testKESKeys
+          counter = 0
+          kesperiod = KESPeriod 0
+          signature = signedDSIGN @ConcreteCrypto (sKey testKey1) (snd testKESKeys, 0, KESPeriod 0)
+       in checkEncodingCBORCBORGroup
+            "operational_cert"
+            (OCert @ConcreteCrypto vkHot counter kesperiod signature)
+            ( S vkHot
+                <> S counter
+                <> S kesperiod
+                <> T testOpCertSigTokens
+            ),
+      -- checkEncodingCBOR "block_header"
+      let sig = Maybe.fromJust $ signedKES () 0 testBHB (fst testKESKeys)
+       in checkEncodingCBORAnnotated
+            "block_header"
+            (BHeader testBHB sig)
+            ( (T $ TkListLen 2)
+                <> S testBHB
+                <> T testBHBSigTokens
+            ),
+      -- checkEncodingCBOR "empty_block"
+      let sig = Maybe.fromJust $ signedKES () 0 testBHB (fst testKESKeys)
+          bh = BHeader testBHB sig
+          txns = TxSeq StrictSeq.Empty
+       in checkEncodingCBORAnnotated
+            "empty_block"
+            (Block bh txns)
+            ( (T $ TkListLen 4)
+                <> S bh
+                <> T (TkListLen 0 . TkListLen 0 . TkMapLen 0)
+            ),
+      -- checkEncodingCBOR "rich_block"
+      let sig = Maybe.fromJust $ signedKES () 0 testBHB (fst testKESKeys)
+          bh = BHeader testBHB sig
+          tin = Set.fromList [TxIn genesisId 1]
+          tout = StrictSeq.singleton $ TxOut testAddrE (Coin 2)
+          txb s = TxBody tin tout StrictSeq.empty (Wdrl Map.empty) (Coin 9) (SlotNo s) SNothing SNothing
+          txb1 = txb 500
+          txb2 = txb 501
+          txb3 = txb 502
+          txb4 = txb 503
+          txb5 = txb 504
+          w1 = makeWitnessVKey (hashTxBody txb1) testKey1
+          w2 = makeWitnessVKey (hashTxBody txb1) testKey2
+          ws = Set.fromList [w1, w2]
+          tx1 = Tx txb1 (Set.singleton w1) mempty SNothing
+          tx2 = Tx txb2 ws mempty SNothing
+          tx3 = Tx txb3 mempty (Map.singleton (hashScript testScript) testScript) SNothing
+          ss =
+            Map.fromList
+              [ (hashScript testScript, testScript),
+                (hashScript testScript2, testScript2)
+              ]
+          tx4 = Tx txb4 mempty ss SNothing
+          tx5MD = MD.MetaData $ Map.singleton 17 (MD.I 42)
+          tx5 = Tx txb5 ws ss (SJust tx5MD)
+          txns = TxSeq $ StrictSeq.fromList [tx1, tx2, tx3, tx4, tx5]
+       in checkEncodingCBORAnnotated
+            "rich_block"
+            (Block bh txns)
+            ( (T $ TkListLen 4)
+                -- header
+                <> S bh
+                -- bodies
+                <> T (TkListLen 5)
+                <> S txb1
+                <> S txb2
+                <> S txb3
+                <> S txb4
+                <> S txb5
+                -- witnesses
+                <> T (TkListLen 5)
+                -- tx 1, one key
+                <> T (TkMapLen 1 . TkWord 0)
+                <> T (TkListLen 1)
+                <> S w1
+                -- tx 2, two keys
+                <> T (TkMapLen 1 . TkWord 0)
+                <> T (TkListLen 2)
+                <> S w1
+                <> S w2
+                -- tx 3, one script
+                <> T (TkMapLen 1 . TkWord 1)
+                <> T (TkListLen 1)
+                <> S testScript
+                -- tx 4, two scripts
+                <> T (TkMapLen 1 . TkWord 1)
+                <> T (TkListLen 2)
+                <> S testScript
+                <> S testScript2
+                -- tx 5, two keys and two scripts
+                <> T (TkMapLen 2)
+                <> T (TkWord 0)
+                <> T (TkListLen 2)
+                <> S w1
+                <> S w2
+                <> T (TkWord 1)
+                <> T (TkListLen 2)
+                <> S testScript
+                <> S testScript2
+                -- metadata
+                <> T (TkMapLen 1)
+                <> T (TkInt 4)
+                <> S tx5MD
+            ),
+      checkEncodingCBOR
+        "epoch"
+        (EpochNo 13)
+        (T (TkWord64 13)),
+      let n = (17 :: Natural)
+          bs = Map.singleton (coerceKeyRole testKeyHash1) n
+       in checkEncodingCBOR
+            "blocks_made"
+            (BlocksMade bs)
+            ( T (TkMapLen 1)
+                <> S testKeyHash1
+                <> S n
+            ),
+      checkEncodingCBOR
+        "account_state"
+        (AccountState (Coin 1) (Coin 2))
+        ( T (TkListLen 2)
+            <> S (Coin 1)
+            <> S (Coin 2)
+        ),
+      let stk = Map.singleton testStakeCred (Coin 13)
+       in checkEncodingCBOR
+            "stake"
+            (Stake stk)
+            ( T (TkMapLen 1)
+                <> S testStakeCred
+                <> S (Coin 13)
+            ),
+      let mark =
+            SnapShot
+              (Stake $ Map.singleton testStakeCred (Coin 11))
+              (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
+              ps
+          set =
+            SnapShot
+              (Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22))
+              (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
+              ps
+          go =
+            SnapShot
+              (Stake $ Map.singleton testStakeCred (Coin 33))
+              (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
+              ps
+          p =
+            PoolParams
+              { _poolPubKey = coerceKeyRole testKeyHash1,
+                _poolVrf = testVRFKH,
+                _poolPledge = Coin 5,
+                _poolCost = Coin 4,
+                _poolMargin = unsafeMkUnitInterval 0.7,
+                _poolRAcnt = RewardAcnt testStakeCred,
+                _poolOwners = Set.singleton testKeyHash2,
+                _poolRelays = StrictSeq.empty,
+                _poolMD =
+                  SJust $
+                    PoolMetaData
+                      { _poolMDUrl = Maybe.fromJust $ textToUrl "web.site",
+                        _poolMDHash = BS.pack "{}"
+                      }
+              }
+          ps = Map.singleton (coerceKeyRole testKeyHash1) p
+          fs = Coin 123
+       in checkEncodingCBOR
+            "snapshots"
+            (SnapShots mark set go fs)
+            ( T (TkListLen 4)
+                <> S mark
+                <> S set
+                <> S go
+                <> S fs
+            ),
+      let e = EpochNo 0
+          ac = AccountState (Coin 100) (Coin 100)
+          mark =
+            SnapShot
+              (Stake $ Map.singleton testStakeCred (Coin 11))
+              (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
+              ps
+          set =
+            SnapShot
+              (Stake $ Map.singleton (KeyHashObj testKeyHash2) (Coin 22))
+              (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
+              ps
+          go =
+            SnapShot
+              (Stake $ Map.singleton testStakeCred (Coin 33))
+              (Map.singleton testStakeCred (coerceKeyRole testKeyHash3))
+              ps
+          p =
+            PoolParams
+              { _poolPubKey = coerceKeyRole testKeyHash1,
+                _poolVrf = testVRFKH,
+                _poolPledge = Coin 5,
+                _poolCost = Coin 4,
+                _poolMargin = unsafeMkUnitInterval 0.7,
+                _poolRAcnt = RewardAcnt testStakeCred,
+                _poolOwners = Set.singleton testKeyHash2,
+                _poolRelays = StrictSeq.empty,
+                _poolMD =
+                  SJust $
+                    PoolMetaData
+                      { _poolMDUrl = Maybe.fromJust $ textToUrl "web.site",
+                        _poolMDHash = BS.pack "{}"
+                      }
+              }
+          ps = Map.singleton (coerceKeyRole testKeyHash1) p
+          fs = Coin 123
+          ss = SnapShots mark set go fs
+          ls = emptyLedgerState
+          pps = emptyPParams
+          bs = Map.singleton (coerceKeyRole testKeyHash1) 1
+          nm = emptyNonMyopic
+          es = EpochState ac ss ls pps pps nm
+          ru =
+            ( SJust
+                RewardUpdate
+                  { deltaT = Coin 100,
+                    deltaR = Coin (-200),
+                    rs = Map.empty,
+                    deltaF = Coin (-10),
+                    nonMyopic = nm
+                  }
+            ) ::
+              StrictMaybe RewardUpdate
+          pd = (PoolDistr Map.empty) :: PoolDistr
+          os = Map.singleton (SlotNo 1) (ActiveSlot testGKeyHash)
+          compactOs = Map.singleton (ActiveSlot testGKeyHash) (SlotNo 1 :| [])
+          nes =
+            NewEpochState
               e
               (BlocksMade bs)
               (BlocksMade bs)
@@ -1123,16 +1368,16 @@ serializationTests = testGroup "Serialization Tests"
               ru
               pd
               os
-    in
-    checkEncodingCBOR "new_epoch_state"
-    nes
-    ( T (TkListLen 7)
-      <> S e
-      <> S (BlocksMade bs)
-      <> S (BlocksMade bs)
-      <> S es
-      <> S ru
-      <> S pd
-      <> S compactOs
-    )
- ]
+       in checkEncodingCBOR
+            "new_epoch_state"
+            nes
+            ( T (TkListLen 7)
+                <> S e
+                <> S (BlocksMade bs)
+                <> S (BlocksMade bs)
+                <> S es
+                <> S ru
+                <> S pd
+                <> S compactOs
+            )
+    ]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/UnitTests.hs
@@ -4,50 +4,89 @@
 
 module Test.Shelley.Spec.Ledger.Examples.UnitTests (unitTests) where
 
-import           Control.Monad (foldM)
-import           Data.Map.Strict (Map)
+import Control.Monad (foldM)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe)
-import           Data.Ratio ((%))
-import           Data.Sequence.Strict (StrictSeq (..))
+import Data.Maybe (fromMaybe)
+import Data.Ratio ((%))
+import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-
-import           Test.Tasty
-import           Test.Tasty.HUnit
-import           Test.Tasty.QuickCheck
-
-import           Shelley.Spec.Ledger.Address
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.BlockChain (checkVRFValue)
-import           Shelley.Spec.Ledger.Coin
-import           Shelley.Spec.Ledger.Delegation.Certificates (pattern Delegate, pattern RegKey,
-                     pattern RegPool, pattern RetirePool, StakeCreds (..), StakePools (..))
-import           Shelley.Spec.Ledger.TxData (pattern Addr, Credential (..), pattern DCertDeleg,
-                     pattern DCertPool, Delegation (..), pattern PoolParams, pattern Ptr,
-                     pattern RewardAcnt, pattern StakeRefBase, Wdrl (..), _poolCost, _poolMD,
-                     _poolMargin, _poolOwners, _poolPledge, _poolPubKey, _poolRAcnt, _poolRelays,
-                     _poolVrf)
-import           Shelley.Spec.Ledger.Validation (ValidationError (..))
-
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), asWitness, coerceKeyRole, hashKey, vKey)
-import           Shelley.Spec.Ledger.LedgerState (pattern LedgerState, pattern UTxOState,
-                     emptyDelegation, genesisCoins, genesisId, genesisState, minfee,
-                     overlaySchedule, _delegationState, _delegations, _dstate, _pParams, _pstate,
-                     _ptrs, _retiring, _rewards, _stPools, _stkCreds)
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.Tx (pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut,
-                     _body, _ttl)
-import           Shelley.Spec.Ledger.UTxO (hashTxBody, pattern UTxO, makeWitnessVKey, makeWitnessesVKey, txid)
-
+import Shelley.Spec.Ledger.Address
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.BlockChain (checkVRFValue)
+import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( StakeCreds (..),
+    StakePools (..),
+    pattern Delegate,
+    pattern RegKey,
+    pattern RegPool,
+    pattern RetirePool,
+  )
+import Shelley.Spec.Ledger.Keys (KeyRole (..), asWitness, coerceKeyRole, hashKey, vKey)
+import Shelley.Spec.Ledger.LedgerState
+  ( _delegationState,
+    _delegations,
+    _dstate,
+    _pParams,
+    _pstate,
+    _ptrs,
+    _retiring,
+    _rewards,
+    _stPools,
+    _stkCreds,
+    emptyDelegation,
+    genesisCoins,
+    genesisId,
+    genesisState,
+    minfee,
+    overlaySchedule,
+    pattern LedgerState,
+    pattern UTxOState,
+  )
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.Tx
+  ( _body,
+    _ttl,
+    pattern Tx,
+    pattern TxBody,
+    pattern TxIn,
+    pattern TxOut,
+  )
+import Shelley.Spec.Ledger.TxData
+  ( Credential (..),
+    Delegation (..),
+    Wdrl (..),
+    _poolCost,
+    _poolMD,
+    _poolMargin,
+    _poolOwners,
+    _poolPledge,
+    _poolPubKey,
+    _poolRAcnt,
+    _poolRelays,
+    _poolVrf,
+    pattern Addr,
+    pattern DCertDeleg,
+    pattern DCertPool,
+    pattern PoolParams,
+    pattern Ptr,
+    pattern RewardAcnt,
+    pattern StakeRefBase,
+  )
+import Shelley.Spec.Ledger.UTxO (hashTxBody, makeWitnessVKey, makeWitnessesVKey, txid, pattern UTxO)
+import Shelley.Spec.Ledger.Validation (ValidationError (..))
 import qualified Test.Cardano.Crypto.VRF.Fake as FakeVRF
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
-import           Test.Shelley.Spec.Ledger.Examples.Fees (sizeTests)
-import           Test.Shelley.Spec.Ledger.Generator.Core (unitIntervalToNatural)
-import           Test.Shelley.Spec.Ledger.PreSTSGenerator (asStateTransition)
-import           Test.Shelley.Spec.Ledger.Utils
-
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+import Test.Shelley.Spec.Ledger.Examples.Fees (sizeTests)
+import Test.Shelley.Spec.Ledger.Generator.Core (unitIntervalToNatural)
+import Test.Shelley.Spec.Ledger.PreSTSGenerator (asStateTransition)
+import Test.Shelley.Spec.Ledger.Utils
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.QuickCheck
 
 alicePay :: KeyPair 'Payment
 alicePay = KeyPair 1 1
@@ -56,9 +95,10 @@ aliceStake :: KeyPair 'Staking
 aliceStake = KeyPair 2 2
 
 aliceAddr :: Addr
-aliceAddr = Addr
-             (KeyHashObj . hashKey $ vKey alicePay)
-             (StakeRefBase . KeyHashObj . hashKey $ vKey aliceStake)
+aliceAddr =
+  Addr
+    (KeyHashObj . hashKey $ vKey alicePay)
+    (StakeRefBase . KeyHashObj . hashKey $ vKey aliceStake)
 
 bobPay :: KeyPair 'Payment
 bobPay = KeyPair 3 3
@@ -67,18 +107,21 @@ bobStake :: KeyPair 'Staking
 bobStake = KeyPair 4 4
 
 bobAddr :: Addr
-bobAddr = Addr
-           (KeyHashObj . hashKey $ vKey bobPay)
-           (StakeRefBase . KeyHashObj . hashKey $ vKey bobStake)
+bobAddr =
+  Addr
+    (KeyHashObj . hashKey $ vKey bobPay)
+    (StakeRefBase . KeyHashObj . hashKey $ vKey bobStake)
 
 testPCs :: PParams
-testPCs = emptyPParams {
-    _minfeeA = 1
-  , _minfeeB = 1
-  , _keyDeposit = 100
-  , _poolDeposit = 250
-  , _maxTxSize = 1024
-  , _eMax = EpochNo 10 }
+testPCs =
+  emptyPParams
+    { _minfeeA = 1,
+      _minfeeB = 1,
+      _keyDeposit = 100,
+      _poolDeposit = 250,
+      _maxTxSize = 1024,
+      _eMax = EpochNo 10
+    }
 
 aliceInitCoin :: Coin
 aliceInitCoin = Coin 10000
@@ -87,9 +130,11 @@ bobInitCoin :: Coin
 bobInitCoin = Coin 1000
 
 genesis :: LedgerState
-genesis = (genesisState Map.empty . genesisCoins)
-            [ TxOut aliceAddr aliceInitCoin
-            , TxOut bobAddr bobInitCoin ]
+genesis =
+  (genesisState Map.empty . genesisCoins)
+    [ TxOut aliceAddr aliceInitCoin,
+      TxOut bobAddr bobInitCoin
+    ]
 
 changeReward :: LedgerState -> RewardAcnt -> Coin -> LedgerState
 changeReward ls acnt c = ls {_delegationState = delSt {_dstate = dstate' {_rewards = newAccounts}}}
@@ -104,77 +149,85 @@ stakePoolKey1 = KeyPair 5 5
 stakePoolVRFKey1 :: VerKeyVRF
 stakePoolVRFKey1 = FakeVRF.VerKeyFakeVRF 15
 
-
 ledgerState :: [Tx] -> Either [ValidationError] LedgerState
 ledgerState = foldM (\l t -> asStateTransition (SlotNo 0) testPCs l t (Coin 0)) genesis
 
 testLedgerValidTransactions ::
   Either [ValidationError] LedgerState -> UTxOState -> Assertion
 testLedgerValidTransactions ls utxoState' =
-    ls @?= Right (LedgerState
-                     utxoState'
-                     emptyDelegation
-                     )
+  ls
+    @?= Right
+      ( LedgerState
+          utxoState'
+          emptyDelegation
+      )
 
 testValidStakeKeyRegistration ::
   Tx -> UTxOState -> DPState -> Assertion
 testValidStakeKeyRegistration tx utxoState' stakeKeyRegistration =
-  let
-    ls2 = ledgerState [tx]
-  in ls2 @?= Right (LedgerState
-                     utxoState'
-                     stakeKeyRegistration
-                     )
+  let ls2 = ledgerState [tx]
+   in ls2
+        @?= Right
+          ( LedgerState
+              utxoState'
+              stakeKeyRegistration
+          )
 
 testValidDelegation ::
   [Tx] -> UTxOState -> DPState -> PoolParams -> Assertion
 testValidDelegation txs utxoState' stakeKeyRegistration pool =
-  let
-    ls2 = ledgerState txs
-    poolhk = hashKey $ vKey stakePoolKey1
-    dstate' = _dstate stakeKeyRegistration
-    pstate' = _pstate stakeKeyRegistration
-  in ls2 @?= Right
-         (LedgerState
-          utxoState'
-          (stakeKeyRegistration
-            { _dstate = dstate'
-              { _delegations = Map.fromList
-                [ ( KeyHashObj $ coerceKeyRole . hashKey $ vKey aliceStake
-                  , coerceKeyRole poolhk)
-                ]
-              }
-            , _pstate = pstate'
-               { _stPools = (StakePools $ Map.fromList [(coerceKeyRole poolhk, SlotNo 0)])
-               , _pParams = Map.fromList [(coerceKeyRole poolhk, pool)]
-               }
-            }
+  let ls2 = ledgerState txs
+      poolhk = hashKey $ vKey stakePoolKey1
+      dstate' = _dstate stakeKeyRegistration
+      pstate' = _pstate stakeKeyRegistration
+   in ls2
+        @?= Right
+          ( LedgerState
+              utxoState'
+              ( stakeKeyRegistration
+                  { _dstate =
+                      dstate'
+                        { _delegations =
+                            Map.fromList
+                              [ ( KeyHashObj $ coerceKeyRole . hashKey $ vKey aliceStake,
+                                  coerceKeyRole poolhk
+                                )
+                              ]
+                        },
+                    _pstate =
+                      pstate'
+                        { _stPools = (StakePools $ Map.fromList [(coerceKeyRole poolhk, SlotNo 0)]),
+                          _pParams = Map.fromList [(coerceKeyRole poolhk, pool)]
+                        }
+                  }
+              )
           )
-         )
 
 testValidRetirement ::
   [Tx] -> UTxOState -> DPState -> EpochNo -> PoolParams -> Assertion
 testValidRetirement txs utxoState' stakeKeyRegistration e pool =
-  let
-    ls2 = ledgerState txs
-    poolhk = hashKey $ vKey stakePoolKey1
-    dstate' = _dstate stakeKeyRegistration
-    pstate' = _pstate stakeKeyRegistration
-  in ls2 @?= Right
-         (LedgerState
-          utxoState'
-          (stakeKeyRegistration
-            {
-              _dstate = dstate'
-                { _delegations = Map.fromList [(KeyHashObj $ coerceKeyRole . hashKey $ vKey aliceStake, coerceKeyRole poolhk)] }
-            , _pstate = pstate'
-                { _stPools  = StakePools $ Map.fromList [(coerceKeyRole poolhk, SlotNo 0)]
-                , _pParams  = Map.fromList [(coerceKeyRole poolhk, pool)]
-                , _retiring = Map.fromList [(coerceKeyRole poolhk, e)]
-                }
-            }
+  let ls2 = ledgerState txs
+      poolhk = hashKey $ vKey stakePoolKey1
+      dstate' = _dstate stakeKeyRegistration
+      pstate' = _pstate stakeKeyRegistration
+   in ls2
+        @?= Right
+          ( LedgerState
+              utxoState'
+              ( stakeKeyRegistration
+                  { _dstate =
+                      dstate'
+                        { _delegations = Map.fromList [(KeyHashObj $ coerceKeyRole . hashKey $ vKey aliceStake, coerceKeyRole poolhk)]
+                        },
+                    _pstate =
+                      pstate'
+                        { _stPools = StakePools $ Map.fromList [(coerceKeyRole poolhk, SlotNo 0)],
+                          _pParams = Map.fromList [(coerceKeyRole poolhk, pool)],
+                          _retiring = Map.fromList [(coerceKeyRole poolhk, e)]
+                        }
+                  }
+              )
           )
-         )
 
 bobWithdrawal :: Map RewardAcnt Coin
 bobWithdrawal = Map.singleton (mkVKeyRwdAcnt bobStake) (Coin 10)
@@ -184,331 +237,425 @@ genesisWithReward = changeReward genesis (mkVKeyRwdAcnt bobStake) (Coin 10)
 
 testValidWithdrawal :: Assertion
 testValidWithdrawal =
-  let
-    tx = TxBody
-           (Set.fromList [TxIn genesisId 0])
-           (StrictSeq.fromList [ TxOut aliceAddr (Coin 6000)
-                               , TxOut bobAddr (Coin 3010) ])
-           Empty
-           (Wdrl bobWithdrawal)
-           (Coin 1000)
-           (SlotNo 0)
-           SNothing
-           SNothing
-    wits = makeWitnessesVKey (hashTxBody tx) [asWitness alicePay, asWitness bobStake]
-    utxo' = Map.fromList
-       [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
-       , (TxIn (txid tx) 0, TxOut aliceAddr (Coin 6000))
-       , (TxIn (txid tx) 1, TxOut bobAddr (Coin 3010)) ]
-    ls = asStateTransition
-           (SlotNo 0) testPCs genesisWithReward (Tx tx wits Map.empty SNothing) (Coin 0)
-    dstate' = _dstate emptyDelegation
-    expectedDS = emptyDelegation
-      { _dstate = dstate' {_rewards = Map.singleton (mkVKeyRwdAcnt bobStake) (Coin 0)}}
-
-  in ls @?= Right (LedgerState
-                     (UTxOState (UTxO utxo') (Coin 0) (Coin 1000) emptyPPPUpdates)
-                     expectedDS
-                     )
+  let tx =
+        TxBody
+          (Set.fromList [TxIn genesisId 0])
+          ( StrictSeq.fromList
+              [ TxOut aliceAddr (Coin 6000),
+                TxOut bobAddr (Coin 3010)
+              ]
+          )
+          Empty
+          (Wdrl bobWithdrawal)
+          (Coin 1000)
+          (SlotNo 0)
+          SNothing
+          SNothing
+      wits = makeWitnessesVKey (hashTxBody tx) [asWitness alicePay, asWitness bobStake]
+      utxo' =
+        Map.fromList
+          [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000)),
+            (TxIn (txid tx) 0, TxOut aliceAddr (Coin 6000)),
+            (TxIn (txid tx) 1, TxOut bobAddr (Coin 3010))
+          ]
+      ls =
+        asStateTransition
+          (SlotNo 0)
+          testPCs
+          genesisWithReward
+          (Tx tx wits Map.empty SNothing)
+          (Coin 0)
+      dstate' = _dstate emptyDelegation
+      expectedDS =
+        emptyDelegation
+          { _dstate = dstate' {_rewards = Map.singleton (mkVKeyRwdAcnt bobStake) (Coin 0)}
+          }
+   in ls
+        @?= Right
+          ( LedgerState
+              (UTxOState (UTxO utxo') (Coin 0) (Coin 1000) emptyPPPUpdates)
+              expectedDS
+          )
 
 testInvalidWintess :: Assertion
 testInvalidWintess =
-  let
-    tx = TxBody
-           (Set.fromList [TxIn genesisId 0])
-           (StrictSeq.fromList
-              [ TxOut aliceAddr (Coin 6000)
-              , TxOut bobAddr (Coin 3000) ])
-           Empty
-           (Wdrl Map.empty)
-           (Coin 1000)
-           (SlotNo 1)
-           SNothing
-           SNothing
-    tx' = tx { _ttl = SlotNo  2}
-    wits = makeWitnessesVKey (hashTxBody tx') [alicePay]
-  in ledgerState [Tx tx wits Map.empty SNothing] @?= Left [InvalidWitness]
+  let tx =
+        TxBody
+          (Set.fromList [TxIn genesisId 0])
+          ( StrictSeq.fromList
+              [ TxOut aliceAddr (Coin 6000),
+                TxOut bobAddr (Coin 3000)
+              ]
+          )
+          Empty
+          (Wdrl Map.empty)
+          (Coin 1000)
+          (SlotNo 1)
+          SNothing
+          SNothing
+      tx' = tx {_ttl = SlotNo 2}
+      wits = makeWitnessesVKey (hashTxBody tx') [alicePay]
+   in ledgerState [Tx tx wits Map.empty SNothing] @?= Left [InvalidWitness]
 
 testWithdrawalNoWit :: Assertion
 testWithdrawalNoWit =
-  let
-    tx = TxBody
-           (Set.fromList [TxIn genesisId 0])
-           (StrictSeq.fromList
-             [ TxOut aliceAddr (Coin 6000)
-             , TxOut bobAddr (Coin 3010) ])
-           Empty
-           (Wdrl bobWithdrawal)
-           (Coin 1000)
-           (SlotNo 0)
-           SNothing
-           SNothing
-    wits = Set.singleton $ makeWitnessVKey (hashTxBody tx) alicePay
-    ls = asStateTransition
-      (SlotNo 0) testPCs genesisWithReward (Tx tx wits Map.empty SNothing) (Coin 0)
-  in ls @?= Left [MissingWitnesses]
+  let tx =
+        TxBody
+          (Set.fromList [TxIn genesisId 0])
+          ( StrictSeq.fromList
+              [ TxOut aliceAddr (Coin 6000),
+                TxOut bobAddr (Coin 3010)
+              ]
+          )
+          Empty
+          (Wdrl bobWithdrawal)
+          (Coin 1000)
+          (SlotNo 0)
+          SNothing
+          SNothing
+      wits = Set.singleton $ makeWitnessVKey (hashTxBody tx) alicePay
+      ls =
+        asStateTransition
+          (SlotNo 0)
+          testPCs
+          genesisWithReward
+          (Tx tx wits Map.empty SNothing)
+          (Coin 0)
+   in ls @?= Left [MissingWitnesses]
 
 testWithdrawalWrongAmt :: Assertion
 testWithdrawalWrongAmt =
-  let
-    tx = TxBody
-           (Set.fromList [TxIn genesisId 0])
-           (StrictSeq.fromList
-             [ TxOut aliceAddr (Coin 6000)
-             , TxOut bobAddr (Coin 3011) ])
-           Empty
-           (Wdrl $ Map.singleton (mkVKeyRwdAcnt bobStake) (Coin 11))
-           (Coin 1000)
-           (SlotNo 0)
-           SNothing
-           SNothing
-    wits = makeWitnessesVKey (hashTxBody tx) [asWitness alicePay, asWitness bobStake]
-    ls =asStateTransition
-          (SlotNo 0) testPCs genesisWithReward (Tx tx wits Map.empty SNothing) (Coin 0)
-  in ls @?= Left [IncorrectRewards]
+  let tx =
+        TxBody
+          (Set.fromList [TxIn genesisId 0])
+          ( StrictSeq.fromList
+              [ TxOut aliceAddr (Coin 6000),
+                TxOut bobAddr (Coin 3011)
+              ]
+          )
+          Empty
+          (Wdrl $ Map.singleton (mkVKeyRwdAcnt bobStake) (Coin 11))
+          (Coin 1000)
+          (SlotNo 0)
+          SNothing
+          SNothing
+      wits = makeWitnessesVKey (hashTxBody tx) [asWitness alicePay, asWitness bobStake]
+      ls =
+        asStateTransition
+          (SlotNo 0)
+          testPCs
+          genesisWithReward
+          (Tx tx wits Map.empty SNothing)
+          (Coin 0)
+   in ls @?= Left [IncorrectRewards]
 
-aliceGivesBobLovelace :: TxIn -> Coin -> Coin -> Coin -> Coin ->
-  [DCert] -> SlotNo -> [KeyPair 'Witness] -> Tx
+aliceGivesBobLovelace ::
+  TxIn ->
+  Coin ->
+  Coin ->
+  Coin ->
+  Coin ->
+  [DCert] ->
+  SlotNo ->
+  [KeyPair 'Witness] ->
+  Tx
 aliceGivesBobLovelace txin coin fee txdeps txrefs cs s signers = Tx txbody wits Map.empty SNothing
   where
     aliceCoin = aliceInitCoin + txrefs - (coin + fee + txdeps)
-    txbody = TxBody
-               (Set.fromList [txin])
-               (StrictSeq.fromList
-                 [ TxOut aliceAddr aliceCoin
-                 , TxOut bobAddr coin ])
-               (StrictSeq.fromList cs)
-               (Wdrl Map.empty)
-               fee
-               s
-               SNothing
-               SNothing
+    txbody =
+      TxBody
+        (Set.fromList [txin])
+        ( StrictSeq.fromList
+            [ TxOut aliceAddr aliceCoin,
+              TxOut bobAddr coin
+            ]
+        )
+        (StrictSeq.fromList cs)
+        (Wdrl Map.empty)
+        fee
+        s
+        SNothing
+        SNothing
     wits = makeWitnessesVKey (hashTxBody txbody) signers
 
 tx1 :: Tx
-tx1 = aliceGivesBobLovelace
-        (TxIn genesisId 0)
-        (Coin 3000) (Coin 600) (Coin 0) (Coin 0)
-        []
-        (SlotNo 0)
-        [asWitness alicePay]
-
+tx1 =
+  aliceGivesBobLovelace
+    (TxIn genesisId 0)
+    (Coin 3000)
+    (Coin 600)
+    (Coin 0)
+    (Coin 0)
+    []
+    (SlotNo 0)
+    [asWitness alicePay]
 
 utxoSt1 :: UTxOState
-utxoSt1 = UTxOState
-            (UTxO $ Map.fromList
-               [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
-               , (TxIn (txid $ _body tx1) 0, TxOut aliceAddr (Coin 6400))
-               , (TxIn (txid $ _body tx1) 1, TxOut bobAddr (Coin 3000)) ])
-            (Coin 0)
-            (Coin 600)
-            emptyPPPUpdates
+utxoSt1 =
+  UTxOState
+    ( UTxO $
+        Map.fromList
+          [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000)),
+            (TxIn (txid $ _body tx1) 0, TxOut aliceAddr (Coin 6400)),
+            (TxIn (txid $ _body tx1) 1, TxOut bobAddr (Coin 3000))
+          ]
+    )
+    (Coin 0)
+    (Coin 600)
+    emptyPPPUpdates
 
 ls1 :: Either [ValidationError] LedgerState
 ls1 = ledgerState [tx1]
 
 tx2 :: Tx
-tx2 = aliceGivesBobLovelace
-        (TxIn genesisId 0)
-        (Coin 3000) (Coin 1300) (Coin 3*100) (Coin 0)
-        [ DCertDeleg (RegKey $ (KeyHashObj . hashKey) $ vKey aliceStake)
-        , DCertDeleg (RegKey $ (KeyHashObj . hashKey) $ vKey bobStake)
-        , DCertDeleg (RegKey $ (KeyHashObj . hashKey) $ vKey stakePoolKey1)]
-        (SlotNo 100)
-        [ asWitness alicePay, asWitness aliceStake
-        , asWitness bobStake, asWitness stakePoolKey1]
-
+tx2 =
+  aliceGivesBobLovelace
+    (TxIn genesisId 0)
+    (Coin 3000)
+    (Coin 1300)
+    (Coin 3 * 100)
+    (Coin 0)
+    [ DCertDeleg (RegKey $ (KeyHashObj . hashKey) $ vKey aliceStake),
+      DCertDeleg (RegKey $ (KeyHashObj . hashKey) $ vKey bobStake),
+      DCertDeleg (RegKey $ (KeyHashObj . hashKey) $ vKey stakePoolKey1)
+    ]
+    (SlotNo 100)
+    [ asWitness alicePay,
+      asWitness aliceStake,
+      asWitness bobStake,
+      asWitness stakePoolKey1
+    ]
 
 utxoSt2 :: UTxOState
-utxoSt2 = UTxOState
-            (UTxO $ Map.fromList
-              [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
-              , (TxIn (txid $ _body tx2) 0, TxOut aliceAddr (Coin 5400))
-              , (TxIn (txid $ _body tx2) 1, TxOut bobAddr (Coin 3000)) ])
-            (Coin 300)
-            (Coin 1300)
-            emptyPPPUpdates
+utxoSt2 =
+  UTxOState
+    ( UTxO $
+        Map.fromList
+          [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000)),
+            (TxIn (txid $ _body tx2) 0, TxOut aliceAddr (Coin 5400)),
+            (TxIn (txid $ _body tx2) 1, TxOut bobAddr (Coin 3000))
+          ]
+    )
+    (Coin 300)
+    (Coin 1300)
+    emptyPPPUpdates
 
 tx3Body :: TxBody
-tx3Body = TxBody
-          (Set.fromList [TxIn (txid $ _body tx2) 0])
-          (StrictSeq.singleton $ TxOut aliceAddr (Coin 3950))
-          (StrictSeq.fromList [ DCertPool (RegPool stakePool)
-                              , DCertDeleg (Delegate (Delegation
-                                                  (KeyHashObj $ hashKey $ vKey aliceStake)
-                                                  (coerceKeyRole . hashKey $ vKey stakePoolKey1)))])
-          (Wdrl Map.empty)
-          (Coin 1200)
-          (SlotNo 100)
-          SNothing
-          SNothing
+tx3Body =
+  TxBody
+    (Set.fromList [TxIn (txid $ _body tx2) 0])
+    (StrictSeq.singleton $ TxOut aliceAddr (Coin 3950))
+    ( StrictSeq.fromList
+        [ DCertPool (RegPool stakePool),
+          DCertDeleg
+            ( Delegate
+                ( Delegation
+                    (KeyHashObj $ hashKey $ vKey aliceStake)
+                    (coerceKeyRole . hashKey $ vKey stakePoolKey1)
+                )
+            )
+        ]
+    )
+    (Wdrl Map.empty)
+    (Coin 1200)
+    (SlotNo 100)
+    SNothing
+    SNothing
 
 tx3 :: Tx
 tx3 = Tx tx3Body (makeWitnessesVKey (hashTxBody tx3Body) keys) Map.empty SNothing
-      where keys = [asWitness alicePay, asWitness aliceStake, asWitness stakePoolKey1]
+  where
+    keys = [asWitness alicePay, asWitness aliceStake, asWitness stakePoolKey1]
 
 utxoSt3 :: UTxOState
-utxoSt3 = UTxOState
-            (UTxO $ Map.fromList
-              [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
-              , (TxIn (txid tx3Body) 0, TxOut aliceAddr (Coin 3950))
-              , (TxIn (txid $ _body tx2) 1, TxOut bobAddr (Coin 3000)) ])
-            (Coin 550)
-            (Coin 2500)
-            emptyPPPUpdates
+utxoSt3 =
+  UTxOState
+    ( UTxO $
+        Map.fromList
+          [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000)),
+            (TxIn (txid tx3Body) 0, TxOut aliceAddr (Coin 3950)),
+            (TxIn (txid $ _body tx2) 1, TxOut bobAddr (Coin 3000))
+          ]
+    )
+    (Coin 550)
+    (Coin 2500)
+    emptyPPPUpdates
 
 stakeKeyRegistration1 :: DPState
-stakeKeyRegistration1 = emptyDelegation
-  { _dstate = (_dstate emptyDelegation)
-      {
-        _rewards = Map.fromList
-          [ (mkVKeyRwdAcnt aliceStake, Coin 0)
-          , (mkVKeyRwdAcnt bobStake, Coin 0)
-          , (mkVKeyRwdAcnt stakePoolKey1, Coin 0)]
-      , _stkCreds = StakeCreds $ Map.fromList
-          [ (KeyHashObj $ hashKey $ vKey aliceStake, SlotNo 0)
-          , (KeyHashObj $ hashKey $ vKey bobStake, SlotNo 0)
-          , (KeyHashObj $ hashKey $ vKey stakePoolKey1, SlotNo 0)]
-      , _ptrs    = Map.fromList
-          [ (Ptr (SlotNo 0) 0 0, KeyHashObj $ hashKey $ vKey aliceStake)
-          , (Ptr (SlotNo 0) 0 1, KeyHashObj $ hashKey $ vKey bobStake)
-          , (Ptr (SlotNo 0) 0 2, KeyHashObj $ hashKey $ vKey stakePoolKey1)
-          ]
-      }
-  }
+stakeKeyRegistration1 =
+  emptyDelegation
+    { _dstate =
+        (_dstate emptyDelegation)
+          { _rewards =
+              Map.fromList
+                [ (mkVKeyRwdAcnt aliceStake, Coin 0),
+                  (mkVKeyRwdAcnt bobStake, Coin 0),
+                  (mkVKeyRwdAcnt stakePoolKey1, Coin 0)
+                ],
+            _stkCreds =
+              StakeCreds $
+                Map.fromList
+                  [ (KeyHashObj $ hashKey $ vKey aliceStake, SlotNo 0),
+                    (KeyHashObj $ hashKey $ vKey bobStake, SlotNo 0),
+                    (KeyHashObj $ hashKey $ vKey stakePoolKey1, SlotNo 0)
+                  ],
+            _ptrs =
+              Map.fromList
+                [ (Ptr (SlotNo 0) 0 0, KeyHashObj $ hashKey $ vKey aliceStake),
+                  (Ptr (SlotNo 0) 0 1, KeyHashObj $ hashKey $ vKey bobStake),
+                  (Ptr (SlotNo 0) 0 2, KeyHashObj $ hashKey $ vKey stakePoolKey1)
+                ]
+          }
+    }
 
 stakePool :: PoolParams
-stakePool = PoolParams
-            {
-              _poolPubKey  = coerceKeyRole . hashKey $ vKey stakePoolKey1
-            , _poolVrf     = hashKeyVRF stakePoolVRFKey1
-            , _poolPledge  = Coin 0
-            , _poolCost    = Coin 0      -- TODO: what is a sensible value?
-            , _poolMargin  = interval0     --          or here?
-            , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
-            , _poolOwners  = Set.empty
-            , _poolRelays  = StrictSeq.empty
-            , _poolMD      = SNothing
-            }
+stakePool =
+  PoolParams
+    { _poolPubKey = coerceKeyRole . hashKey $ vKey stakePoolKey1,
+      _poolVrf = hashKeyVRF stakePoolVRFKey1,
+      _poolPledge = Coin 0,
+      _poolCost = Coin 0, -- TODO: what is a sensible value?
+      _poolMargin = interval0, --          or here?
+      _poolRAcnt = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1),
+      _poolOwners = Set.empty,
+      _poolRelays = StrictSeq.empty,
+      _poolMD = SNothing
+    }
 
 halfInterval :: UnitInterval
 halfInterval =
-    fromMaybe (error "could not construct unit interval") $ mkUnitInterval 0.5
+  fromMaybe (error "could not construct unit interval") $ mkUnitInterval 0.5
 
 stakePoolUpdate :: PoolParams
-stakePoolUpdate = PoolParams
-                   {
-                     _poolPubKey  = coerceKeyRole . hashKey $ vKey stakePoolKey1
-                   , _poolVrf     = hashKeyVRF stakePoolVRFKey1
-                   , _poolPledge  = Coin 0
-                   , _poolCost    = Coin 100      -- TODO: what is a sensible value?
-                   , _poolMargin  = halfInterval     --          or here?
-                   , _poolRAcnt   = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1)
-                   , _poolOwners  = Set.empty
-                   , _poolRelays  = StrictSeq.empty
-                   , _poolMD      = SNothing
-                   }
+stakePoolUpdate =
+  PoolParams
+    { _poolPubKey = coerceKeyRole . hashKey $ vKey stakePoolKey1,
+      _poolVrf = hashKeyVRF stakePoolVRFKey1,
+      _poolPledge = Coin 0,
+      _poolCost = Coin 100, -- TODO: what is a sensible value?
+      _poolMargin = halfInterval, --          or here?
+      _poolRAcnt = RewardAcnt (KeyHashObj . hashKey . vKey $ stakePoolKey1),
+      _poolOwners = Set.empty,
+      _poolRelays = StrictSeq.empty,
+      _poolMD = SNothing
+    }
 
 tx4Body :: TxBody
-tx4Body = TxBody
-          (Set.fromList [TxIn (txid $ _body tx3) 0])
-          (StrictSeq.singleton $ TxOut aliceAddr (Coin 2950)) -- Note the deposit is not charged
-          (StrictSeq.fromList [ DCertPool (RegPool stakePoolUpdate) ])
-          (Wdrl Map.empty)
-          (Coin 1000)
-          (SlotNo 100)
-          SNothing
-          SNothing
+tx4Body =
+  TxBody
+    (Set.fromList [TxIn (txid $ _body tx3) 0])
+    (StrictSeq.singleton $ TxOut aliceAddr (Coin 2950)) -- Note the deposit is not charged
+    (StrictSeq.fromList [DCertPool (RegPool stakePoolUpdate)])
+    (Wdrl Map.empty)
+    (Coin 1000)
+    (SlotNo 100)
+    SNothing
+    SNothing
 
 tx4 :: Tx
-tx4 = Tx
-        tx4Body
-        (makeWitnessesVKey
-          (hashTxBody tx4Body)
-          [asWitness alicePay, asWitness stakePoolKey1])
-        Map.empty
-        SNothing
+tx4 =
+  Tx
+    tx4Body
+    ( makeWitnessesVKey
+        (hashTxBody tx4Body)
+        [asWitness alicePay, asWitness stakePoolKey1]
+    )
+    Map.empty
+    SNothing
 
 utxoSt4 :: UTxOState
-utxoSt4 = UTxOState
-            (UTxO $ Map.fromList
-              [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
-              , (TxIn (txid tx4Body) 0, TxOut aliceAddr (Coin 2950))
-              , (TxIn (txid $ _body tx2) 1, TxOut bobAddr (Coin 3000)) ])
-            (Coin 550)
-            (Coin 3500)
-            emptyPPPUpdates
+utxoSt4 =
+  UTxOState
+    ( UTxO $
+        Map.fromList
+          [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000)),
+            (TxIn (txid tx4Body) 0, TxOut aliceAddr (Coin 2950)),
+            (TxIn (txid $ _body tx2) 1, TxOut bobAddr (Coin 3000))
+          ]
+    )
+    (Coin 550)
+    (Coin 3500)
+    emptyPPPUpdates
 
 utxo5 :: EpochNo -> UTxOState
-utxo5 e = UTxOState
-            (UTxO $ Map.fromList
-              [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000))
-              , (TxIn (txid $ tx5Body e) 0, TxOut aliceAddr (Coin 2950))
-              , (TxIn (txid $ _body tx2) 1, TxOut bobAddr (Coin 3000)) ])
-            (Coin 550)
-            (Coin 3500)
-            emptyPPPUpdates
+utxo5 e =
+  UTxOState
+    ( UTxO $
+        Map.fromList
+          [ (TxIn genesisId 1, TxOut bobAddr (Coin 1000)),
+            (TxIn (txid $ tx5Body e) 0, TxOut aliceAddr (Coin 2950)),
+            (TxIn (txid $ _body tx2) 1, TxOut bobAddr (Coin 3000))
+          ]
+    )
+    (Coin 550)
+    (Coin 3500)
+    emptyPPPUpdates
 
 tx5Body :: EpochNo -> TxBody
-tx5Body e = TxBody
-          (Set.fromList [TxIn (txid $ _body tx3) 0])
-          (StrictSeq.singleton $ TxOut aliceAddr (Coin 2950))
-          (StrictSeq.fromList [ DCertPool (RetirePool (coerceKeyRole . hashKey $ vKey stakePoolKey1) e) ])
-          (Wdrl Map.empty)
-          (Coin 1000)
-          (SlotNo 100)
-          SNothing
-          SNothing
+tx5Body e =
+  TxBody
+    (Set.fromList [TxIn (txid $ _body tx3) 0])
+    (StrictSeq.singleton $ TxOut aliceAddr (Coin 2950))
+    (StrictSeq.fromList [DCertPool (RetirePool (coerceKeyRole . hashKey $ vKey stakePoolKey1) e)])
+    (Wdrl Map.empty)
+    (Coin 1000)
+    (SlotNo 100)
+    SNothing
+    SNothing
 
 tx5 :: EpochNo -> Tx
-tx5 e = Tx
-          (tx5Body e)
-          (makeWitnessesVKey
-            (hashTxBody $ tx5Body e)
-            [asWitness alicePay,asWitness stakePoolKey1])
-          Map.empty
-          SNothing
-
+tx5 e =
+  Tx
+    (tx5Body e)
+    ( makeWitnessesVKey
+        (hashTxBody $ tx5Body e)
+        [asWitness alicePay, asWitness stakePoolKey1]
+    )
+    Map.empty
+    SNothing
 
 testsValidLedger :: TestTree
 testsValidLedger =
-  testGroup "Tests with valid transactions in ledger."
+  testGroup
+    "Tests with valid transactions in ledger."
     [ testCase "Valid Ledger - Alice gives Bob 3000 of her 10000 lovelace" $
-        testLedgerValidTransactions ls1 utxoSt1
-      , testGroup "Tests for stake delegation."
-          [ testCase "Valid stake key registration." $
-              testValidStakeKeyRegistration tx2 utxoSt2 stakeKeyRegistration1
-          , testCase "Valid stake delegation from Alice to stake pool." $
-              testValidDelegation [tx2, tx3] utxoSt3 stakeKeyRegistration1 stakePool
-          , testCase "Update stake pool parameters" $
-              testValidDelegation [tx2, tx3, tx4] utxoSt4 stakeKeyRegistration1 stakePoolUpdate
-          , testCase "Retire Pool" $
+        testLedgerValidTransactions ls1 utxoSt1,
+      testGroup
+        "Tests for stake delegation."
+        [ testCase "Valid stake key registration." $
+            testValidStakeKeyRegistration tx2 utxoSt2 stakeKeyRegistration1,
+          testCase "Valid stake delegation from Alice to stake pool." $
+            testValidDelegation [tx2, tx3] utxoSt3 stakeKeyRegistration1 stakePool,
+          testCase "Update stake pool parameters" $
+            testValidDelegation [tx2, tx3, tx4] utxoSt4 stakeKeyRegistration1 stakePoolUpdate,
+          testCase "Retire Pool" $
             testValidRetirement [tx2, tx3, tx5 (EpochNo 1)] (utxo5 (EpochNo 1)) stakeKeyRegistration1 (EpochNo 1) stakePool
-          ]
-      , testGroup "Tests for withdrawals"
-          [ testCase "Valid withdrawal." testValidWithdrawal
-          ]
+        ],
+      testGroup
+        "Tests for withdrawals"
+        [ testCase "Valid withdrawal." testValidWithdrawal
+        ]
     ]
 
 testOverlayScheduleZero :: Assertion
 testOverlayScheduleZero =
-  let
-    os = runShelleyBase
-      $ overlaySchedule
-        (EpochNo 0)
-        mempty
-        (emptyPParams {_d = unsafeMkUnitInterval 0})
-  in os @?= Map.empty
+  let os =
+        runShelleyBase $
+          overlaySchedule
+            (EpochNo 0)
+            mempty
+            (emptyPParams {_d = unsafeMkUnitInterval 0})
+   in os @?= Map.empty
 
 testNoGenesisOverlay :: Assertion
 testNoGenesisOverlay =
-  let
-    os = runShelleyBase
-      $ overlaySchedule
-        (EpochNo 0)
-        mempty
-        (emptyPParams {_d = unsafeMkUnitInterval 0.5})
-  in os @?= Map.empty
+  let os =
+        runShelleyBase $
+          overlaySchedule
+            (EpochNo 0)
+            mempty
+            (emptyPParams {_d = unsafeMkUnitInterval 0.5})
+   in os @?= Map.empty
 
 testVRFCheckWithActiveSlotCoeffOne :: Assertion
 testVRFCheckWithActiveSlotCoeffOne =
@@ -517,161 +664,189 @@ testVRFCheckWithActiveSlotCoeffOne =
 testVRFCheckWithLeaderValueOne :: Assertion
 testVRFCheckWithLeaderValueOne =
   checkVRFValue vrfOne (1 % 2) (mkActiveSlotCoeff $ unsafeMkUnitInterval 0.5) @?= False
-  where vrfOne = unitIntervalToNatural (unsafeMkUnitInterval 1)
+  where
+    vrfOne = unitIntervalToNatural (unsafeMkUnitInterval 1)
 
 testsPParams :: TestTree
 testsPParams =
-  testGroup "Test the protocol parameters."
+  testGroup
+    "Test the protocol parameters."
     [ testCase "Overlay Schedule when d is zero" $
-        testOverlayScheduleZero
-    , testCase "generate overlay schedule without genesis nodes" $
-        testNoGenesisOverlay
-    , testCase "VRF checks when the activeSlotCoeff is one" $
-        testVRFCheckWithActiveSlotCoeffOne
-    , testCase "VRF checks when the VRF leader value is one" $
+        testOverlayScheduleZero,
+      testCase "generate overlay schedule without genesis nodes" $
+        testNoGenesisOverlay,
+      testCase "VRF checks when the activeSlotCoeff is one" $
+        testVRFCheckWithActiveSlotCoeffOne,
+      testCase "VRF checks when the VRF leader value is one" $
         testVRFCheckWithLeaderValueOne
     ]
 
 testSpendNonexistentInput :: Assertion
 testSpendNonexistentInput =
-  let
-    tx = aliceGivesBobLovelace
-           (TxIn genesisId 42)
-           (Coin 3000) (Coin 1500) (Coin 0) (Coin 0)
-           []
-           (SlotNo 100)
-           [asWitness alicePay]
-  in ledgerState [tx] @?=
-       Left [ ValueNotConserved (Coin 0) (Coin 10000)
-            , BadInputs]
+  let tx =
+        aliceGivesBobLovelace
+          (TxIn genesisId 42)
+          (Coin 3000)
+          (Coin 1500)
+          (Coin 0)
+          (Coin 0)
+          []
+          (SlotNo 100)
+          [asWitness alicePay]
+   in ledgerState [tx]
+        @?= Left
+          [ ValueNotConserved (Coin 0) (Coin 10000),
+            BadInputs
+          ]
 
 testWitnessNotIncluded :: Assertion
 testWitnessNotIncluded =
-  let
-    txbody = TxBody
-              (Set.fromList [TxIn genesisId 0])
-              (StrictSeq.fromList
-                [ TxOut aliceAddr (Coin 6404)
-                , TxOut bobAddr (Coin 3000) ])
-              Empty
-              (Wdrl Map.empty)
-              (Coin 596)
-              (SlotNo 100)
-              SNothing
-              SNothing
-    tx = Tx txbody Set.empty Map.empty SNothing
-  in ledgerState [tx] @?= Left [MissingWitnesses]
+  let txbody =
+        TxBody
+          (Set.fromList [TxIn genesisId 0])
+          ( StrictSeq.fromList
+              [ TxOut aliceAddr (Coin 6404),
+                TxOut bobAddr (Coin 3000)
+              ]
+          )
+          Empty
+          (Wdrl Map.empty)
+          (Coin 596)
+          (SlotNo 100)
+          SNothing
+          SNothing
+      tx = Tx txbody Set.empty Map.empty SNothing
+   in ledgerState [tx] @?= Left [MissingWitnesses]
 
 testSpendNotOwnedUTxO :: Assertion
 testSpendNotOwnedUTxO =
-  let
-    txbody = TxBody
-              (Set.fromList [TxIn genesisId 1])
-              (StrictSeq.singleton $ TxOut aliceAddr (Coin 232))
-              Empty
-              (Wdrl Map.empty)
-              (Coin 768)
-              (SlotNo 100)
-              SNothing
-              SNothing
-    aliceWit = makeWitnessVKey (hashTxBody txbody) alicePay
-    tx = Tx txbody (Set.fromList [aliceWit]) Map.empty SNothing
-  in ledgerState [tx] @?= Left [MissingWitnesses]
+  let txbody =
+        TxBody
+          (Set.fromList [TxIn genesisId 1])
+          (StrictSeq.singleton $ TxOut aliceAddr (Coin 232))
+          Empty
+          (Wdrl Map.empty)
+          (Coin 768)
+          (SlotNo 100)
+          SNothing
+          SNothing
+      aliceWit = makeWitnessVKey (hashTxBody txbody) alicePay
+      tx = Tx txbody (Set.fromList [aliceWit]) Map.empty SNothing
+   in ledgerState [tx] @?= Left [MissingWitnesses]
 
 testWitnessWrongUTxO :: Assertion
 testWitnessWrongUTxO =
-  let
-    txbody = TxBody
-              (Set.fromList [TxIn genesisId 1])
-              (StrictSeq.singleton $ TxOut aliceAddr (Coin 230))
-              Empty
-              (Wdrl Map.empty)
-              (Coin 770)
-              (SlotNo 100)
-              SNothing
-              SNothing
-    tx2body = TxBody
-              (Set.fromList [TxIn genesisId 1])
-              (StrictSeq.singleton $ TxOut aliceAddr (Coin 230))
-              Empty
-              (Wdrl Map.empty)
-              (Coin 770)
-              (SlotNo 101)
-              SNothing
-              SNothing
-    aliceWit = makeWitnessVKey  (hashTxBody tx2body) alicePay
-    tx = Tx txbody (Set.fromList [aliceWit]) Map.empty SNothing
-  in ledgerState [tx] @?= Left [ InvalidWitness
-                               , MissingWitnesses]
+  let txbody =
+        TxBody
+          (Set.fromList [TxIn genesisId 1])
+          (StrictSeq.singleton $ TxOut aliceAddr (Coin 230))
+          Empty
+          (Wdrl Map.empty)
+          (Coin 770)
+          (SlotNo 100)
+          SNothing
+          SNothing
+      tx2body =
+        TxBody
+          (Set.fromList [TxIn genesisId 1])
+          (StrictSeq.singleton $ TxOut aliceAddr (Coin 230))
+          Empty
+          (Wdrl Map.empty)
+          (Coin 770)
+          (SlotNo 101)
+          SNothing
+          SNothing
+      aliceWit = makeWitnessVKey (hashTxBody tx2body) alicePay
+      tx = Tx txbody (Set.fromList [aliceWit]) Map.empty SNothing
+   in ledgerState [tx]
+        @?= Left
+          [ InvalidWitness,
+            MissingWitnesses
+          ]
 
 testEmptyInputSet :: Assertion
 testEmptyInputSet =
-  let
-    aliceWithdrawal = Map.singleton (mkVKeyRwdAcnt aliceStake) (Coin 2000)
-    tx = TxBody
-           Set.empty
-           (StrictSeq.singleton $ TxOut aliceAddr (Coin 1000))
-           Empty
-           (Wdrl aliceWithdrawal)
-           (Coin 1000)
-           (SlotNo 0)
-           SNothing
-           SNothing
-    wits = makeWitnessesVKey (hashTxBody tx) [aliceStake]
-    genesisWithReward' = changeReward genesis (mkVKeyRwdAcnt aliceStake) (Coin 2000)
-    ls = asStateTransition
-           (SlotNo 0) testPCs genesisWithReward' (Tx tx wits Map.empty SNothing) (Coin 0)
-  in ls @?= Left [ InputSetEmpty ]
+  let aliceWithdrawal = Map.singleton (mkVKeyRwdAcnt aliceStake) (Coin 2000)
+      tx =
+        TxBody
+          Set.empty
+          (StrictSeq.singleton $ TxOut aliceAddr (Coin 1000))
+          Empty
+          (Wdrl aliceWithdrawal)
+          (Coin 1000)
+          (SlotNo 0)
+          SNothing
+          SNothing
+      wits = makeWitnessesVKey (hashTxBody tx) [aliceStake]
+      genesisWithReward' = changeReward genesis (mkVKeyRwdAcnt aliceStake) (Coin 2000)
+      ls =
+        asStateTransition
+          (SlotNo 0)
+          testPCs
+          genesisWithReward'
+          (Tx tx wits Map.empty SNothing)
+          (Coin 0)
+   in ls @?= Left [InputSetEmpty]
 
 testFeeTooSmall :: Assertion
 testFeeTooSmall =
-  let
-    tx = aliceGivesBobLovelace
-           (TxIn genesisId 0)
-           (Coin 3000) (Coin 1) (Coin 0) (Coin 0)
-           []
-           (SlotNo 100)
-           [asWitness alicePay]
-  in ledgerState [tx] @?=
-       Left [ FeeTooSmall (minfee testPCs tx) (Coin 1) ]
+  let tx =
+        aliceGivesBobLovelace
+          (TxIn genesisId 0)
+          (Coin 3000)
+          (Coin 1)
+          (Coin 0)
+          (Coin 0)
+          []
+          (SlotNo 100)
+          [asWitness alicePay]
+   in ledgerState [tx]
+        @?= Left [FeeTooSmall (minfee testPCs tx) (Coin 1)]
 
 testExpiredTx :: Assertion
 testExpiredTx =
-  let
-    tx = aliceGivesBobLovelace
-           (TxIn genesisId 0)
-           (Coin 3000) (Coin 600) (Coin 0) (Coin 0)
-           []
-           (SlotNo 0)
-           [asWitness alicePay]
-  in asStateTransition (SlotNo 1) testPCs genesis tx (Coin 0) @?=
-       Left [ Expired (SlotNo 0) (SlotNo 1) ]
+  let tx =
+        aliceGivesBobLovelace
+          (TxIn genesisId 0)
+          (Coin 3000)
+          (Coin 600)
+          (Coin 0)
+          (Coin 0)
+          []
+          (SlotNo 0)
+          [asWitness alicePay]
+   in asStateTransition (SlotNo 1) testPCs genesis tx (Coin 0)
+        @?= Left [Expired (SlotNo 0) (SlotNo 1)]
 
 testTruncateUnitInterval :: TestTree
 testTruncateUnitInterval = testProperty "truncateUnitInterval in [0,1]" $
-  \n -> let x = intervalValue $ truncateUnitInterval n
-        in (x <= 1) && (x >= 0)
-
+  \n ->
+    let x = intervalValue $ truncateUnitInterval n
+     in (x <= 1) && (x >= 0)
 
 testsInvalidLedger :: TestTree
-testsInvalidLedger = testGroup "Tests with invalid transactions in ledger"
-  [ testCase "Invalid Ledger - Alice tries to spend a nonexistent input" testSpendNonexistentInput
-  , testCase "Invalid Ledger - Alice does not include a witness" testWitnessNotIncluded
-  , testCase "Invalid Ledger - Alice tries to spend Bob's UTxO" testSpendNotOwnedUTxO
-  , testCase "Invalid Ledger - Alice provides witness of wrong UTxO" testWitnessWrongUTxO
-  , testCase "Invalid Ledger - Alice's transaction does not consume input" testEmptyInputSet
-  , testCase "Invalid Ledger - Alice's fee is too small" testFeeTooSmall
-  , testCase "Invalid Ledger - Alice's transaction has expired" testExpiredTx
-  , testCase "Invalid Ledger - Invalid witnesses" testInvalidWintess
-  , testCase "Invalid Ledger - No withdrawal witness" testWithdrawalNoWit
-  , testCase "Invalid Ledger - Incorrect withdrawal amount" testWithdrawalWrongAmt
-  ]
+testsInvalidLedger =
+  testGroup
+    "Tests with invalid transactions in ledger"
+    [ testCase "Invalid Ledger - Alice tries to spend a nonexistent input" testSpendNonexistentInput,
+      testCase "Invalid Ledger - Alice does not include a witness" testWitnessNotIncluded,
+      testCase "Invalid Ledger - Alice tries to spend Bob's UTxO" testSpendNotOwnedUTxO,
+      testCase "Invalid Ledger - Alice provides witness of wrong UTxO" testWitnessWrongUTxO,
+      testCase "Invalid Ledger - Alice's transaction does not consume input" testEmptyInputSet,
+      testCase "Invalid Ledger - Alice's fee is too small" testFeeTooSmall,
+      testCase "Invalid Ledger - Alice's transaction has expired" testExpiredTx,
+      testCase "Invalid Ledger - Invalid witnesses" testInvalidWintess,
+      testCase "Invalid Ledger - No withdrawal witness" testWithdrawalNoWit,
+      testCase "Invalid Ledger - Incorrect withdrawal amount" testWithdrawalWrongAmt
+    ]
 
 unitTests :: TestTree
-unitTests = testGroup "Unit Tests"
-  [ testsValidLedger
-  , testsInvalidLedger
-  , testsPParams
-  , sizeTests
-  , testTruncateUnitInterval
-  ]
+unitTests =
+  testGroup
+    "Unit Tests"
+    [ testsValidLedger,
+      testsInvalidLedger,
+      testsPParams,
+      sizeTests,
+      testTruncateUnitInterval
+    ]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Block.hs
@@ -5,201 +5,237 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Test.Shelley.Spec.Ledger.Generator.Block
-  ( genBlock
+  ( genBlock,
   )
-  where
+where
 
-import           Data.Foldable (toList)
+import Byron.Spec.Ledger.Core (dom, range)
+import Cardano.Slotting.Slot (WithOrigin (..))
+import Control.State.Transition.Extended (TRC (..), applySTS)
+import Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
+import Data.Foldable (toList)
 import qualified Data.List as List (find)
-import           Data.Map.Strict (Map)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (listToMaybe)
-import           Data.Ratio (denominator, numerator, (%))
-import           Test.QuickCheck (Gen)
+import Data.Maybe (listToMaybe)
+import Data.Ratio ((%), denominator, numerator)
+import Shelley.Spec.Ledger.BaseTypes (activeSlotCoeff, activeSlotVal, intervalValue)
+import Shelley.Spec.Ledger.BlockChain (LastAppliedBlock (..))
+import Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
+import Shelley.Spec.Ledger.Keys (GenDelegs (..), KeyRole (..), coerceKeyRole, hashKey, vKey)
+import Shelley.Spec.Ledger.LedgerState
+  ( _delegationState,
+    _dstate,
+    _genDelegs,
+    _reserves,
+    esLState,
+    esPp,
+    getGKeys,
+    nesEL,
+    nesEs,
+    nesOsched,
+    nesPd,
+    overlaySchedule,
+    pattern ActiveSlot,
+    pattern EpochState,
+    pattern NewEpochState,
+  )
+import Shelley.Spec.Ledger.OCert (KESPeriod (..), currentIssueNo, kesPeriod)
+import Shelley.Spec.Ledger.STS.Chain
+  ( chainEpochNonce,
+    chainLastAppliedBlock,
+    chainNes,
+    chainOCertIssue,
+  )
+import Shelley.Spec.Ledger.STS.Ledgers (LedgersEnv (..))
+import Shelley.Spec.Ledger.STS.Ocert (pattern OCertEnv)
+import Shelley.Spec.Ledger.STS.Tick (TickEnv (..))
+import Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
+import Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC (choose, discard, shuffle)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Block,
+    ChainState,
+    KeyHash,
+    LEDGERS,
+    OBftSlot,
+    TICK,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( AllPoolKeys (..),
+    GenEnv (..),
+    KeySpace (..),
+    NatNonce (..),
+    genNatural,
+    getKESPeriodRenewalNo,
+    mkBlock,
+    mkOCert,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Trace.Ledger ()
+import Test.Shelley.Spec.Ledger.Utils
+  ( maxKESIterations,
+    runShelleyBase,
+    testGlobals,
+    unsafeMkUnitInterval,
+  )
 
-import           Byron.Spec.Ledger.Core (dom, range)
-import           Cardano.Slotting.Slot (WithOrigin (..))
-import           Control.State.Transition.Extended (TRC (..), applySTS)
-import           Control.State.Transition.Trace.Generator.QuickCheck (sigGen)
-import           Shelley.Spec.Ledger.BaseTypes (activeSlotCoeff, activeSlotVal, intervalValue)
-import           Shelley.Spec.Ledger.BlockChain (LastAppliedBlock (..))
-import           Shelley.Spec.Ledger.Delegation.Certificates (PoolDistr (..))
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), GenDelegs (..), hashKey, vKey, coerceKeyRole)
-import           Shelley.Spec.Ledger.LedgerState (pattern ActiveSlot, pattern EpochState,
-                     pattern NewEpochState, esLState, esPp, getGKeys, nesEL, nesEs, nesOsched,
-                     nesPd, overlaySchedule, _delegationState, _dstate, _genDelegs, _reserves)
-import           Shelley.Spec.Ledger.OCert (KESPeriod (..), currentIssueNo, kesPeriod)
-import           Shelley.Spec.Ledger.Slot (EpochNo (..), SlotNo (..))
-import           Shelley.Spec.Ledger.STS.Chain (chainEpochNonce, chainLastAppliedBlock, chainNes,
-                     chainOCertIssue)
-import           Shelley.Spec.Ledger.STS.Ledgers (LedgersEnv (..))
-import           Shelley.Spec.Ledger.STS.Ocert (pattern OCertEnv)
-import           Shelley.Spec.Ledger.STS.Tick (TickEnv (..))
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Block, ChainState, KeyHash,
-                     LEDGERS, OBftSlot, TICK)
-import           Test.Shelley.Spec.Ledger.Generator.Core (AllPoolKeys (..), GenEnv (..),
-                     KeySpace (..), NatNonce (..), genNatural, getKESPeriodRenewalNo, mkBlock,
-                     mkOCert)
-import           Test.Shelley.Spec.Ledger.Generator.Trace.Ledger ()
-import           Test.Shelley.Spec.Ledger.Utils (maxKESIterations, runShelleyBase, testGlobals,
-                     unsafeMkUnitInterval)
-
-nextCoreNode
-  :: Map SlotNo OBftSlot
-  -> Map SlotNo OBftSlot
-  -> SlotNo
-  -> (SlotNo, KeyHash 'Genesis)
+nextCoreNode ::
+  Map SlotNo OBftSlot ->
+  Map SlotNo OBftSlot ->
+  SlotNo ->
+  (SlotNo, KeyHash 'Genesis)
 nextCoreNode os nextOs s =
   let getNextOSlot os' =
         let (_, nextSlots) = Map.split s os'
-        in listToMaybe [(slot, k) | (slot, ActiveSlot k) <- Map.toAscList nextSlots]
-  in
-  case getNextOSlot os of
-    Nothing -> -- there are no more active overlay slots this epoch
-      case getNextOSlot nextOs of
-        Nothing -> error "TODO - handle d=0"
+         in listToMaybe [(slot, k) | (slot, ActiveSlot k) <- Map.toAscList nextSlots]
+   in case getNextOSlot os of
+        Nothing ->
+          -- there are no more active overlay slots this epoch
+          case getNextOSlot nextOs of
+            Nothing -> error "TODO - handle d=0"
+            Just n -> n
         Just n -> n
-    Just n -> n
 
 -- | Find the next active Praos slot.
-getPraosSlot
-  :: SlotNo
-  -> SlotNo
-  -> Map SlotNo OBftSlot
-  -> Map SlotNo OBftSlot
-  -> Maybe SlotNo
+getPraosSlot ::
+  SlotNo ->
+  SlotNo ->
+  Map SlotNo OBftSlot ->
+  Map SlotNo OBftSlot ->
+  Maybe SlotNo
 getPraosSlot start tooFar os nos =
   let schedules = os `Map.union` nos
-  in List.find (not . (`Map.member` schedules)) [start .. tooFar-1]
+   in List.find (not . (`Map.member` schedules)) [start .. tooFar -1]
 
+genBlock ::
+  GenEnv ->
+  SlotNo ->
+  ChainState ->
+  Gen Block
 genBlock
-  :: GenEnv
-  -> SlotNo
-  -> ChainState
-  -> Gen Block
-genBlock ge@(GenEnv KeySpace_ {ksCoreNodes, ksKeyPairsByStakeHash, ksVRFKeyPairsByHash } _)
-          sNow chainSt = do
-  let os = (nesOsched . chainNes) chainSt
-      dpstate = (_delegationState . esLState . nesEs . chainNes) chainSt
-      pp = (esPp . nesEs . chainNes) chainSt
-      (EpochNo e) = (nesEL . chainNes) chainSt
-      (GenDelegs cores) = (_genDelegs . _dstate) dpstate
-      nextOs = runShelleyBase $ overlaySchedule
-        (EpochNo $ e + 1) (Map.keysSet cores) pp
-      (nextOSlot, gkh) = nextCoreNode os nextOs slot
+  ge@(GenEnv KeySpace_ {ksCoreNodes, ksKeyPairsByStakeHash, ksVRFKeyPairsByHash} _)
+  sNow
+  chainSt = do
+    let os = (nesOsched . chainNes) chainSt
+        dpstate = (_delegationState . esLState . nesEs . chainNes) chainSt
+        pp = (esPp . nesEs . chainNes) chainSt
+        (EpochNo e) = (nesEL . chainNes) chainSt
+        (GenDelegs cores) = (_genDelegs . _dstate) dpstate
+        nextOs =
+          runShelleyBase $
+            overlaySchedule
+              (EpochNo $ e + 1)
+              (Map.keysSet cores)
+              pp
+        (nextOSlot, gkh) = nextCoreNode os nextOs slot
 
-  {- Our slot selection strategy uses the overlay schedule.
-   - Above we calculated the next available core node slot
-   - Note that we will need to do something different
-   - when we start allowing d=0, and there is no such next core slot.
-   - If there are no current stake pools, as determined by the pd mapping
-   - (pools to relative stake), then we take the next core node slot.
-   - Note that the mapping of registered stake pools is different, ie
-   - the one in PState, since news pools will not yet be a part of
-   - a snapshot and are therefore not yet ready to make blocks.
-   - Otherwise, if there are active pools, we generate a small increase
-   - from the current slot, and then take the first slot from this point
-   - that is either available for Praos or is a core node slot.
-   -}
+    {- Our slot selection strategy uses the overlay schedule.
+     - Above we calculated the next available core node slot
+     - Note that we will need to do something different
+     - when we start allowing d=0, and there is no such next core slot.
+     - If there are no current stake pools, as determined by the pd mapping
+     - (pools to relative stake), then we take the next core node slot.
+     - Note that the mapping of registered stake pools is different, ie
+     - the one in PState, since news pools will not yet be a part of
+     - a snapshot and are therefore not yet ready to make blocks.
+     - Otherwise, if there are active pools, we generate a small increase
+     - from the current slot, and then take the first slot from this point
+     - that is either available for Praos or is a core node slot.
+     -}
 
-  lookForPraosStart <- genSlotIncrease
-  let poolParams = (Map.toList . Map.filter ((> 0) . fst) . unPoolDistr . nesPd . chainNes) chainSt
-  poolParams' <- take 1 <$> QC.shuffle poolParams
+    lookForPraosStart <- genSlotIncrease
+    let poolParams = (Map.toList . Map.filter ((> 0) . fst) . unPoolDistr . nesPd . chainNes) chainSt
+    poolParams' <- take 1 <$> QC.shuffle poolParams
 
-  -- Look for a good future slot to make a block for.
-  -- We will find a slot number, a stake value, and an Either type.
-  --
-  -- If we choose an overlay slot, we return this slot number,
-  -- a stake value of 0 (the value here does not matter since
-  -- the overlay slots are not subject to the VRF checks), and Left ghk,
-  -- where gkh is the hash of the genesis key in this overlay position.
-  -- We cannot lookup these genesis keys until we run TICK to see if
-  -- the genesis key delegation has changed.
-  --
-  -- Otherwise, if we choose a Praos solt, we return the chosen slot number,
-  -- and the corresponding stake pool's stake and Right AllPoolKeys for
-  -- some chose stake pool that has non-zero stake.
-  let (nextSlot, poolStake, ks) = case poolParams' of
-        []       -> (nextOSlot, 0, Left gkh)
-        (pkh, (stake, vrfkey)):_ -> case getPraosSlot lookForPraosStart nextOSlot os nextOs of
-                      Nothing -> (nextOSlot, 0, Left gkh)
-                      Just ps -> let apks = AllPoolKeys
-                                       { cold = coerceKeyRole $ ksKeyPairsByStakeHash Map.! coerceKeyRole pkh
-                                       , vrf  = ksVRFKeyPairsByHash Map.! vrfkey
-                                       , hot  = hot $ snd (head ksCoreNodes)
-                                                -- TODO @jc - don't use the genesis hot key
-                                       , hk   = coerceKeyRole pkh
-                                       }
-                                 in (ps, stake, Right apks)
+    -- Look for a good future slot to make a block for.
+    -- We will find a slot number, a stake value, and an Either type.
+    --
+    -- If we choose an overlay slot, we return this slot number,
+    -- a stake value of 0 (the value here does not matter since
+    -- the overlay slots are not subject to the VRF checks), and Left ghk,
+    -- where gkh is the hash of the genesis key in this overlay position.
+    -- We cannot lookup these genesis keys until we run TICK to see if
+    -- the genesis key delegation has changed.
+    --
+    -- Otherwise, if we choose a Praos solt, we return the chosen slot number,
+    -- and the corresponding stake pool's stake and Right AllPoolKeys for
+    -- some chose stake pool that has non-zero stake.
+    let (nextSlot, poolStake, ks) = case poolParams' of
+          [] -> (nextOSlot, 0, Left gkh)
+          (pkh, (stake, vrfkey)) : _ -> case getPraosSlot lookForPraosStart nextOSlot os nextOs of
+            Nothing -> (nextOSlot, 0, Left gkh)
+            Just ps ->
+              let apks =
+                    AllPoolKeys
+                      { cold = coerceKeyRole $ ksKeyPairsByStakeHash Map.! coerceKeyRole pkh,
+                        vrf = ksVRFKeyPairsByHash Map.! vrfkey,
+                        hot = hot $ snd (head ksCoreNodes),
+                        -- TODO @jc - don't use the genesis hot key
+                        hk = coerceKeyRole pkh
+                      }
+               in (ps, stake, Right apks)
 
-  if nextSlot > sNow
-    then QC.discard
-    else do
-
-    let kp@(KESPeriod kesPeriod_) = runShelleyBase $ kesPeriod nextSlot
-        cs = chainOCertIssue chainSt
+    if nextSlot > sNow
+      then QC.discard
+      else do
+        let kp@(KESPeriod kesPeriod_) = runShelleyBase $ kesPeriod nextSlot
+            cs = chainOCertIssue chainSt
 
         -- ran genDelegs
-    let nes  = chainNes chainSt
-        nes' = runShelleyBase $ applySTS @TICK $ TRC (TickEnv (getGKeys nes), nes, nextSlot)
+        let nes = chainNes chainSt
+            nes' = runShelleyBase $ applySTS @TICK $ TRC (TickEnv (getGKeys nes), nes, nextSlot)
 
-    case nes' of
-      Left _ -> QC.discard
-      Right _nes' -> do
-        let NewEpochState _ _ _ es _ _ _ = _nes'
-            EpochState acnt _ ls _ pp' _   = es
-            GenDelegs gds = _genDelegs . _dstate . _delegationState . esLState . nesEs $ _nes'
+        case nes' of
+          Left _ -> QC.discard
+          Right _nes' -> do
+            let NewEpochState _ _ _ es _ _ _ = _nes'
+                EpochState acnt _ ls _ pp' _ = es
+                GenDelegs gds = _genDelegs . _dstate . _delegationState . esLState . nesEs $ _nes'
+                keys = case ks of
+                  -- We chose an overlay slot, and need to lookup the given
+                  -- keys from the genesis key hash.
+                  Left ghk -> gkeys ghk gds
+                  -- We chose a Praos slot, and have everything we need.
+                  Right ks' -> ks'
+                n' =
+                  currentIssueNo
+                    (OCertEnv (dom poolParams) (range gds))
+                    cs
+                    ((coerceKeyRole . hashKey . vKey . cold) keys)
+                m = getKESPeriodRenewalNo keys kp
+                hotKeys = drop (fromIntegral m) (hot keys)
+                keys' = keys {hot = hotKeys}
+                issueNumber =
+                  if n' == Nothing
+                    then error "no issue number available"
+                    else fromIntegral m
+                oCert = mkOCert keys' issueNumber ((fst . head) hotKeys)
 
-            keys = case ks of
-              -- We chose an overlay slot, and need to lookup the given
-              -- keys from the genesis key hash.
-              Left ghk -> gkeys ghk gds
-
-              -- We chose a Praos slot, and have everything we need.
-              Right ks' -> ks'
-
-            n' = currentIssueNo
-                 (OCertEnv (dom poolParams) (range gds))
-                 cs
-                 ((coerceKeyRole . hashKey . vKey . cold) keys)
-
-            m = getKESPeriodRenewalNo keys kp
-
-            hotKeys = drop (fromIntegral m) (hot keys)
-            keys' = keys { hot = hotKeys }
-            issueNumber = if n' == Nothing
-                            then error "no issue number available"
-                            else fromIntegral m
-            oCert = mkOCert keys' issueNumber ((fst . head) hotKeys)
-
-        mkBlock
-          <$> pure hashheader
-          <*> pure keys'
-          <*> toList <$> genTxs pp' (_reserves acnt) ls nextSlot
-          <*> pure nextSlot
-          <*> pure (block + 1)
-          <*> pure (chainEpochNonce chainSt)
-          <*> genBlockNonce
-          <*> genPraosLeader poolStake
-          <*> pure kesPeriod_
-          <*> pure (fromIntegral (m * fromIntegral maxKESIterations))
-          <*> pure oCert
-  where
-    (block, slot, hashheader) = case chainLastAppliedBlock chainSt of
-      Origin -> error "block generator does not support from Origin"
-      At (LastAppliedBlock b s hh) -> (b, s, hh)
-
-    origIssuerKeys h = case List.find (\(k, _) -> (hashKey . vKey) k == h) ksCoreNodes of
-                         Nothing -> error "couldn't find corresponding core node key"
-                         Just k  -> snd k
-
-    gkeys
-      :: KeyHash 'Genesis
-      -> Map (KeyHash 'Genesis) (KeyHash 'GenesisDelegate)
-      -> AllPoolKeys
-    gkeys gkey gds =
+            mkBlock
+              <$> pure hashheader
+              <*> pure keys'
+              <*> toList
+              <$> genTxs pp' (_reserves acnt) ls nextSlot
+              <*> pure nextSlot
+              <*> pure (block + 1)
+              <*> pure (chainEpochNonce chainSt)
+              <*> genBlockNonce
+              <*> genPraosLeader poolStake
+              <*> pure kesPeriod_
+              <*> pure (fromIntegral (m * fromIntegral maxKESIterations))
+              <*> pure oCert
+    where
+      (block, slot, hashheader) = case chainLastAppliedBlock chainSt of
+        Origin -> error "block generator does not support from Origin"
+        At (LastAppliedBlock b s hh) -> (b, s, hh)
+      origIssuerKeys h = case List.find (\(k, _) -> (hashKey . vKey) k == h) ksCoreNodes of
+        Nothing -> error "couldn't find corresponding core node key"
+        Just k -> snd k
+      gkeys ::
+        KeyHash 'Genesis ->
+        Map (KeyHash 'Genesis) (KeyHash 'GenesisDelegate) ->
+        AllPoolKeys
+      gkeys gkey gds =
         case Map.lookup gkey gds of
           Nothing ->
             error "genBlock: CorruptGenenisDelegation"
@@ -212,34 +248,35 @@ genBlock ge@(GenEnv KeySpace_ {ksCoreNodes, ksKeyPairsByStakeHash, ksVRFKeyPairs
               Just updatedCold ->
                 -- if we find the pre-hashed key in keysByStakeHash, we use it instead of the original cold key
                 (origIssuerKeys gkey)
-                  {cold = coerceKeyRole updatedCold
-                  , hk = (hashKey . vKey) $ coerceKeyRole updatedCold
+                  { cold = coerceKeyRole updatedCold,
+                    hk = (hashKey . vKey) $ coerceKeyRole updatedCold
                   }
+      genPraosLeader stake =
+        if stake >= 0 && stake <= 1
+          then do
+            -- we subtract one from the numerator for a non-zero stake e.g. for a
+            -- stake of 3/20, we would go with 2/20 and then divide by a random
+            -- integer in [1,10]. This value is guaranteed to be below the ϕ
+            -- function for the VRF value comparison and generates a valid leader
+            -- value for Praos.
+            let stake' =
+                  if stake > 0
+                    then (numerator stake - 1) % denominator stake
+                    else stake
+                asc = activeSlotCoeff testGlobals
+            n <- genNatural 1 10
+            pure
+              ( unsafeMkUnitInterval
+                  ( (stake' / fromIntegral n)
+                      * ((intervalValue . activeSlotVal) asc)
+                  )
+              )
+          else error "stake not in [0; 1]"
+      -- we assume small gaps in slot numbers
+      genSlotIncrease = SlotNo . (lastSlotNo +) <$> QC.choose (1, 5)
+      lastSlotNo = unSlotNo slot
+      genBlockNonce = NatNonce <$> genNatural 1 100
+      genTxs pp reserves ls s = do
+        let ledgerEnv = LedgersEnv s pp reserves
 
-    genPraosLeader stake =
-      if stake >= 0 && stake <= 1 then do
-        -- we subtract one from the numerator for a non-zero stake e.g. for a
-        -- stake of 3/20, we would go with 2/20 and then divide by a random
-        -- integer in [1,10]. This value is guaranteed to be below the ϕ
-        -- function for the VRF value comparison and generates a valid leader
-        -- value for Praos.
-        let stake' = if stake > 0
-              then (numerator stake - 1) % denominator stake
-              else stake
-            asc = activeSlotCoeff testGlobals
-        n <- genNatural 1 10
-        pure (unsafeMkUnitInterval ((stake' / fromIntegral n)
-                                    * ((intervalValue . activeSlotVal) asc)))
-      else
-        error "stake not in [0; 1]"
-
-    -- we assume small gaps in slot numbers
-    genSlotIncrease = SlotNo . (lastSlotNo +) <$> QC.choose (1, 5)
-    lastSlotNo = unSlotNo slot
-
-    genBlockNonce = NatNonce <$> genNatural 1 100
-
-    genTxs pp reserves ls s = do
-      let ledgerEnv = LedgersEnv s pp reserves
-
-      sigGen @LEDGERS ge ledgerEnv ls
+        sigGen @LEDGERS ge ledgerEnv ls

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Constants.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Constants.hs
@@ -1,156 +1,124 @@
 module Test.Shelley.Spec.Ledger.Generator.Constants
-  ( Constants (..)
-  , defaultConstants
+  ( Constants (..),
+    defaultConstants,
   )
 where
 
-import           Data.Word (Word64)
-import           Numeric.Natural (Natural)
+import Data.Word (Word64)
+import Numeric.Natural (Natural)
 
 data Constants = Constants
-  {
-    -- | minimal number of transaction inputs to select
-    minNumGenInputs :: Int
-
+  { -- | minimal number of transaction inputs to select
+    minNumGenInputs :: Int,
     -- | maximal number of transaction inputs to select
-  , maxNumGenInputs :: Int
-
+    maxNumGenInputs :: Int,
     -- | Relative frequency of generated credential registration certificates
-  , frequencyRegKeyCert :: Int
-
+    frequencyRegKeyCert :: Int,
     -- | Relative frequency of generated pool registration certificates
-  , frequencyRegPoolCert :: Int
-
+    frequencyRegPoolCert :: Int,
     -- | Relative frequency of generated delegation certificates
-  , frequencyDelegationCert :: Int
-
+    frequencyDelegationCert :: Int,
     -- | Relative frequency of generated genesis delegation certificates
-  , frequencyGenesisDelegationCert :: Int
-
+    frequencyGenesisDelegationCert :: Int,
     -- | Relative frequency of generated credential de-registration certificates
-  , frequencyDeRegKeyCert :: Int
-
+    frequencyDeRegKeyCert :: Int,
     -- | Relative frequency of generated pool retirement certificates
-  , frequencyRetirePoolCert :: Int
-
+    frequencyRetirePoolCert :: Int,
     -- | Relative frequency of generated MIR certificates
-  , frequencyMIRCert :: Int
-
+    frequencyMIRCert :: Int,
     -- | Relative frequency of script credentials in credential registration
     -- certificates
-  , frequencyScriptCredReg :: Int
-
+    frequencyScriptCredReg :: Int,
     -- | Relative frequency of key credentials in credential registration
     -- certificates
-  , frequencyKeyCredReg :: Int
-
+    frequencyKeyCredReg :: Int,
     -- | Relative frequency of script credentials in credential de-registration
     -- certificates
-  , frequencyScriptCredDeReg :: Int
-
+    frequencyScriptCredDeReg :: Int,
     -- | Relative frequency of key credentials in credential de-registration
     -- certificates
-  , frequencyKeyCredDeReg :: Int
-
+    frequencyKeyCredDeReg :: Int,
     -- | Relative frequency of script credentials in credential delegation
     -- certificates
-  , frequencyScriptCredDelegation :: Int
-
+    frequencyScriptCredDelegation :: Int,
     -- | Relative frequency of key credentials in credential delegation
     -- certificates
-  , frequencyKeyCredDelegation :: Int
-
+    frequencyKeyCredDelegation :: Int,
     -- | Relative frequency of Prototol/Application Updates in a transaction
-  , frequencyTxUpdates :: Int
-
+    frequencyTxUpdates :: Int,
     -- | minimal number of genesis UTxO outputs
-  , minGenesisUTxOouts :: Int
-
+    minGenesisUTxOouts :: Int,
     -- | maximal number of genesis UTxO outputs
-  , maxGenesisUTxOouts :: Int
-
+    maxGenesisUTxOouts :: Int,
     -- | maximal number of certificates per transaction
-  , maxCertsPerTx :: Word64
-
+    maxCertsPerTx :: Word64,
     -- | maximal number of Txs per block
-  , maxTxsPerBlock :: Word64
-
+    maxTxsPerBlock :: Word64,
     -- | maximal numbers of generated keypairs
-  , maxNumKeyPairs :: Word64
-
+    maxNumKeyPairs :: Word64,
     -- | minimal coin value for generated genesis outputs
-  , minGenesisOutputVal :: Integer
-
+    minGenesisOutputVal :: Integer,
     -- | maximal coin value for generated genesis outputs
-  , maxGenesisOutputVal :: Integer
-
+    maxGenesisOutputVal :: Integer,
     -- | Number of base scripts from which multi sig scripts are built.
-  , numBaseScripts :: Int
-
+    numBaseScripts :: Int,
     -- | Relative frequency that a transaction does not include any reward withdrawals
-  , frequencyNoWithdrawals :: Int
-
+    frequencyNoWithdrawals :: Int,
     -- | Relative frequency that a transaction includes a small number of
     -- reward withdrawals, bounded by 'maxAFewWithdrawals'.
-  , frequencyAFewWithdrawals :: Int
-
+    frequencyAFewWithdrawals :: Int,
     -- | Maximum number of reward withdrawals that counts as a small number.
-  , maxAFewWithdrawals :: Int
-
+    maxAFewWithdrawals :: Int,
     -- | Relative frequency that a transaction includes any positive number of
     -- reward withdrawals
-  , frequencyPotentiallyManyWithdrawals :: Int
-
+    frequencyPotentiallyManyWithdrawals :: Int,
     -- | Minimal slot for CHAIN trace generation.
-  , minSlotTrace :: Int
-
+    minSlotTrace :: Int,
     -- | Maximal slot for CHAIN trace generation.
-  , maxSlotTrace :: Int
-
+    maxSlotTrace :: Int,
     -- | Lower bound of the MaxEpoch protocol parameter
-  , frequencyLowMaxEpoch :: Word64
-
-  , maxMinFeeA :: Natural
-
-  , maxMinFeeB :: Natural
-
-  , numCoreNodes :: Word64
-  } deriving Show
+    frequencyLowMaxEpoch :: Word64,
+    maxMinFeeA :: Natural,
+    maxMinFeeB :: Natural,
+    numCoreNodes :: Word64
+  }
+  deriving (Show)
 
 defaultConstants :: Constants
-defaultConstants = Constants
-  { minNumGenInputs = 1
-  , maxNumGenInputs = 10
-  , frequencyRegKeyCert = 2
-  , frequencyRegPoolCert = 2
-  , frequencyDelegationCert = 3
-  , frequencyGenesisDelegationCert = 1
-  , frequencyDeRegKeyCert = 1
-  , frequencyRetirePoolCert = 1
-  , frequencyMIRCert = 1
-  , frequencyScriptCredReg = 1
-  , frequencyKeyCredReg = 2
-  , frequencyScriptCredDeReg = 1
-  , frequencyKeyCredDeReg = 2
-  , frequencyScriptCredDelegation = 1
-  , frequencyKeyCredDelegation = 2
-  , frequencyTxUpdates = 10
-  , minGenesisUTxOouts = 10
-  , maxGenesisUTxOouts = 100
-  , maxCertsPerTx = 3
-  , maxTxsPerBlock = 10
-  , maxNumKeyPairs = 150
-  , minGenesisOutputVal = 1000000
-  , maxGenesisOutputVal = 100000000
-  , numBaseScripts = 3
-  , frequencyNoWithdrawals = 75
-  , frequencyAFewWithdrawals = 20
-  , maxAFewWithdrawals = 10
-  , frequencyPotentiallyManyWithdrawals = 5
-  , minSlotTrace = 1000
-  , maxSlotTrace = 5000
-  , frequencyLowMaxEpoch = 6
-  , maxMinFeeA = 1000
-  , maxMinFeeB = 3
-  , numCoreNodes = 7
-  }
+defaultConstants =
+  Constants
+    { minNumGenInputs = 1,
+      maxNumGenInputs = 10,
+      frequencyRegKeyCert = 2,
+      frequencyRegPoolCert = 2,
+      frequencyDelegationCert = 3,
+      frequencyGenesisDelegationCert = 1,
+      frequencyDeRegKeyCert = 1,
+      frequencyRetirePoolCert = 1,
+      frequencyMIRCert = 1,
+      frequencyScriptCredReg = 1,
+      frequencyKeyCredReg = 2,
+      frequencyScriptCredDeReg = 1,
+      frequencyKeyCredDeReg = 2,
+      frequencyScriptCredDelegation = 1,
+      frequencyKeyCredDelegation = 2,
+      frequencyTxUpdates = 10,
+      minGenesisUTxOouts = 10,
+      maxGenesisUTxOouts = 100,
+      maxCertsPerTx = 3,
+      maxTxsPerBlock = 10,
+      maxNumKeyPairs = 150,
+      minGenesisOutputVal = 1000000,
+      maxGenesisOutputVal = 100000000,
+      numBaseScripts = 3,
+      frequencyNoWithdrawals = 75,
+      frequencyAFewWithdrawals = 20,
+      maxAFewWithdrawals = 10,
+      frequencyPotentiallyManyWithdrawals = 5,
+      minSlotTrace = 1000,
+      maxSlotTrace = 5000,
+      frequencyLowMaxEpoch = 6,
+      maxMinFeeA = 1000,
+      maxMinFeeB = 3,
+      numCoreNodes = 7
+    }

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -5,93 +5,147 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
-
+{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Test.Shelley.Spec.Ledger.Generator.Core
-  ( AllPoolKeys (..)
-  , GenEnv(..)
-  , KeySpace(..)
-  , pattern KeySpace
-  , NatNonce (..)
-  , Testing
-  , findPayKeyPairAddr
-  , findPayKeyPairCred
-  , findPayScriptFromCred
-  , findStakeScriptFromCred
-  , findPayScriptFromAddr
-  , genBool
-  , genCoin
-  , genCoinList
-  , genInteger
-  , genNatural
-  , genWord64
-  , genTxOut
-  , increasingProbabilityAt
-  , mkScriptsFromKeyPair
-  , pickStakeKey
-  , toAddr
-  , toCred
-  , zero
-  , unitIntervalToNatural
-  , mkBlock
-  , mkOCert
-  , getKESPeriodRenewalNo
-  , tooLateInEpoch
-  , mkKeyPair
-  , mkKeyPairs
-  , mkGenKey
-  , mkMSigScripts
-  , mkMSigCombinations
-  , genesisAccountState
+  ( AllPoolKeys (..),
+    GenEnv (..),
+    KeySpace (..),
+    pattern KeySpace,
+    NatNonce (..),
+    Testing,
+    findPayKeyPairAddr,
+    findPayKeyPairCred,
+    findPayScriptFromCred,
+    findStakeScriptFromCred,
+    findPayScriptFromAddr,
+    genBool,
+    genCoin,
+    genCoinList,
+    genInteger,
+    genNatural,
+    genWord64,
+    genTxOut,
+    increasingProbabilityAt,
+    mkScriptsFromKeyPair,
+    pickStakeKey,
+    toAddr,
+    toCred,
+    zero,
+    unitIntervalToNatural,
+    mkBlock,
+    mkOCert,
+    getKESPeriodRenewalNo,
+    tooLateInEpoch,
+    mkKeyPair,
+    mkKeyPairs,
+    mkGenKey,
+    mkMSigScripts,
+    mkMSigCombinations,
+    genesisAccountState,
   )
-  where
+where
 
-import           Control.Monad (replicateM)
-import           Control.Monad.Trans.Reader (asks)
-import           Data.Coerce (coerce)
-import           Data.List (foldl')
-import qualified Data.List as List (findIndex, (\\))
-import           Data.Map.Strict (Map)
+import Control.Monad (replicateM)
+import Control.Monad.Trans.Reader (asks)
+import Data.Coerce (coerce)
+import Data.List (foldl')
+import qualified Data.List as List ((\\), findIndex)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (empty, fromList, insert, lookup)
-import           Data.Ratio ((%))
+import Data.Ratio ((%))
 import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Tuple (swap)
-import           Data.Word (Word64)
-import           GHC.Stack (HasCallStack)
-
-import           Test.Cardano.Crypto.VRF.Fake (WithResult (..))
-import           Test.QuickCheck (Gen)
+import Data.Tuple (swap)
+import Data.Word (Word64)
+import GHC.Stack (HasCallStack)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.Address (toAddr, toCred)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Nonce (..),
+    UnitInterval,
+    epochInfo,
+    intervalValue,
+    slotsPrior,
+  )
+import Shelley.Spec.Ledger.BlockChain
+  ( TxSeq (..),
+    bBodySize,
+    bbHash,
+    mkSeed,
+    seedEta,
+    seedL,
+    pattern BHBody,
+    pattern BHeader,
+    pattern Block,
+    pattern BlockHash,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Keys (HasKeyRole (coerceKeyRole), KeyRole (..), asWitness, hashKey, signedDSIGN, signedKES, vKey)
+import Shelley.Spec.Ledger.LedgerState (AccountState (..))
+import Shelley.Spec.Ledger.OCert (KESPeriod (..), pattern OCert)
+import Shelley.Spec.Ledger.PParams (ProtVer (..))
+import Shelley.Spec.Ledger.Scripts
+  ( pattern RequireAllOf,
+    pattern RequireAnyOf,
+    pattern RequireMOf,
+    pattern RequireSignature,
+  )
+import Shelley.Spec.Ledger.Slot
+  ( (*-),
+    BlockNo (..),
+    Duration (..),
+    SlotNo (..),
+    epochInfoFirst,
+  )
+import Shelley.Spec.Ledger.Tx (hashScript, pattern TxOut)
+import Shelley.Spec.Ledger.TxData
+  ( pattern Addr,
+    pattern KeyHashObj,
+    pattern ScriptHashObj,
+    pattern StakeRefBase,
+    pattern StakeRefPtr,
+  )
+import Test.Cardano.Crypto.VRF.Fake (WithResult (..))
+import Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
-import           Numeric.Natural (Natural)
-import           Shelley.Spec.Ledger.Address (toAddr, toCred)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), UnitInterval, epochInfo, intervalValue,
-                     slotsPrior)
-import           Shelley.Spec.Ledger.BlockChain (pattern BHBody, pattern BHeader, pattern Block,
-                     pattern BlockHash, TxSeq (..), bBodySize, bbHash, mkSeed, seedEta, seedL)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), HasKeyRole(coerceKeyRole), asWitness, hashKey, vKey, signedKES, signedDSIGN)
-import           Shelley.Spec.Ledger.LedgerState (AccountState (..))
-import           Shelley.Spec.Ledger.OCert (KESPeriod (..), pattern OCert)
-import           Shelley.Spec.Ledger.PParams (ProtVer (..))
-import           Shelley.Spec.Ledger.Scripts (pattern RequireAllOf, pattern RequireAnyOf,
-                     pattern RequireMOf, pattern RequireSignature)
-import           Shelley.Spec.Ledger.Slot (BlockNo (..), Duration (..), SlotNo (..), epochInfoFirst,
-                     (*-))
-import           Shelley.Spec.Ledger.Tx (pattern TxOut, hashScript)
-import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj,
-                     pattern ScriptHashObj, pattern StakeRefBase, pattern StakeRefPtr)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, Block, CoreKeyPair,
-                     Credential, HashHeader, KeyHash, KeyPair, KeyPairs, MultiSig, MultiSigPairs,
-                     OCert, SignKeyVRF, Tx, TxOut, VKey, VerKeyKES, VRFKeyHash, VerKeyVRF,
-                     hashKeyVRF, SignKeyKES, pattern KeyPair, ConcreteCrypto)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
-import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, evolveKESUntil, maxKESIterations,
-                     maxLLSupply, mkCertifiedVRF, mkGenKey, mkKeyPair, runShelleyBase,
-                     unsafeMkUnitInterval)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Addr,
+    Block,
+    ConcreteCrypto,
+    CoreKeyPair,
+    Credential,
+    HashHeader,
+    KeyHash,
+    KeyPair,
+    KeyPairs,
+    MultiSig,
+    MultiSigPairs,
+    OCert,
+    SignKeyKES,
+    SignKeyVRF,
+    Tx,
+    TxOut,
+    VKey,
+    VRFKeyHash,
+    VerKeyKES,
+    VerKeyVRF,
+    hashKeyVRF,
+    pattern KeyPair,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import Test.Shelley.Spec.Ledger.Utils
+  ( epochFromSlotNo,
+    evolveKESUntil,
+    maxKESIterations,
+    maxLLSupply,
+    mkCertifiedVRF,
+    mkGenKey,
+    mkKeyPair,
+    runShelleyBase,
+    unsafeMkUnitInterval,
+  )
 
 -- | I'm in two minds about this. It basically takes advantage of a GHC bug to allow
 --   the inhabiting of a closed kind. On the other hand, the alternatives would be to
@@ -106,54 +160,56 @@ fromTesting :: HasKeyRole a => a Testing crypto -> a r crypto
 fromTesting = coerceKeyRole
 
 data AllPoolKeys = AllPoolKeys
-  { cold :: KeyPair 'StakePool
-  , vrf :: (SignKeyVRF, VerKeyVRF)
-  , hot :: [(KESPeriod, (SignKeyKES, VerKeyKES))]
-  , hk  :: KeyHash 'StakePool
-  } deriving (Show)
+  { cold :: KeyPair 'StakePool,
+    vrf :: (SignKeyVRF, VerKeyVRF),
+    hot :: [(KESPeriod, (SignKeyKES, VerKeyKES))],
+    hk :: KeyHash 'StakePool
+  }
+  deriving (Show)
 
 -- | Generator environment.
 data GenEnv = GenEnv
-  { geKeySpace :: KeySpace
-  , geConstants :: Constants
+  { geKeySpace :: KeySpace,
+    geConstants :: Constants
   }
 
 -- | Collection of all keys which are required to generate a trace.
 --
 --   These are the _only_ keys which should be involved in the trace.
 data KeySpace = KeySpace_
-  { ksCoreNodes :: [(CoreKeyPair, AllPoolKeys)]
-  , ksKeyPairs :: KeyPairs
-  , ksKeyPairsByHash :: Map (KeyHash Testing) (KeyPair Testing)
-  , ksKeyPairsByStakeHash :: Map (KeyHash 'Staking) (KeyPair 'Staking)
-  , ksMSigScripts :: MultiSigPairs
-  , ksVRFKeyPairs :: [(SignKeyVRF, VerKeyVRF)]
-  , ksVRFKeyPairsByHash :: Map VRFKeyHash (SignKeyVRF, VerKeyVRF)
-  } deriving (Show)
+  { ksCoreNodes :: [(CoreKeyPair, AllPoolKeys)],
+    ksKeyPairs :: KeyPairs,
+    ksKeyPairsByHash :: Map (KeyHash Testing) (KeyPair Testing),
+    ksKeyPairsByStakeHash :: Map (KeyHash 'Staking) (KeyPair 'Staking),
+    ksMSigScripts :: MultiSigPairs,
+    ksVRFKeyPairs :: [(SignKeyVRF, VerKeyVRF)],
+    ksVRFKeyPairsByHash :: Map VRFKeyHash (SignKeyVRF, VerKeyVRF)
+  }
+  deriving (Show)
 
-pattern KeySpace
-  :: [(CoreKeyPair, AllPoolKeys)]
-  -> KeyPairs
-  -> MultiSigPairs
-  -> [(SignKeyVRF, VerKeyVRF)]
-  -> KeySpace
-pattern KeySpace ksCoreNodes ksKeyPairs ksMSigScripts ksVRFKeyPairs
-  <- KeySpace_
-      { ksCoreNodes
-      , ksKeyPairs
-      , ksMSigScripts
-      , ksVRFKeyPairs
-      }
+pattern KeySpace ::
+  [(CoreKeyPair, AllPoolKeys)] ->
+  KeyPairs ->
+  MultiSigPairs ->
+  [(SignKeyVRF, VerKeyVRF)] ->
+  KeySpace
+pattern KeySpace ksCoreNodes ksKeyPairs ksMSigScripts ksVRFKeyPairs <-
+  KeySpace_
+    { ksCoreNodes,
+      ksKeyPairs,
+      ksMSigScripts,
+      ksVRFKeyPairs
+    }
   where
-    KeySpace ksCoreNodes ksKeyPairs ksMSigScripts ksVRFKeyPairs
-      = KeySpace_
-        { ksCoreNodes
-        , ksKeyPairs
-        , ksKeyPairsByHash = mkKeyHashMap ksKeyPairs
-        , ksKeyPairsByStakeHash = mkStakeKeyHashMap ksKeyPairs
-        , ksMSigScripts
-        , ksVRFKeyPairs
-        , ksVRFKeyPairsByHash = mkVRFKeyPairsByHash ksVRFKeyPairs
+    KeySpace ksCoreNodes ksKeyPairs ksMSigScripts ksVRFKeyPairs =
+      KeySpace_
+        { ksCoreNodes,
+          ksKeyPairs,
+          ksKeyPairsByHash = mkKeyHashMap ksKeyPairs,
+          ksKeyPairsByStakeHash = mkStakeKeyHashMap ksKeyPairs,
+          ksMSigScripts,
+          ksVRFKeyPairs,
+          ksVRFKeyPairsByHash = mkVRFKeyPairsByHash ksVRFKeyPairs
         }
 
 genBool :: HasCallStack => Gen Bool
@@ -165,26 +221,28 @@ genInteger lower upper = QC.choose (lower, upper)
 -- | Generator for a natural number between 'lower' and 'upper'
 genNatural :: HasCallStack => Natural -> Natural -> Gen Natural
 genNatural lower upper = fromInteger <$> QC.choose (lower', upper')
- where
-  lower' = fromIntegral lower
-  upper' = fromIntegral upper
+  where
+    lower' = fromIntegral lower
+    upper' = fromIntegral upper
 
 -- | Generator for a Word64 between 'lower' and 'upper'
 genWord64 :: HasCallStack => Word64 -> Word64 -> Gen Word64
-genWord64 lower upper = fromIntegral
-  <$> genNatural (fromIntegral lower) (fromIntegral upper)
+genWord64 lower upper =
+  fromIntegral
+    <$> genNatural (fromIntegral lower) (fromIntegral upper)
 
 mkKeyPairs :: HasCallStack => Word64 -> (KeyPair kr, KeyPair kr')
-mkKeyPairs n
-  = (mkKeyPair_ (2*n), mkKeyPair_ (2*n+1))
+mkKeyPairs n =
+  (mkKeyPair_ (2 * n), mkKeyPair_ (2 * n + 1))
   where
-    mkKeyPair_ n_ = (uncurry KeyPair . swap)
-                    (mkKeyPair (n_,n_,n_,n_,n_))
+    mkKeyPair_ n_ =
+      (uncurry KeyPair . swap)
+        (mkKeyPair (n_, n_, n_, n_, n_))
 
 -- | Generate a mapping from stake key hash to stake key pair, from a list of
 -- (payment, staking) key pairs.
-mkStakeKeyHashMap
-  :: HasCallStack => KeyPairs -> Map (KeyHash 'Staking) (KeyPair 'Staking)
+mkStakeKeyHashMap ::
+  HasCallStack => KeyPairs -> Map (KeyHash 'Staking) (KeyPair 'Staking)
 mkStakeKeyHashMap keyPairs =
   Map.fromList (f <$> keyPairs)
   where
@@ -194,10 +252,12 @@ mkStakeKeyHashMap keyPairs =
 -- from a list of (payment, staking) key pairs.
 mkKeyHashMap :: HasCallStack => KeyPairs -> Map (KeyHash Testing) (KeyPair Testing)
 mkKeyHashMap =
-  foldl' (\m (payKey, stakeKey) ->
-           let m' = Map.insert (toTesting . hashKey $ vKey payKey) (toTesting payKey) m
-           in       Map.insert (toTesting . hashKey $ vKey stakeKey) (toTesting stakeKey) m')
-  Map.empty
+  foldl'
+    ( \m (payKey, stakeKey) ->
+        let m' = Map.insert (toTesting . hashKey $ vKey payKey) (toTesting payKey) m
+         in Map.insert (toTesting . hashKey $ vKey stakeKey) (toTesting stakeKey) m'
+    )
+    Map.empty
 
 -- | Multi-Sig Scripts based on the given key pairs
 mkMSigScripts :: HasCallStack => KeyPairs -> MultiSigPairs
@@ -208,28 +268,36 @@ mkMSigScripts = map mkScriptsFromKeyPair
 -- many pairs in order not to create too many of the possible combinations.
 mkMSigCombinations :: HasCallStack => MultiSigPairs -> MultiSigPairs
 mkMSigCombinations msigs =
-  if length msigs < 3 then error "length of input msigs must be at least 3"
-  else foldl' (++) [] $
-       do
-         (k1, k2) <- msigs
-         (k3, k4) <- msigs List.\\ [(k1, k2)]
-         (k5, k6) <- msigs List.\\ [(k1, k2), (k3, k4)]
+  if length msigs < 3
+    then error "length of input msigs must be at least 3"
+    else foldl' (++) [] $
+      do
+        (k1, k2) <- msigs
+        (k3, k4) <- msigs List.\\ [(k1, k2)]
+        (k5, k6) <- msigs List.\\ [(k1, k2), (k3, k4)]
 
-         pure [(pay, stake) | pay <- [ RequireAnyOf [k1, k3, k5]
-                                     , RequireAllOf [k1, k3, k5]
-                                     , RequireMOf 1 [k1, k3, k5]
-                                     , RequireMOf 2 [k1, k3, k5]
-                                     , RequireMOf 3 [k1, k3, k5]]
-                            , stake <- [ RequireAnyOf [k2, k4, k6]
-                                       , RequireAllOf [k2, k4, k6]
-                                       , RequireMOf 1 [k2, k4, k6]
-                                       , RequireMOf 2 [k2, k4, k6]
-                                       , RequireMOf 3 [k2, k4, k6]]]
+        pure
+          [ (pay, stake)
+            | pay <-
+                [ RequireAnyOf [k1, k3, k5],
+                  RequireAllOf [k1, k3, k5],
+                  RequireMOf 1 [k1, k3, k5],
+                  RequireMOf 2 [k1, k3, k5],
+                  RequireMOf 3 [k1, k3, k5]
+                ],
+              stake <-
+                [ RequireAnyOf [k2, k4, k6],
+                  RequireAllOf [k2, k4, k6],
+                  RequireMOf 1 [k2, k4, k6],
+                  RequireMOf 2 [k2, k4, k6],
+                  RequireMOf 3 [k2, k4, k6]
+                ]
+          ]
 
-mkScriptsFromKeyPair
-  :: HasCallStack
-  => (KeyPair 'Payment, KeyPair 'Staking)
-  -> (MultiSig, MultiSig)
+mkScriptsFromKeyPair ::
+  HasCallStack =>
+  (KeyPair 'Payment, KeyPair 'Staking) ->
+  (MultiSig, MultiSig)
 mkScriptsFromKeyPair (k0, k1) =
   (mkScriptFromKey $ asWitness k0, mkScriptFromKey $ asWitness k1)
 
@@ -238,15 +306,15 @@ mkScriptFromKey = (RequireSignature . hashKey . vKey)
 
 -- | Find first matching key pair for a credential. Returns the matching key pair
 -- where the first element of the pair matched the hash in 'addr'.
-findPayKeyPairCred
-  :: HasCallStack
-  => Credential kr
-  -> Map (KeyHash kr) (KeyPair kr)
-  -> KeyPair kr
+findPayKeyPairCred ::
+  HasCallStack =>
+  Credential kr ->
+  Map (KeyHash kr) (KeyPair kr) ->
+  KeyPair kr
 findPayKeyPairCred c keyHashMap =
   case c of
     KeyHashObj addr -> lookforKeyHash addr
-    _                            ->
+    _ ->
       error "findPayKeyPairCred: expects only KeyHashObj"
   where
     lookforKeyHash addr' =
@@ -260,8 +328,8 @@ findPayKeyPairAddr :: HasCallStack => Addr -> Map (KeyHash Testing) (KeyPair Tes
 findPayKeyPairAddr a keyHashMap = fromTesting $
   case a of
     Addr addr (StakeRefBase _) -> findPayKeyPairCred (toTesting addr) keyHashMap
-    Addr addr (StakeRefPtr _)  -> findPayKeyPairCred (toTesting addr) keyHashMap
-    _                            ->
+    Addr addr (StakeRefPtr _) -> findPayKeyPairCred (toTesting addr) keyHashMap
+    _ ->
       error "findPayKeyPairAddr: expects only Base or Ptr addresses"
 
 -- | Find first matching script for a credential.
@@ -269,37 +337,36 @@ findPayScriptFromCred :: HasCallStack => Credential 'Witness -> MultiSigPairs ->
 findPayScriptFromCred c scripts =
   case c of
     ScriptHashObj scriptHash -> lookForScriptHash scriptHash
-    _                        ->
+    _ ->
       error "findPayScriptFromCred: expects only ScriptHashObj"
   where
     lookForScriptHash scriptHash =
       case List.findIndex (\(pay, _) -> scriptHash == hashScript pay) scripts of
         Nothing -> error "findPayScript: could not find matching script for given credential"
-        Just i  -> scripts !! i
+        Just i -> scripts !! i
 
 -- | Find first matching script for a credential.
-findStakeScriptFromCred :: HasCallStack =>  Credential 'Witness -> MultiSigPairs -> (MultiSig, MultiSig)
+findStakeScriptFromCred :: HasCallStack => Credential 'Witness -> MultiSigPairs -> (MultiSig, MultiSig)
 findStakeScriptFromCred c scripts =
   case c of
     ScriptHashObj scriptHash -> lookForScriptHash scriptHash
-    _                        ->
+    _ ->
       error "findStakeScriptFromCred: expects only ScriptHashObj"
   where
     lookForScriptHash scriptHash =
       case List.findIndex (\(_, scr) -> scriptHash == hashScript scr) scripts of
         Nothing -> error $ "findStakeScriptFromCred: could not find matching script for given credential"
-        Just i  -> scripts !! i
-
+        Just i -> scripts !! i
 
 -- | Find first matching script for address.
 findPayScriptFromAddr :: HasCallStack => Addr -> MultiSigPairs -> (MultiSig, MultiSig)
 findPayScriptFromAddr a scripts =
   case a of
     Addr scriptHash (StakeRefBase _) ->
-        findPayScriptFromCred (asWitness scriptHash) scripts
-    Addr scriptHash (StakeRefPtr _)  ->
-        findPayScriptFromCred (asWitness scriptHash) scripts
-    _                     ->
+      findPayScriptFromCred (asWitness scriptHash) scripts
+    Addr scriptHash (StakeRefPtr _) ->
+      findPayScriptFromCred (asWitness scriptHash) scripts
+    _ ->
       error "findPayScriptFromAddr: expects only base and pointer script addresses"
 
 -- | Select one random verification staking key from list of pairs of KeyPair.
@@ -333,16 +400,17 @@ genCoin minCoin maxCoin = Coin <$> QC.choose (minCoin, maxCoin)
 -- This can be used to generate enough extreme values. The exponential and
 -- linear distributions provided by @hedgehog@ will generate a small percentage
 -- of these (0-1%).
-increasingProbabilityAt
-  :: HasCallStack
-  => Gen a
-  -> (a, a)
-  -> Gen a
-increasingProbabilityAt gen (lower, upper)
-  = QC.frequency [ (5, pure lower)
-                 , (90, gen)
-                 , (5, pure upper)
-                 ]
+increasingProbabilityAt ::
+  HasCallStack =>
+  Gen a ->
+  (a, a) ->
+  Gen a
+increasingProbabilityAt gen (lower, upper) =
+  QC.frequency
+    [ (5, pure lower),
+      (90, gen),
+      (5, pure upper)
+    ]
 
 mkVRFKeyPairsByHash :: HasCallStack => [(SignKeyVRF, VerKeyVRF)] -> Map VRFKeyHash (SignKeyVRF, VerKeyVRF)
 mkVRFKeyPairsByHash = Map.fromList . fmap (\p -> (hashKeyVRF (snd p), p))
@@ -356,49 +424,59 @@ zero = unsafeMkUnitInterval 0
 unitIntervalToNatural :: HasCallStack => UnitInterval -> Natural
 unitIntervalToNatural = floor . ((10000 % 1) *) . intervalValue
 
-mkBlock
-  :: HasCallStack
-  => HashHeader   -- ^ Hash of previous block
-  -> AllPoolKeys  -- ^ All keys in the stake pool
-  -> [Tx]         -- ^ Transactions to record
-  -> SlotNo       -- ^ Current slot
-  -> BlockNo      -- ^ Block number/chain length/chain "difficulty"
-  -> Nonce        -- ^ EpochNo nonce
-  -> NatNonce     -- ^ Block nonce
-  -> UnitInterval -- ^ Praos leader value
-  -> Natural      -- ^ Period of KES (key evolving signature scheme)
-  -> Natural      -- ^ KES period of key registration
-  -> OCert        -- ^ Operational certificate
-  -> Block
+mkBlock ::
+  HasCallStack =>
+  -- | Hash of previous block
+  HashHeader ->
+  -- | All keys in the stake pool
+  AllPoolKeys ->
+  -- | Transactions to record
+  [Tx] ->
+  -- | Current slot
+  SlotNo ->
+  -- | Block number/chain length/chain "difficulty"
+  BlockNo ->
+  -- | EpochNo nonce
+  Nonce ->
+  -- | Block nonce
+  NatNonce ->
+  -- | Praos leader value
+  UnitInterval ->
+  -- | Period of KES (key evolving signature scheme)
+  Natural ->
+  -- | KES period of key registration
+  Natural ->
+  -- | Operational certificate
+  OCert ->
+  Block
 mkBlock prev pkeys txns s blockNo enonce (NatNonce bnonce) l kesPeriod c0 oCert =
-  let
-    (_, (sHot, _)) = head $ hot pkeys
-    KeyPair vKeyCold _ = cold pkeys
-    nonceNonce = mkSeed seedEta s enonce
-    leaderNonce = mkSeed seedL s enonce
-    bhb = BHBody
-            blockNo
-            s
-            (BlockHash prev)
-            (coerceKeyRole vKeyCold)
-            (snd $ vrf pkeys)
-            (coerce $ mkCertifiedVRF (WithResult nonceNonce bnonce) (fst $ vrf pkeys))
-            (coerce $ mkCertifiedVRF (WithResult leaderNonce $ unitIntervalToNatural l) (fst $ vrf pkeys))
-            (fromIntegral $ bBodySize $ (TxSeq . StrictSeq.fromList) txns)
-            (bbHash $ TxSeq $ StrictSeq.fromList txns)
-            oCert
-            (ProtVer 0 0)
-    kpDiff = kesPeriod - c0
-    hotKey = case evolveKESUntil sHot (KESPeriod kpDiff) of
-               Nothing ->
-                 error ("could not evolve key to iteration " ++ show kesPeriod)
-               Just hkey -> hkey
-    sig = case signedKES () kpDiff bhb hotKey of
-            Nothing -> error ("could not sign with KES key " ++ show hotKey)
-            Just sig' -> sig'
-    bh = BHeader bhb sig
-  in
-    Block bh (TxSeq $ StrictSeq.fromList txns)
+  let (_, (sHot, _)) = head $ hot pkeys
+      KeyPair vKeyCold _ = cold pkeys
+      nonceNonce = mkSeed seedEta s enonce
+      leaderNonce = mkSeed seedL s enonce
+      bhb =
+        BHBody
+          blockNo
+          s
+          (BlockHash prev)
+          (coerceKeyRole vKeyCold)
+          (snd $ vrf pkeys)
+          (coerce $ mkCertifiedVRF (WithResult nonceNonce bnonce) (fst $ vrf pkeys))
+          (coerce $ mkCertifiedVRF (WithResult leaderNonce $ unitIntervalToNatural l) (fst $ vrf pkeys))
+          (fromIntegral $ bBodySize $ (TxSeq . StrictSeq.fromList) txns)
+          (bbHash $ TxSeq $ StrictSeq.fromList txns)
+          oCert
+          (ProtVer 0 0)
+      kpDiff = kesPeriod - c0
+      hotKey = case evolveKESUntil sHot (KESPeriod kpDiff) of
+        Nothing ->
+          error ("could not evolve key to iteration " ++ show kesPeriod)
+        Just hkey -> hkey
+      sig = case signedKES () kpDiff bhb hotKey of
+        Nothing -> error ("could not sign with KES key " ++ show hotKey)
+        Just sig' -> sig'
+      bh = BHeader bhb sig
+   in Block bh (TxSeq $ StrictSeq.fromList txns)
 
 -- | We provide our own nonces to 'mkBlock', which we then wish to recover as
 -- the output of the VRF functions. In general, however, we just derive them
@@ -410,21 +488,22 @@ newtype NatNonce = NatNonce Natural
 mkOCert :: HasCallStack => AllPoolKeys -> Natural -> KESPeriod -> OCert
 mkOCert pkeys n c0 =
   let (_, (_, vKeyHot)) = head $ hot pkeys
-      KeyPair _vKeyCold sKeyCold = cold pkeys in
-  OCert
-   vKeyHot
-   n
-   c0
-   (signedDSIGN @ConcreteCrypto sKeyCold (vKeyHot, n, c0))
+      KeyPair _vKeyCold sKeyCold = cold pkeys
+   in OCert
+        vKeyHot
+        n
+        c0
+        (signedDSIGN @ConcreteCrypto sKeyCold (vKeyHot, n, c0))
 
 getKESPeriodRenewalNo :: HasCallStack => AllPoolKeys -> KESPeriod -> Integer
 getKESPeriodRenewalNo keys (KESPeriod kp) =
   go (hot keys) 0 kp
-  where go [] _ _ = error "did not find enough KES renewals"
-        go ((KESPeriod p, _):rest) n k =
-          if p <= k && k < p + fromIntegral maxKESIterations
-          then n
-          else go rest (n + 1) k
+  where
+    go [] _ _ = error "did not find enough KES renewals"
+    go ((KESPeriod p, _) : rest) n k =
+      if p <= k && k < p + fromIntegral maxKESIterations
+        then n
+        else go rest (n + 1) k
 
 -- | True if the given slot is within the last `2 * slotsPrior`
 -- slots of the current epoch.

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Delegation.hs
@@ -7,58 +7,99 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Test.Shelley.Spec.Ledger.Generator.Delegation
-  ( genDCert
-  , CertCred (..))
-  where
+  ( genDCert,
+    CertCred (..),
+  )
+where
 
-import           Data.Map.Strict (Map)
+import Byron.Spec.Ledger.Core (dom, range, (∈), (∉))
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (elems, findWithDefault, fromList, keys, lookup, size)
-import           Data.Maybe (fromMaybe)
-import           Data.Ratio ((%))
+import Data.Maybe (fromMaybe)
+import Data.Ratio ((%))
 import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Set ((\\))
+import Data.Set ((\\))
 import qualified Data.Set as Set
-import           GHC.Stack (HasCallStack)
-import           Numeric.Natural (Natural)
-
-import           Test.QuickCheck (Gen)
+import GHC.Stack (HasCallStack)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.Address (mkRwdAcnt, scriptToCred)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), interval0)
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( pattern DCertMir,
+    pattern DeRegKey,
+    pattern Delegate,
+    pattern GenesisDelegCert,
+    pattern MIRCert,
+    pattern RegKey,
+    pattern RegPool,
+    pattern RetirePool,
+    pattern StakeCreds,
+  )
+import Shelley.Spec.Ledger.Keys (GenDelegs (..), KeyRole (..), coerceKeyRole, hashKey, vKey)
+import Shelley.Spec.Ledger.LedgerState
+  ( _dstate,
+    _genDelegs,
+    _pParams,
+    _pstate,
+    _retiring,
+    _rewards,
+    _stPools,
+    _stkCreds,
+  )
+import Shelley.Spec.Ledger.PParams (PParams, _d)
+import Shelley.Spec.Ledger.Slot (EpochNo (EpochNo), SlotNo)
+import Shelley.Spec.Ledger.TxData
+  ( RewardAcnt (..),
+    _poolPubKey,
+    _poolVrf,
+    unStakePools,
+    pattern DCertDeleg,
+    pattern DCertGenesis,
+    pattern DCertPool,
+    pattern Delegation,
+    pattern KeyHashObj,
+    pattern PoolParams,
+    pattern StakePools,
+  )
+import Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( CoreKeyPair,
+    DCert,
+    DPState,
+    DState,
+    KeyHash,
+    KeyPair,
+    KeyPairs,
+    MultiSig,
+    MultiSigPairs,
+    PState,
+    PoolParams,
+    VKey,
+    VrfKeyPairs,
+    hashKeyVRF,
+  )
+import Test.Shelley.Spec.Ledger.Examples.Examples (unsafeMkUnitInterval)
+import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( genCoinList,
+    genInteger,
+    genWord64,
+    toCred,
+    tooLateInEpoch,
+  )
+import Test.Shelley.Spec.Ledger.Utils
 
-import           Byron.Spec.Ledger.Core (dom, range, (∈), (∉))
-import           Shelley.Spec.Ledger.Address (mkRwdAcnt, scriptToCred)
-import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), interval0)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DCertMir, pattern DeRegKey,
-                     pattern Delegate, pattern GenesisDelegCert, pattern MIRCert, pattern RegKey,
-                     pattern RegPool, pattern RetirePool, pattern StakeCreds)
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), GenDelegs (..), hashKey, vKey, coerceKeyRole)
-import           Shelley.Spec.Ledger.LedgerState (_dstate, _genDelegs, _pParams, _pstate, _retiring,
-                     _rewards, _stPools, _stkCreds)
-import           Shelley.Spec.Ledger.PParams (PParams, _d)
-import           Shelley.Spec.Ledger.Slot (EpochNo (EpochNo), SlotNo)
-import           Shelley.Spec.Ledger.TxData (pattern DCertDeleg, pattern DCertGenesis,
-                     pattern DCertPool, pattern Delegation, pattern KeyHashObj, pattern PoolParams,
-                     RewardAcnt (..), pattern StakePools, unStakePools, _poolPubKey, _poolVrf)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CoreKeyPair, DCert, DPState, DState,
-                     KeyHash, KeyPair, KeyPairs, MultiSig, MultiSigPairs, PState, PoolParams, VKey,
-                     VrfKeyPairs, hashKeyVRF)
-import           Test.Shelley.Spec.Ledger.Examples.Examples (unsafeMkUnitInterval)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants(..))
-import           Test.Shelley.Spec.Ledger.Generator.Core (genCoinList, genInteger, genWord64,
-                     toCred, tooLateInEpoch)
-
-import           Test.Shelley.Spec.Ledger.Utils
-
-data CertCred = CoreKeyCred [CoreKeyPair]
-              | KeyCred (KeyPair 'Staking)
-              | ScriptCred (MultiSig, MultiSig)
-              | NoCred
-              deriving (Show)
+data CertCred
+  = CoreKeyCred [CoreKeyPair]
+  | KeyCred (KeyPair 'Staking)
+  | ScriptCred (MultiSig, MultiSig)
+  | NoCred
+  deriving (Show)
 
 -- | Occasionally generate a valid certificate
 --
@@ -70,108 +111,141 @@ data CertCred = CoreKeyCred [CoreKeyPair]
 --
 -- Note: we register keys and pools more often than deregistering/retiring them,
 -- and we generate more delegations than registrations of keys/pools.
+genDCert ::
+  HasCallStack =>
+  Constants ->
+  KeyPairs ->
+  MultiSigPairs ->
+  [CoreKeyPair] ->
+  VrfKeyPairs ->
+  Map (KeyHash 'Staking) (KeyPair 'Staking) -> -- indexed keys By hash
+  PParams ->
+  DPState ->
+  SlotNo ->
+  Gen (Maybe (DCert, CertCred))
 genDCert
-  :: HasCallStack
-  => Constants
-  -> KeyPairs
-  -> MultiSigPairs
-  -> [CoreKeyPair]
-  -> VrfKeyPairs
-  -> Map (KeyHash 'Staking) (KeyPair 'Staking) -- indexed keys By hash
-  -> PParams
-  -> DPState
-  -> SlotNo
-  -> Gen (Maybe (DCert, CertCred))
-genDCert
-  c@(Constants{frequencyRegKeyCert
-              , frequencyRegPoolCert
-              , frequencyDelegationCert
-              , frequencyGenesisDelegationCert
-              , frequencyDeRegKeyCert
-              , frequencyRetirePoolCert
-              , frequencyMIRCert
-              })
-  keys scripts coreKeys vrfKeys keysByHash pparams dpState slot =
-    QC.frequency [ (frequencyRegKeyCert, genRegKeyCert c keys scripts dState)
-                , (frequencyRegPoolCert, genRegPool keys vrfKeys dpState)
-                , (frequencyDelegationCert, genDelegation c keys scripts dpState)
-                , (frequencyGenesisDelegationCert, genGenesisDelegation keys coreKeys dpState)
-                , (frequencyDeRegKeyCert, genDeRegKeyCert c keys scripts dState)
-                , (frequencyRetirePoolCert, genRetirePool c keysByHash pState slot)
-                , (frequencyMIRCert, genInstantaneousRewards slot coreKeys pparams dState)
-                ]
- where
-  dState = _dstate dpState
-  pState = _pstate dpState
+  c@( Constants
+        { frequencyRegKeyCert,
+          frequencyRegPoolCert,
+          frequencyDelegationCert,
+          frequencyGenesisDelegationCert,
+          frequencyDeRegKeyCert,
+          frequencyRetirePoolCert,
+          frequencyMIRCert
+        }
+      )
+  keys
+  scripts
+  coreKeys
+  vrfKeys
+  keysByHash
+  pparams
+  dpState
+  slot =
+    QC.frequency
+      [ (frequencyRegKeyCert, genRegKeyCert c keys scripts dState),
+        (frequencyRegPoolCert, genRegPool keys vrfKeys dpState),
+        (frequencyDelegationCert, genDelegation c keys scripts dpState),
+        (frequencyGenesisDelegationCert, genGenesisDelegation keys coreKeys dpState),
+        (frequencyDeRegKeyCert, genDeRegKeyCert c keys scripts dState),
+        (frequencyRetirePoolCert, genRetirePool c keysByHash pState slot),
+        (frequencyMIRCert, genInstantaneousRewards slot coreKeys pparams dState)
+      ]
+    where
+      dState = _dstate dpState
+      pState = _pstate dpState
 
 -- | Generate a RegKey certificate along and also returns the staking credential
 -- (needed to witness the certificate)
+genRegKeyCert ::
+  HasCallStack =>
+  Constants ->
+  KeyPairs ->
+  MultiSigPairs ->
+  DState ->
+  Gen (Maybe (DCert, CertCred))
 genRegKeyCert
-  :: HasCallStack
-  => Constants
-  -> KeyPairs
-  -> MultiSigPairs
-  -> DState
-  -> Gen (Maybe (DCert, CertCred))
-genRegKeyCert
-  Constants{frequencyKeyCredReg, frequencyScriptCredReg}
-  keys scripts delegSt =
+  Constants {frequencyKeyCredReg, frequencyScriptCredReg}
+  keys
+  scripts
+  delegSt =
     QC.frequency
-      [ ( frequencyKeyCredReg
-        , case availableKeys of
+      [ ( frequencyKeyCredReg,
+          case availableKeys of
             [] -> pure Nothing
-            _  -> do
+            _ -> do
               (_payKey, stakeKey) <- QC.elements availableKeys
-              pure $ Just ( DCertDeleg (RegKey (toCred stakeKey))
-                          , NoCred))
-      , ( frequencyScriptCredReg
-        , case availableScripts of
+              pure $
+                Just
+                  ( DCertDeleg (RegKey (toCred stakeKey)),
+                    NoCred
+                  )
+        ),
+        ( frequencyScriptCredReg,
+          case availableScripts of
             [] -> pure Nothing
-            _  -> do
+            _ -> do
               (_, stakeScript) <- QC.elements availableScripts
-              pure $ Just ( DCertDeleg (RegKey (scriptToCred stakeScript))
-                          , NoCred))
+              pure $
+                Just
+                  ( DCertDeleg (RegKey (scriptToCred stakeScript)),
+                    NoCred
+                  )
+        )
       ]
-  where
-    notRegistered k = k ∉ dom (_stkCreds delegSt)
-    availableKeys = filter (notRegistered . toCred . snd) keys
-    availableScripts = filter (notRegistered . scriptToCred . snd) scripts
+    where
+      notRegistered k = k ∉ dom (_stkCreds delegSt)
+      availableKeys = filter (notRegistered . toCred . snd) keys
+      availableScripts = filter (notRegistered . scriptToCred . snd) scripts
 
 -- | Generate a DeRegKey certificate along with the staking credential, which is
 -- needed to witness the certificate.
-genDeRegKeyCert
-  :: HasCallStack
-  => Constants
-  -> KeyPairs
-  -> MultiSigPairs
-  -> DState
-  -> Gen (Maybe (DCert, CertCred))
+genDeRegKeyCert ::
+  HasCallStack =>
+  Constants ->
+  KeyPairs ->
+  MultiSigPairs ->
+  DState ->
+  Gen (Maybe (DCert, CertCred))
 genDeRegKeyCert Constants {frequencyKeyCredDeReg, frequencyScriptCredDeReg} keys scripts dState =
   QC.frequency
-  [ ( frequencyKeyCredDeReg
-    , case availableKeys of
-        [] -> pure Nothing
-        _ -> do
-          (_payKey, stakeKey) <- QC.elements availableKeys
-          pure $ Just (DCertDeleg (DeRegKey (toCred stakeKey)), KeyCred stakeKey))
-  , ( frequencyScriptCredDeReg
-    , case availableScripts of
-      [] -> pure Nothing
-      _  -> do
-          scriptPair@(_, stakeScript) <- QC.elements availableScripts
-          pure $ Just (DCertDeleg (DeRegKey (scriptToCred stakeScript))
-                      , ScriptCred scriptPair))
-  ]
+    [ ( frequencyKeyCredDeReg,
+        case availableKeys of
+          [] -> pure Nothing
+          _ -> do
+            (_payKey, stakeKey) <- QC.elements availableKeys
+            pure $ Just (DCertDeleg (DeRegKey (toCred stakeKey)), KeyCred stakeKey)
+      ),
+      ( frequencyScriptCredDeReg,
+        case availableScripts of
+          [] -> pure Nothing
+          _ -> do
+            scriptPair@(_, stakeScript) <- QC.elements availableScripts
+            pure $
+              Just
+                ( DCertDeleg (DeRegKey (scriptToCred stakeScript)),
+                  ScriptCred scriptPair
+                )
+      )
+    ]
   where
     registered k = k ∈ dom (_stkCreds dState)
     availableKeys =
-      filter (\(_, k) -> let cred = toCred k in
-                           ((&&) <$> registered <*> zeroRewards) cred) keys
+      filter
+        ( \(_, k) ->
+            let cred = toCred k
+             in ((&&) <$> registered <*> zeroRewards) cred
+        )
+        keys
     availableScripts =
-      filter (\(_, s) -> let cred = scriptToCred s in
-                      ((&&) <$> registered <*> zeroRewards) cred) scripts
+      filter
+        ( \(_, s) ->
+            let cred = scriptToCred s
+             in ((&&) <$> registered <*> zeroRewards) cred
+        )
+        scripts
     zeroRewards k =
-         (Coin 0) == (Map.findWithDefault (Coin 1) (mkRwdAcnt k) (_rewards dState))
+      (Coin 0) == (Map.findWithDefault (Coin 1) (mkRwdAcnt k) (_rewards dState))
 
 -- | Generate a new delegation certificate by picking a registered staking
 -- credential and pool. The delegation is witnessed by the delegator's
@@ -179,96 +253,96 @@ genDeRegKeyCert Constants {frequencyKeyCredDeReg, frequencyScriptCredDeReg} keys
 --
 -- Returns nothing if there are no registered staking credentials or no
 -- registered pools.
+genDelegation ::
+  HasCallStack =>
+  Constants ->
+  KeyPairs ->
+  MultiSigPairs ->
+  DPState ->
+  Gen (Maybe (DCert, CertCred))
 genDelegation
-  :: HasCallStack
-  => Constants
-  -> KeyPairs
-  -> MultiSigPairs
-  -> DPState
-  -> Gen (Maybe (DCert, CertCred))
-genDelegation Constants {frequencyKeyCredDelegation, frequencyScriptCredDelegation}
-              keys scripts dpState =
-  if null availablePools
-    then
-      pure Nothing
-    else
-    QC.frequency
-    [ ( frequencyKeyCredDelegation
-      , if null availableDelegates
-        then pure Nothing
-        else mkCert <$> QC.elements availableDelegates
-                    <*> QC.elements availablePools)
-    , ( frequencyScriptCredDelegation
-      , if null availableDelegatesScripts
-        then pure Nothing
-        else mkCertFromScript <$> QC.elements availableDelegatesScripts
-                              <*> QC.elements availablePools)
-    ]
-  where
-    mkCert (_, delegatorKey) poolKey = Just (cert, KeyCred delegatorKey)
-      where
-        cert = DCertDeleg (Delegate (Delegation (toCred delegatorKey) poolKey))
-    mkCertFromScript (s, delegatorScript) poolKey =
-      Just (scriptCert, ScriptCred (s, delegatorScript))
-      where
-        scriptCert =
-          DCertDeleg (Delegate (Delegation (scriptToCred delegatorScript) poolKey))
+  Constants {frequencyKeyCredDelegation, frequencyScriptCredDelegation}
+  keys
+  scripts
+  dpState =
+    if null availablePools
+      then pure Nothing
+      else
+        QC.frequency
+          [ ( frequencyKeyCredDelegation,
+              if null availableDelegates
+                then pure Nothing
+                else
+                  mkCert <$> QC.elements availableDelegates
+                    <*> QC.elements availablePools
+            ),
+            ( frequencyScriptCredDelegation,
+              if null availableDelegatesScripts
+                then pure Nothing
+                else
+                  mkCertFromScript <$> QC.elements availableDelegatesScripts
+                    <*> QC.elements availablePools
+            )
+          ]
+    where
+      mkCert (_, delegatorKey) poolKey = Just (cert, KeyCred delegatorKey)
+        where
+          cert = DCertDeleg (Delegate (Delegation (toCred delegatorKey) poolKey))
+      mkCertFromScript (s, delegatorScript) poolKey =
+        Just (scriptCert, ScriptCred (s, delegatorScript))
+        where
+          scriptCert =
+            DCertDeleg (Delegate (Delegation (scriptToCred delegatorScript) poolKey))
+      registeredDelegate k = k ∈ dom (_stkCreds (_dstate dpState))
+      availableDelegates = filter (registeredDelegate . toCred . snd) keys
+      availableDelegatesScripts =
+        filter (registeredDelegate . scriptToCred . snd) scripts
+      (StakePools registeredPools) = _stPools (_pstate dpState)
+      availablePools = Set.toList $ dom registeredPools
 
-    registeredDelegate k = k ∈ dom (_stkCreds (_dstate dpState))
-    availableDelegates = filter (registeredDelegate . toCred . snd) keys
-    availableDelegatesScripts =
-      filter (registeredDelegate . scriptToCred . snd) scripts
-
-    (StakePools registeredPools) = _stPools (_pstate dpState)
-    availablePools = Set.toList $ dom registeredPools
-
-genGenesisDelegation
-  :: HasCallStack
-  => KeyPairs
-  -> [CoreKeyPair]
-  -> DPState
-  -> Gen (Maybe (DCert, CertCred))
+genGenesisDelegation ::
+  HasCallStack =>
+  KeyPairs ->
+  [CoreKeyPair] ->
+  DPState ->
+  Gen (Maybe (DCert, CertCred))
 genGenesisDelegation keys coreKeys dpState =
   if null genesisDelegators || null availableDelegatees
-    then
-      pure Nothing
+    then pure Nothing
     else
       mkCert <$> QC.elements genesisDelegators
-             <*> QC.elements availableDelegatees
+        <*> QC.elements availableDelegatees
   where
     hashVKey = hashKey . vKey
-    mkCert gkey key = Just
-      ( DCertGenesis (GenesisDelegCert (hashVKey gkey) (hashVKey (coerceKeyRole $ snd key)))
-      , CoreKeyCred [gkey])
-
+    mkCert gkey key =
+      Just
+        ( DCertGenesis (GenesisDelegCert (hashVKey gkey) (hashVKey (coerceKeyRole $ snd key))),
+          CoreKeyCred [gkey]
+        )
     (GenDelegs genDelegs_) = _genDelegs $ _dstate dpState
-
     genesisDelegator k = k ∈ dom genDelegs_
     genesisDelegators = filter (genesisDelegator . hashVKey) coreKeys
-
     notDelegatee k = (coerceKeyRole k) ∉ range genDelegs_
     availableDelegatees = filter (notDelegatee . hashVKey . snd) keys
 
 -- | Generate and return a RegPool certificate along with its witnessing key.
-genRegPool
-  :: HasCallStack
-  => KeyPairs
-  -> VrfKeyPairs
-  -> DPState
-  -> Gen (Maybe (DCert, CertCred))
+genRegPool ::
+  HasCallStack =>
+  KeyPairs ->
+  VrfKeyPairs ->
+  DPState ->
+  Gen (Maybe (DCert, CertCred))
 genRegPool keys vrfKeys dpState =
   if null availableKeys || null availableVrfKeys
-     then pure Nothing
-     else
-       Just <$> genDCertRegPool availableKeys' availableVrfKeys
- where
-  notRegistered k = k `notElem` ((_poolPubKey <$>) . Map.elems . _pParams . _pstate) dpState
-  keys' = fmap (\(p, s) -> (p, coerceKeyRole s)) keys
-  availableKeys = filter (notRegistered . hashKey . vKey . snd) keys'
-  availableKeys' = fmap (\(p, s) -> (p, coerceKeyRole s)) availableKeys
-
-  notRegisteredVrf k = k `notElem` ((_poolVrf <$>) . Map.elems . _pParams . _pstate) dpState
-  availableVrfKeys = filter (notRegisteredVrf . hashKeyVRF . snd) vrfKeys
+    then pure Nothing
+    else Just <$> genDCertRegPool availableKeys' availableVrfKeys
+  where
+    notRegistered k = k `notElem` ((_poolPubKey <$>) . Map.elems . _pParams . _pstate) dpState
+    keys' = fmap (\(p, s) -> (p, coerceKeyRole s)) keys
+    availableKeys = filter (notRegistered . hashKey . vKey . snd) keys'
+    availableKeys' = fmap (\(p, s) -> (p, coerceKeyRole s)) availableKeys
+    notRegisteredVrf k = k `notElem` ((_poolVrf <$>) . Map.elems . _pParams . _pstate) dpState
+    availableVrfKeys = filter (notRegisteredVrf . hashKeyVRF . snd) vrfKeys
 
 -- | Generate PoolParams and the key witness.
 genStakePool :: HasCallStack => KeyPairs -> VrfKeyPairs -> Gen (PoolParams, KeyPair 'Witness)
@@ -276,29 +350,33 @@ genStakePool skeys vrfKeys =
   mkPoolParams
     <$> (QC.elements skeys')
     <*> (snd <$> QC.elements vrfKeys)
-    <*> (Coin <$> QC.frequency [ (1, genInteger 1 100)
-                               , (5, pure 0)]) -- pledge
+    <*> ( Coin
+            <$> QC.frequency
+              [ (1, genInteger 1 100),
+                (5, pure 0) -- pledge
+              ]
+        )
     <*> (Coin <$> genInteger 1 100) -- cost
     <*> (fromInteger <$> QC.choose (0, 100) :: Gen Natural)
     <*> (getAnyStakeKey skeys)
- where
-  skeys' = fmap (\(p, s) -> (p, coerceKeyRole s)) skeys
-  getAnyStakeKey :: KeyPairs -> Gen (VKey 'Staking)
-  getAnyStakeKey keys = vKey . snd <$> QC.elements keys
-
-  mkPoolParams poolKeyPair vrfKey pledge cost marginPercent acntKey =
-    let interval = unsafeMkUnitInterval $ fromIntegral marginPercent % 100
-        pps = PoolParams
-                (hashKey . vKey . snd $ poolKeyPair)
-                (hashKeyVRF vrfKey)
-                pledge
-                cost
-                interval
-                (RewardAcnt $ KeyHashObj $ hashKey acntKey)
-                Set.empty
-                StrictSeq.empty
-                SNothing
-     in (pps, coerceKeyRole $ snd poolKeyPair)
+  where
+    skeys' = fmap (\(p, s) -> (p, coerceKeyRole s)) skeys
+    getAnyStakeKey :: KeyPairs -> Gen (VKey 'Staking)
+    getAnyStakeKey keys = vKey . snd <$> QC.elements keys
+    mkPoolParams poolKeyPair vrfKey pledge cost marginPercent acntKey =
+      let interval = unsafeMkUnitInterval $ fromIntegral marginPercent % 100
+          pps =
+            PoolParams
+              (hashKey . vKey . snd $ poolKeyPair)
+              (hashKeyVRF vrfKey)
+              pledge
+              cost
+              interval
+              (RewardAcnt $ KeyHashObj $ hashKey acntKey)
+              Set.empty
+              StrictSeq.empty
+              SNothing
+       in (pps, coerceKeyRole $ snd poolKeyPair)
 
 -- | Generate `RegPool` and the key witness.
 genDCertRegPool :: HasCallStack => KeyPairs -> VrfKeyPairs -> Gen (DCert, CertCred)
@@ -313,67 +391,76 @@ genDCertRegPool skeys vrfKeys = do
 -- acceptable range of the current epoch. In addition to the `RetirePool`
 -- constructed value, return the keypair which corresponds to the selected
 -- `KeyHash`, by doing a lookup in the set of `availableKeys`.
-genRetirePool
-  :: HasCallStack
-  => Constants
-  -> Map (KeyHash 'Staking) (KeyPair 'Staking) -- indexed keys By Hash
-  -> PState
-  -> SlotNo
-  -> Gen (Maybe (DCert, CertCred))
-genRetirePool Constants{frequencyLowMaxEpoch} keysByHash pState slot =
+genRetirePool ::
+  HasCallStack =>
+  Constants ->
+  Map (KeyHash 'Staking) (KeyPair 'Staking) -> -- indexed keys By Hash
+  PState ->
+  SlotNo ->
+  Gen (Maybe (DCert, CertCred))
+genRetirePool Constants {frequencyLowMaxEpoch} keysByHash pState slot =
   if (null retireable)
-     then pure Nothing
-     else (\keyHash epoch ->
-              Just ( DCertPool (RetirePool keyHash epoch)
-                   , KeyCred (lookupHash keyHash)))
-                <$> QC.elements retireable
-                <*> (EpochNo <$> genWord64 epochLow epochHigh)
- where
-  stakePools = (unStakePools . _stPools) pState
-
-  registered_ = dom stakePools
-  retiring_ = dom (_retiring pState)
-  retireable = Set.toList (registered_ \\ retiring_)
-
-  lookupHash hk = fromMaybe (error "genRetirePool: could not find keyHash")
-                            (Map.lookup (coerceKeyRole hk) keysByHash)
-  EpochNo cepoch = epochFromSlotNo slot
-  epochLow = cepoch + 1
-  -- we use the lower bound of MaxEpoch as the high mark so that all possible
-  -- future updates of the protocol parameter, MaxEpoch, will not decrease
-  -- the cut-off for pool-retirement and render this RetirePool
-  -- "too late in the epoch" when it is retired
-  epochHigh = cepoch + frequencyLowMaxEpoch - 1
+    then pure Nothing
+    else
+      ( \keyHash epoch ->
+          Just
+            ( DCertPool (RetirePool keyHash epoch),
+              KeyCred (lookupHash keyHash)
+            )
+      )
+        <$> QC.elements retireable
+        <*> (EpochNo <$> genWord64 epochLow epochHigh)
+  where
+    stakePools = (unStakePools . _stPools) pState
+    registered_ = dom stakePools
+    retiring_ = dom (_retiring pState)
+    retireable = Set.toList (registered_ \\ retiring_)
+    lookupHash hk =
+      fromMaybe
+        (error "genRetirePool: could not find keyHash")
+        (Map.lookup (coerceKeyRole hk) keysByHash)
+    EpochNo cepoch = epochFromSlotNo slot
+    epochLow = cepoch + 1
+    -- we use the lower bound of MaxEpoch as the high mark so that all possible
+    -- future updates of the protocol parameter, MaxEpoch, will not decrease
+    -- the cut-off for pool-retirement and render this RetirePool
+    -- "too late in the epoch" when it is retired
+    epochHigh = cepoch + frequencyLowMaxEpoch - 1
 
 -- | Generate an InstantaneousRewards Transfer certificate
-genInstantaneousRewards
-  :: HasCallStack
-  => SlotNo
-  -> [CoreKeyPair]
-  -> PParams
-  -> DState
-  -> Gen (Maybe (DCert, CertCred))
+genInstantaneousRewards ::
+  HasCallStack =>
+  SlotNo ->
+  [CoreKeyPair] ->
+  PParams ->
+  DState ->
+  Gen (Maybe (DCert, CertCred))
 genInstantaneousRewards s coreKeys pparams delegSt = do
   let StakeCreds credentials = _stkCreds delegSt
 
-  winnerCreds <- take <$> QC.elements [0 .. (max 0 $ (Map.size credentials) - 1)]
-                      <*> QC.shuffle (Map.keys credentials)
+  winnerCreds <-
+    take <$> QC.elements [0 .. (max 0 $ (Map.size credentials) - 1)]
+      <*> QC.shuffle (Map.keys credentials)
   coins <- genCoinList 1 1000 (length winnerCreds) (length winnerCreds)
 
-  coreSigners <- take <$> QC.elements [5 .. (max 0 $ (length coreKeys) - 1)]
-                      <*> QC.shuffle coreKeys
+  coreSigners <-
+    take <$> QC.elements [5 .. (max 0 $ (length coreKeys) - 1)]
+      <*> QC.shuffle coreKeys
 
   let credCoinMap = Map.fromList $ zip winnerCreds coins
 
-  pure $ if (-- Discard this generator (by returning Nothing) if:
-             -- we are in full decentralisation mode (d=0) when IR certs are not allowed
-             _d pparams == interval0
-             -- or when we don't have keys available for generating an IR cert
-             || null credCoinMap
-             -- or it's too late in the epoch for IR certs
-             || tooLateInEpoch s)
-    then
-      Nothing
-    else
-      Just ( DCertMir (MIRCert credCoinMap)
-           , CoreKeyCred coreSigners)
+  pure $
+    if ( -- Discard this generator (by returning Nothing) if:
+         -- we are in full decentralisation mode (d=0) when IR certs are not allowed
+         _d pparams == interval0
+           -- or when we don't have keys available for generating an IR cert
+           || null credCoinMap
+           -- or it's too late in the epoch for IR certs
+           || tooLateInEpoch s
+       )
+      then Nothing
+      else
+        Just
+          ( DCertMir (MIRCert credCoinMap),
+            CoreKeyCred coreSigners
+          )

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Presets.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Presets.hs
@@ -23,7 +23,7 @@ import Shelley.Spec.Ledger.Keys
   ( KeyRole (..),
     coerceKeyRole,
     hashKey,
-    vKey
+    vKey,
   )
 import Shelley.Spec.Ledger.LedgerState (genesisCoins)
 import Shelley.Spec.Ledger.OCert (KESPeriod (..))

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -8,51 +8,64 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 -- Allow for an orphan HasTrace instance for CHAIN, since HasTrace only pertains to tests
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Test.Shelley.Spec.Ledger.Generator.Trace.Chain where
 
-import           Data.Coerce (coerce)
-import           Data.Functor.Identity (runIdentity)
-import           Data.Map.Strict (Map)
+import Cardano.Slotting.Slot (WithOrigin (..))
+import Control.Monad.Trans.Reader (runReaderT)
+import Control.State.Transition (IRC (..))
+import Control.State.Transition.Trace.Generator.QuickCheck
+  ( BaseEnv,
+    HasTrace,
+    envGen,
+    interpretSTS,
+    shrinkSignal,
+    sigGen,
+  )
+import Data.Coerce (coerce)
+import Data.Functor.Identity (runIdentity)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map (elems, fromList, keysSet)
-import           Numeric.Natural (Natural)
-import           Test.QuickCheck (Gen)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes (Globals)
+import Shelley.Spec.Ledger.BlockChain
+  ( LastAppliedBlock (..),
+    hashHeaderToNonce,
+    pattern HashHeader,
+  )
+import Shelley.Spec.Ledger.Keys (Hash, KeyRole (BlockIssuer), coerceKeyRole, hash)
+import Shelley.Spec.Ledger.LedgerState (overlaySchedule)
+import Shelley.Spec.Ledger.STS.Chain (initialShelleyState)
+import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
+import Shelley.Spec.Ledger.UTxO (balance)
+import Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
-
-import           Cardano.Slotting.Slot (WithOrigin (..))
-import           Control.Monad.Trans.Reader (runReaderT)
-import           Control.State.Transition (IRC (..))
-import           Control.State.Transition.Trace.Generator.QuickCheck (BaseEnv, HasTrace, envGen,
-                     interpretSTS, shrinkSignal, sigGen)
-import           Shelley.Spec.Ledger.BaseTypes (Globals)
-import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader, LastAppliedBlock (..),
-                     hashHeaderToNonce)
-import           Shelley.Spec.Ledger.Keys (Hash, KeyRole (BlockIssuer), coerceKeyRole, hash)
-import           Shelley.Spec.Ledger.LedgerState (overlaySchedule)
-import           Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
-import           Shelley.Spec.Ledger.STS.Chain (initialShelleyState)
-import           Shelley.Spec.Ledger.UTxO (balance)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN, ChainState, ConcreteCrypto,
-                     GenDelegs, pattern GenDelegs, HashHeader, KeyHash)
-import           Test.Shelley.Spec.Ledger.Generator.Block (genBlock)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
-import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..))
-import           Test.Shelley.Spec.Ledger.Generator.Presets (genUtxo0, genesisDelegs0)
-import           Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
-import           Test.Shelley.Spec.Ledger.Shrinkers (shrinkBlock)
-import           Test.Shelley.Spec.Ledger.Utils (maxLLSupply, runShelleyBase)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( CHAIN,
+    ChainState,
+    ConcreteCrypto,
+    GenDelegs,
+    HashHeader,
+    KeyHash,
+    pattern GenDelegs,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Block (genBlock)
+import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..))
+import Test.Shelley.Spec.Ledger.Generator.Presets (genUtxo0, genesisDelegs0)
+import Test.Shelley.Spec.Ledger.Generator.Update (genPParams)
+import Test.Shelley.Spec.Ledger.Shrinkers (shrinkBlock)
+import Test.Shelley.Spec.Ledger.Utils (maxLLSupply, runShelleyBase)
 
 -- The CHAIN STS at the root of the STS allows for generating blocks of transactions
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
 instance HasTrace CHAIN GenEnv where
   -- the current slot needs to be large enough to allow for many blocks
   -- to be processed (in large CHAIN traces)
-  envGen (GenEnv _ Constants{minSlotTrace, maxSlotTrace})
-    = SlotNo <$> QC.choose (fromIntegral minSlotTrace, fromIntegral maxSlotTrace)
+  envGen (GenEnv _ Constants {minSlotTrace, maxSlotTrace}) =
+    SlotNo <$> QC.choose (fromIntegral minSlotTrace, fromIntegral maxSlotTrace)
 
   sigGen ge env st =
     genBlock
@@ -76,35 +89,38 @@ lastByronHeaderHash = HashHeader $ coerce (hash 0 :: Hash ConcreteCrypto Int)
 -- with the signature 'RuleContext sts -> Gen (Either [[PredicateFailure sts]] (State sts))'.
 -- To achieve this we (1) use 'IRC CHAIN' (the "initial rule context") instead of simply 'Chain Env'
 -- and (2) always return Right (since this function does not raise predicate failures).
-mkGenesisChainState
-  :: Constants
-  -> IRC CHAIN
-  -> Gen (Either a ChainState)
+mkGenesisChainState ::
+  Constants ->
+  IRC CHAIN ->
+  Gen (Either a ChainState)
 mkGenesisChainState constants (IRC _slotNo) = do
   utxo0 <- genUtxo0 constants
 
   pParams <- genPParams constants
-  let osched_ = runShelleyBase $ overlaySchedule
-                epoch0
-                (Map.keysSet delegs0)
-                pParams
+  let osched_ =
+        runShelleyBase $
+          overlaySchedule
+            epoch0
+            (Map.keysSet delegs0)
+            pParams
 
-  pure . Right $ initialShelleyState
-    (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
-    epoch0
-    utxo0
-    (maxLLSupply - balance utxo0)
-    delegs0
-    osched_
-    pParams
-    (hashHeaderToNonce lastByronHeaderHash)
+  pure . Right $
+    initialShelleyState
+      (At $ LastAppliedBlock (BlockNo 0) (SlotNo 0) lastByronHeaderHash)
+      epoch0
+      utxo0
+      (maxLLSupply - balance utxo0)
+      delegs0
+      osched_
+      pParams
+      (hashHeaderToNonce lastByronHeaderHash)
   where
     epoch0 = EpochNo 0
     delegs0 = genesisDelegs0 constants
 
-mkOCertIssueNos
-  :: GenDelegs
-  -> Map (KeyHash 'BlockIssuer) Natural
+mkOCertIssueNos ::
+  GenDelegs ->
+  Map (KeyHash 'BlockIssuer) Natural
 mkOCertIssueNos (GenDelegs delegs0) =
   Map.fromList (fmap f (Map.elems delegs0))
   where

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/DCert.hs
@@ -1,53 +1,60 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
-
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+module Test.Shelley.Spec.Ledger.Generator.Trace.DCert (genDCerts) where
 
-module Test.Shelley.Spec.Ledger.Generator.Trace.DCert
-  (genDCerts)
-  where
-
-import           Control.Monad.Trans.Reader (runReaderT)
-import           Data.Functor.Identity (runIdentity)
-import qualified Data.Map.Strict as Map (lookup)
-import           Data.Maybe (catMaybes)
-import           Data.Sequence.Strict (StrictSeq)
-import qualified Data.Sequence.Strict as StrictSeq
-import           Numeric.Natural (Natural)
-import           Test.QuickCheck (Gen)
-
-import           Control.State.Transition (BaseM, Embed, Environment, PredicateFailure, STS, Signal,
-                     State, TRC (..), TransitionRule, initialRules, judgmentContext, trans,
-                     transitionRules, wrapFailed)
-import           Control.State.Transition.Trace (TraceOrder (OldestFirst), lastState, traceSignals)
+import Control.Monad.Trans.Reader (runReaderT)
+import Control.State.Transition
+  ( BaseM,
+    Embed,
+    Environment,
+    PredicateFailure,
+    STS,
+    Signal,
+    State,
+    TRC (..),
+    TransitionRule,
+    initialRules,
+    judgmentContext,
+    trans,
+    transitionRules,
+    wrapFailed,
+  )
+import Control.State.Transition.Trace (TraceOrder (OldestFirst), lastState, traceSignals)
 import qualified Control.State.Transition.Trace.Generator.QuickCheck as QC
-import           GHC.Generics (Generic)
-import           Shelley.Spec.Ledger.BaseTypes (Globals, ShelleyBase)
-import           Shelley.Spec.Ledger.Coin (Coin)
-import           Shelley.Spec.Ledger.Delegation.Certificates (decayKey, isDeRegKey)
-import           Shelley.Spec.Ledger.Keys (HasKeyRole(coerceKeyRole))
-import           Shelley.Spec.Ledger.LedgerState (keyRefund, _dstate, _pstate, _stPools, _stkCreds)
-import           Shelley.Spec.Ledger.PParams (PParams)
-import           Shelley.Spec.Ledger.Slot (SlotNo (..))
-import           Shelley.Spec.Ledger.STS.Delpl (DelplEnv (..))
-import           Shelley.Spec.Ledger.Tx (getKeyCombination)
-import           Shelley.Spec.Ledger.TxData (Ix, Ptr (..))
-import           Shelley.Spec.Ledger.UTxO (totalDeposits)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DCert, DELPL, DPState)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
-import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..), KeySpace (..))
-import           Test.Shelley.Spec.Ledger.Generator.Delegation (CertCred (..), genDCert)
-import           Test.Shelley.Spec.Ledger.Utils (testGlobals)
+import Data.Functor.Identity (runIdentity)
+import qualified Data.Map.Strict as Map (lookup)
+import Data.Maybe (catMaybes)
+import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
+import GHC.Generics (Generic)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes (Globals, ShelleyBase)
+import Shelley.Spec.Ledger.Coin (Coin)
+import Shelley.Spec.Ledger.Delegation.Certificates (decayKey, isDeRegKey)
+import Shelley.Spec.Ledger.Keys (HasKeyRole (coerceKeyRole))
+import Shelley.Spec.Ledger.LedgerState (_dstate, _pstate, _stPools, _stkCreds, keyRefund)
+import Shelley.Spec.Ledger.PParams (PParams)
+import Shelley.Spec.Ledger.STS.Delpl (DelplEnv (..))
+import Shelley.Spec.Ledger.Slot (SlotNo (..))
+import Shelley.Spec.Ledger.Tx (getKeyCombination)
+import Shelley.Spec.Ledger.TxData (Ix, Ptr (..))
+import Shelley.Spec.Ledger.UTxO (totalDeposits)
+import Test.QuickCheck (Gen)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DCert, DELPL, DPState)
+import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..), KeySpace (..))
+import Test.Shelley.Spec.Ledger.Generator.Delegation (CertCred (..), genDCert)
+import Test.Shelley.Spec.Ledger.Utils (testGlobals)
 
 -- | This is a non-spec STS used to generate a sequence of certificates with
 -- witnesses.
@@ -69,9 +76,12 @@ instance STS CERTS where
 
 certsTransition :: TransitionRule CERTS
 certsTransition = do
-  TRC ( (slot, txIx, pp, reserves)
-      , (dpState, nextCertIx)
-      , c) <- judgmentContext
+  TRC
+    ( (slot, txIx, pp, reserves),
+      (dpState, nextCertIx),
+      c
+      ) <-
+    judgmentContext
 
   case c of
     Just (cert, _wits) -> do
@@ -119,15 +129,15 @@ instance QC.HasTrace CERTS GenEnv where
 
 -- | Generate certificates and also return the associated witnesses and
 -- deposits and refunds required.
-genDCerts
-  :: GenEnv
-  -> PParams
-  -> DPState
-  -> SlotNo
-  -> Natural
-  -> Natural
-  -> Coin
-  -> Gen (StrictSeq DCert, [CertCred], Coin, Coin, DPState)
+genDCerts ::
+  GenEnv ->
+  PParams ->
+  DPState ->
+  SlotNo ->
+  Natural ->
+  Natural ->
+  Coin ->
+  Gen (StrictSeq DCert, [CertCred], Coin, Coin, DPState)
 genDCerts
   ge@( GenEnv
          KeySpace_ {ksKeyPairsByHash}
@@ -139,41 +149,40 @@ genDCerts
   ttl
   txIx
   reserves = do
-  let env = (slot, txIx, pparams, reserves)
-      st0 = (dpState, 0)
+    let env = (slot, txIx, pparams, reserves)
+        st0 = (dpState, 0)
 
-  certsTrace <-
+    certsTrace <-
       QC.traceFrom @CERTS testGlobals maxCertsPerTx ge env st0
 
-  let certsCreds = catMaybes . traceSignals OldestFirst $ certsTrace
-      (lastState_, _) = lastState certsTrace
-      (certs, creds) = unzip certsCreds
-      deRegStakeCreds = filter isDeRegKey certs
-      slotWithTTL = slot + SlotNo (fromIntegral ttl)
+    let certsCreds = catMaybes . traceSignals OldestFirst $ certsTrace
+        (lastState_, _) = lastState certsTrace
+        (certs, creds) = unzip certsCreds
+        deRegStakeCreds = filter isDeRegKey certs
+        slotWithTTL = slot + SlotNo (fromIntegral ttl)
 
-  withScriptCreds <- concat <$> mapM extendWithScriptCred creds
+    withScriptCreds <- concat <$> mapM extendWithScriptCred creds
 
-  pure ( StrictSeq.fromList certs
-       , withScriptCreds
-       , totalDeposits pparams (_stPools (_pstate dpState)) certs
-       , sum (certRefund slotWithTTL <$> deRegStakeCreds)
-       , lastState_)
-
-  where
-    (dval, dmin, lambda) = decayKey pparams
-    stkCreds_ = (_stkCreds . _dstate) dpState
-    certRefund = keyRefund dval dmin lambda stkCreds_
-
-    extendWithScriptCred cred =
-      case cred of
-        ScriptCred (_, stakeScript) -> do
-          let witnessHashes = getKeyCombination stakeScript
-              witnessHashes' = fmap coerceKeyRole witnessHashes
-              foo = catMaybes (map lookupWit witnessHashes')
-              witnessHashes'' = fmap coerceKeyRole foo
-              witnesses = KeyCred <$> witnessHashes''
-          pure (witnesses ++ [cred])
-        _ ->
-          return [cred]
-
-    lookupWit = flip Map.lookup ksKeyPairsByHash
+    pure
+      ( StrictSeq.fromList certs,
+        withScriptCreds,
+        totalDeposits pparams (_stPools (_pstate dpState)) certs,
+        sum (certRefund slotWithTTL <$> deRegStakeCreds),
+        lastState_
+      )
+    where
+      (dval, dmin, lambda) = decayKey pparams
+      stkCreds_ = (_stkCreds . _dstate) dpState
+      certRefund = keyRefund dval dmin lambda stkCreds_
+      extendWithScriptCred cred =
+        case cred of
+          ScriptCred (_, stakeScript) -> do
+            let witnessHashes = getKeyCombination stakeScript
+                witnessHashes' = fmap coerceKeyRole witnessHashes
+                foo = catMaybes (map lookupWit witnessHashes')
+                witnessHashes'' = fmap coerceKeyRole foo
+                witnesses = KeyCred <$> witnessHashes''
+            pure (witnesses ++ [cred])
+          _ ->
+            return [cred]
+      lookupWit = flip Map.lookup ksKeyPairsByHash

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
@@ -6,44 +6,80 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Test.Shelley.Spec.Ledger.Generator.Update
-  ( genPParams
-  , genUpdate
+  ( genPParams,
+    genUpdate,
   )
-  where
+where
 
-import           Data.Map.Strict (Map)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe)
-import           Data.Ratio ((%))
-import           GHC.Stack (HasCallStack)
-
-import           Test.QuickCheck (Gen)
+import Data.Maybe (fromMaybe)
+import Data.Ratio ((%))
+import GHC.Stack (HasCallStack)
+import Numeric.Natural (Natural)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Nonce (NeutralNonce),
+    StrictMaybe (..),
+    UnitInterval,
+    mkNonce,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Keys (GenDelegs (..), KeyRole (..), coerceKeyRole, hashKey, vKey)
+import Shelley.Spec.Ledger.LedgerState (_dstate, _genDelegs)
+import Shelley.Spec.Ledger.PParams
+  ( PParams,
+    PParams' (PParams),
+    ProtVer (..),
+    _a0,
+    _d,
+    _eMax,
+    _extraEntropy,
+    _keyDecayRate,
+    _keyDeposit,
+    _keyMinRefund,
+    _maxBBSize,
+    _maxBHSize,
+    _maxTxSize,
+    _minfeeA,
+    _minfeeB,
+    _nOpt,
+    _poolDecayRate,
+    _poolDeposit,
+    _poolMinRefund,
+    _protocolVersion,
+    _protocolVersion,
+    _rho,
+    _tau,
+    pattern ProposedPPUpdates,
+    pattern Update,
+  )
+import Shelley.Spec.Ledger.Slot (EpochNo (EpochNo), SlotNo)
+import Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
-
-import           Numeric.Natural (Natural)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (NeutralNonce), StrictMaybe (..),
-                     UnitInterval, mkNonce)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Keys (GenDelegs (..), KeyRole(..), coerceKeyRole, hashKey, vKey)
-import           Shelley.Spec.Ledger.LedgerState (_dstate, _genDelegs)
-import           Shelley.Spec.Ledger.PParams (PParams, PParams' (PParams),
-                     pattern ProposedPPUpdates, ProtVer (..), pattern Update, _a0, _d, _eMax,
-                     _extraEntropy, _keyDecayRate, _keyDeposit, _keyMinRefund, _maxBBSize,
-                     _maxBHSize, _maxTxSize, _minfeeA, _minfeeB, _nOpt, _poolDecayRate,
-                     _poolDeposit, _poolMinRefund, _protocolVersion, _protocolVersion, _rho, _tau)
-import           Shelley.Spec.Ledger.Slot (EpochNo (EpochNo), SlotNo)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CoreKeyPair, DPState, KeyHash,
-                     KeyHash, KeyPair, ProposedPPUpdates, UTxOState, Update)
-import           Test.Shelley.Spec.Ledger.Examples.Examples (unsafeMkUnitInterval)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
-import           Test.Shelley.Spec.Ledger.Generator.Core (AllPoolKeys (cold), genInteger,
-                     genNatural, genWord64, increasingProbabilityAt, tooLateInEpoch)
-import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( CoreKeyPair,
+    DPState,
+    KeyHash,
+    KeyHash,
+    KeyPair,
+    ProposedPPUpdates,
+    UTxOState,
+    Update,
+  )
+import Test.Shelley.Spec.Ledger.Examples.Examples (unsafeMkUnitInterval)
+import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( AllPoolKeys (cold),
+    genInteger,
+    genNatural,
+    genWord64,
+    increasingProbabilityAt,
+    tooLateInEpoch,
+  )
+import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo)
 
 genRationalInThousands :: HasCallStack => Integer -> Integer -> Gen Rational
 genRationalInThousands lower upper =
@@ -54,28 +90,25 @@ genIntervalInThousands lower upper =
   unsafeMkUnitInterval <$> genRationalInThousands lower upper
 
 genPParams :: HasCallStack => Constants -> Gen PParams
-genPParams c@(Constants {maxMinFeeA, maxMinFeeB})
-  = mkPParams <$> genNatural 0 maxMinFeeA -- _minfeeA
-              <*> genNatural 0 maxMinFeeB -- _minfeeB
-              <*> szGen  -- (maxBBSize, maxBHSize, maxTxSize)
-              <*> genKeyDeposit
-              <*> genKeyMinRefund
-              <*> genKeyDecayRate
-              <*> genPoolDeposit
-              <*> genPoolMinRefund
-              <*> genPoolDecayRate
-              <*> genEMax c
-              <*> genNOpt
-              <*> genA0
-              <*> genRho
-              <*> genTau
-              <*> genDecentralisationParam
-              <*> genExtraEntropy
-              <*> genProtocolVersion
+genPParams c@(Constants {maxMinFeeA, maxMinFeeB}) =
+  mkPParams <$> genNatural 0 maxMinFeeA -- _minfeeA
+    <*> genNatural 0 maxMinFeeB -- _minfeeB
+    <*> szGen -- (maxBBSize, maxBHSize, maxTxSize)
+    <*> genKeyDeposit
+    <*> genKeyMinRefund
+    <*> genKeyDecayRate
+    <*> genPoolDeposit
+    <*> genPoolMinRefund
+    <*> genPoolDecayRate
+    <*> genEMax c
+    <*> genNOpt
+    <*> genA0
+    <*> genRho
+    <*> genTau
+    <*> genDecentralisationParam
+    <*> genExtraEntropy
+    <*> genProtocolVersion
   where
-
-    -- | Generates max block, header and transaction size. First generates the
-    -- body size and then header and tx sizes no larger than half the body size.
     szGen :: Gen (Natural, Natural, Natural)
     szGen = do
       blockBodySize <- genNatural low hi
@@ -86,7 +119,6 @@ genPParams c@(Constants {maxMinFeeA, maxMinFeeB})
     -- A wrapper to enable the dependent generators for the max sizes
     mkPParams minFeeA minFeeB (maxBBSize, maxTxSize, maxBHSize) =
       PParams minFeeA minFeeB maxBBSize maxTxSize maxBHSize
-
     rangeUpTo :: Natural -> Gen Natural
     rangeUpTo upper = genNatural low upper
 
@@ -94,16 +126,15 @@ genPParams c@(Constants {maxMinFeeA, maxMinFeeB})
 genKeyDecayRate :: HasCallStack => Gen Rational
 genKeyDecayRate = genRationalInThousands 1 100
 
-
 -- poolDeposit
 -- NOTE: we need to keep these deposits small, otherwise
 -- when we generate sequences of transactions we will bleed too
 -- much funds into the deposit pool (i.e. funds not available as utxo)
 genPoolDeposit :: HasCallStack => Gen Coin
 genPoolDeposit =
-    increasingProbabilityAt
-          (Coin <$> genInteger 0 100)
-          (Coin 0, Coin 100)
+  increasingProbabilityAt
+    (Coin <$> genInteger 0 100)
+    (Coin 0, Coin 100)
 
 -- poolMinRefund: 0.1-0.7
 genPoolMinRefund :: HasCallStack => Gen UnitInterval
@@ -115,9 +146,11 @@ genPoolDecayRate = genRationalInThousands 1 100
 
 -- Generates a Neutral or actual Nonces with equal frequency
 genExtraEntropy :: HasCallStack => Gen Nonce
-genExtraEntropy  = QC.frequency [ (1, pure NeutralNonce)
-                                , (1, mkNonce <$> genNatural 1 123)]
-
+genExtraEntropy =
+  QC.frequency
+    [ (1, pure NeutralNonce),
+      (1, mkNonce <$> genNatural 1 123)
+    ]
 
 -- Note: we keep the lower bound high enough so that we can more likely
 -- generate valid transactions and blocks
@@ -130,25 +163,26 @@ genKeyMinRefund :: HasCallStack => Gen UnitInterval
 genKeyMinRefund = genIntervalInThousands 100 500
 
 -- eMax (for an epoch per 5 days, say, this is between a month and 7yrs)
-genEMax
-  :: HasCallStack
-  => Constants
-  -> Gen EpochNo
-genEMax Constants{frequencyLowMaxEpoch}
-  = EpochNo <$> genWord64 frequencyLowMaxEpoch 500
+genEMax ::
+  HasCallStack =>
+  Constants ->
+  Gen EpochNo
+genEMax Constants {frequencyLowMaxEpoch} =
+  EpochNo <$> genWord64 frequencyLowMaxEpoch 500
 
 -- | nOpt
 genNOpt :: HasCallStack => Gen Natural
-genNOpt  = genNatural 1 100
+genNOpt = genNatural 1 100
 
 -- | genKeyDeposit
 -- NOTE: we need to keep these deposits small, otherwise
 -- when we generate sequences of transactions we will bleed too
 -- much funds into the deposit pool (i.e. funds not available as utxo)
 genKeyDeposit :: HasCallStack => Gen Coin
-genKeyDeposit = increasingProbabilityAt
-                  (Coin <$> genInteger 0 20)
-                  (Coin 0, Coin 20)
+genKeyDeposit =
+  increasingProbabilityAt
+    (Coin <$> genInteger 0 20)
+    (Coin 0, Coin 20)
 
 -- | a0: 0.01-1.0
 genA0 :: HasCallStack => Gen Rational
@@ -164,78 +198,81 @@ genTau = genIntervalInThousands 100 300
 
 genDecentralisationParam :: HasCallStack => Gen UnitInterval
 genDecentralisationParam = unsafeMkUnitInterval <$> QC.elements [0.1, 0.2 .. 1]
--- ^^ TODO jc - generating d=0 takes some care, if there are no registered
--- stake pools then d=0 deadlocks the system.
+-- ^ ^ TODO jc - generating d=0 takes some care, if there are no registered
+--  stake pools then d=0 deadlocks the system.
 
 genProtocolVersion :: HasCallStack => Gen ProtVer
-genProtocolVersion  = ProtVer <$> genNatural 1 10 <*> genNatural 1 50
+genProtocolVersion = ProtVer <$> genNatural 1 10 <*> genNatural 1 50
 
 -- | Generate a possible next Protocol version based on the previous version.
 -- Increments the Major or Minor versions and possibly the Alt version.
-genNextProtocolVersion
-  :: HasCallStack
-  => PParams
-  -> Gen ProtVer
+genNextProtocolVersion ::
+  HasCallStack =>
+  PParams ->
+  Gen ProtVer
 genNextProtocolVersion pp = do
   QC.elements
-    [ ProtVer (m + 1) 0
-    , ProtVer m       (n + 1)]
+    [ ProtVer (m + 1) 0,
+      ProtVer m (n + 1)
+    ]
   where
     ProtVer m n = _protocolVersion pp
 
 -- | Generate a proposal for protocol parameter updates for all the given genesis keys.
 -- Return an empty update if it is too late in the epoch for updates.
-genPPUpdate
-  :: HasCallStack
-  => Constants
-  -> SlotNo
-  -> PParams
-  -> [KeyHash 'Genesis]
-  -> Gen ProposedPPUpdates
-genPPUpdate (c@Constants{maxMinFeeA, maxMinFeeB}) s pp genesisKeys =
+genPPUpdate ::
+  HasCallStack =>
+  Constants ->
+  SlotNo ->
+  PParams ->
+  [KeyHash 'Genesis] ->
+  Gen ProposedPPUpdates
+genPPUpdate (c@Constants {maxMinFeeA, maxMinFeeB}) s pp genesisKeys =
   if (tooLateInEpoch s)
-    then
-      pure (ProposedPPUpdates Map.empty)
-    else do -- TODO generate Maybe tyes so not all updates are full
-      minFeeA               <- genNatural 0 maxMinFeeA
-      minFeeB               <- genNatural 0 maxMinFeeB
-      maxBBSize             <- genNatural low hi
-      maxTxSize             <- genNatural low hi
-      maxBHSize             <- genNatural low hi
-      keyDeposit            <- genKeyDeposit
-      keyMinRefund          <- genKeyMinRefund
-      keyDecayRate          <- genKeyDecayRate
-      poolDeposit           <- genPoolDeposit
-      poolMinRefund         <- genPoolMinRefund
-      poolDecayRate         <- genPoolDecayRate
-      eMax                  <- genEMax c
-      nopt                  <- genNOpt
-      a0                    <- genA0
-      rho                   <- genRho
-      tau                   <- genTau
-      d                     <- genDecentralisationParam
-      extraEntropy          <- genExtraEntropy
-      protocolVersion       <- genNextProtocolVersion pp
-      let pps = PParams { _minfeeA               = SJust minFeeA
-                        , _minfeeB               = SJust minFeeB
-                        , _maxBBSize             = SJust maxBBSize
-                        , _maxTxSize             = SJust maxTxSize
-                        , _maxBHSize             = SJust maxBHSize
-                        , _keyDeposit            = SJust keyDeposit
-                        , _keyMinRefund          = SJust keyMinRefund
-                        , _keyDecayRate          = SJust keyDecayRate
-                        , _poolDeposit           = SJust poolDeposit
-                        , _poolMinRefund         = SJust poolMinRefund
-                        , _poolDecayRate         = SJust poolDecayRate
-                        , _eMax                  = SJust eMax
-                        , _nOpt                  = SJust nopt
-                        , _a0                    = SJust a0
-                        , _rho                   = SJust rho
-                        , _tau                   = SJust tau
-                        , _d                     = SJust d
-                        , _extraEntropy          = SJust extraEntropy
-                        , _protocolVersion       = SJust protocolVersion
-                        }
+    then pure (ProposedPPUpdates Map.empty)
+    else do
+      -- TODO generate Maybe tyes so not all updates are full
+      minFeeA <- genNatural 0 maxMinFeeA
+      minFeeB <- genNatural 0 maxMinFeeB
+      maxBBSize <- genNatural low hi
+      maxTxSize <- genNatural low hi
+      maxBHSize <- genNatural low hi
+      keyDeposit <- genKeyDeposit
+      keyMinRefund <- genKeyMinRefund
+      keyDecayRate <- genKeyDecayRate
+      poolDeposit <- genPoolDeposit
+      poolMinRefund <- genPoolMinRefund
+      poolDecayRate <- genPoolDecayRate
+      eMax <- genEMax c
+      nopt <- genNOpt
+      a0 <- genA0
+      rho <- genRho
+      tau <- genTau
+      d <- genDecentralisationParam
+      extraEntropy <- genExtraEntropy
+      protocolVersion <- genNextProtocolVersion pp
+      let pps =
+            PParams
+              { _minfeeA = SJust minFeeA,
+                _minfeeB = SJust minFeeB,
+                _maxBBSize = SJust maxBBSize,
+                _maxTxSize = SJust maxTxSize,
+                _maxBHSize = SJust maxBHSize,
+                _keyDeposit = SJust keyDeposit,
+                _keyMinRefund = SJust keyMinRefund,
+                _keyDecayRate = SJust keyDecayRate,
+                _poolDeposit = SJust poolDeposit,
+                _poolMinRefund = SJust poolMinRefund,
+                _poolDecayRate = SJust poolDecayRate,
+                _eMax = SJust eMax,
+                _nOpt = SJust nopt,
+                _a0 = SJust a0,
+                _rho = SJust rho,
+                _tau = SJust tau,
+                _d = SJust d,
+                _extraEntropy = SJust extraEntropy,
+                _protocolVersion = SJust protocolVersion
+              }
       let ppUpdate = zip genesisKeys (repeat pps)
       pure $
         (ProposedPPUpdates . Map.fromList) ppUpdate
@@ -243,14 +280,14 @@ genPPUpdate (c@Constants{maxMinFeeA, maxMinFeeB}) s pp genesisKeys =
 -- | Generate an @Update (where all the given nodes participate)
 -- with a 50% chance of having non-empty PPUpdates or AVUpdates
 -- and a 25% chance of both being empty or non-empty
-genUpdateForNodes
-  :: HasCallStack
-  => Constants
-  -> SlotNo
-  -> EpochNo -- current epoch
-  -> [CoreKeyPair]
-  -> PParams
-  -> Gen (Maybe Update)
+genUpdateForNodes ::
+  HasCallStack =>
+  Constants ->
+  SlotNo ->
+  EpochNo -> -- current epoch
+  [CoreKeyPair] ->
+  PParams ->
+  Gen (Maybe Update)
 genUpdateForNodes c s e coreKeys pp =
   Just <$> (Update <$> genPPUpdate_ <*> pure e)
   where
@@ -258,41 +295,44 @@ genUpdateForNodes c s e coreKeys pp =
     genPPUpdate_ = genPPUpdate c s pp genesisKeys
 
 -- | Occasionally generate an update and return with the witness keys
+genUpdate ::
+  HasCallStack =>
+  Constants ->
+  SlotNo ->
+  [(CoreKeyPair, AllPoolKeys)] ->
+  Map (KeyHash 'Staking) (KeyPair 'Staking) -> -- indexed keys By StakeHash
+  PParams ->
+  (UTxOState, DPState) ->
+  Gen (Maybe Update, [KeyPair 'Witness])
 genUpdate
-  :: HasCallStack
-  => Constants
-  -> SlotNo
-  -> [(CoreKeyPair, AllPoolKeys)]
-  -> Map (KeyHash 'Staking) (KeyPair 'Staking) -- indexed keys By StakeHash
-  -> PParams
-  -> (UTxOState, DPState)
-  -> Gen (Maybe Update, [KeyPair 'Witness])
-genUpdate
-  c@(Constants{frequencyTxUpdates})
-  s coreKeyPairs keysByStakeHash pp (_utxoSt, delegPoolSt)
-  = do
-    nodes <- take 5 <$> QC.shuffle coreKeyPairs
+  c@(Constants {frequencyTxUpdates})
+  s
+  coreKeyPairs
+  keysByStakeHash
+  pp
+  (_utxoSt, delegPoolSt) =
+    do
+      nodes <- take 5 <$> QC.shuffle coreKeyPairs
 
-    let e = epochFromSlotNo s
-        (GenDelegs genDelegs) = (_genDelegs . _dstate) delegPoolSt
-        genesisKeys = (fst . unzip) nodes
-        updateWitnesses = latestPoolColdKey genDelegs <$> nodes
+      let e = epochFromSlotNo s
+          (GenDelegs genDelegs) = (_genDelegs . _dstate) delegPoolSt
+          genesisKeys = (fst . unzip) nodes
+          updateWitnesses = latestPoolColdKey genDelegs <$> nodes
 
-    QC.frequency [ ( frequencyTxUpdates
-                  , (,updateWitnesses) <$> genUpdateForNodes c s e genesisKeys pp)
-                , ( 100 - frequencyTxUpdates
-                  , pure (Nothing, []))]
-
-  where
-    -- | Lookup the cold key for the given node in the genesis delegations map.
-    -- Then lookup the cold key hash in the `keysByStakeHash` reverse index.
-    -- If we find the key there, we can assume that a GenesisDeleg certificate
-    -- has changed the cold key, in which case we use the new key (otherwise we
-    -- can use the original cold key)
-    latestPoolColdKey genDelegs_ (gkey, pkeys) = coerceKeyRole $
-      case Map.lookup (hashKey . vKey $ gkey) genDelegs_ of
+      QC.frequency
+        [ ( frequencyTxUpdates,
+            (,updateWitnesses) <$> genUpdateForNodes c s e genesisKeys pp
+          ),
+          ( 100 - frequencyTxUpdates,
+            pure (Nothing, [])
+          )
+        ]
+    where
+      latestPoolColdKey genDelegs_ (gkey, pkeys) = coerceKeyRole $
+        case Map.lookup (hashKey . vKey $ gkey) genDelegs_ of
           Nothing ->
             error "genUpdate: NoGenesisStaking"
           Just gkeyHash ->
-            fromMaybe (cold pkeys)
-                      (coerceKeyRole <$> Map.lookup (coerceKeyRole gkeyHash) keysByStakeHash)
+            fromMaybe
+              (cold pkeys)
+              (coerceKeyRole <$> Map.lookup (coerceKeyRole gkeyHash) keysByStakeHash)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Utxo.hs
@@ -5,227 +5,295 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Test.Shelley.Spec.Ledger.Generator.Utxo
-  ( genTx
+  ( genTx,
   )
-  where
+where
 
 import qualified Data.Either as Either (lefts, rights)
-import           Data.List (foldl')
-import           Data.Map.Strict (Map)
+import Data.List (foldl')
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Maybe as Maybe (catMaybes)
-import           Data.Sequence.Strict (StrictSeq)
+import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Set (Set)
+import Data.Set (Set)
 import qualified Data.Set as Set
-import           GHC.Stack (HasCallStack)
-
-import           Test.QuickCheck (Gen)
+import GHC.Stack (HasCallStack)
+import Shelley.Spec.Ledger.Address (scriptToCred, toCred)
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
+import Shelley.Spec.Ledger.Coin (Coin (..), splitCoin)
+import Shelley.Spec.Ledger.Keys (HasKeyRole (..), KeyRole (..))
+import Shelley.Spec.Ledger.LedgerState
+  ( _dstate,
+    _ptrs,
+    _rewards,
+    minfee,
+    pattern UTxOState,
+  )
+import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..))
+import Shelley.Spec.Ledger.Slot (SlotNo (..))
+import Shelley.Spec.Ledger.Tx
+  ( getKeyCombination,
+    hashScript,
+    pattern Tx,
+    pattern TxBody,
+    pattern TxOut,
+  )
+import Shelley.Spec.Ledger.TxData
+  ( Wdrl (..),
+    _outputs,
+    _txfee,
+    getRwdCred,
+    pattern Addr,
+    pattern KeyHashObj,
+    pattern ScriptHashObj,
+    pattern StakeRefBase,
+    pattern StakeRefPtr,
+  )
+import Shelley.Spec.Ledger.UTxO
+  ( balance,
+    hashTxBody,
+    makeWitnessesFromScriptKeys,
+    makeWitnessesVKey,
+    pattern UTxO,
+  )
+import Test.QuickCheck (Gen)
 import qualified Test.QuickCheck as QC
-
-import           Shelley.Spec.Ledger.Address (scriptToCred, toCred)
-import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..), maybeToStrictMaybe)
-import           Shelley.Spec.Ledger.Coin (Coin (..), splitCoin)
-import           Shelley.Spec.Ledger.Keys (KeyRole (..), HasKeyRole(..))
-import           Shelley.Spec.Ledger.LedgerState (pattern UTxOState, minfee, _dstate, _ptrs,
-                     _rewards)
-import           Shelley.Spec.Ledger.Slot (SlotNo (..))
-import           Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..))
-import           Shelley.Spec.Ledger.Tx (pattern Tx, pattern TxBody, pattern TxOut,
-                     getKeyCombination, hashScript)
-import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj,
-                     pattern ScriptHashObj, pattern StakeRefBase, pattern StakeRefPtr, Wdrl (..),
-                     getRwdCred, _outputs, _txfee)
-import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, hashTxBody, makeWitnessesFromScriptKeys,
-                     makeWitnessesVKey)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, CoreKeyPair, Credential, DCert,
-                     DPState, DState, KeyPair, KeyPairs, MultiSig, MultiSigPairs, RewardAcnt, Tx,
-                     TxBody, TxIn, TxOut, UTxO, UTxOState, Update, WitVKey, KeyHash)
-import           Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
-import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (..), KeySpace (..), Testing,
-                     findPayKeyPairAddr, findPayKeyPairCred, findPayScriptFromAddr,
-                     findStakeScriptFromCred, genNatural)
-import           Test.Shelley.Spec.Ledger.Generator.Delegation (CertCred (..))
-import           Test.Shelley.Spec.Ledger.Generator.Trace.DCert (genDCerts)
-import           Test.Shelley.Spec.Ledger.Generator.Update (genUpdate)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Addr,
+    CoreKeyPair,
+    Credential,
+    DCert,
+    DPState,
+    DState,
+    KeyHash,
+    KeyPair,
+    KeyPairs,
+    MultiSig,
+    MultiSigPairs,
+    RewardAcnt,
+    Tx,
+    TxBody,
+    TxIn,
+    TxOut,
+    UTxO,
+    UTxOState,
+    Update,
+    WitVKey,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Constants (Constants (..))
+import Test.Shelley.Spec.Ledger.Generator.Core
+  ( GenEnv (..),
+    KeySpace (..),
+    Testing,
+    findPayKeyPairAddr,
+    findPayKeyPairCred,
+    findPayScriptFromAddr,
+    findStakeScriptFromCred,
+    genNatural,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Delegation (CertCred (..))
+import Test.Shelley.Spec.Ledger.Generator.Trace.DCert (genDCerts)
+import Test.Shelley.Spec.Ledger.Generator.Update (genUpdate)
 
 -- | Generate a new transaction in the context of the LEDGER STS environment and state.
 --
 -- Selects unspent outputs and spends the funds on a some valid addresses.
 -- Also generates valid certificates.
-genTx :: HasCallStack
-      => GenEnv
-      -> LedgerEnv
-      -> (UTxOState, DPState)
-      -> Gen Tx
-genTx ge@(GenEnv KeySpace_ { ksCoreNodes
-                    , ksKeyPairs
-                    , ksKeyPairsByHash
-                    , ksKeyPairsByStakeHash
-                    , ksMSigScripts }
-                  constants)
-      (LedgerEnv slot txIx pparams reserves)
-      (utxoSt@(UTxOState utxo _ _ _), dpState)
-      = do
+genTx ::
+  HasCallStack =>
+  GenEnv ->
+  LedgerEnv ->
+  (UTxOState, DPState) ->
+  Gen Tx
+genTx
+  ge@( GenEnv
+         KeySpace_
+           { ksCoreNodes,
+             ksKeyPairs,
+             ksKeyPairsByHash,
+             ksKeyPairsByStakeHash,
+             ksMSigScripts
+           }
+         constants
+       )
+  (LedgerEnv slot txIx pparams reserves)
+  (utxoSt@(UTxOState utxo _ _ _), dpState) =
+    do
+      keys' <- QC.shuffle ksKeyPairs
+      scripts' <- QC.shuffle ksMSigScripts
 
-  keys' <- QC.shuffle ksKeyPairs
-  scripts' <- QC.shuffle ksMSigScripts
+      -- inputs
+      let ksKeyPairsByHash' =
+            Map.fromList $ fmap (\(k, v) -> (coerceKeyRole k, coerceKeyRole v)) $
+              Map.toList ksKeyPairsByHash
+      (witnessedInputs, spendingBalanceUtxo) <-
+        pickSpendingInputs constants scripts' ksKeyPairsByHash' utxo
 
-  -- inputs
-  let ksKeyPairsByHash' =
-       Map.fromList $ fmap (\(k, v) -> (coerceKeyRole k, coerceKeyRole v)) $
-         Map.toList ksKeyPairsByHash
-  (witnessedInputs, spendingBalanceUtxo) <-
-    pickSpendingInputs constants scripts' ksKeyPairsByHash' utxo
+      wdrls <- pickWithdrawals constants ((_rewards . _dstate) dpState)
 
-  wdrls <- pickWithdrawals constants ((_rewards . _dstate) dpState)
+      let rwdCreds = fmap getRwdCred (Map.keys wdrls)
+          rwdCreds' = fmap coerceKeyRole rwdCreds
+          wdrlCredentials = fmap (mkWdrlWits scripts' ksKeyPairsByHash') rwdCreds'
+          wdrlWitnesses = Either.lefts wdrlCredentials
+          wdrlScripts = Either.rights wdrlCredentials
 
-  let rwdCreds = fmap getRwdCred (Map.keys wdrls)
-      rwdCreds' = fmap coerceKeyRole rwdCreds
-      wdrlCredentials = fmap (mkWdrlWits scripts' ksKeyPairsByHash') rwdCreds'
-      wdrlWitnesses = Either.lefts wdrlCredentials
-      wdrlScripts   = Either.rights wdrlCredentials
+      let spendingBalance = spendingBalanceUtxo + (sum wdrls)
 
-  let spendingBalance = spendingBalanceUtxo + (sum wdrls)
+      let (inputs, spendCredentials) = unzip witnessedInputs
+          spendWitnesses = Either.lefts spendCredentials
+          spendScripts = Either.rights spendCredentials
 
-  let (inputs, spendCredentials) = unzip witnessedInputs
-      spendWitnesses = Either.lefts spendCredentials
-      spendScripts   = Either.rights spendCredentials
+      -- output addresses
+      recipientAddrs' <- genRecipients (length witnessedInputs) keys' scripts'
 
-  -- output addresses
-  recipientAddrs' <- genRecipients (length witnessedInputs) keys' scripts'
+      -- maybe convert some addresss to pointer addresses
+      recipientAddrs <- genPtrAddrs (_dstate dpState) recipientAddrs'
 
-  -- maybe convert some addresss to pointer addresses
-  recipientAddrs  <- genPtrAddrs (_dstate dpState) recipientAddrs'
+      ttl <- genNatural 50 100
+      let slotWithTTL = slot + SlotNo (fromIntegral ttl)
 
-  ttl <- genNatural 50 100
-  let slotWithTTL = slot + SlotNo (fromIntegral ttl)
+      -- certificates
+      (certs, certCreds, deposits_, refunds_, dpState') <-
+        genDCerts ge pparams dpState slot ttl txIx reserves
 
-  -- certificates
-  (certs, certCreds, deposits_, refunds_, dpState')
-    <- genDCerts ge pparams dpState slot ttl txIx reserves
+      let balance_ = spendingBalance - deposits_ + refunds_
+      if balance_ <= 0
+        then QC.discard
+        else do
+          -- attempt to make provision for certificate deposits (otherwise discard this generator)
+          let stakeScripts =
+                Maybe.catMaybes $
+                  map
+                    ( \case
+                        ScriptCred c -> Just c
+                        _ -> Nothing
+                    )
+                    certCreds
+              genesisWitnesses =
+                foldl' (++) []
+                  $ Maybe.catMaybes
+                  $ map
+                    ( \case
+                        CoreKeyCred c -> Just c
+                        _ -> Nothing
+                    )
+                    certCreds
+              certWitnesses =
+                Maybe.catMaybes $
+                  map
+                    ( \case
+                        KeyCred c -> Just c
+                        _ -> Nothing
+                    )
+                    certCreds
 
-  let balance_ = spendingBalance - deposits_ + refunds_
-  if balance_ <= 0
-    then QC.discard
-    else do
+          -- calc. fees and output amounts
+          let (_, outputs) = calcOutputsFromBalance balance_ recipientAddrs (Coin 0)
 
-    -- attempt to make provision for certificate deposits (otherwise discard this generator)
-    let stakeScripts = Maybe.catMaybes $ map (\case
-                                                 ScriptCred c -> Just c
-                                                 _            -> Nothing) certCreds
-        genesisWitnesses = foldl' (++) [] $
-          Maybe.catMaybes $
-          map (\case
-                  CoreKeyCred c -> Just c
-                  _             -> Nothing) certCreds
-        certWitnesses = Maybe.catMaybes $ map (\case
-                                                  KeyCred c -> Just c
-                                                  _         -> Nothing) certCreds
+          --- PParam + AV Updates
+          (update, updateWitnesses) <-
+            genUpdate constants slot ksCoreNodes ksKeyPairsByStakeHash pparams (utxoSt, dpState')
 
+          -- this is the "model" `TxBody` which is used to calculate the fees
+          --
+          -- while it only contains a pseudo fee value of 0, the constructed
+          -- transcation will have the correct set of witnesses.
+          --
+          -- Once the transaction body and the witnesses are constructed, we can use
+          -- this model to calculate the real fee value and update the fees and
+          -- transaction outputs in the final, generated transaction.
+          txBody <- genTxBody (Set.fromList inputs) outputs certs wdrls update (Coin 0) slotWithTTL
+          let multiSig =
+                Map.fromList $
+                  (map (\(payScript, _) -> (hashScript payScript, payScript)) spendScripts)
+                    ++ (map (\(_, sScript) -> (hashScript sScript, sScript)) (stakeScripts ++ wdrlScripts))
 
-    -- calc. fees and output amounts
-    let (_, outputs) = calcOutputsFromBalance balance_ recipientAddrs (Coin 0)
+          -- choose one possible combination of keys for multi-sig scripts
+          --
+          -- TODO mgudemann due to problems with time-outs, we select one combination
+          -- deterministically for each script. Varying the script is possible though.
 
-    --- PParam + AV Updates
-    (update, updateWitnesses) <-
-      genUpdate constants slot ksCoreNodes ksKeyPairsByStakeHash pparams (utxoSt, dpState')
+          let spendWitnesses' = fmap coerceKeyRole spendWitnesses
+              certWitnesses' = fmap coerceKeyRole certWitnesses
+              wdrlWitnesses' = fmap coerceKeyRole wdrlWitnesses
+              updateWitnesses' = fmap coerceKeyRole updateWitnesses
 
-    -- this is the "model" `TxBody` which is used to calculate the fees
-    --
-    -- while it only contains a pseudo fee value of 0, the constructed
-    -- transcation will have the correct set of witnesses.
-    --
-    -- Once the transaction body and the witnesses are constructed, we can use
-    -- this model to calculate the real fee value and update the fees and
-    -- transaction outputs in the final, generated transaction.
-    txBody <- genTxBody (Set.fromList inputs) outputs certs wdrls update (Coin 0) slotWithTTL
-    let multiSig = Map.fromList $
-          (map (\(payScript, _) -> (hashScript payScript, payScript)) spendScripts) ++
-          (map (\(_, sScript) -> (hashScript sScript, sScript)) (stakeScripts ++ wdrlScripts))
+          let keysLists = map getKeyCombination $ Map.elems multiSig
+              msigSignatures = foldl' Set.union Set.empty $ map Set.fromList keysLists
+              wits =
+                mkTxWits
+                  txBody
+                  (spendWitnesses' ++ certWitnesses' ++ wdrlWitnesses' ++ updateWitnesses')
+                  genesisWitnesses
+                  ksKeyPairsByHash'
+                  msigSignatures
 
-    -- choose one possible combination of keys for multi-sig scripts
-    --
-    -- TODO mgudemann due to problems with time-outs, we select one combination
-    -- deterministically for each script. Varying the script is possible though.
+          let metadata = SNothing -- TODO generate metadata
 
-    let spendWitnesses' = fmap coerceKeyRole spendWitnesses
-        certWitnesses' = fmap coerceKeyRole certWitnesses
-        wdrlWitnesses' = fmap coerceKeyRole wdrlWitnesses
-        updateWitnesses' = fmap coerceKeyRole updateWitnesses
+          -- calculate real fees of witnesses transaction
+          let minimalFees = minfee pparams (Tx txBody wits multiSig metadata)
 
-    let keysLists = map getKeyCombination $ Map.elems multiSig
-        msigSignatures = foldl' Set.union Set.empty $ map Set.fromList keysLists
-        wits = mkTxWits
-          txBody
-          (spendWitnesses' ++ certWitnesses' ++ wdrlWitnesses' ++ updateWitnesses')
-          genesisWitnesses
-          ksKeyPairsByHash'
-          msigSignatures
+          -- discard generated transaction if the balance cannot cover the fees
+          if minimalFees > balance_
+            then QC.discard
+            else do
+              -- update model transaction with real fees and outputs
+              let (fees', outputs') =
+                    calcOutputsFromBalance balance_ recipientAddrs minimalFees
+                  txBody' =
+                    txBody
+                      { _txfee = fees',
+                        _outputs = outputs'
+                      }
+                  wits' =
+                    mkTxWits
+                      txBody'
+                      (spendWitnesses' ++ certWitnesses' ++ wdrlWitnesses' ++ updateWitnesses')
+                      genesisWitnesses
+                      ksKeyPairsByHash'
+                      msigSignatures
 
-    let metadata = SNothing -- TODO generate metadata
+              pure (Tx txBody' wits' multiSig metadata)
 
-    -- calculate real fees of witnesses transaction
-    let minimalFees = minfee pparams (Tx txBody wits multiSig metadata)
-
-    -- discard generated transaction if the balance cannot cover the fees
-    if minimalFees > balance_
-      then QC.discard
-      else do
-
-      -- update model transaction with real fees and outputs
-      let (fees', outputs') =
-            calcOutputsFromBalance balance_ recipientAddrs minimalFees
-          txBody' = txBody { _txfee = fees'
-                           , _outputs = outputs' }
-          wits' = mkTxWits
-            txBody'
-            (spendWitnesses' ++ certWitnesses' ++ wdrlWitnesses' ++ updateWitnesses')
-            genesisWitnesses
-            ksKeyPairsByHash'
-            msigSignatures
-
-      pure (Tx txBody' wits' multiSig metadata)
-
-mkTxWits
-  :: HasCallStack
-  => TxBody
-  -> [KeyPair 'Witness]
-  -> [CoreKeyPair]
-  -> Map (KeyHash 'Witness) (KeyPair 'Witness)
-  -> Set (KeyHash 'Witness)
-  -> Set WitVKey
+mkTxWits ::
+  HasCallStack =>
+  TxBody ->
+  [KeyPair 'Witness] ->
+  [CoreKeyPair] ->
+  Map (KeyHash 'Witness) (KeyPair 'Witness) ->
+  Set (KeyHash 'Witness) ->
+  Set WitVKey
 mkTxWits txBody keyWits genesisWits keyHashMap msigs =
   makeWitnessesVKey (hashTxBody txBody) keyWits
-  `Set.union` makeWitnessesVKey (hashTxBody txBody) genesisWits
-  `Set.union` makeWitnessesFromScriptKeys (hashTxBody txBody) keyHashMap msigs
+    `Set.union` makeWitnessesVKey (hashTxBody txBody) genesisWits
+    `Set.union` makeWitnessesFromScriptKeys (hashTxBody txBody) keyHashMap msigs
 
 -- | Generate a transaction body with the given inputs/outputs and certificates
-genTxBody
-  :: HasCallStack
-  => Set TxIn
-  -> StrictSeq TxOut
-  -> StrictSeq DCert
-  -> Map RewardAcnt Coin
-  -> Maybe Update
-  -> Coin
-  -> SlotNo
-  -> Gen TxBody
+genTxBody ::
+  HasCallStack =>
+  Set TxIn ->
+  StrictSeq TxOut ->
+  StrictSeq DCert ->
+  Map RewardAcnt Coin ->
+  Maybe Update ->
+  Coin ->
+  SlotNo ->
+  Gen TxBody
 genTxBody inputs outputs certs wdrls update fee slotWithTTL = do
-  return $ TxBody
-             inputs
-             outputs
-             certs
-             (Wdrl wdrls)
-             fee
-             slotWithTTL
-             (maybeToStrictMaybe update)
-             SNothing -- TODO generate metadata
+  return $
+    TxBody
+      inputs
+      outputs
+      certs
+      (Wdrl wdrls)
+      fee
+      slotWithTTL
+      (maybeToStrictMaybe update)
+      SNothing -- TODO generate metadata
 
 -- | Distribute the sum of `balance_` and `fee` over the addresses, return the
 -- sum of `fee` and the remainder of the equal distribution and the list ouf
@@ -233,15 +301,16 @@ genTxBody inputs outputs certs wdrls update fee slotWithTTL = do
 --
 -- The idea is to have an specified spending balance and fees that must be paid
 -- by the selected addresses.
-calcOutputsFromBalance
-  :: HasCallStack
-  => Coin
-  -> [Addr]
-  -> Coin
-  -> (Coin, StrictSeq TxOut)
+calcOutputsFromBalance ::
+  HasCallStack =>
+  Coin ->
+  [Addr] ->
+  Coin ->
+  (Coin, StrictSeq TxOut)
 calcOutputsFromBalance balance_ addrs fee =
-  ( fee + splitCoinRem
-  , (`TxOut` amountPerOutput) <$> StrictSeq.fromList addrs)
+  ( fee + splitCoinRem,
+    (`TxOut` amountPerOutput) <$> StrictSeq.fromList addrs
+  )
   where
     -- split the available balance into equal portions (one for each address),
     -- if there is a remainder, then add it to the fee.
@@ -258,19 +327,22 @@ calcOutputsFromBalance balance_ addrs fee =
 -- given UTxO originated from (in order to produce the appropriate witnesses to
 -- spend these outputs). If this is not the case, `findPayKeyPairAddr` /
 -- `findPayScriptFromAddr` will fail by not finding the matching keys or scripts.
-pickSpendingInputs
-  :: HasCallStack
-  => Constants
-  -> MultiSigPairs
-  -> Map (KeyHash Testing) (KeyPair Testing)
-  -> UTxO
-  -> Gen ([(TxIn, Either (KeyPair 'Witness) (MultiSig, MultiSig))], Coin)
-pickSpendingInputs Constants { minNumGenInputs, maxNumGenInputs} scripts keyHashMap (UTxO utxo) = do
-  selectedUtxo <- take <$> QC.choose (minNumGenInputs, maxNumGenInputs)
-                       <*> QC.shuffle (Map.toList utxo)
+pickSpendingInputs ::
+  HasCallStack =>
+  Constants ->
+  MultiSigPairs ->
+  Map (KeyHash Testing) (KeyPair Testing) ->
+  UTxO ->
+  Gen ([(TxIn, Either (KeyPair 'Witness) (MultiSig, MultiSig))], Coin)
+pickSpendingInputs Constants {minNumGenInputs, maxNumGenInputs} scripts keyHashMap (UTxO utxo) = do
+  selectedUtxo <-
+    take <$> QC.choose (minNumGenInputs, maxNumGenInputs)
+      <*> QC.shuffle (Map.toList utxo)
 
-  return ( witnessedInput <$> selectedUtxo
-         , balance (UTxO (Map.fromList selectedUtxo)))
+  return
+    ( witnessedInput <$> selectedUtxo,
+      balance (UTxO (Map.fromList selectedUtxo))
+    )
   where
     witnessedInput (input, TxOut addr@(Addr (KeyHashObj _) _) _) =
       (input, Left . asWitness $ findPayKeyPairAddr addr keyHashMap)
@@ -279,11 +351,11 @@ pickSpendingInputs Constants { minNumGenInputs, maxNumGenInputs} scripts keyHash
     witnessedInput _ = error "unsupported address"
 
 -- | Select a subset of the reward accounts to use for reward withdrawals.
-pickWithdrawals
-  :: HasCallStack
-  => Constants
-  -> Map RewardAcnt Coin
-  -> Gen (Map RewardAcnt Coin)
+pickWithdrawals ::
+  HasCallStack =>
+  Constants ->
+  Map RewardAcnt Coin ->
+  Gen (Map RewardAcnt Coin)
 pickWithdrawals
   Constants
     { frequencyNoWithdrawals,
@@ -291,55 +363,61 @@ pickWithdrawals
       frequencyPotentiallyManyWithdrawals,
       maxAFewWithdrawals
     }
-  wdrls = QC.frequency
-  [ (frequencyNoWithdrawals,
-     pure Map.empty)
-  , (frequencyAFewWithdrawals,
-     Map.fromList <$> (QC.sublistOf . (take maxAFewWithdrawals) . Map.toList) wdrls
-    )
-  , (frequencyPotentiallyManyWithdrawals,
-     Map.fromList <$> (QC.sublistOf . Map.toList) wdrls)
-  ]
+  wdrls =
+    QC.frequency
+      [ ( frequencyNoWithdrawals,
+          pure Map.empty
+        ),
+        ( frequencyAFewWithdrawals,
+          Map.fromList <$> (QC.sublistOf . (take maxAFewWithdrawals) . Map.toList) wdrls
+        ),
+        ( frequencyPotentiallyManyWithdrawals,
+          Map.fromList <$> (QC.sublistOf . Map.toList) wdrls
+        )
+      ]
 
 -- | Collect witnesses needed for reward withdrawals.
-mkWdrlWits
-  :: HasCallStack
-  => MultiSigPairs
-  -> Map (KeyHash 'Witness) (KeyPair 'Witness)
-  -> Credential 'Witness
-  -> Either (KeyPair 'Witness) (MultiSig, MultiSig)
+mkWdrlWits ::
+  HasCallStack =>
+  MultiSigPairs ->
+  Map (KeyHash 'Witness) (KeyPair 'Witness) ->
+  Credential 'Witness ->
+  Either (KeyPair 'Witness) (MultiSig, MultiSig)
 mkWdrlWits scripts _ c@(ScriptHashObj _) = Right $ findStakeScriptFromCred c scripts
-mkWdrlWits _ keyHashMap c@(KeyHashObj _)    = Left $ findPayKeyPairCred c keyHashMap
+mkWdrlWits _ keyHashMap c@(KeyHashObj _) = Left $ findPayKeyPairCred c keyHashMap
 
 -- | Select recipient addresses that will serve as output targets for a new transaction.
-genRecipients
-  :: HasCallStack
-  => Int
-  -> KeyPairs
-  -> MultiSigPairs
-  -> Gen [Addr]
+genRecipients ::
+  HasCallStack =>
+  Int ->
+  KeyPairs ->
+  MultiSigPairs ->
+  Gen [Addr]
 genRecipients len keys scripts = do
-  n' <- QC.frequency (  (if len > 1 then [(1, pure (len - 1))] else [])
-                     -- contract size of UTxO (only if at least 2 inputs are chosen)
-                     ++ [(2, pure len)]
-                     -- keep size
-                     ++ [(1, pure $ len + 1)])
-                     -- expand size of UTxO
+  n' <-
+    QC.frequency
+      ( (if len > 1 then [(1, pure (len - 1))] else [])
+          -- contract size of UTxO (only if at least 2 inputs are chosen)
+          ++ [(2, pure len)]
+          -- keep size
+          ++ [(1, pure $ len + 1)]
+      )
+  -- expand size of UTxO
 
   -- choose m scripts and n keys as recipients
-  m  <- QC.choose (0, n' - 1)
+  m <- QC.choose (0, n' - 1)
   -- keys and scripts are shuffled before
   let n = n' - m
-      recipientKeys    = take n keys
+      recipientKeys = take n keys
       recipientScripts = take m scripts
 
-  let payKeys      = (toCred . fst) <$> recipientKeys
-      stakeKeys    = (toCred . snd) <$> recipientKeys
-      payScripts   = (scriptToCred . fst) <$> recipientScripts
+  let payKeys = (toCred . fst) <$> recipientKeys
+      stakeKeys = (toCred . snd) <$> recipientKeys
+      payScripts = (scriptToCred . fst) <$> recipientScripts
       stakeScripts = (scriptToCred . fst) <$> recipientScripts
 
   -- shuffle and zip keys and scripts together as base addresses
-  payCreds   <- QC.shuffle (payKeys ++ payScripts)
+  payCreds <- QC.shuffle (payKeys ++ payScripts)
   stakeCreds <- QC.shuffle (stakeKeys ++ stakeScripts)
   let stakeCreds' = fmap StakeRefBase stakeCreds
 
@@ -355,7 +433,7 @@ genPtrAddrs ds addrs = do
   let addrs' = zipWith baseAddrToPtrAddr (take n addrs) pointerList
 
   pure (addrs' ++ (drop n addrs))
-    where
-      baseAddrToPtrAddr a p = case a of
-        Addr pay _ -> Addr pay (StakeRefPtr p)
-        _          -> a
+  where
+    baseAddrToPtrAddr a p = case a of
+      Addr pay _ -> Addr pay (StakeRefPtr p)
+      _ -> a

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSGenerator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSGenerator.hs
@@ -10,77 +10,102 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-
 module Test.Shelley.Spec.Ledger.PreSTSGenerator
-    ( utxoSize
-    , utxoMap
-    , genNonEmptyAndAdvanceTx
-    , genNonEmptyAndAdvanceTx'
-    , genNonemptyGenesisState
-    , genStateTx
-    , genValidStateTx
-    , genValidStateTxKeys
-    , genDelegationData
-    , genDelegation
-    , genDCertDelegate
-    , genKeyPairs
-    , asStateTransition
-    , asStateTransition'
-    ) where
+  ( utxoSize,
+    utxoMap,
+    genNonEmptyAndAdvanceTx,
+    genNonEmptyAndAdvanceTx',
+    genNonemptyGenesisState,
+    genStateTx,
+    genValidStateTx,
+    genValidStateTxKeys,
+    genDelegationData,
+    genDelegation,
+    genDCertDelegate,
+    genKeyPairs,
+    asStateTransition,
+    asStateTransition',
+  )
+where
 
-import           Data.Map.Strict (Map)
+import Control.State.Transition.Extended (TRC (..), applySTS)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
-import           Data.Word (Word64)
-
-import           Numeric.Natural
-
-import           Hedgehog
+import Data.Word (Word64)
+import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-
-
-import           Control.State.Transition.Extended (TRC (..), applySTS)
-import           Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
-import           Shelley.Spec.Ledger.Coin
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), coerceKeyRole, hashKey, vKey)
-import           Shelley.Spec.Ledger.LedgerState (pattern LedgerValidation, applyTxBody,
-                     genesisCoins, genesisState, validTx, _delegationState, _dstate, _genDelegs,
-                     _stkCreds, _utxo, _utxoState)
-import           Shelley.Spec.Ledger.PParams (PParams, emptyPParams)
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.STS.Delegs (pattern DelegateeNotRegisteredDELEG,
-                     PredicateFailure (..), pattern WithdrawalsNotInRewardsDELEGS)
-import           Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..), PredicateFailure (..))
-import           Shelley.Spec.Ledger.STS.Utxo (pattern BadInputsUTxO, pattern ExpiredUTxO,
-                     pattern FeeTooSmallUTxO, pattern InputSetEmptyUTxO,
-                     pattern ValueNotConservedUTxO)
-import           Shelley.Spec.Ledger.STS.Utxow (pattern InvalidWitnessesUTXOW,
-                     pattern MissingScriptWitnessesUTXOW, pattern MissingVKeyWitnessesUTXOW,
-                     PredicateFailure (..))
-import           Shelley.Spec.Ledger.Tx (pattern Tx, pattern TxBody, pattern TxOut, _body)
-import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern DCertDeleg, pattern DCertPool,
-                     pattern DeRegKey, pattern Delegate, pattern Delegation, pattern KeyHashObj,
-                     pattern RegKey, pattern RetirePool, StakeCreds (..), pattern StakeRefBase,
-                     Wdrl (..))
-import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, hashTxBody, makeWitnessVKey)
-import           Shelley.Spec.Ledger.Validation (ValidationError (..), Validity (..))
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
-import           Test.Shelley.Spec.Ledger.PreSTSMutator
-import           Test.Shelley.Spec.Ledger.Utils
+import Numeric.Natural
+import Shelley.Spec.Ledger.BaseTypes (StrictMaybe (..))
+import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.Keys (KeyRole (..), coerceKeyRole, hashKey, vKey)
+import Shelley.Spec.Ledger.LedgerState
+  ( _delegationState,
+    _dstate,
+    _genDelegs,
+    _stkCreds,
+    _utxo,
+    _utxoState,
+    applyTxBody,
+    genesisCoins,
+    genesisState,
+    validTx,
+    pattern LedgerValidation,
+  )
+import Shelley.Spec.Ledger.PParams (PParams, emptyPParams)
+import Shelley.Spec.Ledger.STS.Delegs
+  ( PredicateFailure (..),
+    pattern DelegateeNotRegisteredDELEG,
+    pattern WithdrawalsNotInRewardsDELEGS,
+  )
+import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..), PredicateFailure (..))
+import Shelley.Spec.Ledger.STS.Utxo
+  ( pattern BadInputsUTxO,
+    pattern ExpiredUTxO,
+    pattern FeeTooSmallUTxO,
+    pattern InputSetEmptyUTxO,
+    pattern ValueNotConservedUTxO,
+  )
+import Shelley.Spec.Ledger.STS.Utxow
+  ( PredicateFailure (..),
+    pattern InvalidWitnessesUTXOW,
+    pattern MissingScriptWitnessesUTXOW,
+    pattern MissingVKeyWitnessesUTXOW,
+  )
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.Tx (_body, pattern Tx, pattern TxBody, pattern TxOut)
+import Shelley.Spec.Ledger.TxData
+  ( StakeCreds (..),
+    Wdrl (..),
+    pattern Addr,
+    pattern DCertDeleg,
+    pattern DCertPool,
+    pattern DeRegKey,
+    pattern Delegate,
+    pattern Delegation,
+    pattern KeyHashObj,
+    pattern RegKey,
+    pattern RetirePool,
+    pattern StakeRefBase,
+  )
+import Shelley.Spec.Ledger.UTxO (balance, hashTxBody, makeWitnessVKey, pattern UTxO)
+import Shelley.Spec.Ledger.Validation (ValidationError (..), Validity (..))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+import Test.Shelley.Spec.Ledger.PreSTSMutator
+import Test.Shelley.Spec.Ledger.Utils
 
 -- | Find first matching key pair for address. Returns the matching key pair
 -- where the first element of the pair matched the hash in 'addr'.
 findPayKeyPair :: Addr -> KeyPairs -> KeyPair 'Payment
 findPayKeyPair (Addr (KeyHashObj addr) _) keyList =
-    case matches of
-      []    -> error "findPayKeyPair: could not find a match for the given address"
-      (x:_) -> fst x
-    where
-      matches = filter (\(pay, _) -> addr == hashKey (vKey pay)) keyList
+  case matches of
+    [] -> error "findPayKeyPair: could not find a match for the given address"
+    (x : _) -> fst x
+  where
+    matches = filter (\(pay, _) -> addr == hashKey (vKey pay)) keyList
 findPayKeyPair _ _ = error "findPayKeyPair: expects only KeyHash addresses"
 
 -- | Generator for a natural number between 'lower' and 'upper'
@@ -102,14 +127,15 @@ utxoMap (UTxO m) = m
 -- | Generates a list of '(pay, stake)' key pairs.
 genKeyPairs :: Int -> Int -> Gen KeyPairs
 genKeyPairs lower upper = do
-  xs <- Gen.list (Range.linear lower upper)
-        $ Gen.integral (Range.linear (1 :: Natural) 1000)
-  return
-    $ fmap
-      (\n ->
-         ( KeyPair (fromIntegral $ 2*n) (fromIntegral $ 2*n)
-         , KeyPair (fromIntegral $ 2*n+1) (fromIntegral $ 2*n+1)
-         )
+  xs <-
+    Gen.list (Range.linear lower upper) $
+      Gen.integral (Range.linear (1 :: Natural) 1000)
+  return $
+    fmap
+      ( \n ->
+          ( KeyPair (fromIntegral $ 2 * n) (fromIntegral $ 2 * n),
+            KeyPair (fromIntegral $ 2 * n + 1) (fromIntegral $ 2 * n + 1)
+          )
       )
       xs
 
@@ -117,10 +143,12 @@ genKeyPairs lower upper = do
 -- hashed keys
 hashKeyPairs :: KeyPairs -> [(Credential 'Payment, StakeReference)]
 hashKeyPairs keyPairs =
-    (\(a, b) ->
-      (KeyHashObj . hashKey $ vKey a
-      , StakeRefBase . KeyHashObj . hashKey $ vKey b))
-      <$> keyPairs
+  ( \(a, b) ->
+      ( KeyHashObj . hashKey $ vKey a,
+        StakeRefBase . KeyHashObj . hashKey $ vKey b
+      )
+  )
+    <$> keyPairs
 
 -- | Transforms list of keypairs into 'Addr' types of the form 'AddrTxin pay
 -- stake'
@@ -131,8 +159,9 @@ addrTxins keyPairs = uncurry Addr <$> hashKeyPairs keyPairs
 -- coins, with values between 'minCoin' and 'maxCoin'.
 genCoinList :: Integer -> Integer -> Int -> Int -> Gen [Coin]
 genCoinList minCoin maxCoin lower upper = do
-  xs <- Gen.list (Range.linear lower upper)
-        $ Gen.integral (Range.exponential minCoin maxCoin)
+  xs <-
+    Gen.list (Range.linear lower upper) $
+      Gen.integral (Range.exponential minCoin maxCoin)
   return (Coin <$> xs)
 
 -- | Generator for a list of 'TxOut' where for each 'Addr' of 'addrs' one Coin
@@ -163,43 +192,51 @@ genTx :: KeyPairs -> UTxO -> SlotNo -> Gen (Coin, Tx)
 genTx keyList (UTxO m) cslot = do
   -- select payer
   selectedInputs <- Gen.shuffle utxoInputs
-  let !selectedAddr    = addr $ head selectedInputs
-  let !selectedUTxO    = Map.filter (\(TxOut a _) -> a == selectedAddr) m
+  let !selectedAddr = addr $ head selectedInputs
+  let !selectedUTxO = Map.filter (\(TxOut a _) -> a == selectedAddr) m
   let !selectedKeyPair = findPayKeyPair selectedAddr keyList
   let !selectedBalance = balance $ UTxO selectedUTxO
 
   -- select receipients, distribute balance of selected UTxO set
   n <- genNatural 1 10 -- (fromIntegral $ length keyList) -- TODO make this variable, but uses too much RAM atm
   receipients <- Seq.fromList . take (fromIntegral n) <$> Gen.shuffle keyList
-  let realN                = length receipients
+  let realN = length receipients
   let (perReceipient, txfee') = splitCoin selectedBalance (fromIntegral realN)
-  let !receipientAddrs = fmap (\(p, d) ->
-                           Addr
-                             (KeyHashObj . hashKey $ vKey p)
-                             (StakeRefBase . KeyHashObj . hashKey $ vKey d))
-                           receipients
+  let !receipientAddrs =
+        fmap
+          ( \(p, d) ->
+              Addr
+                (KeyHashObj . hashKey $ vKey p)
+                (StakeRefBase . KeyHashObj . hashKey $ vKey d)
+          )
+          receipients
   txttl <- genWord64 1 100
-  let !txbody = TxBody
-           (Map.keysSet selectedUTxO)
-           (StrictSeq.toStrict ((`TxOut` perReceipient) <$> receipientAddrs))
-           StrictSeq.Empty
-           (Wdrl Map.empty) -- TODO generate witdrawals
-           txfee'
-           (cslot + SlotNo txttl)
-           SNothing
-           SNothing
+  let !txbody =
+        TxBody
+          (Map.keysSet selectedUTxO)
+          (StrictSeq.toStrict ((`TxOut` perReceipient) <$> receipientAddrs))
+          StrictSeq.Empty
+          (Wdrl Map.empty) -- TODO generate witdrawals
+          txfee'
+          (cslot + SlotNo txttl)
+          SNothing
+          SNothing
   let !txbHash = hashTxBody txbody
   let !txwit = makeWitnessVKey txbHash selectedKeyPair
   pure (txfee', Tx txbody (Set.fromList [txwit]) Map.empty SNothing)
-            where utxoInputs = Map.keys m
-                  addr inp   = getTxOutAddr $ m Map.! inp
+  where
+    utxoInputs = Map.keys m
+    addr inp = getTxOutAddr $ m Map.! inp
 
 -- | Generator for new transaction state transition, starting from a
 -- 'LedgerState' and using a list of pairs of 'KeyPair'. Returns either the
 -- accumulated fees and a resulting ledger state or the 'ValidationError'
 -- information in case of an invalid transaction.
-genLedgerStateTx :: KeyPairs -> SlotNo -> LedgerState ->
-                    Gen (Coin, Tx, Either [ValidationError] LedgerState)
+genLedgerStateTx ::
+  KeyPairs ->
+  SlotNo ->
+  LedgerState ->
+  Gen (Coin, Tx, Either [ValidationError] LedgerState)
 genLedgerStateTx keyList (SlotNo _slot) sourceState = do
   let utxo' = (_utxo . _utxoState) sourceState
   slot' <- genWord64 _slot (_slot + 100)
@@ -210,22 +247,22 @@ genLedgerStateTx keyList (SlotNo _slot) sourceState = do
 -- transactions applied to it. Returns the amount of accumulated fees, the
 -- initial ledger state and the final ledger state or the validation error if an
 -- invalid transaction has been generated.
-genNonEmptyAndAdvanceTx
-  :: Gen (KeyPairs, Natural, Coin, LedgerState, [Tx], Either [ValidationError] LedgerState)
+genNonEmptyAndAdvanceTx ::
+  Gen (KeyPairs, Natural, Coin, LedgerState, [Tx], Either [ValidationError] LedgerState)
 genNonEmptyAndAdvanceTx = do
-  keyPairs    <- genKeyPairs 1 10
-  steps       <- genNatural 1 10
-  ls          <- (genesisState Map.empty . genesisCoins) <$> genTxOut (addrTxins keyPairs)
+  keyPairs <- genKeyPairs 1 10
+  steps <- genNatural 1 10
+  ls <- (genesisState Map.empty . genesisCoins) <$> genTxOut (addrTxins keyPairs)
   (fees, txs, ls') <- repeatCollectTx steps keyPairs (SlotNo 1) (Coin 0) ls []
   pure (keyPairs, steps, fees, ls, txs, ls')
 
 -- | Mutated variant of above, collects validation errors in 'LedgerValidation'.
-genNonEmptyAndAdvanceTx'
-  :: Gen (KeyPairs, Natural, Coin, LedgerState, [Tx], LedgerValidation)
+genNonEmptyAndAdvanceTx' ::
+  Gen (KeyPairs, Natural, Coin, LedgerState, [Tx], LedgerValidation)
 genNonEmptyAndAdvanceTx' = do
-  keyPairs    <- genKeyPairs 1 10
-  steps       <- genNatural 1 10
-  ls          <- (genesisState Map.empty . genesisCoins) <$> genTxOut (addrTxins keyPairs)
+  keyPairs <- genKeyPairs 1 10
+  steps <- genNatural 1 10
+  ls <- (genesisState Map.empty . genesisCoins) <$> genTxOut (addrTxins keyPairs)
   (fees, txs, lv') <- repeatCollectTx' steps keyPairs (Coin 0) ls [] []
   pure (keyPairs, steps, fees, ls, txs, lv')
 
@@ -233,42 +270,42 @@ genNonEmptyAndAdvanceTx' = do
 -- list of pairs of key pairs, the 'fees' coin accumulator, initial ledger state
 -- 'ls' and returns the result of the repeated generation and application of
 -- transactions.
-repeatCollectTx
-    :: Natural
-    -> KeyPairs
-    -> SlotNo
-    -> Coin
-    -> LedgerState
-    -> [Tx]
-    -> Gen (Coin, [Tx], Either [ValidationError] LedgerState)
+repeatCollectTx ::
+  Natural ->
+  KeyPairs ->
+  SlotNo ->
+  Coin ->
+  LedgerState ->
+  [Tx] ->
+  Gen (Coin, [Tx], Either [ValidationError] LedgerState)
 repeatCollectTx 0 _ _ fees ls txs = pure (fees, reverse txs, Right ls)
 repeatCollectTx n keyPairs (SlotNo _slot) fees ls txs = do
   (txfee', tx, next) <- genLedgerStateTx keyPairs (SlotNo _slot) ls
   case next of
-    Left _    -> pure (fees, txs, next)
-    Right ls' -> repeatCollectTx (n - 1) keyPairs (SlotNo $ _slot + 1) (txfee' + fees) ls' (tx:txs)
+    Left _ -> pure (fees, txs, next)
+    Right ls' -> repeatCollectTx (n - 1) keyPairs (SlotNo $ _slot + 1) (txfee' + fees) ls' (tx : txs)
 
 -- | Mutated variant of `repeatCollectTx'`, stops at recursion depth or after
 -- exhausting the UTxO set to prevent calling 'head' on empty input list.
-repeatCollectTx'
-    :: Natural
-    -> KeyPairs
-    -> Coin
-    -> LedgerState
-    -> [Tx]
-    -> [ValidationError]
-    -> Gen (Coin, [Tx], LedgerValidation)
+repeatCollectTx' ::
+  Natural ->
+  KeyPairs ->
+  Coin ->
+  LedgerState ->
+  [Tx] ->
+  [ValidationError] ->
+  Gen (Coin, [Tx], LedgerValidation)
 repeatCollectTx' n keyPairs fees ls txs validationErrors
- | n == 0 || (utxoSize $ (_utxo . _utxoState) ls) == 0 =
-     pure (fees, reverse txs, LedgerValidation validationErrors ls)
- | otherwise = do
+  | n == 0 || (utxoSize $ (_utxo . _utxoState) ls) == 0 =
+    pure (fees, reverse txs, LedgerValidation validationErrors ls)
+  | otherwise = do
     (txfee', tx, LedgerValidation errors' ls') <- genLedgerStateTx' keyPairs ls
-    repeatCollectTx' (n - 1) keyPairs (txfee' + fees) ls' (tx:txs) (validationErrors ++ errors')
+    repeatCollectTx' (n - 1) keyPairs (txfee' + fees) ls' (tx : txs) (validationErrors ++ errors')
 
 -- | Find first matching key pair for stake key in 'AddrTxin'.
 findStakeKeyPair :: Credential 'Staking -> KeyPairs -> KeyPair 'Staking
 findStakeKeyPair (KeyHashObj hk) keyList =
-    snd $ head $ filter (\(_, stake) -> hk == hashKey (vKey stake)) keyList
+  snd $ head $ filter (\(_, stake) -> hk == hashKey (vKey stake)) keyList
 findStakeKeyPair _ _ = undefined -- TODO treat script case
 
 -- | Returns the hashed 'addr' part of a 'TxOut'.
@@ -281,15 +318,18 @@ genValidLedgerState :: Gen (KeyPairs, Natural, [Tx], LedgerState)
 genValidLedgerState = do
   (keyPairs, steps, _, _, txs, newState) <- genNonEmptyAndAdvanceTx
   case newState of
-    Left _   -> Gen.discard
+    Left _ -> Gen.discard
     Right ls -> pure (keyPairs, steps, txs, ls)
 
-genValidSuccessorState :: KeyPairs -> SlotNo -> LedgerState ->
+genValidSuccessorState ::
+  KeyPairs ->
+  SlotNo ->
+  LedgerState ->
   Gen (Coin, Tx, LedgerState)
 genValidSuccessorState keyPairs _slot sourceState = do
   (txfee', entry, next) <- genLedgerStateTx keyPairs _slot sourceState
   case next of
-    Left _   -> Gen.discard
+    Left _ -> Gen.discard
     Right ls -> pure (txfee', entry, ls)
 
 genValidStateTx :: Gen (LedgerState, Natural, Coin, Tx, LedgerState)
@@ -300,33 +340,39 @@ genValidStateTx = do
 genValidStateTxKeys :: Gen (LedgerState, Natural, Coin, Tx, LedgerState, KeyPairs)
 genValidStateTxKeys = do
   (keyPairs, steps, _, ls) <- genValidLedgerState
-  (txfee', entry, ls')     <- genValidSuccessorState keyPairs (SlotNo $ fromIntegral steps + 1) ls
+  (txfee', entry, ls') <- genValidSuccessorState keyPairs (SlotNo $ fromIntegral steps + 1) ls
   pure (ls, steps, txfee', entry, ls', keyPairs)
 
 genStateTx :: Gen (LedgerState, Natural, Coin, Tx, LedgerValidation)
 genStateTx = do
   (keyPairs, steps, _, ls) <- genValidLedgerState
-  (txfee', entry, lv)      <- genLedgerStateTx' keyPairs ls
+  (txfee', entry, lv) <- genLedgerStateTx' keyPairs ls
   pure (ls, steps, txfee', entry, lv)
 
-genLedgerStateTx' :: KeyPairs -> LedgerState ->
-                    Gen (Coin, Tx, LedgerValidation)
+genLedgerStateTx' ::
+  KeyPairs ->
+  LedgerState ->
+  Gen (Coin, Tx, LedgerValidation)
 genLedgerStateTx' keyList sourceState = do
   let utxo' = (_utxo . _utxoState) sourceState
   _slot <- genWord64 0 1000
   (txfee', tx) <- genTx keyList utxo' (SlotNo _slot)
-  tx'          <- mutateTx tx
-  pure (txfee'
-       , tx'
-       , asStateTransition' (SlotNo _slot) defPCs (LedgerValidation [] sourceState) tx' (Coin 0))
+  tx' <- mutateTx tx
+  pure
+    ( txfee',
+      tx',
+      asStateTransition' (SlotNo _slot) defPCs (LedgerValidation [] sourceState) tx' (Coin 0)
+    )
 
 -- Generators for 'DelegationData'
 
 genDelegationData :: KeyPairs -> EpochNo -> Gen DCert
 genDelegationData keys epoch =
-    Gen.choice [ genDCertRegKey keys
-               , genDCertDeRegKey keys
-               , genDCertRetirePool keys epoch]
+  Gen.choice
+    [ genDCertRegKey keys,
+      genDCertDeRegKey keys,
+      genDCertRetirePool keys epoch
+    ]
 
 genDCertRegKey :: KeyPairs -> Gen DCert
 genDCertRegKey keys =
@@ -334,7 +380,7 @@ genDCertRegKey keys =
 
 genDCertDeRegKey :: KeyPairs -> Gen DCert
 genDCertDeRegKey keys =
-    DCertDeleg . DeRegKey . KeyHashObj . hashKey <$> getAnyStakeKey keys
+  DCertDeleg . DeRegKey . KeyHashObj . hashKey <$> getAnyStakeKey keys
 
 genDCertRetirePool :: KeyPairs -> EpochNo -> Gen DCert
 genDCertRetirePool keys epoch = do
@@ -343,90 +389,87 @@ genDCertRetirePool keys epoch = do
 
 genDelegation :: KeyPairs -> DPState -> Gen Delegation
 genDelegation keys d = do
-  poolKey      <- Gen.element $ Map.keys stkCreds'
+  poolKey <- Gen.element $ Map.keys stkCreds'
   delegatorKey <- getAnyStakeKey keys
   pure $ Delegation (KeyHashObj $ hashKey delegatorKey) $ (coerceKeyRole . hashKey $ vKey $ findStakeKeyPair poolKey keys)
-       where (StakeCreds stkCreds') = (_stkCreds . _dstate) d
+  where
+    (StakeCreds stkCreds') = (_stkCreds . _dstate) d
 
 genDCertDelegate :: KeyPairs -> DPState -> Gen DCert
 genDCertDelegate keys ds = (DCertDeleg . Delegate) <$> genDelegation keys ds
 
--- |In the case where a transaction is valid for a given ledger state,
--- apply the transaction as a state transition function on the ledger state.
--- Otherwise, return a list of validation errors.
-asStateTransition
-  :: SlotNo
-  -> PParams
-  -> LedgerState
-  -> Tx
-  -> Coin
-  -> Either [ValidationError] LedgerState
+-- | In the case where a transaction is valid for a given ledger state,
+--  apply the transaction as a state transition function on the ledger state.
+--  Otherwise, return a list of validation errors.
+asStateTransition ::
+  SlotNo ->
+  PParams ->
+  LedgerState ->
+  Tx ->
+  Coin ->
+  Either [ValidationError] LedgerState
 asStateTransition _slot pp ls tx res =
-  let next = runShelleyBase $ applySTS @LEDGER
-              (TRC ((LedgerEnv _slot 0 pp res)
-              , (_utxoState ls, _delegationState ls)
-              , tx))
-  in
-  case next of
-    Left pfs -> Left $ convertPredicateFailuresToValidationErrors pfs
-    Right (u, d)  -> Right $ ls { _utxoState = u
-                                , _delegationState = d
-                                }
+  let next =
+        runShelleyBase $
+          applySTS @LEDGER
+            ( TRC
+                ( (LedgerEnv _slot 0 pp res),
+                  (_utxoState ls, _delegationState ls),
+                  tx
+                )
+            )
+   in case next of
+        Left pfs -> Left $ convertPredicateFailuresToValidationErrors pfs
+        Right (u, d) ->
+          Right $
+            ls
+              { _utxoState = u,
+                _delegationState = d
+              }
 
 -- | Apply transition independent of validity, collect validation errors on the
 -- way.
-asStateTransition'
+asStateTransition' ::
   -- :: ( Crypto crypto
   --    , DSignable crypto (TxBody crypto)
   --    )
   -- =>
-  :: SlotNo
-  -> PParams
-  -> LedgerValidation
-  -> Tx
-  -> Coin
-  -> LedgerValidation
+  SlotNo ->
+  PParams ->
+  LedgerValidation ->
+  Tx ->
+  Coin ->
+  LedgerValidation
 asStateTransition' _slot pp (LedgerValidation valErrors ls) tx _ =
-    let ls' = applyTxBody ls pp (_body tx)
-        d'  = (_genDelegs . _dstate . _delegationState) ls
-    in
-    case validTx tx d' _slot pp ls of
-      Invalid errors -> LedgerValidation (valErrors ++ errors) ls'
-      Valid          -> LedgerValidation valErrors ls'
+  let ls' = applyTxBody ls pp (_body tx)
+      d' = (_genDelegs . _dstate . _delegationState) ls
+   in case validTx tx d' _slot pp ls of
+        Invalid errors -> LedgerValidation (valErrors ++ errors) ls'
+        Valid -> LedgerValidation valErrors ls'
 
 convertPredicateFailuresToValidationErrors :: [[PredicateFailure LEDGER]] -> [ValidationError]
 convertPredicateFailuresToValidationErrors pfs =
   map predicateFailureToValidationError $ foldr (++) [] pfs
 
 predicateFailureToValidationError :: PredicateFailure LEDGER -> ValidationError
-
-predicateFailureToValidationError (UtxowFailure (MissingVKeyWitnessesUTXOW))
-  = MissingWitnesses
-predicateFailureToValidationError (UtxowFailure (MissingScriptWitnessesUTXOW))
-  = MissingWitnesses
-
-predicateFailureToValidationError (UtxowFailure (InvalidWitnessesUTXOW))
-  = InvalidWitness
-
-predicateFailureToValidationError (UtxowFailure (UtxoFailure InputSetEmptyUTxO))
-  = InputSetEmpty
-
-predicateFailureToValidationError (UtxowFailure (UtxoFailure (ExpiredUTxO a b)))
-  = Expired a b
-
-predicateFailureToValidationError (UtxowFailure (UtxoFailure BadInputsUTxO))
-  = BadInputs
-
-predicateFailureToValidationError (UtxowFailure (UtxoFailure (FeeTooSmallUTxO a b)))
-  = FeeTooSmall a b
-
-predicateFailureToValidationError (UtxowFailure (UtxoFailure (ValueNotConservedUTxO a b)))
-  = ValueNotConserved a b
-
-predicateFailureToValidationError (DelegsFailure DelegateeNotRegisteredDELEG)
-  = StakeDelegationImpossible
-
-predicateFailureToValidationError (DelegsFailure WithdrawalsNotInRewardsDELEGS)
-  = IncorrectRewards
-
+predicateFailureToValidationError (UtxowFailure (MissingVKeyWitnessesUTXOW)) =
+  MissingWitnesses
+predicateFailureToValidationError (UtxowFailure (MissingScriptWitnessesUTXOW)) =
+  MissingWitnesses
+predicateFailureToValidationError (UtxowFailure (InvalidWitnessesUTXOW)) =
+  InvalidWitness
+predicateFailureToValidationError (UtxowFailure (UtxoFailure InputSetEmptyUTxO)) =
+  InputSetEmpty
+predicateFailureToValidationError (UtxowFailure (UtxoFailure (ExpiredUTxO a b))) =
+  Expired a b
+predicateFailureToValidationError (UtxowFailure (UtxoFailure BadInputsUTxO)) =
+  BadInputs
+predicateFailureToValidationError (UtxowFailure (UtxoFailure (FeeTooSmallUTxO a b))) =
+  FeeTooSmall a b
+predicateFailureToValidationError (UtxowFailure (UtxoFailure (ValueNotConservedUTxO a b))) =
+  ValueNotConserved a b
+predicateFailureToValidationError (DelegsFailure DelegateeNotRegisteredDELEG) =
+  StakeDelegationImpossible
+predicateFailureToValidationError (DelegsFailure WithdrawalsNotInRewardsDELEGS) =
+  IncorrectRewards
 predicateFailureToValidationError _ = UnknownValidationError

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PreSTSMutator.hs
@@ -1,52 +1,71 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PatternSynonyms #-}
 
-{-|
-Module
-Description : Generators for mutating data.
-
-This module implements a mutation based approach for generating invalid
-data. Input values are mutated depending on their value.
--}
-
+-- |
+-- Module
+-- Description : Generators for mutating data.
+--
+-- This module implements a mutation based approach for generating invalid
+-- data. Input values are mutated depending on their value.
 module Test.Shelley.Spec.Ledger.PreSTSMutator
-    ( mutateNat
-    , mutateCoin
-    , mutateTx
-    , mutateTxBody
-    , mutateDCert
-    , getAnyStakeKey
-    ) where
+  ( mutateNat,
+    mutateCoin,
+    mutateTx,
+    mutateTxBody,
+    mutateDCert,
+    getAnyStakeKey,
+  )
+where
 
 import qualified Data.List as List (map)
 import qualified Data.Map.Strict as Map (fromList, toList)
-import           Data.Maybe (fromMaybe)
-import           Data.Ratio
-import           Data.Sequence.Strict (StrictSeq (..))
+import Data.Maybe (fromMaybe)
+import Data.Ratio
+import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Set as Set
-import           Numeric.Natural
-
-import           Hedgehog
+import Data.Set as Set
+import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-
-import           Shelley.Spec.Ledger.BaseTypes
-import           Shelley.Spec.Ledger.Coin
-import           Shelley.Spec.Ledger.Delegation.Certificates (pattern DeRegKey, pattern Delegate,
-                     pattern GenesisDelegCert, pattern MIRCert, pattern RegKey, pattern RegPool,
-                     pattern RetirePool)
-import           Shelley.Spec.Ledger.Keys (KeyRole(..), coerceKeyRole, hashKey, vKey)
-
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.Tx (pattern Tx, pattern TxBody, pattern TxIn, pattern TxOut,
-                     _body, _certs, _inputs, _outputs, _ttl, _txfee, _wdrls, _witnessMSigMap,
-                     _witnessVKeySet)
-import           Shelley.Spec.Ledger.TxData (Credential (..), pattern DCertDeleg,
-                     pattern DCertGenesis, pattern DCertMir, pattern DCertPool, pattern Delegation,
-                     PoolParams (..))
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+import Numeric.Natural
+import Shelley.Spec.Ledger.BaseTypes
+import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.Delegation.Certificates
+  ( pattern DeRegKey,
+    pattern Delegate,
+    pattern GenesisDelegCert,
+    pattern MIRCert,
+    pattern RegKey,
+    pattern RegPool,
+    pattern RetirePool,
+  )
+import Shelley.Spec.Ledger.Keys (KeyRole (..), coerceKeyRole, hashKey, vKey)
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.Tx
+  ( _body,
+    _certs,
+    _inputs,
+    _outputs,
+    _ttl,
+    _txfee,
+    _wdrls,
+    _witnessMSigMap,
+    _witnessVKeySet,
+    pattern Tx,
+    pattern TxBody,
+    pattern TxIn,
+    pattern TxOut,
+  )
+import Shelley.Spec.Ledger.TxData
+  ( Credential (..),
+    PoolParams (..),
+    pattern DCertDeleg,
+    pattern DCertGenesis,
+    pattern DCertMir,
+    pattern DCertPool,
+    pattern Delegation,
+  )
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
 
 -- | Identity mutator that does not change the input value.
 mutateId :: a -> Gen a
@@ -85,25 +104,27 @@ mutateTx txwits = do
 -- unspent outputs.
 mutateTxBody :: TxBody -> Gen TxBody
 mutateTxBody tx = do
-  inputs'  <- mutateInputs  $ Set.toList (_inputs tx)
+  inputs' <- mutateInputs $ Set.toList (_inputs tx)
   outputs' <- mutateOutputs $ _outputs tx
-  pure $ TxBody (Set.fromList inputs')
-    outputs'
-    (_certs tx)
-    (_wdrls tx)
-    (_txfee tx)
-    (_ttl tx)
-    SNothing
-    SNothing
+  pure $
+    TxBody
+      (Set.fromList inputs')
+      outputs'
+      (_certs tx)
+      (_wdrls tx)
+      (_txfee tx)
+      (_ttl tx)
+      SNothing
+      SNothing
 
 -- | Mutator for a list of 'TxIn'.
 mutateInputs :: [TxIn] -> Gen [TxIn]
 mutateInputs [] = pure []
-mutateInputs (txin:txins) = do
-  mtxin    <- mutateInput txin
-  mtxins   <- mutateInputs txins
+mutateInputs (txin : txins) = do
+  mtxin <- mutateInput txin
+  mtxins <- mutateInputs txins
   dropTxin <- Gen.enumBounded
-  pure $ if dropTxin then mtxins else mtxin:mtxins
+  pure $ if dropTxin then mtxins else mtxin : mtxins
 
 -- | Mutator for a single 'TxIn', which mutates the index of the output to
 -- spend.
@@ -116,8 +137,8 @@ mutateInput (TxIn idx index) = do
 mutateOutputs :: StrictSeq TxOut -> Gen (StrictSeq TxOut)
 mutateOutputs StrictSeq.Empty = pure StrictSeq.Empty
 mutateOutputs (txout :<| txouts) = do
-  mtxout    <- mutateOutput txout
-  mtxouts   <- mutateOutputs txouts
+  mtxout <- mutateOutput txout
+  mtxouts <- mutateOutputs txouts
   dropTxOut <- Gen.enumBounded
   pure $ if dropTxOut then mtxouts else mtxout :<| mtxouts
 
@@ -127,7 +148,6 @@ mutateOutput :: TxOut -> Gen TxOut
 mutateOutput (TxOut addr c) = do
   c' <- mutateCoin 0 100 c
   pure $ TxOut addr c'
-
 
 -- Mutators for 'DelegationData'
 
@@ -140,8 +160,9 @@ getAnyStakeKey keys = vKey . snd <$> Gen.element keys
 
 -- | Mutate 'Epoch' analogously to 'Coin' data.
 mutateEpoch :: Natural -> Natural -> EpochNo -> Gen EpochNo
-mutateEpoch lower upper (EpochNo val) = EpochNo . fromIntegral
-  <$> mutateNat lower upper (fromIntegral val)
+mutateEpoch lower upper (EpochNo val) =
+  EpochNo . fromIntegral
+    <$> mutateNat lower upper (fromIntegral val)
 
 -- | Mutator for delegation certificates.
 -- A 'RegKey' and 'DeRegKey' select randomly a key fomr the supplied list of
@@ -153,33 +174,34 @@ mutateEpoch lower upper (EpochNo val) = EpochNo . fromIntegral
 mutateDCert :: KeyPairs -> DPState -> DCert -> Gen DCert
 mutateDCert keys _ (DCertDeleg (RegKey _)) =
   DCertDeleg . RegKey . KeyHashObj . hashKey . vKey . snd <$> Gen.element keys
-
 mutateDCert keys _ (DCertDeleg (DeRegKey _)) =
   DCertDeleg . DeRegKey . KeyHashObj . hashKey . vKey . snd <$> Gen.element keys
-
 mutateDCert keys _ (DCertPool (RetirePool _ epoch@(EpochNo e))) = do
-    epoch' <- mutateEpoch 0 (fromIntegral e) epoch
-    key'   <- getAnyStakeKey keys
-    pure $ DCertPool (RetirePool (coerceKeyRole $ hashKey key') epoch')
-
-mutateDCert keys _ (DCertPool (RegPool
-  (PoolParams _ vrfHk pledge cost margin rwdacnt owners relays poolMD))) = do
-  key'    <- getAnyStakeKey keys
-  cost'   <- mutateCoin 0 100 cost
-  p'      <- mutateNat 0 100 (fromIntegral $ numerator $ intervalValue margin)
-  let interval = fromMaybe interval0 (mkUnitInterval $ fromIntegral p' % 100)
-  pure $ (DCertPool . RegPool)
-    (PoolParams (coerceKeyRole $ hashKey key') vrfHk pledge cost' interval rwdacnt owners relays poolMD)
-
+  epoch' <- mutateEpoch 0 (fromIntegral e) epoch
+  key' <- getAnyStakeKey keys
+  pure $ DCertPool (RetirePool (coerceKeyRole $ hashKey key') epoch')
+mutateDCert
+  keys
+  _
+  ( DCertPool
+      ( RegPool
+          (PoolParams _ vrfHk pledge cost margin rwdacnt owners relays poolMD)
+        )
+    ) = do
+    key' <- getAnyStakeKey keys
+    cost' <- mutateCoin 0 100 cost
+    p' <- mutateNat 0 100 (fromIntegral $ numerator $ intervalValue margin)
+    let interval = fromMaybe interval0 (mkUnitInterval $ fromIntegral p' % 100)
+    pure $
+      (DCertPool . RegPool)
+        (PoolParams (coerceKeyRole $ hashKey key') vrfHk pledge cost' interval rwdacnt owners relays poolMD)
 mutateDCert keys _ (DCertDeleg (Delegate (Delegation _ _))) = do
   delegator' <- getAnyStakeKey keys
   delegatee' <- getAnyStakeKey keys
   pure $ DCertDeleg $ Delegate $ Delegation (KeyHashObj $ hashKey delegator') (coerceKeyRole $ hashKey delegatee')
-
 mutateDCert keys _ (DCertGenesis (GenesisDelegCert gk _)) = do
   _delegatee <- getAnyStakeKey keys
   pure $ DCertGenesis $ GenesisDelegCert gk (coerceKeyRole $ hashKey _delegatee)
-
 mutateDCert _ _ (DCertMir (MIRCert credCoinMap)) = do
   let credCoinList = Map.toList credCoinMap
       coins = List.map snd credCoinList

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/PropertyTests.hs
@@ -4,112 +4,166 @@
 
 module Test.Shelley.Spec.Ledger.PropertyTests (propertyTests, minimalPropertyTests) where
 
-import           Data.Foldable (toList)
-import           Data.IP (IPv4, IPv6, fromHostAddress, fromHostAddress6)
-import           Data.Map.Strict (Map)
+import Byron.Spec.Ledger.Core ((<|))
+import Data.Foldable (toList)
+import Data.IP (IPv4, IPv6, fromHostAddress, fromHostAddress6)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.MultiSet (filter, fromSet, occur, size, unions)
+import Data.MultiSet (filter, fromSet, occur, size, unions)
 import qualified Data.Set as Set
-
-import           Hedgehog.Internal.Property (LabelName (..))
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.Hedgehog (testProperty)
-import qualified Test.Tasty.QuickCheck as TQC
-
-import           Hedgehog (Gen, Property, classify, failure, label, property, success, withTests,
-                     (/==), (===))
+import Hedgehog
+  ( (/==),
+    (===),
+    Gen,
+    Property,
+    classify,
+    failure,
+    label,
+    property,
+    success,
+    withTests,
+  )
 import qualified Hedgehog
 import qualified Hedgehog.Gen as Gen
+import Hedgehog.Internal.Property (LabelName (..))
 import qualified Hedgehog.Range as Range
-
-import           Byron.Spec.Ledger.Core ((<|))
-import           Shelley.Spec.Ledger.Address (deserialiseAddr, serialiseAddr)
-import           Shelley.Spec.Ledger.Coin
-import           Shelley.Spec.Ledger.LedgerState
-import           Shelley.Spec.Ledger.PParams
-import           Shelley.Spec.Ledger.Serialization (ipv4FromBytes, ipv4ToBytes, ipv6FromBytes,
-                     ipv6ToBytes)
-import           Shelley.Spec.Ledger.Slot
-import           Shelley.Spec.Ledger.Tx (pattern TxIn, pattern TxOut, _body, _certs, _inputs,
-                     _outputs, _witnessVKeySet)
-import           Shelley.Spec.Ledger.UTxO (balance, hashTxBody, makeWitnessVKey, totalDeposits,
-                     txid, txins, txouts, verifyWitVKey)
-import           Shelley.Spec.Ledger.Validation (ValidationError (..))
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
-import           Test.Shelley.Spec.Ledger.Generator.Core (mkKeyPairs, toAddr)
-import           Test.Shelley.Spec.Ledger.PreSTSGenerator
-import           Test.Shelley.Spec.Ledger.Rules.ClassifyTraces (onlyValidChainSignalsAreGenerated,
-                     onlyValidLedgerSignalsAreGenerated, relevantCasesAreCovered)
-import           Test.Shelley.Spec.Ledger.Rules.TestChain (constantSumPots, nonNegativeDeposits,
-                     preservationOfAda, removedAfterPoolreap)
-import           Test.Shelley.Spec.Ledger.Rules.TestLedger (consumedEqualsProduced,
-                     credentialMappingAfterDelegation, credentialRemovedAfterDereg,
-                     eliminateTxInputs, feesNonDecreasing, newEntriesAndUniqueTxIns, noDoubleSpend,
-                     pStateIsInternallyConsistent, poolIsMarkedForRetirement, poolRetireInEpoch,
-                     potsSumIncreaseWdrls, preserveBalance, preserveBalanceRestricted,
-                     preserveOutputsTx, prop_MIRValuesEndUpInMap, prop_MIRentriesEndUpInMap,
-                     registeredPoolIsAdded, rewardZeroAfterRegKey, rewardZeroAfterRegPool,
-                     rewardsDecreasesByWithdrawals, rewardsSumInvariant)
-
+import Shelley.Spec.Ledger.Address (deserialiseAddr, serialiseAddr)
+import Shelley.Spec.Ledger.Coin
+import Shelley.Spec.Ledger.LedgerState
+import Shelley.Spec.Ledger.PParams
+import Shelley.Spec.Ledger.Serialization
+  ( ipv4FromBytes,
+    ipv4ToBytes,
+    ipv6FromBytes,
+    ipv6ToBytes,
+  )
+import Shelley.Spec.Ledger.Slot
+import Shelley.Spec.Ledger.Tx
+  ( _body,
+    _certs,
+    _inputs,
+    _outputs,
+    _witnessVKeySet,
+    pattern TxIn,
+    pattern TxOut,
+  )
+import Shelley.Spec.Ledger.UTxO
+  ( balance,
+    hashTxBody,
+    makeWitnessVKey,
+    totalDeposits,
+    txid,
+    txins,
+    txouts,
+    verifyWitVKey,
+  )
+import Shelley.Spec.Ledger.Validation (ValidationError (..))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+import Test.Shelley.Spec.Ledger.Generator.Core (mkKeyPairs, toAddr)
+import Test.Shelley.Spec.Ledger.PreSTSGenerator
+import Test.Shelley.Spec.Ledger.Rules.ClassifyTraces
+  ( onlyValidChainSignalsAreGenerated,
+    onlyValidLedgerSignalsAreGenerated,
+    relevantCasesAreCovered,
+  )
+import Test.Shelley.Spec.Ledger.Rules.TestChain
+  ( constantSumPots,
+    nonNegativeDeposits,
+    preservationOfAda,
+    removedAfterPoolreap,
+  )
+import Test.Shelley.Spec.Ledger.Rules.TestLedger
+  ( consumedEqualsProduced,
+    credentialMappingAfterDelegation,
+    credentialRemovedAfterDereg,
+    eliminateTxInputs,
+    feesNonDecreasing,
+    newEntriesAndUniqueTxIns,
+    noDoubleSpend,
+    pStateIsInternallyConsistent,
+    poolIsMarkedForRetirement,
+    poolRetireInEpoch,
+    potsSumIncreaseWdrls,
+    preserveBalance,
+    preserveBalanceRestricted,
+    preserveOutputsTx,
+    prop_MIRValuesEndUpInMap,
+    prop_MIRentriesEndUpInMap,
+    registeredPoolIsAdded,
+    rewardZeroAfterRegKey,
+    rewardZeroAfterRegPool,
+    rewardsDecreasesByWithdrawals,
+    rewardsSumInvariant,
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+import qualified Test.Tasty.QuickCheck as TQC
 
 -- | Take 'addr |-> c' pair from 'TxOut' and insert into map or add 'c' to value
 -- already present. Used to fold over 'UTxO' to accumulate funds per address.
 insertOrUpdate :: TxOut -> Map Addr Coin -> Map Addr Coin
 insertOrUpdate (TxOut a c) m =
-    Map.insert a (if Map.member a m
-                  then c + (m Map.! a)
-                  else c) m
+  Map.insert
+    a
+    ( if Map.member a m
+        then c + (m Map.! a)
+        else c
+    )
+    m
 
 -- | Return True if at least half of the keys have non-trivial coin values to
 -- spent, i.e., at least 2 coins per 50% of addresses.
 isNotDustDist :: UTxO -> UTxO -> Bool
 isNotDustDist initUtxo utxo' =
-    utxoSize initUtxo <=
-           2 *Map.size (Map.filter (> Coin 1) coinMap)
-        where coinMap = Map.foldr insertOrUpdate Map.empty (utxoMap utxo')
+  utxoSize initUtxo
+    <= 2 * Map.size (Map.filter (> Coin 1) coinMap)
+  where
+    coinMap = Map.foldr insertOrUpdate Map.empty (utxoMap utxo')
 
 -- | This property states that a non-empty UTxO set in the genesis state has a
 -- non-zero balance.
-propPositiveBalance:: Property
+propPositiveBalance :: Property
 propPositiveBalance =
-    property $ do
-      initialState <- Hedgehog.forAll genNonemptyGenesisState
-      utxoSize ((_utxo . _utxoState) initialState) /== 0
-      Coin 0 /== balance ((_utxo . _utxoState) initialState)
+  property $ do
+    initialState <- Hedgehog.forAll genNonemptyGenesisState
+    utxoSize ((_utxo . _utxoState) initialState) /== 0
+    Coin 0 /== balance ((_utxo . _utxoState) initialState)
 
 -- | This property states that the balance of the initial genesis state equals
 -- the balance of the end ledger state plus the collected fees.
 propPreserveBalanceInitTx :: Property
 propPreserveBalanceInitTx =
-    property $ do
-      (_, steps, fee, ls, _, next)  <- Hedgehog.forAll genNonEmptyAndAdvanceTx
-      classify "non-trivial number of steps" (steps > 1)
-      case next of
-        Left _    -> failure
-        Right ls' -> do
-              classify "non-trivial wealth dist"
-                (isNotDustDist ((_utxo . _utxoState) ls) ((_utxo . _utxoState) ls'))
-              balance ((_utxo . _utxoState) ls) === balance ((_utxo . _utxoState) ls') + fee
+  property $ do
+    (_, steps, fee, ls, _, next) <- Hedgehog.forAll genNonEmptyAndAdvanceTx
+    classify "non-trivial number of steps" (steps > 1)
+    case next of
+      Left _ -> failure
+      Right ls' -> do
+        classify
+          "non-trivial wealth dist"
+          (isNotDustDist ((_utxo . _utxoState) ls) ((_utxo . _utxoState) ls'))
+        balance ((_utxo . _utxoState) ls) === balance ((_utxo . _utxoState) ls') + fee
 
 -- | Property (Preserve Balance Restricted to TxIns in Balance of TxOuts)
 propBalanceTxInTxOut :: Property
 propBalanceTxInTxOut = property $ do
-  (l, steps, fee, txwits, l')  <- Hedgehog.forAll genValidStateTx
-  let tx                       = _body txwits
-  let inps                     = txins tx
+  (l, steps, fee, txwits, l') <- Hedgehog.forAll genValidStateTx
+  let tx = _body txwits
+  let inps = txins tx
   classify "non-trivial valid ledger state" (steps > 1)
-  classify "non-trivial wealth dist"
-    (isNotDustDist ((_utxo . _utxoState) l) ((_utxo. _utxoState) l'))
+  classify
+    "non-trivial wealth dist"
+    (isNotDustDist ((_utxo . _utxoState) l) ((_utxo . _utxoState) l'))
   (balance $ inps <| ((_utxo . _utxoState) l)) === (balance (txouts tx) + fee)
 
 -- | Property (Preserve Outputs of Transaction)
 propPreserveOutputs :: Property
 propPreserveOutputs = property $ do
   (l, steps, _, txwits, l') <- Hedgehog.forAll genValidStateTx
-  let tx                    = _body txwits
+  let tx = _body txwits
   classify "non-trivial valid ledger state" (steps > 1)
-  classify "non-trivial wealth dist"
+  classify
+    "non-trivial wealth dist"
     (isNotDustDist ((_utxo . _utxoState) l) ((_utxo . _utxoState) l'))
   True === Map.isSubmapOf (utxoMap $ txouts tx) (utxoMap $ (_utxo . _utxoState) l')
 
@@ -117,9 +171,10 @@ propPreserveOutputs = property $ do
 propEliminateInputs :: Property
 propEliminateInputs = property $ do
   (l, steps, _, txwits, l') <- Hedgehog.forAll genValidStateTx
-  let tx                    = _body txwits
+  let tx = _body txwits
   classify "non-trivial valid ledger state" (steps > 1)
-  classify "non-trivial wealth dist"
+  classify
+    "non-trivial wealth dist"
     (isNotDustDist ((_utxo . _utxoState) l) ((_utxo . _utxoState) l'))
   -- no element of 'txins tx' is a key in the 'UTxO' of l'
   Map.empty === Map.restrictKeys (utxoMap $ (_utxo . _utxoState) l') (txins tx)
@@ -128,54 +183,63 @@ propEliminateInputs = property $ do
 propUniqueTxIds :: Property
 propUniqueTxIds = property $ do
   (l, steps, _, txwits, l') <- Hedgehog.forAll genValidStateTx
-  let tx                    = _body txwits
-  let origTxIds             = collectIds <$> Map.keys (utxoMap ((_utxo . _utxoState) l))
-  let newTxIds              = collectIds <$> Map.keys (utxoMap (txouts tx))
-  let txId                  = txid tx
+  let tx = _body txwits
+  let origTxIds = collectIds <$> Map.keys (utxoMap ((_utxo . _utxoState) l))
+  let newTxIds = collectIds <$> Map.keys (utxoMap (txouts tx))
+  let txId = txid tx
   classify "non-trivial valid ledger state" (steps > 1)
-  classify "non-trivial wealth dist"
+  classify
+    "non-trivial wealth dist"
     (isNotDustDist ((_utxo . _utxoState) l) ((_utxo . _utxoState) l'))
-  True === (all (== txId) newTxIds &&
-             notElem txId origTxIds &&
-            Map.isSubmapOf (utxoMap $ txouts tx) (utxoMap $ (_utxo . _utxoState) l'))
-         where collectIds (TxIn txId _) = txId
+  True
+    === ( all (== txId) newTxIds
+            && notElem txId origTxIds
+            && Map.isSubmapOf (utxoMap $ txouts tx) (utxoMap $ (_utxo . _utxoState) l')
+        )
+  where
+    collectIds (TxIn txId _) = txId
 
 -- | Property checks no double spend occurs in the currently generated 'TxWits'
 -- transactions. Note: this is more a property of the current generator.
 propNoDoubleSpend :: Property
 propNoDoubleSpend = withTests 1000 $ property $ do
-      (_, _, _, _, txs, next)  <- Hedgehog.forAll genNonEmptyAndAdvanceTx
-      case next of
-        Left _  -> failure
-        Right _ -> do
-          let inputIndicesSet = unions $ map (\txwit -> fromSet $ (_inputs . _body) txwit) txs
-          0 === Data.MultiSet.size (Data.MultiSet.filter
-                     (\idx -> 1 < Data.MultiSet.occur idx inputIndicesSet)
-                     inputIndicesSet)
+  (_, _, _, _, txs, next) <- Hedgehog.forAll genNonEmptyAndAdvanceTx
+  case next of
+    Left _ -> failure
+    Right _ -> do
+      let inputIndicesSet = unions $ map (\txwit -> fromSet $ (_inputs . _body) txwit) txs
+      0
+        === Data.MultiSet.size
+          ( Data.MultiSet.filter
+              (\idx -> 1 < Data.MultiSet.occur idx inputIndicesSet)
+              inputIndicesSet
+          )
 
 -- | Classify mutated transaction into double-spends (validated and
 -- non-validated). This is a property of the validator, i.e., no validated
 -- transaction should ever be able to do a double spend.
 classifyInvalidDoubleSpend :: Property
 classifyInvalidDoubleSpend = withTests 1000 $ property $ do
-      (_, _, _, _, txs, LedgerValidation validationErrors _)
-          <- Hedgehog.forAll genNonEmptyAndAdvanceTx'
-      let inputIndicesSet  = unions $ map (\txwit -> fromSet $ (_inputs . _body) txwit) txs
-      let multiSpentInputs = Data.MultiSet.size $ Data.MultiSet.filter
-                                   (\idx -> 1 < Data.MultiSet.occur idx inputIndicesSet)
-                                   inputIndicesSet
-      let isMultiSpend = 0 < multiSpentInputs
-      classify "multi-spend, validation OK" (null validationErrors)
-      classify "multi-spend, validation KO" (isMultiSpend && validationErrors /= [])
-      classify "multi-spend" isMultiSpend
-      True === (not isMultiSpend || validationErrors /= [])
+  (_, _, _, _, txs, LedgerValidation validationErrors _) <-
+    Hedgehog.forAll genNonEmptyAndAdvanceTx'
+  let inputIndicesSet = unions $ map (\txwit -> fromSet $ (_inputs . _body) txwit) txs
+  let multiSpentInputs =
+        Data.MultiSet.size $
+          Data.MultiSet.filter
+            (\idx -> 1 < Data.MultiSet.occur idx inputIndicesSet)
+            inputIndicesSet
+  let isMultiSpend = 0 < multiSpentInputs
+  classify "multi-spend, validation OK" (null validationErrors)
+  classify "multi-spend, validation KO" (isMultiSpend && validationErrors /= [])
+  classify "multi-spend" isMultiSpend
+  True === (not isMultiSpend || validationErrors /= [])
 
 roundTripAddr :: Property
 roundTripAddr =
   -- We are using a QC generator which means we need QC test
-    Hedgehog.property $ do
-      addr <- Hedgehog.forAll genAddressH
-      Hedgehog.tripping addr serialiseAddr deserialiseAddr
+  Hedgehog.property $ do
+    addr <- Hedgehog.forAll genAddressH
+    Hedgehog.tripping addr serialiseAddr deserialiseAddr
   where
     genAddressH :: Gen Addr -- actually TxData.Addr ConcreteCrypto
     genAddressH = do
@@ -186,9 +250,9 @@ roundTripAddr =
 roundTripIpv4 :: Property
 roundTripIpv4 =
   -- We are using a QC generator which means we need QC test
-    Hedgehog.property $ do
-      ha <- Hedgehog.forAll genIPv4
-      Hedgehog.tripping ha ipv4ToBytes ipv4FromBytes
+  Hedgehog.property $ do
+    ha <- Hedgehog.forAll genIPv4
+    Hedgehog.tripping ha ipv4ToBytes ipv4FromBytes
   where
     genIPv4 :: Gen IPv4
     genIPv4 = fromHostAddress <$> (Gen.word32 Range.constantBounded)
@@ -196,9 +260,9 @@ roundTripIpv4 =
 roundTripIpv6 :: Property
 roundTripIpv6 =
   -- We are using a QC generator which means we need QC test
-    Hedgehog.property $ do
-      ha <- Hedgehog.forAll genIPv6
-      Hedgehog.tripping ha ipv6ToBytes ipv6FromBytes
+  Hedgehog.property $ do
+    ha <- Hedgehog.forAll genIPv6
+    Hedgehog.tripping ha ipv6ToBytes ipv6FromBytes
   where
     genIPv6 :: Gen IPv6
     genIPv6 = do
@@ -206,166 +270,203 @@ roundTripIpv6 =
       w2 <- Gen.word32 Range.constantBounded
       w3 <- Gen.word32 Range.constantBounded
       w4 <- Gen.word32 Range.constantBounded
-      pure $ fromHostAddress6 (w1,w2,w3,w4)
+      pure $ fromHostAddress6 (w1, w2, w3, w4)
 
 minimalPropertyTests :: TestTree
 minimalPropertyTests =
-  testGroup "Minimal Property Tests"
-    [ TQC.testProperty "Chain and Ledger traces cover the relevant cases" relevantCasesAreCovered
-    , TQC.testProperty "total amount of Ada is preserved" preservationOfAda
-    , TQC.testProperty "Only valid CHAIN STS signals are generated" onlyValidChainSignalsAreGenerated
-    , testProperty "Roundtrip Addr serialisation Hedghog" roundTripAddr
-    , testProperty "Roundtrip IPv4 serialisation Hedghog" roundTripIpv4
-    , testProperty "Roundtrip IPv6 serialisation Hedghog" roundTripIpv6
+  testGroup
+    "Minimal Property Tests"
+    [ TQC.testProperty "Chain and Ledger traces cover the relevant cases" relevantCasesAreCovered,
+      TQC.testProperty "total amount of Ada is preserved" preservationOfAda,
+      TQC.testProperty "Only valid CHAIN STS signals are generated" onlyValidChainSignalsAreGenerated,
+      testProperty "Roundtrip Addr serialisation Hedghog" roundTripAddr,
+      testProperty "Roundtrip IPv4 serialisation Hedghog" roundTripIpv4,
+      testProperty "Roundtrip IPv6 serialisation Hedghog" roundTripIpv6
     ]
 
 -- | 'TestTree' of property-based testing properties.
 propertyTests :: TestTree
-propertyTests = testGroup "Property-Based Testing"
-                [ testGroup "Classify Traces"
-                  [TQC.testProperty "Chain and Ledger traces cover the relevant cases" relevantCasesAreCovered]
-                , testGroup "STS Rules - Delegation Properties"
-                  [ TQC.testProperty "newly registered key has a reward of 0" rewardZeroAfterRegKey
-                  , TQC.testProperty "deregistered key's credential is removed" credentialRemovedAfterDereg
-                  , TQC.testProperty "registered stake credential is correctly delegated" credentialMappingAfterDelegation
-                  , TQC.testProperty "sum of rewards does not change" rewardsSumInvariant
-                  , TQC.testProperty "rewards pot decreases by the sum of tx withdrawals" rewardsDecreasesByWithdrawals
-                  ]
-                , testGroup "STS Rules - Utxo Properties"
-                  [ TQC.testProperty "the value consumed by UTXO is equal to the value produced in DELEGS" consumedEqualsProduced
-                  , TQC.testProperty "transaction fees are non-decreasing" feesNonDecreasing
-                  , TQC.testProperty "sum of circulation, deposits and fees increases by the sum of tx withdrawals" potsSumIncreaseWdrls
-                  , TQC.testProperty "preserve the balance in a transaction" preserveBalance
-                  , TQC.testProperty "preserve tx balance restricted to TxIns and TxOuts" preserveBalanceRestricted
-                  , TQC.testProperty "preserve transaction outputs" preserveOutputsTx
-                  , TQC.testProperty "consumed inputs are eliminated" eliminateTxInputs
-                  , TQC.testProperty "new tx entries are included and all txIds are new" newEntriesAndUniqueTxIns
-                  , TQC.testProperty "no double spend" noDoubleSpend
-                  ]
-                , testGroup "STS Rules - Pool Properties"
-                  [ TQC.testProperty "newly registered stake pool is added to \
-                                     \appropriate state mappings"
-                                     registeredPoolIsAdded
-                  , TQC.testProperty "newly registered pool key is not in the retiring map"
-                                     rewardZeroAfterRegPool
-                  , TQC.testProperty "retired stake pool is removed from \
-                                     \appropriate state mappings and marked \
-                                     \ for retiring"
-                                     poolIsMarkedForRetirement
-                  , TQC.testProperty "pool state is internally consistent"
-                                     pStateIsInternallyConsistent
-                  , TQC.testProperty "executing a pool retirement certificate adds to 'retiring'"
-                                     poolRetireInEpoch
-                  ]
-                , testGroup "STS Rules - Poolreap Properties"
-                  [ TQC.testProperty "circulation+deposits+fees+treasury+rewards+reserves is constant."
-                                     constantSumPots
-                  , TQC.testProperty "deposits are always non-negative"
-                                     nonNegativeDeposits
-                  , TQC.testProperty "pool is removed from stake pool and retiring maps"
-                                     removedAfterPoolreap
-                  ]
-                , testGroup "STS Rules - NewEpoch Properties"
-                  [ TQC.testProperty "total amount of Ada is preserved"
-                                     preservationOfAda
-                  ]
-                , testGroup "STS Rules - MIR certificates"
-                  [ TQC.testProperty "entries of MIR certificate are added to\
-                                 \ irwd mapping"
-                    prop_MIRentriesEndUpInMap
-                  , TQC.testProperty "coin values of entries of a MIR certificate\
-                                     \ are added to the irwd mapping"
-                    prop_MIRValuesEndUpInMap
-                  ]
-                , testGroup "Ledger Genesis State"
-                  [testProperty
-                    "non-empty genesis ledger state has non-zero balance"
-                    propPositiveBalance
-                  , testProperty
-                    "several transaction added to genesis ledger state"
-                    propPreserveBalanceInitTx]
-                , testGroup "Property tests starting from valid ledger state"
-                  [testProperty
-                    "preserve balance restricted to TxIns in Balance of outputs"
-                    propBalanceTxInTxOut
-                  , testProperty
-                    "Preserve outputs of transaction"
-                    propPreserveOutputs
-                  , testProperty
-                    "Eliminate Inputs of Transaction"
-                    propEliminateInputs
-                  , testProperty
-                    "Completeness and Collision-Freeness of new TxIds"
-                    propUniqueTxIds
-                  , testProperty
-                    "No Double Spend in valid ledger states"
-                    propNoDoubleSpend
-                  , testProperty
-                    "adding redundant witness"
-                    propCheckRedundantWitnessSet
-                  , testProperty
-                    "using subset of witness set"
-                    propCheckMissingWitness
-                  , testProperty
-                    "Correctly preserve balance"
-                    propPreserveBalance
-                  ]
-                , testGroup "Property tests with mutated transactions"
-                  [testProperty
-                   "preserve balance of change in UTxO"
-                   propBalanceTxInTxOut'
-                  , testProperty
-                    "Classify double spend"
-                    classifyInvalidDoubleSpend
-                  , testProperty
-                    "NonNegative TxOuts"
-                    propNonNegativeTxOuts
-                  ]
-                , testGroup "Properties of Trace generators"
-                  [ TQC.testProperty
-                       "Only valid LEDGER STS signals are generated"
-                       onlyValidLedgerSignalsAreGenerated
-                  , TQC.testProperty
-                       "Only valid CHAIN STS signals are generated"
-                       onlyValidChainSignalsAreGenerated
-                  ]
-                ]
+propertyTests =
+  testGroup
+    "Property-Based Testing"
+    [ testGroup
+        "Classify Traces"
+        [TQC.testProperty "Chain and Ledger traces cover the relevant cases" relevantCasesAreCovered],
+      testGroup
+        "STS Rules - Delegation Properties"
+        [ TQC.testProperty "newly registered key has a reward of 0" rewardZeroAfterRegKey,
+          TQC.testProperty "deregistered key's credential is removed" credentialRemovedAfterDereg,
+          TQC.testProperty "registered stake credential is correctly delegated" credentialMappingAfterDelegation,
+          TQC.testProperty "sum of rewards does not change" rewardsSumInvariant,
+          TQC.testProperty "rewards pot decreases by the sum of tx withdrawals" rewardsDecreasesByWithdrawals
+        ],
+      testGroup
+        "STS Rules - Utxo Properties"
+        [ TQC.testProperty "the value consumed by UTXO is equal to the value produced in DELEGS" consumedEqualsProduced,
+          TQC.testProperty "transaction fees are non-decreasing" feesNonDecreasing,
+          TQC.testProperty "sum of circulation, deposits and fees increases by the sum of tx withdrawals" potsSumIncreaseWdrls,
+          TQC.testProperty "preserve the balance in a transaction" preserveBalance,
+          TQC.testProperty "preserve tx balance restricted to TxIns and TxOuts" preserveBalanceRestricted,
+          TQC.testProperty "preserve transaction outputs" preserveOutputsTx,
+          TQC.testProperty "consumed inputs are eliminated" eliminateTxInputs,
+          TQC.testProperty "new tx entries are included and all txIds are new" newEntriesAndUniqueTxIns,
+          TQC.testProperty "no double spend" noDoubleSpend
+        ],
+      testGroup
+        "STS Rules - Pool Properties"
+        [ TQC.testProperty
+            "newly registered stake pool is added to \
+            \appropriate state mappings"
+            registeredPoolIsAdded,
+          TQC.testProperty
+            "newly registered pool key is not in the retiring map"
+            rewardZeroAfterRegPool,
+          TQC.testProperty
+            "retired stake pool is removed from \
+            \appropriate state mappings and marked \
+            \ for retiring"
+            poolIsMarkedForRetirement,
+          TQC.testProperty
+            "pool state is internally consistent"
+            pStateIsInternallyConsistent,
+          TQC.testProperty
+            "executing a pool retirement certificate adds to 'retiring'"
+            poolRetireInEpoch
+        ],
+      testGroup
+        "STS Rules - Poolreap Properties"
+        [ TQC.testProperty
+            "circulation+deposits+fees+treasury+rewards+reserves is constant."
+            constantSumPots,
+          TQC.testProperty
+            "deposits are always non-negative"
+            nonNegativeDeposits,
+          TQC.testProperty
+            "pool is removed from stake pool and retiring maps"
+            removedAfterPoolreap
+        ],
+      testGroup
+        "STS Rules - NewEpoch Properties"
+        [ TQC.testProperty
+            "total amount of Ada is preserved"
+            preservationOfAda
+        ],
+      testGroup
+        "STS Rules - MIR certificates"
+        [ TQC.testProperty
+            "entries of MIR certificate are added to\
+            \ irwd mapping"
+            prop_MIRentriesEndUpInMap,
+          TQC.testProperty
+            "coin values of entries of a MIR certificate\
+            \ are added to the irwd mapping"
+            prop_MIRValuesEndUpInMap
+        ],
+      testGroup
+        "Ledger Genesis State"
+        [ testProperty
+            "non-empty genesis ledger state has non-zero balance"
+            propPositiveBalance,
+          testProperty
+            "several transaction added to genesis ledger state"
+            propPreserveBalanceInitTx
+        ],
+      testGroup
+        "Property tests starting from valid ledger state"
+        [ testProperty
+            "preserve balance restricted to TxIns in Balance of outputs"
+            propBalanceTxInTxOut,
+          testProperty
+            "Preserve outputs of transaction"
+            propPreserveOutputs,
+          testProperty
+            "Eliminate Inputs of Transaction"
+            propEliminateInputs,
+          testProperty
+            "Completeness and Collision-Freeness of new TxIds"
+            propUniqueTxIds,
+          testProperty
+            "No Double Spend in valid ledger states"
+            propNoDoubleSpend,
+          testProperty
+            "adding redundant witness"
+            propCheckRedundantWitnessSet,
+          testProperty
+            "using subset of witness set"
+            propCheckMissingWitness,
+          testProperty
+            "Correctly preserve balance"
+            propPreserveBalance
+        ],
+      testGroup
+        "Property tests with mutated transactions"
+        [ testProperty
+            "preserve balance of change in UTxO"
+            propBalanceTxInTxOut',
+          testProperty
+            "Classify double spend"
+            classifyInvalidDoubleSpend,
+          testProperty
+            "NonNegative TxOuts"
+            propNonNegativeTxOuts
+        ],
+      testGroup
+        "Properties of Trace generators"
+        [ TQC.testProperty
+            "Only valid LEDGER STS signals are generated"
+            onlyValidLedgerSignalsAreGenerated,
+          TQC.testProperty
+            "Only valid CHAIN STS signals are generated"
+            onlyValidChainSignalsAreGenerated
+        ]
+    ]
 
 propNonNegativeTxOuts :: Property
 propNonNegativeTxOuts =
   withTests 100000 . property $ do
-  (_, _, _, tx, _)  <- Hedgehog.forAll genStateTx
-  all (\(TxOut _ (Coin x)) -> x >= 0) (_outputs . _body $ tx) === True
+    (_, _, _, tx, _) <- Hedgehog.forAll genStateTx
+    all (\(TxOut _ (Coin x)) -> x >= 0) (_outputs . _body $ tx) === True
 
 -- | Mutations for Property 7.2
 propBalanceTxInTxOut' :: Property
 propBalanceTxInTxOut' =
   withTests 1000 $ property $ do
-  (l, _, fee, txwits, lv)  <- Hedgehog.forAll genStateTx
-  let tx                       = _body txwits
-  let inps                     = txins tx
-  let getErrors (LedgerValidation valErrors _) = valErrors
-  let balanceSource            = balance $ inps <| ((_utxo . _utxoState) l)
-  let balanceTarget            = balance $ txouts tx
-  let valErrors                = getErrors lv
-  let nonTrivial               =  balanceSource /= Coin 0
-  let balanceOk                = balanceSource == balanceTarget + fee
-  classify "non-valid, OK" (valErrors /= [] && balanceOk && nonTrivial)
-  if valErrors /= [] && balanceOk && nonTrivial
-
-  then label $ LabelName (   "inputs: "     ++ show (show $ Set.size $ _inputs tx)
-              ++ " outputs: "   ++ show (show $ length $ _outputs tx)
-              ++ " balance l "  ++ show balanceSource
-              ++ " balance l' " ++ show balanceTarget
-              ++ " txfee " ++ show fee
-              ++ "\n  validationErrors: " ++ show valErrors)
-  else (if valErrors /= [] && balanceOk
-        then label "non-validated, OK, trivial"
-        else (if valErrors /= []
-              then label "non-validated, KO"
-              else label "validated"
-        ))
-  success
+    (l, _, fee, txwits, lv) <- Hedgehog.forAll genStateTx
+    let tx = _body txwits
+    let inps = txins tx
+    let getErrors (LedgerValidation valErrors _) = valErrors
+    let balanceSource = balance $ inps <| ((_utxo . _utxoState) l)
+    let balanceTarget = balance $ txouts tx
+    let valErrors = getErrors lv
+    let nonTrivial = balanceSource /= Coin 0
+    let balanceOk = balanceSource == balanceTarget + fee
+    classify "non-valid, OK" (valErrors /= [] && balanceOk && nonTrivial)
+    if valErrors /= [] && balanceOk && nonTrivial
+      then
+        label $
+          LabelName
+            ( "inputs: " ++ show (show $ Set.size $ _inputs tx)
+                ++ " outputs: "
+                ++ show (show $ length $ _outputs tx)
+                ++ " balance l "
+                ++ show balanceSource
+                ++ " balance l' "
+                ++ show balanceTarget
+                ++ " txfee "
+                ++ show fee
+                ++ "\n  validationErrors: "
+                ++ show valErrors
+            )
+      else
+        ( if valErrors /= [] && balanceOk
+            then label "non-validated, OK, trivial"
+            else
+              ( if valErrors /= []
+                  then label "non-validated, KO"
+                  else label "validated"
+              )
+        )
+    success
 
 -- | Check that we correctly test redundant witnesses. We get the list of the
 -- keys from the generator and use one to generate a new witness. If that key
@@ -374,52 +475,60 @@ propBalanceTxInTxOut' =
 -- validate.
 propCheckRedundantWitnessSet :: Property
 propCheckRedundantWitnessSet = property $ do
-  (l, steps, _, txwits, _, keyPairs)  <- Hedgehog.forAll genValidStateTxKeys
-  let keyPair                  = fst $ head keyPairs
-  let tx                       = _body txwits
-  let witness                  = makeWitnessVKey (hashTxBody tx) keyPair
-  let txwits'                  = txwits {_witnessVKeySet = (Set.insert witness (_witnessVKeySet txwits))}
-  let l''                      = asStateTransition (SlotNo $ fromIntegral steps) emptyPParams l txwits' (Coin 0)
-  classify "unneeded signature added"
+  (l, steps, _, txwits, _, keyPairs) <- Hedgehog.forAll genValidStateTxKeys
+  let keyPair = fst $ head keyPairs
+  let tx = _body txwits
+  let witness = makeWitnessVKey (hashTxBody tx) keyPair
+  let txwits' = txwits {_witnessVKeySet = (Set.insert witness (_witnessVKeySet txwits))}
+  let l'' = asStateTransition (SlotNo $ fromIntegral steps) emptyPParams l txwits' (Coin 0)
+  classify
+    "unneeded signature added"
     (not $ witness `Set.member` (_witnessVKeySet txwits))
   case l'' of
-    Right _                    ->
-        True === Set.null (
-         Set.filter (not . verifyWitVKey (hashTxBody tx)) (_witnessVKeySet txwits'))
-    _                          -> failure
+    Right _ ->
+      True
+        === Set.null
+          ( Set.filter (not . verifyWitVKey (hashTxBody tx)) (_witnessVKeySet txwits')
+          )
+    _ -> failure
 
 -- | Check that we correctly report missing witnesses.
 propCheckMissingWitness :: Property
 propCheckMissingWitness = property $ do
   (l, steps, _, txwits, _) <- Hedgehog.forAll genValidStateTx
-  witnessList              <- Hedgehog.forAll (Gen.subsequence $
-                                        Set.toList (_witnessVKeySet txwits))
-  let witnessVKeySet''          = _witnessVKeySet txwits
-  let witnessVKeySet'           = Set.fromList witnessList
-  let l'                    = asStateTransition
-                                (SlotNo $ fromIntegral steps)
-                                emptyPParams
-                                l
-                                (txwits {_witnessVKeySet = witnessVKeySet'})
-                                (Coin 0)
-  let isRealSubset          = witnessVKeySet' `Set.isSubsetOf` witnessVKeySet'' &&
-                              witnessVKeySet' /= witnessVKeySet''
+  witnessList <-
+    Hedgehog.forAll
+      ( Gen.subsequence $
+          Set.toList (_witnessVKeySet txwits)
+      )
+  let witnessVKeySet'' = _witnessVKeySet txwits
+  let witnessVKeySet' = Set.fromList witnessList
+  let l' =
+        asStateTransition
+          (SlotNo $ fromIntegral steps)
+          emptyPParams
+          l
+          (txwits {_witnessVKeySet = witnessVKeySet'})
+          (Coin 0)
+  let isRealSubset =
+        witnessVKeySet' `Set.isSubsetOf` witnessVKeySet''
+          && witnessVKeySet' /= witnessVKeySet''
   classify "real subset" isRealSubset
   label $ LabelName ("witnesses:" ++ show (Set.size witnessVKeySet''))
   case l' of
     Left [MissingWitnesses] -> isRealSubset === True
-    Right _                 -> (witnessVKeySet' == witnessVKeySet'') === True
-    _                       -> failure
+    Right _ -> (witnessVKeySet' == witnessVKeySet'') === True
+    _ -> failure
 
 -- | Property (Preserve Balance)
 propPreserveBalance :: Property
 propPreserveBalance = property $ do
   (l, _, fee, tx, l') <- Hedgehog.forAll genValidStateTx
   let destroyed =
-           balance ((_utxo . _utxoState) l)
-        + (keyRefunds emptyPParams ((_stkCreds . _dstate . _delegationState) l) $ _body tx)
+        balance ((_utxo . _utxoState) l)
+          + (keyRefunds emptyPParams ((_stkCreds . _dstate . _delegationState) l) $ _body tx)
   let created =
-           balance ((_utxo . _utxoState) l')
-        + fee
-        + (totalDeposits emptyPParams ((_stPools . _pstate . _delegationState) l') $ toList $ (_certs . _body) tx)
+        balance ((_utxo . _utxoState) l')
+          + fee
+          + (totalDeposits emptyPParams ((_stPools . _pstate . _delegationState) l') $ toList $ (_certs . _body) tx)
   destroyed === created

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestChain.hs
@@ -4,34 +4,44 @@
 
 module Test.Shelley.Spec.Ledger.Rules.TestChain
   ( -- TestPoolReap
-    constantSumPots
-  , nonNegativeDeposits
-  , removedAfterPoolreap
+    constantSumPots,
+    nonNegativeDeposits,
+    removedAfterPoolreap,
     -- TestNewEpoch
-  , preservationOfAda)
+    preservationOfAda,
+  )
 where
 
-import           Data.Word (Word64)
-import           Test.QuickCheck (Property, Testable, property, withMaxSuccess)
-
-import           Control.State.Transition.Extended (TRC (TRC), applySTS)
-import           Control.State.Transition.Trace (SourceSignalTarget (..), Trace (..),
-                     sourceSignalTargets)
-import           Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState)
-
-import           Shelley.Spec.Ledger.BlockChain (Block (..), bhbody, bheaderSlotNo)
-import           Shelley.Spec.Ledger.LedgerState (pattern DPState, esAccountState, esLState,
-                     getGKeys, nesEs, _delegationState, _utxoState)
-import           Shelley.Spec.Ledger.STS.Chain (ChainState (..))
-import           Shelley.Spec.Ledger.STS.PoolReap (PoolreapState (..))
-import           Shelley.Spec.Ledger.STS.Tick (TickEnv (TickEnv))
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN, NEWEPOCH, POOLREAP, TICK)
-import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (geConstants))
+import Control.State.Transition.Extended (TRC (TRC), applySTS)
+import Control.State.Transition.Trace
+  ( SourceSignalTarget (..),
+    Trace (..),
+    sourceSignalTargets,
+  )
+import Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState)
+import Data.Word (Word64)
+import Shelley.Spec.Ledger.BlockChain (Block (..), bhbody, bheaderSlotNo)
+import Shelley.Spec.Ledger.LedgerState
+  ( _delegationState,
+    _utxoState,
+    esAccountState,
+    esLState,
+    getGKeys,
+    nesEs,
+    pattern DPState,
+  )
+import Shelley.Spec.Ledger.STS.Chain (ChainState (..))
+import Shelley.Spec.Ledger.STS.PoolReap (PoolreapState (..))
+import Shelley.Spec.Ledger.STS.Tick (TickEnv (TickEnv))
+import Test.QuickCheck (Property, Testable, property, withMaxSuccess)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (CHAIN, NEWEPOCH, POOLREAP, TICK)
+import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (geConstants))
 import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (genEnv)
-import           Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
+import Test.Shelley.Spec.Ledger.Generator.Trace.Chain (mkGenesisChainState)
 import qualified Test.Shelley.Spec.Ledger.Rules.TestNewEpoch as TestNewEpoch
 import qualified Test.Shelley.Spec.Ledger.Rules.TestPoolreap as TestPoolreap
-import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, runShelleyBase, testGlobals)
+import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo, runShelleyBase, testGlobals)
+
 ------------------------------
 -- Constants for Properties --
 ------------------------------
@@ -50,19 +60,19 @@ constantSumPots :: Property
 constantSumPots =
   forAllChainTrace $ \tr ->
     let sst = map chainToPoolreapSst (sourceSignalTargets tr)
-    in TestPoolreap.constantSumPots sst
+     in TestPoolreap.constantSumPots sst
 
 nonNegativeDeposits :: Property
 nonNegativeDeposits =
   forAllChainTrace $ \tr ->
     let sst = map chainToPoolreapSst (sourceSignalTargets tr)
-    in TestPoolreap.nonNegativeDeposits sst
+     in TestPoolreap.nonNegativeDeposits sst
 
 removedAfterPoolreap :: Property
 removedAfterPoolreap =
   forAllChainTrace $ \tr ->
     let ssts = map chainToPoolreapSst (chainSstWithTick tr)
-    in TestPoolreap.removedAfterPoolreap ssts
+     in TestPoolreap.removedAfterPoolreap ssts
 
 ----------------------------------------------------------------------
 -- Properties for NewEpoch (using the CHAIN Trace) --
@@ -72,55 +82,64 @@ preservationOfAda :: Property
 preservationOfAda =
   forAllChainTrace $ \tr ->
     let sst = map chainToNewEpochSst (sourceSignalTargets tr)
-    in TestNewEpoch.preservationOfAda sst
+     in TestNewEpoch.preservationOfAda sst
 
 ---------------------------
 -- Utils --
 ---------------------------
 
-forAllChainTrace
-  :: (Testable prop)
-  => (Trace CHAIN -> prop)
-  -> Property
+forAllChainTrace ::
+  (Testable prop) =>
+  (Trace CHAIN -> prop) ->
+  Property
 forAllChainTrace prop =
   withMaxSuccess (fromIntegral numberOfTests) . property $
     forAllTraceFromInitState testGlobals traceLen Preset.genEnv (Just $ mkGenesisChainState (geConstants Preset.genEnv)) prop
 
 -- | Transform CHAIN `sourceSignalTargets`s to POOLREAP ones.
+chainToPoolreapSst ::
+  SourceSignalTarget CHAIN ->
+  SourceSignalTarget POOLREAP
 chainToPoolreapSst
-  :: SourceSignalTarget CHAIN
-  -> SourceSignalTarget POOLREAP
-chainToPoolreapSst (SourceSignalTarget ChainState {chainNes = nes}
-                                       ChainState  {chainNes = nes'}
-                                       (Block bh _)) =
-  SourceSignalTarget (PoolreapState (utxoSt nes)
-                                    (accountSt nes)
-                                    dstate
-                                    pstate)
-                     (PoolreapState (utxoSt nes')
-                                    (accountSt nes')
-                                    dstate'
-                                    pstate')
-                     (epochFromSlotNo s)
-  where
-    s = (bheaderSlotNo . bhbody) bh
-
-    DPState dstate pstate = (_delegationState . esLState . nesEs) nes
-    DPState dstate' pstate' = (_delegationState . esLState . nesEs) nes'
-
-    utxoSt = _utxoState . esLState . nesEs
-    accountSt = esAccountState . nesEs
+  ( SourceSignalTarget
+      ChainState {chainNes = nes}
+      ChainState {chainNes = nes'}
+      (Block bh _)
+    ) =
+    SourceSignalTarget
+      ( PoolreapState
+          (utxoSt nes)
+          (accountSt nes)
+          dstate
+          pstate
+      )
+      ( PoolreapState
+          (utxoSt nes')
+          (accountSt nes')
+          dstate'
+          pstate'
+      )
+      (epochFromSlotNo s)
+    where
+      s = (bheaderSlotNo . bhbody) bh
+      DPState dstate pstate = (_delegationState . esLState . nesEs) nes
+      DPState dstate' pstate' = (_delegationState . esLState . nesEs) nes'
+      utxoSt = _utxoState . esLState . nesEs
+      accountSt = esAccountState . nesEs
 
 -- | Transform CHAIN `sourceSignalTargets`s to NEWEPOCH ones.
+chainToNewEpochSst ::
+  SourceSignalTarget CHAIN ->
+  SourceSignalTarget NEWEPOCH
 chainToNewEpochSst
-  :: SourceSignalTarget CHAIN
-  -> SourceSignalTarget NEWEPOCH
-chainToNewEpochSst (SourceSignalTarget ChainState {chainNes = nes}
-                                       ChainState {chainNes = nes'}
-                                       (Block bh _)) =
-  SourceSignalTarget nes nes' (epochFromSlotNo s)
-  where
-    s = (bheaderSlotNo . bhbody) bh
+  ( SourceSignalTarget
+      ChainState {chainNes = nes}
+      ChainState {chainNes = nes'}
+      (Block bh _)
+    ) =
+    SourceSignalTarget nes nes' (epochFromSlotNo s)
+    where
+      s = (bheaderSlotNo . bhbody) bh
 
 -- | Transform the [(source, signal, target)] of a CHAIN Trace
 -- by manually applying the Chain TICK Rule to each source and producing
@@ -133,19 +152,20 @@ chainSstWithTick ledgerTr =
   map applyTick ssts
   where
     ssts = sourceSignalTargets ledgerTr
-
+    applyTick ::
+      SourceSignalTarget CHAIN ->
+      SourceSignalTarget CHAIN
     applyTick
-      :: SourceSignalTarget CHAIN
-      -> SourceSignalTarget CHAIN
-    applyTick (SourceSignalTarget
-                chainSt@ChainState {chainNes = nes}
-                _
-                b@(Block bh _)) =
-      case runShelleyBase (applySTS @TICK (TRC(TickEnv (getGKeys nes), nes, (bheaderSlotNo . bhbody) bh))) of
-        Left pf ->
-          error ("chainSstWithTick.applyTick Predicate failure " <> show pf)
-        Right nes' ->
-          SourceSignalTarget
-            chainSt
-            (chainSt {chainNes = nes'})
-            b
+      ( SourceSignalTarget
+          chainSt@ChainState {chainNes = nes}
+          _
+          b@(Block bh _)
+        ) =
+        case runShelleyBase (applySTS @TICK (TRC (TickEnv (getGKeys nes), nes, (bheaderSlotNo . bhbody) bh))) of
+          Left pf ->
+            error ("chainSstWithTick.applyTick Predicate failure " <> show pf)
+          Right nes' ->
+            SourceSignalTarget
+              chainSt
+              (chainSt {chainNes = nes'})
+              b

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDelegs.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestDelegs.hs
@@ -6,17 +6,18 @@
 
 module Test.Shelley.Spec.Ledger.Rules.TestDelegs where
 
-import           Control.State.Transition.Trace (SourceSignalTarget, pattern SourceSignalTarget,
-                     source, target)
-import           Data.List (foldl')
-
-import           Test.QuickCheck (Property, conjoin)
-
-import           Shelley.Spec.Ledger.Coin (pattern Coin)
-import           Shelley.Spec.Ledger.LedgerState (_dstate, _rewards)
+import Control.State.Transition.Trace
+  ( SourceSignalTarget,
+    source,
+    target,
+    pattern SourceSignalTarget,
+  )
+import Data.List (foldl')
+import Shelley.Spec.Ledger.Coin (pattern Coin)
+import Shelley.Spec.Ledger.LedgerState (_dstate, _rewards)
 import qualified Shelley.Spec.Ledger.TxData as T
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DELEGS, Wdrl)
+import Test.QuickCheck (Property, conjoin)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DELEGS, Wdrl)
 
 ---------------------------
 -- Properties for DELEGS --
@@ -24,22 +25,24 @@ import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DELEGS, Wdrl)
 
 -- | Check that the rewards pot decreases by the sum of withdrawals in the
 -- transaction.
-rewardsDecreasesByWithdrawals
-  :: [(Wdrl, SourceSignalTarget DELEGS)]
-  -> Property
+rewardsDecreasesByWithdrawals ::
+  [(Wdrl, SourceSignalTarget DELEGS)] ->
+  Property
 rewardsDecreasesByWithdrawals tr =
   conjoin $
     map (uncurry rewardsPotdecreases) tr
   where
-    rewardsPotdecreases (T.Wdrl wdrls) SourceSignalTarget
-                                { source = d
-                                , target = d'} =
-      let rewards  = (_rewards . _dstate) d
-          rewards' = (_rewards . _dstate) d'
-          rewardsSum = foldl' (+) (Coin 0) rewards
-          rewardsSum' = foldl' (+) (Coin 0) rewards'
-          wdrlSum = foldl' (+) (Coin 0) wdrls
-      in
-         rewardsSum >= rewardsSum'
-      && wdrlSum >= Coin 0
-      && rewardsSum == wdrlSum + rewardsSum'
+    rewardsPotdecreases
+      (T.Wdrl wdrls)
+      SourceSignalTarget
+        { source = d,
+          target = d'
+        } =
+        let rewards = (_rewards . _dstate) d
+            rewards' = (_rewards . _dstate) d'
+            rewardsSum = foldl' (+) (Coin 0) rewards
+            rewardsSum' = foldl' (+) (Coin 0) rewards'
+            wdrlSum = foldl' (+) (Coin 0) wdrls
+         in rewardsSum >= rewardsSum'
+              && wdrlSum >= Coin 0
+              && rewardsSum == wdrlSum + rewardsSum'

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestLedger.hs
@@ -7,67 +7,88 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestLedger
-  ( rewardZeroAfterRegKey
-  , credentialRemovedAfterDereg
-  , credentialMappingAfterDelegation
-  , rewardsSumInvariant
-  , rewardsDecreasesByWithdrawals
-  , feesNonDecreasing
-  , potsSumIncreaseWdrls
-  , preserveBalance
-  , preserveBalanceRestricted
-  , preserveOutputsTx
-  , eliminateTxInputs
-  , newEntriesAndUniqueTxIns
-  , noDoubleSpend
-  , consumedEqualsProduced
-  , registeredPoolIsAdded
-  , rewardZeroAfterRegPool
-  , poolIsMarkedForRetirement
-  , poolRetireInEpoch
-  , pStateIsInternallyConsistent
-  , prop_MIRentriesEndUpInMap
-  , prop_MIRValuesEndUpInMap
-  , requiredMSigSignaturesSubset
+  ( rewardZeroAfterRegKey,
+    credentialRemovedAfterDereg,
+    credentialMappingAfterDelegation,
+    rewardsSumInvariant,
+    rewardsDecreasesByWithdrawals,
+    feesNonDecreasing,
+    potsSumIncreaseWdrls,
+    preserveBalance,
+    preserveBalanceRestricted,
+    preserveOutputsTx,
+    eliminateTxInputs,
+    newEntriesAndUniqueTxIns,
+    noDoubleSpend,
+    consumedEqualsProduced,
+    registeredPoolIsAdded,
+    rewardZeroAfterRegPool,
+    poolIsMarkedForRetirement,
+    poolRetireInEpoch,
+    pStateIsInternallyConsistent,
+    prop_MIRentriesEndUpInMap,
+    prop_MIRValuesEndUpInMap,
+    requiredMSigSignaturesSubset,
   )
 where
 
-import           Data.Foldable (toList)
-import           Data.List (foldl')
-import qualified Data.Sequence.Strict as StrictSeq
-import           Data.Word (Word64)
-
-import           Test.QuickCheck (Property, Testable, conjoin, property, withMaxSuccess, (===))
-
-import           Control.State.Transition.Trace (SourceSignalTarget (..), Trace (..),
-                     TraceOrder (NewestFirst), source, sourceSignalTargets, target, traceSignals)
+import Control.State.Transition.Trace
+  ( SourceSignalTarget (..),
+    Trace (..),
+    TraceOrder (NewestFirst),
+    source,
+    sourceSignalTargets,
+    target,
+    traceSignals,
+  )
 import qualified Control.State.Transition.Trace as Trace
-import           Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState)
-
-import           Shelley.Spec.Ledger.Coin (pattern Coin)
-import           Shelley.Spec.Ledger.LedgerState (pattern DPState, pattern DState,
-                     pattern UTxOState, _deposited, _dstate, _fees, _pstate, _rewards, _stPools,
-                     _stkCreds, _utxo)
-import           Shelley.Spec.Ledger.STS.Deleg (DelegEnv (..))
-import           Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..))
-import           Shelley.Spec.Ledger.STS.Pool (PoolEnv (..))
-import           Shelley.Spec.Ledger.Tx (_body)
-import           Shelley.Spec.Ledger.TxData (Ptr (..), _certs, _wdrls)
-import           Shelley.Spec.Ledger.UTxO (balance)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (DELEG, DELEGS, LEDGER, POOL,
-                     StakeCreds, StakePools, UTXO, UTXOW, Wdrl)
-import           Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (geConstants))
+import Control.State.Transition.Trace.Generator.QuickCheck (forAllTraceFromInitState)
+import Data.Foldable (toList)
+import Data.List (foldl')
+import qualified Data.Sequence.Strict as StrictSeq
+import Data.Word (Word64)
+import Shelley.Spec.Ledger.Coin (pattern Coin)
+import Shelley.Spec.Ledger.LedgerState
+  ( _deposited,
+    _dstate,
+    _fees,
+    _pstate,
+    _rewards,
+    _stPools,
+    _stkCreds,
+    _utxo,
+    pattern DPState,
+    pattern DState,
+    pattern UTxOState,
+  )
+import Shelley.Spec.Ledger.STS.Deleg (DelegEnv (..))
+import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (..))
+import Shelley.Spec.Ledger.STS.Pool (PoolEnv (..))
+import Shelley.Spec.Ledger.STS.Pool ()
+import Shelley.Spec.Ledger.Tx (_body)
+import Shelley.Spec.Ledger.TxData (Ptr (..), _certs, _wdrls)
+import Shelley.Spec.Ledger.UTxO (balance)
+import Test.QuickCheck ((===), Property, Testable, conjoin, property, withMaxSuccess)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( DELEG,
+    DELEGS,
+    LEDGER,
+    POOL,
+    StakeCreds,
+    StakePools,
+    UTXO,
+    UTXOW,
+    Wdrl,
+  )
+import Test.Shelley.Spec.Ledger.Generator.Core (GenEnv (geConstants))
 import qualified Test.Shelley.Spec.Ledger.Generator.Presets as Preset (genEnv)
-import           Test.Shelley.Spec.Ledger.Generator.Trace.Ledger (mkGenesisLedgerState)
+import Test.Shelley.Spec.Ledger.Generator.Trace.Ledger (mkGenesisLedgerState)
 import qualified Test.Shelley.Spec.Ledger.Rules.TestDeleg as TestDeleg
 import qualified Test.Shelley.Spec.Ledger.Rules.TestDelegs as TestDelegs
 import qualified Test.Shelley.Spec.Ledger.Rules.TestPool as TestPool
 import qualified Test.Shelley.Spec.Ledger.Rules.TestUtxo as TestUtxo
 import qualified Test.Shelley.Spec.Ledger.Rules.TestUtxow as TestUtxow
-import           Test.Shelley.Spec.Ledger.Utils (runShelleyBase, testGlobals)
-
-import           Shelley.Spec.Ledger.STS.Pool ()
+import Test.Shelley.Spec.Ledger.Utils (runShelleyBase, testGlobals)
 
 ------------------------------
 -- Constants for Properties --
@@ -88,31 +109,31 @@ rewardZeroAfterRegKey :: Property
 rewardZeroAfterRegKey =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToDelegTrace tr)
-    in TestDeleg.rewardZeroAfterReg sst
+     in TestDeleg.rewardZeroAfterReg sst
 
 credentialRemovedAfterDereg :: Property
 credentialRemovedAfterDereg =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToDelegTrace tr)
-    in TestDeleg.credentialRemovedAfterDereg sst
+     in TestDeleg.credentialRemovedAfterDereg sst
 
 credentialMappingAfterDelegation :: Property
 credentialMappingAfterDelegation =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToDelegTrace tr)
-    in TestDeleg.credentialMappingAfterDelegation sst
+     in TestDeleg.credentialMappingAfterDelegation sst
 
 rewardsSumInvariant :: Property
 rewardsSumInvariant =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToDelegTrace tr)
-    in TestDeleg.rewardsSumInvariant sst
+     in TestDeleg.rewardsSumInvariant sst
 
 rewardsDecreasesByWithdrawals :: Property
 rewardsDecreasesByWithdrawals =
   forAllLedgerTrace $ \tr ->
     let sst = map ledgerToDelegsSsts (sourceSignalTargets tr)
-    in TestDelegs.rewardsDecreasesByWithdrawals sst
+     in TestDelegs.rewardsDecreasesByWithdrawals sst
 
 ----------------------------------------------------------------------
 -- Properties for Utxo (using the LEDGER Trace) --
@@ -125,85 +146,88 @@ consumedEqualsProduced =
   forAllLedgerTrace $ \tr ->
     conjoin $
       map consumedSameAsGained (sourceSignalTargets tr)
-
-  where consumedSameAsGained SourceSignalTarget
-                               { source = (UTxOState
-                                           { _utxo = u
-                                           , _deposited = d
-                                           , _fees = fees
-                                           }
-                                          , DPState
-                                            { _dstate = DState { _rewards = rewards }
-                                            }
-                                          )
-                               , target = (UTxOState
-                                            { _utxo = u'
-                                            , _deposited = d'
-                                            , _fees = fees'
-                                            }
-                                         , DPState
-                                           { _dstate = DState { _rewards = rewards' }})} =
-
-          (balance u  + d  + fees  + foldl' (+) (Coin 0) rewards ) ===
-          (balance u' + d' + fees' + foldl' (+) (Coin 0) rewards')
+  where
+    consumedSameAsGained
+      SourceSignalTarget
+        { source =
+            ( UTxOState
+                { _utxo = u,
+                  _deposited = d,
+                  _fees = fees
+                },
+              DPState
+                { _dstate = DState {_rewards = rewards}
+                }
+              ),
+          target =
+            ( UTxOState
+                { _utxo = u',
+                  _deposited = d',
+                  _fees = fees'
+                },
+              DPState
+                { _dstate = DState {_rewards = rewards'}
+                }
+              )
+        } =
+        (balance u + d + fees + foldl' (+) (Coin 0) rewards)
+          === (balance u' + d' + fees' + foldl' (+) (Coin 0) rewards')
 
 feesNonDecreasing :: Property
 feesNonDecreasing =
   forAllLedgerTrace $ \tr ->
     let ssts = map ledgerToUtxoSsts (sourceSignalTargets tr)
-    in TestUtxo.feesNonDecreasing ssts
+     in TestUtxo.feesNonDecreasing ssts
 
 potsSumIncreaseWdrls :: Property
 potsSumIncreaseWdrls =
   forAllLedgerTrace $ \tr ->
     let ssts = map ledgerToUtxoSsts (sourceSignalTargets tr)
-    in TestUtxo.potsSumIncreaseWdrls ssts
+     in TestUtxo.potsSumIncreaseWdrls ssts
 
 preserveBalance :: Property
 preserveBalance =
   forAllLedgerTrace $ \tr ->
     let ssts = map ledgerToUtxowSsts (sourceSignalTargets tr)
         pp = ledgerPp (_traceEnv tr)
-
-    in TestUtxow.preserveBalance pp ssts
+     in TestUtxow.preserveBalance pp ssts
 
 preserveBalanceRestricted :: Property
 preserveBalanceRestricted =
   forAllLedgerTrace $ \tr ->
     let ssts = map ledgerToUtxowSsts (sourceSignalTargets tr)
         pp = ledgerPp (_traceEnv tr)
-
-    in TestUtxow.preserveBalanceRestricted pp ssts
+     in TestUtxow.preserveBalanceRestricted pp ssts
 
 preserveOutputsTx :: Property
 preserveOutputsTx =
   forAllLedgerTrace $ \tr ->
     let ssts = map ledgerToUtxoSsts (sourceSignalTargets tr)
-    in TestUtxow.preserveOutputsTx ssts
+     in TestUtxow.preserveOutputsTx ssts
 
 eliminateTxInputs :: Property
 eliminateTxInputs =
   forAllLedgerTrace $ \tr ->
     let ssts = map ledgerToUtxoSsts (sourceSignalTargets tr)
-    in TestUtxow.eliminateTxInputs ssts
+     in TestUtxow.eliminateTxInputs ssts
 
 newEntriesAndUniqueTxIns :: Property
 newEntriesAndUniqueTxIns =
   forAllLedgerTrace $ \tr ->
     let ssts = map ledgerToUtxoSsts (sourceSignalTargets tr)
-    in TestUtxow.newEntriesAndUniqueTxIns ssts
+     in TestUtxow.newEntriesAndUniqueTxIns ssts
 
 noDoubleSpend :: Property
 noDoubleSpend =
   forAllLedgerTrace $ \tr ->
     let ssts = map ledgerToUtxoSsts (sourceSignalTargets tr)
-    in TestUtxow.noDoubleSpend ssts
+     in TestUtxow.noDoubleSpend ssts
 
 requiredMSigSignaturesSubset :: Property
 requiredMSigSignaturesSubset =
   forAllLedgerTrace $ \tr ->
-  let ssts = map (\(_, _, s) -> s) $ map ledgerToUtxowSsts (sourceSignalTargets tr)
-  in  TestUtxow.requiredMSigSignaturesSubset ssts
+    let ssts = map (\(_, _, s) -> s) $ map ledgerToUtxowSsts (sourceSignalTargets tr)
+     in TestUtxow.requiredMSigSignaturesSubset ssts
 
 ----------------------------------------------------------------------
 -- Properties for Pool (using the LEDGER Trace) --
@@ -214,33 +238,33 @@ registeredPoolIsAdded :: Property
 registeredPoolIsAdded =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToPoolTrace tr)
-    in TestPool.registeredPoolIsAdded (_traceEnv tr) sst
+     in TestPool.registeredPoolIsAdded (_traceEnv tr) sst
 
 -- | Check that a newly registered pool has a reward of 0.
 rewardZeroAfterRegPool :: Property
 rewardZeroAfterRegPool =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToPoolTrace tr)
-    in TestPool.rewardZeroAfterReg sst
+     in TestPool.rewardZeroAfterReg sst
 
 poolRetireInEpoch :: Property
 poolRetireInEpoch =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToPoolTrace tr)
-    in TestPool.poolRetireInEpoch (_traceEnv tr) sst
+     in TestPool.poolRetireInEpoch (_traceEnv tr) sst
 
 -- | Check that a `RetirePool` certificate properly removes a stake pool.
 poolIsMarkedForRetirement :: Property
 poolIsMarkedForRetirement =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToPoolTrace tr)
-    in TestPool.poolIsMarkedForRetirement sst
+     in TestPool.poolIsMarkedForRetirement sst
 
 pStateIsInternallyConsistent :: Property
 pStateIsInternallyConsistent =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToPoolTrace tr)
-    in TestPool.pStateIsInternallyConsistent sst
+     in TestPool.pStateIsInternallyConsistent sst
 
 -- | Check that `InstantaneousRewards` certificate entries are added to the
 -- Instantaneous Rewards map.
@@ -248,7 +272,7 @@ prop_MIRentriesEndUpInMap :: Property
 prop_MIRentriesEndUpInMap =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToDelegTrace tr)
-    in TestDeleg.instantaneousRewardsAdded sst
+     in TestDeleg.instantaneousRewardsAdded sst
 
 -- | Check that the coin values in `InstantaneousRewards` certificate entries
 -- are added to the Instantaneous Rewards map.
@@ -256,43 +280,45 @@ prop_MIRValuesEndUpInMap :: Property
 prop_MIRValuesEndUpInMap =
   forAllLedgerTrace $ \tr ->
     let sst = sourceSignalTargets (ledgerToDelegTrace tr)
-    in TestDeleg.instantaneousRewardsValue sst
+     in TestDeleg.instantaneousRewardsValue sst
 
 ---------------------------
 -- Utils --
 ---------------------------
 
-forAllLedgerTrace
-  :: (Testable prop)
-  => (Trace LEDGER -> prop)
-  -> Property
+forAllLedgerTrace ::
+  (Testable prop) =>
+  (Trace LEDGER -> prop) ->
+  Property
 forAllLedgerTrace prop =
   withMaxSuccess (fromIntegral numberOfTests) . property $
     forAllTraceFromInitState testGlobals traceLen Preset.genEnv (Just $ mkGenesisLedgerState (geConstants Preset.genEnv)) prop
 
 -- | Transform LEDGER `sourceSignalTargets`s to DELEGS ones.
-ledgerToDelegsSsts
-  :: SourceSignalTarget LEDGER
-  -> (Wdrl, SourceSignalTarget DELEGS)
+ledgerToDelegsSsts ::
+  SourceSignalTarget LEDGER ->
+  (Wdrl, SourceSignalTarget DELEGS)
 ledgerToDelegsSsts (SourceSignalTarget (_, dpSt) (_, dpSt') tx) =
-  ( (_wdrls . _body) tx
-  , SourceSignalTarget dpSt dpSt' ((StrictSeq.getSeq . _certs . _body) tx))
+  ( (_wdrls . _body) tx,
+    SourceSignalTarget dpSt dpSt' ((StrictSeq.getSeq . _certs . _body) tx)
+  )
 
 -- | Transform LEDGER to UTXO `SourceSignalTargets`s
-ledgerToUtxoSsts
-  :: SourceSignalTarget LEDGER
-  -> SourceSignalTarget UTXO
+ledgerToUtxoSsts ::
+  SourceSignalTarget LEDGER ->
+  SourceSignalTarget UTXO
 ledgerToUtxoSsts (SourceSignalTarget (utxoSt, _) (utxoSt', _) tx) =
   (SourceSignalTarget utxoSt utxoSt' tx)
 
 -- | Transform LEDGER to UTXOW `SourceSignalTargets`s
-ledgerToUtxowSsts
-  :: SourceSignalTarget LEDGER
-  -> (StakeCreds, StakePools, SourceSignalTarget UTXOW)
+ledgerToUtxowSsts ::
+  SourceSignalTarget LEDGER ->
+  (StakeCreds, StakePools, SourceSignalTarget UTXOW)
 ledgerToUtxowSsts (SourceSignalTarget (utxoSt, delegSt) (utxoSt', _) tx) =
-  ( (_stkCreds . _dstate) delegSt
-  , (_stPools . _pstate) delegSt
-  , SourceSignalTarget utxoSt utxoSt' tx)
+  ( (_stkCreds . _dstate) delegSt,
+    (_stPools . _pstate) delegSt,
+    SourceSignalTarget utxoSt utxoSt' tx
+  )
 
 -- | Transform a LEDGER Trace to a POOL Trace by extracting the certificates
 -- from the LEDGER transactions and then reconstructing a new POOL trace from
@@ -304,11 +330,12 @@ ledgerToPoolTrace ledgerTr =
   where
     txs = traceSignals NewestFirst ledgerTr
     certs = concatMap (toList . _certs . _body)
-
-    poolEnv = let (LedgerEnv s _ pp _) = _traceEnv ledgerTr in
-                PoolEnv s pp
-    poolSt0 = let (_, DPState _ poolSt0_) = _traceInitState ledgerTr in
-                poolSt0_
+    poolEnv =
+      let (LedgerEnv s _ pp _) = _traceEnv ledgerTr
+       in PoolEnv s pp
+    poolSt0 =
+      let (_, DPState _ poolSt0_) = _traceInitState ledgerTr
+       in poolSt0_
 
 -- | Transform a LEDGER Trace to a DELEG Trace by extracting the certificates
 -- from the LEDGER transactions and then reconstructing a new DELEG trace from
@@ -320,10 +347,11 @@ ledgerToDelegTrace ledgerTr =
   where
     txs = traceSignals NewestFirst ledgerTr
     certs = concatMap (toList . _certs . _body)
-
-    delegEnv = let (LedgerEnv s txIx _ reserves) = _traceEnv ledgerTr
-                   dummyCertIx = 0
-                   ptr = Ptr s txIx dummyCertIx in
-                 DelegEnv s ptr reserves
-    delegSt0 = let (_, DPState delegSt0_ _) = _traceInitState ledgerTr in
-                 delegSt0_
+    delegEnv =
+      let (LedgerEnv s txIx _ reserves) = _traceEnv ledgerTr
+          dummyCertIx = 0
+          ptr = Ptr s txIx dummyCertIx
+       in DelegEnv s ptr reserves
+    delegSt0 =
+      let (_, DPState delegSt0_ _) = _traceInitState ledgerTr
+       in delegSt0_

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestNewEpoch.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestNewEpoch.hs
@@ -2,25 +2,40 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Test.Shelley.Spec.Ledger.Rules.TestNewEpoch
-  ( preservationOfAda )
-where
+module Test.Shelley.Spec.Ledger.Rules.TestNewEpoch (preservationOfAda) where
 
-import           Test.QuickCheck (Property, conjoin)
-
-import           Control.State.Transition.Trace (SourceSignalTarget, pattern SourceSignalTarget,
-                     source, target)
-import           Data.List (foldl')
-
-import           Shelley.Spec.Ledger.Coin (pattern Coin)
-import           Shelley.Spec.Ledger.LedgerState (pattern AccountState, pattern DPState,
-                     pattern DState, pattern EpochState, pattern LedgerState,
-                     pattern NewEpochState, pattern UTxOState, esAccountState, esLState, nesEs,
-                     _delegationState, _deposited, _dstate, _fees, _reserves, _rewards, _treasury,
-                     _utxo, _utxoState)
-import           Shelley.Spec.Ledger.UTxO (balance)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (NEWEPOCH)
+import Control.State.Transition.Trace
+  ( SourceSignalTarget,
+    source,
+    target,
+    pattern SourceSignalTarget,
+  )
+import Data.List (foldl')
+import Shelley.Spec.Ledger.Coin (pattern Coin)
+import Shelley.Spec.Ledger.LedgerState
+  ( _delegationState,
+    _deposited,
+    _dstate,
+    _fees,
+    _reserves,
+    _rewards,
+    _treasury,
+    _utxo,
+    _utxoState,
+    esAccountState,
+    esLState,
+    nesEs,
+    pattern AccountState,
+    pattern DPState,
+    pattern DState,
+    pattern EpochState,
+    pattern LedgerState,
+    pattern NewEpochState,
+    pattern UTxOState,
+  )
+import Shelley.Spec.Ledger.UTxO (balance)
+import Test.QuickCheck (Property, conjoin)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (NEWEPOCH)
 
 -----------------------------
 -- Properties for NEWEPOCH --
@@ -28,55 +43,61 @@ import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (NEWEPOCH)
 
 -- | Check that the rewards decrease by the increase of the treasury and the
 -- rewards.
-preservationOfAda
-  :: [SourceSignalTarget NEWEPOCH]
-  -> Property
+preservationOfAda ::
+  [SourceSignalTarget NEWEPOCH] ->
+  Property
 preservationOfAda tr =
   conjoin $
     map rewardsDecreaseBalanced tr
-
-  where sum_ = foldl' (+) (Coin 0)
-
-        rewardsDecreaseBalanced
-          (SourceSignalTarget
-            {
-              source = NewEpochState
-              {
-                nesEs = EpochState
-                { esAccountState = AccountState
-                                   {
-                                     _treasury = treasury
-                                   , _reserves = reserves
-                                   }
-                , esLState = LedgerState
-                             {
-                               _utxoState = UTxOState { _utxo = utxo,_fees = fees, _deposited = deposits_ }
-                             , _delegationState = DPState
-                                                  { _dstate = DState
-                                                              { _rewards = rewards }
-                                                  }
-                             }
+  where
+    sum_ = foldl' (+) (Coin 0)
+    rewardsDecreaseBalanced
+      ( SourceSignalTarget
+          { source =
+              NewEpochState
+                { nesEs =
+                    EpochState
+                      { esAccountState =
+                          AccountState
+                            { _treasury = treasury,
+                              _reserves = reserves
+                            },
+                        esLState =
+                          LedgerState
+                            { _utxoState = UTxOState {_utxo = utxo, _fees = fees, _deposited = deposits_},
+                              _delegationState =
+                                DPState
+                                  { _dstate =
+                                      DState
+                                        { _rewards = rewards
+                                        }
+                                  }
+                            }
+                      }
+                },
+            target =
+              NewEpochState
+                { nesEs =
+                    EpochState
+                      { esAccountState =
+                          AccountState
+                            { _treasury = treasury',
+                              _reserves = reserves'
+                            },
+                        esLState =
+                          LedgerState
+                            { _utxoState = UTxOState {_utxo = utxo', _fees = fees', _deposited = deposits'},
+                              _delegationState =
+                                DPState
+                                  { _dstate =
+                                      DState
+                                        { _rewards = rewards'
+                                        }
+                                  }
+                            }
+                      }
                 }
-              }
-            , target = NewEpochState
-              {
-                nesEs = EpochState
-                { esAccountState = AccountState
-                                   {
-                                     _treasury = treasury'
-                                   , _reserves = reserves'
-                                   }
-                , esLState = LedgerState
-                             {
-                               _utxoState = UTxOState { _utxo = utxo', _fees = fees', _deposited = deposits' }
-                             , _delegationState = DPState
-                                                  { _dstate = DState
-                                                              { _rewards = rewards' }
-                                                  }
-                             }
-                }
-              }
-            }
-          ) =
-          reserves + treasury + sum_ rewards + balance utxo + fees + deposits_
+          }
+        ) =
+        reserves + treasury + sum_ rewards + balance utxo + fees + deposits_
           == reserves' + treasury' + sum_ rewards' + balance utxo' + fees' + deposits'

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
@@ -7,34 +7,52 @@
 
 module Test.Shelley.Spec.Ledger.Rules.TestPool where
 
-import           Data.Map (Map, (!?))
+import Byron.Spec.Ledger.Core (dom, (∈), (∉))
+import Control.State.Transition (Environment, State)
+import Control.State.Transition.Trace
+  ( SourceSignalTarget,
+    signal,
+    source,
+    target,
+    pattern SourceSignalTarget,
+  )
+import Data.Map ((!?), Map)
 import qualified Data.Map as M
 import qualified Data.Maybe as Maybe (maybe)
 import qualified Data.Set as S
-import           Data.Word (Word64)
-
-import           Test.QuickCheck (Property, conjoin, counterexample, property, (===))
-
-import           Control.State.Transition (Environment, State)
-import           Control.State.Transition.Trace (SourceSignalTarget, pattern SourceSignalTarget,
-                     signal, source, target)
-
-import           Byron.Spec.Ledger.Core (dom, (∈), (∉))
-
-import           Shelley.Spec.Ledger.BaseTypes ((==>))
-import           Shelley.Spec.Ledger.Delegation.Certificates (poolCWitness)
-import           Shelley.Spec.Ledger.LedgerState (pattern PState, _pParams, _retiring, _stPools,
-                     _stPools)
-import           Shelley.Spec.Ledger.Keys (KeyRole(..))
-import           Shelley.Spec.Ledger.PParams (_eMax)
-import           Shelley.Spec.Ledger.Slot (EpochNo (..))
-import           Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (ledgerPp, ledgerSlotNo))
-import           Shelley.Spec.Ledger.TxData (pattern DCertPool, pattern KeyHashObj, pattern RegPool,
-                     pattern RetirePool, pattern StakePools, unStakePools, _poolPubKey)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (KeyHash, LEDGER, POOL, PState,
-                     PoolParams, StakePools)
-import           Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo)
+import Data.Word (Word64)
+import Shelley.Spec.Ledger.BaseTypes ((==>))
+import Shelley.Spec.Ledger.Delegation.Certificates (poolCWitness)
+import Shelley.Spec.Ledger.Keys (KeyRole (..))
+import Shelley.Spec.Ledger.LedgerState
+  ( _pParams,
+    _retiring,
+    _stPools,
+    _stPools,
+    pattern PState,
+  )
+import Shelley.Spec.Ledger.PParams (_eMax)
+import Shelley.Spec.Ledger.STS.Ledger (LedgerEnv (ledgerPp, ledgerSlotNo))
+import Shelley.Spec.Ledger.Slot (EpochNo (..))
+import Shelley.Spec.Ledger.TxData
+  ( _poolPubKey,
+    unStakePools,
+    pattern DCertPool,
+    pattern KeyHashObj,
+    pattern RegPool,
+    pattern RetirePool,
+    pattern StakePools,
+  )
+import Test.QuickCheck ((===), Property, conjoin, counterexample, property)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( KeyHash,
+    LEDGER,
+    POOL,
+    PState,
+    PoolParams,
+    StakePools,
+  )
+import Test.Shelley.Spec.Ledger.Utils (epochFromSlotNo)
 
 -------------------------------
 -- helper accessor functions --
@@ -61,139 +79,161 @@ traceLen = 100
 -------------------------
 
 -- | Check that a newly registered pool key is not in the retiring map.
-rewardZeroAfterReg
-  :: [SourceSignalTarget POOL]
-  -> Property
+rewardZeroAfterReg ::
+  [SourceSignalTarget POOL] ->
+  Property
 rewardZeroAfterReg ssts =
   conjoin $
     map registeredPoolNotRetiring ssts
   where
-    registeredPoolNotRetiring SourceSignalTarget
-                                { signal = (DCertPool c@(RegPool _))
-                                , target = p'} =
-      case poolCWitness c of
-        KeyHashObj certWit -> let StakePools stp = getStPools p' in
-                                  (  certWit ∈ dom stp
-                                  && certWit ∉ dom (getRetiring p'))
-        _                  -> False
+    registeredPoolNotRetiring
+      SourceSignalTarget
+        { signal = (DCertPool c@(RegPool _)),
+          target = p'
+        } =
+        case poolCWitness c of
+          KeyHashObj certWit ->
+            let StakePools stp = getStPools p'
+             in ( certWit ∈ dom stp
+                    && certWit ∉ dom (getRetiring p')
+                )
+          _ -> False
     registeredPoolNotRetiring _ = True
 
 -- | Check that if a pool retirement certificate is executed in the correct
 -- epoch interval, then the pool key will be added to the retiring map but stays
 -- in the set of stake pools.
-poolRetireInEpoch
-  :: Environment LEDGER
-  -> [SourceSignalTarget POOL]
-  -> Property
+poolRetireInEpoch ::
+  Environment LEDGER ->
+  [SourceSignalTarget POOL] ->
+  Property
 poolRetireInEpoch env ssts =
   conjoin $
     map (registeredPoolRetired (ledgerSlotNo env) (ledgerPp env)) ssts
   where
-    registeredPoolRetired s pp SourceSignalTarget
-                                { source = p
-                                , target = p'
-                                , signal = (DCertPool c@(RetirePool _ e))} =
-      case poolCWitness c of
-        KeyHashObj certWit -> let StakePools stp  = getStPools p
-                                  StakePools stp' = getStPools p'
-                                  cepoch          = epochFromSlotNo s
-                                  EpochNo ce      = cepoch
-                                  EpochNo emax'   = _eMax pp in
-                                (  cepoch < e
-                                && e < EpochNo (ce + emax')) ==>
-                                (  certWit ∈ dom stp
-                                && certWit ∈ dom stp'
-                                && Maybe.maybe False ((== cepoch) . epochFromSlotNo) (stp' !? certWit))
-        _                  -> False
+    registeredPoolRetired
+      s
+      pp
+      SourceSignalTarget
+        { source = p,
+          target = p',
+          signal = (DCertPool c@(RetirePool _ e))
+        } =
+        case poolCWitness c of
+          KeyHashObj certWit ->
+            let StakePools stp = getStPools p
+                StakePools stp' = getStPools p'
+                cepoch = epochFromSlotNo s
+                EpochNo ce = cepoch
+                EpochNo emax' = _eMax pp
+             in ( cepoch < e
+                    && e < EpochNo (ce + emax')
+                )
+                  ==> ( certWit ∈ dom stp
+                          && certWit ∈ dom stp'
+                          && Maybe.maybe False ((== cepoch) . epochFromSlotNo) (stp' !? certWit)
+                      )
+          _ -> False
     registeredPoolRetired _ _ _ = True
 
 -- | Check that a `RegPool` certificate properly adds a stake pool.
-registeredPoolIsAdded
-  :: Environment LEDGER
-  -> [SourceSignalTarget POOL]
-  -> Property
+registeredPoolIsAdded ::
+  Environment LEDGER ->
+  [SourceSignalTarget POOL] ->
+  Property
 registeredPoolIsAdded env ssts =
   conjoin $
     map addedRegPool ssts
- where
-  addedRegPool :: SourceSignalTarget POOL
-               -> Property
-  addedRegPool sst =
-    case signal sst of
-      DCertPool (RegPool poolParams) -> check poolParams
-      _ -> property ()
-   where
-    check :: PoolParams -> Property
-    check poolParams = do
-      let hk = _poolPubKey poolParams
-          sSt = source sst
-          tSt = target sst
+  where
+    addedRegPool ::
+      SourceSignalTarget POOL ->
+      Property
+    addedRegPool sst =
+      case signal sst of
+        DCertPool (RegPool poolParams) -> check poolParams
+        _ -> property ()
+      where
+        check :: PoolParams -> Property
+        check poolParams = do
+          let hk = _poolPubKey poolParams
+              sSt = source sst
+              tSt = target sst
 
-      conjoin
-        [ -- Check for pool re-registration. If we register a pool which was already
-          -- registered (indicated by presence in `stPools`), then we check that it
-          -- is not in `retiring` after the signal has been processed.
-          if hk ∈ dom ((unStakePools . _stPools) sSt)
-            then
-              conjoin
-                [ counterexample "Pool re-registration: pool should be in 'retiring' before signal"
-                    (hk ∈ dom (_retiring sSt))
-                , counterexample "Pool re-registration: pool should not be in 'retiring' after signal"
-                    (hk ∉ dom (_retiring tSt))
-                ]
-            else property ()
-
-        , counterexample "PoolParams are registered in pParams map"
-            (M.lookup hk (_pParams tSt) === Just poolParams)
-
-        , counterexample "Hashkey is registered in stPools map"
-            (M.lookup hk ((unStakePools . _stPools) tSt)
-               === Just (ledgerSlotNo env))
-        ]
+          conjoin
+            [ -- Check for pool re-registration. If we register a pool which was already
+              -- registered (indicated by presence in `stPools`), then we check that it
+              -- is not in `retiring` after the signal has been processed.
+              if hk ∈ dom ((unStakePools . _stPools) sSt)
+                then
+                  conjoin
+                    [ counterexample
+                        "Pool re-registration: pool should be in 'retiring' before signal"
+                        (hk ∈ dom (_retiring sSt)),
+                      counterexample
+                        "Pool re-registration: pool should not be in 'retiring' after signal"
+                        (hk ∉ dom (_retiring tSt))
+                    ]
+                else property (),
+              counterexample
+                "PoolParams are registered in pParams map"
+                (M.lookup hk (_pParams tSt) === Just poolParams),
+              counterexample
+                "Hashkey is registered in stPools map"
+                ( M.lookup hk ((unStakePools . _stPools) tSt)
+                    === Just (ledgerSlotNo env)
+                )
+            ]
 
 -- | Check that a `RetirePool` certificate properly marks a stake pool for
 -- retirement.
-poolIsMarkedForRetirement
-  :: [SourceSignalTarget POOL]
-  -> Property
+poolIsMarkedForRetirement ::
+  [SourceSignalTarget POOL] ->
+  Property
 poolIsMarkedForRetirement ssts =
   conjoin (map check ssts)
- where
-  check :: SourceSignalTarget POOL
-        -> Property
-  check sst =
-    case signal sst of
-      -- We omit a well-formedness check for `epoch`, because the executable
-      -- spec will throw a PredicateFailure in that case.
-      DCertPool (RetirePool hk _epoch) -> wasRemoved hk
-      _ -> property ()
-   where
-    wasRemoved :: KeyHash 'StakePool -> Property
-    wasRemoved hk = conjoin
-      [ counterexample "hk not in stPools"
-          (hk ∈ dom ((unStakePools . _stPools) (source sst)))
-      , counterexample "hk is not in target's retiring"
-          (hk ∈ dom (_retiring $ target sst))
-      ]
+  where
+    check ::
+      SourceSignalTarget POOL ->
+      Property
+    check sst =
+      case signal sst of
+        -- We omit a well-formedness check for `epoch`, because the executable
+        -- spec will throw a PredicateFailure in that case.
+        DCertPool (RetirePool hk _epoch) -> wasRemoved hk
+        _ -> property ()
+      where
+        wasRemoved :: KeyHash 'StakePool -> Property
+        wasRemoved hk =
+          conjoin
+            [ counterexample
+                "hk not in stPools"
+                (hk ∈ dom ((unStakePools . _stPools) (source sst))),
+              counterexample
+                "hk is not in target's retiring"
+                (hk ∈ dom (_retiring $ target sst))
+            ]
 
 -- | Assert that PState maps are in sync with each other after each `Signal
 -- POOL` transition.
-pStateIsInternallyConsistent
-  :: [SourceSignalTarget POOL]
-  -> Property
+pStateIsInternallyConsistent ::
+  [SourceSignalTarget POOL] ->
+  Property
 pStateIsInternallyConsistent ssts =
   conjoin $
     map isConsistent (concatMap (\sst -> [source sst, target sst]) ssts)
- where
-  isConsistent :: State POOL -> Property
-  isConsistent (PState stPools_ pParams_ retiring_) = do
-    let StakePools stPoolsMap = stPools_
-        poolKeys = M.keysSet stPoolsMap
-        pParamKeys = M.keysSet pParams_
-        retiringKeys = M.keysSet retiring_
+  where
+    isConsistent :: State POOL -> Property
+    isConsistent (PState stPools_ pParams_ retiring_) = do
+      let StakePools stPoolsMap = stPools_
+          poolKeys = M.keysSet stPoolsMap
+          pParamKeys = M.keysSet pParams_
+          retiringKeys = M.keysSet retiring_
 
-    conjoin [ counterexample "All pool keys should be in both stPools and pParams"
-                             (poolKeys === pParamKeys)
-            , counterexample "A retiring pool should still be registered in `stPools`"
-                             ((retiringKeys `S.isSubsetOf` poolKeys) === True)
-            ]
+      conjoin
+        [ counterexample
+            "All pool keys should be in both stPools and pParams"
+            (poolKeys === pParamKeys),
+          counterexample
+            "A retiring pool should still be registered in `stPools`"
+            ((retiringKeys `S.isSubsetOf` poolKeys) === True)
+        ]

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPoolreap.hs
@@ -5,31 +5,46 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestPoolreap
-  ( constantSumPots
-  , nonNegativeDeposits
-  , removedAfterPoolreap)
+  ( constantSumPots,
+    nonNegativeDeposits,
+    removedAfterPoolreap,
+  )
 where
 
-import           Data.List (foldl')
+import Byron.Spec.Ledger.Core (dom, (▷))
+import Control.State.Transition.Trace
+  ( SourceSignalTarget,
+    signal,
+    source,
+    target,
+    pattern SourceSignalTarget,
+  )
+import Data.List (foldl')
 import qualified Data.Set as Set (intersection, isSubsetOf, null, singleton)
-
-import           Test.QuickCheck (Property, conjoin)
-
-import           Control.State.Transition.Trace (SourceSignalTarget, pattern SourceSignalTarget,
-                     signal, source, target)
-
-import           Byron.Spec.Ledger.Core (dom, (▷))
-import           Shelley.Spec.Ledger.Coin (pattern Coin)
-import           Shelley.Spec.Ledger.LedgerState (pattern AccountState, pattern DState,
-                     pattern UTxOState, _deposited, _fees, _reserves, _rewards, _treasury, _utxo)
-import           Shelley.Spec.Ledger.STS.PoolReap (pattern PoolreapState, prAcnt, prDState,
-                     prPState, prUTxOSt)
-import           Shelley.Spec.Ledger.TxData (pattern StakePools)
-import           Shelley.Spec.Ledger.UTxO (balance)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (POOLREAP)
-import           Test.Shelley.Spec.Ledger.Rules.TestPool (getRetiring, getStPools)
-
+import Shelley.Spec.Ledger.Coin (pattern Coin)
+import Shelley.Spec.Ledger.LedgerState
+  ( _deposited,
+    _fees,
+    _reserves,
+    _rewards,
+    _treasury,
+    _utxo,
+    pattern AccountState,
+    pattern DState,
+    pattern UTxOState,
+  )
+import Shelley.Spec.Ledger.STS.PoolReap
+  ( prAcnt,
+    prDState,
+    prPState,
+    prUTxOSt,
+    pattern PoolreapState,
+  )
+import Shelley.Spec.Ledger.TxData (pattern StakePools)
+import Shelley.Spec.Ledger.UTxO (balance)
+import Test.QuickCheck (Property, conjoin)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (POOLREAP)
+import Test.Shelley.Spec.Ledger.Rules.TestPool (getRetiring, getStPools)
 
 -----------------------------
 -- Properties for POOLREAP --
@@ -37,64 +52,85 @@ import           Test.Shelley.Spec.Ledger.Rules.TestPool (getRetiring, getStPool
 
 -- | Check that after a POOLREAP certificate transition the pool is removed from
 -- the stake pool and retiring maps.
-removedAfterPoolreap
-  :: [SourceSignalTarget POOLREAP]
-  -> Property
+removedAfterPoolreap ::
+  [SourceSignalTarget POOLREAP] ->
+  Property
 removedAfterPoolreap tr =
   conjoin $
     map poolRemoved tr
-
-  where poolRemoved (SourceSignalTarget
-                      { source = PoolreapState { prPState = p }
-                      , signal = e
-                      , target = PoolreapState { prPState = p' }}) =
-          let StakePools stp  = getStPools p
-              StakePools stp' = getStPools p'
-              retiring        = getRetiring p
-              retiring'       = getRetiring p'
-              retire          = dom $ retiring ▷ Set.singleton e in
-
-          (retire `Set.isSubsetOf` dom stp)
-          && Set.null (retire `Set.intersection` dom stp')
-          && Set.null (retire `Set.intersection` dom retiring')
-
+  where
+    poolRemoved
+      ( SourceSignalTarget
+          { source = PoolreapState {prPState = p},
+            signal = e,
+            target = PoolreapState {prPState = p'}
+          }
+        ) =
+        let StakePools stp = getStPools p
+            StakePools stp' = getStPools p'
+            retiring = getRetiring p
+            retiring' = getRetiring p'
+            retire = dom $ retiring ▷ Set.singleton e
+         in (retire `Set.isSubsetOf` dom stp)
+              && Set.null (retire `Set.intersection` dom stp')
+              && Set.null (retire `Set.intersection` dom retiring')
 
 -- | Check that deposits are always non-negative
-nonNegativeDeposits
-  :: [SourceSignalTarget POOLREAP]
-  -> Property
+nonNegativeDeposits ::
+  [SourceSignalTarget POOLREAP] ->
+  Property
 nonNegativeDeposits tr =
   conjoin $
-    map (\PoolreapState
+    map
+      ( \PoolreapState
            { prUTxOSt =
-                UTxOState { _deposited = deposit} } -> deposit >= 0)
-        (map source tr)
+               UTxOState {_deposited = deposit}
+           } -> deposit >= 0
+      )
+      (map source tr)
 
 -- | Check that the sum of circulation, deposits, fees, treasury, rewards and
 -- reserves is constant.
-constantSumPots
-  :: [SourceSignalTarget POOLREAP]
-  -> Property
+constantSumPots ::
+  [SourceSignalTarget POOLREAP] ->
+  Property
 constantSumPots tr =
   conjoin $
     map potsSumEqual tr
-
-  where potsSumEqual (SourceSignalTarget
-                      { source = PoolreapState
-                                 { prUTxOSt = UTxOState {
-                                       _utxo = u
-                                     , _deposited = d
-                                     , _fees = fees }
-                                 , prAcnt = AccountState { _treasury = treasury
-                                                         , _reserves = reserves }
-                                 , prDState = DState { _rewards = rewards}}
-                      , target = PoolreapState
-                                 { prUTxOSt = UTxOState {
-                                       _utxo = u'
-                                     , _deposited = d'
-                                     , _fees = fees' }
-                                 , prAcnt = AccountState { _treasury = treasury'
-                                                         , _reserves = reserves' }
-                                 , prDState = DState { _rewards = rewards'}}}) =
-          (balance u + d + fees + treasury + reserves + foldl' (+) (Coin 0) rewards) ==
-          (balance u' + d' + fees' + treasury' + reserves' + foldl' (+) (Coin 0) rewards')
+  where
+    potsSumEqual
+      ( SourceSignalTarget
+          { source =
+              PoolreapState
+                { prUTxOSt =
+                    UTxOState
+                      { _utxo = u,
+                        _deposited = d,
+                        _fees = fees
+                      },
+                  prAcnt =
+                    AccountState
+                      { _treasury = treasury,
+                        _reserves = reserves
+                      },
+                  prDState = DState {_rewards = rewards}
+                },
+            target =
+              PoolreapState
+                { prUTxOSt =
+                    UTxOState
+                      { _utxo = u',
+                        _deposited = d',
+                        _fees = fees'
+                      },
+                  prAcnt =
+                    AccountState
+                      { _treasury = treasury',
+                        _reserves = reserves'
+                      },
+                  prDState = DState {_rewards = rewards'}
+                }
+          }
+        ) =
+        (balance u + d + fees + treasury + reserves + foldl' (+) (Coin 0) rewards)
+          == (balance u' + d' + fees' + treasury' + reserves' + foldl' (+) (Coin 0) rewards')

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestUtxo.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestUtxo.hs
@@ -4,62 +4,73 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestUtxo
-  ( feesNonDecreasing
-  , potsSumIncreaseWdrls)
+  ( feesNonDecreasing,
+    potsSumIncreaseWdrls,
+  )
 where
 
-import           Control.State.Transition.Trace (SourceSignalTarget, pattern SourceSignalTarget,
-                     signal, source, target)
-import           Data.List (foldl')
-import           Test.QuickCheck (Property, conjoin)
-
-import           Shelley.Spec.Ledger.Coin (pattern Coin)
-import           Shelley.Spec.Ledger.LedgerState (pattern UTxOState, _deposited, _fees, _utxo)
-import           Shelley.Spec.Ledger.Tx (pattern Tx, _body)
-import           Shelley.Spec.Ledger.TxData (Wdrl (..), _wdrls)
-import           Shelley.Spec.Ledger.UTxO (balance)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (UTXO)
+import Control.State.Transition.Trace
+  ( SourceSignalTarget,
+    signal,
+    source,
+    target,
+    pattern SourceSignalTarget,
+  )
+import Data.List (foldl')
+import Shelley.Spec.Ledger.Coin (pattern Coin)
+import Shelley.Spec.Ledger.LedgerState (_deposited, _fees, _utxo, pattern UTxOState)
+import Shelley.Spec.Ledger.Tx (_body, pattern Tx)
+import Shelley.Spec.Ledger.TxData (Wdrl (..), _wdrls)
+import Shelley.Spec.Ledger.UTxO (balance)
+import Test.QuickCheck (Property, conjoin)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (UTXO)
 
 --------------------------
 -- Properties for UTXOW --
 --------------------------
 
 -- | Property that checks that the fees are non-decreasing
-feesNonDecreasing
-  :: [SourceSignalTarget UTXO]
-  -> Property
+feesNonDecreasing ::
+  [SourceSignalTarget UTXO] ->
+  Property
 feesNonDecreasing ssts =
   conjoin $
     map feesDoNotIncrease ssts
-
   where
-    feesDoNotIncrease SourceSignalTarget
-                        { source = UTxOState { _fees = fees }
-                        , target = UTxOState { _fees = fees' }} =
-      fees <= fees'
+    feesDoNotIncrease
+      SourceSignalTarget
+        { source = UTxOState {_fees = fees},
+          target = UTxOState {_fees = fees'}
+        } =
+        fees <= fees'
 
 -- | Property that checks that the sum of the pots circulation, deposits and
 -- fees increases by the sum of withdrawals of a transaction.
-potsSumIncreaseWdrls
-  :: [SourceSignalTarget UTXO]
-  -> Property
+potsSumIncreaseWdrls ::
+  [SourceSignalTarget UTXO] ->
+  Property
 potsSumIncreaseWdrls ssts =
   conjoin $
     map potsIncreaseWithWdrlsSum ssts
-
   where
-    potsIncreaseWithWdrlsSum SourceSignalTarget
-                               { source = UTxOState { _utxo = u
-                                                    , _deposited = d
-                                                    , _fees = fees}
-                               , target = UTxOState { _utxo = u'
-                                                    , _deposited = d'
-                                                    , _fees = fees'}
-                               , signal = Tx { _body = txbody }} =
-      let circulation  = balance u
-          circulation' = balance u'
-          withdrawals  = foldl' (+) (Coin 0) $ unWdrl $ _wdrls txbody
-      in
-         withdrawals >= Coin 0
-      && circulation' + d' + fees' == circulation + d + fees + withdrawals
+    potsIncreaseWithWdrlsSum
+      SourceSignalTarget
+        { source =
+            UTxOState
+              { _utxo = u,
+                _deposited = d,
+                _fees = fees
+              },
+          target =
+            UTxOState
+              { _utxo = u',
+                _deposited = d',
+                _fees = fees'
+              },
+          signal = Tx {_body = txbody}
+        } =
+        let circulation = balance u
+            circulation' = balance u'
+            withdrawals = foldl' (+) (Coin 0) $ unWdrl $ _wdrls txbody
+         in withdrawals >= Coin 0
+              && circulation' + d' + fees' == circulation + d + fees + withdrawals

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestUtxow.hs
@@ -5,34 +5,45 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 
 module Test.Shelley.Spec.Ledger.Rules.TestUtxow
-  ( preserveBalance
-  , preserveBalanceRestricted
-  , preserveOutputsTx
-  , eliminateTxInputs
-  , newEntriesAndUniqueTxIns
-  , noDoubleSpend
-  , requiredMSigSignaturesSubset)
+  ( preserveBalance,
+    preserveBalanceRestricted,
+    preserveOutputsTx,
+    eliminateTxInputs,
+    newEntriesAndUniqueTxIns,
+    noDoubleSpend,
+    requiredMSigSignaturesSubset,
+  )
 where
 
-import           Data.Foldable (toList)
+import Byron.Spec.Ledger.Core ((<|), dom)
+import Control.State.Transition.Trace
+  ( SourceSignalTarget,
+    signal,
+    source,
+    target,
+    pattern SourceSignalTarget,
+  )
+import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map (isSubmapOf)
 import qualified Data.Set as Set (fromList, intersection, isSubsetOf, map, null)
-
-import           Test.QuickCheck (Property, conjoin, (===))
-
-import           Control.State.Transition.Trace (SourceSignalTarget, pattern SourceSignalTarget,
-                     signal, source, target)
-
-import           Byron.Spec.Ledger.Core (dom, (<|))
-import           Shelley.Spec.Ledger.LedgerState (pattern UTxOState, keyRefunds)
-import           Shelley.Spec.Ledger.PParams (PParams)
-import           Shelley.Spec.Ledger.Tx (getKeyCombinations, _body, _witnessMSigMap,
-                     _witnessVKeySet)
-import           Shelley.Spec.Ledger.TxData (pattern TxIn, witKeyHash, _certs, _inputs, _txfee)
-import           Shelley.Spec.Ledger.UTxO (pattern UTxO, balance, totalDeposits, txins, txouts)
-
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (StakeCreds, StakePools, Tx, UTXO,
-                     UTXOW)
+import Shelley.Spec.Ledger.LedgerState (keyRefunds, pattern UTxOState)
+import Shelley.Spec.Ledger.PParams (PParams)
+import Shelley.Spec.Ledger.Tx
+  ( _body,
+    _witnessMSigMap,
+    _witnessVKeySet,
+    getKeyCombinations,
+  )
+import Shelley.Spec.Ledger.TxData (_certs, _inputs, _txfee, witKeyHash, pattern TxIn)
+import Shelley.Spec.Ledger.UTxO (balance, totalDeposits, txins, txouts, pattern UTxO)
+import Test.QuickCheck ((===), Property, conjoin)
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( StakeCreds,
+    StakePools,
+    Tx,
+    UTXO,
+    UTXOW,
+  )
 
 --------------------------
 -- Properties for UTXOW --
@@ -40,123 +51,136 @@ import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (StakeCreds, Stake
 
 -- | Preserve the balance in a transaction, i.e., the sum of the consumed value
 -- equals the sum of the created value.
-preserveBalance
-  :: PParams
-  -> [(StakeCreds, StakePools, SourceSignalTarget UTXOW)]
-  -> Property
+preserveBalance ::
+  PParams ->
+  [(StakeCreds, StakePools, SourceSignalTarget UTXOW)] ->
+  Property
 preserveBalance pp tr =
   conjoin $
     map createdIsConsumed tr
   where
-    createdIsConsumed (stk, stp, SourceSignalTarget
-                                   { source = UTxOState u _ _ _
-                                   , signal = tx
-                                   , target = UTxOState u' _ _ _}) =
-      created u' stp tx == consumed u stk tx
-
+    createdIsConsumed
+      ( stk,
+        stp,
+        SourceSignalTarget
+          { source = UTxOState u _ _ _,
+            signal = tx,
+            target = UTxOState u' _ _ _
+          }
+        ) =
+        created u' stp tx == consumed u stk tx
     created u stp_ tx =
-        balance u
-      + _txfee (_body tx)
-      + totalDeposits pp stp_ (toList $ _certs $ _body tx)
-
+      balance u
+        + _txfee (_body tx)
+        + totalDeposits pp stp_ (toList $ _certs $ _body tx)
     consumed u stk_ tx =
-        balance u
-      + keyRefunds pp stk_ (_body tx)
+      balance u
+        + keyRefunds pp stk_ (_body tx)
 
 -- | Preserve balance restricted to TxIns and TxOuts of the Tx
-preserveBalanceRestricted
-  :: PParams
-  -> [(StakeCreds, StakePools, SourceSignalTarget UTXOW)]
-  -> Property
+preserveBalanceRestricted ::
+  PParams ->
+  [(StakeCreds, StakePools, SourceSignalTarget UTXOW)] ->
+  Property
 preserveBalanceRestricted pp tr =
   conjoin $
     map createdIsConsumed tr
   where
-    createdIsConsumed (stk, stp, SourceSignalTarget
-                                   { source = UTxOState u _ _ _
-                                   , signal = tx
-                                   , target = UTxOState _ _ _ _}) =
-      inps u tx == outs stk stp (_body tx)
-
+    createdIsConsumed
+      ( stk,
+        stp,
+        SourceSignalTarget
+          { source = UTxOState u _ _ _,
+            signal = tx,
+            target = UTxOState _ _ _ _
+          }
+        ) =
+        inps u tx == outs stk stp (_body tx)
     inps u tx = balance $ (_inputs $ _body tx) <| u
-
     outs stk_ stp_ tx =
-        balance (txouts tx)
-      + _txfee tx
-      + depositChange stk_ stp_ (toList $ _certs tx) tx
-
+      balance (txouts tx)
+        + _txfee tx
+        + depositChange stk_ stp_ (toList $ _certs tx) tx
     depositChange stk_ stp_ certs txb =
-        totalDeposits pp stp_ certs
-      - (keyRefunds pp stk_ txb)
+      totalDeposits pp stp_ certs
+        - (keyRefunds pp stk_ txb)
 
 -- | Preserve outputs of Txs
-preserveOutputsTx
-  :: [SourceSignalTarget UTXO]
-  -> Property
+preserveOutputsTx ::
+  [SourceSignalTarget UTXO] ->
+  Property
 preserveOutputsTx tr =
   conjoin $
     map outputPreserved tr
   where
-    outputPreserved SourceSignalTarget
-                      { signal = tx
-                      , target = UTxOState (UTxO utxo') _ _ _} =
-      let UTxO outs = txouts (_body tx)
-      in outs `Map.isSubmapOf` utxo'
+    outputPreserved
+      SourceSignalTarget
+        { signal = tx,
+          target = UTxOState (UTxO utxo') _ _ _
+        } =
+        let UTxO outs = txouts (_body tx)
+         in outs `Map.isSubmapOf` utxo'
 
 -- | Check that consumed inputs are eliminated from the resulting UTxO
-eliminateTxInputs
-  :: [SourceSignalTarget UTXO]
-  -> Property
+eliminateTxInputs ::
+  [SourceSignalTarget UTXO] ->
+  Property
 eliminateTxInputs tr =
   conjoin $
     map inputsEliminated tr
   where
-    inputsEliminated SourceSignalTarget
-                       { signal = tx
-                       , target = UTxOState (UTxO utxo') _ _ _} =
-      Set.null $ txins (_body tx) `Set.intersection` dom utxo'
+    inputsEliminated
+      SourceSignalTarget
+        { signal = tx,
+          target = UTxOState (UTxO utxo') _ _ _
+        } =
+        Set.null $ txins (_body tx) `Set.intersection` dom utxo'
 
 -- | Check that all new entries of a Tx are included in the new UTxO and that
 -- all TxIds are new.
-newEntriesAndUniqueTxIns
-  :: [SourceSignalTarget UTXO]
-  -> Property
+newEntriesAndUniqueTxIns ::
+  [SourceSignalTarget UTXO] ->
+  Property
 newEntriesAndUniqueTxIns tr =
   conjoin $
     map newEntryPresent tr
   where
-    newEntryPresent SourceSignalTarget
-                      { source = (UTxOState (UTxO utxo) _ _ _)
-                      , signal = tx
-                      , target = (UTxOState (UTxO utxo') _ _ _)} =
-      let UTxO outs = txouts (_body tx)
-          outIds = Set.map (\(TxIn _id _) -> _id) (dom outs)
-          oldIds = Set.map (\(TxIn _id _) -> _id) (dom utxo)
-      in
-           null (outIds `Set.intersection` oldIds)
-        && (dom outs) `Set.isSubsetOf` (dom utxo')
+    newEntryPresent
+      SourceSignalTarget
+        { source = (UTxOState (UTxO utxo) _ _ _),
+          signal = tx,
+          target = (UTxOState (UTxO utxo') _ _ _)
+        } =
+        let UTxO outs = txouts (_body tx)
+            outIds = Set.map (\(TxIn _id _) -> _id) (dom outs)
+            oldIds = Set.map (\(TxIn _id _) -> _id) (dom utxo)
+         in null (outIds `Set.intersection` oldIds)
+              && (dom outs) `Set.isSubsetOf` (dom utxo')
 
 -- | Check for absence of double spend
-noDoubleSpend
-  :: [SourceSignalTarget UTXO]
-  -> Property
+noDoubleSpend ::
+  [SourceSignalTarget UTXO] ->
+  Property
 noDoubleSpend tr =
   [] === getDoubleInputs (map sig tr)
   where
     sig (SourceSignalTarget _ _ s) = s
-
     getDoubleInputs :: [Tx] -> [(Tx, [Tx])]
     getDoubleInputs [] = []
-    getDoubleInputs (t:ts) = lookForDoubleSpends t ts ++ getDoubleInputs ts
-
+    getDoubleInputs (t : ts) = lookForDoubleSpends t ts ++ getDoubleInputs ts
     lookForDoubleSpends :: Tx -> [Tx] -> [(Tx, [Tx])]
     lookForDoubleSpends _ [] = []
     lookForDoubleSpends tx_j ts =
       if null doubles then [] else [(tx_j, doubles)]
-      where doubles =
-              filter (\tx_i -> (not . Set.null)
-                       (inps_j `Set.intersection` _inputs (_body tx_i))) ts
-            inps_j = _inputs $ _body tx_j
+      where
+        doubles =
+          filter
+            ( \tx_i ->
+                (not . Set.null)
+                  (inps_j `Set.intersection` _inputs (_body tx_i))
+            )
+            ts
+        inps_j = _inputs $ _body tx_j
 
 -- | Check for required signatures in case of Multi-Sig. There has to be one set
 -- of possible signatures for a multi-sig script which is a sub-set of the
@@ -168,12 +192,12 @@ noDoubleSpend tr =
 requiredMSigSignaturesSubset :: [SourceSignalTarget UTXOW] -> Property
 requiredMSigSignaturesSubset tr =
   conjoin $
-  map signaturesSubset tr
+    map signaturesSubset tr
   where
     signaturesSubset sst =
-      let khs = keyHashSet sst in
-      all (existsReqKeyComb khs) (_witnessMSigMap $ signal sst)
-    existsReqKeyComb keyHashes msig  =
+      let khs = keyHashSet sst
+       in all (existsReqKeyComb khs) (_witnessMSigMap $ signal sst)
+    existsReqKeyComb keyHashes msig =
       any (\kl -> (Set.fromList kl) `Set.isSubsetOf` keyHashes) (getKeyCombinations msig)
     keyHashSet sst =
       Set.map witKeyHash (_witnessVKeySet $ signal sst)

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
@@ -2,53 +2,68 @@
 {-# LANGUAGE PatternSynonyms #-}
 
 module Test.Shelley.Spec.Ledger.Utils
-  ( assertAll
-  , mkSeedFromWords
-  , mkCertifiedVRF
-  , epochFromSlotNo
-  , evolveKESUntil
-  , slotFromEpoch
-  , mkKeyPair
-  , mkGenKey
-  , mkKESKeyPair
-  , mkVRFKeyPair
-  , mkAddr
-  , runShelleyBase
-  , testGlobals
-  , maxKESIterations
-  , unsafeMkUnitInterval
-  , slotsPerKESIteration
-  , maxLLSupply
-  ) where
+  ( assertAll,
+    mkSeedFromWords,
+    mkCertifiedVRF,
+    epochFromSlotNo,
+    evolveKESUntil,
+    slotFromEpoch,
+    mkKeyPair,
+    mkGenKey,
+    mkKESKeyPair,
+    mkVRFKeyPair,
+    mkAddr,
+    runShelleyBase,
+    testGlobals,
+    maxKESIterations,
+    unsafeMkUnitInterval,
+    slotsPerKESIteration,
+    maxLLSupply,
+  )
+where
 
-import           Cardano.Binary (ToCBOR (..))
-import           Cardano.Crypto.DSIGN (deriveVerKeyDSIGN, genKeyDSIGN)
-import           Cardano.Crypto.KES (deriveVerKeyKES, genKeyKES)
-import           Cardano.Crypto.VRF (deriveVerKeyVRF, evalCertified, genKeyVRF)
-import           Cardano.Crypto.Seed (Seed, mkSeedFromBytes)
-import           Cardano.Prelude (asks)
-import           Cardano.Slotting.EpochInfo (epochInfoEpoch, epochInfoFirst, fixedSizeEpochInfo)
-import           Control.Monad.Trans.Reader (runReaderT)
-import           Crypto.Random (withDRG, drgNewTest)
+import Cardano.Binary (ToCBOR (..))
+import Cardano.Crypto.DSIGN (deriveVerKeyDSIGN, genKeyDSIGN)
+import Cardano.Crypto.KES (deriveVerKeyKES, genKeyKES)
+import Cardano.Crypto.Seed (Seed, mkSeedFromBytes)
+import Cardano.Crypto.VRF (deriveVerKeyVRF, evalCertified, genKeyVRF)
+import Cardano.Prelude (asks)
+import Cardano.Slotting.EpochInfo (epochInfoEpoch, epochInfoFirst, fixedSizeEpochInfo)
+import Control.Monad.Trans.Reader (runReaderT)
+import Crypto.Random (drgNewTest, withDRG)
+import Data.ByteString.Conversion (toByteString)
 import qualified Data.ByteString.Lazy as BSL
-import           Data.ByteString.Conversion (toByteString)
-import           Data.Coerce (coerce)
-import           Data.Functor.Identity (runIdentity)
-import           Data.Maybe (fromMaybe)
-import           Data.Word (Word64)
-import           Hedgehog (MonadTest, (===))
-import           Shelley.Spec.Ledger.BaseTypes (Globals (..), ShelleyBase, UnitInterval,
-                     mkActiveSlotCoeff, mkUnitInterval)
-import           Shelley.Spec.Ledger.Coin (Coin (..))
-import           Shelley.Spec.Ledger.Keys (KeyRole (..), hashKey, updateKES, vKey)
-import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
-import           Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
-import           Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj, pattern StakeRefBase)
-
-import           Test.Cardano.Crypto.VRF.Fake (WithResult (..))
-import           Test.Shelley.Spec.Ledger.ConcreteCryptoTypes (Addr, CertifiedVRF, KeyPair,
-                     SignKeyDSIGN, SignKeyKES, SignKeyVRF, VKeyGenesis, VerKeyKES,
-                     VerKeyVRF, VKey, pattern VKey)
+import Data.Coerce (coerce)
+import Data.Functor.Identity (runIdentity)
+import Data.Maybe (fromMaybe)
+import Data.Word (Word64)
+import Hedgehog ((===), MonadTest)
+import Shelley.Spec.Ledger.BaseTypes
+  ( Globals (..),
+    ShelleyBase,
+    UnitInterval,
+    mkActiveSlotCoeff,
+    mkUnitInterval,
+  )
+import Shelley.Spec.Ledger.Coin (Coin (..))
+import Shelley.Spec.Ledger.Keys (KeyRole (..), hashKey, updateKES, vKey)
+import Shelley.Spec.Ledger.OCert (KESPeriod (..))
+import Shelley.Spec.Ledger.Slot (EpochNo, EpochSize (..), SlotNo)
+import Shelley.Spec.Ledger.TxData (pattern Addr, pattern KeyHashObj, pattern StakeRefBase)
+import Test.Cardano.Crypto.VRF.Fake (WithResult (..))
+import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
+  ( Addr,
+    CertifiedVRF,
+    KeyPair,
+    SignKeyDSIGN,
+    SignKeyKES,
+    SignKeyVRF,
+    VKey,
+    VKeyGenesis,
+    VerKeyKES,
+    VerKeyVRF,
+    pattern VKey,
+  )
 
 assertAll :: (MonadTest m, Show a, Eq a) => (a -> Bool) -> [a] -> m ()
 assertAll p xs = [] === filter (not . p) xs
@@ -57,57 +72,59 @@ assertAll p xs = [] === filter (not . p) xs
 --
 --   We multiply these words by some extra stuff to make sure they contain
 --   enough bits for our seed.
-mkSeedFromWords
-  :: (Word64, Word64, Word64, Word64, Word64)
-  -> Seed
-mkSeedFromWords (w1, w2, w3, w4, w5) = mkSeedFromBytes . BSL.toStrict $
-  toByteString (w1 * 15485867) <>
-  toByteString (w2 * 32452867) <>
-  toByteString (w3 * 49979693) <>
-  toByteString (w4 * 67867979) <>
-  toByteString (w5 * 86028157) <>
-  toByteString (2147483647 :: Word64)
+mkSeedFromWords ::
+  (Word64, Word64, Word64, Word64, Word64) ->
+  Seed
+mkSeedFromWords (w1, w2, w3, w4, w5) =
+  mkSeedFromBytes . BSL.toStrict $
+    toByteString (w1 * 15485867)
+      <> toByteString (w2 * 32452867)
+      <> toByteString (w3 * 49979693)
+      <> toByteString (w4 * 67867979)
+      <> toByteString (w5 * 86028157)
+      <> toByteString (2147483647 :: Word64)
 
 -- | For testing purposes, generate a deterministic genesis key pair given a seed.
 mkGenKey :: (Word64, Word64, Word64, Word64, Word64) -> (SignKeyDSIGN, VKeyGenesis)
 mkGenKey seed =
   let sk = genKeyDSIGN $ mkSeedFromWords seed
-  in (sk, VKey $ deriveVerKeyDSIGN sk)
-
+   in (sk, VKey $ deriveVerKeyDSIGN sk)
 
 -- | For testing purposes, generate a deterministic key pair given a seed.
 mkKeyPair :: (Word64, Word64, Word64, Word64, Word64) -> (SignKeyDSIGN, VKey kr)
 mkKeyPair seed =
   let sk = genKeyDSIGN $ mkSeedFromWords seed
-  in (sk, VKey $ deriveVerKeyDSIGN sk)
+   in (sk, VKey $ deriveVerKeyDSIGN sk)
 
 -- | For testing purposes, generate a deterministic VRF key pair given a seed.
 mkVRFKeyPair :: (Word64, Word64, Word64, Word64, Word64) -> (SignKeyVRF, VerKeyVRF)
 mkVRFKeyPair seed =
   let sk = genKeyVRF $ mkSeedFromWords seed
-  in (sk, deriveVerKeyVRF sk)
+   in (sk, deriveVerKeyVRF sk)
 
 -- | For testing purposes, create a VRF value
-mkCertifiedVRF
-  :: ToCBOR a
-  => WithResult a
-  -> SignKeyVRF
-  -> CertifiedVRF a
-mkCertifiedVRF a sk = fst . withDRG (drgNewTest seed) $
+mkCertifiedVRF ::
+  ToCBOR a =>
+  WithResult a ->
+  SignKeyVRF ->
+  CertifiedVRF a
+mkCertifiedVRF a sk =
+  fst . withDRG (drgNewTest seed) $
     coerce <$> evalCertified () a sk
   where
-    seed = (4,0,0,0,1)
+    seed = (4, 0, 0, 0, 1)
 
 -- | For testing purposes, generate a deterministic KES key pair given a seed.
 mkKESKeyPair :: (Word64, Word64, Word64, Word64, Word64) -> (SignKeyKES, VerKeyKES)
 mkKESKeyPair seed =
   let sk = genKeyKES $ mkSeedFromWords seed
-  in (sk, deriveVerKeyKES sk)
+   in (sk, deriveVerKeyKES sk)
 
 mkAddr :: (KeyPair 'Payment, KeyPair 'Staking) -> Addr
 mkAddr (payKey, stakeKey) =
-  Addr (KeyHashObj . hashKey $ vKey payKey)
-       (StakeRefBase . KeyHashObj . hashKey $ vKey stakeKey)
+  Addr
+    (KeyHashObj . hashKey $ vKey payKey)
+    (StakeRefBase . KeyHashObj . hashKey $ vKey stakeKey)
 
 -- | You vouch that argument is in [0; 1].
 unsafeMkUnitInterval :: Rational -> UnitInterval
@@ -115,18 +132,19 @@ unsafeMkUnitInterval r =
   fromMaybe (error "could not construct unit interval") $ mkUnitInterval r
 
 testGlobals :: Globals
-testGlobals = Globals
-  { epochInfo = fixedSizeEpochInfo $ EpochSize 100
-  , slotsPerKESPeriod = 20
-  , startRewards = 33
-  , slotsPrior = 33
-  , securityParameter = 10
-  , maxKESEvo = 10
-  , quorum = 5
-  , maxMajorPV = 1000
-  , maxLovelaceSupply = 45*1000*1000*1000*1000*1000
-  , activeSlotCoeff = mkActiveSlotCoeff . unsafeMkUnitInterval $ 0.9
-  }
+testGlobals =
+  Globals
+    { epochInfo = fixedSizeEpochInfo $ EpochSize 100,
+      slotsPerKESPeriod = 20,
+      startRewards = 33,
+      slotsPrior = 33,
+      securityParameter = 10,
+      maxKESEvo = 10,
+      quorum = 5,
+      maxMajorPV = 1000,
+      maxLovelaceSupply = 45 * 1000 * 1000 * 1000 * 1000 * 1000,
+      activeSlotCoeff = mkActiveSlotCoeff . unsafeMkUnitInterval $ 0.9
+    }
 
 runShelleyBase :: ShelleyBase a -> a
 runShelleyBase act = runIdentity $ runReaderT act testGlobals
@@ -135,7 +153,7 @@ epochFromSlotNo :: SlotNo -> EpochNo
 epochFromSlotNo = runIdentity . epochInfoEpoch (epochInfo testGlobals)
 
 slotFromEpoch :: EpochNo -> SlotNo
-slotFromEpoch = runIdentity  . epochInfoFirst (epochInfo testGlobals)
+slotFromEpoch = runIdentity . epochInfoFirst (epochInfo testGlobals)
 
 -- | Try to evolve KES key until specific KES period is reached.
 evolveKESUntil :: SignKeyKES -> KESPeriod -> Maybe SignKeyKES

--- a/shelley/chain-and-ledger/executable-spec/test/Test/TestScenario.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/TestScenario.hs
@@ -1,16 +1,19 @@
-{-# Language TypeApplications #-}
-{-# Language OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.TestScenario where
 
-import Prelude hiding (show)
 import Cardano.Prelude hiding (Option)
-
 import Test.Tasty (TestTree, defaultMainWithIngredients, includingOptions)
-import Test.Tasty.Ingredients (Ingredient(..), composeReporters)
+import Test.Tasty.Ingredients (Ingredient (..), composeReporters)
 import Test.Tasty.Ingredients.Basic (consoleTestReporter, listingTests)
 import Test.Tasty.Options
-  (IsOption(..), OptionDescription(..), lookupOption, safeRead)
+  ( IsOption (..),
+    OptionDescription (..),
+    lookupOption,
+    safeRead,
+  )
+import Prelude hiding (show)
 
 data TestScenario
   = ContinuousIntegration
@@ -32,11 +35,12 @@ logScenario = TestReporter [] $ \options _ -> Just $ \_ -> do
   pure (const (pure True))
 
 mainWithTestScenario :: TestTree -> IO ()
-mainWithTestScenario = defaultMainWithIngredients
-  [ includingOptions [Option (Proxy @TestScenario)]
-  , listingTests
-  , composeReporters logScenario consoleTestReporter
-  ]
+mainWithTestScenario =
+  defaultMainWithIngredients
+    [ includingOptions [Option (Proxy @TestScenario)],
+      listingTests,
+      composeReporters logScenario consoleTestReporter
+    ]
 
 helpText :: [Char]
 helpText =

--- a/shelley/chain-and-ledger/executable-spec/test/Tests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Tests.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE LambdaCase #-}
-import           Test.Tasty
 
-import           Test.Shelley.Spec.Ledger.Examples.CDDL (cddlTests)
-import           Test.Shelley.Spec.Ledger.Examples.Serialization (serializationTests)
-import           Test.Shelley.Spec.Ledger.Examples.STSTests (stsTests)
-import           Test.Shelley.Spec.Ledger.Examples.UnitTests (unitTests)
-import           Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTests)
-import           Test.TestScenario (TestScenario (..), mainWithTestScenario)
+import Test.Shelley.Spec.Ledger.Examples.CDDL (cddlTests)
+import Test.Shelley.Spec.Ledger.Examples.STSTests (stsTests)
+import Test.Shelley.Spec.Ledger.Examples.Serialization (serializationTests)
+import Test.Shelley.Spec.Ledger.Examples.UnitTests (unitTests)
+import Test.Shelley.Spec.Ledger.PropertyTests (minimalPropertyTests, propertyTests)
+import Test.Tasty
+import Test.TestScenario (TestScenario (..), mainWithTestScenario)
 
 tests :: TestTree
 tests = askOption $ \case
@@ -15,27 +15,33 @@ tests = askOption $ \case
   _ -> mainTests
 
 mainTests :: TestTree
-mainTests = testGroup "Ledger with Delegation"
-  [ cddlTests 5
-  , minimalPropertyTests
-  , serializationTests
-  , stsTests
-  , unitTests
-  ]
+mainTests =
+  testGroup
+    "Ledger with Delegation"
+    [ cddlTests 5,
+      minimalPropertyTests,
+      serializationTests,
+      stsTests,
+      unitTests
+    ]
 
 nightlyTests :: TestTree
-nightlyTests = testGroup "Ledger with Delegation nightly"
-  [ propertyTests
-  , cddlTests 50
-  ]
+nightlyTests =
+  testGroup
+    "Ledger with Delegation nightly"
+    [ propertyTests,
+      cddlTests 50
+    ]
 
 fastTests :: TestTree
-fastTests = testGroup "Ledger with Delegation fast"
-  [ cddlTests 1
-  , serializationTests
-  , stsTests
-  , unitTests
-  ]
+fastTests =
+  testGroup
+    "Ledger with Delegation fast"
+    [ cddlTests 1,
+      serializationTests,
+      stsTests,
+      unitTests
+    ]
 
 -- main entry point
 main :: IO ()


### PR DESCRIPTION
Since we were discussing formatting changes... here's a script that formats using ormolu, and an example of what this looks like.

I don't necessarily agree with all of the formatting decisions, but I do like:
- The fact that this defines a single format
- The handling of multi-line things. In particular, I just have to decide "one or many", and the formatter sorts out the rest. I feel like if I'm going to have a formatter, it's useless if I also have to spend a bunch of time thinking about the formatting as well...

Obviously we should not merge this actual PR unless the repo is quiescent, since it will conflict a lot. So this is mostly for discussion