### PR TITLE
rename the stability window constants

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
@@ -316,16 +316,15 @@ activeSlotLog f = (fromIntegral $ unActiveSlotLog f) / fpPrecision
 data Globals = Globals
   { epochInfo :: !(EpochInfo Identity)
   , slotsPerKESPeriod :: !Word64
+    -- | The window size in which our chosen chain growth property
+    --   guarantees at least k blocks. From the paper
+    --   "Ouroboros praos: An adaptively-secure, semi-synchronous proof-of-stake protocol".
+    --   The 'stabilityWindow' constant is used in a number of places; for example,
+    --   protocol updates must be submitted at least twice this many slots before an epoch boundary.
+  , stabilityWindow :: !Word64
     -- | Number of slots before the end of the epoch at which we stop updating
     --   the candidate nonce for the next epoch.
-    --
-    --   This value is also used in a number of other places; for example,
-    --   protocol updates must be submitted at least this many slots before an
-    --   epoch boundary.
-  , slotsPrior :: !Word64
-    -- | Number of slots after the beginning of an epoch when we may begin to
-    --   distribute rewards.
-  , startRewards :: !Word64
+  , randomnessStabilisationWindow :: !Word64
     -- | Maximum number of blocks we are allowed to roll back
   , securityParameter :: !Word64
     -- | Maximum number of KES iterations

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Deleg.hs
@@ -136,7 +136,7 @@ delegationTransition = do
         { _delegations = _delegations ds ⨃ [(hk, dpool)] }
 
     DCertGenesis (GenesisDelegCert gkh vkh) -> do
-      sp <- liftSTS $ asks slotsPrior
+      sp <- liftSTS $ asks stabilityWindow
       -- note that pattern match is used instead of genesisDeleg, as in the spec
       let s' = slot +* Duration sp
           (GenDelegs genDelegs) = _genDelegs ds
@@ -147,7 +147,7 @@ delegationTransition = do
         { _fGenDelegs = _fGenDelegs ds ⨃ [(FutureGenDeleg s' gkh, vkh)]}
 
     DCertMir (MIRCert credCoinMap) -> do
-      sp <- liftSTS $ asks slotsPrior
+      sp <- liftSTS $ asks stabilityWindow
       firstSlot <- liftSTS $ do
         ei <- asks epochInfo
         EpochNo currEpoch <- epochInfoEpoch ei slot

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ppup.hs
@@ -106,7 +106,7 @@ ppupTransitionNonEmpty = do
 
       all ((pvCanFollow (_protocolVersion pp)) . _protocolVersion) pup ?! PVCannotFollowPPUP
 
-      sp <- liftSTS $ asks slotsPrior
+      sp <- liftSTS $ asks stabilityWindow
       firstSlotNextEpoch <- liftSTS $ do
         ei <- asks epochInfo
         EpochNo e <- epochInfoEpoch ei slot

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Rupd.hs
@@ -18,7 +18,7 @@ import           Control.State.Transition (STS (..), TRC (..), TransitionRule, j
 import           Data.Functor ((<&>))
 import           GHC.Generics (Generic)
 import           Shelley.Spec.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..), epochInfo,
-                     maxLovelaceSupply, startRewards)
+                     maxLovelaceSupply, randomnessStabilisationWindow)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade)
 import           Shelley.Spec.Ledger.LedgerState (EpochState, RewardUpdate, createRUpd)
@@ -48,7 +48,7 @@ rupdTransition = do
   TRC (RupdEnv b es, ru, s) <- judgmentContext
   (epoch, slot, maxLL) <- liftSTS $ do
     ei <- asks epochInfo
-    sr <- asks startRewards
+    sr <- asks randomnessStabilisationWindow
     e <- epochInfoEpoch ei s
     slot <- epochInfoFirst ei e <&> (+* (Duration sr))
     maxLL <- asks maxLovelaceSupply

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Updn.hs
@@ -60,7 +60,7 @@ updTransition :: Crypto crypto => TransitionRule (UPDN crypto)
 updTransition = do
   TRC (UpdnEnv eta pp ph ne, UpdnState eta_0 eta_v eta_c eta_h, s) <- judgmentContext
   ei <- liftSTS $ asks epochInfo
-  sp <- liftSTS $ asks slotsPrior
+  sp <- liftSTS $ asks stabilityWindow
   EpochNo e <- liftSTS $ epochInfoEpoch ei s
   firstSlotNextEpoch <- liftSTS $ epochInfoFirst ei (EpochNo (e + 1))
   pure $ UpdnState

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -110,8 +110,8 @@ import           Numeric.Natural (Natural)
 import           Cardano.Slotting.Slot (WithOrigin (..))
 import           Control.State.Transition.Extended (PredicateFailure, TRC (..), applySTS)
 import           Shelley.Spec.Ledger.Address (pattern Addr, mkRwdAcnt)
-import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), mkNonce, startRewards,
-                     textToUrl, (⭒))
+import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), StrictMaybe (..), mkNonce,
+                     randomnessStabilisationWindow, textToUrl, (⭒))
 import           Shelley.Spec.Ledger.BlockChain (pattern HashHeader, LastAppliedBlock (..), bhHash,
                      bheader, hashHeaderToNonce)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
@@ -2343,7 +2343,7 @@ blockEx5F = mkBlock
               0
               (mkOCert (coreNodeKeys 0) 0 (KESPeriod 0))
 
--- | The second transaction in the next epoch and at least `startRewards` slots
+-- | The second transaction in the next epoch and at least `randomnessStabilisationWindow` slots
 -- after the transaction carrying the MIR certificate, then creates the rewards
 -- update that contains the transfer of `100` to Alice.
 
@@ -2358,7 +2358,7 @@ txbodyEx5F' = TxBody
                (Wdrl Map.empty)
                (Coin 1)
                ((slotFromEpoch $ EpochNo 1)
-                +* Duration (startRewards testGlobals) + SlotNo 7)
+                +* Duration (randomnessStabilisationWindow testGlobals) + SlotNo 7)
                SNothing
                SNothing
 
@@ -2371,7 +2371,7 @@ blockEx5F' = mkBlock
               (coreNodeKeys 5)
               [txEx5F']
               ((slotFromEpoch $ EpochNo 1)
-                +* Duration (startRewards testGlobals) + SlotNo 7)
+                +* Duration (randomnessStabilisationWindow testGlobals) + SlotNo 7)
               (BlockNo 2)
               (mkNonce 0)
               (NatNonce 1)
@@ -2420,7 +2420,7 @@ ex5F' = do
   nextState <- runShelleyBase $ applySTS @CHAIN (TRC (SlotNo 90, initStEx2A, blockEx5F))
   midState <-
     runShelleyBase $ applySTS @CHAIN
-      (TRC (((slotFromEpoch $ EpochNo 1) + SlotNo 7) +* Duration (startRewards testGlobals)
+      (TRC (((slotFromEpoch $ EpochNo 1) + SlotNo 7) +* Duration (randomnessStabilisationWindow testGlobals)
            , nextState
            , blockEx5F')
       )

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Core.hs
@@ -68,7 +68,7 @@ import qualified Test.QuickCheck as QC
 import           Numeric.Natural (Natural)
 import           Shelley.Spec.Ledger.Address (pattern Addr, toAddr, toCred)
 import           Shelley.Spec.Ledger.BaseTypes (Nonce (..), UnitInterval, epochInfo, intervalValue,
-                     slotsPrior)
+                     stabilityWindow)
 import           Shelley.Spec.Ledger.BlockChain (pattern BHBody, pattern BHeader, pattern Block,
                      pattern BlockHash, TxSeq (..), bBodySize, bbHash, mkSeed, seedEta, seedL)
 import           Shelley.Spec.Ledger.Coin (Coin (..))
@@ -426,15 +426,15 @@ getKESPeriodRenewalNo keys (KESPeriod kp) =
           then n
           else go rest (n + 1) k
 
--- | True if the given slot is within the last `2 * slotsPrior`
+-- | True if the given slot is within the last `2 * stabilityWindow`
 -- slots of the current epoch.
 tooLateInEpoch :: HasCallStack => SlotNo -> Bool
 tooLateInEpoch s = runShelleyBase $ do
   ei <- asks epochInfo
   firstSlotNo <- epochInfoFirst ei (epochFromSlotNo s + 1)
-  slotsPrior_ <- asks slotsPrior
+  stabilityWindow <- asks stabilityWindow
 
-  return (s >= firstSlotNo *- Duration (2 * slotsPrior_))
+  return (s >= firstSlotNo *- Duration (2 * stabilityWindow))
 
 -- | Account with empty treasury
 genesisAccountState :: HasCallStack => AccountState

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Utils.hs
@@ -119,8 +119,8 @@ testGlobals :: Globals
 testGlobals = Globals
   { epochInfo = fixedSizeEpochInfo $ EpochSize 100
   , slotsPerKESPeriod = 20
-  , startRewards = 33
-  , slotsPrior = 33
+  , stabilityWindow = 33
+  , randomnessStabilisationWindow = 33
   , securityParameter = 10
   , maxKESEvo = 10
   , quorum = 5

--- a/shelley/chain-and-ledger/formal-spec/Properties.md
+++ b/shelley/chain-and-ledger/formal-spec/Properties.md
@@ -269,7 +269,7 @@ mapping inherited from Byron.
 **Consistency Property**
 In the absence of the extra entropy parameter,
 the epoch nonce is what you get from combining the blocks leading up to it
-(and stopping `SlotsPrior`-many slots in the previous epoch).
+(and stopping `StabilityWindow`-many slots in the previous epoch).
 
 # Decentralization Properties
 

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -631,12 +631,12 @@ the epoch nonce $\eta_0$, the candidate nonce $\eta_c$ and the evolving nonce $\
 
 The transition rule $\mathsf{UPDN}$ takes the slot \var{s} as signal. There are
 three different cases for $\mathsf{UPDN}$: one where we are in a new epoch, one
-where \var{s} is not yet \SlotsPrior{} slots from the beginning of the next
-epoch and one where \var{s} is less than \SlotsPrior{} slots until the start of
+where \var{s} is not yet \StabilityWindow{} slots from the beginning of the next
+epoch and one where \var{s} is less than \StabilityWindow{} slots until the start of
 the next epoch.
 
 This does assume that the first block in an epoch will occur before
-\SlotsPrior{} slots before the beginning of the next epoch.
+\StabilityWindow{} slots before the beginning of the next epoch.
 
 Note that in \ref{eq:update-both}, the nonce candidate $\eta_c$ transitions to
 $\eta_v\seedOp\eta$, not $\eta_c\seedOp\eta$. The reason for this is that even
@@ -680,7 +680,7 @@ near the end of the epoch is not discarded).
   \begin{equation}\label{eq:update-both}
     \inference[Update-Both]
     {
-      s < \fun{firstSlot}~((\epoch{s}) + 1) - \SlotsPrior
+      s < \fun{firstSlot}~((\epoch{s}) + 1) - \RandomnessStabilisationWindow
     }
     {
       {\begin{array}{c}
@@ -711,7 +711,7 @@ near the end of the epoch is not discarded).
   \begin{equation}\label{eq:only-evolve}
     \inference[Only-Evolve]
     {
-      s \geq \fun{firstSlot}~((\epoch{s}) + 1) - \SlotsPrior
+      s \geq \fun{firstSlot}~((\epoch{s}) + 1) - \RandomnessStabilisationWindow
     }
     {
       {\begin{array}{c}
@@ -780,12 +780,12 @@ execution of the transition role is as follows:
 
 \begin{itemize}
 \item If the current reward update \var{ru} is empty and \var{s} is greater than
-  the sum of the first slot of its epoch and the duration \StartRewards, then a
+  the sum of the first slot of its epoch and the duration \StabilityWindow, then a
   new rewards update is calculated and the state is updated.
 \item If the current reward update \var{ru} is not \Nothing, i.e., a reward
   update has already been calculated but not yet applied, then the state is not updated.
 \item If the current reward update \var{ru} is empty and \var{s} is less than or equal to the sum
-  of the first slot of its epoch and the duration to start rewards \StartRewards,
+  of the first slot of its epoch and the duration to start rewards \StabilityWindow,
   then the state is not updated.
 \end{itemize}
 
@@ -793,7 +793,7 @@ execution of the transition role is as follows:
   \begin{equation}\label{eq:reward-update}
     \inference[Create-Reward-Update]
     {
-      s > \fun{firstSlot}~(\epoch{s}) + \StartRewards
+      s > \fun{firstSlot}~(\epoch{s}) + \StabilityWindow
       &
       ru = \Nothing
       \\~\\
@@ -833,7 +833,7 @@ execution of the transition role is as follows:
     {
       ru = \Nothing
       \\
-      s \leq \fun{firstSlot}~(\epoch{s}) + \StartRewards
+      s \leq \fun{firstSlot}~(\epoch{s}) + \StabilityWindow
     }
     {
       {\begin{array}{c}

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -227,7 +227,7 @@ state transition types. We define two separate parts of the ledger state.
       stake hashkey of a pointer address.
       \item $\var{fGenDelegs}$ are the future genesis keys delegations. This variable
       is needed because genesis keys can only update their delegation with a
-      delay of $\SlotsPrior$ slots after submitting the certificate (this is
+      delay of $\StabilityWindow$ slots after submitting the certificate (this is
       necessary for header validation, see Section \ref{sec:chain})
       \item $\var{genDelegs}$ maps genesis key hashes to hashes of the cold key
         delegates.
@@ -394,7 +394,7 @@ concerns are independent of the ledger rules.
     Genesis delegation causes the following state transformation:
     \begin{itemize}
       \item The future genesis delegation relation is updated with the new delegate
-        to be adopted in $\SlotsPrior$-many slots.
+        to be adopted in $\StabilityWindow$-many slots.
       \end{itemize}
 
     \item  Moving instantaneous rewards is handled by \cref{eq:deleg-mir}. There
@@ -532,7 +532,7 @@ concerns are independent of the ledger rules.
       \var{c}\in \DCertGen
       & (\var{gkh},~\var{vkh})\leteq\fun{genesisDeleg}~{c}
       \\
-      s'\leteq\var{slot}+\SlotsPrior
+      s'\leteq\var{slot}+\StabilityWindow
       & \var{gkh}\in\dom{genDelegs}
       & \var{vkh}\notin\range{genDelegs}
     }
@@ -580,7 +580,7 @@ concerns are independent of the ledger rules.
     \inference[Deleg-Mir]
     {
       \var{c}\in \DCertMir\\
-      slot < \fun{firstSlot}~((\epoch{slot}) + 1) - \fun{SlotsPrior}\\
+      slot < \fun{firstSlot}~((\epoch{slot}) + 1) - \fun{StabilityWindow}\\
       \left(
         \sum\limits_{\wcard\mapsto\var{val}\in(\var{i_{rwd}}\unionoverrideRight\var{i_{rwd}})} val      \right)\leq\var{reserves}
     }

--- a/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
+++ b/shelley/chain-and-ledger/formal-spec/ledger-spec.tex
@@ -76,13 +76,13 @@
 \newcommand{\PParamsUpdate}{\type{PParamsUpdate}}
 \newcommand{\ProposedPPUpdates}{\type{ProposedPPUpdates}}
 \newcommand{\Slot}{\type{Slot}}
-\newcommand{\SlotsPrior}{\ensuremath{\mathsf{SlotsPrior}}}
+\newcommand{\StabilityWindow}{\ensuremath{\mathsf{StabilityWindow}}}
+\newcommand{\RandomnessStabilisationWindow}{\ensuremath{\mathsf{RandomnessStabilisationWindow}}}
 \newcommand{\SlotsPerEpoch}{\mathsf{SlotsPerEpoch}}
 \newcommand{\SlotsPerKESPeriod}{\mathsf{SlotsPerKESPeriod}}
 \newcommand{\MaxMajorPV}{\mathsf{MaxMajorPV}}
 \newcommand{\ActiveSlotCoeff}{\mathsf{ActiveSlotCoeff}}
 \newcommand{\BlockNo}{\type{BlockNo}}
-\newcommand{\StartRewards}{\ensuremath{\mathsf{StartRewards}}}
 \newcommand{\MaxKESEvo}{\ensuremath{\mathsf{MaxKESEvo}}}
 \newcommand{\Quorum}{\ensuremath{\mathsf{Quorum}}}
 \newcommand{\MaxLovelaceSupply}{\ensuremath{\mathsf{MaxLovelaceSupply}}}

--- a/shelley/chain-and-ledger/formal-spec/notation.tex
+++ b/shelley/chain-and-ledger/formal-spec/notation.tex
@@ -44,7 +44,7 @@ The transition system is explained in \cite{small_step_semantics}.
   It is meant to make the spec easier to read in the sense that each time we use it,
   we use a fresh variable as shorthand notation for an expression, e.g. we write
 
-  \[s := slot + \SlotsPrior\]
+  \[s := slot + \StabilityWindow\]
 
   Then, in subsequent expressions, it is more convenient to write simply $s$.
   It is not meant to shadow variables, and if it does, there is likely a problem with the

--- a/shelley/chain-and-ledger/formal-spec/properties.tex
+++ b/shelley/chain-and-ledger/formal-spec/properties.tex
@@ -668,7 +668,7 @@ of those from Section 8.1 of \cite{byron_chain_spec}.
 In any given chain state, the consensus layer needs to be able to validate the
 block headers without having to download the block bodies.
 Property~\ref{prop:header-only-validation} states that if an extension of a
-chain that spans less than $\SlotsPrior$ slots is valid, then validating the
+chain that spans less than $\StabilityWindow$ slots is valid, then validating the
 headers of that extension is also valid. This property is useful for its
 converse: if the header validation check for a sequence of headers does not
 pass, then we know that the block validation that corresponds to those headers
@@ -771,7 +771,7 @@ it does not call $\mathsf{BBODY}$.
     and chain extensions $E$ with corresponding headers $H$ such that:
   %
   $$
-  0 \leq t_E - t  \leq \SlotsPrior
+  0 \leq t_E - t  \leq \StabilityWindow
   $$
   %
   we have:
@@ -789,7 +789,7 @@ it does not call $\mathsf{BBODY}$.
   For all environments $e$, states $s$ with slot number $t$, and chain
   extensions $E = [b_0, \ldots, b_n]$ with corresponding headers $H$ such that:
   $$
-  0 \leq t_E - t  \leq \SlotsPrior
+  0 \leq t_E - t  \leq \StabilityWindow
   $$
   we have that for all $i \in [1, n]$:
   $$
@@ -835,7 +835,7 @@ block bodies were valid.
 \begin{property}[Existence of roll back function]\label{prop:roll-back-funk}
   There exists a function $\fun{f}$ such that for all chains
   $$C = C_0 ; b; C_1$$
-  we have that if for all alternative chains $C'_1$, $\size{C'_1} \leq \frac{\SlotsPrior}{2}$, with
+  we have that if for all alternative chains $C'_1$, $\size{C'_1} \leq \frac{\StabilityWindow}{2}$, with
   corresponding headers $H'_1$
   $$
   e \vdash s_0 \transtar{\hyperref[fig:rules:chain]{chain}}{C_0;b} s_1 \transtar{\hyperref[fig:rules:chain]{chain}}{C_1} s_2

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -27,7 +27,7 @@ For the software update mechanism, see Section~\ref{sec:software-updates}.
 The constants $\SlotsPerEpoch$ and $\SlotsPerKESPeriod$
 represent the number of slots in an epoch/KES period (for a brief explanation
 of a KES period, see Section \ref{sec:crypto-primitives-shelley}).
-The constants $\SlotsPrior$ and $\StartRewards$ concern the chain stability.
+The constants $\StabilityWindow$ and $\RandomnessStabilisationWindow$ concern the chain stability.
 The maximum number of time a KES key can be evolved before a pool operator
 must create a new operational certificate is given by $\MaxKESEvo$.
 \textbf{Note that if } $\MaxKESEvo$
@@ -164,15 +164,23 @@ without being explicit about the types and conversion.
   %
   \begin{equation*}
     \begin{array}{r@{~\in~}lr}
-      \SlotsPerEpoch & \N & \text{slots per epoch} \\
-      \SlotsPerKESPeriod & \N & \text{slots per KES period} \\
-      \SlotsPrior & \Duration & \text{nonce leakage parameter }\tau\text{ in \cite{ouroboros_praos}}\\
-      \StartRewards & \Duration & \text{duration to start reward calculations}\\
-      \MaxKESEvo & \N & \text{maximum KES key evolutions}\\
-      \Quorum & \N & \text{quorum for update system votes}\\
-      \MaxMajorPV & \N & \text{all blocks are invalid after this value}\\
-      \MaxLovelaceSupply & \Coin & \text{total lovelace in the system}\\
-      \ActiveSlotCoeff & (0, 1] & f\text{ in \cite{ouroboros_praos}}\\
+      \SlotsPerEpoch & \N & \text{- slots per epoch} \\
+      \SlotsPerKESPeriod & \N & \text{- slots per KES period} \\
+      \StabilityWindow & \Duration &
+      \begin{array}{r}
+        \text{- window size for chain growth} \\
+        \text{guarantees, see}\text{ in \cite{ouroboros_praos}}
+      \end{array} \\
+      \RandomnessStabilisationWindow & \Duration &
+      \begin{array}{r}
+        \text{- duration needed for epoch}\\
+        \text{nonce stabilization}\\
+      \end{array} \\
+      \MaxKESEvo & \N & \text{- maximum KES key evolutions}\\
+      \Quorum & \N & \text{- quorum for update system votes}\\
+      \MaxMajorPV & \N & \text{- all blocks are invalid after this value}\\
+      \MaxLovelaceSupply & \Coin & \text{- total lovelace in the system}\\
+      \ActiveSlotCoeff & (0, 1] & -~f\text{ in \cite{ouroboros_praos}}\\
     \end{array}
   \end{equation*}
   %

--- a/shelley/chain-and-ledger/formal-spec/update.tex
+++ b/shelley/chain-and-ledger/formal-spec/update.tex
@@ -53,7 +53,7 @@ parameters, see Figure \ref{fig:ts-types:pp-update} (for the corresponding rules
 see Figure \ref{fig:rules:pp-update}).
 The signal for this transition is an optional update.
 
-Protocol updates are only allowed up until ($2\cdot\SlotsPrior$)-many slots before the
+Protocol updates are only allowed up until ($2\cdot\StabilityWindow$)-many slots before the
 end of the epoch. The reason for this involves how we safely predict hard forks.
 Changing the protocol version can result in a hard fork, and we would like an
 entire stability period between when we know that a hard fork will necessarily happen
@@ -72,7 +72,7 @@ This rule has the following predicate failures:
 
 \begin{enumerate}
 \item In the case of \var{slot} being greater than or equal to
-  $\fun{firstSlot}~((\epoch{slot}) + 1) - 2\cdot\fun{SlotsPrior}$, there is
+  $\fun{firstSlot}~((\epoch{slot}) + 1) - 2\cdot\fun{StabilityWindow}$, there is
   a \emph{PPUpdateTooLate} failure.
 \item In the case that the epoch number in the signal does not match the current epoch,
   there is a \emph{PPUpdateWrongEpoch} failure.
@@ -137,7 +137,7 @@ This rule has the following predicate failures:
       \forall\var{ps}\in\range{pup},~
         \var{pv}\mapsto\var{v}\in\var{ps}\implies\fun{pvCanFollow}~(\fun{pv}~\var{pp})~\var{v}
       \\
-      \var{slot} < \fun{firstSlot}~((\epoch{slot}) + 1) - 2\cdot\SlotsPrior
+      \var{slot} < \fun{firstSlot}~((\epoch{slot}) + 1) - 2\cdot\StabilityWindow
       \\
       \epoch{slot} = e
     }


### PR DESCRIPTION
* `slotsPrior` has been renamed `stabilityWindow` (which corresponds to `3k/f` in Praos)
* `startRewards` has been removed, and reward updates now start `stabilityWindow`-many slots into the epoch
* a new constant, `randomnessStabilisationWindow`, has been added, which is used only in the `UPDN` (update nonce) rule and which determines the point in the epoch when the evolving nonce stabilizes. this constant corresponds to `4k/f` in Ouroboros Genesis.

closes #1391 