### PR TITLE
total stake (for reward calculation) is max supply minus reserves

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -67,7 +67,6 @@ module Shelley.Spec.Ledger.LedgerState
   -- epoch boundary
   , stakeDistr
   , applyRUpd
-  , totalStake
   , createRUpd
   --
   , NewEpochState(..)
@@ -94,7 +93,7 @@ import           Data.Set (Set)
 import qualified Data.Set as Set
 import           GHC.Generics (Generic)
 import           Shelley.Spec.Ledger.Address (Addr (..))
-import           Shelley.Spec.Ledger.Credential (Credential (..), StakeReference (..))
+import           Shelley.Spec.Ledger.Credential (Credential (..))
 import           Shelley.Spec.Ledger.Coin (Coin (..))
 import           Shelley.Spec.Ledger.Crypto (Crypto)
 import           Shelley.Spec.Ledger.EpochBoundary (BlocksMade (..), SnapShot (..), SnapShots (..),
@@ -1002,35 +1001,20 @@ updateNonMypopic nm rPot aps ss = nm
     aps' = Map.mapWithKey performance (aps `Map.union` performanceZero)
 
 
--- | Compute the total stake
-totalStake
-  :: LedgerState crypto
-  -> Coin
-totalStake ls = totalUtxoStake + totalRewardStake
-  where
-    outputStake (TxOut (Addr _ (StakeRefBase _)) c) = c
-    outputStake (TxOut (Addr _ (StakeRefPtr _ )) c) = c
-    outputStake (TxOut (Addr _ (StakeRefNull  )) _) = 0
-    outputStake (TxOut (AddrBootstrap _)         _) = 0
-    (UTxO utxo) = _utxo . _utxoState $ ls
-    totalUtxoStake = Map.foldl' (\acc out -> outputStake out + acc) 0 utxo
-    totalRewardStake = sum $ _rewards . _dstate . _delegationState $ ls
-
 -- | Create a reward update
 createRUpd
   :: EpochNo
   -> BlocksMade crypto
   -> EpochState crypto
+  -> Coin
   -> ShelleyBase (RewardUpdate crypto)
-createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) = do
+createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total = do
     ei <- asks epochInfo
     slotsPerEpoch <- epochInfoSize ei e
     asc <- asks activeSlotCoeff
     let SnapShot stake' delegs' poolParams = _pstakeGo ss
         Coin reserves = _reserves acnt
         ds = _dstate $ _delegationState ls
-
-        total = totalStake ls
 
         -- reserves and rewards change
         deltaR_ = (floor $ min 1 eta * intervalValue (_rho pr) * fromIntegral reserves)

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/LedgerState.hs
@@ -1026,7 +1026,9 @@ createRUpd e b@(BlocksMade b') (EpochState acnt ss ls pr _ nm) total = do
         deltaT1 = floor $ intervalValue (_tau pr) * fromIntegral rPot
         _R = Coin $ rPot - deltaT1
 
-        (rs_, aps) = reward pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' total
+        circulation = total - (_reserves acnt)
+        (rs_, aps) =
+          reward pr b _R (Map.keysSet $ _rewards ds) poolParams stake' delegs' circulation
         deltaT2 = _R - (Map.foldr (+) (Coin 0) rs_)
 
         blocksMade = fromIntegral $ Map.foldr (+) 0 b' :: Integer

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -1271,10 +1271,10 @@ blockEx2HHash :: HashHeader
 blockEx2HHash = bhHash (bheader blockEx2H)
 
 aliceRAcnt2H :: Coin
-aliceRAcnt2H = Coin 23839338840
+aliceRAcnt2H = Coin 5827393939
 
 bobRAcnt2H :: Coin
-bobRAcnt2H = Coin 2124297519
+bobRAcnt2H = Coin 519272726
 
 rewardsEx2H :: Map RewardAcnt Coin
 rewardsEx2H = Map.fromList [ (RewardAcnt aliceSHK, aliceRAcnt2H)
@@ -1291,8 +1291,15 @@ alicePerfEx2H :: ApparentPerformance
 alicePerfEx2H = ApparentPerformance (beta / sigma)
   where
     beta = 1 -- Alice produced the only decentralized block this epoch
-    sigma = fromRational (fromIntegral stake % fromIntegral maxLLSupply)
+    reserves = _reserves acntEx2G
+    sigma = fromRational (fromIntegral stake % (fromIntegral $ maxLLSupply - reserves))
     stake = aliceCoinEx2BBase + aliceCoinEx2BPtr + bobInitCoin
+
+deltaT2H :: Coin
+deltaT2H = Coin 786986666678
+
+deltaR2H :: Coin
+deltaR2H = Coin (-793333333333)
 
 expectedStEx2H :: ChainState
 expectedStEx2H = ChainState
@@ -1301,8 +1308,8 @@ expectedStEx2H = ChainState
      (BlocksMade $ Map.singleton (hk alicePool) 1)
      (BlocksMade Map.empty)
      (EpochState acntEx2G snapsEx2G expectedLSEx2G ppsEx1 ppsEx1 emptyNonMyopic)
-     (SJust RewardUpdate { deltaT        = Coin 767369696984
-                         , deltaR        = Coin (-793333333333)
+     (SJust RewardUpdate { deltaT        = deltaT2H
+                         , deltaR        = deltaR2H
                          , rs            = rewardsEx2H
                          , deltaF        = Coin (-10)
                          , nonMyopic     = NonMyopic
@@ -1354,8 +1361,8 @@ epoch1OSchedEx2I = runShelleyBase $ overlaySchedule
 
 acntEx2I :: AccountState
 acntEx2I = AccountState
-            { _treasury = Coin 767369697024
-            , _reserves = Coin 33999206666666557
+            { _treasury = (_treasury acntEx2G) + deltaT2H
+            , _reserves = (_reserves acntEx2G) + deltaR2H
             }
 
 dsEx2I :: DState

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -131,7 +131,7 @@ import           Shelley.Spec.Ledger.LedgerState (AccountState (..), pattern Act
                      genesisCoins, genesisId, nesEs, nonMyopic, overlaySchedule, rs,
                      _delegationState, _delegations, _dstate, _fGenDelegs, _genDelegs, _irwd,
                      _pParams, _ptrs, _reserves, _retiring, _rewards, _stPools, _stkCreds,
-                     _treasury, totalStake)
+                     _treasury)
 import           Shelley.Spec.Ledger.OCert (KESPeriod (..))
 import           Shelley.Spec.Ledger.PParams (PParams, PParams' (PParams), PParamsUpdate,
                      pattern ProposedPPUpdates, pattern Update, emptyPPPUpdates, emptyPParams, _a0,
@@ -1271,10 +1271,10 @@ blockEx2HHash :: HashHeader
 blockEx2HHash = bhHash (bheader blockEx2H)
 
 aliceRAcnt2H :: Coin
-aliceRAcnt2H = Coin 5827393939
+aliceRAcnt2H = Coin 23839338840
 
 bobRAcnt2H :: Coin
-bobRAcnt2H = Coin 519272726
+bobRAcnt2H = Coin 2124297519
 
 rewardsEx2H :: Map RewardAcnt Coin
 rewardsEx2H = Map.fromList [ (RewardAcnt aliceSHK, aliceRAcnt2H)
@@ -1287,14 +1287,11 @@ oCertIssueNosEx2H =
     2
     oCertIssueNosEx2G
 
-totalStakeEx2H :: Coin
-totalStakeEx2H = totalStake expectedLSEx2G
-
 alicePerfEx2H :: ApparentPerformance
 alicePerfEx2H = ApparentPerformance (beta / sigma)
   where
     beta = 1 -- Alice produced the only decentralized block this epoch
-    sigma = fromRational (fromIntegral stake % fromIntegral totalStakeEx2H)
+    sigma = fromRational (fromIntegral stake % fromIntegral maxLLSupply)
     stake = aliceCoinEx2BBase + aliceCoinEx2BPtr + bobInitCoin
 
 expectedStEx2H :: ChainState
@@ -1304,7 +1301,7 @@ expectedStEx2H = ChainState
      (BlocksMade $ Map.singleton (hk alicePool) 1)
      (BlocksMade Map.empty)
      (EpochState acntEx2G snapsEx2G expectedLSEx2G ppsEx1 ppsEx1 emptyNonMyopic)
-     (SJust RewardUpdate { deltaT        = Coin 786986666678
+     (SJust RewardUpdate { deltaT        = Coin 767369696984
                          , deltaR        = Coin (-793333333333)
                          , rs            = rewardsEx2H
                          , deltaF        = Coin (-10)
@@ -1357,7 +1354,7 @@ epoch1OSchedEx2I = runShelleyBase $ overlaySchedule
 
 acntEx2I :: AccountState
 acntEx2I = AccountState
-            { _treasury = Coin 786986666718
+            { _treasury = Coin 767369697024
             , _reserves = Coin 33999206666666557
             }
 

--- a/shelley/chain-and-ledger/formal-spec/chain.tex
+++ b/shelley/chain-and-ledger/formal-spec/chain.tex
@@ -797,7 +797,7 @@ execution of the transition role is as follows:
       &
       ru = \Nothing
       \\~\\
-      ru' \leteq \createRUpd{b}{es}
+      ru' \leteq \createRUpd{b}{es}{\MaxLovelaceSupply}
     }
     {
       {\begin{array}{c}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -1381,8 +1381,9 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
     & ~~~~~~~\var{rewardPot} = \var{feeSS} + \Delta r \\
     & ~~~~~~~\Delta t_1 = \floor*{(\fun{tau}~\var{prevPp}) \cdot \var{rewardPot}} \\
     & ~~~~~~~\var{R} = \var{rewardPot} - \Delta t_1 \\
+    & ~~~~~~~\var{circulation} = \var{total} - \var{reserves} \\
     & ~~~~~~~\var{rs}
-      = \reward{prevPp}{b}{R}{(\dom{rewards})}{poolsSS}{stake}{delegs}{total} \\
+      = \reward{prevPp}{b}{R}{(\dom{rewards})}{poolsSS}{stake}{delegs}{circulation} \\
     & ~~~~~~~\Delta t_{2} = R - \left(\sum\limits_{\_\mapsto c\in\var{rs}}c\right) \\
     & ~~~~~~~blocksMade = \sum_{\wcard \mapsto m \in b}m
   \end{align*}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -28,7 +28,7 @@
 \newcommand{\lReward}[4]{\fun{r_{operator}}~ \var{#1}~ \var{#2}~ \var{#3}~ {#4}}
 \newcommand{\mReward}[4]{\fun{r_{member}}~ \var{#1}~ \var{#2}~ \var{#3}~ {#4}}
 \newcommand{\poolReward}[5]{\fun{poolReward}~\var{#1}~{#2}~\var{#3}~\var{#4}~\var{#5}}
-\newcommand{\createRUpd}[2]{\fun{createRUpd}~\var{#1}~\var{#2}}
+\newcommand{\createRUpd}[3]{\fun{createRUpd}~\var{#1}~\var{#2}~\var{#3}}
 \newcommand{\getIR}[1]{\fun{getIR}~\var{#1}}
 
 This chapter introduces the epoch boundary transition system and the related reward calculation.
@@ -1314,8 +1314,7 @@ The $\fun{createRUpd}$ function does the following:
   \item Note that for all the calculations below, we use the previous protocol parameters
     $\var{prevPp}$, which corresponds to the parameters during the epoch for which we
     are creating rewards.
-  \item First we calculate the total stake.
-  \item Then we calculate the change to the reserves,
+  \item First we calculate the change to the reserves,
     as determined by the $\rho$ protocol parameter.
   \item Next we calculate $\var{rewardPot}$, the total amount of coin available for rewards this
     epoch, as described in section 6.4 of \cite{delegation_design}. It consists of four pots:
@@ -1360,25 +1359,11 @@ and $\fun{applyRUpd}$ will be used in Equation~\ref{eq:new-epoch}.
   \emph{Calculation to create a reward update}
   %
   \begin{align*}
-    & \fun{totalStake} \in \LState \to \Coin \\
-    & \fun{totalStake}~\var{ls} = \var{totalUtxoStake} + \var{totalRewardStake} \\
-    & ~~~\where \\
-    & ~~~~~~~((\var{utxo},\wcard,\wcard,\wcard),
-    ~((\wcard,~\var{rewards},\wcard,\wcard,\wcard,\wcard,\wcard),~\wcard))
-    = \var{ls} \\
-    & ~~~~~~~totalUtxoStake =
-    \sum \{c~\mid~\wcard\mapsto(a,~c)\in\var{utxo},~a\in\AddrB\uniondistinct\AddrP\} \\
-    & ~~~~~~~totalRewardStake =
-    \sum \{c~\mid~\wcard\mapsto c\in\var{rewards}\}
-  \end{align*}
-  %
-  \begin{align*}
-    & \fun{createRUpd} \in \BlocksMade \to \EpochState \to \RewardUpdate \\
-    & \createRUpd{b}{es} = \left(
+    & \fun{createRUpd} \in \BlocksMade \to \EpochState \to \Coin \to \RewardUpdate \\
+    & \createRUpd{b}{es}{total} = \left(
       \Delta t_1+\Delta t_2,-~\Delta r,~\var{rs},~-\var{feeSS}\right) \\
     & ~~~\where \\
     & ~~~~~~~(\var{acnt},~\var{ss},~\var{ls},~\var{prevPp},~\wcard) = \var{es} \\
-    & ~~~~~~~\var{total} = \fun{totalStake}~\var{ls} \\
     & ~~~~~~~(\wcard,~\wcard,~\var{pstake_{go}},~\var{poolsSS},~\var{feeSS}) = \var{ss}\\
     & ~~~~~~~(\var{stake},~\var{delegs}) = \var{pstate_{go}} \\
     & ~~~~~~~(\wcard,~\var{reserves}) = \var{acnt} \\


### PR DESCRIPTION
In #1428 the total stake valued used for the reward calculation was changed from the the max supply (ie 45B ada) to the sum of the ada held in base addresses, pointer addresses, and reward accounts. Unfortunately this turns out not to be what we want either. This PR reverts the early change and instead uses the max supply less the reserve amount.

The PR is easier to read if you ignore the revert and only look at the second commit. :)