### PR TITLE
Expose Tx.txFullBytes

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/Tx.hs
@@ -18,7 +18,8 @@ module Shelley.Spec.Ledger.Tx
         _witnessVKeySet,
         _witnessMSigMap,
         _metadata,
-        txWitsBytes
+        txWitsBytes,
+        txFullBytes
       ),
     TxBody (..),
     TxOut (..),


### PR DESCRIPTION
Consensus can use this annotation to compute the expected post-serialisation
size of the transaction.