### PR TITLE
Add realistic crypto golden tests for serialiseAddr

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Address.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Address.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Shelley.Spec.Ledger.Address
-  ( addressTests,
+  ( addressTests
   )
 where
 
@@ -33,7 +33,7 @@ import qualified Test.Tasty.HUnit as T
 import qualified Test.Tasty.Hedgehog as T
 
 addressTests :: TestTree
-addressTests = T.testGroup "binary tests" [goldenTests, roundTripTests]
+addressTests = T.testGroup "Address binary and golden tests" [goldenTests, roundTripTests]
 
 goldenTests :: TestTree
 goldenTests =

--- a/shelley/chain-and-ledger/executable-spec/test/Tests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Tests.hs
@@ -24,6 +24,7 @@ mainTests =
       cddlTests 5,
       minimalPropertyTests,
       serializationTests,
+      addressTests,
       stsTests,
       unitTests
     ]

--- a/shelley/chain-and-ledger/executable-spec/test/Tests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Tests.hs
@@ -24,7 +24,6 @@ mainTests =
       cddlTests 5,
       minimalPropertyTests,
       serializationTests,
-      addressTests,
       stsTests,
       unitTests
     ]


### PR DESCRIPTION
Done : 
- [x] switch on AddressTests
- [x] added some tests for enterprise, base and ptr addresses that use proper key length, also used proper hashing.
- [x] added RealisticCrypto based on what is used for Shelley
- [x] added golden tests for network id =0,1,2

I run tests via : 
```
stack test shelley-spec-ledger:test:shelley-spec-ledger-test --ta '-p "golden tests"' 
```