### PR TITLE
Make the encoding/decoding less lenient

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/cddl-files/mock/crypto.cddl
+++ b/shelley/chain-and-ledger/executable-spec/cddl-files/mock/crypto.cddl
@@ -4,7 +4,7 @@ $hash32 /= bytes .size 4
 $vkey /= bytes .size 8
 
 $vrf_vkey /= bytes .size 8
-$vrf_cert /= [natural, bytes .size 16]
+$vrf_cert /= [natural, bytes .size 10]
 natural = #6.2(bytes)
 
 $kes_vkey /= bytes .size 8


### PR DESCRIPTION
We have tests in `ouroboros-network` that verify we can detect corruption. This was causing them to fail, since it didn't care about what was in the high bits of a `Word64`.