### PR TITLE
Minimal Value UTxO outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ corresponding to the Byron release). Then the tests can be run by executing:
 stack test
 ```
 
+**Note** that the tests in `shelley-spec-ledger` require two Ruby gems,
+[cbor-diag](https://rubygems.org/gems/cbor-diag) and
+[cddl](https://rubygems.org/gems/cddl).
+
 For the executable models test suites that use `tasty` (e.g. Byron), it is possible to select which
 tests to run by passing the `-p` flag to the test program, followed by an `awk` pattern. For
 instance for running only the `UTxO` tests, we can pass the `-p UTxO` option. `tasty` allows for

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -52,7 +52,7 @@ import Shelley.Spec.Ledger.STS.Utxo
     pattern FeeTooSmallUTxO,
     pattern InputSetEmptyUTxO,
     pattern MaxTxSizeUTxO,
-    pattern NegativeOutputsUTxO,
+    pattern OutputTooSmallUTxO,
     pattern UpdateFailure,
     pattern ValueNotConservedUTxO,
   )

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Examples.hs
@@ -212,6 +212,7 @@ import Shelley.Spec.Ledger.PParams
     _maxTxSize,
     _minfeeA,
     _minfeeB,
+    _minUTxOValue,
     _nOpt,
     _poolDecayRate,
     _poolDeposit,
@@ -555,7 +556,8 @@ ppsEx1 =
       _keyDecayRate = 0.002,
       _keyMinRefund = unsafeMkUnitInterval 0.5,
       _poolDecayRate = 0.001,
-      _poolMinRefund = unsafeMkUnitInterval 0.5
+      _poolMinRefund = unsafeMkUnitInterval 0.5,
+      _minUTxOValue = 100
     }
 
 -- | Never decay.
@@ -684,7 +686,8 @@ ppupEx2A =
             _tau = SNothing,
             _d = SNothing,
             _extraEntropy = SNothing,
-            _protocolVersion = SNothing
+            _protocolVersion = SNothing,
+            _minUTxOValue = SNothing
           }
       )
 
@@ -2096,7 +2099,8 @@ ppVote3A =
       _tau = SNothing,
       _d = SNothing,
       _extraEntropy = SJust (mkNonce 123),
-      _protocolVersion = SNothing
+      _protocolVersion = SNothing,
+      _minUTxOValue = SNothing
     }
 
 ppupEx3A :: ProposedPPUpdates

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples/Serialization.hs
@@ -130,6 +130,7 @@ import Shelley.Spec.Ledger.PParams
     _maxTxSize,
     _minfeeA,
     _minfeeB,
+    _minUTxOValue,
     _nOpt,
     _poolDecayRate,
     _poolDeposit,
@@ -679,7 +680,8 @@ serializationTests =
               _tau = SNothing,
               _d = SNothing,
               _extraEntropy = SNothing,
-              _protocolVersion = SNothing
+              _protocolVersion = SNothing,
+              _minUTxOValue = SNothing
             } ::
             PParamsUpdate
         )
@@ -704,6 +706,7 @@ serializationTests =
           d = UnsafeUnitInterval $ 1 % 9
           extraEntropy = NeutralNonce
           protocolVersion = ProtVer 0 1
+          minUTxOValue = 121
        in checkEncodingCBOR
             "pparams_update_all"
             ( PParams
@@ -725,11 +728,12 @@ serializationTests =
                   _tau = SJust tau,
                   _d = SJust d,
                   _extraEntropy = SJust extraEntropy,
-                  _protocolVersion = SJust protocolVersion
+                  _protocolVersion = SJust protocolVersion,
+                  _minUTxOValue = SJust minUTxOValue
                 } ::
                 PParamsUpdate
             )
-            ( (T $ TkMapLen 19)
+            ( (T $ TkMapLen 20)
                 <> (T $ TkWord 0)
                 <> S minfeea
                 <> (T $ TkWord 1)
@@ -768,6 +772,8 @@ serializationTests =
                 <> S extraEntropy
                 <> (T $ TkWord 18)
                 <> S protocolVersion
+                <> (T $ TkWord 19)
+                <> S minUTxOValue
             ),
       -- checkEncodingCBOR "full_update"
       let ppup =
@@ -793,7 +799,8 @@ serializationTests =
                         _tau = SNothing,
                         _d = SNothing,
                         _extraEntropy = SNothing,
-                        _protocolVersion = SNothing
+                        _protocolVersion = SNothing,
+                        _minUTxOValue = SNothing
                       }
                   )
               )
@@ -861,7 +868,8 @@ serializationTests =
                             _tau = SNothing,
                             _d = SNothing,
                             _extraEntropy = SNothing,
-                            _protocolVersion = SNothing
+                            _protocolVersion = SNothing,
+                            _minUTxOValue = SNothing
                           }
                       )
                   )
@@ -925,7 +933,8 @@ serializationTests =
                             _tau = SNothing,
                             _d = SNothing,
                             _extraEntropy = SNothing,
-                            _protocolVersion = SNothing
+                            _protocolVersion = SNothing,
+                            _minUTxOValue = SNothing
                           }
                       )
                   )

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Update.hs
@@ -45,11 +45,11 @@ import Shelley.Spec.Ledger.PParams
     _maxTxSize,
     _minfeeA,
     _minfeeB,
+    _minUTxOValue,
     _nOpt,
     _poolDecayRate,
     _poolDeposit,
     _poolMinRefund,
-    _protocolVersion,
     _protocolVersion,
     _rho,
     _tau,
@@ -108,6 +108,7 @@ genPParams c@(Constants {maxMinFeeA, maxMinFeeB}) =
     <*> genDecentralisationParam
     <*> genExtraEntropy
     <*> genProtocolVersion
+    <*> genMinUTxOValue
   where
     szGen :: Gen (Natural, Natural, Natural)
     szGen = do
@@ -204,6 +205,9 @@ genDecentralisationParam = unsafeMkUnitInterval <$> QC.elements [0.1, 0.2 .. 1]
 genProtocolVersion :: HasCallStack => Gen ProtVer
 genProtocolVersion = ProtVer <$> genNatural 1 10 <*> genNatural 1 50
 
+genMinUTxOValue :: HasCallStack => Gen Natural
+genMinUTxOValue = pure 0 -- TODO generate nonzero minimum UTxO values
+
 -- | Generate a possible next Protocol version based on the previous version.
 -- Increments the Major or Minor versions and possibly the Alt version.
 genNextProtocolVersion ::
@@ -251,6 +255,7 @@ genPPUpdate (c@Constants {maxMinFeeA, maxMinFeeB}) s pp genesisKeys =
       d <- genDecentralisationParam
       extraEntropy <- genExtraEntropy
       protocolVersion <- genNextProtocolVersion pp
+      minUTxOValue <- genMinUTxOValue
       let pps =
             PParams
               { _minfeeA = SJust minFeeA,
@@ -271,7 +276,8 @@ genPPUpdate (c@Constants {maxMinFeeA, maxMinFeeB}) s pp genesisKeys =
                 _tau = SJust tau,
                 _d = SJust d,
                 _extraEntropy = SJust extraEntropy,
-                _protocolVersion = SJust protocolVersion
+                _protocolVersion = SJust protocolVersion,
+                _minUTxOValue = SJust minUTxOValue
               }
       let ppUpdate = zip genesisKeys (repeat pps)
       pure $

--- a/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
+++ b/shelley/chain-and-ledger/formal-spec/protocol-parameters.tex
@@ -124,6 +124,7 @@ without being explicit about the types and conversion.
         \var{d} \mapsto \{0,~0.1,~0.2,~\ldots,~1\} & \PParams & \text{decentralization parameter}\\
         \var{extraEntropy} \mapsto \Seed & \PParams & \text{extra entropy}\\
         \var{pv} \mapsto \ProtVer & \PParams & \text{protocol version}\\
+        \var{minUTxOValue} \mapsto \ProtVer & \PParams & \text{minimum allowed value of a new \TxOut}\\
       \end{array}
   \end{equation*}
   %
@@ -148,7 +149,8 @@ without being explicit about the types and conversion.
     \fun{rho},
     \fun{d},
     \fun{extraEntropy},
-    \fun{pv}
+    \fun{pv},
+    \fun{minUTxOValue},
   \end{center}
   %
   \emph{Abstract Functions}

--- a/shelley/chain-and-ledger/formal-spec/utxo.tex
+++ b/shelley/chain-and-ledger/formal-spec/utxo.tex
@@ -218,7 +218,8 @@ The transition contains the following predicates:
   \item
     The $\mathsf{PPUP}$ transition is successful.
   \item
-    The coin value of each new output must be non-negative.
+    The coin value of each new output must be at least as large as the
+    minimum value specified by the protocol parameter $\var{minUTxOValue}$.
   \item
     The transaction size must be below the allowed maximum.
     Note that there is an implicit max transaction size given by the max block size,
@@ -312,7 +313,7 @@ requests).
       \\
       ~
       \\
-      \forall (\_\mapsto (\_, c)) \in \txouts{txb}, c \geq 0
+      \forall (\_\mapsto (\_, c)) \in \txouts{txb}, c \geq (\fun{minUTxOValue}~\var{pp})
       \\
       \fun{txsize}~{tx}\leq\fun{maxTxSize}~\var{pp}
       \\
@@ -357,18 +358,22 @@ requests).
   \label{fig:rules:utxo-shelley}
 \end{figure}
 
-The UTXO rule has five predicate failures:
+The UTXO rule has seven predicate failures:
 \begin{itemize}
 \item In the case of any input not being valid, there is a \emph{BadInput}
   failure.
 \item In the case of the current slot being greater than the time-to-live of the
   current transaction, there is an \emph{Expired} failure.
+\item In the case that the transaction is too large,
+  there is a \emph{MaxTxSize} failure.
 \item In the case of an empty input set, there is a \emph{InputSetEmpty} failure,
   in order to prevent replay attacks.
 \item If the fees are smaller than the minimal transaction fees, there is a
   \emph{FeeTooSmall} failure.
 \item If the transaction does not correctly conserve the balance, there is a
   \emph{ValueNotConserved} failure.
+\item If the transaction creates an output below the allowed minimum value,
+  there is a \emph{OutputTooSmall} failure.
 \end{itemize}
 
 \clearpage


### PR DESCRIPTION
This PR represents a halfway move toward having UTxO deposits. In particular, it creates a new protocol parameter `minUTxOValue` and now checks that each new created transaction output is at least this value (therefore replacing the check that each output is non-negative).

I also took the opportunity to clean up the unit tests in `Test/Shelley.Spec.Ledger.Examples.UnitTests`. Several of them were redundant, less good version of tests now in `Test/Shelley.Spec.Ledger.Examples.Examples`, namely the `valid` ones. Others, the `invalid` ones, were using the `asStateTransition` function that pre-dates the `STS` framework, and I have now removed `asStateTransition` from these tests in favor of using the `LEDGER` rule directly.

I did not run ormolu (`scripts/ormolise.sh`). Or rather, I did run it, but it changed `src` files that I have not edited, so I think must not have the correct configuration. I also get an error on the file `STS/Prtcl.hs`.