### PR TITLE
Make PRTCL block-independent

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/API/Protocol.hs
@@ -88,7 +88,6 @@ instance Crypto crypto => ToCBOR (LedgerView crypto) where
 -- epoch.
 mkPrtclEnv ::
   LedgerView crypto ->
-  SlotNo ->
   -- | New epoch marker. This should be true iff this execution of the PRTCL
   -- rule is being run on the first block in a new epoch.
   Bool ->

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BlockChain.hs
@@ -28,6 +28,7 @@ module Shelley.Spec.Ledger.BlockChain
     bhHash,
     bbHash,
     hashHeaderToNonce,
+    prevHashToNonce,
     bHeaderSize,
     bBodySize,
     slotToNonce,
@@ -298,6 +299,18 @@ instance
         decodeNull
         pure GenesisHash
       _ -> BlockHash <$> fromCBOR
+
+prevHashToNonce ::
+  PrevHash crypto ->
+  Nonce
+prevHashToNonce = \case
+  GenesisHash -> NeutralNonce -- This case can only happen when starting Shelley from genesis,
+  -- setting the intial chain state to some epoch e,
+  -- and having the first block be in epoch e+1.
+  -- In this edge case there is no need to add any extra
+  -- entropy via the previous header hash to the next epoch nonce,
+  -- so using the neutral nonce is appropriate.
+  BlockHash ph -> hashHeaderToNonce ph
 
 data LastAppliedBlock crypto = LastAppliedBlock
   { labBlockNo :: !BlockNo,

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -40,9 +40,13 @@ import Shelley.Spec.Ledger.BlockChain
     Block (..),
     LastAppliedBlock (..),
     bHeaderSize,
+    bhHash,
     bhbody,
+    bheaderBlockNo,
     bheaderSlotNo,
     hBbsize,
+    lastAppliedHash,
+    prevHashToNonce,
   )
 import Shelley.Spec.Ledger.Coin (Coin (..))
 import Shelley.Spec.Ledger.Crypto
@@ -167,7 +171,7 @@ instance
     Signal (CHAIN crypto) =
       Block crypto
 
-  type Environment (CHAIN crypto) = SlotNo
+  type Environment (CHAIN crypto) = ()
   type BaseM (CHAIN crypto) = ShelleyBase
 
   data PredicateFailure (CHAIN crypto)
@@ -208,7 +212,7 @@ chainTransition ::
   TransitionRule (CHAIN crypto)
 chainTransition =
   judgmentContext
-    >>= \(TRC (sNow, ChainState nes cs eta0 etaV etaC etaH lab, block@(Block bh _))) -> do
+    >>= \(TRC ((), ChainState nes cs eta0 etaV etaC etaH lab, block@(Block bh _))) -> do
       let NewEpochState _ _ _ (EpochState _ _ _ _ pp _) _ _ _ = nes
 
       maxpv <- liftSTS $ asks maxMajorPV
@@ -227,11 +231,13 @@ chainTransition =
       let EpochState (AccountState _ _reserves) _ ls _ pp' _ = es
       let LedgerState _ (DPState (DState _ _ _ _ _ _genDelegs _) (PState _ _ _)) = ls
 
-      PrtclState cs' lab' eta0' etaV' etaC' etaH' <-
+      let ph = lastAppliedHash lab
+          etaPH = prevHashToNonce ph
+      PrtclState cs' _etaPH' eta0' etaV' etaC' etaH' <-
         trans @(PRTCL crypto) $
           TRC
-            ( PrtclEnv pp' osched _pd _genDelegs sNow (e1 /= e2),
-              PrtclState cs lab eta0 etaV etaC etaH,
+            ( PrtclEnv pp' osched _pd _genDelegs (e1 /= e2),
+              PrtclState cs etaPH eta0 etaV etaC etaH,
               bh
             )
 
@@ -240,6 +246,13 @@ chainTransition =
           TRC (BbodyEnv (Map.keysSet osched) pp' _reserves, BbodyState ls bcur, block)
 
       let nes'' = updateNES nes' bcur' ls'
+          bhb = bhbody bh
+          lab' =
+            At $
+              LastAppliedBlock
+                (bheaderBlockNo bhb)
+                (bheaderSlotNo bhb)
+                (bhHash bh)
 
       pure $ ChainState nes'' cs' eta0' etaV' etaC' etaH' lab'
 

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Chain.hs
@@ -181,6 +181,7 @@ instance
     | BbodyFailure !(PredicateFailure (BBODY crypto))
     | TickFailure (PredicateFailure (TICK crypto))
     | PrtclFailure !(PredicateFailure (PRTCL crypto))
+    | PrtclSeqFailure !(PrtlSeqFailure crypto)
     deriving (Show, Eq, Generic)
 
   initialRules = []
@@ -213,6 +214,10 @@ chainTransition ::
 chainTransition =
   judgmentContext
     >>= \(TRC ((), ChainState nes cs eta0 etaV etaC etaH lab, block@(Block bh _))) -> do
+      case prtlSeqChecks lab bh of
+        Right () -> pure ()
+        Left e -> failBecause $ PrtclSeqFailure e
+
       let NewEpochState _ _ _ (EpochState _ _ _ _ pp _) _ _ _ = nes
 
       maxpv <- liftSTS $ asks maxMajorPV

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Examples.hs
@@ -331,9 +331,7 @@ import Test.Shelley.Spec.Ledger.Utils
 import Test.Tasty.HUnit (Assertion, assertBool, assertFailure)
 
 data CHAINExample = CHAINExample
-  { -- | Current slot
-    currentSlotNo :: SlotNo,
-    -- | State to start testing with
+  { -- | State to start testing with
     startState :: ChainState,
     -- | Block to run chain state transition system on
     newBlock :: Block,
@@ -648,7 +646,7 @@ expectedStEx1 =
 
 -- | Wraps example all together.
 ex1 :: CHAINExample
-ex1 = CHAINExample (SlotNo 1) initStEx1 blockEx1 (Right expectedStEx1)
+ex1 = CHAINExample initStEx1 blockEx1 (Right expectedStEx1)
 
 -- * Example 2A - apply CHAIN transition to register stake keys and a pool
 
@@ -895,7 +893,7 @@ expectedStEx2A =
     )
 
 ex2A :: CHAINExample
-ex2A = CHAINExample (SlotNo 10) initStEx2A blockEx2A (Right expectedStEx2A)
+ex2A = CHAINExample initStEx2A blockEx2A (Right expectedStEx2A)
 
 -- * Example 2B - process a block late enough in the epoch in order to create a reward update.
 
@@ -1055,7 +1053,7 @@ expectedStEx2Bquater = expectedStEx2Bgeneric ppsExInstantDecay
 
 -- | Wrap plain example
 ex2B :: CHAINExample
-ex2B = CHAINExample (SlotNo 90) expectedStEx2A blockEx2B (Right expectedStEx2B)
+ex2B = CHAINExample expectedStEx2A blockEx2B (Right expectedStEx2B)
 
 -- | Example 2C - process an empty block in the next epoch
 -- so that the (empty) reward update is applied and a stake snapshot is made.
@@ -1184,20 +1182,20 @@ expectedStEx2Cquater =
 
 -- | Example 2C with standard decay.
 ex2C :: CHAINExample
-ex2C = CHAINExample (SlotNo 110) expectedStEx2B blockEx2C (Right expectedStEx2C)
+ex2C = CHAINExample expectedStEx2B blockEx2C (Right expectedStEx2C)
 
 -- | Example 2C with no decay.
 ex2Cbis :: CHAINExample
-ex2Cbis = CHAINExample (SlotNo 110) expectedStEx2Bbis blockEx2C (Right expectedStEx2Cbis)
+ex2Cbis = CHAINExample expectedStEx2Bbis blockEx2C (Right expectedStEx2Cbis)
 
 -- | Example 2C with full refund.
 ex2Cter :: CHAINExample
-ex2Cter = CHAINExample (SlotNo 110) expectedStEx2Bter blockEx2C (Right expectedStEx2Cter)
+ex2Cter = CHAINExample expectedStEx2Bter blockEx2C (Right expectedStEx2Cter)
 
 -- | Example 2C with instant decay.
 ex2Cquater :: CHAINExample
 ex2Cquater =
-  CHAINExample (SlotNo 110) expectedStEx2Bquater blockEx2C (Right expectedStEx2Cquater)
+  CHAINExample expectedStEx2Bquater blockEx2C (Right expectedStEx2Cquater)
 
 -- | Example 2D - process a block late enough
 -- in the epoch in order to create a second reward update, preparing the way for
@@ -1321,7 +1319,7 @@ expectedStEx2D =
     )
 
 ex2D :: CHAINExample
-ex2D = CHAINExample (SlotNo 190) expectedStEx2C blockEx2D (Right expectedStEx2D)
+ex2D = CHAINExample expectedStEx2C blockEx2D (Right expectedStEx2D)
 
 -- | Example 2E - create the first non-empty pool distribution
 -- by creating a block in the third epoch of this running example.
@@ -1427,7 +1425,7 @@ expectedStEx2E =
     )
 
 ex2E :: CHAINExample
-ex2E = CHAINExample (SlotNo 220) expectedStEx2D blockEx2E (Right expectedStEx2E)
+ex2E = CHAINExample expectedStEx2D blockEx2E (Right expectedStEx2E)
 
 -- | Example 2F - create a decentralized Praos block (ie one not in the overlay schedule)
 oCertIssueNosEx2F :: Map (KeyHash 'BlockIssuer) Natural
@@ -1487,7 +1485,7 @@ expectedStEx2F =
     )
 
 ex2F :: CHAINExample
-ex2F = CHAINExample (SlotNo 295) expectedStEx2E blockEx2F (Right expectedStEx2F)
+ex2F = CHAINExample expectedStEx2E blockEx2F (Right expectedStEx2F)
 
 -- | Example 2G - create an empty block in the next epoch
 -- to prepare the way for the first non-trivial reward update
@@ -1567,7 +1565,7 @@ expectedStEx2G =
     )
 
 ex2G :: CHAINExample
-ex2G = CHAINExample (SlotNo 310) expectedStEx2F blockEx2G (Right expectedStEx2G)
+ex2G = CHAINExample expectedStEx2F blockEx2G (Right expectedStEx2G)
 
 -- | Example 2H - create the first non-trivial reward update
 blockEx2H :: Block
@@ -1659,7 +1657,7 @@ expectedStEx2H =
     )
 
 ex2H :: CHAINExample
-ex2H = CHAINExample (SlotNo 390) expectedStEx2G blockEx2H (Right expectedStEx2H)
+ex2H = CHAINExample expectedStEx2G blockEx2H (Right expectedStEx2H)
 
 -- | Example 2I - apply the first non-trivial reward update
 blockEx2I :: Block
@@ -1754,7 +1752,7 @@ expectedStEx2I =
     )
 
 ex2I :: CHAINExample
-ex2I = CHAINExample (SlotNo 410) expectedStEx2H blockEx2I (Right expectedStEx2I)
+ex2I = CHAINExample expectedStEx2H blockEx2I (Right expectedStEx2I)
 
 -- | Example 2J - drain reward account and de-register stake key
 bobAda2J :: Coin
@@ -1866,7 +1864,7 @@ expectedStEx2J =
     )
 
 ex2J :: CHAINExample
-ex2J = CHAINExample (SlotNo 420) expectedStEx2I blockEx2J (Right expectedStEx2J)
+ex2J = CHAINExample expectedStEx2I blockEx2J (Right expectedStEx2J)
 
 -- | Example 2K - start stake pool retirement
 aliceCoinEx2KPtr :: Coin
@@ -1969,7 +1967,7 @@ expectedStEx2K =
     )
 
 ex2K :: CHAINExample
-ex2K = CHAINExample (SlotNo 490) expectedStEx2J blockEx2K (Right expectedStEx2K)
+ex2K = CHAINExample expectedStEx2J blockEx2K (Right expectedStEx2K)
 
 -- | Example 2L - reap a stake pool
 blockEx2L :: Block
@@ -2074,7 +2072,7 @@ expectedStEx2L =
     )
 
 ex2L :: CHAINExample
-ex2L = CHAINExample (SlotNo 510) expectedStEx2K blockEx2L (Right expectedStEx2L)
+ex2L = CHAINExample expectedStEx2K blockEx2L (Right expectedStEx2L)
 
 -- | Example 3A - Setting up for a successful protocol parameter update,
 -- have three genesis keys vote on the same new parameters
@@ -2203,7 +2201,7 @@ expectedStEx3A =
     )
 
 ex3A :: CHAINExample
-ex3A = CHAINExample (SlotNo 10) initStEx2A blockEx3A (Right expectedStEx3A)
+ex3A = CHAINExample initStEx2A blockEx3A (Right expectedStEx3A)
 
 -- | Example 3B - Finish getting enough votes for the protocol parameter update.
 ppupEx3B :: ProposedPPUpdates
@@ -2312,7 +2310,7 @@ expectedStEx3B =
     )
 
 ex3B :: CHAINExample
-ex3B = CHAINExample (SlotNo 20) expectedStEx3A blockEx3B (Right expectedStEx3B)
+ex3B = CHAINExample expectedStEx3A blockEx3B (Right expectedStEx3B)
 
 -- | Example 3C - Adopt protocol parameter update
 blockEx3C :: Block
@@ -2375,7 +2373,7 @@ expectedStEx3C =
     )
 
 ex3C :: CHAINExample
-ex3C = CHAINExample (SlotNo 110) expectedStEx3B blockEx3C (Right expectedStEx3C)
+ex3C = CHAINExample expectedStEx3B blockEx3C (Right expectedStEx3C)
 
 -- | Example 4A - Genesis key delegation
 newGenDelegate :: KeyPair 'GenesisDelegate
@@ -2487,7 +2485,7 @@ expectedStEx4A =
     )
 
 ex4A :: CHAINExample
-ex4A = CHAINExample (SlotNo 10) initStEx2A blockEx4A (Right expectedStEx4A)
+ex4A = CHAINExample initStEx2A blockEx4A (Right expectedStEx4A)
 
 -- | Example 4B - New genesis key delegation updated from future delegations
 blockEx4B :: Block
@@ -2564,7 +2562,7 @@ expectedStEx4B =
     )
 
 ex4B :: CHAINExample
-ex4B = CHAINExample (SlotNo 50) expectedStEx4A blockEx4B (Right expectedStEx4B)
+ex4B = CHAINExample expectedStEx4A blockEx4B (Right expectedStEx4B)
 
 -- | Example 5A - Genesis key delegation
 ir :: Map (Credential 'Staking) Coin
@@ -2666,7 +2664,7 @@ expectedStEx5A =
     )
 
 ex5A :: CHAINExample
-ex5A = CHAINExample (SlotNo 10) initStEx2A blockEx5A (Right expectedStEx5A)
+ex5A = CHAINExample initStEx2A blockEx5A (Right expectedStEx5A)
 
 -- | Example 5B - Instantaneous rewards with insufficient core node signatures
 txEx5B :: Tx
@@ -2704,7 +2702,7 @@ expectedStEx5B :: PredicateFailure CHAIN
 expectedStEx5B = BbodyFailure (LedgersFailure (LedgerFailure (UtxowFailure MIRInsufficientGenesisSigsUTXOW)))
 
 ex5B :: CHAINExample
-ex5B = CHAINExample (SlotNo 10) initStEx2A blockEx5B (Left [[expectedStEx5B]])
+ex5B = CHAINExample initStEx2A blockEx5B (Left [[expectedStEx5B]])
 
 -- | Example 5C - Instantaneous rewards in decentralized era
 expectedStEx5C :: PredicateFailure CHAIN
@@ -2713,7 +2711,6 @@ expectedStEx5C = BbodyFailure (LedgersFailure (LedgerFailure (UtxowFailure MIRIm
 ex5C :: CHAINExample
 ex5C =
   CHAINExample
-    (SlotNo 10)
     (initStEx2A {chainNes = initNesEx2A {nesEs = esEx2A {esPp = ppsEx1 {_d = unsafeMkUnitInterval 0}}}})
     blockEx5A
     (Left [[expectedStEx5C]])
@@ -2723,7 +2720,6 @@ ex5C =
 ex5D :: CHAINExample
 ex5D =
   CHAINExample
-    (SlotNo 10)
     (initStEx2A {chainNes = initNesEx2A {nesEs = esEx2A {esPp = ppsEx1 {_d = unsafeMkUnitInterval 0}}}})
     blockEx5B
     (Left [[expectedStEx5C, expectedStEx5B]])
@@ -2732,7 +2728,6 @@ ex5D =
 ex5E :: CHAINExample
 ex5E =
   CHAINExample
-    (SlotNo 10)
     (initStEx2A {chainNes = initNesEx2A {nesEs = esEx2A {esAccountState = acntEx2A {_reserves = 99}}}})
     blockEx5A
     ( Left
@@ -2883,18 +2878,12 @@ blockEx5F'' =
 
 ex5F' :: Either [[PredicateFailure CHAIN]] ChainState
 ex5F' = do
-  nextState <- runShelleyBase $ applySTS @CHAIN (TRC (SlotNo 90, initStEx2A, blockEx5F))
+  nextState <- runShelleyBase $ applySTS @CHAIN (TRC ((), initStEx2A, blockEx5F))
   midState <-
     runShelleyBase $
-      applySTS @CHAIN
-        ( TRC
-            ( ((slotFromEpoch $ EpochNo 1) + SlotNo 7) +* Duration (randomnessStabilisationWindow testGlobals),
-              nextState,
-              blockEx5F'
-            )
-        )
+      applySTS @CHAIN (TRC ((), nextState, blockEx5F'))
   finalState <-
-    runShelleyBase $ applySTS @CHAIN (TRC (((slotFromEpoch $ EpochNo 2) + SlotNo 10), midState, blockEx5F''))
+    runShelleyBase $ applySTS @CHAIN (TRC ((), midState, blockEx5F''))
 
   pure finalState
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Generator/Trace/Chain.hs
@@ -41,7 +41,6 @@ import Shelley.Spec.Ledger.STS.Chain (initialShelleyState)
 import Shelley.Spec.Ledger.Slot (BlockNo (..), EpochNo (..), SlotNo (..))
 import Shelley.Spec.Ledger.UTxO (balance)
 import Test.QuickCheck (Gen)
-import qualified Test.QuickCheck as QC
 import Test.Shelley.Spec.Ledger.ConcreteCryptoTypes
   ( CHAIN,
     ChainState,
@@ -62,16 +61,9 @@ import Test.Shelley.Spec.Ledger.Utils (maxLLSupply, runShelleyBase)
 -- The CHAIN STS at the root of the STS allows for generating blocks of transactions
 -- with meaningful delegation certificates, protocol and application updates, withdrawals etc.
 instance HasTrace CHAIN GenEnv where
-  -- the current slot needs to be large enough to allow for many blocks
-  -- to be processed (in large CHAIN traces)
-  envGen (GenEnv _ Constants {minSlotTrace, maxSlotTrace}) =
-    SlotNo <$> QC.choose (fromIntegral minSlotTrace, fromIntegral maxSlotTrace)
+  envGen _ = pure ()
 
-  sigGen ge env st =
-    genBlock
-      ge
-      env
-      st
+  sigGen ge _env st = genBlock ge st
 
   shrinkSignal = shrinkBlock
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/STSTests.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/STSTests.hs
@@ -66,16 +66,16 @@ import Test.Tasty.HUnit ((@?=), Assertion, assertBool, assertFailure, testCase)
 -- | Runs example, applies chain state transition system rule (STS),
 --   and checks that trace ends with expected state or expected error.
 testCHAINExample :: CHAINExample -> Assertion
-testCHAINExample (CHAINExample slotNow initSt block (Right expectedSt)) = do
-  checkTrace @CHAIN runShelleyBase slotNow $ pure initSt .- block .-> expectedSt
-testCHAINExample (CHAINExample slotNow initSt block predicateFailure@(Left _)) = do
-  let st = runShelleyBase $ applySTS @CHAIN (TRC (slotNow, initSt, block))
+testCHAINExample (CHAINExample initSt block (Right expectedSt)) = do
+  checkTrace @CHAIN runShelleyBase () $ pure initSt .- block .-> expectedSt
+testCHAINExample (CHAINExample initSt block predicateFailure@(Left _)) = do
+  let st = runShelleyBase $ applySTS @CHAIN (TRC ((), initSt, block))
   st @?= predicateFailure
 
 testPreservationOfAda :: CHAINExample -> Assertion
-testPreservationOfAda (CHAINExample _ _ _ (Right expectedSt)) =
+testPreservationOfAda (CHAINExample _ _ (Right expectedSt)) =
   totalAda expectedSt @?= maxLLSupply
-testPreservationOfAda (CHAINExample _ _ _ (Left predicateFailure)) =
+testPreservationOfAda (CHAINExample _ _ (Left predicateFailure)) =
   assertFailure $ "Ada not preserved " ++ show predicateFailure
 
 stsTests :: TestTree

--- a/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
+++ b/shelley/chain-and-ledger/executable-spec/test/shelley-spec-ledger-test.cabal
@@ -32,6 +32,7 @@ library
                      Test.Shelley.Spec.Ledger.MultiSigExamples
                      Test.Shelley.Spec.Ledger.NonTraceProperties.Generator
                      Test.Shelley.Spec.Ledger.NonTraceProperties.Mutator
+                     Test.Shelley.Spec.Ledger.NonTraceProperties.Validity
                      Test.Shelley.Spec.Ledger.Serialization
                      Test.Shelley.Spec.Ledger.Shrinkers
                      Test.Shelley.Spec.Ledger.Utils


### PR DESCRIPTION
The PRTCL transition was doing block-specific checks:
* Hashes must align
* Slot number must increase
* Slot number must not be in the future (compared to wall clock slot)
* Block number must increase by one

These checks are *all* already done in consensus. Them being redundant is not
a problem, but in order to perform these checks, the PRTCL state stored
`LastAppliedBlock`. This coupled the *protocol* transition, which should be
independent/agnostic of the block, to the *block type* through its hash. One
could argue that this coupling should not be there.

The real problem is that when we hard fork from Byron to Shelley, we must be
able to translate the Byron protocol state to the Shelley protocol
state (called `ConsensusState` in consensus). At this point, we would have to
produce a `LastAppliedBlock` for the Shelley protocol state while the Byron
protocol state stores no such info. In consensus (and in the Byron ledger),
the protocol state is agnostic of the block, so we simply can't conjure up
such a `LastAppliedBlock`.

Moreover, having to know the current wall clock slot is also problematic,
because we don't always *know* the current wall clock slot. For example, when
we're validating blocks in the middle of the chain, there might be a hard fork
at a later point in the chain, which changes the slot length, so we simply
can't compute the current slot yet, because we don't yet know when the slot
lengths will change. In consensus, we have our own "not in the future" check,
which is implemented differently, making the check in the ledger redundant.
Actually, for this reason, the current Shelley integration in consensus just
passed the block's slot as the current wall clock slot, effectively making
this check useless in the ledger.

The PRTCL transition still needs to know the previous hash to pass it to the
UPDN transition, which uses this as extra entropy (converts it to a `Nonce`)
when a new epoch starts. Instead of storing and passing a `PrevHash`, we now
convert it earlier to a `Nonce`, and store and pass that `Nonce`. This
decouples the PRTCL (and UPDN) transition from the block type.

* All block-specific checks are removed from the PRTCL transition. The
  corresponding `PredicateFailure` constructors are also removed.

* The PRTCL state now stores a nonce derived from the previous hash instead of
  `WithOrigin (LastAppliedBlock c)` (previous block number + slot number +
  hash), as that info was only needed by the removed checks.

* The PRTCL environment no longer contains the current wall clock slot.

* The UPDN environment now contains a nonce derived from the previous
  hash (comes from the PRTCL state) instead of the previous hash. The only
  thing it did with the previous hash was to derive a nonce from it. Now we
  just do it earlier.

* The CHAIN state still stores the `LastAppliedBlock`. Consensus doesn't have
  an equivalent of the `ChainState`, so consensus doesn't care about this.
  Keeping that `LastAppliedBlock` there makes the test easier, i.e.,
  `mkBlock`.

* The CHAIN environment is now `()` instead of `SlotNo` (current wall clock
  slot number).