### PR TITLE
Goblins, make them optional

### DIFF
--- a/byron/ledger/executable-spec/byron-spec-ledger.cabal
+++ b/byron/ledger/executable-spec/byron-spec-ledger.cabal
@@ -20,6 +20,11 @@ flag development
     default: False
     manual: True
 
+flag goblins
+    description: Enable globlins
+    default: True
+    manual: True
+
 library
   hs-source-dirs:      src
   exposed-modules:     Hedgehog.Gen.Double
@@ -63,6 +68,9 @@ library
                -Wredundant-constraints
   if (!flag(development))
     ghc-options: -Werror
+
+  if (flag(goblins))
+    ghc-options: -DGOBLINS
 
 test-suite doctests
   hs-source-dirs:      test

--- a/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Delegation.hs
+++ b/byron/ledger/executable-spec/src/Byron/Spec/Ledger/Delegation.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 
 module Byron.Spec.Ledger.Delegation
   ( -- * Delegation scheduling
@@ -119,7 +120,7 @@ import           Control.State.Transition (Embed, Environment, IRC (IRC), Predic
                      Signal, State, TRC (TRC), initialRules, judgmentContext, trans,
                      transitionRules, wrapFailed, (?!))
 import           Control.State.Transition.Generator (HasTrace, SignalGenerator, envGen, genTrace,
-                     sigGen, tinkerWithSigGen)
+                     sigGen)
 import           Control.State.Transition.Trace (TraceOrder (OldestFirst), traceSignals)
 import           Byron.Spec.Ledger.Core (BlockCount, Epoch (Epoch), HasHash, Hash (Hash), Owner (Owner), Sig,
                      Slot (Slot), SlotCount (SlotCount), VKey (VKey), VKeyGenesis (VKeyGenesis),
@@ -130,10 +131,13 @@ import qualified Byron.Spec.Ledger.Core.Generators as CoreGen
 import           Byron.Spec.Ledger.Core.Omniscient (signWithGenesisKey)
 
 import           Byron.Spec.Ledger.Util (mkGoblinGens)
-import           Test.Goblin (AddShrinks (..), Goblin (..), GoblinData, SeedGoblin (..),
-                     mkEmptyGoblin)
+import           Test.Goblin (AddShrinks (..), Goblin (..), SeedGoblin (..))
 import           Test.Goblin.TH (deriveAddShrinks, deriveGoblin, deriveSeedGoblin)
 
+#if defined(GOBLINS)
+import           Control.State.Transition.Generator (tinkerWithSigGen)
+import           Test.Goblin (GoblinData, mkEmptyGoblin)
+#endif
 
 --------------------------------------------------------------------------------
 -- Abstract types
@@ -809,10 +813,13 @@ deriveSeedGoblin ''DIState
 
 mkGoblinGens
   "DELEG"
-  [ "SDelegSFailure_SDelegFailure_EpochInThePast"
+  [
+#if defined(GOBLINS)
+    "SDelegSFailure_SDelegFailure_EpochInThePast"
   , "SDelegSFailure_SDelegFailure_EpochPastNextEpoch"
   , "SDelegSFailure_SDelegFailure_IsAlreadyScheduled"
   , "SDelegSFailure_SDelegFailure_IsNotGenesisKey"
+#endif
   ]
 
 tamperedDcerts :: DIEnv -> DIState -> Gen [DCert]

--- a/byron/ledger/executable-spec/src/Byron/Spec/Ledger/STS/UTXOW.hs
+++ b/byron/ledger/executable-spec/src/Byron/Spec/Ledger/STS/UTXOW.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 
 -- | UTXO transition system with witnessing
 
@@ -29,7 +30,7 @@ import           Control.State.Transition (Embed, Environment, IRC (IRC), Predic
                      Signal, State, TRC (TRC), initialRules, judgmentContext, trans,
                      transitionRules, wrapFailed, (?!))
 import           Control.State.Transition.Generator (HasTrace, SignalGenerator, coverFailures,
-                     envGen, sigGen, tinkerWithSigGen)
+                     envGen, sigGen)
 
 import           Byron.Spec.Ledger.Core (Addr (Addr),VKey, mkAddr, verify)
 import qualified Byron.Spec.Ledger.Update.Generators as UpdateGen
@@ -40,8 +41,10 @@ import qualified Byron.Spec.Ledger.UTxO.Generators as UTxOGen
 
 import           Byron.Spec.Ledger.STS.UTXO
 
+#if defined(GOBLINS)
+import           Control.State.Transition.Generator (tinkerWithSigGen)
 import           Test.Goblin (GoblinData, mkEmptyGoblin)
-
+#endif
 
 data UTXOW deriving (Data, Typeable)
 
@@ -118,12 +121,15 @@ instance HasTrace UTXOW where
 
 mkGoblinGens
   "UTXOW"
-  [ "InsufficientWitnesses"
+  [
+#if defined(GOBLINS)
+    "InsufficientWitnesses"
   , "UtxoFailure_EmptyTxInputs"
   , "UtxoFailure_EmptyTxOutputs"
   , "UtxoFailure_FeeTooLow"
   , "UtxoFailure_InputsNotInUTxO"
   , "UtxoFailure_NonPositiveOutputs"
+#endif
   ]
 
 tamperedTxList :: UTxOEnv -> UTxOState -> Gen [Tx]


### PR DESCRIPTION
The GHC linker for rpi32 (used for TH on static targets: e.g. musl),
appears to have a bug that causes the TH
process to segfault.