### PR TITLE
Pool Registration Certs not valid late in epoch

### DIFF
--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/BaseTypes.hs
@@ -251,7 +251,7 @@ text64FromCBOR = do
 --
 
 newtype Url = Url {urlToText :: Text}
-  deriving (Eq, Generic, Show, ToCBOR, NoUnexpectedThunks)
+  deriving (Eq, Ord, Generic, Show, ToCBOR, NoUnexpectedThunks)
 
 textToUrl :: Text -> Maybe Url
 textToUrl t = Url <$> text64 t
@@ -260,7 +260,7 @@ instance FromCBOR Url where
   fromCBOR = Url <$> text64FromCBOR
 
 newtype DnsName = DnsName {dnsToText :: Text}
-  deriving (Eq, Generic, Show, ToCBOR, NoUnexpectedThunks)
+  deriving (Eq, Ord, Generic, Show, ToCBOR, NoUnexpectedThunks)
 
 textToDns :: Text -> Maybe DnsName
 textToDns t = DnsName <$> text64 t

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Ledger.hs
@@ -132,7 +132,7 @@ ledgerTransition = do
 
   let DPState dstate pstate = dpstate
       DState stkCreds _ _ _ _ genDelegs _ = dstate
-      PState stpools _ _ = pstate
+      PState stpools _ _ _ = pstate
 
   utxoSt' <-
     trans @(UTXOW crypto) $

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/STS/Snap.hs
@@ -65,7 +65,7 @@ snapTransition = do
 
   let UTxOState utxo deposits' fees _ = u
   let DState stkCreds _ _ _ _ _ _ = dstate
-  let PState stpools _ _ = pstate
+  let PState stpools _ _ _ = pstate
   let stake = stakeDistr utxo dstate pstate
   _slot <- liftSTS $ do
     ei <- asks epochInfo

--- a/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
+++ b/shelley/chain-and-ledger/executable-spec/src/Shelley/Spec/Ledger/TxData.hs
@@ -170,7 +170,7 @@ data PoolMetaData = PoolMetaData
   { _poolMDUrl :: !Url,
     _poolMDHash :: !ByteString
   }
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Ord, Generic, Show)
 
 instance NoUnexpectedThunks PoolMetaData
 
@@ -181,7 +181,7 @@ data StakePoolRelay
     SingleHostName !(StrictMaybe Port) !DnsName
   | -- | A @SRV@ DNS record
     MultiHostName !(StrictMaybe Port) !DnsName
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Ord, Generic, Show)
 
 instance NoUnexpectedThunks StakePoolRelay
 
@@ -230,7 +230,7 @@ data PoolParams crypto = PoolParams
     _poolRelays :: !(StrictSeq StakePoolRelay),
     _poolMD :: !(StrictMaybe PoolMetaData)
   }
-  deriving (Show, Generic, Eq)
+  deriving (Show, Generic, Eq, Ord)
   deriving (ToCBOR) via CBORGroup (PoolParams crypto)
   deriving (FromCBOR) via CBORGroup (PoolParams crypto)
 

--- a/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
+++ b/shelley/chain-and-ledger/executable-spec/test/Test/Shelley/Spec/Ledger/Rules/TestPool.hs
@@ -223,7 +223,7 @@ pStateIsInternallyConsistent ssts =
     map isConsistent (concatMap (\sst -> [source sst, target sst]) ssts)
   where
     isConsistent :: State POOL -> Property
-    isConsistent (PState stPools_ pParams_ retiring_) = do
+    isConsistent (PState stPools_ pParams_ _ retiring_) = do
       let StakePools stPoolsMap = stPools_
           poolKeys = M.keysSet stPoolsMap
           pParamKeys = M.keysSet pParams_

--- a/shelley/chain-and-ledger/formal-spec/delegation.tex
+++ b/shelley/chain-and-ledger/formal-spec/delegation.tex
@@ -240,6 +240,10 @@ state transition types. We define two separate parts of the ledger state.
         mapping from hashkeys to the slot of the registration.
       \item $\var{poolParams}$ tracks the parameters associated with each stake pool, such as
         their costs and margin.
+      \item When changes are made to the pool parameters late in an epoch, they are staged
+        in $\var{fPoolParams}$.
+        These parameters will be updated by another transaction (namely $\mathsf{EPOCH}$)
+        when the next epoch starts.
       \item $\var{retiring}$ tracks stake pool retirements, using a map from hashkeys to
         the epoch in which it will retire.
     \end{itemize}
@@ -662,17 +666,26 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
       \item The key is added to the set of registered stake pools.
       \item The pool's parameters are stored.
     \end{itemize}
-  \item Stake pool parameter updates are handled by \cref{eq:pool-rereg}.
-    This rule, which also matches on the certificate type $\type{DCertRegPool}$,
-    is distinguished from \cref{eq:pool-reg} by the requirement that
-    the pool be registered. This rule also ends stake pool retirements.
-    Reregistration causes the following state transformation:
-    \begin{itemize}
-      \item The pool's parameters are updated.
-      \item The pool is removed from the collection of retiring pools.
-      \item Note that $\var{stpools}$ is \textbf{not} updated.
-        The registration creation slot does does not change.
-    \end{itemize}
+  \item Stake pool parameter updates are handled by \cref{eq:pool-rereg} and \cref{eq:pool-rereg-late}.
+    These rules, which also matches on the certificate type $\type{DCertRegPool}$,
+    are distinguished from \cref{eq:pool-reg} by the requirement that the pool be registered.
+
+    The reason for the two update cases is to provide delegators some time to react when
+    stake pools change their parameters. The stake distribution snapshots are taken
+    at the end of the epoch, so if stake pool wishes to change parameters near
+    the end of an epoch, we apply the update just after the next snapshot is taken.
+
+    In particular, \cref{eq:pool-rereg} handles the case that the certificate is received
+    before the last $\StabilityWindow$-many slots of the epoch.
+    In this case, the update immediately included in $\var{poolParam}$.
+    Otherwise, in \cref{eq:pool-rereg-late}, the update is added to
+    the future pool parameters $\var{fPoolParam}$,
+    which will override $\var{poolParam}$ with the new values in the $\mathsf{EPOCH}$ transition
+    (see Figure~\cref{fig:rules:epoch}).
+
+    This rule also ends stake pool retirements.
+    Note that $\var{stpools}$ is \textbf{not} updated.
+    The registration creation slot does does not change.
   \item Stake pool retirements are handled by \cref{eq:pool-ret}.
     Given a slot number $\var{slot}$, the application of this rule requires that the
     planned retirement epoch $\var{e}$ stated in the certificate is in the future,
@@ -717,6 +730,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
       \begin{array}{r}
         \var{stpools} \\
         \var{poolParams} \\
+        \var{fPoolParams} \\
         \var{retiring} \\
       \end{array}
       \right)
@@ -727,6 +741,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
                                   & \varUpdate{\{\var{hk} \mapsto \var{slot}\}} \\
         \varUpdate{\var{poolParams}} & \varUpdate{\union}
                                     & \varUpdate{\{\var{hk} \mapsto \poolParam{c}\}} \\
+       \var{fPoolParams} \\
        \var{retiring} \\
       \end{array}
       \right)
@@ -739,6 +754,10 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
       \var{c}\in\DCertRegPool
       & \var{hk} \leteq \cwitness{c}
       & hk \in \dom \var{stpools}
+      \\
+      \var{fslot} \leteq \fun{firstSlot}~((\epoch{slot}) + 1)
+      &
+      slot < \var{fslot} - \fun{StabilityWindow}\\
     }
     {
       \begin{array}{r}
@@ -750,6 +769,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
       \begin{array}{r}
         \var{stpools} \\
         \var{poolParams} \\
+        \var{fPoolParams} \\
         \var{retiring} \\
       \end{array}
       \right)
@@ -759,8 +779,47 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
         \var{stpools} \\
         \varUpdate{\var{poolParams}} & \varUpdate{\unionoverrideRight}
                                   & \varUpdate{\{\var{hk} \mapsto \poolParam{c}\}}\\
+                                  \var{fPoolParams} \\
         \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
       \end{array}
+      \right)
+    }
+  \end{equation}
+
+  \begin{equation}\label{eq:pool-rereg-late}
+    \inference[Pool-reReg-late]
+    {
+      \var{c}\in\DCertRegPool
+      & \var{hk} \leteq \cwitness{c}
+      & hk \in \dom \var{stpools}
+      \\
+      \var{fslot} \leteq \fun{firstSlot}~((\epoch{slot}) + 1)
+      &
+      slot \geq \var{fslot} - \fun{StabilityWindow}\\
+    }
+    {
+      \begin{array}{r}
+        \var{slot} \\
+        \var{pp} \\
+      \end{array}
+      \vdash
+      \left(
+        \begin{array}{r}
+          \var{stpools} \\
+          \var{poolParams} \\
+          \var{fPoolParams} \\
+          \var{retiring} \\
+        \end{array}
+      \right)
+      \trans{pool}{c}
+      \left(
+        \begin{array}{rcl}
+          \var{stpools} \\
+          \var{poolParams} \\
+          \varUpdate{\var{fPoolParams}} & \varUpdate{\unionoverrideRight}
+                                        & \varUpdate{\{\var{hk} \mapsto \poolParam{c}\}}\\
+          \varUpdate{\{\var{hk}\}} & \varUpdate{\subtractdom} & \varUpdate{\var{retiring}} \\
+        \end{array}
       \right)
     }
   \end{equation}
@@ -785,6 +844,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
       \begin{array}{r}
         \var{stpools} \\
         \var{poolParams} \\
+        \var{fPoolParams} \\
         \var{retiring} \\
       \end{array}
     \right)
@@ -793,6 +853,7 @@ For each rule, again, we first check that a given certificate $c$ is of the corr
       \begin{array}{rcl}
         \var{stpools} \\
         \var{poolParams} \\
+        \var{fPoolParams} \\
         \varUpdate{\var{retiring}} & \varUpdate{\unionoverrideRight}
                                    & \varUpdate{\{\var{hk} \mapsto \var{e}\}} \\
       \end{array}

--- a/shelley/chain-and-ledger/formal-spec/epoch.tex
+++ b/shelley/chain-and-ledger/formal-spec/epoch.tex
@@ -862,10 +862,13 @@ $\Quorum > |\var{genDelegs}|/2$ \textbf{.}
 The epoch transition rule calls $\mathsf{SNAP}$, $\mathsf{POOLREAP}$ and $\mathsf{NEWPP}$
 in sequence. It also stores the previous protocol parameters in $\var{prevPp}$.
 The previous protocol parameters will be used for the reward calculation in the upcoming epoch,
-note that they correspond to the epoch for which the reward are being calculated.
+note that they correspond to the epoch for which the rewards are being calculated.
+Additionally, this transition also adopts the pool parameters $\var{fPoolParams}$
+corresponding to the pool re-registration certificates which we submitted late in the ending epoch.
 The ordering of these rules is important.
-The stake pools which will be reaped during the $\mathsf{POOLREAP}$ transition must still be a
-part of the new snapshot, and so $\mathsf{SNAP}$ must occur before $\mathsf{POOLREAP}$.
+The stake pools which will be updated by $\var{fPoolParams}$ or
+reaped during the $\mathsf{POOLREAP}$ transition must still be a
+part of the new snapshot, and so $\mathsf{SNAP}$ must occur before these two actions.
 Moreover, $\mathsf{SNAP}$ sets the deposit pot equal to current obligation,
 which is a property that is preserved by $\mathsf{POOLREAP}$ and which
 is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ transition.
@@ -908,6 +911,11 @@ is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ trans
         \right)
       }
       \\~\\~\\
+      (\var{stpools},~\var{poolParams},~\var{fPoolParams},~\var{retiring})\leteq\var{pstate}
+      \\
+      \var{pstate'}\leteq(\var{stpools},~\var{poolParams}\unionoverrideRight\var{fPoolParams},
+      ~\emptyset,~\var{retiring})
+      \\~\\~\\
       \var{pp}
       \vdash
       \left(
@@ -916,7 +924,7 @@ is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ trans
             \var{utxoSt'} \\
             \var{acnt} \\
             \var{dstate} \\
-            \var{pstate} \\
+            \var{pstate'} \\
           \end{array}
         }
       \right)
@@ -927,7 +935,7 @@ is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ trans
             \var{utxoSt''} \\
             \var{acnt'} \\
             \var{dstate'} \\
-            \var{pstate'} \\
+            \var{pstate''} \\
         \end{array}
       }
       \right)
@@ -939,7 +947,7 @@ is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ trans
         \begin{array}{r}
           \var{pp_{new}}\\
           \var{dstate'}\\
-          \var{pstate'}\\
+          \var{pstate''}\\
         \end{array}
       }
       \vdash
@@ -963,7 +971,7 @@ is necessary for the preservation of Ada property in the $ \mathsf{NEWPP}$ trans
       }
       \right)
       \\~\\~\\
-      \var{ls}' \leteq (\var{utxoSt}''',~(\var{dstate}',~\var{pstate}'))
+      \var{ls}' \leteq (\var{utxoSt}''',~(\var{dstate}',~\var{pstate}''))
     }
     {
       \vdash


### PR DESCRIPTION
**Edited with new plan**

In order to give delegators time to respond to stake pools changing their parameters, if I registered stake pool re-registers within the the last `StabilityWindow`-many slots in an epoch, the parameter updates are staged for adoption on the epoch boundary.

To handle this staging, a new mapping was added to `PState`, namely `fPoolParams`. These future pool parameters are adopted in the `Epoch` transition, right before the pool reap transition.

closes #1453 