### PR TITLE
Ledger API function for stake distribution and pool parameters query

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -181,9 +181,7 @@ getUTxOSubset ss txins =
 -- Stake pools and pool rewards
 --------------------------------------------------------------------------------
 
--- | Get the /current/ registered stake pool parameters for a given set of
--- stake pools. The result map will contain entries for all the given stake
--- pools that are currently registered.
+-- | Get the /current/ registered stake pools.
 getPools ::
   NewEpochState era ->
   Set (KeyHash 'StakePool (Crypto era))
@@ -448,7 +446,7 @@ getRewardInfoPools globals ss =
 -- ('RewardProvenance').
 --
 -- For a calculation of rewards based on the current stake distribution,
--- see 'getRewardInfo'.
+-- see 'getRewardInfoPools'.
 getRewardInfo ::
   forall era.
   ( HasField "_a0" (Core.PParams era) NonNegativeInterval,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -95,9 +98,11 @@ import Cardano.Protocol.TPraos.BHeader (checkLeaderValue, mkSeed, seedL)
 import Cardano.Protocol.TPraos.Rules.Tickn (TicknState (..))
 import Cardano.Slotting.EpochInfo (epochInfoRange)
 import Cardano.Slotting.Slot (EpochSize, SlotNo)
+import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (runReader)
 import Control.Provenance (runWithProvM)
 import qualified Data.ByteString.Lazy as LBS
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Default.Class (Default (..))
 import Data.Either (fromRight)
 import Data.Foldable (fold)
@@ -111,6 +116,8 @@ import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import GHC.Records (HasField (..), getField)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
 import Numeric.Natural (Natural)
 
 --------------------------------------------------------------------------------
@@ -317,6 +324,13 @@ data RewardInfoPool = RewardInfoPool
     -- Can be larger than @1.0@ for pool that gets lucky.
     -- (If some pools get unlucky, some pools must get lucky.)
   }
+  deriving (Eq, Show, Generic)
+
+instance NoThunks RewardInfoPool
+instance NFData RewardInfoPool
+deriving instance FromJSON RewardInfoPool
+deriving instance ToJSON RewardInfoPool
+
 -- | Global information that influences stake pool rewards
 data RewardParams = RewardParams
   { nOpt :: Natural -- ^ Desired number of stake pools
@@ -324,6 +338,13 @@ data RewardParams = RewardParams
   , rPot :: Coin -- ^ Total rewards available for the given epoch
   , totalStake :: Coin -- ^ Maximum lovelace supply minus treasury
   }
+  deriving (Eq, Show, Generic)
+
+instance NoThunks RewardParams
+instance NFData RewardParams
+deriving instance FromJSON RewardParams
+deriving instance ToJSON RewardParams
+
 
 -- | Retrieve the information necessary to calculate stake pool member rewards
 -- from the /current/ stake distribution.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -13,9 +13,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.Shelley.API.Wallet
-  ( getNonMyopicMemberRewards,
-
-    -- * UTxOs
+  ( -- * UTxOs
     getUTxO,
     getUTxOSubset,
     getFilteredUTxO,
@@ -30,6 +28,7 @@ module Cardano.Ledger.Shelley.API.Wallet
     RewardParams (..),
     getRewardInfoPools,
     getRewardInfo,
+    getNonMyopicMemberRewards,
 
     -- * Transaction helpers
     CLI (..),

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -42,7 +42,15 @@ module Cardano.Ledger.Shelley.API.Wallet
   )
 where
 
-import Cardano.Binary (ToCBOR (..), decodeFull, decodeFullDecoder, serialize)
+import Cardano.Binary
+  ( FromCBOR (..),
+    ToCBOR (..),
+    decodeDouble,
+    decodeFull,
+    decodeFullDecoder,
+    encodeDouble,
+    serialize
+  )
 import Cardano.Crypto.DSIGN.Class (decodeSignedDSIGN, sizeSigDSIGN, sizeVerKeyDSIGN)
 import qualified Cardano.Crypto.VRF as VRF
 import Cardano.Ledger.Address (Addr (..))
@@ -107,6 +115,14 @@ import Control.Monad.Trans.Reader (runReader)
 import Control.Provenance (runWithProvM)
 import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.ByteString.Lazy as LBS
+import Data.Coders
+  ( Decode (..),
+    Encode (..),
+    decode,
+    encode,
+    (!>),
+    (<!),
+  )
 import Data.Default.Class (Default (..))
 import Data.Either (fromRight)
 import Data.Foldable (fold)
@@ -654,3 +670,46 @@ totalAdaES cs =
         depositsAdaPot,
         feesAdaPot
       } = totalAdaPotsES cs
+--------------------------------------------------------------------------------
+-- CBOR instances
+--------------------------------------------------------------------------------
+
+instance ToCBOR RewardParams where
+  toCBOR (RewardParams p1 p2 p3 p4) =
+    encode $
+      Rec RewardParams
+        !> To p1
+        !> To p2
+        !> To p3
+        !> To p4
+
+instance FromCBOR RewardParams where
+  fromCBOR =
+    decode $
+      RecD RewardParams
+        <! From
+        <! From
+        <! From
+        <! From
+
+instance ToCBOR RewardInfoPool where
+  toCBOR (RewardInfoPool p1 p2 p3 p4 p5 d6) =
+    encode $
+      Rec RewardInfoPool
+        !> To p1
+        !> To p2
+        !> To p3
+        !> To p4
+        !> To p5
+        !> E encodeDouble d6
+
+instance FromCBOR RewardInfoPool where
+  fromCBOR =
+    decode $
+      RecD RewardInfoPool
+        <! From
+        <! From
+        <! From
+        <! From
+        <! From
+        <! D decodeDouble

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -27,6 +27,7 @@ module Cardano.Ledger.Shelley.API.Wallet
     RewardInfoPool (..),
     RewardParams (..),
     getRewardInfoPools,
+    getRewardProvenance,
     getRewardInfo,
     getNonMyopicMemberRewards,
 
@@ -440,12 +441,7 @@ getRewardInfoPools globals ss =
             mempty
             (_poolOwners poolp)
 
--- | Calculate stake pool rewards from the snapshot labeled `go`.
--- Also includes information on how the rewards were calculated
--- ('RewardProvenance').
---
--- For a calculation of rewards based on the current stake distribution,
--- see 'getRewardInfoPools'.
+{-# DEPRECATED getRewardInfo "Use 'getRewardProvenance' instead." #-}
 getRewardInfo ::
   forall era.
   ( HasField "_a0" (Core.PParams era) NonNegativeInterval,
@@ -458,7 +454,31 @@ getRewardInfo ::
   Globals ->
   NewEpochState era ->
   (RewardUpdate (Crypto era), RewardProvenance (Crypto era))
-getRewardInfo globals newepochstate =
+getRewardInfo = getRewardProvenance
+
+-- | Calculate stake pool rewards from the snapshot labeled `go`.
+-- Also includes information on how the rewards were calculated
+-- ('RewardProvenance').
+--
+-- For a calculation of rewards based on the current stake distribution,
+-- see 'getRewardInfoPools'.
+--
+-- TODO: Deprecate 'getRewardProvenance', because wallets are more
+-- likely to use 'getRewardInfoPools' for up-to-date information
+-- on stake pool rewards.
+getRewardProvenance ::
+  forall era.
+  ( HasField "_a0" (Core.PParams era) NonNegativeInterval,
+    HasField "_d" (Core.PParams era) UnitInterval,
+    HasField "_nOpt" (Core.PParams era) Natural,
+    HasField "_protocolVersion" (Core.PParams era) ProtVer,
+    HasField "_rho" (Core.PParams era) UnitInterval,
+    HasField "_tau" (Core.PParams era) UnitInterval
+  ) =>
+  Globals ->
+  NewEpochState era ->
+  (RewardUpdate (Crypto era), RewardProvenance (Crypto era))
+getRewardProvenance globals newepochstate =
   runReader
     ( runWithProvM def $
         createRUpd slotsPerEpoch blocksmade epochstate maxsupply asc secparam

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolLifetime.hs
@@ -33,7 +33,7 @@ import Cardano.Ledger.Era (Crypto (..))
 import Cardano.Ledger.Keys (asWitness, coerceKeyRole)
 import Cardano.Ledger.SafeHash (hashAnnotated)
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Cardano.Ledger.Shelley.API (getRewardInfo)
+import Cardano.Ledger.Shelley.API (getRewardProvenance)
 import Cardano.Ledger.Shelley.BlockChain (Block, bheader)
 import qualified Cardano.Ledger.Shelley.EpochBoundary as EB
 import Cardano.Ledger.Shelley.LedgerState
@@ -771,7 +771,7 @@ poolLifetime8 :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample (ShelleyEra c)
 poolLifetime8 = CHAINExample expectedStEx7 blockEx8 (Right expectedStEx8)
 
 rewardInfoEx8 :: RP.RewardProvenance C_Crypto
-rewardInfoEx8 = snd $ getRewardInfo testGlobals (chainNes expectedStEx8)
+rewardInfoEx8 = snd $ getRewardProvenance testGlobals (chainNes expectedStEx8)
 
 rewardInfoTest :: Assertion
 rewardInfoTest = rewardInfoEx8 @?= expected

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -48,7 +48,7 @@ import Cardano.Ledger.Keys
     vKey,
   )
 import Cardano.Ledger.Pretty (PrettyA (..))
-import Cardano.Ledger.Shelley.API.Wallet (getRewardInfo)
+import Cardano.Ledger.Shelley.API.Wallet (getRewardProvenance)
 import Cardano.Ledger.Shelley.EpochBoundary
   ( BlocksMade (..),
     SnapShot (..),
@@ -397,7 +397,7 @@ rewardsProvenance _ = do
               slotsPerEpoch
   pure (prov, bs)
 
--- Analog to getRewardInfo, but does not produce Provenance
+-- Analog to getRewardProvenance, but does not produce Provenance
 justRewardInfo ::
   forall era.
   (Core.PParams era ~ PParams era) =>
@@ -428,7 +428,7 @@ sameWithOrWithoutProvenance ::
   Property
 sameWithOrWithoutProvenance globals newepochstate = with === without
   where
-    (with, _) = getRewardInfo globals newepochstate
+    (with, _) = getRewardProvenance globals newepochstate
     without = justRewardInfo globals newepochstate
 
 nothingInNothingOut ::


### PR DESCRIPTION
### Issue Number

[CAD-3480](https://input-output.atlassian.net/browse/CAD-3480)

### Summary

module `Cardano.Ledger.Shelley.API.Wallet`:
* Introduce and export types `RewardParams` and `RewardInfoPool`
* The `getRewardInfoPools` function is essentially a refactoring of the `getNonMyopicMemberRewards` function.
* Also reorder the functions in the file and export list more thematically.

### Comments

Exporting `getRewardInfoPools` helps the wallet to calculate reward predictions (e.g. stake pool desirability, non-myopic rewards, but also future reward measures) for stake pools. It's intended to become a local state query in the node.

I have made a best effort to conform with the coding conventions in the ledger, but I'm probably off. I did not know where to put the types. Also, I did not know whether or how to write unit tests (though it seems that the old `GetRewardProvenance` does not have many tests either.)