### PR TITLE
force the reward pulser to completion sooner

### DIFF
--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/PoolReReg.hs
@@ -16,7 +16,8 @@ module Test.Cardano.Ledger.Shelley.Examples.PoolReReg
 where
 
 import Cardano.Ledger.BaseTypes
-  ( Globals (..),
+  ( BlocksMade (..),
+    Globals (..),
     Nonce,
     StrictMaybe (..),
   )
@@ -65,7 +66,7 @@ import Test.Cardano.Ledger.Shelley.Examples.Init
     nonce0,
     ppEx,
   )
-import Test.Cardano.Ledger.Shelley.Examples.PoolLifetime (makePulser')
+import Test.Cardano.Ledger.Shelley.Examples.PoolLifetime (makeCompletedPulser)
 import Test.Cardano.Ledger.Shelley.Generator.Core
   ( AllIssuerKeys (..),
     NatNonce (..),
@@ -249,7 +250,7 @@ poolReReg2A :: (ExMock (Crypto (ShelleyEra c))) => CHAINExample BHeader (Shelley
 poolReReg2A = CHAINExample expectedStEx1 blockEx2A (Right expectedStEx2A)
 
 pulserEx2 :: forall c. (ExMock c) => PulsingRewUpdate c
-pulserEx2 = makePulser' expectedStEx2
+pulserEx2 = makeCompletedPulser (BlocksMade mempty) expectedStEx2
 
 expectedStEx2B :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx2B =

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/TwoPools.hs
@@ -121,7 +121,7 @@ import Test.Cardano.Ledger.Shelley.Examples.Init
     nonce0,
     ppEx,
   )
-import Test.Cardano.Ledger.Shelley.Examples.PoolLifetime (makePulser)
+import Test.Cardano.Ledger.Shelley.Examples.PoolLifetime (makeCompletedPulser)
 import Test.Cardano.Ledger.Shelley.Generator.Core
   ( AllIssuerKeys (..),
     NatNonce (..),
@@ -773,7 +773,7 @@ pulserEx9 ::
   PParams era ->
   PulsingRewUpdate (Crypto era)
 pulserEx9 pp =
-  makePulser
+  makeCompletedPulser
     ( BlocksMade $
         Map.fromList
           [(hk Cast.alicePoolKeys, 2), (hk Cast.bobPoolKeys, 1)]

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Updates.hs
@@ -15,7 +15,8 @@ module Test.Cardano.Ledger.Shelley.Examples.Updates
 where
 
 import Cardano.Ledger.BaseTypes
-  ( Nonce,
+  ( BlocksMade (..),
+    Nonce,
     StrictMaybe (..),
     mkNonceFromNumber,
     (⭒),
@@ -74,7 +75,7 @@ import Test.Cardano.Ledger.Shelley.Examples.Init
     nonce0,
     ppEx,
   )
-import Test.Cardano.Ledger.Shelley.Examples.PoolLifetime (makePulser')
+import Test.Cardano.Ledger.Shelley.Examples.PoolLifetime (makeCompletedPulser)
 import Test.Cardano.Ledger.Shelley.Generator.Core
   ( AllIssuerKeys (..),
     NatNonce (..),
@@ -353,7 +354,7 @@ blockEx3 =
     (mkOCert (coreNodeKeysBySchedule @(ShelleyEra c) ppEx 80) 0 (KESPeriod 0))
 
 pulserEx3 :: forall c. (ExMock c) => PulsingRewUpdate c
-pulserEx3 = makePulser' expectedStEx2
+pulserEx3 = makeCompletedPulser (BlocksMade mempty) expectedStEx2
 
 expectedStEx3 :: forall c. (ExMock (Crypto (ShelleyEra c))) => ChainState (ShelleyEra c)
 expectedStEx3 =


### PR DESCRIPTION
Some tools, such as db-sync and the stake credential history tool, rely on being able to inspect the ledger state for the reward update. If the pulser does not finish before the end of the epoch (which has happened on the Shelley-QA network, see
https://github.com/input-output-hk/cardano-db-sync/issues/882) then the pulser is forced to completion at the moment it is applied, as is therefore invisible to downstream tools.

To solve this problem, we force completion of the reward pulser by `(2k/f)`-many slots before the end of the epoch (one day on mainnet).