### PR TITLE
fix required_signers CDDL type

### DIFF
--- a/eras/alonzo/test-suite/cddl-files/alonzo.cddl
+++ b/eras/alonzo/test-suite/cddl-files/alonzo.cddl
@@ -64,7 +64,7 @@ transaction_body =
  , ? 15 : network_id             ; New
  }
 
-required_signers = set<$vkey>
+required_signers = set<$addr_keyhash>
 
 transaction_input = [ transaction_id : $hash32
                     , index : uint


### PR DESCRIPTION
:microscope: PR

In the Alonzo CDDL spec,  `required_signers` was listed as `set<$vkey>`, when it should have been `set<$addr_keyhash>`. These type are both `bytes .size 28`, so the tests did not catch the mistake.