### PR TITLE
correct a mistake in 9ab85598f0cf1c780665b8b3bc52b

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWitness.hs
@@ -378,7 +378,7 @@ encodeWitnessRaw vkeys boots scripts dats rdmrs =
     isTimelock (TimelockScript _) = True
     isTimelock (PlutusScript _ _) = False
 
-    isPlutus _ (TimelockScript _) = True
+    isPlutus _ (TimelockScript _) = False
     isPlutus lang (PlutusScript l _) = lang == l
 
 instance


### PR DESCRIPTION
Timelock scripts were not filtered out of the Plutus witnesses on the wire. I will add more golden tests (round trip tests would not catch this mistake) soon.