### PR TITLE
at PV 7 make MissingScriptWitnessesUTXOW clearer

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -59,7 +59,7 @@ translateTimeForPlutusScripts ::
 translateTimeForPlutusScripts pp = pvMajor (getField @"_protocolVersion" pp) > 5
 
 -- | Starting with protocol version 7, the UTXO rule predicate failure
--- MissingScriptWitnessesUTXOW will not be used for unnecessary scripts
+-- MissingScriptWitnessesUTXOW will not be used for extraneous scripts
 missingScriptsSymmetricDifference ::
   (HasField "_protocolVersion" pp ProtVer) =>
   pp ->

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/HardForks.hs
@@ -8,6 +8,7 @@ module Cardano.Ledger.Shelley.HardForks
     validatePoolRewardAccountNetID,
     allowScriptStakeCredsToEarnRewards,
     translateTimeForPlutusScripts,
+    missingScriptsSymmetricDifference,
   )
 where
 
@@ -56,3 +57,11 @@ translateTimeForPlutusScripts ::
   pp ->
   Bool
 translateTimeForPlutusScripts pp = pvMajor (getField @"_protocolVersion" pp) > 5
+
+-- | Starting with protocol version 7, the UTXO rule predicate failure
+-- MissingScriptWitnessesUTXOW will not be used for unnecessary scripts
+missingScriptsSymmetricDifference ::
+  (HasField "_protocolVersion" pp ProtVer) =>
+  pp ->
+  Bool
+missingScriptsSymmetricDifference pp = pvMajor (getField @"_protocolVersion" pp) > 6

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -58,6 +58,7 @@ import Cardano.Ledger.Serialization
   )
 import Cardano.Ledger.Shelley.Address.Bootstrap (BootstrapWitness)
 import Cardano.Ledger.Shelley.Delegation.Certificates (isInstantaneousRewards)
+import qualified Cardano.Ledger.Shelley.HardForks as HardForks
 import Cardano.Ledger.Shelley.LedgerState
   ( UTxOState (..),
     WitHashes (..),
@@ -137,6 +138,8 @@ data UtxowPredicateFailure era
       !(AuxiliaryDataHash (Crypto era)) -- hash of the full metadata
       -- Contains out of range values (strings too long)
   | InvalidMetadata
+  | ExtraneousScriptWitnessesUTXOW
+      !(Set (ScriptHash (Crypto era))) -- extraneous scripts
   deriving (Generic)
 
 newtype UtxowEvent era
@@ -193,6 +196,9 @@ instance
       encodeListLen 3 <> toCBOR (8 :: Word8) <> toCBOR bodyHash <> toCBOR fullMDHash
     InvalidMetadata ->
       encodeListLen 1 <> toCBOR (9 :: Word8)
+    ExtraneousScriptWitnessesUTXOW ss ->
+      encodeListLen 2 <> toCBOR (10 :: Word8)
+        <> encodeFoldable ss
 
 instance
   ( Era era,
@@ -233,6 +239,9 @@ instance
         fullMDHash <- fromCBOR
         pure (3, ConflictingMetadataHash bodyHash fullMDHash)
       9 -> pure (1, InvalidMetadata)
+      10 -> do
+        ss <- decodeSet fromCBOR
+        pure (2, ExtraneousScriptWitnessesUTXOW ss)
       k -> invalidKey k
 
 -- =================================================
@@ -320,8 +329,15 @@ shelleyStyleWitness collectVKeyWitnesses embed = do
   {-  { s | (_,s) ∈ scriptsNeeded utxo tx} = dom(txscripts txw)          -}
   let sNeeded = scriptsNeeded utxo tx
       sReceived = Map.keysSet (getField @"scriptWits" tx)
-  sNeeded == sReceived
-    ?! embed (MissingScriptWitnessesUTXOW (sNeeded `Set.difference` sReceived))
+  if HardForks.missingScriptsSymmetricDifference pp
+    then do
+      sNeeded `Set.isSubsetOf` sReceived
+        ?! embed (MissingScriptWitnessesUTXOW (sNeeded `Set.difference` sReceived))
+      sReceived `Set.isSubsetOf` sNeeded
+        ?! embed (ExtraneousScriptWitnessesUTXOW (sReceived `Set.difference` sNeeded))
+    else
+      sNeeded == sReceived
+        ?! embed (MissingScriptWitnessesUTXOW (sNeeded `Set.difference` sReceived))
 
   -- check VKey witnesses
 

--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -59,7 +59,6 @@ library
     cardano-ledger-core,
     cardano-ledger-pretty,
     cardano-ledger-shelley-ma,
-    cardano-protocol-tpraos,
     cardano-slotting,
     containers,
     data-default-class,


### PR DESCRIPTION
The `MissingScriptWitnessesUTXOW` failure is confusing, it reports an empty set in the case of extraneous scripts. Starting at major protocol version 7, we use a new failure, `ExtraneousScriptWitnessesUTXOW` for the other side of the symmetric difference.