### PR TITLE
Make Show Attributes useful for debugging

### DIFF
--- a/eras/byron/ledger/impl/cardano-ledger-byron.cabal
+++ b/eras/byron/ledger/impl/cardano-ledger-byron.cabal
@@ -192,6 +192,7 @@ test-suite cardano-ledger-byron-test
                        Test.Cardano.Chain.Buildable
 
                        Test.Cardano.Chain.Common.Address
+                       Test.Cardano.Chain.Common.Attributes
                        Test.Cardano.Chain.Common.CBOR
                        Test.Cardano.Chain.Common.Compact
                        Test.Cardano.Chain.Common.Example

--- a/eras/byron/ledger/impl/src/Cardano/Chain/Common/Attributes.hs
+++ b/eras/byron/ledger/impl/src/Cardano/Chain/Common/Attributes.hs
@@ -90,7 +90,7 @@ instance Show h => Show (Attributes h) where
             ""
           | otherwise =
             ", remain: <" <> show (unknownAttributesLength attr) <> " bytes>"
-     in mconcat ["Attributes { data: ", show (attrData attr), remain, " }"]
+     in mconcat ["Attributes { data_ = ", show (attrData attr), remain, " }"]
 
 instance {-# OVERLAPPABLE #-} Buildable h => Buildable (Attributes h) where
   build attr =

--- a/eras/byron/ledger/impl/test/Test/Cardano/Chain/Common/Attributes.hs
+++ b/eras/byron/ledger/impl/test/Test/Cardano/Chain/Common/Attributes.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Test.Cardano.Chain.Common.Attributes
+  ( tests,
+  )
+where
+
+import Cardano.Prelude
+import Hedgehog (assert, forAll, property)
+import Hedgehog.Internal.Show (mkValue)
+import Test.Cardano.Chain.Common.Gen (genAddrAttributes, genAttributes)
+import Test.Cardano.Prelude
+import Test.Options (TSGroup, TSProperty, withTestsTS)
+
+-- | Test wether instance Show (Attributes AddrAttributes) makes a string that
+-- is useful for gebugging. More specifically, Hedgehog is able to parse it.
+ts_prop_show_AddressAttributes_is_haskell :: TSProperty
+ts_prop_show_AddressAttributes_is_haskell =
+  withTestsTS 1000 . property $ do
+    attr <- forAll $ genAttributes genAddrAttributes
+    assert $ isJust $ mkValue attr
+
+tests :: TSGroup
+tests = $$discoverPropArg

--- a/eras/byron/ledger/impl/test/test.hs
+++ b/eras/byron/ledger/impl/test/test.hs
@@ -12,6 +12,7 @@ import qualified Test.Cardano.Chain.Block.ValidationMode
 import qualified Test.Cardano.Chain.Buildable
 import qualified Test.Cardano.Chain.Byron.API
 import qualified Test.Cardano.Chain.Common.Address
+import qualified Test.Cardano.Chain.Common.Attributes
 import qualified Test.Cardano.Chain.Common.CBOR
 import qualified Test.Cardano.Chain.Common.Compact
 import qualified Test.Cardano.Chain.Common.Lovelace
@@ -47,6 +48,7 @@ main =
               Test.Cardano.Chain.Block.ValidationMode.tests,
               Test.Cardano.Chain.Buildable.tests,
               Test.Cardano.Chain.Common.Address.tests,
+              Test.Cardano.Chain.Common.Attributes.tests,
               Test.Cardano.Chain.Common.CBOR.tests,
               Test.Cardano.Chain.Common.Compact.tests,
               Test.Cardano.Chain.Common.Lovelace.tests,


### PR DESCRIPTION
Because Hedgehog cannot destruct and pretty-print `{data: ...}`