### PR TITLE
only store the go snapshot in the reward pulser

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -1153,7 +1153,8 @@ startStep slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ss ls pr _ nm) max
       totalStake = circulation es maxSupply
       rewsnap =
         RewardSnapShot
-          { rewSnapshots = ss,
+          { rewSnapshot = _pstakeGo ss,
+            rewFees = _feeSS ss,
             rewa0 = getField @"_a0" pr,
             rewnOpt = getField @"_nOpt" pr,
             rewprotocolVersion = getField @"_protocolVersion" pr,
@@ -1246,12 +1247,13 @@ completeRupd
   ( Pulsing
       rewsnap@RewardSnapShot
         { rewDeltaR1 = deltaR1,
+          rewFees = feesSS,
           rewR = oldr,
           rewDeltaT1 = (Coin deltaT1),
           rewNonMyopic = nm,
           rewTotalStake = totalstake,
           rewRPot = rpot,
-          rewSnapshots = snaps,
+          rewSnapshot = snap,
           rewa0 = a0,
           rewnOpt = nOpt
         }
@@ -1266,7 +1268,7 @@ completeRupd
         -- A function to compute the 'desirablity' aggregate. Called only if we are computing
         -- provenance. Adds nested pair ('key',(LikeliHoodEstimate,Desirability)) to the Map 'ans'
         addDesireability ans key likelihood =
-          let SnapShot _ _ poolParams = _pstakeGo snaps
+          let SnapShot _ _ poolParams = snap
               estimate = percentile' likelihood
            in Map.insert
                 key
@@ -1285,7 +1287,7 @@ completeRupd
         { deltaT = DeltaCoin deltaT1,
           deltaR = invert (toDeltaCoin deltaR1) <> toDeltaCoin deltaR2,
           rs = rs_,
-          deltaF = invert (toDeltaCoin $ _feeSS snaps),
+          deltaF = invert (toDeltaCoin feesSS),
           nonMyopic = updateNonMyopic nm oldr newLikelihoods
         }
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Serialisation/EraIndepGenerators.hs
@@ -969,6 +969,7 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance
   Mock crypto =>

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty.hs
@@ -490,10 +490,11 @@ ppRewardUpdate (RewardUpdate dt dr rss df nonmyop) =
     ]
 
 ppRewardSnapShot :: RewardSnapShot crypto -> PDoc
-ppRewardSnapShot (RewardSnapShot snaps a0 nopt ver non deltaR1 rR deltaT1 total pot) =
+ppRewardSnapShot (RewardSnapShot snap fee a0 nopt ver non deltaR1 rR deltaT1 total pot) =
   ppRecord
     "RewardSnapShot"
-    [ ("snapshots", ppSnapShots snaps),
+    [ ("snapshots", ppSnapShot snap),
+      ("fees", ppCoin fee),
       ("a0", ppRational $ unboundRational a0),
       ("nOpt", ppNatural nopt),
       ("version", ppProtVer ver),


### PR DESCRIPTION
The reward pulser is currently storing all three snapshots. It only needs to store the `go` stapshot and the fees, so this PR makes the adjustment.

Note that this is a change to the ledger state serialization (causing nodes to have to replay from genesis after upgrading). I think it is worth it, though. Though sharing might usually mean no extra memory is used, if a node is shut down and brought back up while the pulser is pulsing, the sharing is lost. In practice this means that if Deadalus is started up on day three of an epoch, it is holding in memory two stake distributions and two delegation mappings that it doesn't need to.