### PR TITLE
removed the unused function minCollateral

### DIFF
--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Collateral.hs
@@ -16,10 +16,8 @@ import Cardano.Ledger.Babbage.TxBody
     TxOut (..),
     collateralReturn',
     outputs',
-    txfee',
   )
 import Cardano.Ledger.BaseTypes (TxIx (..), txIxFromIntegral)
-import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Era (Era (Crypto), ValidateScript (..))
 import Cardano.Ledger.Shelley.UTxO (UTxO (..), balance)
@@ -31,7 +29,6 @@ import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Set (Set)
 import Data.Word (Word16)
 import GHC.Records (HasField (..))
-import Numeric.Natural (Natural)
 
 -- ============================================================
 
@@ -45,19 +42,6 @@ isTwoPhaseScriptAddress ::
   Addr (Crypto era) ->
   Bool
 isTwoPhaseScriptAddress tx utxo = isTwoPhaseScriptAddressFromMap @era (txscripts utxo tx)
-
-minCollateral ::
-  HasField "_collateralPercentage" (Core.PParams era) Natural =>
-  TxBody era ->
-  Core.PParams era ->
-  Coin
-minCollateral txb pp = Coin ((fee * percent) `divideCeiling` 100)
-  where
-    fee = unCoin (txfee' txb)
-    percent = fromIntegral (getField @"_collateralPercentage" pp)
-    divideCeiling x y = if r == 0 then n else n + 1 -- Works when both x and y are positive
-      where
-        (n, r) = x `divMod` y
 
 collBalance ::
   forall era.


### PR DESCRIPTION
The function `minCollateral` is not used anywhere, and is delete by this PR. Great catch by @jmhrpr!

The babbage UTxO rule calls `validateTotalCollateral`, which uses `validateTotalCollateral` from the Alonzo era, to check that enough collateral was provided. The spec does not used a named function either.

For reference:

https://github.com/input-output-hk/cardano-ledger/blob/0b0d066bf35f4062545bfaeeaf2cca9a1a87a2c3/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs#L219

https://github.com/input-output-hk/cardano-ledger/blob/0b0d066bf35f4062545bfaeeaf2cca9a1a87a2c3/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs#L337-L344