### PR TITLE
no longe re-export assertWellFormedCostModelParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ in the naming of release branches.
   function `EraUTxO.getScriptsNeeded` #3019
 - Remove model test framework #3019
 - The `Cardano.Ledger.Alonzo.Scripts` module no longer re-exports the
-  `plutus-ledger-api`'s `assertWellFormedCostModelParams`. #XXXX
+  `plutus-ledger-api`'s `assertWellFormedCostModelParams`. #3065
 
 ## Release branch 1.1.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ in the naming of release branches.
 - Deprecated `scriptsNeededFromBody` and `scriptsNeeded` in all eras in favor of new class
   function `EraUTxO.getScriptsNeeded` #3019
 - Remove model test framework #3019
+- The `Cardano.Ledger.Alonzo.Scripts` module no longer re-exports the
+  `plutus-ledger-api`'s `assertWellFormedCostModelParams`. #XXXX
 
 ## Release branch 1.1.x
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -39,7 +39,6 @@ module Cardano.Ledger.Alonzo.Scripts
     ExUnits',
     Prices (..),
     hashCostModel,
-    PV1.assertWellFormedCostModelParams,
     decodeCostModelMap,
     decodeCostModel,
     CostModels (..),
@@ -109,7 +108,6 @@ import qualified PlutusLedgerApi.V1 as PV1
     ProtocolVersion (ProtocolVersion),
     ScriptDecodeError,
     assertScriptWellFormed,
-    assertWellFormedCostModelParams,
     mkEvaluationContext,
   )
 import qualified PlutusLedgerApi.V2 as PV2 (ParamName, assertScriptWellFormed, mkEvaluationContext)


### PR DESCRIPTION
The Plutus API is deprecating `assertWellFormedCostModelParams`, so we stop re-exporting it (it is not used in the ledger).

resolves #3064