### PR TITLE
Change environment for `ShelleyPOOLREAP` rule

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Epoch.hs
@@ -73,6 +73,7 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Shelley.Rewards ()
 import Cardano.Ledger.Shelley.Rules (
   ShelleyPOOLREAP,
+  ShelleyPoolreapEnv (..),
   ShelleyPoolreapEvent,
   ShelleyPoolreapPredFailure,
   ShelleyPoolreapState (..),
@@ -132,7 +133,7 @@ instance
   , State (EraRule "SNAP" era) ~ SnapShots (EraCrypto era)
   , Signal (EraRule "SNAP" era) ~ ()
   , Embed (EraRule "POOLREAP" era) (ConwayEPOCH era)
-  , Environment (EraRule "POOLREAP" era) ~ PParams era
+  , Environment (EraRule "POOLREAP" era) ~ ShelleyPoolreapEnv era
   , State (EraRule "POOLREAP" era) ~ ShelleyPoolreapState era
   , Signal (EraRule "POOLREAP" era) ~ EpochNo
   , Eq (UpecPredFailure era)
@@ -188,7 +189,7 @@ epochTransition ::
   , State (EraRule "SNAP" era) ~ SnapShots (EraCrypto era)
   , Signal (EraRule "SNAP" era) ~ ()
   , Embed (EraRule "POOLREAP" era) (ConwayEPOCH era)
-  , Environment (EraRule "POOLREAP" era) ~ PParams era
+  , Environment (EraRule "POOLREAP" era) ~ ShelleyPoolreapEnv era
   , State (EraRule "POOLREAP" era) ~ ShelleyPoolreapState era
   , Signal (EraRule "POOLREAP" era) ~ EpochNo
   , Embed (EraRule "RATIFY" era) (ConwayEPOCH era)
@@ -226,7 +227,7 @@ epochTransition = do
           }
   PoolreapState utxoSt' acnt' dstate' pstate'' <-
     trans @(EraRule "POOLREAP" era) $
-      TRC (pp, PoolreapState utxoSt acnt dstate pstate', eNo)
+      TRC (ShelleyPoolreapEnv vstate, PoolreapState utxoSt acnt dstate pstate', eNo)
 
   let adjustedCertState = CertState vstate pstate'' dstate'
       adjustedLState =

--- a/eras/conway/test-suite/cddl-files/conway.cddl
+++ b/eras/conway/test-suite/cddl-files/conway.cddl
@@ -279,8 +279,8 @@ certificate =
   // stake_reg_deleg_cert
   // vote_reg_deleg_cert
   // stake_vote_reg_deleg_cert
-  // reg_committee_hot_key_cert
-  // unreg_committee_hot_key_cert
+  // auth_committee_hot_cert
+  // resign_committee_cold_cert
   // reg_drep_cert
   // unreg_drep_cert
   // update_drep_cert
@@ -307,8 +307,8 @@ vote_reg_deleg_cert = (12, stake_credential, drep, coin)
 stake_vote_reg_deleg_cert = (13, stake_credential, pool_keyhash, drep, coin)
 
 ; GOVCERT
-reg_committee_hot_key_cert = (14, committee_cold_credential, committee_hot_credential)
-unreg_committee_hot_key_cert = (15, committee_cold_credential)
+auth_committee_hot_cert = (14, committee_cold_credential, committee_hot_credential)
+resign_committee_cold_cert = (15, committee_cold_credential)
 reg_drep_cert = (16, drep_credential, coin, anchor / null)
 unreg_drep_cert = (17, drep_credential, coin)
 update_drep_cert = (18, drep_credential, anchor / null)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.5.0.0
 
+* Introduce `ShelleyPoolreapEnv` and replace `Environment` for `ShelleyPOOLREAP`
 * Remove redundant reimplementation of lens function `%~`: `updateWithLens`.
 * Change `getConstituitionHash` to `getConstitution`
 * Replace `constitutionHash` with `constitutionAnchor`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
@@ -31,7 +31,7 @@ import Cardano.Ledger.Binary (EncCBORGroup)
 import Cardano.Ledger.Block (Block)
 import qualified Cardano.Ledger.Chain as STS
 import Cardano.Ledger.Core
-import qualified Cardano.Ledger.Crypto as CC (Crypto)
+import Cardano.Ledger.Crypto (Crypto)
 import Cardano.Ledger.Keys (DSignable, Hash)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Core (EraGov)
@@ -182,14 +182,14 @@ applyBlock =
       }
 
 type ShelleyEraCrypto c =
-  ( CC.Crypto c
+  ( Crypto c
   , DSignable c (Hash c EraIndependentTxBody)
   )
 
 {-# DEPRECATED ShelleyEraCrypto "Constraint synonyms are being removed" #-}
 
 instance
-  ( CC.Crypto c
+  ( Crypto c
   , DSignable c (Hash c EraIndependentTxBody)
   ) =>
   ApplyBlock (ShelleyEra c)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Epoch.hs
@@ -47,6 +47,7 @@ import Cardano.Ledger.Shelley.LedgerState.Types (esAccountStateL, prevPParamsEpo
 import Cardano.Ledger.Shelley.Rewards ()
 import Cardano.Ledger.Shelley.Rules.PoolReap (
   ShelleyPOOLREAP,
+  ShelleyPoolreapEnv (..),
   ShelleyPoolreapEvent,
   ShelleyPoolreapPredFailure,
   ShelleyPoolreapState (..),
@@ -116,7 +117,7 @@ instance
   , State (EraRule "SNAP" era) ~ SnapShots (EraCrypto era)
   , Signal (EraRule "SNAP" era) ~ ()
   , Embed (EraRule "POOLREAP" era) (ShelleyEPOCH era)
-  , Environment (EraRule "POOLREAP" era) ~ PParams era
+  , Environment (EraRule "POOLREAP" era) ~ ShelleyPoolreapEnv era
   , State (EraRule "POOLREAP" era) ~ ShelleyPoolreapState era
   , Signal (EraRule "POOLREAP" era) ~ EpochNo
   , Embed (EraRule "UPEC" era) (ShelleyEPOCH era)
@@ -151,7 +152,7 @@ epochTransition ::
   , State (EraRule "SNAP" era) ~ SnapShots (EraCrypto era)
   , Signal (EraRule "SNAP" era) ~ ()
   , Embed (EraRule "POOLREAP" era) (ShelleyEPOCH era)
-  , Environment (EraRule "POOLREAP" era) ~ PParams era
+  , Environment (EraRule "POOLREAP" era) ~ ShelleyPoolreapEnv era
   , State (EraRule "POOLREAP" era) ~ ShelleyPoolreapState era
   , Signal (EraRule "POOLREAP" era) ~ EpochNo
   , Embed (EraRule "UPEC" era) (ShelleyEPOCH era)
@@ -190,7 +191,7 @@ epochTransition = do
           }
   PoolreapState utxoSt' acnt' dstate' pstate'' <-
     trans @(EraRule "POOLREAP" era) $
-      TRC (pp, PoolreapState utxoSt acnt dstate pstate', e)
+      TRC (ShelleyPoolreapEnv vstate, PoolreapState utxoSt acnt dstate pstate', e)
 
   let adjustedCertState = CertState vstate pstate'' dstate'
       epochState' =


### PR DESCRIPTION
# Description

Previous type for environment was `PParams`, which was unused. Current environment is set to `VState`, because it will be needed for correct implemention of `obligationCertState` used in the rule's assertion. It will be needed for DRep deposits: #3645

Also rename CDDL Committee certificates variables:
* `reg_committee_hot_key_cert` -> `auth_committee_hot_cert`
* `unreg_committee_hot_key_cert` -> `resign_committee_cold_cert`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
