### PR TITLE
Fix delegation validation

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add `PulsingSnapshot` and `psProposalsL`, `psDRepDistrL`, `psDRepStateL` #3759
 * Add `RunConwayRatify` class #3759
 * Enforce no duplicates from `certsTxBodyL` and `proposalProceduresTxBodyL` #3779
+* Remove `WrongCertificateTypeDELEG` predicate failure.
 * Add `getDelegateeTxCert` and `getStakePoolDelegatee`
 * Add `enactStateGovStateL` to `ConwayEraGov`
 * Add `psDRepDistrG`.

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -16,7 +16,8 @@
   `setCompleteDRepPulsingState`
 * Add `PulsingSnapshot` and `psProposalsL`, `psDRepDistrL`, `psDRepStateL` #3759
 * Add `RunConwayRatify` class #3759
-* Forbid duplicates from `certsTxBodyL` and `proposalProceduresTxBodyL` #3779
+* Enforce no duplicates from `certsTxBodyL` and `proposalProceduresTxBodyL` #3779
+* Add `getDelegateeTxCert` and `getStakePoolDelegatee`
 * Add `enactStateGovStateL` to `ConwayEraGov`
 * Add `psDRepDistrG`.
 * Rename `ensPParams` to `ensCurPParams`.

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -77,7 +77,7 @@ library
         cardano-ledger-babbage >=1.4.1,
         cardano-ledger-core ^>=1.8,
         cardano-ledger-mary >=1.1,
-        cardano-ledger-shelley >=1.6.2 && <1.8,
+        cardano-ledger-shelley >=1.7 && <1.8,
         cardano-slotting,
         cardano-strict-containers,
         containers,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -68,7 +68,6 @@ data ConwayDelegPredFailure era
   | StakeKeyNotRegisteredDELEG !(Credential 'Staking (EraCrypto era))
   | StakeKeyHasNonZeroRewardAccountBalanceDELEG !Coin
   | DRepAlreadyRegisteredForStakeKeyDELEG !(Credential 'Staking (EraCrypto era))
-  | WrongCertificateTypeDELEG
   deriving (Show, Eq, Generic)
 
 instance ToExpr (ConwayDelegPredFailure era)
@@ -90,8 +89,6 @@ instance Era era => EncCBOR (ConwayDelegPredFailure era) where
         Sum (StakeKeyHasNonZeroRewardAccountBalanceDELEG @era) 4 !> To mCoin
       DRepAlreadyRegisteredForStakeKeyDELEG stakeCred ->
         Sum (DRepAlreadyRegisteredForStakeKeyDELEG @era) 5 !> To stakeCred
-      WrongCertificateTypeDELEG ->
-        Sum (WrongCertificateTypeDELEG @era) 6
 
 instance Era era => DecCBOR (ConwayDelegPredFailure era) where
   decCBOR = decode $ Summands "ConwayDelegPredFailure" $ \case
@@ -100,7 +97,6 @@ instance Era era => DecCBOR (ConwayDelegPredFailure era) where
     3 -> SumD StakeKeyNotRegisteredDELEG <! From
     4 -> SumD StakeKeyHasNonZeroRewardAccountBalanceDELEG <! From
     5 -> SumD DRepAlreadyRegisteredForStakeKeyDELEG <! From
-    6 -> SumD WrongCertificateTypeDELEG
     n -> Invalid n
 
 newtype ConwayDelegEvent era = DelegEvent (Event (EraRule "DELEG" era))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -82,7 +82,7 @@ import Cardano.Ledger.Conway.Era (ConwayEra)
 import Cardano.Ledger.Conway.Governance.Procedures (ProposalProcedure, VotingProcedures (..))
 import Cardano.Ledger.Conway.PParams (ConwayEraPParams, ppGovActionDepositL)
 import Cardano.Ledger.Conway.Scripts ()
-import Cardano.Ledger.Conway.TxCert (ConwayTxCert, ConwayTxCertUpgradeError)
+import Cardano.Ledger.Conway.TxCert (ConwayEraTxCert, ConwayTxCert, ConwayTxCertUpgradeError)
 import Cardano.Ledger.Conway.TxOut ()
 import Cardano.Ledger.Crypto
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
@@ -678,7 +678,7 @@ instance ConwayEraTxBody era => EncCBOR (ConwayTxBodyRaw era) where
 -- | Encodes memoized bytes created upon construction.
 instance Era era => EncCBOR (ConwayTxBody era)
 
-class BabbageEraTxBody era => ConwayEraTxBody era where
+class (BabbageEraTxBody era, ConwayEraTxCert era) => ConwayEraTxBody era where
   -- | Lens for getting and setting number of `Coin` that is expected to be in the
   -- Treasury at the current Epoch
   currentTreasuryValueTxBodyL :: Lens' (TxBody era) (StrictMaybe Coin)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -23,6 +23,8 @@ module Cardano.Ledger.Conway.TxCert (
   toShelleyDelegCert,
   getScriptWitnessConwayTxCert,
   getVKeyWitnessConwayTxCert,
+  getDelegateeTxCert,
+  getStakePoolDelegatee,
   pattern RegDepositTxCert,
   pattern UnRegDepositTxCert,
   pattern DelegTxCert,
@@ -329,12 +331,24 @@ pattern UpdateDRepTxCert cred mAnchor <- (getUpdateDRepTxCert -> Just (cred, mAn
   , UpdateDRepTxCert
   #-}
 
+getDelegateeTxCert :: ConwayEraTxCert era => TxCert era -> Maybe (Delegatee (EraCrypto era))
+getDelegateeTxCert = \case
+  DelegTxCert _ delegatee -> Just delegatee
+  RegDepositDelegTxCert _ delegatee _ -> Just delegatee
+  _ -> Nothing
+
 -- | First type argument is the deposit
 data Delegatee c
   = DelegStake !(KeyHash 'StakePool c)
   | DelegVote !(DRep c)
   | DelegStakeVote !(KeyHash 'StakePool c) !(DRep c)
   deriving (Show, Generic, Eq, Ord)
+
+getStakePoolDelegatee :: Delegatee c -> Maybe (KeyHash 'StakePool c)
+getStakePoolDelegatee = \case
+  DelegStake targetPool -> Just targetPool
+  DelegVote {} -> Nothing
+  DelegStakeVote targetPool _ -> Just targetPool
 
 instance NFData (Delegatee c)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -82,7 +82,6 @@ getConwayScriptsNeeded utxo txb = getAlonzoScriptsNeeded utxo txb <> voterScript
 
 conwayProducedValue ::
   ( ConwayEraTxBody era
-  , ConwayEraTxCert era
   , ConwayEraPParams era
   ) =>
   PParams era ->

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -434,7 +434,6 @@ instance
       , StakeKeyNotRegisteredDELEG <$> arbitrary
       , StakeKeyHasNonZeroRewardAccountBalanceDELEG <$> arbitrary
       , DRepAlreadyRegisteredForStakeKeyDELEG <$> arbitrary
-      , pure WrongCertificateTypeDELEG
       ]
 
 -- GOVCERT

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -100,7 +100,7 @@ import Cardano.Ledger.Conway.TxCert (
 import Cardano.Ledger.Core (EraRule)
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Crypto (Crypto (..))
-import Cardano.Ledger.Keys (HasKeyRole (..), KeyHash, KeyRole (..))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Shelley.Governance (EraGov (GovState))
 import Cardano.Ledger.Shelley.LedgerState (
   IncrementalStake (..),
@@ -234,7 +234,7 @@ setupSingleDRep = do
           .~ SSeq.fromList
             [ mkRegDepositDelegTxCert @era
                 (KeyHashObj khDelegator)
-                (DelegStakeVote (coerceKeyRole khDRep) (DRepCredential $ KeyHashObj khDRep))
+                (DelegVote (DRepCredential $ KeyHashObj khDRep))
                 zero
             ]
   pure khDRep

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.7.0.0
 
+* Remove `validateDelegationRegistered` in favor of a new and more specific validating
+  function `validateStakePoolDelegateeRegistered`.
 * Add `ToExpr` instances for:
   * `ShelleyDelegPredFailure`
   * `ShelleyDelegsPredFailure`

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -58,7 +58,7 @@ library
         cardano-ledger-alonzo >=1.4,
         cardano-ledger-babbage >=1.1,
         cardano-ledger-binary >=1.0,
-        cardano-ledger-conway >=1.7,
+        cardano-ledger-conway >=1.10,
         cardano-ledger-core >=1.8 && <1.9,
         cardano-ledger-mary >=1.1,
         cardano-ledger-shelley >=1.6,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Cert.hs
@@ -53,7 +53,9 @@ module Cardano.Ledger.Api.Tx.Cert (
   --   `UnRegDRepTxCert`
   -- @
   ConwayEraTxCert,
+  getDelegateeTxCert,
   Delegatee (..),
+  getStakePoolDelegatee,
   pattern RegDepositTxCert,
   pattern UnRegDepositTxCert,
   pattern DelegTxCert,
@@ -68,6 +70,8 @@ where
 import Cardano.Ledger.Conway.TxCert (
   ConwayEraTxCert,
   Delegatee (..),
+  getDelegateeTxCert,
+  getStakePoolDelegatee,
   pattern AuthCommitteeHotKeyTxCert,
   pattern DelegTxCert,
   pattern RegDRepTxCert,

--- a/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
+++ b/libs/cardano-ledger-pretty/cardano-ledger-pretty.cabal
@@ -40,7 +40,7 @@ library
         cardano-ledger-alonzo >=1.2,
         cardano-ledger-babbage >=1.1,
         cardano-ledger-byron,
-        cardano-ledger-conway >=1.9,
+        cardano-ledger-conway >=1.10,
         cardano-ledger-core >=1.6,
         cardano-ledger-mary >=1.0,
         cardano-ledger-shelley >=1.6,

--- a/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
+++ b/libs/cardano-ledger-pretty/src/Cardano/Ledger/Pretty/Conway.hs
@@ -561,10 +561,6 @@ instance PrettyA (ConwayDelegPredFailure era) where
       ppRecord
         "DRepAlreadyRegisteredForStakeKeyDELEG"
         [("Credential", prettyA x)]
-    WrongCertificateTypeDELEG ->
-      ppRecord
-        "WrongCertificateTypeDELEG"
-        []
 
 instance PrettyA (ConwayGovCertPredFailure era) where
   prettyA = const $ ppRecord "ConwayGovCertPredFailure" []


### PR DESCRIPTION
# Description

Fixes #3802 

Problem was in the fact that we added new certificate type that allows for delegation and registration at the same time, which did not participate in validation of StakePool existence. 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff
