### PR TITLE
Added constrained generators to conformance tests - Part 1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-ledger-executable-spec.git
-  tag: 1dc69a3b8b80838ffa38a600879ae530c0fcab16
-  --sha256: 03h6c544qc9cgx103imjyh5sra8pjwyrf5v2rf2gnhf5vq6ih2dc
+  tag: 31f592b682171df7d5f395b7dfcbb06421589580
+  --sha256: sha256-yd5Md2OlSj9DN3msLYgV2H6jwUTD4rxSk02ktwQNXiM=
 
 index-state:
   -- Bump this if you need newer packages from Hackage

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
@@ -67,7 +68,7 @@ import Cardano.Ledger.Conway.Governance (
   ConwayGovState,
   DRepPulsingState (DRComplete),
   EnactState (..),
-  GovAction,
+  GovAction (..),
   GovActionId (..),
   GovActionIx (..),
   GovActionState (..),
@@ -112,7 +113,10 @@ import Cardano.Ledger.Conway.Rules (
   validCommitteeTerm,
   withdrawalCanWithdraw,
  )
-import Cardano.Ledger.Conway.TxBody (ConwayEraTxBody (..))
+import Cardano.Ledger.Conway.TxBody (
+  ConwayEraTxBody (..),
+  proposalProceduresTxBodyL,
+ )
 import Cardano.Ledger.Conway.TxCert (
   ConwayEraTxCert (..),
   Delegatee (..),
@@ -145,9 +149,8 @@ import Cardano.Ledger.Shelley.LedgerState (
   vsCommitteeStateL,
   vsDRepsL,
  )
-import Cardano.Ledger.TxIn (TxId)
+import Cardano.Ledger.TxIn (TxId (..))
 import Cardano.Ledger.Val (Val (..))
-import Control.Monad (void)
 import Control.State.Transition.Extended (STS (..))
 import Data.Default.Class (Default (..))
 import Data.Foldable (Foldable (..))

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### `testlib`
 
+* Add:
+  `fixupFees`
+  `impLastTickL`
+  `withNoFixup`
+  `ImpTestEnv`
+  `iteDoFixupL`
 * Add `runImpTestM`, `runImpTestM_`, `evalImpTestM` and `execImpTestM`
 * Add instance `Example (a -> ImpTestM era ())`, which allows use of `Arbitrary`
 * Add `getNextEpochCommitteeMembers` to `EraGov` typeclass, with a default empty implementation

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/EpochSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/EpochSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Shelley.Imp.EpochSpec (
   spec,

--- a/hie.yaml
+++ b/hie.yaml
@@ -180,6 +180,9 @@ cradle:
     - path: "libs/cardano-ledger-conformance/src"
       component: "lib:cardano-ledger-conformance"
 
+    - path: "libs/cardano-ledger-conformance/test"
+      component: "cardano-ledger-conformance:test:tests"
+
     - path: "libs/cardano-ledger-core/src"
       component: "lib:cardano-ledger-core"
 

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Moved `ToExpr` instances out of the main library and into the testlib.
 
+### `testlib`
+
+* Add `diffExprCompact`
+
 ## 1.2.1.0
 
 * Export `decodeListLikeEnforceNoDuplicates` #3791

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
@@ -9,6 +9,7 @@ module Test.Cardano.Ledger.Binary.TreeDiff (
   HexBytes (..),
   showExpr,
   diffExpr,
+  diffExprCompact,
   diffExprNoColor,
   hexByteStringExpr,
   showHexBytesGrouped,
@@ -84,6 +85,9 @@ diffExpr x y = show (ansiWlEditExpr (ediff x y))
 
 diffExprNoColor :: ToExpr a => a -> a -> String
 diffExprNoColor x y = show (prettyEditExpr (ediff x y))
+
+diffExprCompact :: ToExpr a => a -> a -> String
+diffExprCompact x y = show (ansiWlEditExprCompact (ediff x y))
 
 -- | Wraps regular ByteString, but shows and diffs it as hex
 newtype HexBytes = HexBytes {unHexBytes :: BS.ByteString}

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -21,6 +21,7 @@ flag asserts
 library
     exposed-modules:  Test.Cardano.Ledger.Conformance
     hs-source-dirs:   src
+    other-modules:    Test.Cardano.Ledger.Conformance.Orphans
     default-language: Haskell2010
     ghc-options:
         -Wall -Wcompat -Wincomplete-record-updates
@@ -28,20 +29,44 @@ library
         -Wunused-packages
 
     build-depends:
-        base >=4.14 && <4.19,
-        bytestring,
+        base >=4.14 && <5,
         cardano-strict-containers,
         microlens,
+        mtl,
+        bytestring,
+        data-default-class,
         cardano-ledger-binary,
         cardano-ledger-core,
         cardano-ledger-allegra,
+        cardano-ledger-mary,
         cardano-ledger-shelley,
         cardano-ledger-alonzo,
-        cardano-ledger-conway,
+        cardano-ledger-conway:{cardano-ledger-conway, testlib},
         cardano-ledger-executable-spec,
         cardano-crypto-class,
+        cardano-ledger-core:testlib,
+        cardano-ledger-test,
         containers,
+        small-steps,
         text
+
+    if !impl(ghc >=9.2)
+        ghc-options: -Wno-incomplete-patterns
 
     if flag(asserts)
         ghc-options: -fno-ignore-asserts
+
+test-suite tests
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   test
+    default-language: Haskell2010
+    ghc-options:
+        -Wall -Wcompat -Wincomplete-record-updates
+        -Wincomplete-uni-patterns -Wredundant-constraints -Wpartial-fields
+        -Wunused-packages -threaded -rtsopts -with-rtsopts=-N
+
+    build-depends:
+        base >=4.14 && <5,
+        cardano-ledger-conformance,
+        cardano-ledger-core:testlib

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Ledger.Conformance.Orphans () where
+
+import Lib
+
+deriving instance Eq AgdaEmpty
+
+deriving instance Eq TxBody
+
+deriving instance Eq TxWitnesses
+
+deriving instance Eq Tx
+
+deriving instance Eq PParams
+
+deriving instance Eq UTxOState

--- a/libs/cardano-ledger-conformance/test/Main.hs
+++ b/libs/cardano-ledger-conformance/test/Main.hs
@@ -1,0 +1,10 @@
+module Main where
+
+import qualified Test.Cardano.Ledger.Conformance as Conformance
+import Test.Cardano.Ledger.Imp.Common (describe, ledgerTestMain)
+
+main :: IO ()
+main =
+  ledgerTestMain $
+    describe "Conformance" $ do
+      Conformance.spec

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -9,6 +9,11 @@
 * Change the type of `ppEMaxL` and `ppuEMaxL`
 * Moved `ToExpr` instances out of the main library and into the testlib.
 
+### `testlib`
+
+* Add `diffExprCompact`
+* Add `expectLeftDeep_`, `expectRightDeep_`
+
 ## 1.9.0.0
 
 * Add `certsTotalDepositsTxBody` and `certsTotalRefundsTxBody`

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
@@ -8,6 +8,7 @@ module Test.Cardano.Ledger.Common (
   ToExpr (..),
   showExpr,
   diffExpr,
+  diffExprCompact,
 
   -- * Expectations
   assertBool,
@@ -21,17 +22,19 @@ module Test.Cardano.Ledger.Common (
   shouldBeLeftExpr,
   expectRight,
   expectRightDeep,
+  expectRightDeep_,
   expectRightExpr,
   expectRightDeepExpr,
   expectLeft,
   expectLeftExpr,
   expectLeftDeep,
+  expectLeftDeep_,
   expectLeftDeepExpr,
 )
 where
 
 import Control.DeepSeq (NFData)
-import Control.Monad as X (forM_, unless, when, (>=>))
+import Control.Monad as X (forM_, unless, void, when, (>=>))
 import System.IO (
   BufferMode (LineBuffering),
   hSetBuffering,
@@ -42,6 +45,7 @@ import System.IO (
 import Test.Cardano.Ledger.Binary.TreeDiff (
   ToExpr (..),
   diffExpr,
+  diffExprCompact,
   expectExprEqualWithMessage,
   showExpr,
  )
@@ -86,6 +90,10 @@ expectRight (Left l) = assertFailure $ "Expected Right, got Left:\n" <> show l
 expectRightDeep :: (HasCallStack, Show a, NFData b) => Either a b -> IO b
 expectRightDeep = expectRight >=> evaluateDeep
 
+-- | Same as `expectRightDeep`, but discards the result
+expectRightDeep_ :: (HasCallStack, Show a, NFData b) => Either a b -> IO ()
+expectRightDeep_ = void . expectRightDeep
+
 -- | Same as `expectRight`, but use `ToExpr` instead of `Show`
 expectRightExpr :: (HasCallStack, ToExpr a) => Either a b -> IO b
 expectRightExpr (Right r) = pure $! r
@@ -111,6 +119,10 @@ expectLeft (Right r) = assertFailure $ "Expected Left, got Right:\n" <> show r
 -- | Same as `expectLeft`, but also evaluate the returned value to NF
 expectLeftDeep :: (HasCallStack, NFData a, Show b) => Either a b -> IO a
 expectLeftDeep = expectLeft >=> evaluateDeep
+
+-- | Same as `expectLeftDeep`, but discards the result
+expectLeftDeep_ :: (HasCallStack, NFData a, Show b) => Either a b -> IO ()
+expectLeftDeep_ = void . expectLeftDeep
 
 -- | Same as `expectLeft`, but use `ToExpr` instead of `Show`
 expectLeftExpr :: (HasCallStack, ToExpr b) => Either a b -> IO a

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Imp/Common.hs
@@ -27,10 +27,12 @@ module Test.Cardano.Ledger.Imp.Common (
   shouldBeRightExpr,
   shouldBeLeftExpr,
   expectRight,
+  expectRightDeep_,
   expectRightDeep,
   expectRightExpr,
   expectRightDeepExpr,
   expectLeft,
+  expectLeftDeep_,
   expectLeftExpr,
   expectLeftDeep,
   expectLeftDeepExpr,
@@ -46,10 +48,12 @@ import Test.Cardano.Ledger.Common as X hiding (
   expectLeft,
   expectLeftDeep,
   expectLeftDeepExpr,
+  expectLeftDeep_,
   expectLeftExpr,
   expectRight,
   expectRightDeep,
   expectRightDeepExpr,
+  expectRightDeep_,
   expectRightExpr,
   expectationFailure,
   shouldBe,
@@ -176,10 +180,14 @@ shouldNotReturn f a = withRunInIO $ \run -> H.shouldNotReturn (run f) a
 shouldThrow :: (HasCallStack, Exception e, MonadUnliftIO m) => m a -> Selector e -> m ()
 shouldThrow f s = withRunInIO $ \run -> H.shouldThrow (run f) s
 
--- | Return value on the `Right` an fail otherwise. Lifted version of `H.expectRight`.
+-- | Return value on the `Right` and fail otherwise. Lifted version of `H.expectRight`.
 expectRight :: (HasCallStack, Show a, MonadIO m) => Either a b -> m b
 expectRight (Right r) = pure $! r
 expectRight (Left l) = assertFailure $ "Expected Right, got Left:\n" <> show l
+
+-- | Same as `expectRightDeep`, but discards the result
+expectRightDeep_ :: (HasCallStack, Show a, NFData b, MonadIO m) => Either a b -> m ()
+expectRightDeep_ = void . expectRightDeep
 
 -- | Same as `expectRight`, but also evaluate the returned value to NF
 expectRightDeep :: (HasCallStack, Show a, NFData b, MonadIO m) => Either a b -> m b
@@ -202,10 +210,14 @@ shouldBeRight e x = expectRight e >>= (`shouldBe` x)
 shouldBeRightExpr :: (HasCallStack, ToExpr a, Eq b, ToExpr b, MonadIO m) => Either a b -> b -> m ()
 shouldBeRightExpr e x = expectRightExpr e >>= (`shouldBeExpr` x)
 
--- | Return value on the `Left` an fail otherwise
+-- | Return value on the `Left` and fail otherwise
 expectLeft :: (HasCallStack, Show b, MonadIO m) => Either a b -> m a
 expectLeft (Left l) = pure $! l
 expectLeft (Right r) = assertFailure $ "Expected Left, got Right:\n" <> show r
+
+-- | Same as `expectLeftDeep`, but discards the result
+expectLeftDeep_ :: (HasCallStack, MonadIO m, Show b, NFData a) => Either a b -> m ()
+expectLeftDeep_ = void . expectLeftDeep
 
 -- | Same as `expectLeft`, but also evaluate the returned value to NF
 expectLeftDeep :: (HasCallStack, NFData a, Show b, MonadIO m) => Either a b -> m a

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Certs.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -49,7 +50,7 @@ import Test.Cardano.Ledger.Constrained.Monad (generateWithSeed, monadTyped)
 import Test.Cardano.Ledger.Constrained.Preds.CertState (dstateStage, pstateStage, vstateStage)
 import Test.Cardano.Ledger.Constrained.Preds.PParams (pParamsStage)
 import Test.Cardano.Ledger.Constrained.Preds.Repl (ReplMode (..), modeRepl)
-import Test.Cardano.Ledger.Constrained.Preds.Universes (universeStage)
+import Test.Cardano.Ledger.Constrained.Preds.Universes (UnivSize (..), universeStage)
 import Test.Cardano.Ledger.Constrained.Rewrite
 import Test.Cardano.Ledger.Constrained.Solver (toolChainSub)
 import Test.Cardano.Ledger.Constrained.TypeRep
@@ -207,8 +208,8 @@ And generate: partC suchthat: (Sum partC) = availableC
 
 -}
 
-certsPreds :: forall era. Reflect era => Proof era -> [Pred era]
-certsPreds p = case whichTxCert p of
+certsPreds :: forall era. Reflect era => UnivSize -> Proof era -> [Pred era]
+certsPreds UnivSize {usMinCerts, usMaxCerts} p = case whichTxCert p of
   TxCertShelleyToBabbage ->
     [ certs :<-: (Constr "TxCertF" (fmap (TxCertF p)) ^$ shelleycerts)
     , Sized (Range 1 6) epochDelta -- Note that last Epoch is stored in 'maxEpoch' which was 100 on 7/7/23 see PParams.hs
@@ -320,7 +321,7 @@ certsPreds p = case whichTxCert p of
     [ certs :<-: (Constr "TxCertF" (fmap (TxCertF p)) ^$ conwaycerts)
     , Sized (Range 1 6) epochDelta
     , Choose
-        (Range 4 6)
+        (Range usMinCerts usMaxCerts)
         conwaycerts
         [
           ( 1
@@ -433,11 +434,12 @@ certsPreds p = case whichTxCert p of
 
 certsStage ::
   Reflect era =>
+  UnivSize ->
   Proof era ->
   Subst era ->
   Gen (Subst era)
-certsStage proof subst0 = do
-  let preds = certsPreds proof
+certsStage us proof subst0 = do
+  let preds = certsPreds us proof
   toolChainSub proof standardOrderInfo preds subst0
 
 demo :: ReplMode -> Int -> IO ()
@@ -454,7 +456,7 @@ demo mode seed = do
           >>= vstateStage proof
           >>= pstateStage proof
           >>= dstateStage proof
-          >>= certsStage proof
+          >>= certsStage def proof
           >>= (\subst -> monadTyped (substToEnv subst emptyEnv))
       )
   certsv <- monadTyped (findVar (unVar certs) env)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/LedgerState.hs
@@ -88,9 +88,9 @@ ledgerStatePreds usize p =
   , Sized (Range 0 1) currProposals
   , proposalDeposits :<-: (Constr "sumActionStateDeposits" (foldMap gasDeposit) :$ (Simple currProposals))
   , -- TODO, introduce ProjList so we can write: SumsTo (Right (Coin 1)) proposalDeposits  EQL [ProjList CoinR gasDepositL currProposals]
-    MetaSize (SzRng 90 (usNumPreUtxo usize)) utxoSize -- must be bigger than sum of (maxsize inputs 10) and (mazsize collateral 3)
+    MetaSize (SzRng (usNumPreUtxo usize) (usNumPreUtxo usize)) utxoSize -- must be bigger than sum of (maxsize inputs 10) and (mazsize collateral 3)
   , Sized utxoSize preUtxo
-  , Sized (Range 15 (usNumColUtxo usize)) colUtxo
+  , Sized (Range (usNumColUtxo usize) (usNumColUtxo usize)) colUtxo
   , MapMember feeTxIn feeTxOut (Right preUtxo)
   , Subset (Dom preUtxo) txinUniv
   , Subset (Rng preUtxo) (txoutUniv p)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/TxOut.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/TxOut.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -114,13 +115,18 @@ isBootstrapAddr (Addr _ _ _) = False
 -- ================================================================================
 
 txOutPreds :: Reflect era => UnivSize -> Proof era -> Term era Coin -> Term era [TxOutF era] -> [Pred era]
-txOutPreds size p balanceCoin outputS =
+txOutPreds size@UnivSize {usDatumFreq} p balanceCoin outputS =
   [ Choose
       (Range 6 6)
       datums
       [ (1, Simple (Lit DatumR NoDatum), [])
       , (1, Constr "DatumHash" DatumHash ^$ hash, [Member (Left hash) (Dom dataUniv)])
-      , (1, Constr "Datum" (Datum . dataToBinaryData) ^$ dat, [Member (Left (HashD dat)) (Dom dataUniv)])
+      ,
+        ( usDatumFreq
+        , Constr "Datum" (Datum . dataToBinaryData)
+            ^$ dat
+        , [Member (Left (HashD dat)) (Dom dataUniv)]
+        )
       ]
   , datumsSet :<-: listToSetTarget datums
   , case whichTxOut p of

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Preds/Universes.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -96,6 +97,14 @@ data UnivSize = UnivSize
   , usNumPreUtxo :: Int -- must be smaller than numTxIn
   , usNumColUtxo :: Int -- max size of the UTxo = numPreUtxo + numColUtxo
   , usNumDReps :: Int -- Should be less than the number of numCredentials
+  , usMinCerts :: Int
+  , usMaxCerts :: Int
+  , usDatumFreq :: Int
+  , usGenerateWithdrawals :: Bool
+  , usMinInputs :: Int
+  , usMaxInputs :: Int
+  , usMinCollaterals :: Int
+  , usMaxCollaterals :: Int
   }
 
 instance Default UnivSize where
@@ -118,6 +127,14 @@ instance Default UnivSize where
       , usNumPreUtxo = 100 -- must be smaller than numTxIn
       , usNumColUtxo = 20 -- max size of the UTxo = numPreUtxo + numColUtxo
       , usNumDReps = 20 -- -- Should be less than the number of numCredentials
+      , usMaxCerts = 6
+      , usMinCerts = 4
+      , usDatumFreq = 1
+      , usGenerateWithdrawals = True
+      , usMinInputs = 2
+      , usMaxInputs = 10
+      , usMinCollaterals = 2
+      , usMaxCollaterals = 2
       }
 
 -- ============================================================
@@ -192,15 +209,19 @@ bootWitness hash bootaddrs byronuniv = List.foldl' accum Set.empty bootaddrs
 -- Datums
 
 -- | The universe of non-empty Datums. i.e. There are no NoDatum Datums in this list
-genDatums :: Era era => Int -> Map (DataHash (EraCrypto era)) (Data era) -> Gen [Datum era]
-genDatums n datauniv = vectorOf n (genDatum datauniv)
+genDatums :: Era era => UnivSize -> Int -> Map (DataHash (EraCrypto era)) (Data era) -> Gen [Datum era]
+genDatums sizes n datauniv = vectorOf n (genDatum sizes datauniv)
 
 -- | Only generate non-empty Datums. I.e. There are no NoDatum Datums generated.
-genDatum :: Era era => Map (DataHash (EraCrypto era)) (Data era) -> Gen (Datum era)
-genDatum datauniv =
-  oneof
-    [ DatumHash . fst <$> genFromMap ["from genDatums DatumHash case"] datauniv
-    , Datum . dataToBinaryData . snd <$> genFromMap ["from genDatums Datum case"] datauniv
+genDatum :: Era era => UnivSize -> Map (DataHash (EraCrypto era)) (Data era) -> Gen (Datum era)
+genDatum UnivSize {usDatumFreq} datauniv =
+  frequency
+    [ (1, DatumHash . fst <$> genFromMap ["from genDatums DatumHash case"] datauniv)
+    ,
+      ( usDatumFreq
+      , Datum . dataToBinaryData . snd
+          <$> genFromMap ["from genDatums Datum case"] datauniv
+      )
     ]
 
 -- ==============
@@ -209,6 +230,7 @@ genDatum datauniv =
 
 genTxOut ::
   Reflect era =>
+  UnivSize ->
   (Coin -> Map (ScriptHash (EraCrypto era)) (ScriptF era) -> Gen (Value era)) ->
   Proof era ->
   Coin ->
@@ -217,7 +239,7 @@ genTxOut ::
   Map (ScriptHash (EraCrypto era)) (ScriptF era) ->
   Map (DataHash (EraCrypto era)) (Data era) ->
   Gen (TxOut era)
-genTxOut genvalue p c addruniv scriptuniv spendscriptuniv datauniv =
+genTxOut sizes genvalue p c addruniv scriptuniv spendscriptuniv datauniv =
   case whichTxOut p of
     TxOutShelleyToMary ->
       ShelleyTxOut <$> pick1 ["genTxOut ShelleyToMary Addr"] addruniv <*> genvalue c scriptuniv
@@ -241,7 +263,7 @@ genTxOut genvalue p c addruniv scriptuniv spendscriptuniv datauniv =
         AddrBootstrap _ -> pure $ BabbageTxOut addr v NoDatum maybescript
         Addr _ paycred _ ->
           if needsDatum paycred spendscriptuniv
-            then BabbageTxOut addr v <$> genDatum datauniv <*> pure maybescript
+            then BabbageTxOut addr v <$> genDatum sizes datauniv <*> pure maybescript
             else pure $ BabbageTxOut addr v NoDatum maybescript
 
 needsDatum :: EraScript era => Credential 'Payment (EraCrypto era) -> Map (ScriptHash (EraCrypto era)) (ScriptF era) -> Bool
@@ -252,6 +274,7 @@ needsDatum _ _ = False
 
 genTxOuts ::
   Reflect era =>
+  UnivSize ->
   (Coin -> Map (ScriptHash (EraCrypto era)) (ScriptF era) -> Gen (Value era)) ->
   Proof era ->
   Int ->
@@ -260,10 +283,10 @@ genTxOuts ::
   Map (ScriptHash (EraCrypto era)) (ScriptF era) ->
   Map (DataHash (EraCrypto era)) (Data era) ->
   Gen [TxOutF era]
-genTxOuts genvalue p ntxouts addruniv scriptuniv spendscriptuniv datauniv = do
+genTxOuts sizes genvalue p ntxouts addruniv scriptuniv spendscriptuniv datauniv = do
   let genOne = do
         c <- noZeroCoin
-        genTxOut genvalue p c addruniv scriptuniv spendscriptuniv datauniv
+        genTxOut sizes genvalue p c addruniv scriptuniv spendscriptuniv datauniv
   vectorOf ntxouts (TxOutF p <$> genOne)
 
 -- ==================================================================
@@ -490,7 +513,7 @@ universePreds size p =
   , spendCredsUniv :<-: listToSetTarget spendcredList
   , currentEpoch :<-: (Constr "epochFromSlotNo" epochFromSlotNo ^$ currentSlot)
   , GenFrom dataUniv (Constr "dataWits" (genDataWits p) ^$ (Lit IntR 30))
-  , GenFrom datumsUniv (Constr "genDatums" (genDatums (usNumDatums size)) ^$ dataUniv)
+  , GenFrom datumsUniv (Constr "genDatums" (genDatums size (usNumDatums size)) ^$ dataUniv)
   , -- 'network' is set by testGlobals which contains 'Testnet'
     network :<-: constTarget (Utils.networkId Utils.testGlobals)
   , GenFrom ptrUniv (ptrUnivT (usNumPtr size) currentSlot)
@@ -499,7 +522,7 @@ universePreds size p =
   , GenFrom multiAssetUniv (Constr "multiAsset" (vectorOf (usNumMultiAsset size) . multiAsset size) ^$ (nonSpendScriptUniv p))
   , GenFrom
       preTxoutUniv
-      ( Constr "genTxOuts" (genTxOuts (genValueF size p) p (usNumTxOuts size))
+      ( Constr "genTxOuts" (genTxOuts size (genValueF size p) p (usNumTxOuts size))
           ^$ addrUniv
           ^$ (nonSpendScriptUniv p)
           ^$ (spendscriptUniv p)


### PR DESCRIPTION
# Description

This PR implements conformance testing with constrained generators. It's now possible to generate test cases with the constrained generator and then run the test against the Agda spec.

I had to disable the following parts of the generator to accommodate for features that the spec does not yet model:
 * failing scripts
 * withdrawals
 * certificates (currently there's no field for certs in the MAlonzo type, but otherwise the certs are implemented in the spec)
 * inline datums

#3811

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/input-output-hk/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/input-output-hk/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [ ] Self-reviewed the diff
