### PR TITLE
Fix a NoThunks test failure on nightly builds

### DIFF
--- a/libs/vector-map/src/Data/VMap/KVVector.hs
+++ b/libs/vector-map/src/Data/VMap/KVVector.hs
@@ -61,7 +61,9 @@ toMap ::
   (VG.Vector kv k, VG.Vector vv v) =>
   KVVector kv vv (k, v) ->
   Map.Map k v
-toMap = Map.fromDistinctAscList . VG.toList
+toMap = Map.fromDistinctAscList . map evalSecond . VG.toList
+  where
+    evalSecond kv@(_, !_) = kv
 {-# INLINE toMap #-}
 
 -- | Convert a `Map.Map` into a sorted key/value vector.


### PR DESCRIPTION
# Description

There's a strictness bug in `Data.Map.Strict.fromDistinctAscList` and this PR adds a workaround for it.

I've also also submitted a [PR](https://github.com/haskell/containers/pull/996) to `containers`.

Closes #4184

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated. **If you change the bounds in a cabal file, that package itself must have a version increase.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process))
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages. **New section is never added with the code changes.** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd))
- [x] Code is formatted with [`fourmolu`](https://github.com/fourmolu/fourmolu) (use `scripts/fourmolize.sh`)
- [x] Cabal files are formatted (use `scripts/cabal-format.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) has been updated (use `scripts/gen-hie.sh`)
- [x] Self-reviewed the diff