### PR TITLE
Change the type of `psDeposits` to `CompactForm Coin`

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/PParams.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/PParams.hs
@@ -28,7 +28,7 @@ instance EraPParams AllegraEra where
   hkdMaxTxSizeL = lens sppMaxTxSize $ \pp x -> pp {sppMaxTxSize = x}
   hkdMaxBHSizeL = lens sppMaxBHSize $ \pp x -> pp {sppMaxBHSize = x}
   hkdKeyDepositL = lens sppKeyDeposit $ \pp x -> pp {sppKeyDeposit = x}
-  hkdPoolDepositL = lens sppPoolDeposit $ \pp x -> pp {sppPoolDeposit = x}
+  hkdPoolDepositCompactL = lens sppPoolDeposit $ \pp x -> pp {sppPoolDeposit = x}
   hkdEMaxL = lens sppEMax $ \pp x -> pp {sppEMax = x}
   hkdNOptL = lens sppNOpt $ \pp x -> pp {sppNOpt = x}
   hkdA0L = lens sppA0 $ \pp x -> pp {sppA0 = x}

--- a/eras/alonzo/impl/golden/pparams-update.json
+++ b/eras/alonzo/impl/golden/pparams-update.json
@@ -22,7 +22,7 @@
     "monetaryExpansion": 0.7810966919969065,
     "poolPledgeInfluence": 8.319022570290014789e16,
     "poolRetireMaxEpoch": 1843493333,
-    "stakePoolDeposit": 855059,
+    "stakePoolDeposit": 3827864344574364691,
     "stakePoolTargetNum": 10900,
     "treasuryCut": 0.234167131785253734
 }

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -86,7 +86,7 @@ import Cardano.Ledger.Binary (
   encodePreEncoded,
   serialize',
  )
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
 import Cardano.Ledger.Core (EraPParams (..))
 import Cardano.Ledger.HKD (HKDFunctor (..))
 import Cardano.Ledger.Mary.Core
@@ -237,7 +237,7 @@ data AlonzoPParams f era = AlonzoPParams
   -- ^ Maximal block header size
   , appKeyDeposit :: !(HKD f Coin)
   -- ^ The amount of a key registration deposit
-  , appPoolDeposit :: !(HKD f Coin)
+  , appPoolDeposit :: !(HKD f (CompactForm Coin))
   -- ^ The amount of a pool registration deposit
   , appEMax :: !(HKD f EpochInterval)
   -- ^ Maximum number of epochs in the future a pool retirement is allowed to
@@ -319,7 +319,7 @@ instance EraPParams AlonzoEra where
   hkdMaxTxSizeL = lens appMaxTxSize $ \pp x -> pp {appMaxTxSize = x}
   hkdMaxBHSizeL = lens appMaxBHSize $ \pp x -> pp {appMaxBHSize = x}
   hkdKeyDepositL = lens appKeyDeposit $ \pp x -> pp {appKeyDeposit = x}
-  hkdPoolDepositL = lens appPoolDeposit $ \pp x -> pp {appPoolDeposit = x}
+  hkdPoolDepositCompactL = lens appPoolDeposit $ \pp x -> pp {appPoolDeposit = x}
   hkdEMaxL = lens appEMax $ \pp x -> pp {appEMax = x}
   hkdNOptL = lens appNOpt $ \pp x -> pp {appNOpt = x}
   hkdA0L = lens appA0 $ \pp x -> pp {appA0 = x}
@@ -465,7 +465,7 @@ emptyAlonzoPParams =
     , appMaxTxSize = 2048
     , appMaxBHSize = 0
     , appKeyDeposit = Coin 0
-    , appPoolDeposit = Coin 0
+    , appPoolDeposit = CompactCoin 0
     , appEMax = EpochInterval 0
     , appNOpt = 100
     , appA0 = minBound

--- a/eras/babbage/impl/golden/pparams-update.json
+++ b/eras/babbage/impl/golden/pparams-update.json
@@ -20,7 +20,7 @@
     "poolPledgeInfluence": 6.790200579626650307,
     "poolRetireMaxEpoch": 1676560372,
     "stakeAddressDeposit": 664860,
-    "stakePoolDeposit": 763288,
+    "stakePoolDeposit": 1.7453986152646146491e19,
     "stakePoolTargetNum": 40749,
     "treasuryCut": 0.34109,
     "txFeeFixed": 321937

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -60,7 +60,7 @@ import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
  )
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
 import Cardano.Ledger.Core (EraPParams (..))
 import Cardano.Ledger.HKD (HKDFunctor (..))
 import Cardano.Ledger.Orphans ()
@@ -113,7 +113,7 @@ data BabbagePParams f era = BabbagePParams
   -- ^ Maximal block header size
   , bppKeyDeposit :: !(HKD f Coin)
   -- ^ The amount of a key registration deposit
-  , bppPoolDeposit :: !(HKD f Coin)
+  , bppPoolDeposit :: !(HKD f (CompactForm Coin))
   -- ^ The amount of a pool registration deposit
   , bppEMax :: !(HKD f EpochInterval)
   -- ^ Maximum number of epochs in the future a pool retirement is allowed to
@@ -192,7 +192,7 @@ instance EraPParams BabbageEra where
   hkdMaxTxSizeL = lens bppMaxTxSize $ \pp x -> pp {bppMaxTxSize = x}
   hkdMaxBHSizeL = lens bppMaxBHSize $ \pp x -> pp {bppMaxBHSize = x}
   hkdKeyDepositL = lens bppKeyDeposit $ \pp x -> pp {bppKeyDeposit = x}
-  hkdPoolDepositL = lens bppPoolDeposit $ \pp x -> pp {bppPoolDeposit = x}
+  hkdPoolDepositCompactL = lens bppPoolDeposit $ \pp x -> pp {bppPoolDeposit = x}
   hkdEMaxL = lens bppEMax $ \pp x -> pp {bppEMax = x}
   hkdNOptL = lens bppNOpt $ \pp x -> pp {bppNOpt = x}
   hkdA0L = lens bppA0 $ \pp x -> pp {bppA0 = x}
@@ -274,7 +274,7 @@ emptyBabbagePParams =
     , bppMaxTxSize = 2048
     , bppMaxBHSize = 0
     , bppKeyDeposit = Coin 0
-    , bppPoolDeposit = Coin 0
+    , bppPoolDeposit = CompactCoin 0
     , bppEMax = EpochInterval 0
     , bppNOpt = 100
     , bppA0 = minBound

--- a/eras/conway/impl/golden/pparams-update.json
+++ b/eras/conway/impl/golden/pparams-update.json
@@ -832,7 +832,7 @@
         "ppSecurityGroup": 0.4
     },
     "stakeAddressDeposit": 479647,
-    "stakePoolDeposit": 569,
+    "stakePoolDeposit": 1.2522864161500168761e19,
     "treasuryCut": 0.5,
     "txFeeFixed": 203771,
     "txFeePerByte": 379061,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -113,7 +113,7 @@ import Cardano.Ledger.Binary (
   encodeListLen,
  )
 import Cardano.Ledger.Binary.Coders
-import Cardano.Ledger.Coin (Coin (Coin))
+import Cardano.Ledger.Coin (Coin (Coin), CompactForm (..))
 import Cardano.Ledger.Conway.Era (ConwayEra, hardforkConwayBootstrapPhase)
 import Cardano.Ledger.Core (EraPParams (..))
 import Cardano.Ledger.HKD (
@@ -612,7 +612,7 @@ data ConwayPParams f era = ConwayPParams
   -- ^ Maximal block header size
   , cppKeyDeposit :: !(THKD ('PPGroups 'EconomicGroup 'NoStakePoolGroup) f Coin)
   -- ^ The amount of a key registration deposit
-  , cppPoolDeposit :: !(THKD ('PPGroups 'EconomicGroup 'NoStakePoolGroup) f Coin)
+  , cppPoolDeposit :: !(THKD ('PPGroups 'EconomicGroup 'NoStakePoolGroup) f (CompactForm Coin))
   -- ^ The amount of a pool registration deposit
   , cppEMax :: !(THKD ('PPGroups 'TechnicalGroup 'NoStakePoolGroup) f EpochInterval)
   -- ^ Maximum number of epochs in the future a pool retirement is allowed to
@@ -788,7 +788,7 @@ instance EraPParams ConwayEra where
   hkdMaxTxSizeL = lens (unTHKD . cppMaxTxSize) $ \pp x -> pp {cppMaxTxSize = THKD x}
   hkdMaxBHSizeL = lens (unTHKD . cppMaxBHSize) $ \pp x -> pp {cppMaxBHSize = THKD x}
   hkdKeyDepositL = lens (unTHKD . cppKeyDeposit) $ \pp x -> pp {cppKeyDeposit = THKD x}
-  hkdPoolDepositL = lens (unTHKD . cppPoolDeposit) $ \pp x -> pp {cppPoolDeposit = THKD x}
+  hkdPoolDepositCompactL = lens (unTHKD . cppPoolDeposit) $ \pp x -> pp {cppPoolDeposit = THKD x}
   hkdEMaxL = lens (unTHKD . cppEMax) $ \pp x -> pp {cppEMax = THKD x}
   hkdNOptL = lens (unTHKD . cppNOpt) $ \pp x -> pp {cppNOpt = THKD x}
   hkdA0L = lens (unTHKD . cppA0) $ \pp x -> pp {cppA0 = THKD x}
@@ -883,7 +883,7 @@ instance ConwayEraPParams ConwayEra where
       , isValid (/= EpochInterval 0) ppuCommitteeMaxTermLengthL
       , isValid (/= EpochInterval 0) ppuGovActionLifetimeL
       , -- Coins
-        isValid (/= zero) ppuPoolDepositL
+        isValid (/= CompactCoin 0) ppuPoolDepositCompactL
       , isValid (/= zero) ppuGovActionDepositL
       , isValid (/= zero) ppuDRepDepositL
       , hardforkConwayBootstrapPhase pv
@@ -929,7 +929,7 @@ emptyConwayPParams =
     , cppMaxTxSize = THKD 2048
     , cppMaxBHSize = THKD 0
     , cppKeyDeposit = THKD (Coin 0)
-    , cppPoolDeposit = THKD (Coin 0)
+    , cppPoolDeposit = THKD (CompactCoin 0)
     , cppEMax = THKD (EpochInterval 0)
     , cppNOpt = THKD 100
     , cppA0 = THKD minBound

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -13,7 +13,7 @@ module Test.Cardano.Ledger.Conway.Imp.GovSpec (spec) where
 
 import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Coin (Coin (Coin))
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (hardforkConwayDisallowUnelectedCommitteeFromVoting)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
@@ -223,7 +223,7 @@ pparamUpdateSpec =
       testMalformedProposal
         "ppuPoolDepositL cannot be 0"
         ppuPoolDepositL
-        zero
+        $ Coin 0
       testMalformedProposal
         "ppuGovActionDepositL cannot be 0"
         ppuGovActionDepositL

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/PParams.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/PParams.hs
@@ -45,7 +45,7 @@ instance EraPParams DijkstraEra where
   hkdMaxTxSizeL = lens (unTHKD . cppMaxTxSize) $ \pp x -> pp {cppMaxTxSize = THKD x}
   hkdMaxBHSizeL = lens (unTHKD . cppMaxBHSize) $ \pp x -> pp {cppMaxBHSize = THKD x}
   hkdKeyDepositL = lens (unTHKD . cppKeyDeposit) $ \pp x -> pp {cppKeyDeposit = THKD x}
-  hkdPoolDepositL = lens (unTHKD . cppPoolDeposit) $ \pp x -> pp {cppPoolDeposit = THKD x}
+  hkdPoolDepositCompactL = lens (unTHKD . cppPoolDeposit) $ \pp x -> pp {cppPoolDeposit = THKD x}
   hkdEMaxL = lens (unTHKD . cppEMax) $ \pp x -> pp {cppEMax = THKD x}
   hkdNOptL = lens (unTHKD . cppNOpt) $ \pp x -> pp {cppNOpt = THKD x}
   hkdA0L = lens (unTHKD . cppA0) $ \pp x -> pp {cppA0 = THKD x}
@@ -139,7 +139,7 @@ instance ConwayEraPParams DijkstraEra where
       , isValid (/= EpochInterval 0) ppuCommitteeMaxTermLengthL
       , isValid (/= EpochInterval 0) ppuGovActionLifetimeL
       , -- Coins
-        isValid (/= zero) ppuPoolDepositL
+        isValid (/= mempty) ppuPoolDepositL
       , isValid (/= zero) ppuGovActionDepositL
       , isValid (/= zero) ppuDRepDepositL
       , isValid ((/= zero) . unCoinPerByte) ppuCoinsPerUTxOByteL

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/PParams.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/PParams.hs
@@ -35,7 +35,7 @@ instance EraPParams MaryEra where
   hkdMaxTxSizeL = lens sppMaxTxSize $ \pp x -> pp {sppMaxTxSize = x}
   hkdMaxBHSizeL = lens sppMaxBHSize $ \pp x -> pp {sppMaxBHSize = x}
   hkdKeyDepositL = lens sppKeyDeposit $ \pp x -> pp {sppKeyDeposit = x}
-  hkdPoolDepositL = lens sppPoolDeposit $ \pp x -> pp {sppPoolDeposit = x}
+  hkdPoolDepositCompactL = lens sppPoolDeposit $ \pp x -> pp {sppPoolDeposit = x}
   hkdEMaxL = lens sppEMax $ \pp x -> pp {sppEMax = x}
   hkdNOptL = lens sppNOpt $ \pp x -> pp {sppNOpt = x}
   hkdA0L = lens sppA0 $ \pp x -> pp {sppA0 = x}

--- a/eras/shelley/impl/golden/pparams-update.json
+++ b/eras/shelley/impl/golden/pparams-update.json
@@ -8,7 +8,7 @@
     "poolPledgeInfluence": 3.8777413926852632e7,
     "poolRetireMaxEpoch": 2414041002,
     "stakeAddressDeposit": 180016,
-    "stakePoolDeposit": 205173,
+    "stakePoolDeposit": 1.1630186357330223477e19,
     "stakePoolTargetNum": 52993,
     "treasuryCut": 0.3,
     "txFeeFixed": 601034,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
@@ -67,7 +67,8 @@ import Cardano.Ledger.Binary (
   encodeListLen,
  )
 import Cardano.Ledger.Binary.Coders (Decode (From, RecD), decode, (<!))
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
+import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.HKD (HKD)
 import Cardano.Ledger.Hashes (GenDelegs)
@@ -103,7 +104,7 @@ data ShelleyPParams f era = ShelleyPParams
   -- ^ Maximal block header size
   , sppKeyDeposit :: !(HKD f Coin)
   -- ^ The amount of a key registration deposit
-  , sppPoolDeposit :: !(HKD f Coin)
+  , sppPoolDeposit :: !(HKD f (CompactForm Coin))
   -- ^ The amount of a pool registration deposit
   , sppEMax :: !(HKD f EpochInterval)
   -- ^ epoch bound on pool retirement
@@ -171,7 +172,7 @@ instance EraPParams ShelleyEra where
   hkdMaxTxSizeL = lens sppMaxTxSize $ \pp x -> pp {sppMaxTxSize = x}
   hkdMaxBHSizeL = lens sppMaxBHSize $ \pp x -> pp {sppMaxBHSize = x}
   hkdKeyDepositL = lens sppKeyDeposit $ \pp x -> pp {sppKeyDeposit = x}
-  hkdPoolDepositL = lens sppPoolDeposit $ \pp x -> pp {sppPoolDeposit = x}
+  hkdPoolDepositCompactL = lens sppPoolDeposit $ \pp x -> pp {sppPoolDeposit = x}
   hkdEMaxL = lens sppEMax $ \pp x -> pp {sppEMax = x}
   hkdNOptL = lens sppNOpt $ \pp x -> pp {sppNOpt = x}
   hkdA0L = lens sppA0 $ \pp x -> pp {sppA0 = x}
@@ -194,7 +195,7 @@ emptyShelleyPParams =
     , sppMaxTxSize = 2048
     , sppMaxBHSize = 0
     , sppKeyDeposit = Coin 0
-    , sppPoolDeposit = Coin 0
+    , sppPoolDeposit = CompactCoin 0
     , sppEMax = EpochInterval 0
     , sppNOpt = 100
     , sppA0 = minBound
@@ -380,8 +381,8 @@ ppPoolDeposit :: EraPParams era => PParam era
 ppPoolDeposit =
   PParam
     { ppName = "stakePoolDeposit"
-    , ppLens = ppPoolDepositL
-    , ppUpdate = Just $ PParamUpdate 6 ppuPoolDepositL
+    , ppLens = ppPoolDepositCompactL
+    , ppUpdate = Just $ PParamUpdate 6 ppuPoolDepositCompactL
     }
 
 ppEMax :: EraPParams era => PParam era

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -149,7 +149,7 @@ adaPreservationProps =
       , map feesNonDecreasing noEpochBoundarySsts
       ]
 
-infoRetire :: Map (KeyHash 'StakePool) Coin -> KeyHash 'StakePool -> String
+infoRetire :: Show a => Map (KeyHash 'StakePool) a -> KeyHash 'StakePool -> String
 infoRetire deposits keyhash = showKeyHash keyhash ++ extra
   where
     extra = case Map.lookup keyhash deposits of

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deposits.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Deposits.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.Shelley.Rules.Reports (synopsisCoinMap)
 import Cardano.Ledger.Shelley.State
-import Cardano.Ledger.UMap (depositMap)
+import Cardano.Ledger.UMap (depositMap, fromCompact)
 import qualified Cardano.Ledger.UMap as UM
 import Cardano.Ledger.Val ((<+>))
 import qualified Data.Map.Strict as Map
@@ -87,14 +87,14 @@ depositInvariant SourceSignalTarget {source = chainSt} =
       allDeposits = utxosDeposited utxost
       sumCoin = Map.foldl' (<+>) (Coin 0)
       keyDeposits = (UM.fromCompact . UM.sumDepositUView . UM.RewDepUView . dsUnified) dstate
-      poolDeposits = sumCoin (psDeposits pstate)
+      poolDeposits = sumCoin (fromCompact <$> psDeposits pstate)
    in counterexample
         ( ansiDocToString . Pretty.vsep $
             [ "Deposit invariant fails:"
             , Pretty.indent 2 . Pretty.vsep . map Pretty.pretty $
                 [ "All deposits = " ++ show allDeposits
                 , "Key deposits = " ++ synopsisCoinMap (Just (depositMap (dsUnified dstate)))
-                , "Pool deposits = " ++ synopsisCoinMap (Just (psDeposits pstate))
+                , "Pool deposits = " ++ synopsisCoinMap (Just (fromCompact <$> psDeposits pstate))
                 ]
             ]
         )

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/Combinators.hs
@@ -191,10 +191,10 @@ feesAndDeposits ppEx newFees stakes pools cs = cs {chainNes = nes'}
     accum n x = if Map.member (ppId x) (psDeposits pstate) then (n :: Integer) else n + 1
     newDeposits =
       Map.fromList (map (\cred -> (cred, compactCoinOrError (ppEx ^. ppKeyDepositL))) stakes)
-    newPools = Map.fromList (map (\p -> (ppId p, ppEx ^. ppPoolDepositL)) pools)
+    newPools = Map.fromList (map (\p -> (ppId p, ppEx ^. ppPoolDepositCompactL)) pools)
     dpstate' =
       mkShelleyCertState
-        (pstate & psDepositsL %~ Map.unionWith (\old _new -> old) newPools)
+        (pstate & psDepositsCompactL %~ Map.unionWith (\old _new -> old) newPools)
         (dstate & dsUnifiedL .~ UM.unionKeyDeposits (RewDepUView (dstate ^. dsUnifiedL)) newDeposits)
     es' = es {esLState = ls'}
     nes' = nes {nesEs = es'}
@@ -473,7 +473,7 @@ reapPool pool cs = cs {chainNes = nes'}
         Just (UM.RDPair ccoin dep) ->
           ( UM.insert'
               rewardAddr
-              (UM.RDPair (addCompactCoin ccoin (compactCoinOrError (pp ^. ppPoolDepositL))) dep)
+              (UM.RDPair (addCompactCoin ccoin (pp ^. ppPoolDepositCompactL)) dep)
               (rewards ds)
           , Coin 0
           )

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.18.0.0
 
+* Replaced `hkdPoolDepositL` method with `hkdPoolDepositCompactL`
+* Add `ppPoolDepositCompactL` and `ppuPoolDepositCompactL`
 * Add `standardHashSize` and `standardAddrHashSize`
 * Add `zeroCostModels` method to `EraTest`
 * Added support for `PlutusV4`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -26,6 +26,7 @@ module Cardano.Ledger.Coin (
   compactCoinOrError,
   addCompactCoin,
   sumCompactCoin,
+  partialCompactCoinL,
   -- NonZero helpers
   toCompactCoinNonZero,
   unCoinNonZero,
@@ -63,6 +64,7 @@ import Data.Primitive.Types
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import GHC.Stack
+import Lens.Micro (Lens', lens)
 import NoThunks.Class (NoThunks (..))
 import Quiet
 import System.Random.Stateful (Uniform (..), UniformRange (..))
@@ -122,7 +124,7 @@ rationalToCoinViaCeiling = Coin . ceiling
 
 instance Compactible Coin where
   newtype CompactForm Coin = CompactCoin {unCompactCoin :: Word64}
-    deriving (Eq, Show, NoThunks, NFData, Prim, Ord, ToCBOR, ToJSON, FromJSON)
+    deriving (Eq, Show, NoThunks, NFData, Prim, Ord, ToCBOR, ToJSON, FromJSON, Generic)
     deriving (Semigroup, Monoid, Group, Abelian) via Sum Word64
 
   toCompact (Coin c) = CompactCoin <$> integerToWord64 c
@@ -218,3 +220,6 @@ toCoinNonZero = unsafeNonZero . Coin . toInteger . unNonZero
 
 compactCoinNonZero :: NonZero Word64 -> NonZero (CompactForm Coin)
 compactCoinNonZero = unsafeNonZero . CompactCoin . unNonZero
+
+partialCompactCoinL :: HasCallStack => Lens' (CompactForm Coin) Coin
+partialCompactCoinL = lens fromCompact $ const compactCoinOrError

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ToPlutusData.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/ToPlutusData.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -20,6 +21,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Binary.Version (Version, getVersion, mkVersion)
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Plutus.CostModels (
   CostModels,
   flattenCostModels,
@@ -98,6 +100,11 @@ instance ToPlutusData Prices where
   fromPlutusData _ = Nothing
 
 deriving instance ToPlutusData Coin
+
+instance ToPlutusData (CompactForm Coin) where
+  toPlutusData = toPlutusData . fromCompact
+  fromPlutusData (I i) = toCompact (Coin i)
+  fromPlutusData _ = Nothing
 
 instance ToPlutusData Word32 where
   toPlutusData w32 = I (toInteger @Word32 w32)

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/PlutusSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/PlutusSpec.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.BaseTypes (
   UnitInterval,
  )
 import Cardano.Ledger.Binary.Version (Version)
-import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Coin (Coin, CompactForm)
 import Cardano.Ledger.Plutus
 import Data.Map.Strict (Map)
 import Data.Word
@@ -38,6 +38,7 @@ spec = do
     roundTripPlutusDataSpec @[Word8]
     roundTripPlutusDataSpec @(Map Word Version)
     roundTripPlutusDataSpec @Coin
+    roundTripPlutusDataSpec @(CompactForm Coin)
     roundTripPlutusDataSpec @ExUnits
     roundTripPlutusDataSpec @Prices
     roundTripPlutusDataSpec @Natural

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
@@ -296,10 +296,19 @@ instance ToExpr DRepVotingThresholds
 instance (EraSpecPParams era, EraGov era, EraTxOut era) => Show (SimplePParams era) where
   show x = show (toExpr (subsetToPP @era x))
 
+instance HasSimpleRep (CompactForm Coin)
+
+instance HasSpec (CompactForm Coin)
+
 -- | Use then generic HasSimpleRep and HasSpec instances for SimplePParams
 instance HasSimpleRep (SimplePParams era)
 
-instance (EraSpecPParams era, EraGov era, EraTxOut era) => HasSpec (SimplePParams era)
+instance
+  ( EraSpecPParams era
+  , EraGov era
+  , EraTxOut era
+  ) =>
+  HasSpec (SimplePParams era)
 
 -- | Use this as the SimpleRep of (PParamsUpdate era)
 data SimplePPUpdate = SimplePPUpdate
@@ -369,7 +378,13 @@ instance EraSpecPParams era => HasSimpleRep (PParams era) where
   fromSimpleRep = subsetToPP
 
 -- | HasSpec instance for PParams
-instance (EraSpecPParams era, EraTxOut era, EraGov era) => HasSpec (PParams era) where
+instance
+  ( EraSpecPParams era
+  , EraTxOut era
+  , EraGov era
+  ) =>
+  HasSpec (PParams era)
+  where
   genFromTypeSpec x = fromSimpleRep <$> genFromTypeSpec x
 
 -- =======================================
@@ -380,7 +395,12 @@ instance EraSpecPParams era => HasSpec (ProposedPPUpdates era)
 
 instance EraSpecPParams era => HasSimpleRep (FuturePParams era)
 
-instance (EraGov era, EraTxOut era, EraSpecPParams era) => HasSpec (FuturePParams era)
+instance
+  ( EraGov era
+  , EraTxOut era
+  , EraSpecPParams era
+  ) =>
+  HasSpec (FuturePParams era)
 
 -- =============================================================
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -78,7 +78,6 @@ import Cardano.Ledger.BaseTypes hiding (inject)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), Sized (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin
-import Cardano.Ledger.Compactible
 import Cardano.Ledger.Conway (ConwayEra, Tx (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
@@ -382,30 +381,6 @@ txOutVal_ ::
   Term (BabbageTxOut era) ->
   Term (Value era)
 txOutVal_ = sel @1
-
-instance
-  ( Compactible a
-  , HasSimpleRep a
-  , Show (SimpleRep a)
-  ) =>
-  HasSimpleRep (CompactForm a)
-  where
-  type SimpleRep (CompactForm a) = SimpleRep a
-  toSimpleRep = toSimpleRep . fromCompact
-  fromSimpleRep x = fromMaybe err . toCompact $ fromSimpleRep x
-    where
-      err = error $ "toCompact @" ++ show (typeOf x) ++ " " ++ show x
-
-instance
-  ( Compactible a
-  , GenericallyInstantiated (CompactForm a)
-  , Typeable (TypeSpec (SimpleRep a))
-  , Show (TypeSpec (SimpleRep a))
-  , HasSpec a
-  , HasSimpleRep a
-  , HasSpec (SimpleRep a)
-  ) =>
-  HasSpec (CompactForm a)
 
 instance HasSimpleRep MaryValue where
   type TheSop MaryValue = '["MaryValue" ::: '[Coin]]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -340,7 +340,7 @@ pstateSpec univ currepoch = constrained $ \ [var|pState|] ->
         dom_ pooldeposits ==. dom_ stakePoolParams
     , assertExplain (pure "no deposit is 0") $
         not_ $
-          lit (Coin 0) `elem_` rng_ pooldeposits
+          lit (CompactCoin 0) `elem_` rng_ pooldeposits
     , assertExplain (pure "dom of stakePoolParams is disjoint from futureStakePoolParams") $
         dom_ stakePoolParams `disjoint_` dom_ futureStakePoolParams
     , assertExplain (pure "retiring after current epoch") $

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Pool.hs
@@ -55,8 +55,8 @@ pStateSpec univ = constrained $ \ps ->
         dom_ retiring `subset_` dom_ stakePoolParams
     , assertExplain (pure "dom of deposits is dom of stakePoolParams") $
         dom_ deposits ==. dom_ stakePoolParams
-    , forAll (rng_ deposits) $ \ [var|dep|] ->
-        assertExplain (pure "all deposits are greater then (Coin 0)") $ dep >=. lit (Coin 0)
+    , forAll' (rng_ deposits) $ \ [var|dep|] ->
+        assertExplain (pure "all deposits are greater then (Coin 0)") $ dep >=. lit 0
     , assertExplain (pure "dom of stakePoolParams is disjoint from futureStakePoolParams") $
         dom_ stakePoolParams `disjoint_` dom_ futureStakePoolParams
     ]

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/AggPropTests.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/AggPropTests.hs
@@ -143,16 +143,16 @@ depositInvariant SourceSignalTarget {source = mockChainSt} =
       pstate = certState ^. certPStateL
       dstate = certState ^. certDStateL
       allDeposits = utxosDeposited utxost
-      sumCoin m = Map.foldl' (<+>) (Coin 0) m
+      sumCoin = Map.foldl' (<+>) (Coin 0)
       keyDeposits = fromCompact $ sumDepositUView (RewDepUView (dsUnified dstate))
-      poolDeposits = sumCoin (psDeposits pstate)
+      poolDeposits = sumCoin $ fromCompact <$> psDeposits pstate
    in counterexample
         ( ansiDocToString . Pretty.vsep $
             [ "Deposit invariant fails:"
             , Pretty.indent 2 . Pretty.vsep . map Pretty.pretty $
                 [ "All deposits = " ++ show allDeposits
                 , "Key deposits = " ++ synopsisCoinMap (Just (depositMap (dsUnified dstate)))
-                , "Pool deposits = " ++ synopsisCoinMap (Just (psDeposits pstate))
+                , "Pool deposits = " ++ synopsisCoinMap (Just (fromCompact <$> psDeposits pstate))
                 ]
             ]
         )

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.BaseTypes (
   Globals (epochInfo),
  )
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.State (ChainAccountState (..), VState (..))
 import Cardano.Ledger.Credential (Credential, StakeReference (..))
@@ -331,7 +332,7 @@ instance TotalAda (DState era) where
       <> (UM.fromCompact $ UM.sumDepositUView (UM.RewDepUView (dsUnified dstate)))
 
 instance TotalAda (PState era) where
-  totalAda pstate = Fold.fold (psDeposits pstate)
+  totalAda pstate = Fold.fold (fromCompact <$> psDeposits pstate)
 
 instance TotalAda (VState era) where
   totalAda _ = mempty

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -715,7 +715,7 @@ initialLedgerState gstate = LedgerState utxostate dpstate
     pools = gsInitialPoolParams gstate
     pp = mPParams (gsModel gstate)
     keyDeposit = pp ^. ppKeyDepositL
-    !poolDeposit = pp ^. ppPoolDepositL
+    !poolDeposit = pp ^. ppPoolDepositCompactL
     rdpair rew = UM.RDPair (UM.compactCoinOrError rew) (UM.compactCoinOrError keyDeposit)
 
 -- =============================================

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/ModelState.hs
@@ -37,6 +37,7 @@ module Test.Cardano.Ledger.Generic.ModelState where
 
 import Cardano.Ledger.BaseTypes (BlocksMade (..))
 import Cardano.Ledger.Coin (Coin (..), CompactForm (CompactCoin))
+import Cardano.Ledger.Compactible (Compactible (..))
 import Cardano.Ledger.Conway.State (ConwayEraCertState (..), VState (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Hashes (GenDelegs (..))
@@ -347,7 +348,7 @@ abstract :: (EraGov era, EraCertState era) => NewEpochState era -> ModelNewEpoch
 abstract x =
   ModelNewEpochState
     { mPoolParams = (psStakePoolParams . certPState . lsCertState . esLState . nesEs) x
-    , mPoolDeposits = (psDeposits . certPState . lsCertState . esLState . nesEs) x
+    , mPoolDeposits = (fmap fromCompact . psDeposits . certPState . lsCertState . esLState . nesEs) x
     , mRewards = (UM.rewardMap . dsUnified . certDState . lsCertState . esLState . nesEs) x
     , mDelegations = (UM.sPoolMap . dsUnified . certDState . lsCertState . esLState . nesEs) x
     , mKeyDeposits = (UM.depositMap . dsUnified . certDState . lsCertState . esLState . nesEs) x


### PR DESCRIPTION
# Description

This PR changes the type of pool deposits to `CompactForm Coin`. I added two lenses `ppPoolDepositsCompact` and `ppuPoolDepositsCompact` to make it possible to access the compacted value of pool deposits.

close #4984

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
