### PR TITLE
Translate some tests from BabbageFeatures to Imp test

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.14.0.0
 
+* Added `eraUnsupportedLanguage`
+* Changed return type of `mkPlutusScript` and `mkBinaryPlutusScript` from `Maybe` to `MonadFail`
 * Deprecate `Alonzo.TxSeq` in favour of `Alonzo.BlockBody`. #5156
   * Rename `AlonzoTxSeq` to `AlonzoBlockBody`
 * Rename `alonzoEqTxRaw` to `alonzoTxEqRaw`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -140,6 +140,7 @@ library testlib
     -Wunused-packages
 
   build-depends:
+    FailT,
     HUnit,
     base,
     bytestring,

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -85,9 +85,9 @@ import Cardano.Ledger.Plutus.Language (
   Plutus (..),
   PlutusLanguage,
   asSLanguage,
-  plutusLanguage,
  )
 import Cardano.Ledger.Shelley.Rules (PredicateFailure, ShelleyUtxowPredFailure)
+import Control.Monad.Trans.Fail (runFail)
 import Data.Functor.Identity (Identity)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NE (toList)
@@ -464,12 +464,7 @@ mkPlutusScript' ::
   (HasCallStack, AlonzoEraScript era, PlutusLanguage l) =>
   Plutus l ->
   Script era
-mkPlutusScript' plutus =
-  case mkPlutusScript plutus of
-    Nothing ->
-      error $
-        "Plutus version " ++ show (plutusLanguage plutus) ++ " is not supported in " ++ eraName @era
-    Just plutusScript -> fromPlutusScript plutusScript
+mkPlutusScript' = either error fromPlutusScript . runFail . mkPlutusScript
 {-# DEPRECATED mkPlutusScript' "In favor of `fromPlutusScript` . `mkSupportedPlutusScript`" #-}
 
 instance Arbitrary (TransitionConfig AlonzoEra) where

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -107,7 +107,10 @@ library testlib
     Test.Cardano.Ledger.Babbage.Era
     Test.Cardano.Ledger.Babbage.Imp
     Test.Cardano.Ledger.Babbage.Imp.UtxoSpec
+    Test.Cardano.Ledger.Babbage.Imp.UtxosSpec
     Test.Cardano.Ledger.Babbage.Imp.UtxowSpec
+    Test.Cardano.Ledger.Babbage.Imp.UtxowSpec.Invalid
+    Test.Cardano.Ledger.Babbage.Imp.UtxowSpec.Valid
     Test.Cardano.Ledger.Babbage.ImpTest
     Test.Cardano.Ledger.Babbage.Translation.TranslatableGen
     Test.Cardano.Ledger.Babbage.TreeDiff

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Scripts.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   AlonzoScript (..),
   PlutusScript (..),
   alonzoScriptPrefixTag,
+  eraUnsupportedLanguage,
   isPlutusScript,
  )
 import Cardano.Ledger.Babbage.Era
@@ -63,9 +64,9 @@ instance AlonzoEraScript BabbageEra where
 
   mkPlutusScript plutus =
     case plutusSLanguage plutus of
-      SPlutusV1 -> Just $ BabbagePlutusV1 plutus
-      SPlutusV2 -> Just $ BabbagePlutusV2 plutus
-      _ -> Nothing
+      SPlutusV1 -> pure $ BabbagePlutusV1 plutus
+      SPlutusV2 -> pure $ BabbagePlutusV2 plutus
+      slang -> eraUnsupportedLanguage @BabbageEra slang
 
   withPlutusScript (BabbagePlutusV1 plutus) f = f plutus
   withPlutusScript (BabbagePlutusV2 plutus) f = f plutus

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -13,7 +13,7 @@ import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxosPredFailure,
   AlonzoUtxowPredFailure,
  )
-import Cardano.Ledger.Babbage.Core
+import Cardano.Ledger.Babbage.Core (BabbageEraTxBody, InjectRuleFailure)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
 import Cardano.Ledger.BaseTypes (Inject)
@@ -26,6 +26,7 @@ import Cardano.Ledger.Shelley.Rules (
 import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
 import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp, LedgerSpec)
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxoSpec as Utxo
+import qualified Test.Cardano.Ledger.Babbage.Imp.UtxosSpec as Utxos
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Imp.Common
 
@@ -46,6 +47,8 @@ spec ::
   Spec
 spec = do
   AlonzoImp.spec @era
-  describe "BabbageImpSpec" . withImpInit @(LedgerSpec era) $ do
-    Utxow.spec
-    Utxo.spec
+  withImpInit @(LedgerSpec era) $
+    describe "BabbageImpSpec" $ do
+      Utxo.spec
+      Utxow.spec
+      Utxos.spec @era

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -7,17 +7,16 @@
 
 module Test.Cardano.Ledger.Babbage.Imp (spec) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (ContextError, EraPlutusTxInfo)
+import Cardano.Ledger.Alonzo.Plutus.Context (ContextError)
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
   AlonzoUtxowPredFailure,
  )
 import Cardano.Ledger.Babbage.Core (BabbageEraTxBody, InjectRuleFailure)
-import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
+import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
 import Cardano.Ledger.BaseTypes (Inject)
-import Cardano.Ledger.Plutus (Language (..))
 import Cardano.Ledger.Shelley.Rules (
   ShelleyDelegPredFailure,
   ShelleyUtxoPredFailure,
@@ -34,13 +33,13 @@ spec ::
   forall era.
   ( AlonzoEraImp era
   , BabbageEraTxBody era
-  , EraPlutusTxInfo 'PlutusV2 era
   , InjectRuleFailure "LEDGER" ShelleyDelegPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxoPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxoPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
   , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
   , InjectRuleFailure "LEDGER" BabbageUtxowPredFailure era
   , Inject (BabbageContextError era) (ContextError era)
   ) =>

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxoSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxoSpec.hs
@@ -1,30 +1,27 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Babbage.Imp.UtxoSpec (spec) where
 
-import Cardano.Ledger.Babbage.Core (
-  BabbageEraTxBody (..),
-  BabbageEraTxOut (..),
-  EraTx (..),
-  EraTxBody (..),
-  EraTxOut (..),
-  ppProtocolVersionL,
- )
-import Cardano.Ledger.BaseTypes (Inject (..), ProtVer (..), natVersion)
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Babbage.Core
+import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..))
+import Cardano.Ledger.BaseTypes (Inject (..), ProtVer (..), StrictMaybe (..), natVersion)
+import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Credential (StakeReference (..))
 import Cardano.Ledger.Plutus (
-  Data (..),
-  Datum (..),
+  Language (..),
   SLanguage (..),
-  dataToBinaryData,
   hashPlutusScript,
+  mkInlineDatum,
+  withSLanguage,
  )
+import qualified Data.ByteString as BS
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Lens.Micro ((&), (.~))
@@ -33,16 +30,25 @@ import Test.Cardano.Ledger.Babbage.ImpTest (
   AlonzoEraImp,
   ImpInit,
   LedgerSpec,
+  freshKeyAddr_,
   getsPParams,
+  sendCoinTo,
+  submitFailingTx,
   submitTx,
   submitTx_,
  )
-import Test.Cardano.Ledger.Common (SpecWith, describe, it, pendingWith, when)
+import Test.Cardano.Ledger.Common (SpecWith, describe, it, when)
 import Test.Cardano.Ledger.Core.Utils (txInAt)
 import Test.Cardano.Ledger.Imp.Common (mkAddr)
-import Test.Cardano.Ledger.Plutus.Examples (inputsOverlapsWithRefInputs)
+import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum, inputsOverlapsWithRefInputs)
 
-spec :: forall era. (AlonzoEraImp era, BabbageEraTxBody era) => SpecWith (ImpInit (LedgerSpec era))
+spec ::
+  forall era.
+  ( AlonzoEraImp era
+  , BabbageEraTxBody era
+  , InjectRuleFailure "LEDGER" BabbageUtxoPredFailure era
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
 spec = describe "UTXO" $ do
   describe "Reference scripts" $ do
     it "Reference inputs can overlap with regular inputs in PlutusV2" $ do
@@ -54,7 +60,7 @@ spec = describe "UTXO" $ do
                 StakeRefNull
             )
             (inject $ Coin 1_000_000)
-            & datumTxOutL .~ Datum (dataToBinaryData . Data $ PV1.I 0)
+            & datumTxOutL .~ mkInlineDatum (PV1.I 0)
       tx <-
         submitTx $
           mkBasicTx mkBasicTxBody
@@ -68,7 +74,36 @@ spec = describe "UTXO" $ do
             & bodyTxL . referenceInputsTxBodyL .~ Set.singleton txIn
 
   it "Incorrect collateral total" $ do
-    const $ pendingWith "not implemented yet"
+    let scriptHash = withSLanguage PlutusV2 (hashPlutusScript . alwaysSucceedsWithDatum)
+        txOut =
+          mkBasicTxOut (mkAddr scriptHash StakeRefNull) mempty
+            & datumTxOutL .~ mkInlineDatum (PV1.I 1)
+        tx1 = mkBasicTx $ mkBasicTxBody & outputsTxBodyL .~ [txOut]
+    txIn <- txInAt 0 <$> submitTx tx1
+    addr <- freshKeyAddr_
+    coll <- sendCoinTo addr $ Coin 5_000_000
+    let collReturn = mkBasicTxOut addr . inject $ Coin 2_000_000
+        tx2 =
+          mkBasicTx $
+            mkBasicTxBody
+              & inputsTxBodyL .~ [txIn]
+              & collateralInputsTxBodyL .~ [coll]
+              & collateralReturnTxBodyL .~ SJust collReturn
+              & totalCollateralTxBodyL .~ SJust (Coin 1_000_000)
+    submitFailingTx
+      tx2
+      [injectFailure (IncorrectTotalCollateralField (DeltaCoin 3_000_000) (Coin 1_000_000))]
 
+  -- TxOut too large for the included ADA, using a large inline datum
   it "Min-utxo value with output too large" $ do
-    const $ pendingWith "not implemented yet"
+    pp <- getsPParams id
+    addr <- freshKeyAddr_
+    let
+      amount = inject $ Coin 5_000_000
+      largeDatum = PV1.B $ BS.replicate 1500 0
+      txOut = mkBasicTxOut addr amount & datumTxOutL .~ mkInlineDatum largeDatum
+    submitFailingTx
+      (mkBasicTx mkBasicTxBody & bodyTxL . outputsTxBodyL .~ [txOut])
+      [ injectFailure $
+          BabbageOutputTooSmallUTxO [(txOut, getMinCoinTxOut pp txOut)]
+      ]

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxoSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxoSpec.hs
@@ -37,7 +37,7 @@ import Test.Cardano.Ledger.Babbage.ImpTest (
   submitTx,
   submitTx_,
  )
-import Test.Cardano.Ledger.Common (SpecWith, describe, it, when)
+import Test.Cardano.Ledger.Common (SpecWith, describe, it, pendingWith, when)
 import Test.Cardano.Ledger.Core.Utils (txInAt)
 import Test.Cardano.Ledger.Imp.Common (mkAddr)
 import Test.Cardano.Ledger.Plutus.Examples (inputsOverlapsWithRefInputs)
@@ -66,3 +66,9 @@ spec = describe "UTXO" $ do
           mkBasicTx mkBasicTxBody
             & bodyTxL . inputsTxBodyL .~ Set.singleton txIn
             & bodyTxL . referenceInputsTxBodyL .~ Set.singleton txIn
+
+  it "Incorrect collateral total" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Min-utxo value with output too large" $ do
+    const $ pendingWith "not implemented yet"

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
@@ -1,13 +1,102 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
 module Test.Cardano.Ledger.Babbage.Imp.UtxosSpec (spec) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (ContextError)
+import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (BadTranslation))
+import Cardano.Ledger.Alonzo.Plutus.TxInfo (
+  TxOutSource (TxOutFromOutput),
+ )
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure (CollectErrors))
+import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.Babbage.Core (BabbageEraTxBody, referenceInputsTxBodyL)
+import Cardano.Ledger.Babbage.TxInfo (
+  BabbageContextError (
+    ReferenceInputsNotSupported,
+    ReferenceScriptsNotSupported
+  ),
+ )
+import Cardano.Ledger.Babbage.TxOut (referenceScriptTxOutL)
+import Cardano.Ledger.BaseTypes (Inject, StrictMaybe (..), TxIx (..), inject)
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (
+  InjectRuleFailure,
+  eraProtVerHigh,
+  eraProtVerLow,
+  fromNativeScript,
+  hashScript,
+  injectFailure,
+  inputsTxBodyL,
+  mkBasicTx,
+  mkBasicTxBody,
+  mkCoinTxOut,
+  outputsTxBodyL,
+ )
+import Cardano.Ledger.Plutus (Language (..), hashPlutusScript, withSLanguage)
+import Cardano.Ledger.Shelley.Scripts (pattern RequireAllOf)
+import Lens.Micro
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples
 
-spec :: SpecWith (ImpInit (LedgerSpec era))
+spec ::
+  forall era.
+  ( AlonzoEraImp era
+  , BabbageEraTxBody era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  , Inject (BabbageContextError era) (ContextError era)
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
 spec = describe "UTXOS" $ do
   describe "Plutus V1 with references" $ do
-    it "fails with a reference script" $ do
-      const $ pendingWith "not implemented yet"
+    let inBabbage = eraProtVerLow @era <= eraProtVerHigh @BabbageEra
+        behavior = if inBabbage then "fails" else "succeeds"
+        submitBabbageFailingTx tx failures =
+          if inBabbage then submitFailingTx tx failures else submitTx_ tx
 
-    it "fails with a reference input" $ do
-      const $ pendingWith "not implemented yet"
+    it (behavior <> " with a reference script") $ do
+      let plutusScriptHash = withSLanguage PlutusV1 $ hashPlutusScript . alwaysSucceedsWithDatum
+          nativeScript = fromNativeScript @era $ RequireAllOf []
+      txIn <- produceScript plutusScriptHash
+      addr <- freshKeyAddr_
+      let txOut =
+            mkCoinTxOut addr (inject $ Coin 5_000_000)
+              & referenceScriptTxOutL .~ SJust nativeScript
+          tx =
+            mkBasicTx $
+              mkBasicTxBody
+                & inputsTxBodyL .~ [txIn]
+                & outputsTxBodyL .~ [txOut]
+      submitBabbageFailingTx
+        tx
+        [ injectFailure $
+            CollectErrors
+              [ BadTranslation . inject $
+                  ReferenceScriptsNotSupported @era (TxOutFromOutput (TxIx 0))
+              ]
+        ]
+
+    it (behavior <> " with a reference input") $ do
+      let plutusScriptHash = withSLanguage PlutusV1 $ hashPlutusScript . alwaysSucceedsWithDatum
+          nativeScriptHash = hashScript . fromNativeScript @era $ RequireAllOf []
+      txIn <- produceScript plutusScriptHash
+      refIn <- produceScript nativeScriptHash
+      let tx =
+            mkBasicTx $
+              mkBasicTxBody
+                & inputsTxBodyL .~ [txIn]
+                & referenceInputsTxBodyL .~ [refIn]
+      submitBabbageFailingTx
+        tx
+        [ injectFailure $
+            CollectErrors
+              [ BadTranslation . inject $
+                  ReferenceInputsNotSupported @era [refIn]
+              ]
+        ]

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
@@ -1,0 +1,8 @@
+module Test.Cardano.Ledger.Babbage.Imp.UtxosSpec (spec) where
+
+import Test.Cardano.Ledger.Alonzo.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+
+spec :: SpecWith (ImpInit (LedgerSpec era))
+spec = describe "UTXOS" $ do
+  pure ()

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
@@ -5,4 +5,9 @@ import Test.Cardano.Ledger.Imp.Common
 
 spec :: SpecWith (ImpInit (LedgerSpec era))
 spec = describe "UTXOS" $ do
-  pure ()
+  describe "Plutus V1 with references" $ do
+    it "fails with a reference script" $ do
+      const $ pendingWith "not implemented yet"
+
+    it "fails with a reference input" $ do
+      const $ pendingWith "not implemented yet"

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec.hs
@@ -1,108 +1,35 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Babbage.Imp.UtxowSpec (spec) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (ContextError, EraPlutusTxInfo, mkSupportedPlutusScript)
-import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
+import Cardano.Ledger.Alonzo.Plutus.Context (ContextError, EraPlutusTxInfo)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure (..), AlonzoUtxowPredFailure (..))
-import Cardano.Ledger.Alonzo.Scripts
-import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
-import Cardano.Ledger.Babbage.Core
+import Cardano.Ledger.Babbage.Core (BabbageEraTxBody, InjectRuleFailure)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
-import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Plutus
-import Cardano.Ledger.Shelley.Scripts (pattern RequireAnyOf)
-import Cardano.Ledger.TxIn (mkTxInPartial)
-import Data.Either (isRight)
-import qualified Data.Map.Strict as Map
-import qualified Data.Sequence.Strict as SSeq
-import qualified Data.Set as Set
-import Lens.Micro
-import Test.Cardano.Ledger.Alonzo.ImpTest
+import Cardano.Ledger.BaseTypes (Inject)
+import Cardano.Ledger.Plutus (Language (..))
+import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp, ImpInit, LedgerSpec)
+import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec.Invalid as Invalid
+import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec.Valid as Valid
 import Test.Cardano.Ledger.Imp.Common
-import Test.Cardano.Ledger.Plutus.Examples (redeemerSameAsDatum)
 
 spec ::
   forall era.
   ( AlonzoEraImp era
   , BabbageEraTxBody era
-  , EraPlutusTxInfo 'PlutusV2 era
+  , EraPlutusTxInfo PlutusV2 era
   , InjectRuleFailure "LEDGER" BabbageUtxowPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
   , Inject (BabbageContextError era) (ContextError era)
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = describe "UTXOW" $ do
-  it "MalformedScriptWitnesses" $ do
-    let scriptHash = hashPlutusScript (malformedPlutus @'PlutusV2)
-    txIn <- produceScript scriptHash
-    let tx = mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
-    submitFailingTx
-      tx
-      [ injectFailure $
-          MalformedScriptWitnesses [scriptHash]
-      ]
-
-  it "MalformedReferenceScripts" $ do
-    let script = fromPlutusScript (mkSupportedPlutusScript (malformedPlutus @'PlutusV2))
-    let scriptHash = hashScript script
-    addr <- freshKeyAddr_
-    let tx =
-          mkBasicTx mkBasicTxBody
-            & bodyTxL . outputsTxBodyL
-              .~ [ mkBasicTxOut addr mempty & referenceScriptTxOutL .~ SJust script
-                 ]
-    submitFailingTx
-      tx
-      [ injectFailure $
-          MalformedReferenceScripts [scriptHash]
-      ]
-
-  it "ExtraRedeemers/RedeemerPointerPointsToNothing" $
-    -- There is ExtraRedeemers test for PlutusV1 in Alonzo, thus we start with PlutusV2
-    forM_ ([PlutusV2 .. eraMaxLanguage @era] :: [Language]) $ \lang -> do
-      logString $ "Testing for " <> show lang
-      let scriptHash = withSLanguage lang (hashPlutusScript . redeemerSameAsDatum)
-      txIn <- produceScript scriptHash
-      let prp = MintingPurpose (AsIx 2)
-      dt <- arbitrary
-      let tx =
-            mkBasicTx mkBasicTxBody
-              & bodyTxL . inputsTxBodyL .~ [txIn]
-              & witsTxL . rdmrsTxWitsL . unRedeemersL %~ Map.insert prp (dt, ExUnits 0 0)
-      submitFailingTx
-        tx
-        [ injectFailure $ ExtraRedeemers [prp]
-        , injectFailure $
-            CollectErrors [BadTranslation (inject $ RedeemerPointerPointsToNothing prp)]
-        ]
-
-  it "P1 reference scripts must be witnessed" $ do
-    (_, addr) <- freshKeyAddr
-    let
-      timelock = fromNativeScript @era $ RequireAnyOf []
-      txOut =
-        mkCoinTxOut addr (inject $ Coin 15_000_000)
-          & referenceScriptTxOutL .~ SJust timelock
-    tx0 <-
-      submitTx $
-        mkBasicTx mkBasicTxBody
-          & bodyTxL . outputsTxBodyL .~ SSeq.singleton txOut
-    let
-      txIn = mkTxInPartial (txIdTx tx0) 0
-      tx1 =
-        mkBasicTx mkBasicTxBody
-          & bodyTxL . referenceInputsTxBodyL .~ Set.singleton txIn
-    res <- trySubmitTx tx1
-    res `shouldSatisfyExpr` isRight
+spec = do
+  describe "UTXOW" $ do
+    Valid.spec
+    Invalid.spec

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec.hs
@@ -6,13 +6,13 @@
 
 module Test.Cardano.Ledger.Babbage.Imp.UtxowSpec (spec) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (ContextError, EraPlutusTxInfo)
-import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure (..), AlonzoUtxowPredFailure (..))
+import Cardano.Ledger.Alonzo.Plutus.Context (ContextError)
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure, AlonzoUtxowPredFailure)
 import Cardano.Ledger.Babbage.Core (BabbageEraTxBody, InjectRuleFailure)
-import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
-import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
+import Cardano.Ledger.Babbage.TxInfo (BabbageContextError)
 import Cardano.Ledger.BaseTypes (Inject)
-import Cardano.Ledger.Plutus (Language (..))
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure)
 import Test.Cardano.Ledger.Alonzo.ImpTest (AlonzoEraImp, ImpInit, LedgerSpec)
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec.Invalid as Invalid
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec.Valid as Valid
@@ -22,7 +22,7 @@ spec ::
   forall era.
   ( AlonzoEraImp era
   , BabbageEraTxBody era
-  , EraPlutusTxInfo PlutusV2 era
+  , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   , InjectRuleFailure "LEDGER" BabbageUtxowPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
@@ -36,6 +36,9 @@ spec ::
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
 spec = describe "Invalid" $ do
+  it "Inline datum with Plutus V1" $ do
+    const $ pendingWith "not implemented yet"
+
   it "MalformedScriptWitnesses" $ do
     let scriptHash = hashPlutusScript @PlutusV2 malformedPlutus
     txIn <- produceScript scriptHash
@@ -79,3 +82,18 @@ spec = describe "Invalid" $ do
         , injectFailure $
             CollectErrors [BadTranslation (inject $ RedeemerPointerPointsToNothing prp)]
         ]
+
+  it "Inline datum failing script" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Use a collateral output" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Inline datum and ref script and redundant script witness" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Inline datum with redundant datum witness" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "No such thing as a reference datum" $ do
+    const $ pendingWith "not implemented yet"

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Babbage.Imp.UtxowSpec.Invalid (spec) where
+
+import Cardano.Ledger.Alonzo.Plutus.Context (ContextError, EraPlutusTxInfo, mkSupportedPlutusScript)
+import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure (..), AlonzoUtxowPredFailure (..))
+import Cardano.Ledger.Alonzo.Scripts
+import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
+import Cardano.Ledger.Babbage.Core
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
+import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Plutus
+import qualified Data.Map.Strict as Map
+import Lens.Micro
+import Test.Cardano.Ledger.Alonzo.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+import Test.Cardano.Ledger.Plutus.Examples (redeemerSameAsDatum)
+
+spec ::
+  forall era.
+  ( AlonzoEraImp era
+  , BabbageEraTxBody era
+  , EraPlutusTxInfo PlutusV2 era
+  , InjectRuleFailure "LEDGER" BabbageUtxowPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
+  , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
+  , Inject (BabbageContextError era) (ContextError era)
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
+spec = describe "Invalid" $ do
+  it "MalformedScriptWitnesses" $ do
+    let scriptHash = hashPlutusScript @PlutusV2 malformedPlutus
+    txIn <- produceScript scriptHash
+    let tx = mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
+    submitFailingTx
+      tx
+      [ injectFailure $
+          MalformedScriptWitnesses [scriptHash]
+      ]
+
+  it "MalformedReferenceScripts" $ do
+    let script = fromPlutusScript $ mkSupportedPlutusScript @PlutusV2 @era malformedPlutus
+    let scriptHash = hashScript script
+    addr <- freshKeyAddr_
+    let tx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . outputsTxBodyL
+              .~ [ mkBasicTxOut addr mempty & referenceScriptTxOutL .~ SJust script
+                 ]
+    submitFailingTx
+      tx
+      [ injectFailure $
+          MalformedReferenceScripts [scriptHash]
+      ]
+
+  it "ExtraRedeemers/RedeemerPointerPointsToNothing" $
+    -- There is ExtraRedeemers test for PlutusV1 in Alonzo, thus we start with PlutusV2
+    forM_ ([PlutusV2 .. eraMaxLanguage @era] :: [Language]) $ \lang -> do
+      logString $ "Testing for " <> show lang
+      let scriptHash = withSLanguage lang (hashPlutusScript . redeemerSameAsDatum)
+      txIn <- produceScript scriptHash
+      let prp = MintingPurpose (AsIx 2)
+      dt <- arbitrary
+      let tx =
+            mkBasicTx mkBasicTxBody
+              & bodyTxL . inputsTxBodyL .~ [txIn]
+              & witsTxL . rdmrsTxWitsL . unRedeemersL %~ Map.insert prp (dt, ExUnits 0 0)
+      submitFailingTx
+        tx
+        [ injectFailure $ ExtraRedeemers [prp]
+        , injectFailure $
+            CollectErrors [BadTranslation (inject $ RedeemerPointerPointsToNothing prp)]
+        ]

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -8,27 +9,42 @@
 
 module Test.Cardano.Ledger.Babbage.Imp.UtxowSpec.Invalid (spec) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (ContextError, EraPlutusTxInfo, mkSupportedPlutusScript)
+import Cardano.Ledger.Alonzo.Plutus.Context (ContextError)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError (..))
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxosPredFailure (..), AlonzoUtxowPredFailure (..))
 import Cardano.Ledger.Alonzo.Scripts
-import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
+import Cardano.Ledger.Alonzo.TxWits (TxDats (..), unRedeemersL)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure (..))
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Plutus
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Credential (StakeReference (..))
+import Cardano.Ledger.Plutus (
+  Data (..),
+  Datum (..),
+  Language (..),
+  TxOutSource (TxOutFromInput),
+  asSLanguage,
+  hashData,
+  hashPlutusScript,
+  mkInlineDatum,
+  withSLanguage,
+ )
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (ExtraneousScriptWitnessesUTXOW))
 import qualified Data.Map.Strict as Map
 import Lens.Micro
+import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Alonzo.ImpTest
+import Test.Cardano.Ledger.Core.Utils (txInAt)
 import Test.Cardano.Ledger.Imp.Common
-import Test.Cardano.Ledger.Plutus.Examples (redeemerSameAsDatum)
+import Test.Cardano.Ledger.Plutus.Examples
 
 spec ::
   forall era.
   ( AlonzoEraImp era
   , BabbageEraTxBody era
-  , EraPlutusTxInfo PlutusV2 era
+  , InjectRuleFailure "LEDGER" ShelleyUtxowPredFailure era
   , InjectRuleFailure "LEDGER" BabbageUtxowPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxosPredFailure era
   , InjectRuleFailure "LEDGER" AlonzoUtxowPredFailure era
@@ -37,63 +53,172 @@ spec ::
   SpecWith (ImpInit (LedgerSpec era))
 spec = describe "Invalid" $ do
   it "Inline datum with Plutus V1" $ do
-    const $ pendingWith "not implemented yet"
-
-  it "MalformedScriptWitnesses" $ do
-    let scriptHash = hashPlutusScript @PlutusV2 malformedPlutus
-    txIn <- produceScript scriptHash
-    let tx = mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
+    let scriptHash = withSLanguage PlutusV1 $ hashPlutusScript . alwaysSucceedsWithDatum
+        txOut =
+          mkBasicTxOut (mkAddr scriptHash StakeRefNull) mempty
+            & datumTxOutL .~ mkInlineDatum (PV1.I 0)
+        tx = mkBasicTx mkBasicTxBody & bodyTxL . outputsTxBodyL .~ [txOut]
+    txIn <- txInAt 0 <$> submitTx tx
     submitFailingTx
-      tx
+      (mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn])
       [ injectFailure $
-          MalformedScriptWitnesses [scriptHash]
+          CollectErrors
+            [ BadTranslation . inject $
+                InlineDatumsNotSupported @era (TxOutFromInput txIn)
+            ]
       ]
 
-  it "MalformedReferenceScripts" $ do
-    let script = fromPlutusScript $ mkSupportedPlutusScript @PlutusV2 @era malformedPlutus
-    let scriptHash = hashScript script
-    addr <- freshKeyAddr_
-    let tx =
-          mkBasicTx mkBasicTxBody
-            & bodyTxL . outputsTxBodyL
-              .~ [ mkBasicTxOut addr mempty & referenceScriptTxOutL .~ SJust script
-                 ]
-    submitFailingTx
-      tx
-      [ injectFailure $
-          MalformedReferenceScripts [scriptHash]
-      ]
+  forM_ @[] [PlutusV2 .. eraMaxLanguage @era] $ \slang -> do
+    describe (show slang) $ do
+      withSLanguage slang $ \lang -> do
+        it "MalformedScriptWitnesses" $ do
+          let scriptHash = hashPlutusScript $ asSLanguage lang malformedPlutus
+          txIn <- produceScript scriptHash
+          let tx = mkBasicTx mkBasicTxBody & bodyTxL . inputsTxBodyL .~ [txIn]
+          submitFailingTx
+            tx
+            [ injectFailure $
+                MalformedScriptWitnesses [scriptHash]
+            ]
 
-  it "ExtraRedeemers/RedeemerPointerPointsToNothing" $
-    -- There is ExtraRedeemers test for PlutusV1 in Alonzo, thus we start with PlutusV2
-    forM_ ([PlutusV2 .. eraMaxLanguage @era] :: [Language]) $ \lang -> do
-      logString $ "Testing for " <> show lang
-      let scriptHash = withSLanguage lang (hashPlutusScript . redeemerSameAsDatum)
-      txIn <- produceScript scriptHash
-      let prp = MintingPurpose (AsIx 2)
-      dt <- arbitrary
-      let tx =
+        it "MalformedReferenceScripts" $ do
+          plutus <- mkPlutusScript $ asSLanguage lang malformedPlutus
+          let script = fromPlutusScript plutus
+              scriptHash = hashScript script
+          addr <- freshKeyAddr_
+          let tx =
+                mkBasicTx mkBasicTxBody
+                  & bodyTxL . outputsTxBodyL
+                    .~ [ mkBasicTxOut addr mempty & referenceScriptTxOutL .~ SJust script
+                       ]
+          submitFailingTx
+            tx
+            [ injectFailure $
+                MalformedReferenceScripts [scriptHash]
+            ]
+
+        -- There's already an ExtraRedeemers test for PlutusV1 in Alonzo, thus it's OK to start with PlutusV2
+        it "ExtraRedeemers/RedeemerPointerPointsToNothing" $ do
+          let scriptHash = hashPlutusScript $ redeemerSameAsDatum lang
+          txIn <- produceScript scriptHash
+          let prp = MintingPurpose (AsIx 2)
+          dt <- arbitrary
+          let tx =
+                mkBasicTx mkBasicTxBody
+                  & bodyTxL . inputsTxBodyL .~ [txIn]
+                  & witsTxL . rdmrsTxWitsL . unRedeemersL %~ Map.insert prp (dt, ExUnits 0 0)
+          submitFailingTx
+            tx
+            [ injectFailure $ ExtraRedeemers [prp]
+            , injectFailure $
+                CollectErrors [BadTranslation (inject $ RedeemerPointerPointsToNothing prp)]
+            ]
+
+        it "Inline datum with a failing script" $ do
+          let scriptHash = hashPlutusScript $ evenDatum lang
+              txOut =
+                mkBasicTxOut (mkAddr scriptHash StakeRefNull) mempty
+                  & datumTxOutL .~ mkInlineDatum (PV1.I 1)
+              tx = mkBasicTx mkBasicTxBody & bodyTxL . outputsTxBodyL .~ [txOut]
+          txIn <- txInAt 0 <$> submitTx tx
+          submitPhase2Invalid_ $ mkBasicTx $ mkBasicTxBody & inputsTxBodyL .~ [txIn]
+
+        it "Use a collateral output" $ do
+          let scriptHash = hashPlutusScript $ alwaysFailsWithDatum lang
+              datum = Data @era $ PV1.B "abcde"
+              datumHash = hashData datum
+              txOut =
+                mkBasicTxOut (mkAddr scriptHash StakeRefNull) mempty
+                  & datumTxOutL .~ DatumHash datumHash
+              tx = mkBasicTx $ mkBasicTxBody & outputsTxBodyL .~ [txOut]
+          txIn <- txInAt 0 <$> submitTx tx
+          addr <- freshKeyAddr_
+          coll <- sendCoinTo addr $ Coin 5_000_000
+          let collReturn = mkBasicTxOut addr . inject $ Coin 2_000_000
+          submitPhase2Invalid_ $
             mkBasicTx mkBasicTxBody
               & bodyTxL . inputsTxBodyL .~ [txIn]
-              & witsTxL . rdmrsTxWitsL . unRedeemersL %~ Map.insert prp (dt, ExUnits 0 0)
-      submitFailingTx
-        tx
-        [ injectFailure $ ExtraRedeemers [prp]
-        , injectFailure $
-            CollectErrors [BadTranslation (inject $ RedeemerPointerPointsToNothing prp)]
-        ]
+              & bodyTxL . collateralInputsTxBodyL .~ [coll]
+              & bodyTxL . collateralReturnTxBodyL .~ SJust collReturn
+              & witsTxL . datsTxWitsL .~ TxDats [(datumHash, datum)]
 
-  it "Inline datum failing script" $ do
-    const $ pendingWith "not implemented yet"
+        -- Spend a UTxO that has an inline datum, using a reference script,
+        -- and also redundantly supply the script witness.
+        it "Inline datum and ref script and redundant script witness" $ do
+          addr <- freshKeyAddr_
+          plutus <- mkPlutusScript $ alwaysSucceedsWithDatum lang
+          let script = fromPlutusScript plutus
+              scriptHash = hashScript script
+              txOutDatum =
+                mkBasicTxOut (mkAddr scriptHash StakeRefNull) mempty
+                  & datumTxOutL .~ mkInlineDatum (PV1.B "abcde")
+              txOutScript =
+                mkBasicTxOut addr mempty
+                  & referenceScriptTxOutL .~ SJust script
+          tx <-
+            submitTx $
+              mkBasicTx mkBasicTxBody
+                & bodyTxL . outputsTxBodyL .~ [txOutDatum, txOutScript]
+          let txInDatum = txInAt 0 tx
+              txInScript = txInAt 1 tx
+          submitFailingTx
+            ( mkBasicTx mkBasicTxBody
+                & bodyTxL . inputsTxBodyL .~ [txInDatum]
+                & bodyTxL . referenceInputsTxBodyL .~ [txInScript]
+                & witsTxL . scriptTxWitsL
+                  .~ Map.fromList [(scriptHash, script)]
+            )
+            [ injectFailure $
+                ExtraneousScriptWitnessesUTXOW [scriptHash]
+            ]
 
-  it "Use a collateral output" $ do
-    const $ pendingWith "not implemented yet"
+        it "Inline datum with redundant datum witness" $ do
+          let scriptHash = hashPlutusScript $ alwaysSucceedsWithDatum lang
+              txOut =
+                mkBasicTxOut (mkAddr scriptHash StakeRefNull) mempty
+                  & datumTxOutL .~ mkInlineDatum (PV1.B "abcde")
+              tx = mkBasicTx mkBasicTxBody & bodyTxL . outputsTxBodyL .~ [txOut]
+          txIn <- txInAt 0 <$> submitTx tx
+          let redundantDatum = Data @era $ PV1.I 1
+          submitFailingTx
+            ( mkBasicTx mkBasicTxBody
+                & bodyTxL . inputsTxBodyL .~ [txIn]
+                & witsTxL . datsTxWitsL .~ TxDats [(hashData redundantDatum, redundantDatum)]
+            )
+            [ injectFailure $
+                NotAllowedSupplementalDatums [hashData redundantDatum] mempty
+            ]
 
-  it "Inline datum and ref script and redundant script witness" $ do
-    const $ pendingWith "not implemented yet"
+        -- There is no such thing as a "reference datum". In other words, you cannot
+        -- include a reference input that contains an inline datum and have it count
+        -- for the datum witness where ever it is needed.
+        it "No such thing as a reference datum" $ do
+          addr <- freshKeyAddr_
 
-  it "Inline datum with redundant datum witness" $ do
-    const $ pendingWith "not implemented yet"
+          let scriptHash = hashPlutusScript $ alwaysFailsWithDatum lang
+              datum = PV1.B "abcde"
+              datumHash = hashData $ Data @era datum
+              txOutInline =
+                mkBasicTxOut addr mempty
+                  & datumTxOutL .~ mkInlineDatum datum
+              txOutHash =
+                mkBasicTxOut (mkAddr scriptHash StakeRefNull) mempty
+                  & datumTxOutL .~ DatumHash datumHash
 
-  it "No such thing as a reference datum" $ do
-    const $ pendingWith "not implemented yet"
+          tx <-
+            submitTx $
+              mkBasicTx mkBasicTxBody
+                & bodyTxL . outputsTxBodyL .~ [txOutInline, txOutHash]
+          let txInInline = txInAt 0 tx
+              txInHash = txInAt 1 tx
+
+          -- The reference input has the required inline datum, but that doesn't
+          -- witness the datum hash for the Plutus script in the other input
+          submitFailingTx
+            ( mkBasicTx mkBasicTxBody
+                & bodyTxL . referenceInputsTxBodyL .~ [txInInline]
+                & bodyTxL . inputsTxBodyL .~ [txInHash]
+            )
+            [ injectFailure $
+                MissingRequiredDatums [datumHash] mempty
+            ]

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Valid.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Valid.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Babbage.Imp.UtxowSpec.Valid (spec) where
+
+import Cardano.Ledger.Babbage.Core
+import Cardano.Ledger.BaseTypes
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Shelley.Scripts (pattern RequireAnyOf)
+import Cardano.Ledger.TxIn (mkTxInPartial)
+import Lens.Micro
+import Test.Cardano.Ledger.Alonzo.ImpTest
+import Test.Cardano.Ledger.Imp.Common
+
+spec ::
+  forall era.
+  ( AlonzoEraImp era
+  , BabbageEraTxBody era
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
+spec = describe "Valid" $ do
+  it "Native reference scripts must be witnessed" $ do
+    addr <- freshKeyAddr_
+    let
+      timelock = fromNativeScript @era $ RequireAnyOf []
+      txOut =
+        mkCoinTxOut addr (inject $ Coin 15_000_000)
+          & referenceScriptTxOutL .~ SJust timelock
+    tx0 <-
+      submitTx $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . outputsTxBodyL .~ [txOut]
+    let
+      txIn = mkTxInPartial (txIdTx tx0) 0
+      tx1 =
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . referenceInputsTxBodyL .~ [txIn]
+    submitTx_ tx1

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Valid.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Valid.hs
@@ -43,3 +43,27 @@ spec = describe "Valid" $ do
         mkBasicTx mkBasicTxBody
           & bodyTxL . referenceInputsTxBodyL .~ [txIn]
     submitTx_ tx1
+
+  it "Inline datum" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Reference script" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Inline datum and ref script" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Reference input with data hash, no data witness" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Reference input with data hash, with data witness" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Reference script to authorize delegation certificate" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Reference script in output" $ do
+    const $ pendingWith "not implemented yet"
+
+  it "Spend simple script output with reference script" $ do
+    const $ pendingWith "not implemented yet"

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -31,6 +31,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   AlonzoPlutusPurpose (..),
   AlonzoScript (..),
   alonzoScriptPrefixTag,
+  eraUnsupportedLanguage,
   isPlutusScript,
  )
 import Cardano.Ledger.Babbage.Core
@@ -99,10 +100,10 @@ instance AlonzoEraScript ConwayEra where
 
   mkPlutusScript plutus =
     case plutusSLanguage plutus of
-      SPlutusV1 -> Just $ ConwayPlutusV1 plutus
-      SPlutusV2 -> Just $ ConwayPlutusV2 plutus
-      SPlutusV3 -> Just $ ConwayPlutusV3 plutus
-      _ -> Nothing
+      SPlutusV1 -> pure $ ConwayPlutusV1 plutus
+      SPlutusV2 -> pure $ ConwayPlutusV2 plutus
+      SPlutusV3 -> pure $ ConwayPlutusV3 plutus
+      slang -> eraUnsupportedLanguage @ConwayEra slang
 
   withPlutusScript (ConwayPlutusV1 plutus) f = f plutus
   withPlutusScript (ConwayPlutusV2 plutus) f = f plutus

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -8,7 +8,7 @@
 
 module Test.Cardano.Ledger.Conway.Imp (spec, conwaySpec) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (..), EraPlutusTxInfo)
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (ContextError))
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
@@ -31,7 +31,6 @@ import Cardano.Ledger.Conway.Rules (
   ConwayUtxoPredFailure,
  )
 import Cardano.Ledger.Conway.TxInfo (ConwayContextError)
-import Cardano.Ledger.Plutus (Language (..))
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Rules (
   ShelleyDelegPredFailure,
@@ -63,7 +62,6 @@ import Test.Cardano.Ledger.Shelley.ImpTest (ImpInit)
 spec ::
   forall era.
   ( ConwayEraImp era
-  , EraPlutusTxInfo 'PlutusV2 era
   , Inject (BabbageContextError era) (ContextError era)
   , Inject (ConwayContextError era) (ContextError era)
   , InjectRuleFailure "LEDGER" ConwayGovPredFailure era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -58,7 +58,7 @@ spec ::
   SpecWith (ImpInit (LedgerSpec era))
 spec = do
   it "BodyRefScriptsSizeTooBig" $ do
-    Just plutusScript <- pure $ mkPlutusScript @era $ purposeIsWellformedNoDatum SPlutusV2
+    plutusScript <- mkPlutusScript @era $ purposeIsWellformedNoDatum SPlutusV2
     let scriptSize = originalBytesSize plutusScript
 
     -- Determine a number of transactions and a number of times the reference script

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -56,7 +56,7 @@ spec = do
   it "TxRefScriptsSizeTooBig" $ do
     -- we use here the largest script we currently have as many times as necessary to
     -- trigger the predicate failure
-    Just plutusScript <- pure $ mkPlutusScript @era $ purposeIsWellformedNoDatum SPlutusV3
+    plutusScript <- mkPlutusScript @era $ purposeIsWellformedNoDatum SPlutusV3
     let script :: Script era
         script = fromPlutusScript plutusScript
         size = originalBytesSize script

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Add `mkInlineDatum`, `mkHashedDatum`
 * Rename `EraSegWits` to `EraBlockBody`. #5156
   * Rename `TxSeq` to `BlockBody`
   * Add `mkBasicBlockBody`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
@@ -32,6 +32,8 @@ module Cardano.Ledger.Plutus.Data (
   binaryDataToData,
   dataToBinaryData,
   Datum (..),
+  mkInlineDatum,
+  mkHashedDatum,
   datumDataHash,
   translateDatum,
 ) where
@@ -248,6 +250,12 @@ instance Era era => ToJSON (Datum era) where
     case datumDataHash d of
       SNothing -> toEncoding Null
       SJust dh -> toEncoding dh
+
+mkInlineDatum :: forall era. Era era => PV1.Data -> Datum era
+mkInlineDatum = Datum . dataToBinaryData . Data @era
+
+mkHashedDatum :: forall era. Era era => PV1.Data -> Datum era
+mkHashedDatum = DatumHash . hashData . Data @era
 
 -- | Get the Hash of the datum.
 datumDataHash :: Datum era -> StrictMaybe DataHash


### PR DESCRIPTION
# Description

Partially addresses #4183.

As part of this, I've generalized the return type of `mkPlutusScript` from `Maybe` to `MonadFail`. I could have just changed the function and left all the places that call it (which were previously expecting a `Maybe` and can still get one) unchanged. However, I decided to add improvements where it simplifies the code. This change is in its own commit.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
