### PR TITLE
`constrained-generators`: Simplify `HasSpec` instance for `Bool` and move more things to `NumSpec`

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
@@ -48,9 +48,8 @@ import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (..))
 import Constrained.API
 import Constrained.Base
 import Constrained.GenT
-import Constrained.NumSpec
+import Constrained.NumOrd
 import Constrained.SumList (genListWithSize)
-import Constrained.TheKnot
 import Control.Monad.Identity (Identity (..))
 import Control.Monad.Trans.Fail.String
 import Data.Maybe

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -120,7 +120,7 @@ import Constrained.API
 import Constrained.Base
 import Constrained.GenT (pureGen, vectorOfT)
 import Constrained.Generic
-import Constrained.NumSpec
+import Constrained.NumOrd
 import Constrained.Spec.Map
 import Constrained.Spec.Tree ()
 import Constrained.SumList (genListWithSize)

--- a/libs/constrained-generators/constrained-generators.cabal
+++ b/libs/constrained-generators/constrained-generators.cabal
@@ -39,7 +39,7 @@ library
     Constrained.Generic
     Constrained.Graph
     Constrained.List
-    Constrained.NumSpec
+    Constrained.NumOrd
     Constrained.PrettyUtils
     Constrained.Properties
     Constrained.Spec.Map

--- a/libs/constrained-generators/src/Constrained/API.hs
+++ b/libs/constrained-generators/src/Constrained/API.hs
@@ -179,7 +179,7 @@ import Constrained.Conformance (
 import Constrained.Core (NonEmpty ((:|)))
 import Constrained.FunctionSymbol
 import Constrained.Generic (HasSimpleRep (..), Prod (..))
-import Constrained.NumSpec (
+import Constrained.NumOrd (
   MaybeBounded (..),
   NumLike,
   NumSpec (..),
@@ -188,6 +188,13 @@ import Constrained.NumSpec (
   addFn,
   cardinality,
   negateFn,
+  negate_,
+  (+.),
+  (-.),
+  (<.),
+  (<=.),
+  (>.),
+  (>=.),
  )
 import Constrained.Spec.Map (
   MapSpec (..),

--- a/libs/constrained-generators/src/Constrained/Generic.hs
+++ b/libs/constrained-generators/src/Constrained/Generic.hs
@@ -150,8 +150,6 @@ class Typeable (SimpleRep a) => HasSimpleRep a where
 type family SimplifyRep f where
   SimplifyRep f = SOP (SOPOf f)
 
-instance HasSimpleRep Bool
-
 instance HasSimpleRep () where
   type SimpleRep () = ()
   toSimpleRep x = x

--- a/libs/constrained-generators/src/Constrained/Properties.hs
+++ b/libs/constrained-generators/src/Constrained/Properties.hs
@@ -51,9 +51,9 @@ import Constrained.List (
   uncurryList,
   uncurryList_,
  )
-import Constrained.NumSpec (
+import Constrained.NumOrd (
   IntW (..),
-  NumOrdW (..),
+  OrdW (..),
  )
 import Constrained.PrettyUtils
 import Constrained.Spec.Map (
@@ -288,7 +288,7 @@ instance QC.Arbitrary TestableFn where
       , TestableFn $ InjRightW @Int @Int
       , TestableFn $ InjLeftW @Int @Int
       , TestableFn $ ElemW @Int
-      , TestableFn $ FromGenericW @Bool -- These require GenericC constraints
+      , TestableFn $ FromGenericW @(Either Int Bool)
       , TestableFn $ ToGenericW @(Either Int Bool)
       , -- data SetW
         TestableFn $ SingletonW @Int
@@ -300,7 +300,7 @@ instance QC.Arbitrary TestableFn where
       , -- data BoolW
         TestableFn $ NotW
       , TestableFn $ OrW
-      , -- data NumOrdW
+      , -- data OrdW
         TestableFn $ LessW @Int
       , TestableFn $ LessOrEqualW @Int
       , -- data MapW

--- a/libs/constrained-generators/src/Constrained/Spec/Map.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Map.hs
@@ -25,7 +25,7 @@ import Constrained.FunctionSymbol
 import Constrained.GenT
 import Constrained.Generic (Prod (..))
 import Constrained.List
-import Constrained.NumSpec (cardinality, geqSpec, leqSpec, nubOrd)
+import Constrained.NumOrd (cardinality, geqSpec, leqSpec, nubOrd)
 import Constrained.PrettyUtils
 import Constrained.Spec.Set
 import Constrained.Spec.SumProd

--- a/libs/constrained-generators/src/Constrained/Spec/Set.hs
+++ b/libs/constrained-generators/src/Constrained/Spec/Set.hs
@@ -51,7 +51,7 @@ import Constrained.Core
 import Constrained.FunctionSymbol
 import Constrained.GenT
 import Constrained.List
-import Constrained.NumSpec
+import Constrained.NumOrd
 import Constrained.PrettyUtils
 import Constrained.SumList (knownUpperBound, maxFromSpec)
 import Constrained.Syntax

--- a/libs/constrained-generators/src/Constrained/SumList.hs
+++ b/libs/constrained-generators/src/Constrained/SumList.hs
@@ -37,7 +37,7 @@ import Constrained.GenT (
   tryGenT,
  )
 import Constrained.List (List (..), ListCtx (..))
-import Constrained.NumSpec (
+import Constrained.NumOrd (
   IntW (..),
   MaybeBounded (..),
   NumSpec (..),
@@ -461,7 +461,6 @@ genListWithSize ::
   , Arbitrary a
   , MaybeBounded a
   , Complete Integer
-  , TypeSpec Integer ~ NumSpec Integer
   ) =>
   Specification Integer ->
   Specification a ->


### PR DESCRIPTION
# Description


# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
