### PR TITLE
Simplify `ToJSON` instance for `TransitionConfig`

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### `testlib`
 
+* Added `Arbitrary` instance for `TransitionConfig AllegraEra`
 * Added `Era` module with `AllegraEraTest` class
 
 ## 1.7.0.0

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Transition.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Transition.hs
@@ -11,7 +11,7 @@ import Cardano.Ledger.Allegra.Translation ()
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Shelley
 import Cardano.Ledger.Shelley.Transition
-import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Aeson (FromJSON (..))
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 
@@ -19,7 +19,7 @@ instance EraTransition AllegraEra where
   newtype TransitionConfig AllegraEra = AllegraTransitionConfig
     { atcShelleyTransitionConfig :: TransitionConfig ShelleyEra
     }
-    deriving (Show, Eq, NoThunks, ToJSON, FromJSON)
+    deriving (Show, Eq, NoThunks, FromJSON)
 
   mkTransitionConfig NoGenesis = AllegraTransitionConfig
 
@@ -28,4 +28,4 @@ instance EraTransition AllegraEra where
   tcPreviousEraConfigL =
     lens atcShelleyTransitionConfig (\atc pc -> atc {atcShelleyTransitionConfig = pc})
 
-  tcTranslationContextL = lens (const NoGenesis) (const . id)
+  tcTranslationContextL = lens (const NoGenesis) const

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Transition.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Transition.hs
@@ -11,7 +11,6 @@ import Cardano.Ledger.Allegra.Translation ()
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Shelley
 import Cardano.Ledger.Shelley.Transition
-import Data.Aeson (FromJSON (..))
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 
@@ -19,7 +18,7 @@ instance EraTransition AllegraEra where
   newtype TransitionConfig AllegraEra = AllegraTransitionConfig
     { atcShelleyTransitionConfig :: TransitionConfig ShelleyEra
     }
-    deriving (Show, Eq, NoThunks, FromJSON)
+    deriving (Show, Eq, NoThunks)
 
   mkTransitionConfig NoGenesis = AllegraTransitionConfig
 

--- a/eras/allegra/impl/test/Main.hs
+++ b/eras/allegra/impl/test/Main.hs
@@ -8,6 +8,8 @@ import qualified Test.Cardano.Ledger.Allegra.BinarySpec as BinarySpec
 import qualified Test.Cardano.Ledger.Allegra.Imp as Imp
 import Test.Cardano.Ledger.Allegra.ImpTest ()
 import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
+import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 main :: IO ()
 main =
@@ -17,3 +19,5 @@ main =
       CddlSpec.spec
       describe "Imp" $ do
         Imp.spec @AllegraEra
+      roundTripJsonEraSpec @AllegraEra
+      roundTripJsonShelleyEraSpec @AllegraEra

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Arbitrary.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -25,6 +28,7 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeExpire,
   pattern RequireTimeStart,
  )
+import Cardano.Ledger.Allegra.Transition
 import Cardano.Ledger.Allegra.TxAuxData (AllegraTxAuxData (..))
 import Cardano.Ledger.Allegra.TxBody (pattern AllegraTxBody)
 import Cardano.Ledger.Core
@@ -124,3 +128,5 @@ instance
 instance Arbitrary ValidityInterval where
   arbitrary = genericArbitraryU
   shrink = genericShrink
+
+deriving newtype instance Arbitrary (TransitionConfig AllegraEra)

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.14.0.0
 
+* Deprecated `toAlonzoTransitionConfigPairs`
+* Fixed `FromJSON` instance for `TransitionConfig AlonzoEra`
 * Added `COMPLETE` pragma for `TxCert AlonzoEra`
 * Added `COMPLETE` pragma for `NativeScript AlonzoEra`
 * Deprecated `toAlonzoGenesisPairs`
@@ -31,6 +33,7 @@
 
 ### `testlib`
 
+* Added `Arbitrary` instance for `TransitionConfig BabbageEra`
 * Added `ToExpr` instances for:
   * `AsIxItem`
   * `AlonzoScriptsNeeded`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -235,4 +235,5 @@ test-suite tests
     cardano-ledger-alonzo,
     cardano-ledger-binary:testlib,
     cardano-ledger-core:{cardano-ledger-core, testlib},
+    cardano-ledger-shelley:testlib,
     testlib,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -52,6 +53,6 @@ toAlonzoTransitionConfigPairs = toKeyValuePairs
 
 instance FromJSON (TransitionConfig AlonzoEra) where
   parseJSON = withObject "AlonzoTransitionConfig" $ \o -> do
-    pc <- parseJSON (Object o)
-    ag <- o .: "alonzo"
-    pure $ mkTransitionConfig pc ag
+    prevTransitionConfig :: TransitionConfig MaryEra <- parseJSON (Object o)
+    alonzoGenesis :: AlonzoGenesis <- o .: "alonzo"
+    pure $ mkTransitionConfig alonzoGenesis prevTransitionConfig

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
@@ -19,10 +19,7 @@ import Cardano.Ledger.Shelley.Transition
 import Data.Aeson (
   FromJSON (..),
   KeyValue (..),
-  ToJSON (..),
   Value (..),
-  object,
-  pairs,
   withObject,
   (.:),
  )
@@ -49,18 +46,9 @@ instance EraTransition AlonzoEra where
 
 instance NoThunks (TransitionConfig AlonzoEra)
 
-instance ToJSON (TransitionConfig AlonzoEra) where
-  toJSON = object . toAlonzoTransitionConfigPairs
-  toEncoding = pairs . mconcat . toAlonzoTransitionConfigPairs
-
 toAlonzoTransitionConfigPairs :: KeyValue e a => TransitionConfig AlonzoEra -> [a]
-toAlonzoTransitionConfigPairs alonzoConfig =
-  toShelleyTransitionConfigPairs shelleyConfig
-    ++ ["alonzo" .= object (toKeyValuePairs (alonzoConfig ^. tcTranslationContextL))]
-  where
-    maryConfig = alonzoConfig ^. tcPreviousEraConfigL
-    allegraConfig = maryConfig ^. tcPreviousEraConfigL
-    shelleyConfig = allegraConfig ^. tcPreviousEraConfigL
+toAlonzoTransitionConfigPairs = toKeyValuePairs
+{-# DEPRECATED toAlonzoTransitionConfigPairs "In favor of `toKeyValuePairs`" #-}
 
 instance FromJSON (TransitionConfig AlonzoEra) where
   parseJSON = withObject "AlonzoTransitionConfig" $ \o -> do

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -17,13 +16,7 @@ import Cardano.Ledger.BaseTypes (toKeyValuePairs)
 import Cardano.Ledger.Mary
 import Cardano.Ledger.Mary.Transition (TransitionConfig (MaryTransitionConfig))
 import Cardano.Ledger.Shelley.Transition
-import Data.Aeson (
-  FromJSON (..),
-  KeyValue (..),
-  Value (..),
-  withObject,
-  (.:),
- )
+import Data.Aeson (KeyValue (..))
 import GHC.Generics
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
@@ -50,9 +43,3 @@ instance NoThunks (TransitionConfig AlonzoEra)
 toAlonzoTransitionConfigPairs :: KeyValue e a => TransitionConfig AlonzoEra -> [a]
 toAlonzoTransitionConfigPairs = toKeyValuePairs
 {-# DEPRECATED toAlonzoTransitionConfigPairs "In favor of `toKeyValuePairs`" #-}
-
-instance FromJSON (TransitionConfig AlonzoEra) where
-  parseJSON = withObject "AlonzoTransitionConfig" $ \o -> do
-    prevTransitionConfig :: TransitionConfig MaryEra <- parseJSON (Object o)
-    alonzoGenesis :: AlonzoGenesis <- o .: "alonzo"
-    pure $ mkTransitionConfig alonzoGenesis prevTransitionConfig

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -13,6 +13,7 @@ import qualified Test.Cardano.Ledger.Alonzo.Imp as Imp
 import Test.Cardano.Ledger.Alonzo.ImpTest ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
+import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 main :: IO ()
 main =
@@ -21,6 +22,7 @@ main =
       BinarySpec.spec
       CddlSpec.spec
       roundTripJsonEraSpec @AlonzoEra
+      roundTripJsonShelleyEraSpec @AlonzoEra
       GoldenTranslation.tests
       Golden.spec
       describe "Imp" $ do

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -58,6 +58,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   AlonzoPlutusPurpose (..),
   AlonzoScript (..),
  )
+import Cardano.Ledger.Alonzo.Transition (TransitionConfig (..))
 import Cardano.Ledger.Alonzo.Tx (
   AlonzoTx (AlonzoTx),
   IsValid (IsValid),
@@ -480,3 +481,6 @@ mkPlutusScript' plutus =
         "Plutus version " ++ show (plutusLanguage plutus) ++ " is not supported in " ++ eraName @era
     Just plutusScript -> fromPlutusScript plutusScript
 {-# DEPRECATED mkPlutusScript' "In favor of `fromPlutusScript` . `mkSupportedPlutusScript`" #-}
+
+instance Arbitrary (TransitionConfig AlonzoEra) where
+  arbitrary = AlonzoTransitionConfig <$> arbitrary <*> arbitrary

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.12.0.0
 
+* Fixed `FromJSON` instance for `TransitionConfig BabbageEra`
 * Added `COMPLETE` pragma for `TxCert BabbageEra`
 * Added `COMPLETE` pragma for `NativeScript BabbageEra`
 * Move to `testlib` the `DecCBOR` instance for `TxBody BabbageEra`
@@ -16,6 +17,7 @@
 
 ### `testlib`
 
+* Added `Arbitrary` instance for `TransitionConfig BabbageEra`
 * Added `Era` module with `BabbageEraTest` class
 
 ## 1.11.0.0

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -218,5 +218,6 @@ test-suite tests
     cardano-ledger-binary:testlib,
     cardano-ledger-core,
     cardano-ledger-core:testlib,
+    cardano-ledger-shelley:testlib,
     data-default,
     testlib,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Transition.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Transition.hs
@@ -12,7 +12,6 @@ import Cardano.Ledger.Babbage.State ()
 import Cardano.Ledger.Babbage.Translation ()
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Shelley.Transition
-import Data.Aeson (FromJSON (..))
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 
@@ -20,7 +19,7 @@ instance EraTransition BabbageEra where
   newtype TransitionConfig BabbageEra = BabbageTransitionConfig
     { btcAlonzoTransitionConfig :: TransitionConfig AlonzoEra
     }
-    deriving (Show, Eq, NoThunks, FromJSON)
+    deriving (Show, Eq, NoThunks)
 
   mkTransitionConfig NoGenesis = BabbageTransitionConfig
 
@@ -29,4 +28,4 @@ instance EraTransition BabbageEra where
   tcPreviousEraConfigL =
     lens btcAlonzoTransitionConfig (\btc pc -> btc {btcAlonzoTransitionConfig = pc})
 
-  tcTranslationContextL = lens (const NoGenesis) (const . id)
+  tcTranslationContextL = lens (const NoGenesis) const

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Transition.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Transition.hs
@@ -12,7 +12,7 @@ import Cardano.Ledger.Babbage.State ()
 import Cardano.Ledger.Babbage.Translation ()
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Shelley.Transition
-import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Aeson (FromJSON (..))
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 
@@ -20,7 +20,7 @@ instance EraTransition BabbageEra where
   newtype TransitionConfig BabbageEra = BabbageTransitionConfig
     { btcAlonzoTransitionConfig :: TransitionConfig AlonzoEra
     }
-    deriving (Show, Eq, NoThunks, ToJSON, FromJSON)
+    deriving (Show, Eq, NoThunks, FromJSON)
 
   mkTransitionConfig NoGenesis = BabbageTransitionConfig
 

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -13,6 +13,7 @@ import qualified Test.Cardano.Ledger.Babbage.Imp as Imp
 import Test.Cardano.Ledger.Babbage.ImpTest ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
+import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 main :: IO ()
 main =
@@ -23,6 +24,7 @@ main =
       BinarySpec.spec
       CddlSpec.spec
       roundTripJsonEraSpec @BabbageEra
+      roundTripJsonShelleyEraSpec @BabbageEra
       describe "Imp" $ do
         Imp.spec @BabbageEra
       describe "CostModels" $ do

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -14,6 +15,7 @@ import Cardano.Ledger.Babbage
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.PParams
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure (..), BabbageUtxowPredFailure (..))
+import Cardano.Ledger.Babbage.Transition (TransitionConfig (..))
 import Cardano.Ledger.Babbage.TxBody (BabbageTxOut (..))
 import Cardano.Ledger.Babbage.TxInfo (BabbageContextError (..))
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
@@ -154,3 +156,5 @@ instance Arbitrary (TxBody BabbageEra) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+
+deriving newtype instance Arbitrary (TransitionConfig BabbageEra)

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.20.0.0
 
+* Deprecated `toConwayTransitionConfigPairs`
+* Fixed `FromJSON` instance for `TransitionConfig ConwayEra`
 * Added `COMPLETE` pragma for `NativeScript ConwayEra`
 * Add default implementation for `tcConwayGenesisL`
 * Remove `tcDelegsL` and `tcInitialDRepsL`
@@ -50,6 +52,8 @@
 
 ### `testlib`
 
+* Fixed `Arbitrary` instance for `ConwayGenesis`
+* Added `Arbitrary` instance for `TransitionConfig ConwayEra`
 * Added `ToExpr` instances for:
   * `ConwayPlutusPurpose AsIxItem`
   * `DRepPulser`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -272,4 +272,5 @@ test-suite tests
     cardano-ledger-binary:testlib,
     cardano-ledger-conway,
     cardano-ledger-core:{cardano-ledger-core, testlib},
+    cardano-ledger-shelley:testlib,
     testlib,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
@@ -91,13 +91,12 @@ instance EncCBOR ConwayGenesis
 instance FromJSON ConwayGenesis where
   parseJSON =
     withObject "ConwayGenesis" $ \obj -> do
-      upgradeProtocolPParams <- parseJSON (Object obj)
-      ConwayGenesis
-        <$> pure upgradeProtocolPParams
-        <*> obj .: "constitution"
-        <*> obj .: "committee"
-        <*> obj .:? "delegs" .!= mempty
-        <*> obj .:? "initialDReps" .!= mempty
+      cgUpgradePParams <- parseJSON (Object obj)
+      cgConstitution <- obj .: "constitution"
+      cgCommittee <- obj .: "committee"
+      cgDelegs <- obj .:? "delegs" .!= mempty
+      cgInitialDReps <- obj .:? "initialDReps" .!= mempty
+      pure ConwayGenesis {..}
 
 instance ToKeyValuePairs ConwayGenesis where
   toKeyValuePairs cg@(ConwayGenesis _ _ _ _ _) =
@@ -105,9 +104,9 @@ instance ToKeyValuePairs ConwayGenesis where
      in [ "constitution" .= cgConstitution
         , "committee" .= cgCommittee
         ]
+          ++ toKeyValuePairs cgUpgradePParams
           ++ ["delegs" .= cgDelegs | not (null cgDelegs)]
           ++ ["initialDReps" .= cgInitialDReps | not (null cgInitialDReps)]
-          ++ toKeyValuePairs cgUpgradePParams
 
 toConwayGenesisPairs :: KeyValue e a => ConwayGenesis -> [a]
 toConwayGenesisPairs = toKeyValuePairs

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
@@ -105,9 +105,9 @@ toConwayTransitionConfigPairs = toKeyValuePairs
 
 instance FromJSON (TransitionConfig ConwayEra) where
   parseJSON = withObject "ConwayTransitionConfig" $ \o -> do
-    pc <- parseJSON (Object o)
-    ag <- o .: "conway"
-    pure $ mkTransitionConfig pc ag
+    prevTransitionConfig :: TransitionConfig BabbageEra <- parseJSON (Object o)
+    conwayGenesis :: ConwayGenesis <- o .: "conway"
+    pure $ mkTransitionConfig conwayGenesis prevTransitionConfig
 
 registerInitialDReps ::
   ConwayEraTransition era =>

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
@@ -16,7 +16,6 @@ module Cardano.Ledger.Conway.Transition (
   registerDRepsThenDelegs,
 ) where
 
-import Cardano.Ledger.Alonzo.Transition (toAlonzoTransitionConfigPairs)
 import Cardano.Ledger.Babbage
 import Cardano.Ledger.Babbage.Transition (TransitionConfig (BabbageTransitionConfig))
 import Cardano.Ledger.BaseTypes (toKeyValuePairs)
@@ -38,10 +37,7 @@ import Cardano.Ledger.Shelley.Transition
 import Data.Aeson (
   FromJSON (..),
   KeyValue (..),
-  ToJSON (..),
   Value (..),
-  object,
-  pairs,
   withObject,
   (.:),
  )
@@ -103,17 +99,9 @@ tcInitialDRepsL =
 
 instance NoThunks (TransitionConfig ConwayEra)
 
-instance ToJSON (TransitionConfig ConwayEra) where
-  toJSON = object . toConwayTransitionConfigPairs
-  toEncoding = pairs . mconcat . toConwayTransitionConfigPairs
-
 toConwayTransitionConfigPairs :: KeyValue e a => TransitionConfig ConwayEra -> [a]
-toConwayTransitionConfigPairs conwayConfig =
-  toAlonzoTransitionConfigPairs alonzoConfig
-    ++ ["conway" .= object (toKeyValuePairs (conwayConfig ^. tcTranslationContextL))]
-  where
-    babbageConfig = conwayConfig ^. tcPreviousEraConfigL
-    alonzoConfig = babbageConfig ^. tcPreviousEraConfigL
+toConwayTransitionConfigPairs = toKeyValuePairs
+{-# DEPRECATED toConwayTransitionConfigPairs "In favor of `toKeyValuePairs`" #-}
 
 instance FromJSON (TransitionConfig ConwayEra) where
   parseJSON = withObject "ConwayTransitionConfig" $ \o -> do

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Transition.hs
@@ -34,13 +34,7 @@ import Cardano.Ledger.Shelley.LedgerState (
   nesEsL,
  )
 import Cardano.Ledger.Shelley.Transition
-import Data.Aeson (
-  FromJSON (..),
-  KeyValue (..),
-  Value (..),
-  withObject,
-  (.:),
- )
+import Data.Aeson (KeyValue (..))
 import Data.ListMap (ListMap)
 import qualified Data.ListMap as ListMap
 import GHC.Generics
@@ -102,12 +96,6 @@ instance NoThunks (TransitionConfig ConwayEra)
 toConwayTransitionConfigPairs :: KeyValue e a => TransitionConfig ConwayEra -> [a]
 toConwayTransitionConfigPairs = toKeyValuePairs
 {-# DEPRECATED toConwayTransitionConfigPairs "In favor of `toKeyValuePairs`" #-}
-
-instance FromJSON (TransitionConfig ConwayEra) where
-  parseJSON = withObject "ConwayTransitionConfig" $ \o -> do
-    prevTransitionConfig :: TransitionConfig BabbageEra <- parseJSON (Object o)
-    conwayGenesis :: ConwayGenesis <- o .: "conway"
-    pure $ mkTransitionConfig conwayGenesis prevTransitionConfig
 
 registerInitialDReps ::
   ConwayEraTransition era =>

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -12,6 +12,7 @@ import qualified Test.Cardano.Ledger.Conway.GoldenTranslation as GoldenTranslati
 import qualified Test.Cardano.Ledger.Conway.GovActionReorderSpec as GovActionReorder
 import Test.Cardano.Ledger.Conway.Plutus.PlutusSpec as PlutusSpec
 import qualified Test.Cardano.Ledger.Conway.Spec as ConwaySpec
+import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 main :: IO ()
 main = ledgerTestMain $ do
@@ -31,3 +32,4 @@ main = ledgerTestMain $ do
       let step = 25600
       map (tierRefScriptFee 1.5 step 15) [0, step .. 204800]
         `shouldBe` map Coin [0, 384000, 960000, 1824000, 3120000, 5064000, 7980000, 12354000, 18915000]
+  roundTripJsonShelleyEraSpec @ConwayEra

--- a/eras/dijkstra/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/cardano-ledger-dijkstra.cabal
@@ -152,3 +152,4 @@ test-suite tests
     cardano-ledger-conway:testlib,
     cardano-ledger-core:testlib,
     cardano-ledger-dijkstra:{cardano-ledger-dijkstra, testlib},
+    cardano-ledger-shelley:testlib,

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Genesis.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Genesis.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -6,10 +7,10 @@ module Cardano.Ledger.Dijkstra.Genesis (
   DijkstraGenesis (..),
 ) where
 
-import Cardano.Ledger.BaseTypes (ToKeyValuePairs (..))
+import Cardano.Ledger.BaseTypes (KeyValuePairs (..), ToKeyValuePairs (..))
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Genesis (EraGenesis (..))
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON (..), ToJSON, withObject)
 import GHC.Generics
 import NoThunks.Class (NoThunks)
 
@@ -17,10 +18,10 @@ import NoThunks.Class (NoThunks)
 -- in the Dijkstra era
 data DijkstraGenesis = DijkstraGenesis
   deriving (Eq, Show, Generic)
+  deriving (ToJSON) via KeyValuePairs DijkstraGenesis
 
-instance ToJSON DijkstraGenesis
-
-instance FromJSON DijkstraGenesis
+instance FromJSON DijkstraGenesis where
+  parseJSON = withObject "DijkstraGenesis" $ \_ -> pure DijkstraGenesis
 
 instance NoThunks DijkstraGenesis
 

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Genesis.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Genesis.hs
@@ -4,9 +4,9 @@
 
 module Cardano.Ledger.Dijkstra.Genesis (
   DijkstraGenesis (..),
-  toDijkstraGenesisPairs,
 ) where
 
+import Cardano.Ledger.BaseTypes (ToKeyValuePairs (..))
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Genesis (EraGenesis (..))
 import Data.Aeson (FromJSON, ToJSON)
@@ -28,5 +28,5 @@ instance EraGenesis DijkstraEra where
   type Genesis DijkstraEra = DijkstraGenesis
 
 -- TODO: Implement this and use for ToJSON instance
-toDijkstraGenesisPairs :: DijkstraGenesis -> [a]
-toDijkstraGenesisPairs _ = []
+instance ToKeyValuePairs DijkstraGenesis where
+  toKeyValuePairs DijkstraGenesis = []

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Transition.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Transition.hs
@@ -21,12 +21,6 @@ import Cardano.Ledger.Dijkstra.Era
 import Cardano.Ledger.Dijkstra.Genesis
 import Cardano.Ledger.Dijkstra.Translation ()
 import Cardano.Ledger.Shelley.Transition
-import Data.Aeson (
-  FromJSON (..),
-  Value (..),
-  withObject,
-  (.:),
- )
 import GHC.Generics
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
@@ -53,9 +47,3 @@ instance EraTransition DijkstraEra where
 instance ConwayEraTransition DijkstraEra
 
 instance NoThunks (TransitionConfig DijkstraEra)
-
-instance FromJSON (TransitionConfig DijkstraEra) where
-  parseJSON = withObject "DijkstraTransitionConfig" $ \o -> do
-    prevTransitionConfig :: TransitionConfig ConwayEra <- parseJSON (Object o)
-    alonzoGenesis :: DijkstraGenesis <- o .: "dijkstra"
-    pure $ mkTransitionConfig alonzoGenesis prevTransitionConfig

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Transition.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Transition.hs
@@ -10,14 +10,12 @@
 
 module Cardano.Ledger.Dijkstra.Transition (
   TransitionConfig (..),
-  toDijkstraTransitionConfigPairs,
 ) where
 
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.Transition (
   ConwayEraTransition,
   registerDRepsThenDelegs,
-  toConwayTransitionConfigPairs,
  )
 import Cardano.Ledger.Dijkstra.Era
 import Cardano.Ledger.Dijkstra.Genesis
@@ -25,11 +23,7 @@ import Cardano.Ledger.Dijkstra.Translation ()
 import Cardano.Ledger.Shelley.Transition
 import Data.Aeson (
   FromJSON (..),
-  KeyValue (..),
-  ToJSON (..),
   Value (..),
-  object,
-  pairs,
   withObject,
   (.:),
  )
@@ -59,17 +53,6 @@ instance EraTransition DijkstraEra where
 instance ConwayEraTransition DijkstraEra
 
 instance NoThunks (TransitionConfig DijkstraEra)
-
-instance ToJSON (TransitionConfig DijkstraEra) where
-  toJSON = object . toDijkstraTransitionConfigPairs
-  toEncoding = pairs . mconcat . toDijkstraTransitionConfigPairs
-
-toDijkstraTransitionConfigPairs :: KeyValue e a => TransitionConfig DijkstraEra -> [a]
-toDijkstraTransitionConfigPairs dijkstraConfig =
-  toConwayTransitionConfigPairs conwayConfig
-    ++ ["dijkstra" .= object (toDijkstraGenesisPairs (dijkstraConfig ^. tcTranslationContextL))]
-  where
-    conwayConfig = dijkstraConfig ^. tcPreviousEraConfigL
 
 instance FromJSON (TransitionConfig DijkstraEra) where
   parseJSON = withObject "DijkstraTransitionConfig" $ \o -> do

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Transition.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Transition.hs
@@ -56,6 +56,6 @@ instance NoThunks (TransitionConfig DijkstraEra)
 
 instance FromJSON (TransitionConfig DijkstraEra) where
   parseJSON = withObject "DijkstraTransitionConfig" $ \o -> do
-    pc <- parseJSON (Object o)
-    ag <- o .: "dijkstra"
-    pure $ mkTransitionConfig pc ag
+    prevTransitionConfig :: TransitionConfig ConwayEra <- parseJSON (Object o)
+    alonzoGenesis :: DijkstraGenesis <- o .: "dijkstra"
+    pure $ mkTransitionConfig alonzoGenesis prevTransitionConfig

--- a/eras/dijkstra/test/Main.hs
+++ b/eras/dijkstra/test/Main.hs
@@ -9,9 +9,11 @@ import qualified Test.Cardano.Ledger.Conway.Spec as ConwaySpec
 import Test.Cardano.Ledger.Dijkstra.Binary.Annotator ()
 import Test.Cardano.Ledger.Dijkstra.Binary.RoundTrip ()
 import Test.Cardano.Ledger.Dijkstra.ImpTest ()
+import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 main :: IO ()
 main =
-  ledgerTestMain $
+  ledgerTestMain $ do
     describe "Dijkstra" $ do
       ConwaySpec.spec @DijkstraEra
+    roundTripJsonShelleyEraSpec @DijkstraEra

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -5,6 +5,8 @@ module Test.Cardano.Ledger.Dijkstra.Arbitrary () where
 
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core (EraTxBody (..))
+import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
+import Cardano.Ledger.Dijkstra.Transition (TransitionConfig (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Test.Cardano.Ledger.Common (Arbitrary (..), scale)
 import Test.Cardano.Ledger.Conway.Arbitrary ()
@@ -31,3 +33,9 @@ instance Arbitrary (TxBody DijkstraEra) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+
+instance Arbitrary DijkstraGenesis where
+  arbitrary = pure DijkstraGenesis
+
+instance Arbitrary (TransitionConfig DijkstraEra) where
+  arbitrary = DijkstraTransitionConfig <$> arbitrary <*> arbitrary

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### `testlib`
 
+* Added `Arbitrary` instance for `TransitionConfig MaryEra`
 * Added `Era` module with `MaryEraTest` class
 
 ## 1.8.0.0

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Transition.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Transition.hs
@@ -12,7 +12,6 @@ import Cardano.Ledger.Mary.Era
 import Cardano.Ledger.Mary.State ()
 import Cardano.Ledger.Mary.Translation ()
 import Cardano.Ledger.Shelley.Transition
-import Data.Aeson (FromJSON (..))
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 
@@ -20,7 +19,7 @@ instance EraTransition MaryEra where
   newtype TransitionConfig MaryEra = MaryTransitionConfig
     { mtcAllegraTransitionConfig :: TransitionConfig AllegraEra
     }
-    deriving (Show, Eq, NoThunks, FromJSON)
+    deriving (Show, Eq, NoThunks)
 
   mkTransitionConfig NoGenesis = MaryTransitionConfig
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Transition.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Transition.hs
@@ -12,7 +12,7 @@ import Cardano.Ledger.Mary.Era
 import Cardano.Ledger.Mary.State ()
 import Cardano.Ledger.Mary.Translation ()
 import Cardano.Ledger.Shelley.Transition
-import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Aeson (FromJSON (..))
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
 
@@ -20,7 +20,7 @@ instance EraTransition MaryEra where
   newtype TransitionConfig MaryEra = MaryTransitionConfig
     { mtcAllegraTransitionConfig :: TransitionConfig AllegraEra
     }
-    deriving (Show, Eq, NoThunks, ToJSON, FromJSON)
+    deriving (Show, Eq, NoThunks, FromJSON)
 
   mkTransitionConfig NoGenesis = MaryTransitionConfig
 
@@ -29,4 +29,4 @@ instance EraTransition MaryEra where
   tcPreviousEraConfigL =
     lens mtcAllegraTransitionConfig (\mtc pc -> mtc {mtcAllegraTransitionConfig = pc})
 
-  tcTranslationContextL = lens (const NoGenesis) (const . id)
+  tcTranslationContextL = lens (const NoGenesis) const

--- a/eras/mary/impl/test/Main.hs
+++ b/eras/mary/impl/test/Main.hs
@@ -4,11 +4,13 @@ module Main where
 
 import Cardano.Ledger.Mary (MaryEra)
 import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
 import qualified Test.Cardano.Ledger.Mary.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Mary.BinarySpec as BinarySpec
 import qualified Test.Cardano.Ledger.Mary.Imp as Imp
 import Test.Cardano.Ledger.Mary.ImpTest ()
 import qualified Test.Cardano.Ledger.Mary.ValueSpec as ValueSpec
+import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 main :: IO ()
 main =
@@ -19,3 +21,5 @@ main =
       CddlSpec.spec
       describe "Imp" $ do
         Imp.spec @MaryEra
+      roundTripJsonEraSpec @MaryEra
+      roundTripJsonShelleyEraSpec @MaryEra

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Arbitrary.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -23,6 +26,7 @@ import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary (MaryEra, TxBody (MaryTxBody))
+import Cardano.Ledger.Mary.Transition
 import Cardano.Ledger.Mary.Value (
   AssetName (..),
   MaryValue (..),
@@ -229,3 +233,5 @@ digitByteStrings = [fromString [x] | x <- ['0' .. '9']]
 
 hashOfDigitByteStrings :: HashAlgorithm h => [Hash h a]
 hashOfDigitByteStrings = castHash . hashWith id <$> digitByteStrings
+
+deriving newtype instance Arbitrary (TransitionConfig MaryEra)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.17.0.0
 
-* Deprecated `toShelleyGenesisPairs`
+* Add `ToJSON` and `FromJSON` instances for `FromByronTranslationContext`
+* Deprecated `toShelleyGenesisPairs` and `toShelleyTransitionConfigPairs`
 * Removed `toShelleyGenesisPairs`
 * Remove `ShelleyTxRaw`, `MkShelleyTx`, `segWitTx`, `unsafeConstructTxWithBytes`
 * Added `Generic` instances for:
@@ -42,6 +43,7 @@
 
 ### `testlib`
 
+* Added `Arbitrary` instance for `TransitionConfig ShelleyEra`
 * Rename `poolParams` to `freshPoolParams`
 * Added `ToExpr` instances for:
   * `ShelleyScriptsNeeded`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -147,6 +147,7 @@ library testlib
     Test.Cardano.Ledger.Shelley.Imp.UtxoSpec
     Test.Cardano.Ledger.Shelley.Imp.UtxowSpec
     Test.Cardano.Ledger.Shelley.ImpTest
+    Test.Cardano.Ledger.Shelley.JSON
     Test.Cardano.Ledger.Shelley.TreeDiff
     Test.Cardano.Ledger.Shelley.UnitTests.InstantStakeTest
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -31,6 +32,7 @@ module Cardano.Ledger.Shelley.Transition (
     tcShelleyGenesisL,
     tcInitialPParamsG
   ),
+  pattern ShelleyTransitionConfig,
   tcInitialFundsL,
   tcInitialStakingL,
   mkShelleyTransitionConfig,
@@ -80,6 +82,8 @@ class
   , EraStake era
   , EraGenesis era
   , EraCertState era
+  , Eq (TransitionConfig era)
+  , Show (TransitionConfig era)
   , FromJSON (TransitionConfig era)
   , Default (StashedAVVMAddresses era)
   ) =>

--- a/eras/shelley/impl/test/Main.hs
+++ b/eras/shelley/impl/test/Main.hs
@@ -8,6 +8,7 @@ import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
 import qualified Test.Cardano.Ledger.Shelley.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Shelley.BinarySpec as Binary
 import qualified Test.Cardano.Ledger.Shelley.Imp as Imp
+import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 main :: IO ()
 main =
@@ -17,3 +18,4 @@ main =
       Cddl.spec
       Imp.spec @ShelleyEra
       roundTripJsonEraSpec @ShelleyEra
+      roundTripJsonShelleyEraSpec @ShelleyEra

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -33,14 +33,12 @@ import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API (
   ApplyTxError (ApplyTxError),
   MultiSig,
-  NominalDiffTimeMicro (..),
   ShelleyDelegCert,
-  ShelleyGenesis (..),
-  ShelleyGenesisStaking (ShelleyGenesisStaking),
   ShelleyTx (ShelleyTx),
   TxBody (ShelleyTxBody),
  )
 import Cardano.Ledger.Shelley.Core
+import Cardano.Ledger.Shelley.Genesis
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.PParams
 import Cardano.Ledger.Shelley.PoolRank
@@ -71,6 +69,8 @@ import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
 import Cardano.Ledger.Shelley.State
+import Cardano.Ledger.Shelley.Transition
+import Cardano.Ledger.Shelley.Translation (FromByronTranslationContext)
 import Cardano.Ledger.Shelley.TxAuxData
 import Cardano.Ledger.Shelley.TxCert (
   GenesisDelegCert (..),
@@ -533,7 +533,7 @@ sizedMetadatum 0 =
   oneof
     [ I <$> arbitrary
     , B <$> arbitrary
-    , S <$> (T.pack <$> arbitrary)
+    , S . T.pack <$> arbitrary
     ]
 sizedMetadatum n =
   let xsGen = listOf (sizedMetadatum (n - 1))
@@ -542,7 +542,7 @@ sizedMetadatum n =
         , List <$> resize maxMetadatumListLens xsGen
         , I <$> arbitrary
         , B <$> arbitrary
-        , S <$> (T.pack <$> arbitrary)
+        , S . T.pack <$> arbitrary
         ]
 
 instance Arbitrary VotingPeriod where
@@ -741,3 +741,9 @@ instance Arbitrary RawSeed where
 instance Era era => Arbitrary (ShelleyCertState era) where
   arbitrary = ShelleyCertState <$> arbitrary <*> arbitrary
   shrink = genericShrink
+
+instance Arbitrary FromByronTranslationContext where
+  arbitrary = genericArbitraryU
+  shrink _ = []
+
+deriving newtype instance Arbitrary (TransitionConfig ShelleyEra)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Era.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Era.hs
@@ -10,6 +10,7 @@ module Test.Cardano.Ledger.Shelley.Era (
 import Cardano.Ledger.Shelley
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Scripts
+import Cardano.Ledger.Shelley.Transition
 import Cardano.Ledger.State
 import Data.Default
 import Test.Cardano.Ledger.Common
@@ -20,6 +21,8 @@ import Test.Cardano.Ledger.Shelley.TreeDiff ()
 class
   ( EraTest era
   , ShelleyEraScript era
+  , EraTransition era
+  , Arbitrary (TransitionConfig era)
   , Eq (StashedAVVMAddresses era)
   , Show (StashedAVVMAddresses era)
   , ToExpr (StashedAVVMAddresses era)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/JSON.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/JSON.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Shelley.JSON (
+  roundTripJsonShelleyEraSpec,
+) where
+
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.Transition
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.JSON
+import Test.Cardano.Ledger.Shelley.Era
+
+roundTripJsonShelleyEraSpec :: forall era. ShelleyEraTest era => Spec
+roundTripJsonShelleyEraSpec =
+  describe ("Shelley era JSON Roundtrip: " <> eraName @era) $ do
+    roundTripJsonSpec @(TransitionConfig era)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -55,6 +55,8 @@
 
 ### `testlib`
 
+* Add `roundTripJsonShelleyEraSpec`
+* Add superclass constraint to `EraTest` for `Eq`, `Show`, `Typeable`, `ToJSON`, `FromJSON` and `Arbitrary` classes for `TranslationContext` type
 * Added `goldenJsonPParamsUpdateSpec`
 * Added `Era` module with `EraTest` class
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -8,7 +10,7 @@ module Cardano.Ledger.Genesis (
   NoGenesis (..),
 ) where
 
-import Cardano.Ledger.BaseTypes (ToKeyValuePairs (..))
+import Cardano.Ledger.BaseTypes (KeyValuePairs (..), ToKeyValuePairs (..))
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
@@ -16,6 +18,13 @@ import Cardano.Ledger.Binary (
   ToCBOR (..),
  )
 import Cardano.Ledger.Core.Era (Era)
+import Control.Monad (unless)
+import Data.Aeson (
+  FromJSON (..),
+  ToJSON,
+  Value (..),
+ )
+import qualified Data.Aeson.KeyMap as KV
 import Data.Kind (Type)
 
 class Era era => EraGenesis era where
@@ -24,6 +33,7 @@ class Era era => EraGenesis era where
 
 data NoGenesis era = NoGenesis
   deriving (Eq, Show)
+  deriving (ToJSON) via KeyValuePairs (NoGenesis era)
 
 instance Era era => ToCBOR (NoGenesis era) where
   toCBOR _ = toCBOR ()
@@ -37,3 +47,11 @@ instance Era era => DecCBOR (NoGenesis era)
 
 instance ToKeyValuePairs (NoGenesis era) where
   toKeyValuePairs _ = []
+
+instance FromJSON (NoGenesis era) where
+  parseJSON = \case
+    Null -> pure NoGenesis
+    Object o -> do
+      unless (KV.null o) $ fail "NoGenesis cannot have any fields"
+      pure NoGenesis
+    _ -> fail "Unexpected value type for NoGenesis"

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Genesis.hs
@@ -8,6 +8,7 @@ module Cardano.Ledger.Genesis (
   NoGenesis (..),
 ) where
 
+import Cardano.Ledger.BaseTypes (ToKeyValuePairs (..))
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
@@ -33,3 +34,6 @@ instance Era era => FromCBOR (NoGenesis era) where
 instance Era era => EncCBOR (NoGenesis era)
 
 instance Era era => DecCBOR (NoGenesis era)
+
+instance ToKeyValuePairs (NoGenesis era) where
+  toKeyValuePairs _ = []

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -78,6 +78,7 @@ import Cardano.Ledger.Binary (EncCBOR, Sized, mkSized)
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..), DeltaCoin (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), Ptr (..), SlotNo32 (..), StakeReference (..))
+import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.HKD (NoUpdate (..))
 import Cardano.Ledger.Hashes (GenDelegPair (..), GenDelegs (..), unsafeMakeSafeHash)
 import Cardano.Ledger.Keys (BootstrapWitness (..), ChainCode (..), VKey (..), WitVKey (..))
@@ -958,3 +959,6 @@ genCostModelValues lang = do
     listAtLeast x = do
       NonNegative y <- arbitrary
       replicateM (x + y) arbitrary
+
+instance Arbitrary (NoGenesis era) where
+  arbitrary = pure NoGenesis

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/JSON.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/JSON.hs
@@ -61,6 +61,7 @@ roundTripJsonEraSpec =
   describe (eraName @era) $ do
     describe "RoundTrip JSON" $ do
       roundTripJsonSpec @(PParams era)
+      roundTripJsonSpec @(TranslationContext era)
 
 goldenJsonPParamsSpec ::
   forall era.

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Era.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Era.hs
@@ -8,7 +8,9 @@ module Test.Cardano.Ledger.Era (
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Core
 import Cardano.Ledger.State
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Functor.Identity
+import Data.Typeable
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Arbitrary ()
 import Test.Cardano.Ledger.TreeDiff ()
@@ -59,5 +61,12 @@ class
     ToExpr (CertState era)
   , ToExpr (GovState era)
   , ToExpr (InstantStake era)
+  , -- TranslationContext
+    Eq (TranslationContext era)
+  , Show (TranslationContext era)
+  , Typeable (TranslationContext era)
+  , ToJSON (TranslationContext era)
+  , FromJSON (TranslationContext era)
+  , Arbitrary (TranslationContext era)
   ) =>
   EraTest era


### PR DESCRIPTION
# Description

Using inductive definition of `ToKeyValue` instance completely remove the need to manually define `ToJSON` instance for `TransitionConfig`

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
