### PR TITLE
Added `DijkstraPlutusPurpose`

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.20.0.0
 
+* Rename `transScriptPurpose` to `transPlutusPurposeV3`
 * Make `transValidityInterval` implicit to eras instead of protocol versions.
   * Implement `transValidityInterval` for Conway.
 * Add `NFData` for `ConwayGenesis`

--- a/eras/dijkstra/cddl-files/dijkstra.cddl
+++ b/eras/dijkstra/cddl-files/dijkstra.cddl
@@ -684,24 +684,14 @@ bootstrap_witness =
   ]
 
 
-; Flat Array support is included for backwards compatibility and
-; will be removed in the next era. It is recommended for tools to
-; adopt using a Map instead of Array going forward.
 redeemers = 
-  [ + [ tag      : redeemer_tag
-  , index    : uint .size 4
-  , data     : plutus_data 
-  , ex_units : ex_units    
-  ]
-
-
-  ]
-  / { + [tag : redeemer_tag, index : uint .size 4] => [ data     : plutus_data
-                                                      , ex_units : ex_units
-                                                      ]
+  { + [tag : redeemer_tag, index : uint .size 4] => [ data     : plutus_data
+                                                    , ex_units : ex_units
+                                                    ]
 
 
   }
+
 
 redeemer_tag = 
   0 ; spend    
@@ -710,7 +700,7 @@ redeemer_tag =
   / 3 ; reward   
   / 4 ; voting   
   / 5 ; proposing
-  / 6 ; guarding
+  / 6 ; guarding 
 
 transaction_index = uint .size 2
 

--- a/eras/dijkstra/cddl-files/dijkstra.cddl
+++ b/eras/dijkstra/cddl-files/dijkstra.cddl
@@ -710,6 +710,7 @@ redeemer_tag =
   / 3 ; reward   
   / 4 ; voting   
   / 5 ; proposing
+  / 6 ; guarding
 
 transaction_index = uint .size 2
 

--- a/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Scripts.hs
+++ b/eras/dijkstra/src/Cardano/Ledger/Dijkstra/Scripts.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -11,6 +10,7 @@
 
 module Cardano.Ledger.Dijkstra.Scripts (PlutusScript (..)) where
 
+import Cardano.Ledger.Address (RewardAccount)
 import Cardano.Ledger.Allegra.Scripts (
   AllegraEraScript (..),
   Timelock,
@@ -35,21 +35,35 @@ import Cardano.Ledger.Alonzo.Scripts (
   AsIx (..),
   alonzoScriptPrefixTag,
  )
+import Cardano.Ledger.Conway.Governance (ProposalProcedure, Voter)
 import Cardano.Ledger.Conway.Scripts (
   ConwayEraScript (..),
   ConwayPlutusPurpose (..),
   PlutusScript (..),
  )
-import Cardano.Ledger.Core (EraScript (..), SafeToHash (..))
+import Cardano.Ledger.Core (EraScript (..), EraTxCert (..), SafeToHash (..), ScriptHash)
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Dijkstra.PParams ()
 import Cardano.Ledger.Dijkstra.TxCert ()
+import Cardano.Ledger.Mary.Value (PolicyID)
 import Cardano.Ledger.Plutus (Language (..), Plutus, SLanguage (..), plutusSLanguage)
 import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..))
+import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.MemPack (MemPack (..), packTagM, packedTagByteCount, unknownTagM, unpackTagM)
+import Data.Word (Word32)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
+
+data DijkstraPlutusPurpose f era
+  = DijkstraSpending !(f Word32 TxIn)
+  | DijkstraMinting !(f Word32 PolicyID)
+  | DijkstraCertifying !(f Word32 (TxCert era))
+  | DijkstraRewarding !(f Word32 RewardAccount)
+  | DijkstraVoting !(f Word32 Voter)
+  | DijkstraProposing !(f Word32 (ProposalProcedure era))
+  | DijkstraGuarding !(f Word32 ScriptHash)
+  deriving (Generic)
 
 instance EraScript DijkstraEra where
   type Script DijkstraEra = AlonzoScript DijkstraEra

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Dijkstra.Arbitrary () where
@@ -11,6 +14,7 @@ import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core (EraTx (..), EraTxBody (..))
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams, UpgradeDijkstraPParams)
+import Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose)
 import Cardano.Ledger.Dijkstra.Transition (TransitionConfig (..))
 import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
@@ -56,5 +60,11 @@ instance Arbitrary DijkstraGenesis where
 
 instance Arbitrary (TransitionConfig DijkstraEra) where
   arbitrary = DijkstraTransitionConfig <$> arbitrary <*> arbitrary
+
+instance
+  (forall a b. (Arbitrary a, Arbitrary b) => Arbitrary (f a b)) =>
+  Arbitrary (DijkstraPlutusPurpose f DijkstraEra)
+  where
+  arbitrary = genericArbitraryU
 
 deriving newtype instance Arbitrary (Tx DijkstraEra)

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/CDDL.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/CDDL.hs
@@ -35,6 +35,7 @@ import Test.Cardano.Ledger.Conway.CDDL hiding (
   proposal_procedures,
   protocol_param_update,
   protocol_version,
+  redeemers,
   script_data_hash,
   single_host_name,
   transaction,
@@ -347,6 +348,20 @@ protocol_param_update =
       , opt (idx 37 ==> positive_interval) //- "refScript cost multiplier"
       ]
 
+redeemers :: Rule -> Rule
+redeemers redeemer_tag =
+  "redeemers"
+    =:= mp
+      [ 1
+          <+ asKey
+            ( arr
+                [ "tag" ==> redeemer_tag
+                , "index" ==> (VUInt `sized` (4 :: Word64))
+                ]
+            )
+          ==> arr ["data" ==> plutus_data, "ex_units" ==> ex_units]
+      ]
+
 -- TODO: add entry for Plutus v4
 transaction_witness_set :: Rule
 transaction_witness_set =
@@ -372,6 +387,7 @@ dijkstra_redeemer_tag =
     / (int 3 //- "reward")
     / (int 4 //- "voting")
     / (int 5 //- "proposing")
+    / (int 6 //- "guarding")
 
 -- TODO: add Plutus V4
 language :: Rule

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
@@ -16,8 +16,8 @@ import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
 import Cardano.Ledger.Conway.Rules (ConwayDELEG, ConwayDelegPredFailure (..), ConwayLEDGER)
-import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Plutus.Data (
@@ -72,7 +72,7 @@ ledgerExamples =
     exampleDijkstraGenesis
 
 exampleTxDijkstra :: Tx DijkstraEra
-exampleTxDijkstra = exampleTx exampleTxBodyDijkstra (ConwaySpending $ AsIx 0)
+exampleTxDijkstra = exampleTx exampleTxBodyDijkstra (DijkstraSpending $ AsIx 0)
 
 exampleTxBodyDijkstra :: TxBody DijkstraEra
 exampleTxBodyDijkstra =

--- a/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Dijkstra.TreeDiff (
@@ -9,9 +12,14 @@ import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core (EraTx (..), EraTxBody (..), PlutusScript)
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams)
+import Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose)
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraTxBodyRaw)
 import Data.Functor.Identity (Identity)
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr)
+
+instance
+  (forall a b. (ToExpr a, ToExpr b) => ToExpr (f a b)) =>
+  ToExpr (DijkstraPlutusPurpose f DijkstraEra)
 
 instance ToExpr (PlutusScript DijkstraEra)
 

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.5.0
 
+* Add `mapMaybeR`, `mapMaybeL`
 * Add `decodeOSet`
 
 ## 1.2.4.0

--- a/libs/cardano-data/src/Data/OSet/Strict.hs
+++ b/libs/cardano-data/src/Data/OSet/Strict.hs
@@ -36,6 +36,8 @@ module Data.OSet.Strict (
   filter,
   mapL,
   mapR,
+  mapMaybeR,
+  mapMaybeL,
   decodeOSet,
 ) where
 
@@ -294,3 +296,17 @@ mapR f = F.foldr' ((:<|:) . f) Empty
 -- duplicates
 mapL :: Ord b => (a -> b) -> OSet a -> OSet b
 mapL f = F.foldl' (\x y -> x :|>: f y) Empty
+
+-- | Map a function over the elements, discarding elements on which the
+-- function returns `Nothing`. Right-biased.
+mapMaybeR :: Ord b => (a -> Maybe b) -> OSet a -> OSet b
+mapMaybeR f = F.foldr' helper Empty
+  where
+    helper x s = maybe s (:<|: s) $ f x
+
+-- | Map a function over the elements, discarding elements on which the
+-- function returns `Nothing`. Left-biased.
+mapMaybeL :: Ord b => (a -> Maybe b) -> OSet a -> OSet b
+mapMaybeL f = F.foldl' helper Empty
+  where
+    helper s x = maybe s (s :|>:) $ f x


### PR DESCRIPTION
# Description

Adds `DijkstraPlutusPurpose` with the new guarding purpose. I also removed the possibility to represent redeemers as a flat array in CDDL, since the comment said it should be removed in Dijkstra.

close https://github.com/IntersectMBO/cardano-ledger/issues/5204
close https://github.com/IntersectMBO/cardano-ledger/issues/5205

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
