### PR TITLE
Changed the type of Tx size to Word32

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Changed `MaxTxSizeUTxO` to use `Word32`
 * Remove `TriesToForgeADA`
 * Change the type of `actualSize` and `PParameterMaxValue` fields in `OutputTooBigUTxO` to `Int`
 * Added `COMPLETE` pragma for `TxCert AllegraEra`

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -60,6 +60,7 @@ import Data.Foldable (toList)
 import Data.Int (Int64)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
+import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -72,7 +73,7 @@ data AllegraUtxoPredFailure era
   | OutsideValidityIntervalUTxO
       ValidityInterval -- transaction's validity interval
       SlotNo -- current slot
-  | MaxTxSizeUTxO (Mismatch 'RelLTEQ Integer)
+  | MaxTxSizeUTxO (Mismatch 'RelLTEQ Word32)
   | InputSetEmptyUTxO
   | FeeTooSmallUTxO (Mismatch 'RelGTEQ Coin)
   | ValueNotConservedUTxO (Mismatch 'RelEQ (Value era)) -- Consumed, then produced

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Changed `MaxTxSizeUTxO` to use `Word32`
 * Make `transValidityInterval` based on eras instead of protocol versions.
   * Remove `hardforkConwayTranslateUpperBoundForPlutusScripts` from `Cardano.Ledger.Alonzo.Era`.
   * Remove protocol version from arguments to `transValidityInterval`.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -108,6 +108,7 @@ import Data.Foldable as F (foldl', sequenceA_, toList)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -125,7 +126,7 @@ data AlonzoUtxoPredFailure era
       ValidityInterval
       -- | current slot
       SlotNo
-  | MaxTxSizeUTxO (Mismatch 'RelLTEQ Integer)
+  | MaxTxSizeUTxO (Mismatch 'RelLTEQ Word32)
   | InputSetEmptyUTxO
   | FeeTooSmallUTxO (Mismatch 'RelGTEQ Coin)
   | ValueNotConservedUTxO (Mismatch 'RelEQ (Value era))

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.20.0.0
 
+* Changed `MaxTxSizeUTxO` to use `Word32`
 * Rename `transScriptPurpose` to `transPlutusPurposeV3`
 * Make `transValidityInterval` implicit to eras instead of protocol versions.
   * Implement `transValidityInterval` for Conway.

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -74,6 +74,7 @@ import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (Embed (..), STS (..))
 import Data.List.NonEmpty (NonEmpty)
 import Data.Set (Set)
+import Data.Word (Word32)
 import GHC.Generics (Generic)
 import GHC.Natural (Natural)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
@@ -92,8 +93,7 @@ data ConwayUtxoPredFailure era
       ValidityInterval
       -- | current slot
       SlotNo
-  | MaxTxSizeUTxO
-      (Mismatch 'RelLTEQ Integer)
+  | MaxTxSizeUTxO (Mismatch 'RelLTEQ Word32)
   | InputSetEmptyUTxO
   | FeeTooSmallUTxO
       (Mismatch 'RelGTEQ Coin) -- The values are serialised in reverse order

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.17.0.0
 
+* Changed `MaxTxSizeUTxO` and `sizeShelleyTxF` to use `Word32`
 * Remove:
   * `ShelleyEpochPredFailure`
   * `ShelleyMirPredFailure`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -102,6 +102,7 @@ library
     -Wunused-packages
 
   build-depends:
+    FailT,
     aeson >=2,
     base >=4.18 && <5,
     bytestring,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -98,6 +98,7 @@ import qualified Data.Map.Strict as Map
 import Data.MapExtras (extractKeys)
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
 import Lens.Micro.Extras (view)
@@ -169,7 +170,7 @@ data ShelleyUtxoPredFailure era
   | ExpiredUTxO
       (Mismatch 'RelLTEQ SlotNo)
   | MaxTxSizeUTxO
-      (Mismatch 'RelLTEQ Integer)
+      (Mismatch 'RelLTEQ Word32)
   | InputSetEmptyUTxO
   | FeeTooSmallUTxO
       (Mismatch 'RelGTEQ Coin)
@@ -578,7 +579,7 @@ validateMaxTxSizeUTxO pp tx =
         , mismatchExpected = maxTxSize
         }
   where
-    maxTxSize = toInteger (pp ^. ppMaxTxSizeL)
+    maxTxSize = pp ^. ppMaxTxSizeL
     txSize = tx ^. sizeTxF
 
 -- | This monadic action captures the final stages of the UTXO(S) rule. In particular it

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -434,7 +434,7 @@ txSizeBound ::
   EraTx era =>
   Tx era ->
   Integer
-txSizeBound tx = numInputs * inputSize + numOutputs * outputSize + rest
+txSizeBound tx = numInputs * inputSize + numOutputs * outputSize + toInteger rest
   where
     uint = 5
     smallArray = 1

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Fees.hs
@@ -58,10 +58,12 @@ import Cardano.Protocol.Crypto (StandardCrypto, hashVerKeyVRF)
 import qualified Data.ByteString.Base16.Lazy as Base16
 import qualified Data.ByteString.Char8 as BS (pack)
 import qualified Data.ByteString.Lazy as BSL
+import Data.Int (Int64)
 import qualified Data.Map.Strict as Map (empty, singleton)
 import Data.Maybe (fromJust)
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import Data.Word (Word32)
 import GHC.Stack (HasCallStack)
 import Lens.Micro
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkAddr, mkWitnessesVKey, vKey)
@@ -80,7 +82,7 @@ import Test.Tasty.HUnit (Assertion, testCase, (@?=))
 sizeTest :: HasCallStack => BSL.ByteString -> Tx ShelleyEra -> Assertion
 sizeTest b16 tx = do
   Base16.encode (Plain.serialize tx) @?= b16
-  (tx ^. sizeTxF) @?= toInteger (BSL.length b16 `div` 2)
+  (tx ^. sizeTxF) @?= (fromIntegral @Int64 @Word32 (BSL.length b16) `div` 2)
 
 alicePay :: KeyPair 'Payment
 alicePay = KeyPair vk sk

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Changed `sizeTxF` and `sizeTxForFeeCalculation` to use `Word32`
 * Move pool deposits from `PState` into `StakePoolState`. #5234
   * Add `spsDeposit` field to `StakePoolState`
   * Remove `psDeposits` field from `PState` data constructor


### PR DESCRIPTION
# Description

close https://github.com/IntersectMBO/cardano-ledger/issues/5181

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
