### PR TITLE
Check in CI if changelogs need a bump

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -667,4 +667,4 @@ jobs:
       run: scripts/format-changelogs.sh || git diff --exit-code
 
     - name: Check if changelogs need a bump
-      run: scripts/bump-changelogs.sh || git diff --exit-code
+      run: scripts/bump-changelogs.sh

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -667,4 +667,4 @@ jobs:
       run: scripts/format-changelogs.sh || git diff --exit-code
 
     - name: Check if changelogs need a bump
-      run: scripts/bump-changelogs.sh
+      run: scripts/bump-changelogs.sh || git diff --exit-code

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -665,3 +665,6 @@ jobs:
 
     - name: Run linter
       run: scripts/format-changelogs.sh || git diff --exit-code
+
+    - name: Check if changelogs need a bump
+      run: scripts/bump-changelogs.sh || git diff --exit-code

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -667,4 +667,4 @@ jobs:
       run: scripts/format-changelogs.sh || git diff --exit-code
 
     - name: Check if changelogs need a bump
-      run: scripts/bump-changelogs.sh || git diff --exit-code
+      run: scripts/bump-changelogs.sh || (git diff; false)

--- a/libs/small-steps/CHANGELOG.md
+++ b/libs/small-steps/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Version history for `small-steps`
 
-## 1.1.2.1
-
-*
-
 ## 1.1.2.0
 
 * Add `whenFailureFreeDefault`

--- a/libs/small-steps/CHANGELOG.md
+++ b/libs/small-steps/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `small-steps`
 
+## 1.1.2.1
+
+*
+
 ## 1.1.2.0
 
 * Add `whenFailureFreeDefault`

--- a/scripts/bump-changelogs.sh
+++ b/scripts/bump-changelogs.sh
@@ -2,7 +2,7 @@
 
 CHAP=./cardano-haskell-packages
 # Download a shallow copy of CHaP
-git clone --depth 1 git@github.com:IntersectMBO/cardano-haskell-packages.git $CHAP
+git clone --depth 1 https://github.com/IntersectMBO/cardano-haskell-packages $CHAP
 
 cd $CHAP || exit
 # Save all the available packages from CHaP
@@ -41,6 +41,10 @@ do
 done
 
 rm -rf $CHAP
-printf "\n!!!!!!\n%s %s\n!!!!!!\n" \
-  "WARNING! DO NOT BUMP THE VERSION NUMBER IN THE CABAL FILES" \
-  "(unless its dependencies were bumped)!"
+BUMPED=$(git diff --exit-code)
+if [[ $BUMPED ]]; then
+  printf "\n!!!!!!\n%s %s\n!!!!!!\n" \
+    "WARNING! DO NOT BUMP THE VERSION NUMBER IN THE CABAL FILES" \
+    "(unless its dependencies were bumped)!"
+fi
+echo $(( BUMPED ))

--- a/scripts/bump-changelogs.sh
+++ b/scripts/bump-changelogs.sh
@@ -47,4 +47,8 @@ if [[ $BUMPED ]]; then
     "WARNING! DO NOT BUMP THE VERSION NUMBER IN THE CABAL FILES" \
     "(unless their dependencies were bumped)!"
 fi
-echo $(( BUMPED ))
+if git diff --exit-code; then
+  printf "\n!!!!!!\n%s %s\n!!!!!!\n" \
+    "WARNING! DO NOT BUMP THE VERSION NUMBER IN THE CABAL FILES" \
+    "(unless their dependencies were bumped)!"
+fi

--- a/scripts/bump-changelogs.sh
+++ b/scripts/bump-changelogs.sh
@@ -50,4 +50,5 @@ if ! git diff -s --exit-code; then
   printf "\n!!!!!!\n%s %s\n!!!!!!\n" \
     "WARNING! DO NOT BUMP THE VERSION NUMBER IN THE CABAL FILES" \
     "(unless their dependencies were bumped)!"
+  exit 1
 fi

--- a/scripts/bump-changelogs.sh
+++ b/scripts/bump-changelogs.sh
@@ -45,6 +45,6 @@ BUMPED=$(git diff --exit-code)
 if [[ $BUMPED ]]; then
   printf "\n!!!!!!\n%s %s\n!!!!!!\n" \
     "WARNING! DO NOT BUMP THE VERSION NUMBER IN THE CABAL FILES" \
-    "(unless its dependencies were bumped)!"
+    "(unless their dependencies were bumped)!"
 fi
 echo $(( BUMPED ))

--- a/scripts/bump-changelogs.sh
+++ b/scripts/bump-changelogs.sh
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 
-CHAP=./cardano-haskell-packages
-# Download a shallow copy of CHaP
-git clone --depth 1 https://github.com/IntersectMBO/cardano-haskell-packages $CHAP
-
-cd $CHAP || exit
 # Save all the available packages from CHaP
-CHAP_PACKAGES=$(./scripts/list-packages.sh)
-cd - || exit
-echo "The following packages are available in CHaP:"
+CHAP_PACKAGES=$(mktemp)
+trap 'rm -f "$CHAP_PACKAGES"' EXIT
+
+if tar --version | grep -q 'GNU tar'
+then
+  tar () { command tar --wildcards "$@"; }
+fi
+
+curl -sSL https://chap.intersectmbo.org/01-index.tar.gz |
+  tar -tz \*.cabal |
+  cut -d/ -f1-2 |
+  LANG=C sort -t/ -k1,1 -k2,2Vr |
+  LANG=C sort -t/ -k1,1 -u -o "$CHAP_PACKAGES"
+echo "The complete CHaP package index is here:"
 echo "$CHAP_PACKAGES"
 
 # Save the paths to every `cardano-ledger` cabal file
-CABAL_FILES=$(find . -wholename '*/eras/*.cabal' -o -wholename '*/libs/*.cabal')
+CABAL_FILES=$(git ls-files '*.cabal')
 
 for i in $CABAL_FILES;
 do
@@ -29,7 +35,7 @@ do
     # Check if the package had a release with
     # the most recent `CHANGELOG` version number
     printf "Looking for %s with version %s in CHaP\n" "$PACKAGE" "$VERSION"
-    RESULT=$(echo "$CHAP_PACKAGES" | grep -o "$PACKAGE $VERSION")
+    RESULT=$(grep -o "$PACKAGE/$VERSION" "$CHAP_PACKAGES")
     if [[ -n "$RESULT" ]]; then
       # A release was found and thus the `CHANGELOG` has to be bumped
       # with the incremented patch version
@@ -40,14 +46,7 @@ do
   fi
 done
 
-rm -rf $CHAP
-BUMPED=$(git diff --exit-code)
-if [[ $BUMPED ]]; then
-  printf "\n!!!!!!\n%s %s\n!!!!!!\n" \
-    "WARNING! DO NOT BUMP THE VERSION NUMBER IN THE CABAL FILES" \
-    "(unless their dependencies were bumped)!"
-fi
-if git diff --exit-code; then
+if ! git diff -s --exit-code; then
   printf "\n!!!!!!\n%s %s\n!!!!!!\n" \
     "WARNING! DO NOT BUMP THE VERSION NUMBER IN THE CABAL FILES" \
     "(unless their dependencies were bumped)!"


### PR DESCRIPTION
# Description

This PR adds a simple safeguard to CI that checks if `CHANGELOG`s need bumping, using our existing `bump-changelogs.sh` script. 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
