### PR TITLE
Update formal-ledger-specifications, enable and disable some tests

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: 61f0683c62adf1efe67f14e11dc0edfe884c348f
+  tag: bc6aa8374a6a0ed856ccec77c9c5a38e8603d362
 
 source-repository-package
   type: git

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
@@ -643,7 +643,9 @@ votingSpec =
           passNEpochs 2
           -- The same vote should now successfully ratify the proposal
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-        it "Rewards contribute to active voting stake" $ whenPostBootstrap $ do
+        -- https://github.com/IntersectMBO/cardano-ledger/5014
+        -- TODO: Re-enable after issue is resolved, by removing this override
+        disableInConformanceIt "Rewards contribute to active voting stake" $ whenPostBootstrap $ do
           -- Setup DRep delegation #1
           (drep1, staking1, _) <- setupSingleDRep 1_000_000_000
           -- Setup DRep delegation #2
@@ -712,7 +714,9 @@ votingSpec =
           passEpoch
           getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
         describe "Proposal deposits contribute to active voting stake" $ do
-          it "Directly" $ whenPostBootstrap $ do
+          -- https://github.com/IntersectMBO/cardano-ledger/5014
+          -- TODO: Re-enable after issue is resolved, by removing this override
+          disableInConformanceIt "Directly" $ whenPostBootstrap $ do
             -- Only modify the applicable thresholds
             modifyPParams $ ppGovActionDepositL .~ Coin 1_000_000
             -- Setup DRep delegation without stake #1

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
@@ -1036,9 +1036,7 @@ votingSpec =
             passNEpochs 2
             getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
         describe "Proposal deposits contribute to active voting stake" $ do
-          -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/926
-          -- TODO: Re-enable after issue is resolved, by removing this override
-          disableInConformanceIt "Directly" $ whenPostBootstrap $ do
+          it "Directly" $ whenPostBootstrap $ do
             -- Only modify the applicable thresholds
             modifyPParams $ \pp ->
               pp
@@ -1088,9 +1086,7 @@ votingSpec =
             passNEpochs 2
             -- The same vote should now successfully ratify the proposal
             getLastEnactedCommittee `shouldReturn` SJust (GovPurposeId addCCGaid)
-          -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/926
-          -- TODO: Re-enable after issue is resolved, by removing this override
-          disableInConformanceIt "After switching delegations" $ whenPostBootstrap $ do
+          it "After switching delegations" $ whenPostBootstrap $ do
             -- Only modify the applicable thresholds
             modifyPParams $ \pp ->
               pp

--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1758124240,
-        "narHash": "sha256-WDOqa3EuAxGhbcJee6WRaHv8haQTH6nsNh5A3mik8ik=",
+        "lastModified": 1759103868,
+        "narHash": "sha256-U+V1lIXqQUms6KuUTKOabhkbmhzYBC9xboyQpx9JGdo=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "61f0683c62adf1efe67f14e11dc0edfe884c348f",
+        "rev": "bc6aa8374a6a0ed856ccec77c9c5a38e8603d362",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

This PR updates `formal-ledger-specifications` and enables two previously failing conformance tests.

In addition, it disables two conformance tests in which the implementation and the specification differ in the way stake distribution is calculated for DReps (how active stake is considered). There is an ongoing issue about changing voting stake distribution for DReps in `cardano-ledger` (#5014).

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
