### PR TITLE
Refactor "Haddocks to GitHub Pages" workflow

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -4,39 +4,59 @@ on:
     branches:
       - master
       - lehins/bench
+  workflow_dispatch:
 
 permissions:
   contents: write
-  deployments: write
 
 jobs:
   benchmark:
     name: cardano-ledger benchmarks
+
     runs-on: ubuntu-latest
+
+    env:
+      GH_PAGES_BRANCH: benchmark-pages
+
     steps:
       - uses: actions/checkout@v2
+
       - uses: cachix/install-nix-action@v15
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
             substituters = https://cache.iog.io https://cache.nixos.org/
+
       - name: Build benchmarks
         run: nix build .#cardano-ledger-test:bench:bench
-      - name: Run benchmark
+
+      - name: Run benchmarks
         run: |
           cd libs/cardano-ledger-test
           ../../result/bin/bench "applyTxBenchmarks" --json bench.json
+
       - name: Transform results
         run: |
           nix-env -i jq -f '<nixpkgs>'
           jq -f .github/tools/extract_criterion.jq < libs/cardano-ledger-test/bench.json > output.json
-      - name: Store benchmark result
+
+      - name: Truncate benchmark git history
+        run: |
+          git checkout $GH_PAGES_BRANCH
+          START=$(git rev-parse "@{2 weeks ago}")
+          git checkout --orphan new-root $START
+          git commit -m "Truncated history"
+          git rebase --onto new-root $START $GH_PAGES_BRANCH
+          git push -f
+
+      - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Haskell Benchmark
           tool: 'customSmallerIsBetter'
           output-file-path: output.json
+          gh-pages-branch: ${{ env.GH_PAGES_BRANCH }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,10 +6,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  gh-pages:
+  haddocks:
     runs-on: ubuntu-latest
+
     permissions:
-      contents: write
+      pages: write     # to deploy to Pages
+      id-token: write  # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
     - uses: actions/checkout@v4
@@ -39,45 +45,24 @@ jobs:
     - name: Build haddocks
       run: scripts/haddocks.sh haddocks all
 
-    - name: Add files
+    - name: Include benchmark pages
       run: |
-        git config --local user.name ${{ github.actor }}
-        git config --local user.email "${{ github.actor }}@users.noreply.github.com"
-
-        # Start a new version of the gh-pages branch
-        git for-each-ref refs/heads/gh-pages --format='%(refname:short)' |
-          while read -r REFNAME; do
-            git branch -D "$REFNAME"
-          done
-        git checkout -b gh-pages
-
-        git rm -rfq .
-        git commit -qm "Remove all existing files"
-
-        echo "cardano-ledger.cardano.intersectmbo.org" >CNAME
-        touch .nojekyll
-        git add CNAME .nojekyll
-        git commit -qm "Add CNAME and .nojekyll"
-
-        # Preserve benchmark results, if any
-        git ls-remote origin --heads gh-pages |
+        git ls-remote origin --heads benchmark-pages |
           while read -r _SHA REFNAME; do
             git fetch origin "$REFNAME"
             if git diff --name-only FETCH_HEAD -- dev | grep -q .; then
-              git checkout FETCH_HEAD dev
-              git commit -qC "$(git log -1 --format=%H FETCH_HEAD dev)"
+              git archive FETCH_HEAD dev | tar -xC haddocks
             fi
           done
 
-        # Add Haddocks
-        git add -A --force ./haddocks
-        git mv ./haddocks/* .
-        git commit -qm "Updated from ${GITHUB_SHA} via ${GITHUB_EVENT_NAME}"
+    - name: Add housekeeping files
+      run: echo cardano-ledger.cardano.intersectmbo.org >haddocks/CNAME
 
-    - name: Push to gh-pages
-      uses: ad-m/github-push-action@v0.8.0
+    - name: Upload pages artifact
+      uses: actions/upload-pages-artifact@v4
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: gh-pages
-        force: true
-        directory: .
+        path: haddocks
+
+    - name: Deploy pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Description

This changes the deployment method so that it no longer uses the `gh-pages` branch and instead creates a pages artifact directly and deploys it explicitly. This avoids a large amount of repo churn that manifests as a large download whenever the repo is fetched/pulled on a developer machine.

It's still necessary to use a branch for the storage of the benchmark results, since the benchmark publishing plugin we're using requires this. However, I've changed the name of the branch it uses (to avoid auto-deployment of the results) and added logic to truncate the branch history to 2 weeks. Also, the amount of churn on the branch will be much less since it's storing only the benchmark JSON and doesn't include the generated HTML from haddock.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
