### PR TITLE
Use tasty-hspec in cardano-ledger-test

### DIFF
--- a/libs/cardano-ledger-test/cardano-ledger-test.cabal
+++ b/libs/cardano-ledger-test/cardano-ledger-test.cabal
@@ -141,9 +141,9 @@ test-suite cardano-ledger-test
 
   build-depends:
     base,
-    cardano-ledger-core:testlib,
     cardano-ledger-test,
     tasty,
+    tasty-hspec,
 
 benchmark bench
   type: exitcode-stdio-1.0

--- a/libs/cardano-ledger-test/test/Tests.hs
+++ b/libs/cardano-ledger-test/test/Tests.hs
@@ -9,7 +9,6 @@ module Main where
 
 import System.Environment (lookupEnv)
 import System.IO (hSetEncoding, stdout, utf8)
-import Test.Cardano.Ledger.Common (hspec)
 import qualified Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Tests as LedgerTypes
 import qualified Test.Cardano.Ledger.Constrained.Conway.MiniTrace as MiniTrace
 import qualified Test.Cardano.Ledger.Examples.AlonzoAPI as AlonzoAPI (tests)
@@ -23,17 +22,19 @@ import qualified Test.Cardano.Ledger.NoThunks as NoThunks
 import qualified Test.Cardano.Ledger.STS as ConstraintSTS
 import Test.Cardano.Ledger.Tickf (calcPoolDistOldEqualsNew)
 import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.Hspec (testSpec)
 
 main :: IO ()
 main = do
   hSetEncoding stdout utf8
   nightly <- lookupEnv "NIGHTLY"
-  hspec MiniTrace.spec
+  minitrace <- testSpec "MiniTrace" MiniTrace.spec
   case nightly of
-    Nothing -> defaultMain $ testGroup "cardano-core" defaultTests
+    Nothing -> do
+      defaultMain $ testGroup "cardano-core" $ minitrace : defaultTests
     Just _ -> do
-      hspec LedgerTypes.spec
-      defaultMain $ testGroup "cardano-core - nightly" nightlyTests
+      ledgerTypesSpec <- testSpec "LedgerTypes" LedgerTypes.spec
+      defaultMain $ testGroup "cardano-core - nightly" $ ledgerTypesSpec : nightlyTests
 
 defaultTests :: [TestTree]
 defaultTests =


### PR DESCRIPTION
# Description

Without this change `--test-options` do not get passed on correctly and the invocation ends up throwing an error.

Thanks @teodanciu for all the real work behind this change :raised_hands: 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] ~~`CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).~~
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
