### PR TITLE
Add filename to diagnostics in `undefined` CI check

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -641,7 +641,12 @@ jobs:
       run: |
         PR_TARGET=${{ github.base_ref }}
         git fetch origin -n --refmap= +$PR_TARGET:pr-target
-        if git diff -U0 pr-target '*.hs' | grep '^\+.*undefined'; then
+        if git diff -U0 pr-target '*.hs' |
+            awk '
+              /^\+\+\+/ { sub(/^b\//, "", $2); FILE = $2; }
+              /^\+.*undefined/ { printf "%s: %s\n", FILE, $0; FOUND=1; }
+              END { exit !FOUND; }
+            '; then
           echo 'The diff must not contain any `undefined` values'
           false
         fi


### PR DESCRIPTION
# Description

The current check doesn't show the filename, just the offending lines. It's convenient to have the filename in the CI log when the check fails.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
