### PR TITLE
Disable old redeemer deserialization

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -578,7 +578,11 @@ instance AlonzoEraScript era => DecCBOR (Annotator (RedeemersRaw era)) where
       ( peekTokenType >>= \case
           TypeMapLenIndef -> decodeMapRedeemers
           TypeMapLen -> decodeMapRedeemers
-          _ -> decodeListRedeemers
+          _ ->
+            ifDecoderVersionAtLeast
+              (natVersion @12)
+              (fail "List encoding of redeemers not supported starting with PV 12")
+              decodeListRedeemers
       )
       ( mapTraverseableDecoderA
           (decodeList decodeAnnElement)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
@@ -209,7 +209,11 @@ instance AlonzoEraScript era => DecCBOR (RedeemersRaw era) where
       ( peekTokenType >>= \case
           TypeMapLenIndef -> decodeMapRedeemers
           TypeMapLen -> decodeMapRedeemers
-          _ -> decodeListRedeemers
+          _ ->
+            ifDecoderVersionAtLeast
+              (natVersion @12)
+              (fail "List encoding of redeemers not supported starting with PV 12")
+              decodeListRedeemers
       )
       (RedeemersRaw . Map.fromList <$> decodeList decodeElement)
     where

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -127,6 +127,7 @@ library testlib
     Test.Cardano.Ledger.Conway.Arbitrary
     Test.Cardano.Ledger.Conway.Binary.Annotator
     Test.Cardano.Ledger.Conway.Binary.Cddl
+    Test.Cardano.Ledger.Conway.Binary.Golden
     Test.Cardano.Ledger.Conway.Binary.Regression
     Test.Cardano.Ledger.Conway.Binary.RoundTrip
     Test.Cardano.Ledger.Conway.BinarySpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Golden.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Golden.hs
@@ -21,24 +21,25 @@ import Cardano.Ledger.Alonzo.Core (
   pattern SpendingPurpose,
  )
 import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
-import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
+import Cardano.Ledger.Alonzo.TxWits (Redeemers (..), unRedeemers)
 import Cardano.Ledger.BaseTypes (Version)
 import Cardano.Ledger.Binary (
   Annotator (..),
   DecCBOR (..),
   ToCBOR (..),
   decodeFullAnnotator,
-  toStrictByteString,
+  toLazyByteString,
  )
 import Cardano.Ledger.Binary.Plain (DecoderError (..), Tokens (..))
 import Cardano.Ledger.Plutus (Data (..))
-import Data.ByteString (fromStrict)
 import qualified Data.Map as Map
 import Data.Typeable (Proxy (..), Typeable)
 import PlutusLedgerApi.Common (Data (..))
 import Test.Cardano.Ledger.Binary.Plain.Golden (Enc (..))
+import Test.Cardano.Ledger.Binary.RoundTrip (embedTripAnnExpectation)
 import Test.Cardano.Ledger.Common (
   Expectation,
+  HasCallStack,
   Spec,
   ToExpr,
   expectationFailure,
@@ -51,7 +52,7 @@ import Test.Cardano.Ledger.Conway.Era (ConwayEraTest)
 
 expectDecoderFailure ::
   forall a.
-  (ToExpr a, DecCBOR (Annotator a), Typeable a) =>
+  (ToExpr a, DecCBOR (Annotator a), Typeable a, HasCallStack) =>
   Version ->
   Enc ->
   DecoderError ->
@@ -64,20 +65,15 @@ expectDecoderFailure version enc expectedErr =
         "Expected a failure, but decoder succeeded:\n"
           <> showExpr x
   where
-    bytes = fromStrict . toStrictByteString $ toCBOR enc
+    bytes = toLazyByteString $ toCBOR enc
     result = decodeFullAnnotator @a version (label $ Proxy @(Annotator a)) decCBOR bytes
 
 expectDecoderResultOn ::
   forall a b.
-  (ToExpr b, DecCBOR (Annotator a), Typeable a, Eq b) =>
+  (ToExpr b, DecCBOR (Annotator a), Eq b, HasCallStack) =>
   Version -> Enc -> a -> (a -> b) -> Expectation
 expectDecoderResultOn version enc expected f =
-  case result of
-    Left err -> expectationFailure $ "Decoder failed with:\n" <> show err
-    Right x -> f x `shouldBeExpr` f expected
-  where
-    bytes = fromStrict . toStrictByteString $ toCBOR enc
-    result = decodeFullAnnotator @a version (label $ Proxy @(Annotator a)) decCBOR bytes
+  embedTripAnnExpectation version version (\x _ -> f x `shouldBeExpr` f expected) enc
 
 -- | A simple redeemer encoded as a list
 listRedeemersEnc :: Enc
@@ -87,12 +83,12 @@ listRedeemersEnc =
     , mconcat
         [ E (TkListLen 4)
         , E (0 :: Int)
-        , E (0 :: Int)
-        , E (0 :: Int)
+        , E (10 :: Int)
+        , E (20 :: Int)
         , mconcat
             [ E (TkListLen 2)
-            , E (0 :: Int)
-            , E (0 :: Int)
+            , E (30 :: Int)
+            , E (40 :: Int)
             ]
         ]
     ]
@@ -103,5 +99,5 @@ goldenListRedeemers =
     expectDecoderResultOn @(Redeemers era)
       (eraProtVerLow @era)
       listRedeemersEnc
-      (Redeemers $ Map.singleton (SpendingPurpose $ AsIx 0) (Data $ I 0, ExUnits 0 0))
-      (\(Redeemers m) -> m)
+      (Redeemers $ Map.singleton (SpendingPurpose $ AsIx 10) (Data $ I 20, ExUnits 30 40))
+      unRedeemers

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Golden.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Golden.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-unused-foralls #-}
+
+module Test.Cardano.Ledger.Conway.Binary.Golden (
+  expectDecoderResultOn,
+  expectDecoderFailure,
+  listRedeemersEnc,
+  goldenListRedeemers,
+) where
+
+import Cardano.Ledger.Alonzo.Core (
+  AsIx (..),
+  eraProtVerLow,
+  pattern SpendingPurpose,
+ )
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import Cardano.Ledger.Alonzo.TxWits (Redeemers (..))
+import Cardano.Ledger.BaseTypes (Version)
+import Cardano.Ledger.Binary (
+  Annotator (..),
+  DecCBOR (..),
+  ToCBOR (..),
+  decodeFullAnnotator,
+  toStrictByteString,
+ )
+import Cardano.Ledger.Binary.Plain (DecoderError (..), Tokens (..))
+import Cardano.Ledger.Plutus (Data (..))
+import Data.ByteString (fromStrict)
+import qualified Data.Map as Map
+import Data.Typeable (Proxy (..), Typeable)
+import PlutusLedgerApi.Common (Data (..))
+import Test.Cardano.Ledger.Binary.Plain.Golden (Enc (..))
+import Test.Cardano.Ledger.Common (
+  Expectation,
+  Spec,
+  ToExpr,
+  expectationFailure,
+  it,
+  shouldBe,
+  shouldBeExpr,
+  showExpr,
+ )
+import Test.Cardano.Ledger.Conway.Era (ConwayEraTest)
+
+expectDecoderFailure ::
+  forall a.
+  (ToExpr a, DecCBOR (Annotator a), Typeable a) =>
+  Version ->
+  Enc ->
+  DecoderError ->
+  Expectation
+expectDecoderFailure version enc expectedErr =
+  case result of
+    Left err -> err `shouldBe` expectedErr
+    Right x ->
+      expectationFailure $
+        "Expected a failure, but decoder succeeded:\n"
+          <> showExpr x
+  where
+    bytes = fromStrict . toStrictByteString $ toCBOR enc
+    result = decodeFullAnnotator @a version (label $ Proxy @(Annotator a)) decCBOR bytes
+
+expectDecoderResultOn ::
+  forall a b.
+  (ToExpr b, DecCBOR (Annotator a), Typeable a, Eq b) =>
+  Version -> Enc -> a -> (a -> b) -> Expectation
+expectDecoderResultOn version enc expected f =
+  case result of
+    Left err -> expectationFailure $ "Decoder failed with:\n" <> show err
+    Right x -> f x `shouldBeExpr` f expected
+  where
+    bytes = fromStrict . toStrictByteString $ toCBOR enc
+    result = decodeFullAnnotator @a version (label $ Proxy @(Annotator a)) decCBOR bytes
+
+-- | A simple redeemer encoded as a list
+listRedeemersEnc :: Enc
+listRedeemersEnc =
+  mconcat
+    [ E (TkListLen 1)
+    , mconcat
+        [ E (TkListLen 4)
+        , E (0 :: Int)
+        , E (0 :: Int)
+        , E (0 :: Int)
+        , mconcat
+            [ E (TkListLen 2)
+            , E (0 :: Int)
+            , E (0 :: Int)
+            ]
+        ]
+    ]
+
+goldenListRedeemers :: forall era. ConwayEraTest era => Spec
+goldenListRedeemers =
+  it "Decoding Redeemers encoded as a list succeeds" $
+    expectDecoderResultOn @(Redeemers era)
+      (eraProtVerLow @era)
+      listRedeemersEnc
+      (Redeemers $ Map.singleton (SpendingPurpose $ AsIx 0) (Data $ I 0, ExUnits 0 0))
+      (\(Redeemers m) -> m)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
@@ -20,6 +20,7 @@ import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsS
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
 import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as BabbageTxInfo
 import Test.Cardano.Ledger.Common
+import qualified Test.Cardano.Ledger.Conway.Binary.Golden as Golden
 import qualified Test.Cardano.Ledger.Conway.Binary.Regression as Regression
 import qualified Test.Cardano.Ledger.Conway.BinarySpec as Binary
 import qualified Test.Cardano.Ledger.Conway.CommitteeRatifySpec as CommitteeRatify
@@ -60,3 +61,4 @@ spec =
       BabbageTxInfo.spec @era
       describe "PlutusV3" $
         BabbageTxInfo.txInfoSpec @era SPlutusV3
+    describe "Golden" $ Golden.goldenListRedeemers @era

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -112,6 +112,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Arbitrary
     Test.Cardano.Ledger.Dijkstra.Binary.Annotator
     Test.Cardano.Ledger.Dijkstra.Binary.Cddl
+    Test.Cardano.Ledger.Dijkstra.Binary.Golden
     Test.Cardano.Ledger.Dijkstra.Binary.RoundTrip
     Test.Cardano.Ledger.Dijkstra.CDDL
     Test.Cardano.Ledger.Dijkstra.Era
@@ -137,7 +138,7 @@ library testlib
     bytestring,
     cardano-data,
     cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
-    cardano-ledger-alonzo:testlib,
+    cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
     cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
     cardano-ledger-binary,
     cardano-ledger-conway:{cardano-ledger-conway, testlib},

--- a/eras/dijkstra/impl/test/Main.hs
+++ b/eras/dijkstra/impl/test/Main.hs
@@ -10,6 +10,7 @@ import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as BabbageTxInfo
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Dijkstra.Binary.Annotator ()
 import qualified Test.Cardano.Ledger.Dijkstra.Binary.CddlSpec as Cddl
+import qualified Test.Cardano.Ledger.Dijkstra.Binary.Golden as Golden
 import Test.Cardano.Ledger.Dijkstra.Binary.RoundTrip ()
 import qualified Test.Cardano.Ledger.Dijkstra.GoldenSpec as GoldenSpec
 import qualified Test.Cardano.Ledger.Dijkstra.Imp as Imp
@@ -29,3 +30,5 @@ main =
         BabbageTxInfo.spec @DijkstraEra
         txInfoSpec @DijkstraEra SPlutusV3
         txInfoSpec @DijkstraEra SPlutusV4
+      describe "Golden" $ do
+        Golden.goldenListRedeemersDisallowed @DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Dijkstra.Binary.Golden (
+  goldenListRedeemersDisallowed,
+) where
+
+import Cardano.Ledger.Alonzo.TxWits (Redeemers)
+import Cardano.Ledger.Binary (DecoderError (..), DeserialiseFailure (..))
+import Cardano.Ledger.Dijkstra.Core (eraProtVerLow)
+import Test.Cardano.Ledger.Common (Spec, it)
+import Test.Cardano.Ledger.Conway.Binary.Golden (expectDecoderFailure, listRedeemersEnc)
+import Test.Cardano.Ledger.Dijkstra.Era (DijkstraEraTest)
+
+goldenListRedeemersDisallowed :: forall era. DijkstraEraTest era => Spec
+goldenListRedeemersDisallowed =
+  it "Decoding Redeemers encoded as a list fails" $
+    expectDecoderFailure @(Redeemers era)
+      (eraProtVerLow @era)
+      listRedeemersEnc
+      ( DecoderErrorDeserialiseFailure
+          "Annotator (MemoBytes (RedeemersRaw DijkstraEra))"
+          (DeserialiseFailure 0 "List encoding of redeemers not supported starting with PV 12")
+      )

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary.hs
@@ -9,6 +9,7 @@ module Cardano.Ledger.Binary (
   Term (..),
   C.DeserialiseFailure (..),
   translateViaCBORAnnotator,
+  toLazyByteString,
 ) where
 
 import Cardano.Ledger.Binary.Decoding
@@ -40,6 +41,7 @@ import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Binary.Version
 import qualified Codec.CBOR.Read as C (DeserialiseFailure (..))
 import Codec.CBOR.Term (Term (..))
+import Codec.CBOR.Write (toLazyByteString)
 import Control.Monad.Except (Except, MonadError (throwError))
 import Data.Text (Text)
 


### PR DESCRIPTION
# Description

This PR disables the deprecated list deserializer for `Redeemers`.

close https://github.com/IntersectMBO/cardano-ledger/issues/5345

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
