### PR TITLE
Make `Annotator` capable of failing.

### DIFF
--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -254,3 +254,4 @@ test-suite tests
     microlens,
     microlens-mtl,
     testlib,
+    text,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/BlockBody/Internal.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/BlockBody/Internal.hs
@@ -291,11 +291,12 @@ alonzoSegwitTx ::
   IsValid ->
   Maybe (Annotator (TxAuxData era)) ->
   Annotator (Tx era)
-alonzoSegwitTx txBodyAnn txWitsAnn txIsValid auxDataAnn = Annotator $ \bytes ->
-  let txBody = runAnnotator txBodyAnn bytes
-      txWits = runAnnotator txWitsAnn bytes
-      txAuxData = maybeToStrictMaybe (flip runAnnotator bytes <$> auxDataAnn)
-   in mkBasicTx txBody
-        & witsTxL .~ txWits
-        & auxDataTxL .~ txAuxData
-        & isValidTxL .~ txIsValid
+alonzoSegwitTx txBodyAnn txWitsAnn isValid auxDataAnn = Annotator $ \bytes -> do
+  txBody <- runAnnotator txBodyAnn bytes
+  txWits <- runAnnotator txWitsAnn bytes
+  txAuxData <- mapM (`runAnnotator` bytes) auxDataAnn
+  pure $
+    mkBasicTx txBody
+      & witsTxL .~ txWits
+      & auxDataTxL .~ maybeToStrictMaybe txAuxData
+      & isValidTxL .~ isValid

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -73,7 +73,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   toPlutusSLanguage,
  )
 import Cardano.Ledger.Binary (
-  Annotator,
+  Annotator (..),
   DecCBOR (..),
   DecCBORGroup (..),
   Decoder,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody/Internal.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody/Internal.hs
@@ -266,13 +266,14 @@ instance
       )
 
     let
-      segWitAnnTx bodyAnn witsAnn' metaAnn = Annotator $ \bytes ->
-        let body' = runAnnotator bodyAnn bytes
-            witnessSet = runAnnotator witsAnn' bytes
-            metadata' = flip runAnnotator bytes <$> metaAnn
-         in mkBasicTx @era body'
-              & witsTxL .~ witnessSet
-              & auxDataTxL .~ maybeToStrictMaybe metadata'
+      segWitAnnTx txBodyAnn txWitsAnn txAuxDataAnnMaybe = Annotator $ \bytes -> do
+        txBody <- runAnnotator txBodyAnn bytes
+        txWits <- runAnnotator txWitsAnn bytes
+        txAuxData <- mapM (`runAnnotator` bytes) txAuxDataAnnMaybe
+        pure $
+          mkBasicTx @era txBody
+            & witsTxL .~ txWits
+            & auxDataTxL .~ maybeToStrictMaybe txAuxData
       txns =
         sequenceA $
           StrictSeq.forceToStrict $

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -36,7 +36,7 @@ module Cardano.Ledger.Shelley.TxWits (
 ) where
 
 import Cardano.Ledger.Binary (
-  Annotator,
+  Annotator (..),
   DecCBOR (decCBOR),
   Decoder,
   EncCBOR (encCBOR),

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.8.0.0
 
+* Make `decodeAnnSet` fail when there are duplicates, starting with protocol version `12`.
+* Provide ability for `Annotator` to fail, by changing its type signature to return `Either` and adding `MonadFail` instance.
 * Remove `encodedSizeExpr` and `encodedListSizeExpr` from `EncCBOR`
 * Remove `Typeable` superconstraint from `EncCBOR`
 * Remove `Range`, `szEval`, `Size`, `Case`, `caseValue`, `LengthOf`, `SizeOverride`, `isTodo`, `szCases`, `szLazy`, `szGreedy`, `szForce`, `szWithCtx`, `szSimplify`, `apMono`, `szBounds`, `encodedVerKeyDSIGNSizeExpr`, `encodedSignKeyDSIGNSizeExpr`, `encodedSigDSIGNSizeExpr`, `encodedSignedDSIGNSizeExpr`, `encodedVerKeyKESSizeExpr`, `encodedSignKeyKESSizeExpr`, `encodedSigKESSizeExpr`, `encodedVerKeyVRFSizeExpr`, `encodedSignKeyVRFSizeExpr` and `encodedCertVRFSizeExpr`

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding.hs
@@ -175,7 +175,7 @@ decodeFullAnnotator ::
   BSL.ByteString ->
   Either DecoderError a
 decodeFullAnnotator v lbl decoder bytes =
-  (\x -> runAnnotator x (Full bytes)) <$> decodeFullDecoder v lbl decoder bytes
+  (`runAnnotator` Full bytes) =<< decodeFullDecoder v lbl decoder bytes
 {-# INLINE decodeFullAnnotator #-}
 
 -- | Same as `decodeFullDecoder`, decodes a Haskell value from a lazy

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
@@ -173,7 +173,8 @@ instance
   where
   decCBOR = do
     (Annotator getT, Annotator getBytes) <- withSlice decCBOR
-    pure $ Annotator (\fullbytes -> mkMemoBytes (getT fullbytes) (getBytes fullbytes))
+    pure $ Annotator $ \fullBytes ->
+      mkMemoBytes <$> getT fullBytes <*> getBytes fullBytes
 
 -- | Both binary representation and Haskell types are compared.
 instance Eq t => Eq (MemoBytes t) where


### PR DESCRIPTION
# Description

This PR solves an issue where we could not look into the result of Annotator in order to fail the Decoder. Eg. failing decoder on duplicates when decoding a Set

This is an alternative to the solution that was implemented in #4009, which could not be applied due to the limitation described in #5003

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
