### PR TITLE
Add DecCBOR for ShelleyBbodyPredFailure

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -71,7 +71,6 @@ import Control.State.Transition (
  )
 import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
-import Data.Typeable
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks (..))
@@ -146,14 +145,15 @@ deriving anyclass instance
   (Era era, NoThunks (PredicateFailure (EraRule "LEDGERS" era))) =>
   NoThunks (AlonzoBbodyPredFailure era)
 
-instance EncCBOR (ShelleyBbodyPredFailure era) => EncCBOR (AlonzoBbodyPredFailure era) where
+instance
+  (Era era, EncCBOR (PredicateFailure (EraRule "LEDGERS" era))) =>
+  EncCBOR (AlonzoBbodyPredFailure era)
+  where
   encCBOR (ShelleyInAlonzoBbodyPredFailure x) = encode (Sum ShelleyInAlonzoBbodyPredFailure 0 !> To x)
   encCBOR (TooManyExUnits m) = encode (Sum TooManyExUnits 1 !> To m)
 
 instance
-  ( Typeable era
-  , DecCBOR (ShelleyBbodyPredFailure era) -- TODO why is there no DecCBOR for (ShelleyBbodyPredFailure era)
-  ) =>
+  (Era era, DecCBOR (PredicateFailure (EraRule "LEDGERS" era))) =>
   DecCBOR (AlonzoBbodyPredFailure era)
   where
   decCBOR = decode (Summands "AlonzoBbodyPredFail" dec)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Add `EncCBOR` and `DecCBOR` instances to `ShelleyBbodyPredFailure`
 * Rename `poolParamsP` field to `stakePoolParamsP` in `RewardProvenancePool`
 * Move withdrawals-draining from `DELEGS` to `LEDGER`
   - Remove `WithdrawalsNotInRewardsDELEGS`


### PR DESCRIPTION
# Description

Fix #5331 

This still has a constraint on another CBOR instance which is widely used - I just got this piece of code [from `Conway`](https://github.com/IntersectMBO/cardano-ledger/blob/951a280e38fbb5d03c9a585986fd9d926ec1f7ba/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs#L126)

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
