### PR TITLE
Add a golden test for duplicate certificates

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Golden.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Golden.hs
@@ -10,7 +10,7 @@
 
 module Test.Cardano.Ledger.Conway.Binary.Golden (
   expectDecoderResultOn,
-  expectDecoderFailure,
+  expectDecoderFailureAnn,
   listRedeemersEnc,
   goldenListRedeemers,
 ) where
@@ -50,14 +50,14 @@ import Test.Cardano.Ledger.Common (
  )
 import Test.Cardano.Ledger.Conway.Era (ConwayEraTest)
 
-expectDecoderFailure ::
+expectDecoderFailureAnn ::
   forall a.
   (ToExpr a, DecCBOR (Annotator a), Typeable a, HasCallStack) =>
   Version ->
   Enc ->
   DecoderError ->
   Expectation
-expectDecoderFailure version enc expectedErr =
+expectDecoderFailureAnn version enc expectedErr =
   case result of
     Left err -> err `shouldBe` expectedErr
     Right x ->

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -140,7 +140,7 @@ library testlib
     cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
     cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
     cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
-    cardano-ledger-binary,
+    cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-conway:{cardano-ledger-conway, testlib},
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-dijkstra,

--- a/eras/dijkstra/impl/test/Main.hs
+++ b/eras/dijkstra/impl/test/Main.hs
@@ -31,4 +31,4 @@ main =
         txInfoSpec @DijkstraEra SPlutusV3
         txInfoSpec @DijkstraEra SPlutusV4
       describe "Golden" $ do
-        Golden.goldenListRedeemersDisallowed @DijkstraEra
+        Golden.spec @DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
@@ -1,27 +1,83 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Dijkstra.Binary.Golden (
-  goldenListRedeemersDisallowed,
+  spec,
 ) where
 
 import Cardano.Ledger.Alonzo.TxWits (Redeemers)
-import Cardano.Ledger.Binary (DecoderError (..), DeserialiseFailure (..))
-import Cardano.Ledger.Dijkstra.Core (eraProtVerLow)
-import Test.Cardano.Ledger.Common (Spec, it)
-import Test.Cardano.Ledger.Conway.Binary.Golden (expectDecoderFailure, listRedeemersEnc)
+import Cardano.Ledger.BaseTypes (Version)
+import Cardano.Ledger.Binary (DecoderError (..), DeserialiseFailure (..), Tokens (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.TxCert (Delegatee (..))
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Dijkstra.Core (
+  EraTxBody (..),
+  EraTxOut (..),
+  TxLevel (..),
+  eraProtVerLow,
+  pattern DelegTxCert,
+ )
+import Cardano.Ledger.TxIn (TxIn (..))
+import qualified Data.Set as Set
+import Test.Cardano.Ledger.Binary.Plain.Golden (Enc (..))
+import Test.Cardano.Ledger.Common (Spec, describe, it)
+import Test.Cardano.Ledger.Conway.Binary.Golden (expectDecoderFailureAnn, listRedeemersEnc)
+import Test.Cardano.Ledger.Core.KeyPair (mkKeyHash)
 import Test.Cardano.Ledger.Dijkstra.Era (DijkstraEraTest)
+
+spec :: forall era. DijkstraEraTest era => Spec
+spec = describe "Golden" $ do
+  goldenListRedeemersDisallowed @era
+  goldenDuplicateCertsDisallowed @era
 
 goldenListRedeemersDisallowed :: forall era. DijkstraEraTest era => Spec
 goldenListRedeemersDisallowed =
   it "Decoding Redeemers encoded as a list fails" $
-    expectDecoderFailure @(Redeemers era)
+    expectDecoderFailureAnn @(Redeemers era)
       (eraProtVerLow @era)
       listRedeemersEnc
       ( DecoderErrorDeserialiseFailure
           "Annotator (MemoBytes (RedeemersRaw DijkstraEra))"
           (DeserialiseFailure 0 "List encoding of redeemers not supported starting with PV 12")
       )
+
+duplicateCertsTx :: forall era. DijkstraEraTest era => Version -> Enc
+duplicateCertsTx v =
+  mconcat
+    [ E $ TkMapLen 4
+    , Em [E @Int 0, Ev v $ Set.empty @TxIn]
+    , Em [E @Int 1, Ev v $ [] @(TxOut era)]
+    , Em [E @Int 2, E $ Coin 0]
+    , Em
+        [ E @Int 4
+        , Em
+            [ E $ TkTag 258
+            , E $ TkListLen 2
+            , Ev v cert
+            , Ev v cert
+            ]
+        ]
+    ]
+  where
+    cert = DelegTxCert @era (KeyHashObj (mkKeyHash 0)) (DelegStake (mkKeyHash 1))
+
+goldenDuplicateCertsDisallowed :: forall era. DijkstraEraTest era => Spec
+goldenDuplicateCertsDisallowed =
+  it "Decoding a transaction body with duplicate certificates fails" $
+    expectDecoderFailureAnn @(TxBody TopTx era)
+      version
+      (duplicateCertsTx @era version)
+      ( DecoderErrorDeserialiseFailure
+          "Annotator (MemoBytes (DijkstraTxBodyRaw TopTx DijkstraEra))"
+          ( DeserialiseFailure
+              143
+              "Final number of elements: 1 does not match the total count that was decoded: 2"
+          )
+      )
+  where
+    version = eraProtVerLow @era


### PR DESCRIPTION
> [!NOTE]
> The base branch here (`leios-prototype`) is the state before the recreation;
> this PR is intended to merge by fast-forwarding `leios-prototype` to the head
> of `leios-prototype-remake`. The diff is huge because it includes the
> snapshot-merge to upstream `main`. For focused review:
> - Recreation against current main: https://github.com/IntersectMBO/ouroboros-network/compare/main...leios-prototype-remake
> - Per-commit first-parent view: `git log --first-parent ebc8eac0a8..leios-prototype-remake`

> [!IMPORTANT]
> Cross-repo: this branch is consumed by `ouroboros-consensus`'s
> `leios-prototype-remake` (PR IntersectMBO/ouroboros-consensus#2041), where
> the Leios threadnet test is currently green (20 QC iters / 78 s) with this
> branch pinned via SRP and the BearerBytes + Reception adapters wired in.

## Done

- [x] **Snapshot-merge onto upstream `main`** (`ebc8eac0a8`) — the
      `leios-prototype-remake` ref is reset to upstream `main`'s tree while
      keeping the prototype's historic commits reachable via the merge
      commit's first parent.
- [x] **Demo-tuning: `BearerBytes` class replaces `dataSize`** (`55c16cf687`)
      Drop the `dataSize :: bytes -> Word` field from `ProtocolSizeLimits`;
      replace with a `class BearerBytes bytes where bearerBytesSize :: bytes
      -> Word` and default instances for `BS.ByteString`, `BL.ByteString`,
      `[Char]`, `AnyMessage msg`. The seven `byteLimits*` codec helpers no
      longer take a `(bytes -> Word)` argument; call sites drop the
      `(fromIntegral . LBS.length)` boilerplate. `Driver.Limits` gains a
      `BearerBytes bytes` constraint on the public entry points
      (`runPeerWithLimits` and friends).
- [x] **Demo-tuning: arrival-time `Reception` on `recv` + `TraceRecvMsg`**
      (`319743abd0`) — bearer-side recv now returns `Maybe (Reception a)`
      where `Reception a = MkReception !(IntMap Time) !a` records per-chunk
      arrival times keyed by starting-byte offset, and that arrival time is
      threaded all the way through the decoder to surface on `TraceRecvMsg ::
      Maybe Time -> AnyMessage ps -> TraceSendRecv ps` (with `TraceSendMsg ::
      Time -> AnyMessage ps -> ...` for symmetry). The mux demuxer pairs each
      SDU's read time with its offset into the ingress queue
      (`IngressQueueVal Int64 (IntMap Time) Builder`). The driver's decoder
      threads `(IntMap Time, Word rsz, Word sz)` so the next-message arrival
      time isn't lost when a message boundary lands inside a chunk
      (`runDecoderWithChannel_DecodeDone` helper, `mbEq <|> mbTm` fallback).
      `Reception` is re-exported from `Network.Mux` and `Ouroboros.Network.Mux`;
      `MonadMonotonicTime m` propagates to a handful of test entry points.
      *Squashes the prototype's original `Reception` drop together with the
      subsequent `TraceRecvMsg` consumer-side wiring + the four `runDecoder*`
      bugfixes that followed.*
- [x] **Demo-tuning: field names on `Reception`** (`3afd70f505`) — name the
      `MkReception` fields `receivalTimes` / `received` for ergonomic access.

## Still TODO

- [ ] `TCP_NOTSENT_LOWAT` + `TCP_NODELAY` on socket bearer set on the
      `mw/leios-prototype` branch — can be rebased.
- [ ] Open question: can these add-ons be PRed straight upstream into
      `ouroboros-network` master, eliminating the need for a fork branch?
      The two demo-tuning patches are self-contained and don't require any
      Leios protocol context, so they could land independently.

## Intentional differences from the original prototype

The Leios mini-protocols (`LeiosNotify`, `LeiosFetch`) live in `ouroboros-consensus`
rather than here — easier iteration in one repo. That's why this branch carries
only the bearer-layer demo-tuning (arrival times, `BearerBytes`) but no Leios
protocol content.

## Merge plan

Fast-forward `leios-prototype` to the head of this branch (after the
TODOs above are resolved).
