### PR TITLE
Intern stake credentials in reverse delegations

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -286,15 +286,15 @@ delegationTransition = do
     DelegStakeTxCert cred stakePool -> do
       -- note that pattern match is used instead of cwitness and dpool, as in the spec
       -- (hk ∈ dom (rewards ds))
-      case lookupAccountState cred (ds ^. accountsL) of
+      case lookupAccountStateIntern cred (ds ^. accountsL) of
         Nothing -> do
           failBecause $ StakeDelegationImpossibleDELEG cred
           pure certState
-        Just accountState ->
+        Just (internedCred, accountState) ->
           pure $
             certState
               & certDStateL . accountsL %~ adjustAccountState (stakePoolDelegationAccountStateL ?~ stakePool) cred
-              & certPStateL %~ unDelegReDelegStakePool cred accountState (Just stakePool)
+              & certPStateL %~ unDelegReDelegStakePool internedCred accountState (Just stakePool)
     GenesisDelegTxCert gkh vkh vrf -> do
       sp <- liftSTS $ asks stabilityWindow
       -- note that pattern match is used instead of genesisDeleg, as in the spec

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.0.0
 
+* Add `lookupInternMap`
 * Replace `okeyL` with `toOKey`
 
 ## 1.2.4.1

--- a/libs/cardano-data/src/Data/MapExtras.hs
+++ b/libs/cardano-data/src/Data/MapExtras.hs
@@ -28,6 +28,7 @@ module Data.MapExtras (
   extractKeysSmallSet,
   fromKeys,
   fromElems,
+  lookupInternMap,
 ) where
 
 import Data.Foldable (toList)
@@ -270,3 +271,16 @@ fromElems f vs =
   -- a nice optimization for already sorted keys and with list fusion there should be no overhead
   Map.fromList [(f v, v) | v <- toList vs]
 {-# INLINE fromElems #-}
+
+-- | Look up a key in a map and return the interned key together with its value, if present.
+-- The returned key is exactly the one stored in the map.
+-- Useful for maximizing sharing by avoiding duplicate-but-equal keys.
+lookupInternMap :: Ord k => k -> Map k v -> Maybe (k, v)
+lookupInternMap k = go
+  where
+    go Tip = Nothing
+    go (Bin _ kx v l r) =
+      case compare k kx of
+        LT -> go l
+        GT -> go r
+        EQ -> Just (kx, v)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `lookupAccountStateIntern` to `State.Account` module
 * Add `HasOKey` instance for `TxId (Tx l era)`
 * Remove `Generic` instance from `BoundedRatio` type
 * Remove deprecated function `addrPtrNormalize`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
@@ -15,6 +15,7 @@ module Cardano.Ledger.State.Account (
   CanSetAccounts (..),
   EraAccounts (..),
   lookupAccountState,
+  lookupAccountStateIntern,
   updateLookupAccountState,
   isAccountRegistered,
   adjustAccountState,
@@ -44,6 +45,7 @@ import Data.Kind (Type)
 import qualified Data.Map.Merge.Strict as Map
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.MapExtras (lookupInternMap)
 import Data.Set (Set)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -144,6 +146,12 @@ addToBalanceAccounts addBalanceMap accounts =
 lookupAccountState ::
   EraAccounts era => Credential 'Staking -> Accounts era -> Maybe (AccountState era)
 lookupAccountState cred accounts = Map.lookup cred (accounts ^. accountsMapL)
+
+lookupAccountStateIntern ::
+  EraAccounts era =>
+  Credential 'Staking -> Accounts era -> Maybe (Credential 'Staking, AccountState era)
+lookupAccountStateIntern cred accounts =
+  lookupInternMap cred (accounts ^. accountsMapL)
 
 -- | Update account state. Returns Nothing if the value is not present and modified value otherwise
 updateLookupAccountState ::


### PR DESCRIPTION
# Description

Don't allocate new credentials in memory for reverse-delegations.
Resolves https://github.com/IntersectMBO/cardano-ledger/issues/5378 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
