### PR TITLE
Subtransactions CBOR deserializer

### DIFF
--- a/eras/allegra/impl/cddl-files/allegra.cddl
+++ b/eras/allegra/impl/cddl-files/allegra.cddl
@@ -166,7 +166,6 @@ pool_keyhash = hash28
 
 pool_registration_cert = (3, pool_params)
 
-; Pool parameters for stake pool registration
 pool_params = 
   ( operator       : pool_keyhash      
   , vrf_keyhash    : vrf_keyhash       
@@ -293,6 +292,8 @@ transaction_witness_set =
 vkeywitness = [vkey, signature]
 
 ; Allegra introduces timelock support for native scripts.
+; This is the 6-variant native script format used by
+; Allegra, Mary, Alonzo, Babbage, and Conway.
 ; 
 ; Timelock validity intervals are half-open intervals [a, b).
 ;   script_invalid_before: specifies the left (included) endpoint a.

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
@@ -141,6 +141,7 @@ instance
       auxDataField 2 = field (addPlutusScripts PlutusV1) (D (guardPlutus PlutusV1 >> decCBOR))
       auxDataField 3 = field (addPlutusScripts PlutusV2) (D (guardPlutus PlutusV2 >> decCBOR))
       auxDataField 4 = field (addPlutusScripts PlutusV3) (D (guardPlutus PlutusV3 >> decCBOR))
+      auxDataField 5 = field (addPlutusScripts PlutusV4) (D (guardPlutus PlutusV4 >> decCBOR))
       auxDataField n = invalidField n
 
 deriving newtype instance (Era era, DecCBOR (NativeScript era)) => DecCBOR (AlonzoTxAuxData era)

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -205,7 +205,7 @@ test-suite tests
     cardano-ledger-alonzo,
     cardano-ledger-babbage:testlib,
     cardano-ledger-binary:testlib,
-    cardano-ledger-conway,
+    cardano-ledger-conway:{cardano-ledger-conway, testlib},
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-dijkstra:{cardano-ledger-dijkstra, testlib},
     cardano-ledger-shelley:testlib,

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
@@ -382,18 +382,10 @@ instance
               fieldAA (subTransactionsDijkstraTxBodyRawL .~) (D decodeSubTransactions)
         n -> invalidField n
       decodeSubTransactions :: Decoder s (Annotator (OMap TxId (Tx SubTx era)))
-      decodeSubTransactions = do
-        allowTag setTag
-        txAnns <- decodeList decCBOR
-        pure $ go (OMap.empty, 0) txAnns
-        where
-          go (m, n) []
-            | OMap.null m = fail "Empty list found, expected non-empty"
-            | OMap.size m /= n = fail "Duplicates found, expected no duplicates"
-            | otherwise = pure m
-          go (!m, !n) (x : xs) = do
-            v <- x
-            go (m OMap.|> v, n + 1) xs
+      decodeSubTransactions =
+        decodeNonEmptySetLikeEnforceNoDuplicatesAnn
+          (flip (OMap.|>))
+          (\o -> (OMap.size o, o))
       requiredFields :: STxBothLevels l era -> [(Word, String)]
       requiredFields = \case
         STopTx -> [(0, "inputs"), (1, "outputs"), (2, "fee")]

--- a/eras/dijkstra/impl/test/Main.hs
+++ b/eras/dijkstra/impl/test/Main.hs
@@ -8,6 +8,7 @@ import Cardano.Ledger.Plutus (SLanguage (..))
 import Test.Cardano.Ledger.Babbage.TxInfoSpec (txInfoSpec)
 import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as BabbageTxInfo
 import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Conway.Binary.RoundTrip (roundTripConwayCommonSpec)
 import Test.Cardano.Ledger.Dijkstra.Binary.Annotator ()
 import qualified Test.Cardano.Ledger.Dijkstra.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Dijkstra.Binary.Golden as Golden
@@ -21,6 +22,8 @@ main :: IO ()
 main =
   ledgerTestMain $
     describe "Dijkstra" $ do
+      describe "RoundTrip" $ do
+        roundTripConwayCommonSpec @DijkstraEra
       Cddl.spec
       GoldenSpec.spec
       roundTripJsonShelleyEraSpec @DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
 import Data.Functor.Identity (Identity)
+import qualified Data.OMap.Strict as OMap
 import Data.Typeable (Typeable)
 import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Allegra.Arbitrary (maxTimelockDepth)
@@ -87,7 +88,7 @@ instance Arbitrary (TxBody TopTx DijkstraEra) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> (choose (0, 4) >>= \n -> OMap.fromFoldable <$> vectorOf n arbitrary)
 
 instance Arbitrary (UpgradeDijkstraPParams Identity DijkstraEra) where
   arbitrary = genericArbitraryU

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -7,24 +8,136 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Dijkstra.Binary.Annotator (
 
 ) where
 
+import Cardano.Ledger.Address (Withdrawals (..))
+import Cardano.Ledger.Allegra.Scripts (invalidBeforeL, invalidHereAfterL)
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Binary.Coders
+import Cardano.Ledger.Coin (decodePositiveCoin)
+import Cardano.Ledger.Conway.Governance (
+  VotingProcedures (..),
+ )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Scripts
 import Cardano.Ledger.Dijkstra.Tx (DijkstraTx (..), Tx (..))
-import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
+import Cardano.Ledger.Dijkstra.TxBody
 import Cardano.Ledger.MemoBytes (decodeMemoized)
+import Cardano.Ledger.Val (Val (..))
+import qualified Data.OMap.Strict as OMap
+import qualified Data.OSet.Strict as OSet
 import Data.Typeable (Typeable)
+import Lens.Micro
 import Test.Cardano.Ledger.Conway.Binary.Annotator ()
 
 deriving newtype instance Typeable l => DecCBOR (TxBody l DijkstraEra)
+
+instance Typeable l => DecCBOR (DijkstraTxBodyRaw l DijkstraEra) where
+  decCBOR = withSTxBothLevels @l $ \sTxLevel ->
+    decode $
+      SparseKeyed
+        "TxBodyRaw"
+        (basicDijkstraTxBodyRaw sTxLevel)
+        (bodyFields sTxLevel)
+        (requiredFields sTxLevel)
+    where
+      bodyFields :: STxBothLevels l DijkstraEra -> Word -> Field (DijkstraTxBodyRaw l DijkstraEra)
+      bodyFields sTxLevel = \case
+        0 -> field (inputsDijkstraTxBodyRawL .~) From
+        1 -> field (outputsDijkstraTxBodyRawL .~) From
+        2 | STopTx <- sTxLevel -> field (feeDijkstraTxBodyRawL .~) From
+        3 -> ofield (vldtDijkstraTxBodyRawL . invalidHereAfterL .~) From
+        4 ->
+          fieldGuarded
+            (emptyFailure "Certificates" "non-empty")
+            OSet.null
+            (certsDijkstraTxBodyRawL .~)
+            From
+        5 ->
+          fieldGuarded
+            (emptyFailure "Withdrawals" "non-empty")
+            (null . unWithdrawals)
+            (withdrawalsDijkstraTxBodyRawL .~)
+            From
+        7 -> ofield (auxDataHashDijkstraTxBodyRawL .~) From
+        8 -> ofield (vldtDijkstraTxBodyRawL . invalidBeforeL .~) From
+        9 ->
+          fieldGuarded
+            (emptyFailure "Mint" "non-empty")
+            (== mempty)
+            (mintDijkstraTxBodyRawL .~)
+            From
+        11 -> ofield (scriptIntegrityHashDijkstraTxBodyRawL .~) From
+        13
+          | STopTx <- sTxLevel ->
+              fieldGuarded
+                (emptyFailure "Collateral Inputs" "non-empty")
+                null
+                (collateralInputsDijkstraTxBodyRawL .~)
+                From
+        14 ->
+          ofield
+            (\x -> guardsDijkstraTxBodyRawL .~ fromSMaybe mempty x)
+            (D decodeGuards)
+        15 -> ofield (networkIdDijkstraTxBodyRawL .~) From
+        16
+          | STopTx <- sTxLevel ->
+              ofield (collateralReturnDijkstraTxBodyRawL .~) From
+        17
+          | STopTx <- sTxLevel ->
+              ofield (totalCollateralDijkstraTxBodyRawL .~) From
+        18 ->
+          fieldGuarded
+            (emptyFailure "Reference Inputs" "non-empty")
+            null
+            (referenceInputsDijkstraTxBodyRawL .~)
+            From
+        19 ->
+          fieldGuarded
+            (emptyFailure "VotingProcedures" "non-empty")
+            (null . unVotingProcedures)
+            (votingProceduresDijkstraTxBodyRawL .~)
+            From
+        20 ->
+          fieldGuarded
+            (emptyFailure "ProposalProcedures" "non-empty")
+            OSet.null
+            (proposalProceduresDijkstraTxBodyRawL .~)
+            From
+        21 -> ofield (currentTreasuryValueDijkstraTxBodyRawL .~) From
+        22 ->
+          ofield
+            (\x -> treasuryDonationDijkstraTxBodyRawL .~ fromSMaybe zero x)
+            (D (decodePositiveCoin $ emptyFailure "Treasury Donation" "non-zero"))
+        23
+          | STopTx <- sTxLevel ->
+              fieldGuarded
+                (emptyFailure "Subtransactions" "non-empty")
+                OMap.null
+                (subTransactionsDijkstraTxBodyRawL .~)
+                (D $ allowTag setTag >> decCBOR)
+        n -> invalidField n
+      requiredFields :: STxBothLevels l DijkstraEra -> [(Word, String)]
+      requiredFields sTxLevel
+        | STopTx <- sTxLevel =
+            [ (0, "inputs")
+            , (1, "outputs")
+            , (2, "fee")
+            ]
+        | SSubTx <- sTxLevel =
+            [ (0, "inputs")
+            , (1, "outputs")
+            ]
+
+      emptyFailure fieldName requirement =
+        "TxBody: '" <> fieldName <> "' must be " <> requirement <> " when supplied"
 
 instance Era era => DecCBOR (DijkstraNativeScriptRaw era) where
   decCBOR = decode $ Summands "DijkstraNativeScriptRaw" $ \case

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
@@ -168,13 +168,7 @@ goldenDuplicateVKeyWitsDisallowed =
     expectDecoderFailureAnn @(TxWits era)
       (eraProtVerLow @era)
       witsDuplicateVKeyWits
-      ( DecoderErrorDeserialiseFailure
-          "Annotator (MemoBytes (AlonzoTxWitsRaw DijkstraEra))"
-          ( DeserialiseFailure
-              208
-              "Final number of elements: 1 does not match the total count that was decoded: 2"
-          )
-      )
+      (DecoderErrorCustom "Annotator" "Duplicates found, expected no duplicates")
 
 goldenDuplicateNativeScriptsDisallowed :: forall era. DijkstraEraTest era => Spec
 goldenDuplicateNativeScriptsDisallowed =
@@ -184,7 +178,7 @@ goldenDuplicateNativeScriptsDisallowed =
       witsDuplicateNativeScripts
       ( DecoderErrorCustom
           "Annotator"
-          "Duplicate elements in the scripts Set were encountered"
+          "Duplicates found, expected no duplicates"
       )
   where
     version = eraProtVerLow @era
@@ -216,7 +210,7 @@ goldenDuplicatePlutusDataDisallowed =
       witsDuplicatePlutusData
       ( DecoderErrorCustom
           "Annotator"
-          "Duplicate elements in the scripts Set were encountered"
+          "Duplicates found, expected no duplicates"
       )
 
 goldenSubTransactions :: forall era. DijkstraEraTest era => Spec
@@ -235,7 +229,10 @@ goldenSubTransactions = do
     expectDecoderFailureAnn @(TxBody TopTx era)
       version
       txBodyEmptySubTransactionsEnc
-      (DecoderErrorCustom "Annotator" "Empty list found, expected non-empty")
+      ( DecoderErrorDeserialiseFailure
+          "Annotator (MemoBytes (DijkstraTxBodyRaw TopTx DijkstraEra))"
+          (DeserialiseFailure 12 "Empty list found, expected non-empty")
+      )
   it "Subtransactions have to be distinct" $
     expectDecoderFailureAnn @(TxBody TopTx era)
       version

--- a/eras/shelley/impl/cddl-files/shelley.cddl
+++ b/eras/shelley/impl/cddl-files/shelley.cddl
@@ -164,7 +164,6 @@ pool_keyhash = hash28
 
 pool_registration_cert = (3, pool_params)
 
-; Pool parameters for stake pool registration
 pool_params = 
   ( operator       : pool_keyhash      
   , vrf_keyhash    : vrf_keyhash       

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Add `ofieldA` and `fieldAGuarded` to `Coders` module
 * Change `Density` type to only be available at the type level
 * Change `Wrapped` type to only be available at the type level
 * Make `decodeAnnSet` fail when there are duplicates, starting with protocol version `12`.

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.0.0
 
+* Add `decodeNonEmptySetLikeEnforceNoDuplicatesAnn` to `Annotated` module
 * Add `ofieldA` and `fieldAGuarded` to `Coders` module
 * Change `Density` type to only be available at the type level
 * Change `Wrapped` type to only be available at the type level

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `HasOKey` instance for `TxId (TxBody l era)`
 * Add `cddl` sub-library.
 * Limit `DecCBORGroup` decoding of `ProtVer` fields to `Word32` starting from protocol version `12`
 * Change `Relation` type to only be visible at the type level

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -683,3 +683,6 @@ fromStrictMaybeL = lens strictMaybeToMaybe (const maybeToStrictMaybe)
 
 instance EraTx era => HasOKey TxId (Tx l era) where
   toOKey = txIdTx
+
+instance EraTxBody era => HasOKey TxId (TxBody l era) where
+  toOKey = txIdTxBody


### PR DESCRIPTION
# Description

In order to deserialize subtransactions within a transaction body, we need to implement an instance of `DeCBOR (Annotator (TxBody era))` , which is what this PR does. 

Also adds some golden tests , enables round trip tests for Dijkstra and reduces some decoder-related duplication.
 
Closes https://github.com/IntersectMBO/cardano-ledger/issues/5405

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
