### PR TITLE
Fix `Monoid` instance for `VMap`

### DIFF
--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -128,7 +128,7 @@ library
     time,
     transformers,
     validation-selective,
-    vector-map ^>=1.1,
+    vector-map >=1.1,
 
   if flag(asserts)
     ghc-options: -fno-ignore-asserts

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -79,7 +79,7 @@ library
     time,
     transformers >=0.5,
     vector,
-    vector-map ^>=1.1,
+    vector-map >=1.1,
 
 library testlib
   exposed-modules:

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -142,7 +142,7 @@ library
     transformers,
     utf8-string,
     validation-selective,
-    vector-map ^>=1.1,
+    vector-map >=1.1,
 
   if flag(asserts)
     ghc-options: -fno-ignore-asserts

--- a/libs/vector-map/CHANGELOG.md
+++ b/libs/vector-map/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.2.0.0
 
 * Add `mapMaybeWithKey`
-* Add `unionWithKey`
+* Add `unionWithKey`, `unionWith` and `union`
 * Switch `Semigroup` instance for `VMap` to be left-biased, just like it is for `Map`
 
 ## 1.1.0.1

--- a/libs/vector-map/CHANGELOG.md
+++ b/libs/vector-map/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `vector-map`
 
-## 1.1.0.2
+## 1.1.1.0
 
-*
+* Add `unionWithKey`
 
 ## 1.1.0.1
 

--- a/libs/vector-map/CHANGELOG.md
+++ b/libs/vector-map/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Version history for `vector-map`
 
-## 1.1.1.0
+## 1.2.0.0
 
 * Add `unionWithKey`
+* Switch `Semigroup` instance for `VMap` to be left-biased, just like it is for `Map`
 
 ## 1.1.0.1
 

--- a/libs/vector-map/CHANGELOG.md
+++ b/libs/vector-map/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.0.0
 
+* Add `mapMaybeWithKey`
 * Add `unionWithKey`
 * Switch `Semigroup` instance for `VMap` to be left-biased, just like it is for `Map`
 

--- a/libs/vector-map/src/Data/VMap.hs
+++ b/libs/vector-map/src/Data/VMap.hs
@@ -24,6 +24,7 @@ module Data.VMap (
   foldlWithKey,
   foldMap,
   foldMapWithKey,
+  unionWithKey,
   fromMap,
   toMap,
   fromList,
@@ -136,6 +137,15 @@ findWithDefault ::
   (Ord k, VG.Vector kv k, VG.Vector vv v) => v -> k -> VMap kv vv k v -> v
 findWithDefault a k = fromMaybe a . lookup k
 {-# INLINE findWithDefault #-}
+
+unionWithKey ::
+  (Ord k, VG.Vector kv k, VG.Vector vv v) =>
+  (k -> v -> v -> v) ->
+  VMap kv vv k v ->
+  VMap kv vv k v ->
+  VMap kv vv k v
+unionWithKey f (VMap kv1) (VMap kv2) = VMap (KV.unionWithKey f kv1 kv2)
+{-# INLINE unionWithKey #-}
 
 fromMap :: (VG.Vector kv k, VG.Vector vv v) => Map.Map k v -> VMap kv vv k v
 fromMap = VMap . KV.fromMap

--- a/libs/vector-map/src/Data/VMap.hs
+++ b/libs/vector-map/src/Data/VMap.hs
@@ -25,6 +25,8 @@ module Data.VMap (
   foldlWithKey,
   foldMap,
   foldMapWithKey,
+  union,
+  unionWith,
   unionWithKey,
   fromMap,
   toMap,
@@ -138,6 +140,23 @@ findWithDefault ::
   (Ord k, VG.Vector kv k, VG.Vector vv v) => v -> k -> VMap kv vv k v -> v
 findWithDefault a k = fromMaybe a . lookup k
 {-# INLINE findWithDefault #-}
+
+union ::
+  (Ord k, VG.Vector kv k, VG.Vector vv v) =>
+  VMap kv vv k v ->
+  VMap kv vv k v ->
+  VMap kv vv k v
+union = unionWithKey KV.keepFirstDuplicate
+{-# INLINE union #-}
+
+unionWith ::
+  (Ord k, VG.Vector kv k, VG.Vector vv v) =>
+  (v -> v -> v) ->
+  VMap kv vv k v ->
+  VMap kv vv k v ->
+  VMap kv vv k v
+unionWith f = unionWithKey (const f)
+{-# INLINE unionWith #-}
 
 unionWithKey ::
   (Ord k, VG.Vector kv k, VG.Vector vv v) =>

--- a/libs/vector-map/src/Data/VMap.hs
+++ b/libs/vector-map/src/Data/VMap.hs
@@ -17,6 +17,7 @@ module Data.VMap (
   notMember,
   map,
   mapMaybe,
+  mapMaybeWithKey,
   mapWithKey,
   filter,
   fold,
@@ -216,8 +217,16 @@ mapMaybe ::
   (a -> Maybe b) ->
   VMap kv vv k a ->
   VMap kv vv k b
-mapMaybe f (VMap vec) = VMap (VG.mapMaybe (\(k, x) -> (,) k <$> f x) vec)
+mapMaybe f = mapMaybeWithKey (const f)
 {-# INLINE mapMaybe #-}
+
+mapMaybeWithKey ::
+  (VG.Vector kv k, VG.Vector vv a, VG.Vector vv b) =>
+  (k -> a -> Maybe b) ->
+  VMap kv vv k a ->
+  VMap kv vv k b
+mapMaybeWithKey f (VMap vec) = VMap (VG.mapMaybe (\(k, x) -> (,) k <$> f k x) vec)
+{-# INLINE mapMaybeWithKey #-}
 
 mapWithKey ::
   (VG.Vector kv k, VG.Vector vv a, VG.Vector vv b) =>

--- a/libs/vector-map/src/Data/VMap/KVVector.hs
+++ b/libs/vector-map/src/Data/VMap/KVVector.hs
@@ -316,7 +316,7 @@ normalizeM mv = sortAscKVMVector mv >> removeDuplicates keepFirstDuplicate mv
 {-# INLINE normalizeM #-}
 
 instance (VG.Vector kv k, VG.Vector vv v, Ord k) => Semigroup (KVVector kv vv (k, v)) where
-  (<>) v1 v2 = normalize (v1 VG.++ v2)
+  (<>) = unionWithKey keepFirstDuplicate
   {-# INLINE (<>) #-}
   sconcat = normalize . VG.concat . NE.toList
   {-# INLINE sconcat #-}

--- a/libs/vector-map/src/Data/VMap/KVVector.hs
+++ b/libs/vector-map/src/Data/VMap/KVVector.hs
@@ -34,6 +34,8 @@ module Data.VMap.KVVector (
   internKVVectorMaybe,
   normalize,
   normalizeM,
+  keepFirstDuplicate,
+  keepSecondDuplicate,
 ) where
 
 import Control.Applicative

--- a/libs/vector-map/test/Test/VMap.hs
+++ b/libs/vector-map/test/Test/VMap.hs
@@ -50,6 +50,11 @@ vMapTests =
           (VMap.fromAscListWithKeyN n (applyFun3 f))
           (Map.fromAscListWithKey (applyFun3 f) . take n)
           (List.sortOn fst xs)
+      prop "unionWithKey" $ \xs1 xs2 f ->
+        prop_AsMapFrom
+          (\(m1, m2) -> VMap.unionWithKey (applyFun3 f) (VMap.fromMap m1) (VMap.fromMap m2))
+          (uncurry (Map.unionWithKey (applyFun3 f)))
+          (Map.fromList xs1, Map.fromList xs2)
       prop "toAscList" $ prop_AsMapTo VMap.toAscList Map.toAscList
       prop "foldMapWithKey" $ \f ->
         let f' k v = applyFun2 f k v :: String

--- a/libs/vector-map/test/Test/VMap.hs
+++ b/libs/vector-map/test/Test/VMap.hs
@@ -55,6 +55,11 @@ vMapTests =
           (\(m1, m2) -> VMap.unionWithKey (applyFun3 f) (VMap.fromMap m1) (VMap.fromMap m2))
           (uncurry (Map.unionWithKey (applyFun3 f)))
           (Map.fromList xs1, Map.fromList xs2)
+      prop "mappend" $ \xs1 xs2 ->
+        prop_AsMapFrom
+          (\(m1, m2) -> VMap.fromMap m1 <> VMap.fromMap m2)
+          (uncurry (<>))
+          (Map.fromList xs1, Map.fromList xs2)
       prop "toAscList" $ prop_AsMapTo VMap.toAscList Map.toAscList
       prop "foldMapWithKey" $ \f ->
         let f' k v = applyFun2 f k v :: String

--- a/libs/vector-map/test/Test/VMap.hs
+++ b/libs/vector-map/test/Test/VMap.hs
@@ -39,6 +39,11 @@ vMapTests =
       prop "to/fromList" $ prop_Roundtrip VMap.toAscList VMap.fromList
       prop "to/fromMap" $ prop_Roundtrip VMap.toMap VMap.fromMap
     describe "asMap" $ do
+      prop "mapMaybeWithKey" $ \xs f ->
+        prop_AsMapFrom
+          (\m -> VMap.mapMaybeWithKey (applyFun2 f) (VMap.fromMap m))
+          (Map.mapMaybeWithKey (applyFun2 f) :: MapT -> MapT)
+          (Map.fromList xs)
       prop "fromList" $ prop_AsMapFrom VMap.fromList Map.fromList
       prop "fromAscListWithKey" $ \xs f ->
         prop_AsMapFrom

--- a/libs/vector-map/vector-map.cabal
+++ b/libs/vector-map/vector-map.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: vector-map
-version: 1.1.0.1
+version: 1.1.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/libs/vector-map/vector-map.cabal
+++ b/libs/vector-map/vector-map.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: vector-map
-version: 1.1.1.0
+version: 1.2.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK


### PR DESCRIPTION
# Description

I've accidentally discovered a discrepancy in how `Monoid`/`Semigroup` instance is implemented for `VMap`, in particular that it didn't match the one for `Map`.

This is not really an issue for us, since `Monoid` instance was not used for anything, but in case it does get used, we want to avoid surprises.

This PR also adds `unionWithKey` and `mapMaybeWithKey`, in case they become useful in the future.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
