### PR TITLE
Type-class-based CDDL generation

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Add `cddl` sub-library.
 * Remove deprecated type `Allegra`
 * Remove deprecated type `TimelockConstr`
 * Add `invalidBeforeL`, `invalidHereAfterL`
@@ -10,6 +11,12 @@
 * Add `HasEraTxLevel` instances for `Tx` and `TxBody`
 * Add `EraTxLevel` instance
 * Remove deprecated `timelockScriptsTxAuxDataL`
+
+### `cddl`
+
+* Add `HuddleSpec` module with `Huddle{Rule|Group}` instances for all types.
+* Add smart constructors `mkBlock` and `mkTransaction`.
+* Add `generate-cddl` executable target to test the generation of `.cddl` files against the existing `huddle-cddl` executable.
 
 ### `testlib`
 

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -84,6 +84,50 @@ library
     transformers,
     validation-selective,
 
+library cddl
+  exposed-modules:
+    Cardano.Ledger.Allegra.HuddleSpec
+
+  visibility: public
+  hs-source-dirs: cddl/lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+  build-depends:
+    base,
+    cardano-ledger-allegra,
+    cardano-ledger-shelley:cddl,
+    cuddle >=0.4,
+    heredoc,
+
+executable generate-cddl
+  main-is: Main.hs
+  hs-source-dirs: cddl/exe
+  other-modules: Paths_cardano_ledger_allegra
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+  build-depends:
+    base,
+    cardano-ledger-binary:testlib >=1.4,
+    cddl,
+    directory,
+    filepath,
+
 library testlib
   exposed-modules:
     Test.Cardano.Ledger.Allegra.Arbitrary

--- a/eras/allegra/impl/cddl-files/allegra.cddl
+++ b/eras/allegra/impl/cddl-files/allegra.cddl
@@ -166,6 +166,7 @@ pool_keyhash = hash28
 
 pool_registration_cert = (3, pool_params)
 
+; Pool parameters for stake pool registration
 pool_params = 
   ( operator       : pool_keyhash      
   , vrf_keyhash    : vrf_keyhash       
@@ -292,8 +293,6 @@ transaction_witness_set =
 vkeywitness = [vkey, signature]
 
 ; Allegra introduces timelock support for native scripts.
-; This is the 6-variant native script format used by
-; Allegra, Mary, Alonzo, Babbage, and Conway.
 ; 
 ; Timelock validity intervals are half-open intervals [a, b).
 ;   script_invalid_before: specifies the left (included) endpoint a.

--- a/eras/allegra/impl/cddl/exe/Main.hs
+++ b/eras/allegra/impl/cddl/exe/Main.hs
@@ -1,0 +1,14 @@
+module Main where
+
+import Cardano.Ledger.Allegra.HuddleSpec (allegraCDDL)
+import Paths_cardano_ledger_allegra (getDataFileName)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath (takeDirectory)
+import Test.Cardano.Ledger.Binary.Cuddle (writeSpec)
+
+main :: IO ()
+main = do
+  outputPath <- getDataFileName "cddl-files/allegra.cddl"
+  createDirectoryIfMissing True (takeDirectory outputPath)
+  writeSpec allegraCDDL outputPath
+  putStrLn $ "Generated CDDL file at: " ++ outputPath

--- a/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
+++ b/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
@@ -1,0 +1,280 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Allegra.HuddleSpec (
+  allegraCDDL,
+  blockRule,
+  transactionRule,
+) where
+
+import Cardano.Ledger.Allegra (AllegraEra)
+import Cardano.Ledger.Shelley.HuddleSpec
+import Codec.CBOR.Cuddle.Huddle
+import Data.Proxy (Proxy (..))
+import Text.Heredoc
+import Prelude hiding ((/))
+
+allegraCDDL :: Huddle
+allegraCDDL =
+  collectFrom
+    [ HIRule $ huddleRule @"block" (Proxy @AllegraEra)
+    , HIRule $ huddleRule @"transaction" (Proxy @AllegraEra)
+    ]
+
+blockRule ::
+  forall era.
+  ( HuddleRule "header" era
+  , HuddleRule "transaction_body" era
+  , HuddleRule "transaction_witness_set" era
+  , HuddleRule "auxiliary_data" era
+  ) =>
+  Proxy era ->
+  Rule
+blockRule p =
+  "block"
+    =:= arr
+      [ a $ huddleRule @"header" p
+      , "transaction_bodies" ==> arr [0 <+ a (huddleRule @"transaction_body" p)]
+      , "transaction_witness_sets" ==> arr [0 <+ a (huddleRule @"transaction_witness_set" p)]
+      , "auxiliary_data_set"
+          ==> mp
+            [ 0
+                <+ asKey (huddleRule @"transaction_index" p)
+                ==> huddleRule @"auxiliary_data" p
+            ]
+      ]
+
+transactionRule ::
+  forall era.
+  ( HuddleRule "transaction_body" era
+  , HuddleRule "transaction_witness_set" era
+  , HuddleRule "auxiliary_data" era
+  ) =>
+  Proxy era ->
+  Rule
+transactionRule p =
+  "transaction"
+    =:= arr
+      [ a $ huddleRule @"transaction_body" p
+      , a $ huddleRule @"transaction_witness_set" p
+      , a (huddleRule @"auxiliary_data" p / VNil)
+      ]
+
+instance HuddleRule "major_protocol_version" AllegraEra where
+  huddleRule = majorProtocolVersionRule @AllegraEra
+
+instance HuddleGroup "protocol_version" AllegraEra where
+  huddleGroup = protocolVersionGroup @AllegraEra
+
+instance HuddleRule "protocol_param_update" AllegraEra where
+  huddleRule = protocolParamUpdateRule @AllegraEra
+
+instance HuddleRule "proposed_protocol_parameter_updates" AllegraEra where
+  huddleRule = proposedProtocolParameterUpdatesRule @AllegraEra
+
+instance HuddleRule "update" AllegraEra where
+  huddleRule = updateRule @AllegraEra
+
+instance HuddleRule "genesis_hash" AllegraEra where
+  huddleRule = genesisHashRule @AllegraEra
+
+instance HuddleGroup "operational_cert" AllegraEra where
+  huddleGroup = operationalCertGroup @AllegraEra
+
+instance HuddleRule "header_body" AllegraEra where
+  huddleRule = headerBodyRule @AllegraEra
+
+instance HuddleRule "header" AllegraEra where
+  huddleRule = headerRule @AllegraEra
+
+instance HuddleRule "min_int64" AllegraEra where
+  huddleRule _ = "min_int64" =:= (-9223372036854775808 :: Integer)
+
+instance HuddleRule "max_int64" AllegraEra where
+  huddleRule _ = "max_int64" =:= (9223372036854775807 :: Integer)
+
+instance HuddleRule "int64" AllegraEra where
+  huddleRule p = "int64" =:= huddleRule @"min_int64" p ... huddleRule @"max_int64" p
+
+instance HuddleGroup "script_all" AllegraEra where
+  huddleGroup p = "script_all" =:~ grp [1, a $ arr [0 <+ a (huddleRule @"native_script" p)]]
+
+instance HuddleGroup "script_any" AllegraEra where
+  huddleGroup p = "script_any" =:~ grp [2, a $ arr [0 <+ a (huddleRule @"native_script" p)]]
+
+instance HuddleGroup "script_n_of_k" AllegraEra where
+  huddleGroup p =
+    "script_n_of_k"
+      =:~ grp
+        [ 3
+        , "n" ==> huddleRule @"int64" p
+        , a $ arr [0 <+ a (huddleRule @"native_script" p)]
+        ]
+
+instance HuddleGroup "script_invalid_before" AllegraEra where
+  huddleGroup p =
+    comment
+      [str|Timelock validity intervals are half-open intervals [a, b).
+          |This field specifies the left (included) endpoint a.
+          |]
+      $ "script_invalid_before"
+        =:~ grp [4, a (huddleRule @"slot" p)]
+
+instance HuddleGroup "script_invalid_hereafter" AllegraEra where
+  huddleGroup p =
+    comment
+      [str|Timelock validity intervals are half-open intervals [a, b).
+          |This field specifies the right (excluded) endpoint b.
+          |]
+      $ "script_invalid_hereafter"
+        =:~ grp [5, a (huddleRule @"slot" p)]
+
+instance HuddleRule "native_script" AllegraEra where
+  huddleRule p =
+    comment
+      [str|Allegra introduces timelock support for native scripts.
+          |
+          |Timelock validity intervals are half-open intervals [a, b).
+          |  script_invalid_before: specifies the left (included) endpoint a.
+          |  script_invalid_hereafter: specifies the right (excluded) endpoint b.
+          |
+          |Note: Allegra switched to int64 for script_n_of_k thresholds.
+          |]
+      $ "native_script"
+        =:= arr [a $ huddleGroup @"script_pubkey" p]
+        / arr [a $ huddleGroup @"script_all" p]
+        / arr [a $ huddleGroup @"script_any" p]
+        / arr [a $ huddleGroup @"script_n_of_k" p]
+        / arr [a $ huddleGroup @"script_invalid_before" p]
+        / arr [a $ huddleGroup @"script_invalid_hereafter" p]
+
+instance HuddleRule "vkeywitness" AllegraEra where
+  huddleRule = vkeywitnessRule @AllegraEra
+
+instance HuddleRule "bootstrap_witness" AllegraEra where
+  huddleRule = bootstrapWitnessRule @AllegraEra
+
+instance HuddleRule "transaction_witness_set" AllegraEra where
+  huddleRule = transactionWitnessSetRule @AllegraEra
+
+instance HuddleGroup "script_pubkey" AllegraEra where
+  huddleGroup = scriptPubkeyGroup @AllegraEra
+
+instance HuddleRule "transaction_id" AllegraEra where
+  huddleRule = transactionIdRule @AllegraEra
+
+instance HuddleRule "transaction_input" AllegraEra where
+  huddleRule = transactionInputRule @AllegraEra
+
+instance HuddleRule "transaction_output" AllegraEra where
+  huddleRule = transactionOutputRule @AllegraEra
+
+instance HuddleRule "dns_name" AllegraEra where
+  huddleRule _ = dnsNameRule
+
+instance HuddleRule "url" AllegraEra where
+  huddleRule _ = urlRule
+
+instance HuddleRule "pool_metadata" AllegraEra where
+  huddleRule = poolMetadataRule @AllegraEra
+
+instance HuddleGroup "single_host_addr" AllegraEra where
+  huddleGroup = singleHostAddrGroup @AllegraEra
+
+instance HuddleGroup "single_host_name" AllegraEra where
+  huddleGroup = singleHostNameGroup @AllegraEra
+
+instance HuddleGroup "multi_host_name" AllegraEra where
+  huddleGroup = multiHostNameGroup @AllegraEra
+
+instance HuddleRule "relay" AllegraEra where
+  huddleRule = relayRule @AllegraEra
+
+instance HuddleGroup "pool_params" AllegraEra where
+  huddleGroup = poolParamsGroup @AllegraEra
+
+instance HuddleGroup "pool_registration_cert" AllegraEra where
+  huddleGroup = poolRegistrationCertGroup @AllegraEra
+
+instance HuddleGroup "pool_retirement_cert" AllegraEra where
+  huddleGroup = poolRetirementCertGroup @AllegraEra
+
+instance HuddleRule "genesis_delegate_hash" AllegraEra where
+  huddleRule = genesisDelegateHashRule @AllegraEra
+
+instance HuddleGroup "genesis_delegation_cert" AllegraEra where
+  huddleGroup = genesisDelegationCertGroup @AllegraEra
+
+instance HuddleRule "delta_coin" AllegraEra where
+  huddleRule _ = deltaCoinRule
+
+instance HuddleRule "move_instantaneous_reward" AllegraEra where
+  huddleRule = moveInstantaneousRewardRule @AllegraEra
+
+instance HuddleGroup "move_instantaneous_rewards_cert" AllegraEra where
+  huddleGroup = moveInstantaneousRewardsCertGroup @AllegraEra
+
+instance HuddleGroup "account_registration_cert" AllegraEra where
+  huddleGroup = accountRegistrationCertGroup @AllegraEra
+
+instance HuddleGroup "account_unregistration_cert" AllegraEra where
+  huddleGroup = accountUnregistrationCertGroup @AllegraEra
+
+instance HuddleGroup "delegation_to_stake_pool_cert" AllegraEra where
+  huddleGroup = delegationToStakePoolCertGroup @AllegraEra
+
+instance HuddleRule "certificate" AllegraEra where
+  huddleRule = certificateRule @AllegraEra
+
+instance HuddleRule "withdrawals" AllegraEra where
+  huddleRule = withdrawalsRule @AllegraEra
+
+instance HuddleRule "auxiliary_scripts" AllegraEra where
+  huddleRule p = "auxiliary_scripts" =:= arr [0 <+ a (huddleRule @"native_script" p)]
+
+instance HuddleRule "auxiliary_data_array" AllegraEra where
+  huddleRule p =
+    "auxiliary_data_array"
+      =:= arr
+        [ "transaction_metadata" ==> huddleRule @"metadata" p
+        , "auxiliary_scripts" ==> huddleRule @"auxiliary_scripts" p
+        ]
+
+instance HuddleRule "auxiliary_data" AllegraEra where
+  huddleRule p =
+    "auxiliary_data"
+      =:= huddleRule @"metadata" p
+      / huddleRule @"auxiliary_data_array" p
+
+instance HuddleRule "transaction_body" AllegraEra where
+  huddleRule p =
+    comment
+      [str|Allegra transaction body adds the validity interval start at index 8
+          |]
+      $ "transaction_body"
+        =:= mp
+          [ idx 0 ==> untaggedSet (huddleRule @"transaction_input" p)
+          , idx 1 ==> arr [0 <+ a (huddleRule @"transaction_output" p)]
+          , idx 2 ==> huddleRule @"coin" p
+          , opt (idx 3 ==> huddleRule @"slot" p)
+          , opt (idx 4 ==> arr [0 <+ a (huddleRule @"certificate" p)])
+          , opt (idx 5 ==> huddleRule @"withdrawals" p)
+          , opt (idx 6 ==> huddleRule @"update" p)
+          , opt (idx 7 ==> huddleRule @"auxiliary_data_hash" p)
+          , opt (idx 8 ==> huddleRule @"slot" p)
+          ]
+
+instance HuddleRule "transaction" AllegraEra where
+  huddleRule = transactionRule @AllegraEra
+
+instance HuddleRule "block" AllegraEra where
+  huddleRule = blockRule @AllegraEra

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Add `cddl` sub-library.
 * Replace `StakePoolState` values in `psFutureStakePoolParams` with `StakePoolParams`
 * Remove `psFutureStakePoolsL`
 * Add `psFutureStakePoolParamsL`
@@ -30,6 +31,12 @@
   - Add `testIncompleteAndMissingWithdrawals`
 * Added `Generic` instance to `ShelleyTxOut`
 * Add `AtMostEra "Conway" era` constraint to `ShelleyEraTxCert`, effectively disabling it for Dijkstra onwards
+
+### `cddl`
+
+* Add `HuddleSpec` module with `Huddle{Rule|Group}` instances for all types.
+* Add and export smart constructors for transaction components, certificates, pool infrastructure, and block structures.
+* Add `generate-cddl` executable target to test the generation of `.cddl` files against the existing `huddle-cddl` executable.
 
 ### `testlib`
 

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -133,6 +133,51 @@ library
   if flag(asserts)
     ghc-options: -fno-ignore-asserts
 
+library cddl
+  exposed-modules:
+    Cardano.Ledger.Shelley.HuddleSpec
+
+  visibility: public
+  hs-source-dirs: cddl/lib
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+  build-depends:
+    base,
+    cardano-ledger-core,
+    cardano-ledger-core:cddl,
+    cardano-ledger-shelley,
+    cuddle >=0.4,
+    heredoc,
+
+executable generate-cddl
+  main-is: Main.hs
+  hs-source-dirs: cddl/exe
+  other-modules: Paths_cardano_ledger_shelley
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+  build-depends:
+    base,
+    cardano-ledger-binary:testlib >=1.4,
+    cddl,
+    directory,
+    filepath,
+
 library testlib
   exposed-modules:
     Test.Cardano.Ledger.Shelley.Arbitrary

--- a/eras/shelley/impl/cddl-files/shelley.cddl
+++ b/eras/shelley/impl/cddl-files/shelley.cddl
@@ -164,6 +164,7 @@ pool_keyhash = hash28
 
 pool_registration_cert = (3, pool_params)
 
+; Pool parameters for stake pool registration
 pool_params = 
   ( operator       : pool_keyhash      
   , vrf_keyhash    : vrf_keyhash       

--- a/eras/shelley/impl/cddl/exe/Main.hs
+++ b/eras/shelley/impl/cddl/exe/Main.hs
@@ -1,0 +1,14 @@
+module Main where
+
+import Cardano.Ledger.Shelley.HuddleSpec (shelleyCDDL)
+import Paths_cardano_ledger_shelley (getDataFileName)
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath (takeDirectory)
+import Test.Cardano.Ledger.Binary.Cuddle (writeSpec)
+
+main :: IO ()
+main = do
+  outputPath <- getDataFileName "cddl-files/shelley.cddl"
+  createDirectoryIfMissing True (takeDirectory outputPath)
+  writeSpec shelleyCDDL outputPath
+  putStrLn $ "Generated CDDL file at: " ++ outputPath

--- a/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
+++ b/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
@@ -1,0 +1,568 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Shelley.HuddleSpec (
+  module Cardano.Ledger.Huddle,
+  shelleyCDDL,
+  headerRule,
+  proposedProtocolParameterUpdatesRule,
+  updateRule,
+  protocolParamUpdateRule,
+  headerBodyRule,
+  protocolVersionGroup,
+  majorProtocolVersionRule,
+  transactionWitnessSetRule,
+  vkeywitnessRule,
+  bootstrapWitnessRule,
+  operationalCertGroup,
+  genesisHashRule,
+  scriptPubkeyGroup,
+  transactionIdRule,
+  transactionInputRule,
+  transactionOutputRule,
+  withdrawalsRule,
+  dnsNameRule,
+  urlRule,
+  poolMetadataRule,
+  singleHostAddrGroup,
+  singleHostNameGroup,
+  multiHostNameGroup,
+  relayRule,
+  poolParamsGroup,
+  poolRegistrationCertGroup,
+  poolRetirementCertGroup,
+  genesisDelegateHashRule,
+  genesisDelegationCertGroup,
+  deltaCoinRule,
+  moveInstantaneousRewardRule,
+  moveInstantaneousRewardsCertGroup,
+  accountRegistrationCertGroup,
+  accountUnregistrationCertGroup,
+  delegationToStakePoolCertGroup,
+  certificateRule,
+  untaggedSet,
+) where
+
+import Cardano.Ledger.BaseTypes (getVersion)
+import Cardano.Ledger.Core (ByronEra, Era, eraProtVerHigh, eraProtVerLow)
+import Cardano.Ledger.Core.HuddleSpec ()
+import Cardano.Ledger.Huddle
+import Cardano.Ledger.Shelley (ShelleyEra)
+import Codec.CBOR.Cuddle.Comments ((//-))
+import Codec.CBOR.Cuddle.Huddle
+import Data.Proxy (Proxy (..))
+import Data.Word (Word64)
+import Text.Heredoc
+import Prelude hiding ((/))
+
+shelleyCDDL :: Huddle
+shelleyCDDL =
+  collectFrom
+    [ HIRule $ huddleRule @"block" (Proxy @ShelleyEra)
+    , HIRule $ huddleRule @"transaction" (Proxy @ShelleyEra)
+    , HIRule $ huddleRule @"signkey_kes" (Proxy @ShelleyEra)
+    ]
+
+headerRule :: forall era. HuddleRule "header_body" era => Proxy era -> Rule
+headerRule p =
+  "header"
+    =:= arr [a $ huddleRule @"header_body" p, "body_signature" ==> huddleRule @"kes_signature" p]
+
+proposedProtocolParameterUpdatesRule ::
+  forall era.
+  (HuddleRule "genesis_hash" era, HuddleRule "protocol_param_update" era) => Proxy era -> Rule
+proposedProtocolParameterUpdatesRule p =
+  "proposed_protocol_parameter_updates"
+    =:= mp [0 <+ asKey (huddleRule @"genesis_hash" p) ==> huddleRule @"protocol_param_update" p]
+
+updateRule ::
+  forall era. HuddleRule "proposed_protocol_parameter_updates" era => Proxy era -> Rule
+updateRule p =
+  "update"
+    =:= arr [a $ huddleRule @"proposed_protocol_parameter_updates" p, a $ huddleRule @"epoch" p]
+
+protocolParamUpdateRule ::
+  forall era. HuddleGroup "protocol_version" era => Proxy era -> Rule
+protocolParamUpdateRule p =
+  "protocol_param_update"
+    =:= mp
+      [ opt (idx 0 ==> VUInt) //- "minfee A"
+      , opt (idx 1 ==> VUInt) //- "minfee B"
+      , opt (idx 2 ==> VUInt) //- "max block body size"
+      , opt (idx 3 ==> VUInt) //- "max transaction size"
+      , opt (idx 4 ==> VUInt `sized` (2 :: Word64)) //- "max block header size"
+      , opt (idx 5 ==> huddleRule @"coin" p) //- "key deposit"
+      , opt (idx 6 ==> huddleRule @"coin" p) //- "pool deposit"
+      , opt (idx 7 ==> huddleRule @"epoch_interval" p) //- "maximum epoch"
+      , opt (idx 8 ==> VUInt `sized` (2 :: Word64)) //- "n_opt: desired number of stake pools"
+      , opt (idx 9 ==> huddleRule @"nonnegative_interval" p) //- "pool pledge influence"
+      , opt (idx 10 ==> huddleRule @"unit_interval" p) //- "expansion rate"
+      , opt (idx 11 ==> huddleRule @"unit_interval" p) //- "treasury growth rate"
+      , opt (idx 12 ==> huddleRule @"unit_interval" p) //- "decentralization constant"
+      , opt (idx 13 ==> huddleRule @"nonce" p) //- "extra entropy"
+      , opt (idx 14 ==> arr [a $ huddleGroup @"protocol_version" p]) //- "protocol version"
+      , opt (idx 15 ==> huddleRule @"coin" p) //- "min utxo value"
+      , opt (idx 16 ==> huddleRule @"coin" p) //- "min pool cost"
+      ]
+
+headerBodyRule ::
+  forall era.
+  ( HuddleGroup "operational_cert" era
+  , HuddleGroup "protocol_version" era
+  ) =>
+  Proxy era ->
+  Rule
+headerBodyRule p =
+  "header_body"
+    =:= arr
+      [ "block_number" ==> huddleRule @"block_number" p
+      , "slot" ==> huddleRule @"slot" p
+      , "prev_hash" ==> huddleRule @"hash32" p / VNil
+      , "issuer_vkey" ==> huddleRule @"vkey" p
+      , "vrf_vkey" ==> huddleRule @"vrf_vkey" p
+      , "nonce_vrf" ==> huddleRule @"vrf_cert" p
+      , "leader_vrf" ==> huddleRule @"vrf_cert" p
+      , "block_body_size" ==> VUInt `sized` (4 :: Word64)
+      , "block_body_hash" ==> huddleRule @"hash32" p
+      , a (huddleGroup @"operational_cert" p)
+      , a (huddleGroup @"protocol_version" p)
+      ]
+
+protocolVersionGroup ::
+  forall era. HuddleRule "major_protocol_version" era => Proxy era -> Named Group
+protocolVersionGroup p = "protocol_version" =:~ grp [a $ huddleRule @"major_protocol_version" p, a VUInt]
+
+majorProtocolVersionRule :: forall era. Era era => Proxy era -> Rule
+majorProtocolVersionRule _ =
+  "major_protocol_version"
+    =:= getVersion @Integer (eraProtVerLow @ByronEra)
+    ... succ (getVersion @Integer (eraProtVerHigh @era))
+
+transactionWitnessSetRule ::
+  forall era.
+  ( HuddleRule "vkeywitness" era
+  , HuddleRule "native_script" era
+  , HuddleRule "bootstrap_witness" era
+  ) =>
+  Proxy era ->
+  Rule
+transactionWitnessSetRule p =
+  "transaction_witness_set"
+    =:= mp
+      [ opt $ idx 0 ==> arr [0 <+ a (huddleRule @"vkeywitness" p)]
+      , opt $ idx 1 ==> arr [0 <+ a (huddleRule @"native_script" p)]
+      , opt $ idx 2 ==> arr [0 <+ a (huddleRule @"bootstrap_witness" p)]
+      ]
+
+vkeywitnessRule :: forall era. Era era => Proxy era -> Rule
+vkeywitnessRule p =
+  "vkeywitness"
+    =:= arr [a $ huddleRule @"vkey" p, a $ huddleRule @"signature" p]
+
+bootstrapWitnessRule :: forall era. Era era => Proxy era -> Rule
+bootstrapWitnessRule p =
+  "bootstrap_witness"
+    =:= arr
+      [ "public_key" ==> huddleRule @"vkey" p
+      , "signature" ==> huddleRule @"signature" p
+      , "chain_code" ==> VBytes `sized` (32 :: Word64)
+      , "attributes" ==> VBytes
+      ]
+
+operationalCertGroup :: forall era. Era era => Proxy era -> Named Group
+operationalCertGroup p =
+  "operational_cert"
+    =:~ grp
+      [ "hot_vkey" ==> huddleRule @"kes_vkey" p
+      , "sequence_number" ==> huddleRule @"sequence_number" p
+      , "kes_period" ==> huddleRule @"kes_period" p
+      , "sigma" ==> huddleRule @"signature" p
+      ]
+
+genesisHashRule :: forall era. Era era => Proxy era -> Rule
+genesisHashRule p = "genesis_hash" =:= huddleRule @"hash28" p
+
+scriptPubkeyGroup :: forall era. Era era => Proxy era -> Named Group
+scriptPubkeyGroup p = "script_pubkey" =:~ grp [0, a $ huddleRule @"addr_keyhash" p]
+
+transactionIdRule :: forall era. Era era => Proxy era -> Rule
+transactionIdRule p = "transaction_id" =:= huddleRule @"hash32" p
+
+transactionInputRule :: forall era. HuddleRule "transaction_id" era => Proxy era -> Rule
+transactionInputRule p =
+  "transaction_input"
+    =:= arr
+      [ "id" ==> huddleRule @"transaction_id" p
+      , "index" ==> VUInt `sized` (2 :: Word64)
+      ]
+
+transactionOutputRule :: forall era. Era era => Proxy era -> Rule
+transactionOutputRule p =
+  "transaction_output"
+    =:= arr [a $ huddleRule @"address" p, "amount" ==> huddleRule @"coin" p]
+
+withdrawalsRule :: forall era. Era era => Proxy era -> Rule
+withdrawalsRule p =
+  "withdrawals"
+    =:= mp [0 <+ asKey (huddleRule @"reward_account" p) ==> huddleRule @"coin" p]
+
+dnsNameRule :: Rule
+dnsNameRule = "dns_name" =:= VText `sized` (0 :: Word64, 64 :: Word64)
+
+urlRule :: Rule
+urlRule = "url" =:= VText `sized` (0 :: Word64, 64 :: Word64)
+
+poolMetadataRule :: forall era. HuddleRule "url" era => Proxy era -> Rule
+poolMetadataRule p =
+  "pool_metadata"
+    =:= arr [a $ huddleRule @"url" p, a VBytes]
+
+singleHostAddrGroup :: forall era. Era era => Proxy era -> Named Group
+singleHostAddrGroup p =
+  "single_host_addr"
+    =:~ grp
+      [ 0
+      , a $ huddleRule @"port" p / VNil
+      , a $ huddleRule @"ipv4" p / VNil
+      , a $ huddleRule @"ipv6" p / VNil
+      ]
+
+singleHostNameGroup :: forall era. HuddleRule "dns_name" era => Proxy era -> Named Group
+singleHostNameGroup p =
+  comment
+    "dns_name: An A or AAAA DNS record"
+    $ "single_host_name"
+      =:~ grp
+        [ 1
+        , a $ huddleRule @"port" p / VNil
+        , a $ huddleRule @"dns_name" p
+        ]
+
+multiHostNameGroup :: forall era. HuddleRule "dns_name" era => Proxy era -> Named Group
+multiHostNameGroup p =
+  comment
+    "dns_name: An SRV DNS record"
+    $ "multi_host_name"
+      =:~ grp [2, a $ huddleRule @"dns_name" p]
+
+relayRule ::
+  forall era.
+  ( HuddleGroup "single_host_addr" era
+  , HuddleGroup "single_host_name" era
+  , HuddleGroup "multi_host_name" era
+  ) =>
+  Proxy era ->
+  Rule
+relayRule p =
+  "relay"
+    =:= arr [a $ huddleGroup @"single_host_addr" p]
+    / arr [a $ huddleGroup @"single_host_name" p]
+    / arr [a $ huddleGroup @"multi_host_name" p]
+
+poolParamsGroup ::
+  forall era.
+  ( HuddleRule "relay" era
+  , HuddleRule "pool_metadata" era
+  ) =>
+  Proxy era ->
+  Named Group
+poolParamsGroup p =
+  comment
+    "Pool parameters for stake pool registration"
+    $ "pool_params"
+      =:~ grp
+        [ "operator" ==> huddleRule @"pool_keyhash" p
+        , "vrf_keyhash" ==> huddleRule @"vrf_keyhash" p
+        , "pledge" ==> huddleRule @"coin" p
+        , "cost" ==> huddleRule @"coin" p
+        , "margin" ==> huddleRule @"unit_interval" p
+        , "reward_account" ==> huddleRule @"reward_account" p
+        , "pool_owners" ==> untaggedSet (huddleRule @"addr_keyhash" p)
+        , "relays" ==> arr [0 <+ a (huddleRule @"relay" p)]
+        , "pool_metadata" ==> huddleRule @"pool_metadata" p / VNil
+        ]
+
+poolRegistrationCertGroup :: forall era. HuddleGroup "pool_params" era => Proxy era -> Named Group
+poolRegistrationCertGroup p = "pool_registration_cert" =:~ grp [3, a $ huddleGroup @"pool_params" p]
+
+poolRetirementCertGroup :: forall era. Era era => Proxy era -> Named Group
+poolRetirementCertGroup p =
+  "pool_retirement_cert"
+    =:~ grp [4, a $ huddleRule @"pool_keyhash" p, a $ huddleRule @"epoch" p]
+
+genesisDelegateHashRule :: forall era. Era era => Proxy era -> Rule
+genesisDelegateHashRule p = "genesis_delegate_hash" =:= huddleRule @"hash28" p
+
+genesisDelegationCertGroup ::
+  forall era.
+  ( HuddleRule "genesis_hash" era
+  , HuddleRule "genesis_delegate_hash" era
+  ) =>
+  Proxy era ->
+  Named Group
+genesisDelegationCertGroup p =
+  "genesis_delegation_cert"
+    =:~ grp
+      [ 5
+      , a $ huddleRule @"genesis_hash" p
+      , a $ huddleRule @"genesis_delegate_hash" p
+      , a $ huddleRule @"vrf_keyhash" p
+      ]
+
+deltaCoinRule :: Rule
+deltaCoinRule =
+  comment
+    "This too has been introduced in Shelley as a backport from Alonzo."
+    $ "delta_coin" =:= VInt
+
+moveInstantaneousRewardRule :: forall era. HuddleRule "delta_coin" era => Proxy era -> Rule
+moveInstantaneousRewardRule p =
+  comment
+    [str|The first field determines where the funds are drawn from.
+        |  0 denotes the reserves,
+        |  1 denotes the treasury.
+        |If the second field is a map, funds are moved to stake credentials.
+        |Otherwise, the funds are given to the other accounting pot.
+        |NOTE:
+        |  This has been safely backported to Shelley from Alonzo.
+        |]
+    $ "move_instantaneous_reward"
+      =:= arr
+        [ a (int 0 / int 1)
+        , a
+            ( smp
+                [0 <+ asKey (huddleRule @"stake_credential" p) ==> huddleRule @"delta_coin" p]
+                / huddleRule @"coin" p
+            )
+        ]
+
+moveInstantaneousRewardsCertGroup ::
+  forall era. HuddleRule "move_instantaneous_reward" era => Proxy era -> Named Group
+moveInstantaneousRewardsCertGroup p =
+  "move_instantaneous_rewards_cert"
+    =:~ grp [6, a $ huddleRule @"move_instantaneous_reward" p]
+
+accountRegistrationCertGroup :: forall era. Era era => Proxy era -> Named Group
+accountRegistrationCertGroup p =
+  comment
+    "This certificate will be deprecated in a future era"
+    $ "account_registration_cert"
+      =:~ grp [0, a $ huddleRule @"stake_credential" p]
+
+accountUnregistrationCertGroup :: forall era. Era era => Proxy era -> Named Group
+accountUnregistrationCertGroup p =
+  comment
+    "This certificate will be deprecated in a future era"
+    $ "account_unregistration_cert"
+      =:~ grp [1, a $ huddleRule @"stake_credential" p]
+
+delegationToStakePoolCertGroup :: forall era. Era era => Proxy era -> Named Group
+delegationToStakePoolCertGroup p =
+  "delegation_to_stake_pool_cert"
+    =:~ grp [2, a $ huddleRule @"stake_credential" p, a $ huddleRule @"pool_keyhash" p]
+
+certificateRule ::
+  forall era.
+  ( HuddleGroup "account_registration_cert" era
+  , HuddleGroup "account_unregistration_cert" era
+  , HuddleGroup "delegation_to_stake_pool_cert" era
+  , HuddleGroup "pool_registration_cert" era
+  , HuddleGroup "pool_retirement_cert" era
+  , HuddleGroup "genesis_delegation_cert" era
+  , HuddleGroup "move_instantaneous_rewards_cert" era
+  ) =>
+  Proxy era ->
+  Rule
+certificateRule p =
+  "certificate"
+    =:= arr [a $ huddleGroup @"account_registration_cert" p]
+    / arr [a $ huddleGroup @"account_unregistration_cert" p]
+    / arr [a $ huddleGroup @"delegation_to_stake_pool_cert" p]
+    / arr [a $ huddleGroup @"pool_registration_cert" p]
+    / arr [a $ huddleGroup @"pool_retirement_cert" p]
+    / arr [a $ huddleGroup @"genesis_delegation_cert" p]
+    / arr [a $ huddleGroup @"move_instantaneous_rewards_cert" p]
+
+instance HuddleRule "dns_name" ShelleyEra where
+  huddleRule _ = dnsNameRule
+
+instance HuddleRule "url" ShelleyEra where
+  huddleRule _ = urlRule
+
+instance HuddleRule "pool_metadata" ShelleyEra where
+  huddleRule = poolMetadataRule @ShelleyEra
+
+instance HuddleGroup "single_host_addr" ShelleyEra where
+  huddleGroup = singleHostAddrGroup @ShelleyEra
+
+instance HuddleGroup "single_host_name" ShelleyEra where
+  huddleGroup = singleHostNameGroup @ShelleyEra
+
+instance HuddleGroup "multi_host_name" ShelleyEra where
+  huddleGroup = multiHostNameGroup @ShelleyEra
+
+instance HuddleRule "relay" ShelleyEra where
+  huddleRule = relayRule @ShelleyEra
+
+instance HuddleGroup "pool_params" ShelleyEra where
+  huddleGroup = poolParamsGroup @ShelleyEra
+
+untaggedSet :: IsType0 a => a -> GRuleCall
+untaggedSet = binding $ \x -> "set" =:= arr [0 <+ a x]
+
+instance HuddleGroup "pool_registration_cert" ShelleyEra where
+  huddleGroup = poolRegistrationCertGroup @ShelleyEra
+
+instance HuddleGroup "pool_retirement_cert" ShelleyEra where
+  huddleGroup = poolRetirementCertGroup @ShelleyEra
+
+instance HuddleRule "genesis_hash" ShelleyEra where
+  huddleRule = genesisHashRule @ShelleyEra
+
+instance HuddleRule "genesis_delegate_hash" ShelleyEra where
+  huddleRule = genesisDelegateHashRule @ShelleyEra
+
+instance HuddleGroup "genesis_delegation_cert" ShelleyEra where
+  huddleGroup = genesisDelegationCertGroup @ShelleyEra
+
+instance HuddleRule "delta_coin" ShelleyEra where
+  huddleRule _ = deltaCoinRule
+
+instance HuddleRule "move_instantaneous_reward" ShelleyEra where
+  huddleRule = moveInstantaneousRewardRule @ShelleyEra
+
+instance HuddleGroup "move_instantaneous_rewards_cert" ShelleyEra where
+  huddleGroup = moveInstantaneousRewardsCertGroup @ShelleyEra
+
+instance HuddleGroup "account_registration_cert" ShelleyEra where
+  huddleGroup = accountRegistrationCertGroup @ShelleyEra
+
+instance HuddleGroup "account_unregistration_cert" ShelleyEra where
+  huddleGroup = accountUnregistrationCertGroup @ShelleyEra
+
+instance HuddleGroup "delegation_to_stake_pool_cert" ShelleyEra where
+  huddleGroup = delegationToStakePoolCertGroup @ShelleyEra
+
+instance HuddleRule "certificate" ShelleyEra where
+  huddleRule = certificateRule @ShelleyEra
+
+instance HuddleRule "withdrawals" ShelleyEra where
+  huddleRule = withdrawalsRule @ShelleyEra
+
+instance HuddleRule "major_protocol_version" ShelleyEra where
+  huddleRule = majorProtocolVersionRule @ShelleyEra
+
+instance HuddleGroup "protocol_version" ShelleyEra where
+  huddleGroup = protocolVersionGroup @ShelleyEra
+
+instance HuddleRule "protocol_param_update" ShelleyEra where
+  huddleRule = protocolParamUpdateRule @ShelleyEra
+
+instance HuddleRule "proposed_protocol_parameter_updates" ShelleyEra where
+  huddleRule = proposedProtocolParameterUpdatesRule @ShelleyEra
+
+instance HuddleRule "update" ShelleyEra where
+  huddleRule = updateRule @ShelleyEra
+
+instance HuddleGroup "operational_cert" ShelleyEra where
+  huddleGroup = operationalCertGroup @ShelleyEra
+
+instance HuddleRule "header_body" ShelleyEra where
+  huddleRule = headerBodyRule @ShelleyEra
+
+instance HuddleRule "header" ShelleyEra where
+  huddleRule = headerRule @ShelleyEra
+
+instance HuddleRule "transaction_id" ShelleyEra where
+  huddleRule = transactionIdRule @ShelleyEra
+
+instance HuddleRule "transaction_input" ShelleyEra where
+  huddleRule = transactionInputRule @ShelleyEra
+
+instance HuddleRule "transaction_output" ShelleyEra where
+  huddleRule = transactionOutputRule @ShelleyEra
+
+instance HuddleGroup "script_pubkey" ShelleyEra where
+  huddleGroup = scriptPubkeyGroup @ShelleyEra
+
+instance HuddleGroup "script_all" ShelleyEra where
+  huddleGroup p = "script_all" =:~ grp [1, a $ arr [0 <+ a (huddleRule @"native_script" p)]]
+
+instance HuddleGroup "script_any" ShelleyEra where
+  huddleGroup p = "script_any" =:~ grp [2, a $ arr [0 <+ a (huddleRule @"native_script" p)]]
+
+instance HuddleGroup "script_n_of_k" ShelleyEra where
+  huddleGroup p =
+    "script_n_of_k"
+      =:~ grp [3, "n" ==> VUInt, a $ arr [0 <+ a (huddleRule @"native_script" p)]]
+
+instance HuddleRule "native_script" ShelleyEra where
+  huddleRule p =
+    comment
+      [str|Native scripts support 4 operations:
+          |  - Signature verification (script_pubkey)
+          |  - Conjunctions (script_all)
+          |  - Disjunctions (script_any)
+          |  - M-of-N thresholds (script_n_of_k)
+          |
+          |Note: Shelley uses VUInt for the threshold in script_n_of_k.
+          |]
+      $ "native_script"
+        =:= arr [a $ huddleGroup @"script_pubkey" p]
+        / arr [a $ huddleGroup @"script_all" p]
+        / arr [a $ huddleGroup @"script_any" p]
+        / arr [a $ huddleGroup @"script_n_of_k" p]
+
+instance HuddleRule "vkeywitness" ShelleyEra where
+  huddleRule = vkeywitnessRule @ShelleyEra
+
+instance HuddleRule "bootstrap_witness" ShelleyEra where
+  huddleRule = bootstrapWitnessRule @ShelleyEra
+
+instance HuddleRule "transaction_witness_set" ShelleyEra where
+  huddleRule = transactionWitnessSetRule @ShelleyEra
+
+instance HuddleRule "transaction_body" ShelleyEra where
+  huddleRule p =
+    "transaction_body"
+      =:= mp
+        [ idx 0 ==> untaggedSet (huddleRule @"transaction_input" p)
+        , idx 1 ==> arr [0 <+ a (huddleRule @"transaction_output" p)]
+        , idx 2 ==> huddleRule @"coin" p
+        , idx 3 ==> huddleRule @"slot" p
+        , opt (idx 4 ==> arr [0 <+ a (huddleRule @"certificate" p)])
+        , opt (idx 5 ==> huddleRule @"withdrawals" p)
+        , opt (idx 6 ==> huddleRule @"update" p)
+        , opt (idx 7 ==> huddleRule @"auxiliary_data_hash" p)
+        ]
+
+instance HuddleRule "transaction" ShelleyEra where
+  huddleRule p =
+    "transaction"
+      =:= arr
+        [ a $ huddleRule @"transaction_body" p
+        , a $ huddleRule @"transaction_witness_set" p
+        , a $ huddleRule @"metadata" p / VNil
+        ]
+
+instance HuddleRule "block" ShelleyEra where
+  huddleRule p =
+    "block"
+      =:= arr
+        [ a $ huddleRule @"header" p
+        , "transaction_bodies" ==> arr [0 <+ a (huddleRule @"transaction_body" p)]
+        , "transaction_witness_sets" ==> arr [0 <+ a (huddleRule @"transaction_witness_set" p)]
+        , "transaction_metadata_set"
+            ==> mp
+              [ 0 <+ asKey (huddleRule @"transaction_index" p) ==> huddleRule @"metadata" p
+              ]
+        ]

--- a/hie.yaml
+++ b/hie.yaml
@@ -3,6 +3,15 @@ cradle:
     - path: "eras/allegra/impl/src"
       component: "lib:cardano-ledger-allegra"
 
+    - path: "eras/allegra/impl/cddl/lib"
+      component: "cardano-ledger-allegra:lib:cddl"
+
+    - path: "eras/allegra/impl/cddl/exe/Main.hs"
+      component: "cardano-ledger-allegra:exe:generate-cddl"
+
+    - path: "eras/allegra/impl/cddl/exe/Paths_cardano_ledger_allegra.hs"
+      component: "cardano-ledger-allegra:exe:generate-cddl"
+
     - path: "eras/allegra/impl/testlib"
       component: "cardano-ledger-allegra:lib:testlib"
 
@@ -150,6 +159,15 @@ cradle:
     - path: "eras/shelley/impl/src"
       component: "lib:cardano-ledger-shelley"
 
+    - path: "eras/shelley/impl/cddl/lib"
+      component: "cardano-ledger-shelley:lib:cddl"
+
+    - path: "eras/shelley/impl/cddl/exe/Main.hs"
+      component: "cardano-ledger-shelley:exe:generate-cddl"
+
+    - path: "eras/shelley/impl/cddl/exe/Paths_cardano_ledger_shelley.hs"
+      component: "cardano-ledger-shelley:exe:generate-cddl"
+
     - path: "eras/shelley/impl/testlib"
       component: "cardano-ledger-shelley:lib:testlib"
 
@@ -230,6 +248,9 @@ cradle:
 
     - path: "libs/cardano-ledger-core/internal"
       component: "cardano-ledger-core:lib:internal"
+
+    - path: "libs/cardano-ledger-core/cddl"
+      component: "cardano-ledger-core:lib:cddl"
 
     - path: "libs/cardano-ledger-core/testlib"
       component: "cardano-ledger-core:lib:testlib"

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `cddl` sub-library.
 * Limit `DecCBORGroup` decoding of `ProtVer` fields to `Word32` starting from protocol version `12`
 * Change `Relation` type to only be visible at the type level
 * Change `KeyRole` type to only be visible at the type level
@@ -51,6 +52,11 @@
 * Expose `dRepToText`
 * Modify `withdrawalsThatDoNotDrainAccounts` to return `Maybe (Withdrawals, Withdrawals)` where the `fst` are either missing accounts or in the wrong network and `snd` are incomplete withdrawals.
 * Add `FromJSON` instance for `PParamUpdate`
+
+### `cddl`
+
+* Add `HuddleRule`, `HuddleGroup` and `HuddleGRule` type class for era-polymorphic CDDL generation.
+* Add `HuddleSpec` for all common CDDL types.
 
 ### `testlib`
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -163,6 +163,31 @@ library internal
   hs-source-dirs: internal
   default-language: Haskell2010
 
+library cddl
+  import: warnings
+  exposed-modules:
+    Cardano.Ledger.Core.HuddleSpec
+    Cardano.Ledger.Huddle
+
+  visibility: public
+  hs-source-dirs: cddl
+  default-language: Haskell2010
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+    -Wpartial-fields
+    -Wunused-packages
+
+  build-depends:
+    base,
+    cardano-ledger-core,
+    cuddle >=0.4,
+    heredoc,
+    text,
+
 library testlib
   import: warnings
   exposed-modules:

--- a/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
+++ b/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
@@ -1,0 +1,265 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Core.HuddleSpec where
+
+import Cardano.Ledger.Core (Era)
+import Cardano.Ledger.Huddle
+import Codec.CBOR.Cuddle.Huddle
+import qualified Data.Text as T
+import Data.Word (Word64)
+import Text.Heredoc
+import Prelude hiding ((/))
+
+instance Era era => HuddleRule "hash28" era where
+  huddleRule _ = "hash28" =:= VBytes `sized` (28 :: Word64)
+
+instance Era era => HuddleRule "hash32" era where
+  huddleRule _ = "hash32" =:= VBytes `sized` (32 :: Word64)
+
+instance Era era => HuddleRule "max_word64" era where
+  huddleRule _ = "max_word64" =:= (18446744073709551615 :: Integer)
+
+instance Era era => HuddleRule "positive_int" era where
+  huddleRule p = "positive_int" =:= (1 :: Integer) ... huddleRule @"max_word64" p
+
+instance Era era => HuddleRule "max_word32" era where
+  huddleRule _ = "max_word32" =:= (4294967295 :: Integer)
+
+instance Era era => HuddleRule "positive_word32" era where
+  huddleRule p = "positive_word32" =:= (1 :: Integer) ... huddleRule @"max_word32" p
+
+instance Era era => HuddleRule "unit_interval" era where
+  huddleRule _ =
+    comment
+      [str|The real unit_interval is: #6.30([uint, uint])
+          |
+          |A unit interval is a number in the range between 0 and 1, which
+          |means there are two extra constraints:
+          |  1. numerator <= denominator
+          |  2. denominator > 0
+          |
+          |The relation between numerator and denominator can be
+          |expressed in CDDL, but we have a limitation currently
+          |(see: https://github.com/input-output-hk/cuddle/issues/30)
+          |which poses a problem for testing. We need to be able to
+          |generate random valid data for testing implementation of
+          |our encoders/decoders. Which means we cannot use the actual
+          |definition here and we hard code the value to 1/2
+          |]
+      $ "unit_interval"
+        =:= tag 30 (arr [1, 2])
+
+instance Era era => HuddleRule "nonnegative_interval" era where
+  huddleRule p =
+    "nonnegative_interval" =:= tag 30 (arr [a VUInt, a (huddleRule @"positive_int" p)])
+
+distinct :: IsSizeable s => Value s -> HuddleItem
+distinct x =
+  HIRule
+    $ comment
+      [str|A type for distinct values.
+          |The type parameter must support .size, for example: bytes or uint
+          |]
+    $ "distinct_"
+      <> show' x
+        =:= (x `sized` (8 :: Word64))
+        / (x `sized` (16 :: Word64))
+        / (x `sized` (20 :: Word64))
+        / (x `sized` (24 :: Word64))
+        / (x `sized` (30 :: Word64))
+        / (x `sized` (32 :: Word64))
+  where
+    show' :: Value s -> T.Text
+    show' = \case
+      VBytes -> T.pack "bytes"
+      VUInt -> T.pack "uint"
+      _ -> error "Unsupported Value for `distinct`"
+
+instance Era era => HuddleRule "nonce" era where
+  huddleRule p = "nonce" =:= arr [0] / arr [1, a (huddleRule @"hash32" p)]
+
+instance Era era => HuddleRule "epoch" era where
+  huddleRule _ = "epoch" =:= VUInt `sized` (8 :: Word64)
+
+instance Era era => HuddleRule "epoch_interval" era where
+  huddleRule _ = "epoch_interval" =:= VUInt `sized` (4 :: Word64)
+
+instance Era era => HuddleRule "slot" era where
+  huddleRule _ = "slot" =:= VUInt `sized` (8 :: Word64)
+
+instance Era era => HuddleRule "block_number" era where
+  huddleRule _ = "block_number" =:= VUInt `sized` (8 :: Word64)
+
+instance Era era => HuddleRule "addr_keyhash" era where
+  huddleRule p = "addr_keyhash" =:= huddleRule @"hash28" p
+
+instance Era era => HuddleRule "pool_keyhash" era where
+  huddleRule p = "pool_keyhash" =:= huddleRule @"hash28" p
+
+instance Era era => HuddleRule "vrf_keyhash" era where
+  huddleRule p = "vrf_keyhash" =:= huddleRule @"hash32" p
+
+instance Era era => HuddleRule "vkey" era where
+  huddleRule _ = "vkey" =:= VBytes `sized` (32 :: Word64)
+
+instance Era era => HuddleRule "vrf_vkey" era where
+  huddleRule _ = "vrf_vkey" =:= VBytes `sized` (32 :: Word64)
+
+instance Era era => HuddleRule "vrf_cert" era where
+  huddleRule _ = "vrf_cert" =:= arr [a VBytes, a (VBytes `sized` (80 :: Word64))]
+
+instance Era era => HuddleRule "kes_vkey" era where
+  huddleRule _ = "kes_vkey" =:= VBytes `sized` (32 :: Word64)
+
+instance Era era => HuddleRule "kes_signature" era where
+  huddleRule _ = "kes_signature" =:= VBytes `sized` (448 :: Word64)
+
+instance Era era => HuddleRule "signkey_kes" era where
+  huddleRule _ = "signkey_kes" =:= VBytes `sized` (64 :: Word64)
+
+instance Era era => HuddleRule "sequence_number" era where
+  huddleRule _ = "sequence_number" =:= VUInt `sized` (8 :: Word64)
+
+instance Era era => HuddleRule "kes_period" era where
+  huddleRule _ = "kes_period" =:= VUInt `sized` (8 :: Word64)
+
+instance Era era => HuddleRule "signature" era where
+  huddleRule _ = "signature" =:= VBytes `sized` (64 :: Word64)
+
+instance Era era => HuddleRule "coin" era where
+  huddleRule _ = "coin" =:= VUInt
+
+instance Era era => HuddleRule "positive_coin" era where
+  huddleRule p = "positive_coin" =:= (1 :: Integer) ... huddleRule @"max_word64" p
+
+instance Era era => HuddleRule "address" era where
+  huddleRule _ =
+    comment
+      [str|address = bytes
+          |
+          |address format:
+          |  [ 8 bit header | payload ];
+          |
+          |shelley payment addresses:
+          |     bit 7: 0
+          |     bit 6: base/other
+          |     bit 5: pointer/enterprise [for base: stake cred is keyhash/scripthash]
+          |     bit 4: payment cred is keyhash/scripthash
+          |  bits 3-0: network id
+          |
+          |reward addresses:
+          |  bits 7-5: 111
+          |     bit 4: credential is keyhash/scripthash
+          |  bits 3-0: network id
+          |
+          |byron addresses:
+          |  bits 7-4: 1000
+          |
+          |     0000: base address: keyhash28,keyhash28
+          |     0001: base address: scripthash28,keyhash28
+          |     0010: base address: keyhash28,scripthash28
+          |     0011: base address: scripthash28,scripthash28
+          |     0100: pointer address: keyhash28, 3 variable length uint
+          |     0101: pointer address: scripthash28, 3 variable length uint
+          |     0110: enterprise address: keyhash28
+          |     0111: enterprise address: scripthash28
+          |     1000: byron address
+          |     1110: reward account: keyhash28
+          |     1111: reward account: scripthash28
+          |1001-1101: future formats
+          |]
+      $ "address"
+        =:= bstr
+          "001000000000000000000000000000000000000000000000000000000011000000000000000000000000000000000000000000000000000000"
+        / bstr
+          "102000000000000000000000000000000000000000000000000000000022000000000000000000000000000000000000000000000000000000"
+        / bstr
+          "203000000000000000000000000000000000000000000000000000000033000000000000000000000000000000000000000000000000000000"
+        / bstr
+          "304000000000000000000000000000000000000000000000000000000044000000000000000000000000000000000000000000000000000000"
+        / bstr "405000000000000000000000000000000000000000000000000000000087680203"
+        / bstr "506000000000000000000000000000000000000000000000000000000087680203"
+        / bstr "6070000000000000000000000000000000000000000000000000000000"
+        / bstr "7080000000000000000000000000000000000000000000000000000000"
+
+instance Era era => HuddleRule "reward_account" era where
+  huddleRule _ =
+    comment
+      "reward_account = bytes"
+      $ "reward_account"
+        =:= bstr "E090000000000000000000000000000000000000000000000000000000"
+        / bstr "F0A0000000000000000000000000000000000000000000000000000000"
+
+instance Era era => HuddleRule "transaction_index" era where
+  huddleRule _ = "transaction_index" =:= VUInt `sized` (2 :: Word64)
+
+instance Era era => HuddleRule "metadatum_label" era where
+  huddleRule _ = "metadatum_label" =:= VUInt `sized` (8 :: Word64)
+
+instance Era era => HuddleRule "metadatum" era where
+  huddleRule p =
+    "metadatum"
+      =:= smp
+        [ 0 <+ asKey (huddleRule @"metadatum" p) ==> huddleRule @"metadatum" p
+        ]
+      / sarr [0 <+ a (huddleRule @"metadatum" p)]
+      / VInt
+      / (VBytes `sized` (0 :: Word64, 64 :: Word64))
+      / (VText `sized` (0 :: Word64, 64 :: Word64))
+
+instance Era era => HuddleRule "metadata" era where
+  huddleRule p =
+    "metadata"
+      =:= mp
+        [ 0
+            <+ asKey (huddleRule @"metadatum_label" p)
+            ==> huddleRule @"metadatum" p
+        ]
+
+instance Era era => HuddleRule "auxiliary_data_hash" era where
+  huddleRule p = "auxiliary_data_hash" =:= huddleRule @"hash32" p
+
+instance Era era => HuddleRule "script_hash" era where
+  huddleRule p =
+    comment
+      [str|To compute a script hash, note that you must prepend
+          |a tag to the bytes of the script before hashing.
+          |The tag is determined by the language.
+          |The tags are:
+          |  "\x00" for multisig/native scripts
+          |  "\x01" for Plutus V1 scripts
+          |  "\x02" for Plutus V2 scripts
+          |  "\x03" for Plutus V3 scripts
+          |  "\x04" for Plutus V4 scripts
+          |]
+      $ "script_hash"
+        =:= huddleRule @"hash28" p
+
+instance Era era => HuddleRule "credential" era where
+  huddleRule p =
+    "credential"
+      =:= arr [0, a (huddleRule @"addr_keyhash" p)]
+      / arr [1, a (huddleRule @"script_hash" p)]
+
+instance Era era => HuddleRule "stake_credential" era where
+  huddleRule p = "stake_credential" =:= huddleRule @"credential" p
+
+instance Era era => HuddleRule "port" era where
+  huddleRule _ = "port" =:= VUInt `le` 65535
+
+instance Era era => HuddleRule "ipv4" era where
+  huddleRule _ = "ipv4" =:= VBytes `sized` (4 :: Word64)
+
+instance Era era => HuddleRule "ipv6" era where
+  huddleRule _ = "ipv6" =:= VBytes `sized` (16 :: Word64)

--- a/libs/cardano-ledger-core/cddl/Cardano/Ledger/Huddle.hs
+++ b/libs/cardano-ledger-core/cddl/Cardano/Ledger/Huddle.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+module Cardano.Ledger.Huddle (
+  HuddleRule (..),
+  HuddleGroup (..),
+  HuddleGRule (..),
+) where
+
+import Cardano.Ledger.Core (Era)
+import Codec.CBOR.Cuddle.Huddle
+import Data.Proxy (Proxy (..))
+import GHC.TypeLits (KnownSymbol, Symbol)
+
+class (KnownSymbol name, Era era) => HuddleRule (name :: Symbol) era where
+  huddleRule :: Proxy era -> Rule
+
+class (KnownSymbol name, Era era) => HuddleGroup (name :: Symbol) era where
+  huddleGroup :: Proxy era -> Named Group
+
+class (KnownSymbol name, Era era) => HuddleGRule (name :: Symbol) era where
+  huddleGRule :: Proxy era -> GRuleDef


### PR DESCRIPTION
# Description

New libraries named `cddl` for Shelley and Allegra to implement type-class-based cuddle definitions to generate .cddl files from.

Follow-up PRs should implement for eras Mary-onwards.

This is the second phase in our efforts to address #5194 

## NOTE

`codegen` on CI is expected to **FAIL**, and its diff is important to know exactly what has changed in the new implementation.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] ~~Tests added or updated when needed.~~
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
