### PR TITLE
Upgrade the version of Ruby used in GH CI to match the nix flake

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -272,11 +272,11 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: 3.14
 
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby
       if: contains(fromJson(env.packages-with-ruby-cddl-tests), matrix.package)
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.3
 
     - name: Install cbor-diag and cddl
       if: contains(fromJson(env.packages-with-ruby-cddl-tests), matrix.package)


### PR DESCRIPTION
# Description

The current version of Ruby being used in our GitHub CI is 2.7, which went [EoL](https://versionlog.com/ruby/2.7/) on March 31, 2023. Our nix flake uses 3.3, so this upgrades CI to match.

We had a CBOR [CI failure](https://github.com/IntersectMBO/cardano-ledger/actions/runs/19455869506/job/55671169432) recently that couldn't be reproduced locally, and hopefully this upgrade will prevent that in future.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
