### PR TITLE
Test "accepted" predicates in conformance

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: 209fbde423c0ee900cdfce694f2c5c5c24382482
+  tag: 99420c6806ed42c4c2e8bb74c593d161fd821456
 
 source-repository-package
   type: git

--- a/flake.lock
+++ b/flake.lock
@@ -204,11 +204,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1763475890,
-        "narHash": "sha256-3KaiL4mtGlJ/LrI3EvD3e7F1IryZ4vpVEADWqXo0tao=",
+        "lastModified": 1763569424,
+        "narHash": "sha256-Xx9iB+C2nFwHuCYYR5K+IcmJ6kE/z5YRwhyfYqFzC6A=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "209fbde423c0ee900cdfce694f2c5c5c24382482",
+        "rev": "99420c6806ed42c4c2e8bb74c593d161fd821456",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -114,6 +114,7 @@ test-suite tests
     Test.Cardano.Ledger.Conformance.Imp.Core
     Test.Cardano.Ledger.Conformance.Spec.Base
     Test.Cardano.Ledger.Conformance.Spec.Conway
+    Test.Cardano.Ledger.Conformance.Spec.Conway.Ratify
     Test.Cardano.Ledger.Conformance.Spec.Core
 
   default-language: Haskell2010

--- a/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
+++ b/libs/cardano-ledger-conformance/cardano-ledger-conformance.cabal
@@ -144,6 +144,7 @@ test-suite tests
     microlens,
     microlens-mtl,
     mtl,
+    prettyprinter,
     small-steps,
     text,
     unliftio,

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway.hs
@@ -12,6 +12,7 @@ module Test.Cardano.Ledger.Conformance.Spec.Conway (spec) where
 
 import Data.Map.Strict qualified as Map
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (ConwayCertExecContext (..))
+import Test.Cardano.Ledger.Conformance.Spec.Conway.Ratify qualified as Ratify
 import Test.Cardano.Ledger.Conformance.Spec.Core
 import Test.Cardano.Ledger.Constrained.Conway (genUtxoExecContext)
 import Test.Cardano.Ledger.Constrained.Conway.MiniTrace (
@@ -24,7 +25,6 @@ import Test.Cardano.Ledger.Constrained.Conway.MiniTrace (
   constrainedGov,
   constrainedGovCert,
   constrainedPool,
-  constrainedRatify,
   constrainedUtxo,
  )
 import Test.Cardano.Ledger.Imp.Common
@@ -36,7 +36,7 @@ spec = do
       prop "ENACT" $
         conformsToImplConstrained constrainedEnact $
           \curEpoch _ _ _ -> pure curEpoch
-      prop "RATIFY" $ conformsToImplConstrained_ constrainedRatify
+      Ratify.spec
       xprop "EPOCH" $ conformsToImplConstrained_ constrainedEpoch
       xprop "NEWEPOCH" $ conformsToImplConstrained_ constrainedEpoch
     describe "Blocks transition graph" $ do

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Test.Cardano.Ledger.Conformance.Spec.Conway.Ratify (spec) where
+
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Governance (
+  EnactState,
+  GovActionState (..),
+  RatifyEnv (..),
+  RatifyState (..),
+  rsEnactStateL,
+ )
+import Cardano.Ledger.Conway.Rules (
+  committeeAccepted,
+  dRepAccepted,
+  spoAccepted,
+ )
+import Constrained.Generation
+import Data.Either (fromRight)
+import Lens.Micro
+import MAlonzo.Code.Ledger.Foreign.API qualified as Agda
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway ()
+import Test.Cardano.Ledger.Conformance.Spec.Core
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
+import Test.Cardano.Ledger.Constrained.Conway.MiniTrace (
+  ConstrainedGeneratorBundle (..),
+  constrainedRatify,
+ )
+import Test.Cardano.Ledger.Imp.Common
+
+conformsToImplAccepted ::
+  era ~ ConwayEra =>
+  (RatifyEnv era -> RatifyState era -> GovActionState era -> Bool) ->
+  (SpecRep (RatifyEnv era) -> SpecRep (EnactState era) -> SpecRep (GovActionState era) -> Bool) ->
+  Property
+conformsToImplAccepted impl agda = property $ do
+  let ConstrainedGeneratorBundle {..} = constrainedRatify
+  govActions <- cgbContextGen
+  ratifyEnv <- genFromSpec $ cgbEnvironmentSpec govActions
+  ratifySt <- genFromSpec $ cgbStateSpec govActions ratifyEnv
+  let specEnv = fromRight (error "conformsToImplAccepted") $ runSpecTransM @Coin 0 $ toSpecRep ratifyEnv
+      specSt =
+        fromRight (error "conformsToImplAccepted") $
+          runSpecTransM govActions $
+            toSpecRep (ratifySt ^. rsEnactStateL)
+      specGovActions = fromRight (error "conformsToImplAccepted") $ runSpecTransM () $ toSpecRep govActions
+  return $
+    and $
+      zipWith (\ga sga -> impl ratifyEnv ratifySt ga == agda specEnv specSt sga) govActions specGovActions
+
+spec :: Spec
+spec = describe "RATIFY" $ do
+  prop "STS" $ conformsToImplConstrained_ constrainedRatify
+  describe "Accepted" $ do
+    forM_
+      [ ("DRep", (dRepAccepted, Agda.acceptedByDRep))
+      , ("SPO", (spoAccepted, Agda.acceptedBySPO))
+      ]
+      $ \(l, (impl, agda)) ->
+        prop l $ conformsToImplAccepted impl agda
+    -- https://github.com/IntersectMBO/cardano-ledger/issues/5418
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    xprop "CC" $ conformsToImplAccepted committeeAccepted Agda.acceptedByCC


### PR DESCRIPTION
# Description

~Blocked by https://github.com/IntersectMBO/cardano-ledger/pull/5428~
~Blocked by https://github.com/IntersectMBO/formal-ledger-specifications/pull/991~
If https://github.com/IntersectMBO/formal-ledger-specifications/pull/992 is resolved probably we can make `xprop "CC"` into `prop`.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
