### PR TITLE
Add Peras certificate to the block body

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.2.0.0
 
+* Add `DijkstraBlockBody` type and pattern
+* Add `mkBasicBlockBodyDijkstra`
+* Add `DijkstraEraBlockBody` class and instance for `DijkstraEraBlockBody`
+* Add `EraBlockBody` instance for `DijkstraEra`
+* Re-export `DijkstraBlockBody` from `Cardano.Ledger.Dijkstra.Core`
 * Add `Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec`
 * Add `DijkstraUtxoPredFailure`
 * Add `DijkstraUTXO`

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -49,6 +49,7 @@ library
     Cardano.Ledger.Dijkstra.UTxO
 
   other-modules:
+    Cardano.Ledger.Dijkstra.BlockBody.Internal
     Cardano.Ledger.Dijkstra.Rules.Bbody
     Cardano.Ledger.Dijkstra.Rules.Cert
     Cardano.Ledger.Dijkstra.Rules.Certs

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody.hs
@@ -1,16 +1,7 @@
-{-# LANGUAGE TypeFamilies #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+module Cardano.Ledger.Dijkstra.BlockBody (
+  DijkstraBlockBody (DijkstraBlockBody),
+  mkBasicBlockBodyDijkstra,
+  DijkstraEraBlockBody (..),
+) where
 
-module Cardano.Ledger.Dijkstra.BlockBody where
-
-import Cardano.Ledger.Alonzo.BlockBody
-import Cardano.Ledger.Core
-import Cardano.Ledger.Dijkstra.Era
-import Cardano.Ledger.Dijkstra.Tx ()
-
-instance EraBlockBody DijkstraEra where
-  type BlockBody DijkstraEra = AlonzoBlockBody DijkstraEra
-  mkBasicBlockBody = mkBasicBlockBodyAlonzo
-  txSeqBlockBodyL = txSeqBlockBodyAlonzoL
-  hashBlockBody = alonzoBlockBodyHash
-  numSegComponents = 4
+import Cardano.Ledger.Dijkstra.BlockBody.Internal

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -1,0 +1,302 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_HADDOCK not-home #-}
+
+-- | Provides BlockBody internals
+--
+-- = Warning
+--
+-- This module is considered __internal__.
+--
+-- The contents of this module may change __in any way whatsoever__
+-- and __without any warning__ between minor versions of this package.
+module Cardano.Ledger.Dijkstra.BlockBody.Internal (
+  DijkstraBlockBody (DijkstraBlockBody, ..),
+  hashDijkstraSegWits,
+  alignedValidFlags,
+  mkBasicBlockBodyDijkstra,
+  txSeqBlockBodyDijkstraL,
+) where
+
+import qualified Cardano.Crypto.Hash as Hash
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsValid (..))
+import Cardano.Ledger.Binary (
+  Annotator (..),
+  DecCBOR (..),
+  EncCBORGroup (..),
+  encCBOR,
+  encodeFoldableEncoder,
+  encodeFoldableMapEncoder,
+  encodePreEncoded,
+  serialize,
+  withSlice,
+ )
+import Cardano.Ledger.Core
+import Cardano.Ledger.Dijkstra.Era
+import Cardano.Ledger.Dijkstra.Tx ()
+import Cardano.Ledger.Shelley.BlockBody (auxDataSeqDecoder)
+import Control.Monad (unless)
+import Data.ByteString (ByteString)
+import Data.ByteString.Builder (Builder, shortByteString, toLazyByteString)
+import qualified Data.ByteString.Lazy as BSL
+import Data.Coerce (coerce)
+import Data.Maybe.Strict (maybeToStrictMaybe, strictMaybeToMaybe)
+import qualified Data.Sequence as Seq
+import Data.Sequence.Strict (StrictSeq)
+import qualified Data.Sequence.Strict as StrictSeq
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import Lens.Micro
+import Lens.Micro.Extras (view)
+import NoThunks.Class (AllowThunksIn (..), NoThunks)
+
+-- =================================================
+
+-- $BlockBody
+--
+-- * BlockBody
+--
+-- BlockBody provides an alternate way of formatting transactions in a block, in
+-- order to support segregated witnessing.
+
+data DijkstraBlockBody era = DijkstraBlockBodyInternal
+  { dbbTxs :: !(StrictSeq (Tx TopTx era))
+  , dbbHash :: Hash.Hash HASH EraIndependentBlockBody
+  -- ^ Memoized hash to avoid recomputation. Lazy on purpose.
+  , dbbTxsBodyBytes :: BSL.ByteString
+  -- ^ Bytes encoding @Seq ('TxBody' era)@
+  , dbbTxsWitsBytes :: BSL.ByteString
+  -- ^ Bytes encoding @Seq ('TxWits' era)@
+  , dbbTxsAuxDataBytes :: BSL.ByteString
+  -- ^ Bytes encoding a @'TxAuxData')@. Missing indices have
+  -- 'SNothing' for metadata
+  , dbbTxsIsValidBytes :: BSL.ByteString
+  -- ^ Bytes representing a set of integers. These are the indices of
+  -- transactions with 'isValid' == False.
+  }
+  deriving (Generic)
+
+instance EraBlockBody DijkstraEra where
+  type BlockBody DijkstraEra = DijkstraBlockBody DijkstraEra
+  mkBasicBlockBody = mkBasicBlockBodyDijkstra
+  txSeqBlockBodyL = lens dbbTxs (\bb p -> bb {dbbTxs = p})
+  hashBlockBody = dbbHash
+  numSegComponents = 4
+
+mkBasicBlockBodyDijkstra ::
+  ( SafeToHash (TxWits era)
+  , BlockBody era ~ DijkstraBlockBody era
+  , AlonzoEraTx era
+  ) =>
+  BlockBody era
+mkBasicBlockBodyDijkstra = DijkstraBlockBody mempty
+{-# INLINEABLE mkBasicBlockBodyDijkstra #-}
+
+txSeqBlockBodyDijkstraL ::
+  ( SafeToHash (TxWits era)
+  , BlockBody era ~ DijkstraBlockBody era
+  , AlonzoEraTx era
+  ) =>
+  Lens' (BlockBody era) (StrictSeq (Tx TopTx era))
+txSeqBlockBodyDijkstraL = lens dbbTxs (\_ s -> DijkstraBlockBody s)
+{-# INLINEABLE txSeqBlockBodyDijkstraL #-}
+
+pattern DijkstraBlockBody ::
+  forall era.
+  ( AlonzoEraTx era
+  , SafeToHash (TxWits era)
+  ) =>
+  StrictSeq (Tx TopTx era) ->
+  DijkstraBlockBody era
+pattern DijkstraBlockBody xs <-
+  DijkstraBlockBodyInternal xs _ _ _ _ _
+  where
+    DijkstraBlockBody txns =
+      let version = eraProtVerLow @era
+          serializeFoldablePreEncoded x =
+            serialize version $
+              encodeFoldableEncoder encodePreEncoded x
+          metaChunk index m = encodeIndexed <$> strictMaybeToMaybe m
+            where
+              encodeIndexed metadata = encCBOR index <> encodePreEncoded metadata
+          txSeqBodies =
+            serializeFoldablePreEncoded $ originalBytes . view bodyTxL <$> txns
+          txSeqWits =
+            serializeFoldablePreEncoded $ originalBytes . view witsTxL <$> txns
+          txSeqAuxDatas =
+            serialize version . encodeFoldableMapEncoder metaChunk $
+              fmap originalBytes . view auxDataTxL <$> txns
+          txSeqIsValids =
+            serialize version $ encCBOR $ nonValidatingIndices txns
+       in DijkstraBlockBodyInternal
+            { dbbTxs = txns
+            , dbbHash = hashDijkstraSegWits txSeqBodies txSeqWits txSeqAuxDatas txSeqIsValids
+            , dbbTxsBodyBytes = txSeqBodies
+            , dbbTxsWitsBytes = txSeqWits
+            , dbbTxsAuxDataBytes = txSeqAuxDatas
+            , dbbTxsIsValidBytes = txSeqIsValids
+            }
+
+{-# COMPLETE DijkstraBlockBody #-}
+
+deriving via
+  AllowThunksIn
+    '[ "dbbHash"
+     , "dbbTxsBodyBytes"
+     , "dbbTxsWitsBytes"
+     , "dbbTxsAuxDataBytes"
+     , "dbbTxsIsValidBytes"
+     ]
+    (DijkstraBlockBody era)
+  instance
+    (Typeable era, NoThunks (Tx TopTx era)) => NoThunks (DijkstraBlockBody era)
+
+deriving stock instance Show (Tx TopTx era) => Show (DijkstraBlockBody era)
+
+deriving stock instance Eq (Tx TopTx era) => Eq (DijkstraBlockBody era)
+
+--------------------------------------------------------------------------------
+-- Serialisation and hashing
+--------------------------------------------------------------------------------
+
+instance Era era => EncCBORGroup (DijkstraBlockBody era) where
+  encCBORGroup (DijkstraBlockBodyInternal _ _ bodyBytes witsBytes metadataBytes invalidBytes) =
+    encodePreEncoded $
+      BSL.toStrict $
+        bodyBytes <> witsBytes <> metadataBytes <> invalidBytes
+  listLen _ = 4
+
+hashDijkstraSegWits ::
+  BSL.ByteString ->
+  -- | Bytes for transaction bodies
+  BSL.ByteString ->
+  -- | Bytes for transaction witnesses
+  BSL.ByteString ->
+  -- | Bytes for transaction auxiliary datas
+  BSL.ByteString ->
+  -- | Bytes for transaction isValid flags
+  Hash HASH EraIndependentBlockBody
+hashDijkstraSegWits txSeqBodies txSeqWits txAuxData txSeqIsValids =
+  coerce . hashLazy . toLazyByteString $
+    hashPart txSeqBodies
+      <> hashPart txSeqWits
+      <> hashPart txAuxData
+      <> hashPart txSeqIsValids
+  where
+    hashLazy :: BSL.ByteString -> Hash HASH ByteString
+    hashLazy = Hash.hashWith id . BSL.toStrict
+    {-# INLINE hashLazy #-}
+    hashPart :: BSL.ByteString -> Builder
+    hashPart = shortByteString . Hash.hashToBytesShort . hashLazy
+    {-# INLINE hashPart #-}
+{-# INLINE hashDijkstraSegWits #-}
+
+instance
+  ( AlonzoEraTx era
+  , DecCBOR (Annotator (TxAuxData era))
+  , DecCBOR (Annotator (TxBody TopTx era))
+  , DecCBOR (Annotator (TxWits era))
+  ) =>
+  DecCBOR (Annotator (DijkstraBlockBody era))
+  where
+  decCBOR = do
+    (bodies, bodiesAnn) <- withSlice decCBOR
+    (wits, witsAnn) <- withSlice decCBOR
+    let bodiesLength = length bodies
+        inRange x = (0 <= x) && (x <= (bodiesLength - 1))
+        witsLength = length wits
+    (auxData, auxDataAnn) <- withSlice $ do
+      auxDataMap <- decCBOR
+      auxDataSeqDecoder bodiesLength auxDataMap
+
+    (isValIdxs, isValAnn) <- withSlice decCBOR
+    let validFlags = alignedValidFlags bodiesLength isValIdxs
+    unless (bodiesLength == witsLength) $
+      fail $
+        "different number of transaction bodies ("
+          <> show bodiesLength
+          <> ") and witness sets ("
+          <> show witsLength
+          <> ")"
+    unless (all inRange isValIdxs) $
+      fail $
+        "Some IsValid index is not in the range: 0 .. "
+          ++ show (bodiesLength - 1)
+          ++ ", "
+          ++ show isValIdxs
+
+    let txns =
+          sequenceA $
+            StrictSeq.forceToStrict $
+              Seq.zipWith4 dijkstraSegwitTx bodies wits validFlags auxData
+    pure $
+      DijkstraBlockBodyInternal
+        <$> txns
+        <*> (hashDijkstraSegWits <$> bodiesAnn <*> witsAnn <*> auxDataAnn <*> isValAnn)
+        <*> bodiesAnn
+        <*> witsAnn
+        <*> auxDataAnn
+        <*> isValAnn
+
+--------------------------------------------------------------------------------
+-- Internal utility functions
+--------------------------------------------------------------------------------
+
+-- | Given a sequence of transactions, return the indices of those which do not
+-- validate. We store the indices of the non-validating transactions because we
+-- expect this to be a much smaller set than the validating transactions.
+nonValidatingIndices :: AlonzoEraTx era => StrictSeq (Tx TopTx era) -> [Int]
+nonValidatingIndices (StrictSeq.fromStrict -> xs) =
+  Seq.foldrWithIndex
+    ( \idx tx acc ->
+        if tx ^. isValidTxL == IsValid False
+          then idx : acc
+          else acc
+    )
+    []
+    xs
+
+-- | Given the number of transactions, and the set of indices for which these
+-- transactions do not validate, create an aligned sequence of `IsValid`
+-- flags.
+--
+-- This function operates much as the inverse of 'nonValidatingIndices'.
+alignedValidFlags :: Int -> [Int] -> Seq.Seq IsValid
+alignedValidFlags = alignedValidFlags' (-1)
+  where
+    alignedValidFlags' _ n [] = Seq.replicate n $ IsValid True
+    alignedValidFlags' prev n (x : xs) =
+      Seq.replicate (x - prev - 1) (IsValid True)
+        Seq.>< IsValid False
+        Seq.<| alignedValidFlags' x (n - (x - prev)) xs
+
+-- | Construct an annotated Dijkstra style transaction.
+dijkstraSegwitTx ::
+  AlonzoEraTx era =>
+  Annotator (TxBody TopTx era) ->
+  Annotator (TxWits era) ->
+  IsValid ->
+  Maybe (Annotator (TxAuxData era)) ->
+  Annotator (Tx TopTx era)
+dijkstraSegwitTx txBodyAnn txWitsAnn txIsValid txAuxDataAnn = Annotator $ \bytes -> do
+  txBody <- runAnnotator txBodyAnn bytes
+  txWits <- runAnnotator txWitsAnn bytes
+  txAuxData <- mapM (`runAnnotator` bytes) txAuxDataAnn
+  pure $
+    mkBasicTx txBody
+      & witsTxL .~ txWits
+      & auxDataTxL .~ maybeToStrictMaybe txAuxData
+      & isValidTxL .~ txIsValid

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Core.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Core.hs
@@ -1,5 +1,7 @@
 module Cardano.Ledger.Dijkstra.Core (
+  DijkstraBlockBody (..),
   module Cardano.Ledger.Conway.Core,
 ) where
 
 import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Dijkstra.BlockBody (DijkstraBlockBody (..))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -1001,3 +1001,12 @@ instance ToKeyValuePairs a => ToJSON (KeyValuePairs a) where
 -- NOTE: The real type will be brought from 'cardano-base' once it's ready.
 data PerasCert = PerasCert
   deriving (Eq, Show, Generic, NoThunks)
+
+instance EncCBOR PerasCert where
+  encCBOR PerasCert =
+    encCBOR ()
+
+instance DecCBOR PerasCert where
+  decCBOR = do
+    () <- decCBOR
+    pure PerasCert

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -90,6 +90,9 @@ module Cardano.Ledger.BaseTypes (
   -- * Aeson helpers
   KeyValuePairs (..),
   ToKeyValuePairs (..),
+
+  -- * Peras-specific types
+  PerasCert,
 ) where
 
 import Cardano.Crypto.Hash
@@ -988,3 +991,13 @@ newtype KeyValuePairs a = KeyValuePairs {unKeyValuePairs :: a}
 instance ToKeyValuePairs a => ToJSON (KeyValuePairs a) where
   toJSON = object . toKeyValuePairs . unKeyValuePairs
   toEncoding = pairs . mconcat . toKeyValuePairs . unKeyValuePairs
+
+--------------------------------------------------------------------------------
+-- Peras-related types
+--------------------------------------------------------------------------------
+
+-- | Placeholder for Peras certificates
+--
+-- NOTE: The real type will be brought from 'cardano-base' once it's ready.
+data PerasCert = PerasCert
+  deriving (Eq, Show, Generic, NoThunks)


### PR DESCRIPTION
# Description

This PR addresses #5436 by:

1. Defining a concrete `DijkstraBlockBody` as a spiritual copy of `AlonzoBlockBody`
2. Enhancing Dijkstra block bodies with an optional Peras certificate (mocked up until we are ready to integrate the one defined in `cardano-base`). Serialization of these certificates is also mocked up at this point.
3. Tweaking the serialization instances of Dijkstra block bodies to account for optional Peras certificates.

Some notes:
* I'm not entirely sure what you had in mind w.r.t. also storing the certificate bytes in the block body or not. The current version does it, additionally plumbing it into `hashDijkstraSegWits` so it also counts towards the block body hash.
* I'm not super confident about the `DecCBOR` instance proposed here, especially w.r.t. backwards compatibility. Is there an existing set of tests I could try adapting for this purpose?

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
