### PR TITLE
Redefine predicate failures in Dijkstra without using CBOR group encoding

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Generalise and expose some rule transition functions: `conwayBbodyTransition`, `conwayGovTransition`, `conwayGovCertTransition`, `conwayLedgerTransition`
 * Change the field type of `ConwayIncompleteWithdrawals` to `Map RewardAccount (Mismatch RelEQ Coin)`
 * Make `ConwayAccountState` a pattern synonym
 * Remove deprecated type `Conway`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -22,6 +22,7 @@ module Cardano.Ledger.Conway.Rules.Bbody (
   alonzoToConwayBbodyPredFailure,
   shelleyToConwayBbodyPredFailure,
   totalRefScriptSizeInBlock,
+  conwayBbodyTransition,
 ) where
 
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -326,7 +326,7 @@ instance
     10 -> SumD OutputBootAddrAttrsTooBig <! From
     11 -> SumD OutputTooBigUTxO <! From
     12 -> SumD InsufficientCollateral <! From <! From
-    13 -> SumD ScriptsNotPaidUTxO <! D (UTxO <$> decCBOR)
+    13 -> SumD ScriptsNotPaidUTxO <! From
     14 -> SumD ExUnitsTooBigUTxO <! mapCoder unswapMismatch FromGroup
     15 -> SumD CollateralContainsNonADA <! From
     16 -> SumD WrongNetworkInTxBody <! mapCoder unswapMismatch FromGroup

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## 0.2.0.0
 
+* Change some rule transitions to use Dijkstra's own rules instead of reusing Conway's:
+  - `DijkstraBBODY`
+  - `DijkstraGOV`
+  - `DijkstraGOVCERT`
+  - `DijkstraLEDGER`
+  - `DijkstraMEMPOOL`
+  - `DijkstraUTXO`
+  - `DijkstraUTXOW`
+* Change some rule predicate failures to use Dijkstra-era versions:
+  - `DijkstraBbodyPredFailure` for the BBODY rule
+  - `DijkstraGovPredFailure` for the GOV rule
+  - `DijkstraGovCertPredFailure` for the GOVCERT rule
+  - `DijkstraLedgerPredFailure` for the LEDGER rule
+  - `DijkstraUtxoPredFailure` for the UTXO rule
+  - `DijkstraUtxowPredFailure` for the UTXOW rule
 * Add `requiredTopLevelGuardsDijkstraTxBodyRawL`
 * Add `dstbRequiredTopLevelGuards` to `TxBody`
 * Add `dstbrRequiredTopLevelGuards` to `DijkstraSubTxBodyRaw`

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -57,6 +57,7 @@ library
     Cardano.Ledger.Dijkstra.Rules.GovCert
     Cardano.Ledger.Dijkstra.Rules.Ledger
     Cardano.Ledger.Dijkstra.Rules.Ledgers
+    Cardano.Ledger.Dijkstra.Rules.Mempool
     Cardano.Ledger.Dijkstra.Rules.Pool
     Cardano.Ledger.Dijkstra.Rules.Utxo
     Cardano.Ledger.Dijkstra.Rules.Utxos
@@ -101,6 +102,7 @@ library
     nothunks,
     plutus-ledger-api,
     small-steps >=1.1.2,
+    text,
 
   if flag(asserts)
     ghc-options: -fno-ignore-asserts

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Era.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Era.hs
@@ -8,7 +8,14 @@
 
 module Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
+  DijkstraBBODY,
   DijkstraCERT,
+  DijkstraGOV,
+  DijkstraGOVCERT,
+  DijkstraLEDGER,
+  DijkstraMEMPOOL,
+  DijkstraUTXO,
+  DijkstraUTXOW,
 ) where
 
 import Cardano.Ledger.Conway.Core
@@ -61,7 +68,9 @@ type instance EraRuleEvent "DELEGS" DijkstraEra = VoidEraRule "DELEGS" DijkstraE
 
 type instance Value DijkstraEra = MaryValue
 
-type instance EraRule "GOV" DijkstraEra = ConwayGOV DijkstraEra
+data DijkstraGOV era
+
+type instance EraRule "GOV" DijkstraEra = DijkstraGOV DijkstraEra
 
 type instance EraRule "NEWEPOCH" DijkstraEra = ConwayNEWEPOCH DijkstraEra
 
@@ -71,7 +80,9 @@ type instance EraRule "ENACT" DijkstraEra = ConwayENACT DijkstraEra
 
 type instance EraRule "UTXOS" DijkstraEra = ConwayUTXOS DijkstraEra
 
-type instance EraRule "LEDGER" DijkstraEra = ConwayLEDGER DijkstraEra
+data DijkstraLEDGER era
+
+type instance EraRule "LEDGER" DijkstraEra = DijkstraLEDGER DijkstraEra
 
 type instance EraRule "TICKF" DijkstraEra = ConwayTICKF DijkstraEra
 
@@ -85,15 +96,25 @@ type instance EraRule "CERT" DijkstraEra = DijkstraCERT DijkstraEra
 
 type instance EraRule "DELEG" DijkstraEra = ConwayDELEG DijkstraEra
 
-type instance EraRule "GOVCERT" DijkstraEra = ConwayGOVCERT DijkstraEra
+data DijkstraGOVCERT era
 
-type instance EraRule "UTXOW" DijkstraEra = ConwayUTXOW DijkstraEra
+type instance EraRule "GOVCERT" DijkstraEra = DijkstraGOVCERT DijkstraEra
 
-type instance EraRule "UTXO" DijkstraEra = ConwayUTXO DijkstraEra
+data DijkstraUTXOW era
 
-type instance EraRule "BBODY" DijkstraEra = ConwayBBODY DijkstraEra
+type instance EraRule "UTXOW" DijkstraEra = DijkstraUTXOW DijkstraEra
 
-type instance EraRule "MEMPOOL" DijkstraEra = ConwayMEMPOOL DijkstraEra
+data DijkstraUTXO era
+
+type instance EraRule "UTXO" DijkstraEra = DijkstraUTXO DijkstraEra
+
+data DijkstraBBODY era
+
+type instance EraRule "BBODY" DijkstraEra = DijkstraBBODY DijkstraEra
+
+data DijkstraMEMPOOL era
+
+type instance EraRule "MEMPOOL" DijkstraEra = DijkstraMEMPOOL DijkstraEra
 
 type instance EraRule "HARDFORK" DijkstraEra = ConwayHARDFORK DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules.hs
@@ -4,7 +4,15 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Dijkstra.Rules () where
+module Cardano.Ledger.Dijkstra.Rules (
+  module Cardano.Ledger.Dijkstra.Rules.Bbody,
+  module Cardano.Ledger.Dijkstra.Rules.Gov,
+  module Cardano.Ledger.Dijkstra.Rules.GovCert,
+  module Cardano.Ledger.Dijkstra.Rules.Ledger,
+  module Cardano.Ledger.Dijkstra.Rules.Mempool,
+  module Cardano.Ledger.Dijkstra.Rules.Utxo,
+  module Cardano.Ledger.Dijkstra.Rules.Utxow,
+) where
 
 import Cardano.Ledger.Conway.Rules (
   ConwayEpochEvent (..),
@@ -13,18 +21,19 @@ import Cardano.Ledger.Conway.Rules (
  )
 import Cardano.Ledger.Dijkstra.Core (EraRuleEvent, InjectRuleEvent (..))
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
-import Cardano.Ledger.Dijkstra.Rules.Bbody ()
+import Cardano.Ledger.Dijkstra.Rules.Bbody
 import Cardano.Ledger.Dijkstra.Rules.Cert ()
 import Cardano.Ledger.Dijkstra.Rules.Certs ()
 import Cardano.Ledger.Dijkstra.Rules.Deleg ()
-import Cardano.Ledger.Dijkstra.Rules.Gov ()
-import Cardano.Ledger.Dijkstra.Rules.GovCert ()
-import Cardano.Ledger.Dijkstra.Rules.Ledger ()
+import Cardano.Ledger.Dijkstra.Rules.Gov
+import Cardano.Ledger.Dijkstra.Rules.GovCert
+import Cardano.Ledger.Dijkstra.Rules.Ledger
 import Cardano.Ledger.Dijkstra.Rules.Ledgers ()
+import Cardano.Ledger.Dijkstra.Rules.Mempool
 import Cardano.Ledger.Dijkstra.Rules.Pool ()
-import Cardano.Ledger.Dijkstra.Rules.Utxo ()
+import Cardano.Ledger.Dijkstra.Rules.Utxo
 import Cardano.Ledger.Dijkstra.Rules.Utxos ()
-import Cardano.Ledger.Dijkstra.Rules.Utxow ()
+import Cardano.Ledger.Dijkstra.Rules.Utxow
 import Cardano.Ledger.Shelley.Rules (ShelleyTickEvent (..))
 
 type instance EraRuleEvent "TICK" DijkstraEra = ShelleyTickEvent DijkstraEra

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
@@ -1,110 +1,342 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Dijkstra.Rules.Bbody () where
+module Cardano.Ledger.Dijkstra.Rules.Bbody (
+  DijkstraBBODY,
+  DijkstraBbodyPredFailure (..),
+  conwayToDijkstraBbodyPredFailure,
+) where
 
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
+import Cardano.Ledger.Alonzo.BlockBody (AlonzoBlockBody)
+import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams)
 import Cardano.Ledger.Alonzo.Rules (
-  AlonzoBbodyEvent,
+  AlonzoBbodyEvent (ShelleyInAlonzoEvent),
   AlonzoBbodyPredFailure,
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
   AlonzoUtxowPredFailure,
+  alonzoBbodyTransition,
  )
+import Cardano.Ledger.Alonzo.Scripts (ExUnits (..))
+import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx)
+import Cardano.Ledger.Alonzo.TxWits (AlonzoEraTxWits (..))
+import Cardano.Ledger.BHeaderView (BHeaderView (..))
+import Cardano.Ledger.Babbage.Core (BabbageEraTxBody)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
+import Cardano.Ledger.BaseTypes (
+  Mismatch (..),
+  Relation (..),
+  ShelleyBase,
+ )
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
+import Cardano.Ledger.Block (Block (..))
+import Cardano.Ledger.Conway.PParams (ConwayEraPParams (..))
 import Cardano.Ledger.Conway.Rules (
   ConwayBbodyPredFailure,
   ConwayCertPredFailure,
   ConwayCertsPredFailure,
   ConwayDelegPredFailure,
-  ConwayGovCertPredFailure,
   ConwayGovPredFailure,
-  ConwayLedgerPredFailure,
-  ConwayUtxoPredFailure,
   ConwayUtxosPredFailure,
-  ConwayUtxowPredFailure,
   alonzoToConwayBbodyPredFailure,
   shelleyToConwayBbodyPredFailure,
  )
-import Cardano.Ledger.Dijkstra.Core (EraRuleEvent, EraRuleFailure, InjectRuleFailure (..))
-import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
+import qualified Cardano.Ledger.Conway.Rules as Conway
+import Cardano.Ledger.Core
+import Cardano.Ledger.Dijkstra.Era (DijkstraBBODY, DijkstraEra)
+import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.Ledger (DijkstraLedgerPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Ledgers ()
+import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure)
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..))
 import Cardano.Ledger.Shelley.Rules (
+  BbodyEnv (..),
   ShelleyBbodyPredFailure,
+  ShelleyBbodyState (..),
+  ShelleyLedgersEnv (..),
   ShelleyLedgersPredFailure,
   ShelleyPoolPredFailure,
   ShelleyUtxoPredFailure,
   ShelleyUtxowPredFailure,
  )
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Control.State.Transition (
+  Embed (..),
+  STS (..),
+ )
+import Data.Sequence (Seq)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
 
-type instance EraRuleFailure "BBODY" DijkstraEra = ConwayBbodyPredFailure DijkstraEra
+data DijkstraBbodyPredFailure era
+  = WrongBlockBodySizeBBODY (Mismatch RelEQ Int)
+  | InvalidBodyHashBBODY (Mismatch RelEQ (Hash HASH EraIndependentBlockBody))
+  | -- | LEDGERS rule subtransition Failures
+    LedgersFailure (PredicateFailure (EraRule "LEDGERS" era))
+  | TooManyExUnits (Mismatch RelLTEQ ExUnits)
+  | BodyRefScriptsSizeTooBig (Mismatch RelLTEQ Int)
+  deriving (Generic)
+
+deriving instance
+  (Era era, Show (PredicateFailure (EraRule "LEDGERS" era))) =>
+  Show (DijkstraBbodyPredFailure era)
+
+deriving instance
+  (Era era, Eq (PredicateFailure (EraRule "LEDGERS" era))) =>
+  Eq (DijkstraBbodyPredFailure era)
+
+deriving anyclass instance
+  (Era era, NoThunks (PredicateFailure (EraRule "LEDGERS" era))) =>
+  NoThunks (DijkstraBbodyPredFailure era)
+
+instance
+  ( Era era
+  , EncCBOR (PredicateFailure (EraRule "LEDGERS" era))
+  ) =>
+  EncCBOR (DijkstraBbodyPredFailure era)
+  where
+  encCBOR =
+    encode . \case
+      WrongBlockBodySizeBBODY mm -> Sum WrongBlockBodySizeBBODY 0 !> To mm
+      InvalidBodyHashBBODY mm -> Sum (InvalidBodyHashBBODY @era) 1 !> To mm
+      LedgersFailure x -> Sum (LedgersFailure @era) 2 !> To x
+      TooManyExUnits mm -> Sum TooManyExUnits 3 !> To mm
+      BodyRefScriptsSizeTooBig mm -> Sum BodyRefScriptsSizeTooBig 4 !> To mm
+
+instance
+  ( Era era
+  , DecCBOR (PredicateFailure (EraRule "LEDGERS" era))
+  ) =>
+  DecCBOR (DijkstraBbodyPredFailure era)
+  where
+  decCBOR = decode . Summands "ConwayBbodyPred" $ \case
+    0 -> SumD WrongBlockBodySizeBBODY <! From
+    1 -> SumD InvalidBodyHashBBODY <! From
+    2 -> SumD LedgersFailure <! From
+    3 -> SumD TooManyExUnits <! From
+    4 -> SumD BodyRefScriptsSizeTooBig <! From
+    n -> Invalid n
+
+type instance EraRuleFailure "BBODY" DijkstraEra = DijkstraBbodyPredFailure DijkstraEra
 
 type instance EraRuleEvent "BBODY" DijkstraEra = AlonzoBbodyEvent DijkstraEra
 
-instance InjectRuleFailure "BBODY" ConwayBbodyPredFailure DijkstraEra
+instance InjectRuleFailure "BBODY" DijkstraBbodyPredFailure DijkstraEra
+
+instance InjectRuleFailure "BBODY" ConwayBbodyPredFailure DijkstraEra where
+  injectFailure = conwayToDijkstraBbodyPredFailure
 
 instance InjectRuleFailure "BBODY" AlonzoBbodyPredFailure DijkstraEra where
-  injectFailure = alonzoToConwayBbodyPredFailure
+  injectFailure = conwayToDijkstraBbodyPredFailure . alonzoToConwayBbodyPredFailure
 
 instance InjectRuleFailure "BBODY" ShelleyBbodyPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure
+  injectFailure = conwayToDijkstraBbodyPredFailure . shelleyToConwayBbodyPredFailure
 
 instance InjectRuleFailure "BBODY" ShelleyLedgersPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure
+  injectFailure = conwayToDijkstraBbodyPredFailure . shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure
 
-instance InjectRuleFailure "BBODY" ConwayLedgerPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+instance InjectRuleFailure "BBODY" DijkstraLedgerPredFailure DijkstraEra where
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
-instance InjectRuleFailure "BBODY" ConwayUtxowPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+instance InjectRuleFailure "BBODY" DijkstraUtxowPredFailure DijkstraEra where
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" BabbageUtxowPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" AlonzoUtxowPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" ShelleyUtxowPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
-instance InjectRuleFailure "BBODY" ConwayUtxoPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+instance InjectRuleFailure "BBODY" DijkstraUtxoPredFailure DijkstraEra where
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" BabbageUtxoPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" AlonzoUtxoPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" AlonzoUtxosPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" ConwayUtxosPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" ShelleyUtxoPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" AllegraUtxoPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" ConwayCertsPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" ConwayCertPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" ConwayDelegPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" ShelleyPoolPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
-instance InjectRuleFailure "BBODY" ConwayGovCertPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+instance InjectRuleFailure "BBODY" DijkstraGovCertPredFailure DijkstraEra where
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
 
 instance InjectRuleFailure "BBODY" ConwayGovPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayBbodyPredFailure . Shelley.LedgersFailure . injectFailure
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
+
+instance InjectRuleFailure "BBODY" DijkstraGovPredFailure DijkstraEra where
+  injectFailure =
+    conwayToDijkstraBbodyPredFailure
+      . shelleyToConwayBbodyPredFailure
+      . Shelley.LedgersFailure
+      . injectFailure
+
+instance
+  ( Embed (EraRule "LEDGERS" era) (EraRule "BBODY" era)
+  , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
+  , State (EraRule "LEDGERS" era) ~ LedgerState era
+  , Signal (EraRule "LEDGERS" era) ~ Seq (Tx TopTx era)
+  , AlonzoEraTxWits era
+  , BlockBody era ~ AlonzoBlockBody era
+  , EraBlockBody era
+  , AlonzoEraPParams era
+  , InjectRuleFailure "BBODY" AlonzoBbodyPredFailure era
+  , InjectRuleFailure "BBODY" ConwayBbodyPredFailure era
+  , EraRule "BBODY" era ~ DijkstraBBODY era
+  , AlonzoEraTx era
+  , BabbageEraTxBody era
+  , ConwayEraPParams era
+  ) =>
+  STS (DijkstraBBODY era)
+  where
+  type State (DijkstraBBODY era) = ShelleyBbodyState era
+
+  type Signal (DijkstraBBODY era) = Block BHeaderView era
+
+  type Environment (DijkstraBBODY era) = BbodyEnv era
+
+  type BaseM (DijkstraBBODY era) = ShelleyBase
+
+  type PredicateFailure (DijkstraBBODY era) = DijkstraBbodyPredFailure era
+
+  type Event (DijkstraBBODY era) = AlonzoBbodyEvent era
+
+  initialRules = []
+  transitionRules = [Conway.conwayBbodyTransition @era >> alonzoBbodyTransition @era]
+
+conwayToDijkstraBbodyPredFailure ::
+  forall era. ConwayBbodyPredFailure era -> DijkstraBbodyPredFailure era
+conwayToDijkstraBbodyPredFailure = \case
+  Conway.WrongBlockBodySizeBBODY mm -> WrongBlockBodySizeBBODY mm
+  Conway.InvalidBodyHashBBODY mm -> InvalidBodyHashBBODY mm
+  Conway.LedgersFailure f -> LedgersFailure f
+  Conway.TooManyExUnits mm -> TooManyExUnits mm
+  Conway.BodyRefScriptsSizeTooBig mm -> BodyRefScriptsSizeTooBig mm
+
+instance
+  ( Era era
+  , BaseM ledgers ~ ShelleyBase
+  , ledgers ~ EraRule "LEDGERS" era
+  , STS ledgers
+  ) =>
+  Embed ledgers (DijkstraBBODY era)
+  where
+  wrapFailed = LedgersFailure
+  wrapEvent = ShelleyInAlonzoEvent . Shelley.LedgersEvent

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Certs.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Certs.hs
@@ -22,6 +22,7 @@ import Cardano.Ledger.Conway.Rules (
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era
 import Cardano.Ledger.Dijkstra.Rules.Cert ()
+import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
 import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPOOL, ShelleyPoolPredFailure)
 import Control.State.Transition.Extended
 import GHC.Base (absurd)
@@ -39,6 +40,9 @@ instance InjectRuleFailure "CERTS" ConwayDelegPredFailure DijkstraEra where
   injectFailure = CertFailure . injectFailure
 
 instance InjectRuleFailure "CERTS" ShelleyPoolPredFailure DijkstraEra where
+  injectFailure = CertFailure . injectFailure
+
+instance InjectRuleFailure "CERTS" DijkstraGovCertPredFailure DijkstraEra where
   injectFailure = CertFailure . injectFailure
 
 instance InjectRuleFailure "CERTS" ConwayGovCertPredFailure DijkstraEra where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Gov.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Gov.hs
@@ -1,16 +1,251 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Dijkstra.Rules.Gov () where
+module Cardano.Ledger.Dijkstra.Rules.Gov (
+  DijkstraGOV,
+  DijkstraGovPredFailure (..),
+  conwayToDijkstraGovPredFailure,
+) where
 
-import Cardano.Ledger.Conway.Rules (ConwayGovEvent, ConwayGovPredFailure)
+import Cardano.Ledger.Address (RewardAccount)
+import Cardano.Ledger.BaseTypes (
+  EpochNo (..),
+  Mismatch (..),
+  Network,
+  ProtVer,
+  Relation (..),
+  ShelleyBase,
+  StrictMaybe,
+ )
+import Cardano.Ledger.Binary (
+  DecCBOR (..),
+  EncCBOR (..),
+  FromCBOR (..),
+  ToCBOR (..),
+ )
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway.Governance (
+  ConwayEraGov,
+  GovAction (..),
+  GovActionId (..),
+  GovActionPurpose (..),
+  GovPurposeId (..),
+  ProposalProcedure (..),
+  Proposals,
+  Voter (..),
+ )
+import Cardano.Ledger.Conway.Rules (
+  ConwayGovEvent,
+  ConwayGovPredFailure,
+  GovEnv,
+  GovSignal,
+  conwayGovTransition,
+ )
+import qualified Cardano.Ledger.Conway.Rules as Conway
+import Cardano.Ledger.Conway.State
+import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Dijkstra.Core
-import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
+import Cardano.Ledger.Dijkstra.Era (DijkstraEra, DijkstraGOV)
+import Control.DeepSeq (NFData)
+import Control.State.Transition.Extended (
+  STS (..),
+ )
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
 
-type instance EraRuleFailure "GOV" DijkstraEra = ConwayGovPredFailure DijkstraEra
+data DijkstraGovPredFailure era
+  = GovActionsDoNotExist (NonEmpty GovActionId)
+  | MalformedProposal (GovAction era)
+  | ProposalProcedureNetworkIdMismatch RewardAccount Network
+  | TreasuryWithdrawalsNetworkIdMismatch (Set.Set RewardAccount) Network
+  | ProposalDepositIncorrect (Mismatch RelEQ Coin)
+  | -- | Some governance actions are not allowed to be voted on by certain types of
+    -- Voters. This failure lists all governance action ids with their respective voters
+    -- that are not allowed to vote on those governance actions.
+    DisallowedVoters (NonEmpty (Voter, GovActionId))
+  | ConflictingCommitteeUpdate
+      -- | Credentials that are mentioned as members to be both removed and added
+      (Set.Set (Credential ColdCommitteeRole))
+  | ExpirationEpochTooSmall
+      -- | Members for which the expiration epoch has already been reached
+      (Map.Map (Credential ColdCommitteeRole) EpochNo)
+  | InvalidPrevGovActionId (ProposalProcedure era)
+  | VotingOnExpiredGovAction (NonEmpty (Voter, GovActionId))
+  | ProposalCantFollow
+      -- | The PrevGovActionId of the HardForkInitiation that fails
+      (StrictMaybe (GovPurposeId 'HardForkPurpose))
+      -- | Its protocol version and the protocal version of the previous gov-action pointed to by the proposal
+      (Mismatch RelGT ProtVer)
+  | InvalidPolicyHash
+      -- | The policy script hash in the proposal
+      (StrictMaybe ScriptHash)
+      -- | The policy script hash of the current constitution
+      (StrictMaybe ScriptHash)
+  | DisallowedProposalDuringBootstrap (ProposalProcedure era)
+  | DisallowedVotesDuringBootstrap
+      (NonEmpty (Voter, GovActionId))
+  | -- | Predicate failure for votes by entities that are not present in the ledger state
+    VotersDoNotExist (NonEmpty Voter)
+  | -- | Treasury withdrawals that sum up to zero are not allowed
+    ZeroTreasuryWithdrawals (GovAction era)
+  | -- | Proposals that have an invalid reward account for returns of the deposit
+    ProposalReturnAccountDoesNotExist RewardAccount
+  | -- | Treasury withdrawal proposals to an invalid reward account
+    TreasuryWithdrawalReturnAccountsDoNotExist (NonEmpty RewardAccount)
+  | -- | Disallow votes by unelected committee members
+    UnelectedCommitteeVoters (NonEmpty (Credential HotCommitteeRole))
+  deriving (Eq, Show, Generic)
+
+type instance EraRuleFailure "GOV" DijkstraEra = DijkstraGovPredFailure DijkstraEra
 
 type instance EraRuleEvent "GOV" DijkstraEra = ConwayGovEvent DijkstraEra
 
-instance InjectRuleFailure "GOV" ConwayGovPredFailure DijkstraEra
+instance InjectRuleFailure "GOV" DijkstraGovPredFailure DijkstraEra
+
+instance InjectRuleFailure "GOV" ConwayGovPredFailure DijkstraEra where
+  injectFailure = conwayToDijkstraGovPredFailure
+
+instance EraPParams era => NFData (DijkstraGovPredFailure era)
+
+instance EraPParams era => NoThunks (DijkstraGovPredFailure era)
+
+instance EraPParams era => DecCBOR (DijkstraGovPredFailure era) where
+  decCBOR = decode $ Summands "DijkstraGovPredFailure" $ \case
+    0 -> SumD GovActionsDoNotExist <! From
+    1 -> SumD MalformedProposal <! From
+    2 -> SumD ProposalProcedureNetworkIdMismatch <! From <! From
+    3 -> SumD TreasuryWithdrawalsNetworkIdMismatch <! From <! From
+    4 -> SumD ProposalDepositIncorrect <! From
+    5 -> SumD DisallowedVoters <! From
+    6 -> SumD ConflictingCommitteeUpdate <! From
+    7 -> SumD ExpirationEpochTooSmall <! From
+    8 -> SumD InvalidPrevGovActionId <! From
+    9 -> SumD VotingOnExpiredGovAction <! From
+    10 -> SumD ProposalCantFollow <! From <! From
+    11 -> SumD InvalidPolicyHash <! From <! From
+    12 -> SumD DisallowedProposalDuringBootstrap <! From
+    13 -> SumD DisallowedVotesDuringBootstrap <! From
+    14 -> SumD VotersDoNotExist <! From
+    15 -> SumD ZeroTreasuryWithdrawals <! From
+    16 -> SumD ProposalReturnAccountDoesNotExist <! From
+    17 -> SumD TreasuryWithdrawalReturnAccountsDoNotExist <! From
+    18 -> SumD UnelectedCommitteeVoters <! From
+    k -> Invalid k
+
+instance EraPParams era => EncCBOR (DijkstraGovPredFailure era) where
+  encCBOR =
+    encode . \case
+      GovActionsDoNotExist gid ->
+        Sum GovActionsDoNotExist 0 !> To gid
+      MalformedProposal ga ->
+        Sum MalformedProposal 1 !> To ga
+      ProposalProcedureNetworkIdMismatch acnt nid ->
+        Sum ProposalProcedureNetworkIdMismatch 2 !> To acnt !> To nid
+      TreasuryWithdrawalsNetworkIdMismatch acnts nid ->
+        Sum TreasuryWithdrawalsNetworkIdMismatch 3 !> To acnts !> To nid
+      ProposalDepositIncorrect mm ->
+        Sum ProposalDepositIncorrect 4 !> To mm
+      DisallowedVoters votes ->
+        Sum DisallowedVoters 5 !> To votes
+      ConflictingCommitteeUpdate members ->
+        Sum ConflictingCommitteeUpdate 6 !> To members
+      ExpirationEpochTooSmall members ->
+        Sum ExpirationEpochTooSmall 7 !> To members
+      InvalidPrevGovActionId proposal ->
+        Sum InvalidPrevGovActionId 8 !> To proposal
+      VotingOnExpiredGovAction ga ->
+        Sum VotingOnExpiredGovAction 9 !> To ga
+      ProposalCantFollow prevgaid mm ->
+        Sum ProposalCantFollow 10 !> To prevgaid !> To mm
+      InvalidPolicyHash got expected ->
+        Sum InvalidPolicyHash 11 !> To got !> To expected
+      DisallowedProposalDuringBootstrap proposal ->
+        Sum DisallowedProposalDuringBootstrap 12 !> To proposal
+      DisallowedVotesDuringBootstrap votes ->
+        Sum DisallowedVotesDuringBootstrap 13 !> To votes
+      VotersDoNotExist voters ->
+        Sum VotersDoNotExist 14 !> To voters
+      ZeroTreasuryWithdrawals ga ->
+        Sum ZeroTreasuryWithdrawals 15 !> To ga
+      ProposalReturnAccountDoesNotExist returnAccount ->
+        Sum ProposalReturnAccountDoesNotExist 16 !> To returnAccount
+      TreasuryWithdrawalReturnAccountsDoNotExist accounts ->
+        Sum TreasuryWithdrawalReturnAccountsDoNotExist 17 !> To accounts
+      UnelectedCommitteeVoters committee ->
+        Sum UnelectedCommitteeVoters 18 !> To committee
+
+instance EraPParams era => ToCBOR (DijkstraGovPredFailure era) where
+  toCBOR = toEraCBOR @era
+
+instance EraPParams era => FromCBOR (DijkstraGovPredFailure era) where
+  fromCBOR = fromEraCBOR @era
+
+instance
+  ( ConwayEraTxCert era
+  , ConwayEraPParams era
+  , ConwayEraGov era
+  , EraRule "GOV" era ~ DijkstraGOV era
+  , InjectRuleFailure "GOV" ConwayGovPredFailure era
+  , EraCertState era
+  , ConwayEraCertState era
+  ) =>
+  STS (DijkstraGOV era)
+  where
+  type State (DijkstraGOV era) = Proposals era
+  type Signal (DijkstraGOV era) = GovSignal era
+  type Environment (DijkstraGOV era) = GovEnv era
+  type BaseM (DijkstraGOV era) = ShelleyBase
+  type PredicateFailure (DijkstraGOV era) = DijkstraGovPredFailure era
+  type Event (DijkstraGOV era) = ConwayGovEvent era
+
+  initialRules = []
+
+  transitionRules = [conwayGovTransition @era]
+
+conwayToDijkstraGovPredFailure :: forall era. ConwayGovPredFailure era -> DijkstraGovPredFailure era
+conwayToDijkstraGovPredFailure = \case
+  Conway.GovActionsDoNotExist gaId -> GovActionsDoNotExist gaId
+  Conway.MalformedProposal ga -> MalformedProposal ga
+  Conway.ProposalProcedureNetworkIdMismatch ras n -> ProposalProcedureNetworkIdMismatch ras n
+  Conway.TreasuryWithdrawalsNetworkIdMismatch ras n -> TreasuryWithdrawalsNetworkIdMismatch ras n
+  Conway.ProposalDepositIncorrect mm -> ProposalDepositIncorrect mm
+  Conway.DisallowedVoters vs -> DisallowedVoters vs
+  Conway.ConflictingCommitteeUpdate ccrs -> ConflictingCommitteeUpdate ccrs
+  Conway.ExpirationEpochTooSmall ccrs -> ExpirationEpochTooSmall ccrs
+  Conway.InvalidPrevGovActionId pp -> InvalidPrevGovActionId pp
+  Conway.VotingOnExpiredGovAction ga -> VotingOnExpiredGovAction ga
+  Conway.ProposalCantFollow gpId mm -> ProposalCantFollow gpId mm
+  Conway.InvalidPolicyHash sh1 sh2 -> InvalidPolicyHash sh1 sh2
+  Conway.DisallowedProposalDuringBootstrap pp -> DisallowedProposalDuringBootstrap pp
+  Conway.DisallowedVotesDuringBootstrap vs -> DisallowedVotesDuringBootstrap vs
+  Conway.VotersDoNotExist vs -> VotersDoNotExist vs
+  Conway.ZeroTreasuryWithdrawals ga -> ZeroTreasuryWithdrawals ga
+  Conway.ProposalReturnAccountDoesNotExist ra -> ProposalReturnAccountDoesNotExist ra
+  Conway.TreasuryWithdrawalReturnAccountsDoNotExist ra -> TreasuryWithdrawalReturnAccountsDoNotExist ra
+  Conway.UnelectedCommitteeVoters vs -> UnelectedCommitteeVoters vs

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/GovCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/GovCert.hs
@@ -1,16 +1,130 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE EmptyDataDeriving #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Dijkstra.Rules.GovCert () where
+module Cardano.Ledger.Dijkstra.Rules.GovCert (
+  DijkstraGOVCERT,
+  DijkstraGovCertPredFailure (..),
+  conwayToDijkstraGovCertPredFailure,
+) where
 
-import Cardano.Ledger.Conway.Rules (ConwayGovCertPredFailure)
-import Cardano.Ledger.Dijkstra.Core
-import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
+import Cardano.Ledger.BaseTypes (
+  Mismatch (..),
+  Relation (..),
+  ShelleyBase,
+ )
+import Cardano.Ledger.Binary (
+  DecCBOR (..),
+  EncCBOR (..),
+ )
+import Cardano.Ledger.Binary.Coders
+import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Rules (ConwayGovCertEnv, ConwayGovCertPredFailure (..))
+import qualified Cardano.Ledger.Conway.Rules as Conway
+import Cardano.Ledger.Conway.State
+import Cardano.Ledger.Conway.TxCert (ConwayGovCert (..))
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.Dijkstra.Era (DijkstraEra, DijkstraGOVCERT)
+import Control.DeepSeq (NFData)
+import Control.State.Transition.Extended (
+  BaseM,
+  Environment,
+  Event,
+  PredicateFailure,
+  STS,
+  Signal,
+  State,
+  transitionRules,
+ )
+import Data.Typeable (Typeable)
+import Data.Void (Void)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
 
-type instance EraRuleFailure "GOVCERT" DijkstraEra = ConwayGovCertPredFailure DijkstraEra
+data DijkstraGovCertPredFailure era
+  = DijkstraDRepAlreadyRegistered (Credential DRepRole)
+  | DijkstraDRepNotRegistered (Credential DRepRole)
+  | DijkstraDRepIncorrectDeposit (Mismatch RelEQ Coin)
+  | DijkstraCommitteeHasPreviouslyResigned (Credential ColdCommitteeRole)
+  | DijkstraDRepIncorrectRefund (Mismatch RelEQ Coin)
+  | -- | Predicate failure whenever an update to an unknown committee member is
+    -- attempted. Current Constitutional Committee and all available proposals will be
+    -- searched before reporting this predicate failure.
+    DijkstraCommitteeIsUnknown (Credential ColdCommitteeRole)
+  deriving (Show, Eq, Generic)
+
+type instance EraRuleFailure "GOVCERT" DijkstraEra = DijkstraGovCertPredFailure DijkstraEra
 
 type instance EraRuleEvent "GOVCERT" DijkstraEra = VoidEraRule "GOVCERT" DijkstraEra
 
-instance InjectRuleFailure "GOVCERT" ConwayGovCertPredFailure DijkstraEra
+instance InjectRuleFailure "GOVCERT" DijkstraGovCertPredFailure DijkstraEra
+
+instance InjectRuleFailure "GOVCERT" ConwayGovCertPredFailure DijkstraEra where
+  injectFailure = conwayToDijkstraGovCertPredFailure
+
+instance NoThunks (DijkstraGovCertPredFailure era)
+
+instance NFData (DijkstraGovCertPredFailure era)
+
+instance Era era => EncCBOR (DijkstraGovCertPredFailure era) where
+  encCBOR =
+    encode @_ @(DijkstraGovCertPredFailure era) . \case
+      DijkstraDRepAlreadyRegistered cred -> Sum DijkstraDRepAlreadyRegistered 0 !> To cred
+      DijkstraDRepNotRegistered cred -> Sum DijkstraDRepNotRegistered 1 !> To cred
+      DijkstraDRepIncorrectDeposit mm -> Sum DijkstraDRepIncorrectDeposit 2 !> To mm
+      DijkstraCommitteeHasPreviouslyResigned coldCred -> Sum DijkstraCommitteeHasPreviouslyResigned 3 !> To coldCred
+      DijkstraDRepIncorrectRefund mm -> Sum DijkstraDRepIncorrectRefund 4 !> To mm
+      DijkstraCommitteeIsUnknown coldCred -> Sum DijkstraCommitteeIsUnknown 5 !> To coldCred
+
+instance Typeable era => DecCBOR (DijkstraGovCertPredFailure era) where
+  decCBOR = decode . Summands "DijkstraGovCertPredFailure" $ \case
+    0 -> SumD DijkstraDRepAlreadyRegistered <! From
+    1 -> SumD DijkstraDRepNotRegistered <! From
+    2 -> SumD DijkstraDRepIncorrectDeposit <! From
+    3 -> SumD DijkstraCommitteeHasPreviouslyResigned <! From
+    4 -> SumD DijkstraDRepIncorrectRefund <! From
+    5 -> SumD DijkstraCommitteeIsUnknown <! From
+    n -> Invalid n
+
+instance
+  ( ConwayEraPParams era
+  , State (EraRule "GOVCERT" era) ~ CertState era
+  , Signal (EraRule "GOVCERT" era) ~ ConwayGovCert
+  , Environment (EraRule "GOVCERT" era) ~ ConwayGovCertEnv era
+  , InjectRuleFailure "GOVCERT" ConwayGovCertPredFailure era
+  , EraRule "GOVCERT" era ~ DijkstraGOVCERT era
+  , Eq (PredicateFailure (EraRule "GOVCERT" era))
+  , Show (PredicateFailure (EraRule "GOVCERT" era))
+  , ConwayEraCertState era
+  ) =>
+  STS (DijkstraGOVCERT era)
+  where
+  type State (DijkstraGOVCERT era) = CertState era
+  type Signal (DijkstraGOVCERT era) = ConwayGovCert
+  type Environment (DijkstraGOVCERT era) = ConwayGovCertEnv era
+  type BaseM (DijkstraGOVCERT era) = ShelleyBase
+  type PredicateFailure (DijkstraGOVCERT era) = DijkstraGovCertPredFailure era
+  type Event (DijkstraGOVCERT era) = Void
+
+  transitionRules = [Conway.conwayGovCertTransition @era]
+
+conwayToDijkstraGovCertPredFailure ::
+  forall era. ConwayGovCertPredFailure era -> DijkstraGovCertPredFailure era
+conwayToDijkstraGovCertPredFailure = \case
+  ConwayDRepAlreadyRegistered c -> DijkstraDRepAlreadyRegistered c
+  ConwayDRepNotRegistered c -> DijkstraDRepNotRegistered c
+  ConwayDRepIncorrectDeposit mm -> DijkstraDRepIncorrectDeposit mm
+  ConwayCommitteeHasPreviouslyResigned c -> DijkstraCommitteeHasPreviouslyResigned c
+  ConwayDRepIncorrectRefund mm -> DijkstraDRepIncorrectRefund mm
+  ConwayCommitteeIsUnknown c -> DijkstraCommitteeIsUnknown c

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledgers.hs
@@ -16,16 +16,16 @@ import Cardano.Ledger.Conway.Rules (
   ConwayCertPredFailure,
   ConwayCertsPredFailure,
   ConwayDelegPredFailure,
-  ConwayGovCertPredFailure,
   ConwayGovPredFailure,
-  ConwayLedgerPredFailure,
-  ConwayUtxoPredFailure,
   ConwayUtxosPredFailure,
-  ConwayUtxowPredFailure,
  )
 import Cardano.Ledger.Dijkstra.Core (EraRuleEvent, EraRuleFailure, InjectRuleFailure (..))
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
-import Cardano.Ledger.Dijkstra.Rules.Ledger ()
+import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.Ledger (DijkstraLedgerPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure)
 import Cardano.Ledger.Shelley.Rules (
   ShelleyLedgersEvent,
   ShelleyLedgersPredFailure (..),
@@ -40,10 +40,10 @@ type instance EraRuleEvent "LEDGERS" DijkstraEra = ShelleyLedgersEvent DijkstraE
 
 instance InjectRuleFailure "LEDGERS" ShelleyLedgersPredFailure DijkstraEra
 
-instance InjectRuleFailure "LEDGERS" ConwayLedgerPredFailure DijkstraEra where
+instance InjectRuleFailure "LEDGERS" DijkstraLedgerPredFailure DijkstraEra where
   injectFailure = LedgerFailure
 
-instance InjectRuleFailure "LEDGERS" ConwayUtxowPredFailure DijkstraEra where
+instance InjectRuleFailure "LEDGERS" DijkstraUtxowPredFailure DijkstraEra where
   injectFailure = LedgerFailure . injectFailure
 
 instance InjectRuleFailure "LEDGERS" BabbageUtxowPredFailure DijkstraEra where
@@ -55,7 +55,7 @@ instance InjectRuleFailure "LEDGERS" AlonzoUtxowPredFailure DijkstraEra where
 instance InjectRuleFailure "LEDGERS" ShelleyUtxowPredFailure DijkstraEra where
   injectFailure = LedgerFailure . injectFailure
 
-instance InjectRuleFailure "LEDGERS" ConwayUtxoPredFailure DijkstraEra where
+instance InjectRuleFailure "LEDGERS" DijkstraUtxoPredFailure DijkstraEra where
   injectFailure = LedgerFailure . injectFailure
 
 instance InjectRuleFailure "LEDGERS" BabbageUtxoPredFailure DijkstraEra where
@@ -88,8 +88,11 @@ instance InjectRuleFailure "LEDGERS" ConwayDelegPredFailure DijkstraEra where
 instance InjectRuleFailure "LEDGERS" ShelleyPoolPredFailure DijkstraEra where
   injectFailure = LedgerFailure . injectFailure
 
-instance InjectRuleFailure "LEDGERS" ConwayGovCertPredFailure DijkstraEra where
+instance InjectRuleFailure "LEDGERS" DijkstraGovCertPredFailure DijkstraEra where
   injectFailure = LedgerFailure . injectFailure
 
 instance InjectRuleFailure "LEDGERS" ConwayGovPredFailure DijkstraEra where
+  injectFailure = LedgerFailure . injectFailure
+
+instance InjectRuleFailure "LEDGERS" DijkstraGovPredFailure DijkstraEra where
   injectFailure = LedgerFailure . injectFailure

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -1,52 +1,382 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Dijkstra.Rules.Utxo () where
+module Cardano.Ledger.Dijkstra.Rules.Utxo (
+  DijkstraUTXO,
+  DijkstraUtxoPredFailure (..),
+  conwayToDijkstraUtxoPredFailure,
+) where
 
-import Cardano.Ledger.Allegra.Rules (shelleyToAllegraUtxoPredFailure)
+import Cardano.Ledger.Address (
+  Addr,
+  RewardAccount,
+ )
+import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure, shelleyToAllegraUtxoPredFailure)
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
-import Cardano.Ledger.Alonzo.Rules (AlonzoUtxoEvent, AlonzoUtxoPredFailure, AlonzoUtxosPredFailure)
+import Cardano.Ledger.Alonzo.Rules (
+  AlonzoUtxoEvent,
+  AlonzoUtxoPredFailure,
+  AlonzoUtxosPredFailure,
+ )
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure)
+import Cardano.Ledger.Babbage.Rules (
+  BabbageUtxoPredFailure,
+ )
+import qualified Cardano.Ledger.Babbage.Rules as Babbage (
+  utxoTransition,
+ )
+import Cardano.Ledger.BaseTypes (
+  Mismatch (..),
+  Network,
+  Relation (..),
+  ShelleyBase,
+  SlotNo,
+ )
+import Cardano.Ledger.Binary (
+  DecCBOR (..),
+  EncCBOR (..),
+ )
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
+import Cardano.Ledger.Coin (Coin, DeltaCoin)
+import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (
-  ConwayUtxoPredFailure (..),
-  ConwayUtxosPredFailure,
+  ConwayUTXOS,
+  ConwayUtxoPredFailure,
+  ConwayUtxosPredFailure (..),
   allegraToConwayUtxoPredFailure,
   alonzoToConwayUtxoPredFailure,
   babbageToConwayUtxoPredFailure,
  )
-import Cardano.Ledger.Dijkstra.Core (EraRuleEvent, EraRuleFailure, InjectRuleFailure (..))
-import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
+import qualified Cardano.Ledger.Conway.Rules as Conway
+import Cardano.Ledger.Dijkstra.Era (DijkstraEra, DijkstraUTXO)
 import Cardano.Ledger.Dijkstra.Rules.Utxos ()
-import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure)
+import Cardano.Ledger.Plutus (ExUnits)
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley (UTxOState)
+import Cardano.Ledger.Shelley.Rules (
+  ShelleyUtxoPredFailure,
+ )
+import qualified Cardano.Ledger.Shelley.Rules as Shelley (UtxoEnv, validSizeComputationCheck)
+import Cardano.Ledger.State (
+  EraCertState (..),
+  EraUTxO,
+  UTxO (..),
+ )
+import Cardano.Ledger.TxIn (TxIn)
+import Control.DeepSeq (NFData)
+import Control.State.Transition.Extended (Embed (..), STS (..))
+import Data.List.NonEmpty (NonEmpty)
+import Data.Set (Set)
+import Data.Word (Word32)
+import GHC.Generics (Generic)
+import GHC.Natural (Natural)
+import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
-type instance EraRuleFailure "UTXO" DijkstraEra = ConwayUtxoPredFailure DijkstraEra
+-- ======================================================
+
+-- | Predicate failure for the Dijkstra Era
+data DijkstraUtxoPredFailure era
+  = -- | Subtransition Failures
+    UtxosFailure (PredicateFailure (EraRule "UTXOS" era))
+  | -- | The bad transaction inputs
+    BadInputsUTxO (Set TxIn)
+  | OutsideValidityIntervalUTxO
+      -- | transaction's validity interval
+      ValidityInterval
+      -- | current slot
+      SlotNo
+  | MaxTxSizeUTxO (Mismatch RelLTEQ Word32)
+  | InputSetEmptyUTxO
+  | FeeTooSmallUTxO
+      (Mismatch RelGTEQ Coin)
+  | ValueNotConservedUTxO
+      (Mismatch RelEQ (Value era)) -- Serialise consumed first, then produced
+  | -- | the set of addresses with incorrect network IDs
+    WrongNetwork
+      -- | the expected network id
+      Network
+      -- | the set of addresses with incorrect network IDs
+      (Set Addr)
+  | WrongNetworkWithdrawal
+      -- | the expected network id
+      Network
+      -- | the set of reward addresses with incorrect network IDs
+      (Set RewardAccount)
+  | -- | list of supplied transaction outputs that are too small
+    OutputTooSmallUTxO [TxOut era]
+  | -- | list of supplied bad transaction outputs
+    OutputBootAddrAttrsTooBig [TxOut era]
+  | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
+    OutputTooBigUTxO [(Int, Int, TxOut era)]
+  | InsufficientCollateral
+      -- | balance computed
+      DeltaCoin
+      -- | the required collateral for the given fee
+      Coin
+  | -- | The UTxO entries which have the wrong kind of script
+    ScriptsNotPaidUTxO (UTxO era)
+  | ExUnitsTooBigUTxO
+      (Mismatch RelLTEQ ExUnits)
+  | -- | The inputs marked for use as fees contain non-ADA tokens
+    CollateralContainsNonADA (Value era)
+  | -- | Wrong Network ID in body
+    WrongNetworkInTxBody
+      (Mismatch RelEQ Network)
+  | -- | slot number outside consensus forecast range
+    OutsideForecast SlotNo
+  | -- | There are too many collateral inputs
+    TooManyCollateralInputs
+      (Mismatch RelLTEQ Natural)
+  | NoCollateralInputs
+  | -- | The collateral is not equivalent to the total collateral asserted by the transaction
+    IncorrectTotalCollateralField
+      -- | collateral provided
+      DeltaCoin
+      -- | collateral amount declared in transaction body
+      Coin
+  | -- | list of supplied transaction outputs that are too small,
+    -- together with the minimum value for the given output.
+    BabbageOutputTooSmallUTxO [(TxOut era, Coin)]
+  | -- | TxIns that appear in both inputs and reference inputs
+    BabbageNonDisjointRefInputs (NonEmpty TxIn)
+  deriving (Generic)
+
+type instance EraRuleFailure "UTXO" DijkstraEra = DijkstraUtxoPredFailure DijkstraEra
 
 type instance EraRuleEvent "UTXO" DijkstraEra = AlonzoUtxoEvent DijkstraEra
 
-instance InjectRuleFailure "UTXO" ConwayUtxoPredFailure DijkstraEra
+instance InjectRuleFailure "UTXO" DijkstraUtxoPredFailure DijkstraEra
+
+instance InjectRuleFailure "UTXO" ConwayUtxoPredFailure DijkstraEra where
+  injectFailure = conwayToDijkstraUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" BabbageUtxoPredFailure DijkstraEra where
-  injectFailure = babbageToConwayUtxoPredFailure
+  injectFailure = conwayToDijkstraUtxoPredFailure . babbageToConwayUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" AlonzoUtxoPredFailure DijkstraEra where
-  injectFailure = alonzoToConwayUtxoPredFailure
+  injectFailure = conwayToDijkstraUtxoPredFailure . alonzoToConwayUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" ShelleyUtxoPredFailure DijkstraEra where
   injectFailure =
-    allegraToConwayUtxoPredFailure
-      . shelleyToAllegraUtxoPredFailure
+    conwayToDijkstraUtxoPredFailure . allegraToConwayUtxoPredFailure . shelleyToAllegraUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" Allegra.AllegraUtxoPredFailure DijkstraEra where
-  injectFailure = allegraToConwayUtxoPredFailure
+  injectFailure = conwayToDijkstraUtxoPredFailure . allegraToConwayUtxoPredFailure
 
 instance InjectRuleFailure "UTXO" ConwayUtxosPredFailure DijkstraEra where
   injectFailure = UtxosFailure
 
 instance InjectRuleFailure "UTXO" AlonzoUtxosPredFailure DijkstraEra where
   injectFailure =
-    alonzoToConwayUtxoPredFailure
+    conwayToDijkstraUtxoPredFailure
+      . alonzoToConwayUtxoPredFailure
       . Alonzo.UtxosFailure
       . injectFailure
+
+deriving instance
+  ( Era era
+  , Show (Value era)
+  , Show (PredicateFailure (EraRule "UTXOS" era))
+  , Show (TxOut era)
+  , Show (Script era)
+  , Show TxIn
+  ) =>
+  Show (DijkstraUtxoPredFailure era)
+
+deriving instance
+  ( Era era
+  , Eq (Value era)
+  , Eq (PredicateFailure (EraRule "UTXOS" era))
+  , Eq (TxOut era)
+  , Eq (Script era)
+  , Eq TxIn
+  ) =>
+  Eq (DijkstraUtxoPredFailure era)
+
+deriving via
+  InspectHeapNamed "ConwayUtxoPred" (DijkstraUtxoPredFailure era)
+  instance
+    NoThunks (DijkstraUtxoPredFailure era)
+
+instance
+  ( Era era
+  , NFData (Value era)
+  , NFData (TxOut era)
+  , NFData (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  NFData (DijkstraUtxoPredFailure era)
+
+--------------------------------------------------------------------------------
+-- DijkstraUTXO STS
+--------------------------------------------------------------------------------
+
+instance
+  forall era.
+  ( EraTx era
+  , EraUTxO era
+  , ConwayEraTxBody era
+  , AlonzoEraTxWits era
+  , EraRule "UTXO" era ~ DijkstraUTXO era
+  , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
+  , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
+  , InjectRuleFailure "UTXO" AlonzoUtxoPredFailure era
+  , InjectRuleFailure "UTXO" BabbageUtxoPredFailure era
+  , InjectRuleFailure "UTXO" ConwayUtxoPredFailure era
+  , InjectRuleFailure "UTXO" DijkstraUtxoPredFailure era
+  , Embed (EraRule "UTXOS" era) (DijkstraUTXO era)
+  , Environment (EraRule "UTXOS" era) ~ Shelley.UtxoEnv era
+  , State (EraRule "UTXOS" era) ~ Shelley.UTxOState era
+  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , PredicateFailure (EraRule "UTXO" era) ~ DijkstraUtxoPredFailure era
+  , EraCertState era
+  , SafeToHash (TxWits era)
+  ) =>
+  STS (DijkstraUTXO era)
+  where
+  type State (DijkstraUTXO era) = Shelley.UTxOState era
+  type Signal (DijkstraUTXO era) = Tx TopTx era
+  type Environment (DijkstraUTXO era) = Shelley.UtxoEnv era
+  type BaseM (DijkstraUTXO era) = ShelleyBase
+  type PredicateFailure (DijkstraUTXO era) = DijkstraUtxoPredFailure era
+  type Event (DijkstraUTXO era) = AlonzoUtxoEvent era
+
+  initialRules = []
+
+  transitionRules = [Babbage.utxoTransition @era]
+
+  assertions = [Shelley.validSizeComputationCheck]
+
+instance
+  ( Era era
+  , STS (ConwayUTXOS era)
+  , PredicateFailure (EraRule "UTXOS" era) ~ ConwayUtxosPredFailure era
+  , Event (EraRule "UTXOS" era) ~ Event (ConwayUTXOS era)
+  ) =>
+  Embed (ConwayUTXOS era) (DijkstraUTXO era)
+  where
+  wrapFailed = UtxosFailure
+  wrapEvent = Alonzo.UtxosEvent
+
+--------------------------------------------------------------------------------
+-- Serialisation
+--------------------------------------------------------------------------------
+
+instance
+  ( Era era
+  , EncCBOR (TxOut era)
+  , EncCBOR (Value era)
+  , EncCBOR (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  EncCBOR (DijkstraUtxoPredFailure era)
+  where
+  encCBOR =
+    encode . \case
+      UtxosFailure a -> Sum (UtxosFailure @era) 0 !> To a
+      BadInputsUTxO ins -> Sum (BadInputsUTxO @era) 1 !> To ins
+      OutsideValidityIntervalUTxO a b -> Sum OutsideValidityIntervalUTxO 2 !> To a !> To b
+      MaxTxSizeUTxO mm -> Sum MaxTxSizeUTxO 3 !> To mm
+      InputSetEmptyUTxO -> Sum InputSetEmptyUTxO 4
+      FeeTooSmallUTxO mm -> Sum FeeTooSmallUTxO 5 !> To mm
+      ValueNotConservedUTxO mm -> Sum (ValueNotConservedUTxO @era) 6 !> To mm
+      WrongNetwork right wrongs -> Sum (WrongNetwork @era) 7 !> To right !> To wrongs
+      WrongNetworkWithdrawal right wrongs -> Sum (WrongNetworkWithdrawal @era) 8 !> To right !> To wrongs
+      OutputTooSmallUTxO outs -> Sum (OutputTooSmallUTxO @era) 9 !> To outs
+      OutputBootAddrAttrsTooBig outs -> Sum (OutputBootAddrAttrsTooBig @era) 10 !> To outs
+      OutputTooBigUTxO outs -> Sum (OutputTooBigUTxO @era) 11 !> To outs
+      InsufficientCollateral a b -> Sum InsufficientCollateral 12 !> To a !> To b
+      ScriptsNotPaidUTxO a -> Sum ScriptsNotPaidUTxO 13 !> To a
+      ExUnitsTooBigUTxO mm -> Sum ExUnitsTooBigUTxO 14 !> To mm
+      CollateralContainsNonADA a -> Sum CollateralContainsNonADA 15 !> To a
+      WrongNetworkInTxBody mm -> Sum WrongNetworkInTxBody 16 !> To mm
+      OutsideForecast a -> Sum OutsideForecast 17 !> To a
+      TooManyCollateralInputs mm -> Sum TooManyCollateralInputs 18 !> To mm
+      NoCollateralInputs -> Sum NoCollateralInputs 19
+      IncorrectTotalCollateralField c1 c2 -> Sum IncorrectTotalCollateralField 20 !> To c1 !> To c2
+      BabbageOutputTooSmallUTxO x -> Sum BabbageOutputTooSmallUTxO 21 !> To x
+      BabbageNonDisjointRefInputs x -> Sum BabbageNonDisjointRefInputs 22 !> To x
+
+instance
+  ( Era era
+  , DecCBOR (TxOut era)
+  , EncCBOR (Value era)
+  , DecCBOR (Value era)
+  , DecCBOR (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  DecCBOR (DijkstraUtxoPredFailure era)
+  where
+  decCBOR = decode . Summands "DijkstraUtxoPredFailure" $ \case
+    0 -> SumD UtxosFailure <! From
+    1 -> SumD BadInputsUTxO <! From
+    2 -> SumD OutsideValidityIntervalUTxO <! From <! From
+    3 -> SumD MaxTxSizeUTxO <! From
+    4 -> SumD InputSetEmptyUTxO
+    5 -> SumD FeeTooSmallUTxO <! From
+    6 -> SumD ValueNotConservedUTxO <! From
+    7 -> SumD WrongNetwork <! From <! From
+    8 -> SumD WrongNetworkWithdrawal <! From <! From
+    9 -> SumD OutputTooSmallUTxO <! From
+    10 -> SumD OutputBootAddrAttrsTooBig <! From
+    11 -> SumD OutputTooBigUTxO <! From
+    12 -> SumD InsufficientCollateral <! From <! From
+    13 -> SumD ScriptsNotPaidUTxO <! From
+    14 -> SumD ExUnitsTooBigUTxO <! From
+    15 -> SumD CollateralContainsNonADA <! From
+    16 -> SumD WrongNetworkInTxBody <! From
+    17 -> SumD OutsideForecast <! From
+    18 -> SumD TooManyCollateralInputs <! From
+    19 -> SumD NoCollateralInputs
+    20 -> SumD IncorrectTotalCollateralField <! From <! From
+    21 -> SumD BabbageOutputTooSmallUTxO <! From
+    22 -> SumD BabbageNonDisjointRefInputs <! From
+    n -> Invalid n
+
+-- =====================================================
+-- Injecting from one PredicateFailure to another
+
+conwayToDijkstraUtxoPredFailure ::
+  forall era.
+  ConwayUtxoPredFailure era ->
+  DijkstraUtxoPredFailure era
+conwayToDijkstraUtxoPredFailure = \case
+  Conway.BadInputsUTxO x -> BadInputsUTxO x
+  Conway.OutsideValidityIntervalUTxO vi slotNo -> OutsideValidityIntervalUTxO vi slotNo
+  Conway.MaxTxSizeUTxO m -> MaxTxSizeUTxO m
+  Conway.InputSetEmptyUTxO -> InputSetEmptyUTxO
+  Conway.FeeTooSmallUTxO m -> FeeTooSmallUTxO m
+  Conway.ValueNotConservedUTxO m -> ValueNotConservedUTxO m
+  Conway.WrongNetwork x y -> WrongNetwork x y
+  Conway.WrongNetworkWithdrawal x y -> WrongNetworkWithdrawal x y
+  Conway.OutputTooSmallUTxO x -> OutputTooSmallUTxO x
+  Conway.UtxosFailure x -> UtxosFailure x
+  Conway.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs
+  Conway.OutputTooBigUTxO xs -> OutputTooBigUTxO xs
+  Conway.InsufficientCollateral c1 c2 -> InsufficientCollateral c1 c2
+  Conway.ScriptsNotPaidUTxO u -> ScriptsNotPaidUTxO u
+  Conway.ExUnitsTooBigUTxO m -> ExUnitsTooBigUTxO m
+  Conway.CollateralContainsNonADA v -> CollateralContainsNonADA v
+  Conway.WrongNetworkInTxBody m -> WrongNetworkInTxBody m
+  Conway.OutsideForecast sno -> OutsideForecast sno
+  Conway.TooManyCollateralInputs m -> TooManyCollateralInputs m
+  Conway.NoCollateralInputs -> NoCollateralInputs
+  Conway.IncorrectTotalCollateralField dc c -> IncorrectTotalCollateralField dc c
+  Conway.BabbageOutputTooSmallUTxO txouts -> BabbageOutputTooSmallUTxO txouts
+  Conway.BabbageNonDisjointRefInputs txin -> BabbageNonDisjointRefInputs txin

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -1,45 +1,170 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Dijkstra.Rules.Utxow () where
+module Cardano.Ledger.Dijkstra.Rules.Utxow (
+  DijkstraUTXOW,
+  DijkstraUtxowPredFailure (..),
+) where
 
-import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
+import Cardano.Crypto.Hash (ByteString)
+import Cardano.Ledger.Allegra.Rules (
+  AllegraUtxoPredFailure,
+ )
 import Cardano.Ledger.Alonzo.Rules (
+  AlonzoUtxoEvent,
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
-  AlonzoUtxowEvent,
+  AlonzoUtxowEvent (WrappedShelleyEraEvent),
   AlonzoUtxowPredFailure,
  )
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
+import Cardano.Ledger.Babbage.Rules (
+  BabbageUtxoPredFailure,
+  BabbageUtxowPredFailure,
+  babbageUtxowTransition,
+ )
+import Cardano.Ledger.BaseTypes (
+  Mismatch (..),
+  Relation (..),
+  ShelleyBase,
+  StrictMaybe (..),
+ )
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
+import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (
   ConwayUtxoPredFailure,
   ConwayUtxosPredFailure,
-  ConwayUtxowPredFailure (..),
+  ConwayUtxowPredFailure,
   alonzoToConwayUtxowPredFailure,
   babbageToConwayUtxowPredFailure,
   shelleyToConwayUtxowPredFailure,
  )
-import Cardano.Ledger.Dijkstra.Core (EraRuleEvent, EraRuleFailure, InjectRuleFailure (..))
-import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
-import Cardano.Ledger.Dijkstra.Rules.Utxo ()
-import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
+import qualified Cardano.Ledger.Conway.Rules as Conway
+import Cardano.Ledger.Dijkstra.Era (DijkstraEra, DijkstraUTXO, DijkstraUTXOW)
+import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
+import Cardano.Ledger.Keys (VKey)
+import qualified Cardano.Ledger.Shelley.LedgerState as Shelley (UTxOState)
+import Cardano.Ledger.Shelley.Rules (
+  ShelleyUtxoPredFailure,
+  ShelleyUtxowEvent (UtxoEvent),
+  ShelleyUtxowPredFailure,
+ )
+import qualified Cardano.Ledger.Shelley.Rules as Shelley (
+  UtxoEnv,
+ )
+import Cardano.Ledger.State (EraUTxO (..))
+import Cardano.Ledger.TxIn (TxIn)
+import Control.DeepSeq (NFData)
+import Control.State.Transition.Extended (
+  Embed (..),
+  STS (..),
+ )
+import Data.Set (Set)
+import GHC.Generics (Generic)
+import NoThunks.Class (
+  InspectHeapNamed (..),
+  NoThunks (..),
+ )
 
-type instance EraRuleFailure "UTXOW" DijkstraEra = ConwayUtxowPredFailure DijkstraEra
+-- ================================
+
+-- | Predicate failure type for the Conway Era
+data DijkstraUtxowPredFailure era
+  = UtxoFailure (PredicateFailure (EraRule "UTXO" era))
+  | InvalidWitnessesUTXOW [VKey Witness]
+  | -- | witnesses which failed in verifiedWits function
+    MissingVKeyWitnessesUTXOW
+      -- | witnesses which were needed and not supplied
+      (Set (KeyHash Witness))
+  | -- | missing scripts
+    MissingScriptWitnessesUTXOW (Set ScriptHash)
+  | -- | failed scripts
+    ScriptWitnessNotValidatingUTXOW (Set ScriptHash)
+  | -- | hash of the full metadata
+    MissingTxBodyMetadataHash TxAuxDataHash
+  | -- | hash of the metadata included in the transaction body
+    MissingTxMetadata TxAuxDataHash
+  | ConflictingMetadataHash (Mismatch RelEQ TxAuxDataHash)
+  | -- | Contains out of range values (string`s too long)
+    InvalidMetadata
+  | -- | extraneous scripts
+    ExtraneousScriptWitnessesUTXOW (Set ScriptHash)
+  | MissingRedeemers [(PlutusPurpose AsItem era, ScriptHash)]
+  | MissingRequiredDatums
+      -- TODO: Make this NonEmpty #4066
+
+      -- | Set of missing data hashes
+      (Set DataHash)
+      -- | Set of received data hashes
+      (Set DataHash)
+  | NotAllowedSupplementalDatums
+      -- TODO: Make this NonEmpty #4066
+
+      -- | Set of unallowed data hashes.
+      (Set DataHash)
+      -- | Set of acceptable supplemental data hashes
+      (Set DataHash)
+  | PPViewHashesDontMatch
+      (Mismatch RelEQ (StrictMaybe ScriptIntegrityHash))
+  | -- | Set of transaction inputs that are TwoPhase scripts, and should have a DataHash but don't
+    UnspendableUTxONoDatumHash
+      -- TODO: Make this NonEmpty #4066
+      (Set TxIn)
+  | -- | List of redeemers not needed
+    ExtraRedeemers [PlutusPurpose AsIx era]
+  | -- | Embed UTXO rule failures
+    MalformedScriptWitnesses (Set ScriptHash)
+  | -- | the set of malformed script witnesses
+    MalformedReferenceScripts (Set ScriptHash)
+  | -- | The computed script integrity hash does not match the provided script integrity hash
+    ScriptIntegrityHashMismatch
+      (Mismatch RelEQ (StrictMaybe ScriptIntegrityHash))
+      (StrictMaybe ByteString)
+  deriving (Generic)
+
+type instance EraRuleFailure "UTXOW" DijkstraEra = DijkstraUtxowPredFailure DijkstraEra
 
 type instance EraRuleEvent "UTXOW" DijkstraEra = AlonzoUtxowEvent DijkstraEra
 
-instance InjectRuleFailure "UTXOW" ConwayUtxowPredFailure DijkstraEra
+instance InjectRuleFailure "UTXOW" DijkstraUtxowPredFailure DijkstraEra
+
+instance InjectRuleFailure "UTXOW" ConwayUtxowPredFailure DijkstraEra where
+  injectFailure = conwayToDijkstraUtxowPredFailure
 
 instance InjectRuleFailure "UTXOW" BabbageUtxowPredFailure DijkstraEra where
-  injectFailure = babbageToConwayUtxowPredFailure
+  injectFailure = conwayToDijkstraUtxowPredFailure . babbageToConwayUtxowPredFailure
 
 instance InjectRuleFailure "UTXOW" AlonzoUtxowPredFailure DijkstraEra where
-  injectFailure = alonzoToConwayUtxowPredFailure
+  injectFailure = conwayToDijkstraUtxowPredFailure . alonzoToConwayUtxowPredFailure
 
 instance InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure DijkstraEra where
-  injectFailure = shelleyToConwayUtxowPredFailure
+  injectFailure = conwayToDijkstraUtxowPredFailure . shelleyToConwayUtxowPredFailure
+
+instance InjectRuleFailure "UTXOW" DijkstraUtxoPredFailure DijkstraEra where
+  injectFailure = UtxoFailure . injectFailure
 
 instance InjectRuleFailure "UTXOW" ConwayUtxoPredFailure DijkstraEra where
   injectFailure = UtxoFailure . injectFailure
@@ -61,3 +186,164 @@ instance InjectRuleFailure "UTXOW" ShelleyUtxoPredFailure DijkstraEra where
 
 instance InjectRuleFailure "UTXOW" AllegraUtxoPredFailure DijkstraEra where
   injectFailure = UtxoFailure . injectFailure
+
+deriving instance
+  ( ConwayEraScript era
+  , Show (PredicateFailure (EraRule "UTXO" era))
+  ) =>
+  Show (DijkstraUtxowPredFailure era)
+
+deriving instance
+  ( ConwayEraScript era
+  , Eq (PredicateFailure (EraRule "UTXO" era))
+  ) =>
+  Eq (DijkstraUtxowPredFailure era)
+
+deriving via
+  InspectHeapNamed "ConwayUtxowPred" (DijkstraUtxowPredFailure era)
+  instance
+    NoThunks (DijkstraUtxowPredFailure era)
+
+instance
+  ( ConwayEraScript era
+  , NFData (TxCert era)
+  , NFData (PredicateFailure (EraRule "UTXO" era))
+  ) =>
+  NFData (DijkstraUtxowPredFailure era)
+
+--------------------------------------------------------------------------------
+-- DijkstraUTXOW STS
+--------------------------------------------------------------------------------
+
+instance
+  forall era.
+  ( AlonzoEraTx era
+  , AlonzoEraUTxO era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ConwayEraTxBody era
+  , EraRule "UTXOW" era ~ DijkstraUTXOW era
+  , InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure era
+  , InjectRuleFailure "UTXOW" AlonzoUtxowPredFailure era
+  , InjectRuleFailure "UTXOW" BabbageUtxowPredFailure era
+  , InjectRuleFailure "UTXOW" ConwayUtxowPredFailure era
+  , InjectRuleFailure "UTXOW" DijkstraUtxowPredFailure era
+  , -- Allow UTXOW to call UTXO
+    Embed (EraRule "UTXO" era) (DijkstraUTXOW era)
+  , Environment (EraRule "UTXO" era) ~ Shelley.UtxoEnv era
+  , State (EraRule "UTXO" era) ~ Shelley.UTxOState era
+  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Eq (PredicateFailure (EraRule "UTXOS" era))
+  , Show (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  STS (DijkstraUTXOW era)
+  where
+  type State (DijkstraUTXOW era) = Shelley.UTxOState era
+  type Signal (DijkstraUTXOW era) = Tx TopTx era
+  type Environment (DijkstraUTXOW era) = Shelley.UtxoEnv era
+  type BaseM (DijkstraUTXOW era) = ShelleyBase
+  type PredicateFailure (DijkstraUTXOW era) = DijkstraUtxowPredFailure era
+  type Event (DijkstraUTXOW era) = AlonzoUtxowEvent era
+  transitionRules = [babbageUtxowTransition @era]
+  initialRules = []
+
+instance
+  ( Era era
+  , STS (DijkstraUTXO era)
+  , PredicateFailure (EraRule "UTXO" era) ~ DijkstraUtxoPredFailure era
+  , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
+  , BaseM (DijkstraUTXOW era) ~ ShelleyBase
+  , PredicateFailure (DijkstraUTXOW era) ~ DijkstraUtxowPredFailure era
+  , Event (DijkstraUTXOW era) ~ AlonzoUtxowEvent era
+  ) =>
+  Embed (DijkstraUTXO era) (DijkstraUTXOW era)
+  where
+  wrapFailed = UtxoFailure
+  wrapEvent = WrappedShelleyEraEvent . UtxoEvent
+
+--------------------------------------------------------------------------------
+-- Serialisation
+--------------------------------------------------------------------------------
+
+instance
+  ( ConwayEraScript era
+  , EncCBOR (PredicateFailure (EraRule "UTXO" era))
+  ) =>
+  EncCBOR (DijkstraUtxowPredFailure era)
+  where
+  encCBOR =
+    encode . \case
+      UtxoFailure x -> Sum UtxoFailure 0 !> To x
+      InvalidWitnessesUTXOW xs -> Sum InvalidWitnessesUTXOW 1 !> To xs
+      MissingVKeyWitnessesUTXOW xs -> Sum MissingVKeyWitnessesUTXOW 2 !> To xs
+      MissingScriptWitnessesUTXOW xs -> Sum MissingScriptWitnessesUTXOW 3 !> To xs
+      ScriptWitnessNotValidatingUTXOW xs -> Sum ScriptWitnessNotValidatingUTXOW 4 !> To xs
+      MissingTxBodyMetadataHash xs -> Sum MissingTxBodyMetadataHash 5 !> To xs
+      MissingTxMetadata xs -> Sum MissingTxMetadata 6 !> To xs
+      ConflictingMetadataHash mm -> Sum ConflictingMetadataHash 7 !> To mm
+      InvalidMetadata -> Sum InvalidMetadata 8
+      ExtraneousScriptWitnessesUTXOW xs -> Sum ExtraneousScriptWitnessesUTXOW 9 !> To xs
+      MissingRedeemers x -> Sum MissingRedeemers 10 !> To x
+      MissingRequiredDatums x y -> Sum MissingRequiredDatums 11 !> To x !> To y
+      NotAllowedSupplementalDatums x y -> Sum NotAllowedSupplementalDatums 12 !> To x !> To y
+      PPViewHashesDontMatch mm -> Sum PPViewHashesDontMatch 13 !> To mm
+      UnspendableUTxONoDatumHash x -> Sum UnspendableUTxONoDatumHash 14 !> To x
+      ExtraRedeemers x -> Sum ExtraRedeemers 15 !> To x
+      MalformedScriptWitnesses x -> Sum MalformedScriptWitnesses 16 !> To x
+      MalformedReferenceScripts x -> Sum MalformedReferenceScripts 17 !> To x
+      ScriptIntegrityHashMismatch x y -> Sum ScriptIntegrityHashMismatch 18 !> To x !> To y
+
+instance
+  ( ConwayEraScript era
+  , DecCBOR (PredicateFailure (EraRule "UTXO" era))
+  ) =>
+  DecCBOR (DijkstraUtxowPredFailure era)
+  where
+  decCBOR = decode . Summands "ConwayUtxowPred" $ \case
+    0 -> SumD UtxoFailure <! From
+    1 -> SumD InvalidWitnessesUTXOW <! From
+    2 -> SumD MissingVKeyWitnessesUTXOW <! From
+    3 -> SumD MissingScriptWitnessesUTXOW <! From
+    4 -> SumD ScriptWitnessNotValidatingUTXOW <! From
+    5 -> SumD MissingTxBodyMetadataHash <! From
+    6 -> SumD MissingTxMetadata <! From
+    7 -> SumD ConflictingMetadataHash <! From
+    8 -> SumD InvalidMetadata
+    9 -> SumD ExtraneousScriptWitnessesUTXOW <! From
+    10 -> SumD MissingRedeemers <! From
+    11 -> SumD MissingRequiredDatums <! From <! From
+    12 -> SumD NotAllowedSupplementalDatums <! From <! From
+    13 -> SumD PPViewHashesDontMatch <! From
+    14 -> SumD UnspendableUTxONoDatumHash <! From
+    15 -> SumD ExtraRedeemers <! From
+    16 -> SumD MalformedScriptWitnesses <! From
+    17 -> SumD MalformedReferenceScripts <! From
+    18 -> SumD ScriptIntegrityHashMismatch <! From <! From
+    n -> Invalid n
+
+-- =====================================================
+-- Injecting from one PredicateFailure to another
+
+conwayToDijkstraUtxowPredFailure ::
+  forall era.
+  ConwayUtxowPredFailure era ->
+  DijkstraUtxowPredFailure era
+conwayToDijkstraUtxowPredFailure = \case
+  Conway.UtxoFailure f -> UtxoFailure f
+  Conway.InvalidWitnessesUTXOW ks -> InvalidWitnessesUTXOW ks
+  Conway.MissingVKeyWitnessesUTXOW ks -> MissingVKeyWitnessesUTXOW ks
+  Conway.MissingScriptWitnessesUTXOW hs -> MissingScriptWitnessesUTXOW hs
+  Conway.ScriptWitnessNotValidatingUTXOW hs -> ScriptWitnessNotValidatingUTXOW hs
+  Conway.MissingTxBodyMetadataHash dh -> MissingTxBodyMetadataHash dh
+  Conway.MissingTxMetadata dh -> MissingTxMetadata dh
+  Conway.ConflictingMetadataHash mm -> ConflictingMetadataHash mm
+  Conway.InvalidMetadata -> InvalidMetadata
+  Conway.ExtraneousScriptWitnessesUTXOW hs -> ExtraneousScriptWitnessesUTXOW hs
+  Conway.MissingRedeemers pps -> MissingRedeemers pps
+  Conway.MissingRequiredDatums hs1 hs2 -> MissingRequiredDatums hs1 hs2
+  Conway.NotAllowedSupplementalDatums hs1 hs2 -> NotAllowedSupplementalDatums hs1 hs2
+  Conway.PPViewHashesDontMatch mm -> PPViewHashesDontMatch mm
+  Conway.UnspendableUTxONoDatumHash txs -> UnspendableUTxONoDatumHash txs
+  Conway.ExtraRedeemers pps -> ExtraRedeemers pps
+  Conway.MalformedScriptWitnesses hs -> MalformedScriptWitnesses hs
+  Conway.MalformedReferenceScripts hs -> MalformedReferenceScripts hs
+  Conway.ScriptIntegrityHashMismatch mm f -> ScriptIntegrityHashMismatch mm f

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -24,6 +25,7 @@ import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams, UpgradeDijkstraPParams)
+import Cardano.Ledger.Dijkstra.Rules
 import Cardano.Ledger.Dijkstra.Scripts
 import Cardano.Ledger.Dijkstra.Transition (TransitionConfig (..))
 import Cardano.Ledger.Dijkstra.Tx (DijkstraTx (..), Tx (..))
@@ -32,6 +34,9 @@ import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError)
 import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
+ )
+import Control.State.Transition (
+  STS (..),
  )
 import Data.Functor.Identity (Identity)
 import qualified Data.OMap.Strict as OMap
@@ -150,5 +155,55 @@ instance
   , Arbitrary (TxOut era)
   ) =>
   Arbitrary (DijkstraContextError era)
+  where
+  arbitrary = genericArbitraryU
+
+instance
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "LEDGERS" era))
+  ) =>
+  Arbitrary (DijkstraBbodyPredFailure era)
+  where
+  arbitrary = genericArbitraryU
+
+instance
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "UTXOW" era))
+  , Arbitrary (PredicateFailure (EraRule "CERTS" era))
+  , Arbitrary (PredicateFailure (EraRule "GOV" era))
+  ) =>
+  Arbitrary (DijkstraLedgerPredFailure era)
+  where
+  arbitrary = genericArbitraryU
+
+instance
+  ( EraTxOut era
+  , Arbitrary (Value era)
+  , Arbitrary (TxOut era)
+  , Arbitrary (PredicateFailure (EraRule "UTXOS" era))
+  ) =>
+  Arbitrary (DijkstraUtxoPredFailure era)
+  where
+  arbitrary = genericArbitraryU
+
+instance
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "UTXO" era))
+  , Arbitrary (TxCert era)
+  , Arbitrary (PlutusPurpose AsItem era)
+  , Arbitrary (PlutusPurpose AsIx era)
+  ) =>
+  Arbitrary (DijkstraUtxowPredFailure era)
+  where
+  arbitrary = genericArbitraryU
+
+instance Era era => Arbitrary (DijkstraGovCertPredFailure era) where
+  arbitrary = genericArbitraryU
+
+instance
+  ( Era era
+  , Arbitrary (PParamsHKD StrictMaybe era)
+  ) =>
+  Arbitrary (DijkstraGovPredFailure era)
   where
   arbitrary = genericArbitraryU

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
@@ -15,8 +15,9 @@ import Cardano.Ledger.Binary (mkSized)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
-import Cardano.Ledger.Conway.Rules (ConwayDELEG, ConwayDelegPredFailure (..), ConwayLEDGER)
+import Cardano.Ledger.Conway.Rules (ConwayDELEG, ConwayDelegPredFailure (..))
 import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Dijkstra.Rules (DijkstraLEDGER)
 import Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Cardano.Ledger.Dijkstra.TxCert
@@ -66,7 +67,7 @@ ledgerExamples =
   mkLedgerExamples
     ( ApplyTxError $
         pure $
-          wrapFailed @(ConwayDELEG DijkstraEra) @(ConwayLEDGER DijkstraEra) $
+          wrapFailed @(ConwayDELEG DijkstraEra) @(DijkstraLEDGER DijkstraEra) $
             DelegateeStakePoolNotRegisteredDELEG @DijkstraEra (mkKeyHash 1)
     )
     exampleBabbageNewEpochState

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -27,7 +27,6 @@ import Cardano.Ledger.Conway.Rules (
   ConwayCertPredFailure (..),
   ConwayCertsPredFailure (..),
   ConwayDelegPredFailure (..),
-  ConwayLedgerPredFailure (..),
  )
 import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Credential
@@ -35,6 +34,7 @@ import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
 import Cardano.Ledger.Dijkstra.PParams (UpgradeDijkstraPParams (..))
+import Cardano.Ledger.Dijkstra.Rules (DijkstraLedgerPredFailure (..))
 import Cardano.Ledger.Dijkstra.Scripts (
   DijkstraNativeScript,
   evalDijkstraNativeScript,
@@ -104,7 +104,7 @@ instance DijkstraEraImp DijkstraEra
 
 -- Partial implementation used for checking predicate failures
 instance InjectRuleFailure "LEDGER" ShelleyDelegPredFailure DijkstraEra where
-  injectFailure = ConwayCertsFailure . injectFailure
+  injectFailure = DijkstraCertsFailure . injectFailure
 
 instance InjectRuleFailure "CERTS" ShelleyDelegPredFailure DijkstraEra where
   injectFailure = CertFailure . injectFailure


### PR DESCRIPTION
# Description

Fix #5388: we redefine all the rule `PredicateFailure`s in Dijkstra that used `EncCBORGroup` and `DecCBORGroup` classes, so that we can eventually remove these classes.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
