### PR TITLE
Improve memory representation of ConwayAccountState

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Make `ConwayAccountState` a pattern synonym
 * Remove deprecated type `Conway`
 * Remove deprecated function `toConwayGenesisPairs`
 * Remove deprecated function `toUpgradeConwayPParamsUpdatePairs`

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -1039,7 +1039,26 @@ instance Typeable era => HasSimpleRep (ShelleyAccounts era)
 
 instance Typeable era => HasSpec (ShelleyAccounts era)
 
-instance Typeable era => HasSimpleRep (ConwayAccountState era)
+type ConwayAccountStateTypes era =
+  '[ CompactForm Coin
+   , CompactForm Coin
+   , StrictMaybe (KeyHash StakePool)
+   , StrictMaybe DRep
+   ]
+
+instance HasSimpleRep (ConwayAccountState era) where
+  type TheSop (ConwayAccountState era) = '["ConwayAccountState" ::: ConwayAccountStateTypes era]
+  toSimpleRep (ConwayAccountState {..}) =
+    inject @"ConwayAccountState" @'["ConwayAccountState" ::: ConwayAccountStateTypes era]
+      casBalance
+      casDeposit
+      casStakePoolDelegation
+      casDRepDelegation
+  fromSimpleRep rep =
+    algebra @'["ConwayAccountState" ::: ConwayAccountStateTypes era]
+      rep
+      $ \casBalance casDeposit casStakePoolDelegation casDRepDelegation ->
+        ConwayAccountState {..}
 
 instance Typeable era => HasSpec (ConwayAccountState era)
 


### PR DESCRIPTION
# Description

This PR changes the `ConwayAccountState` datatype so that it makes more efficient use of memory. I added a pattern synonym to keep the interface as it was before.

close https://github.com/IntersectMBO/cardano-ledger/issues/5446

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
