### PR TITLE
Make IncompleteWithdrawals more informative

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Change the field type of `ConwayIncompleteWithdrawals` to `Map RewardAccount (Mismatch RelEQ Coin)`
 * Make `ConwayAccountState` a pattern synonym
 * Remove deprecated type `Conway`
 * Remove deprecated function `toConwayGenesisPairs`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -27,7 +27,6 @@ module Cardano.Ledger.Conway.Rules.Certs (
   updateVotingDRepExpiries,
 ) where
 
-import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.BaseTypes (
   EpochInterval,
   EpochNo (EpochNo),
@@ -233,13 +232,12 @@ conwayCertsTransition = do
           network <- liftSTS $ asks networkId
           let accounts = certState ^. certDStateL . accountsL
               withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
-              incompleteToWithdrawalsMap = fmap mismatchSupplied . Map.mapKeys (RewardAccount network)
           failOnJust
             (withdrawalsThatDoNotDrainAccounts withdrawals network accounts)
             ( \(invalid, incomplete) ->
                 WithdrawalsNotInRewardsCERTS $
                   Withdrawals $
-                    unWithdrawals invalid <> incompleteToWithdrawalsMap incomplete
+                    unWithdrawals invalid <> fmap mismatchSupplied incomplete
             )
           pure $
             certState

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -144,7 +144,7 @@ data ConwayLedgerPredFailure era
   | ConwayTxRefScriptsSizeTooBig (Mismatch RelLTEQ Int)
   | ConwayMempoolFailure Text
   | ConwayWithdrawalsMissingAccounts Withdrawals
-  | ConwayIncompleteWithdrawals (Map.Map (Credential Staking) (Mismatch RelEQ Coin))
+  | ConwayIncompleteWithdrawals (Map.Map RewardAccount (Mismatch RelEQ Coin))
   deriving (Generic)
 
 type instance EraRuleFailure "LEDGER" ConwayEra = ConwayLedgerPredFailure ConwayEra

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -144,7 +144,7 @@ data ConwayLedgerPredFailure era
   | ConwayTxRefScriptsSizeTooBig (Mismatch RelLTEQ Int)
   | ConwayMempoolFailure Text
   | ConwayWithdrawalsMissingAccounts Withdrawals
-  | ConwayIncompleteWithdrawals Withdrawals
+  | ConwayIncompleteWithdrawals (Map.Map (Credential Staking) (Mismatch RelEQ Coin))
   deriving (Generic)
 
 type instance EraRuleFailure "LEDGER" ConwayEra = ConwayLedgerPredFailure ConwayEra

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
@@ -10,7 +10,6 @@
 
 module Test.Cardano.Ledger.Conway.Imp.CertsSpec (spec) where
 
-import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.BaseTypes (EpochInterval (..), Mismatch (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule)
@@ -109,7 +108,7 @@ spec = do
         [ if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
             then
               injectFailure $
-                ConwayIncompleteWithdrawals @era [(raCredential rwdAccount1, Mismatch (reward1 <+> Coin 1) reward1)]
+                ConwayIncompleteWithdrawals @era [(rwdAccount1, Mismatch (reward1 <+> Coin 1) reward1)]
             else
               injectFailure . WithdrawalsNotInRewardsCERTS @era $ Withdrawals [(rwdAccount1, reward1 <+> Coin 1)]
         ]
@@ -123,7 +122,7 @@ spec = do
         )
         [ if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
             then
-              injectFailure . ConwayIncompleteWithdrawals @era $ [(raCredential rwdAccount1, Mismatch zero reward1)]
+              injectFailure . ConwayIncompleteWithdrawals @era $ [(rwdAccount1, Mismatch zero reward1)]
             else injectFailure . WithdrawalsNotInRewardsCERTS @era $ Withdrawals [(rwdAccount1, zero)]
         ]
   where

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
@@ -10,7 +10,8 @@
 
 module Test.Cardano.Ledger.Conway.Imp.CertsSpec (spec) where
 
-import Cardano.Ledger.BaseTypes (EpochInterval (..))
+import Cardano.Ledger.Address (RewardAccount (..))
+import Cardano.Ledger.BaseTypes (EpochInterval (..), Mismatch (..))
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule)
 import Cardano.Ledger.Conway.Core
@@ -105,11 +106,12 @@ spec = do
                   , (rwdAccount2, reward2)
                   ]
         )
-        [ ( if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
-              then injectFailure . ConwayIncompleteWithdrawals @era
-              else injectFailure . WithdrawalsNotInRewardsCERTS @era
-          )
-            $ Withdrawals [(rwdAccount1, reward1 <+> Coin 1)]
+        [ if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
+            then
+              injectFailure $
+                ConwayIncompleteWithdrawals @era [(raCredential rwdAccount1, Mismatch (reward1 <+> Coin 1) reward1)]
+            else
+              injectFailure . WithdrawalsNotInRewardsCERTS @era $ Withdrawals [(rwdAccount1, reward1 <+> Coin 1)]
         ]
 
       submitFailingTx
@@ -119,11 +121,10 @@ spec = do
                 .~ Withdrawals
                   [(rwdAccount1, zero)]
         )
-        [ ( if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
-              then injectFailure . ConwayIncompleteWithdrawals @era
-              else injectFailure . WithdrawalsNotInRewardsCERTS @era
-          )
-            $ Withdrawals [(rwdAccount1, zero)]
+        [ if hardforkConwayMoveWithdrawalsAndDRepChecksToLedgerRule pv
+            then
+              injectFailure . ConwayIncompleteWithdrawals @era $ [(raCredential rwdAccount1, Mismatch zero reward1)]
+            else injectFailure . WithdrawalsNotInRewardsCERTS @era $ Withdrawals [(rwdAccount1, zero)]
         ]
   where
     setupRewardAccount = do

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Change the field type of `ShelleyIncompleteWithdrawals` to `Map RewardAccount (Mismatch RelEQ Coin)`
 * Add `cddl` sub-library.
 * Replace `StakePoolState` values in `psFutureStakePoolParams` with `StakePoolParams`
 * Remove `psFutureStakePoolsL`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -34,6 +34,7 @@ module Cardano.Ledger.Shelley.Rules.Ledger (
   testIncompleteAndMissingWithdrawals,
 ) where
 
+import Cardano.Ledger.Address (RewardAccount)
 import Cardano.Ledger.BaseTypes (Mismatch, Relation (..), ShelleyBase, TxIx, invalidKey, networkId)
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -43,7 +44,6 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
 import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Shelley.AdaPots (consumedTxBody, producedTxBody)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra, ShelleyLEDGER)
@@ -131,7 +131,7 @@ data ShelleyLedgerPredFailure era
   = UtxowFailure (PredicateFailure (EraRule "UTXOW" era)) -- Subtransition Failures
   | DelegsFailure (PredicateFailure (EraRule "DELEGS" era)) -- Subtransition Failures
   | ShelleyWithdrawalsMissingAccounts Withdrawals
-  | ShelleyIncompleteWithdrawals (Map (Credential Staking) (Mismatch RelEQ Coin))
+  | ShelleyIncompleteWithdrawals (Map RewardAccount (Mismatch RelEQ Coin))
   deriving (Generic)
 
 ledgerSlotNoL :: Lens' (LedgerEnv era) SlotNo

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -34,7 +34,7 @@ module Cardano.Ledger.Shelley.Rules.Ledger (
   testIncompleteAndMissingWithdrawals,
 ) where
 
-import Cardano.Ledger.BaseTypes (ShelleyBase, TxIx, invalidKey, networkId)
+import Cardano.Ledger.BaseTypes (Mismatch, Relation (..), ShelleyBase, TxIx, invalidKey, networkId)
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
@@ -42,6 +42,8 @@ import Cardano.Ledger.Binary (
   encodeListLen,
  )
 import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
+import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Shelley.AdaPots (consumedTxBody, producedTxBody)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra, ShelleyLEDGER)
@@ -89,6 +91,7 @@ import Control.State.Transition (
   liftSTS,
   trans,
  )
+import Data.Map.Strict (Map)
 import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Word (Word8)
@@ -128,7 +131,7 @@ data ShelleyLedgerPredFailure era
   = UtxowFailure (PredicateFailure (EraRule "UTXOW" era)) -- Subtransition Failures
   | DelegsFailure (PredicateFailure (EraRule "DELEGS" era)) -- Subtransition Failures
   | ShelleyWithdrawalsMissingAccounts Withdrawals
-  | ShelleyIncompleteWithdrawals Withdrawals
+  | ShelleyIncompleteWithdrawals (Map (Credential Staking) (Mismatch RelEQ Coin))
   deriving (Generic)
 
 ledgerSlotNoL :: Lens' (LedgerEnv era) SlotNo
@@ -359,7 +362,7 @@ testIncompleteAndMissingWithdrawals accounts withdrawals = do
           Nothing -> (Nothing, Nothing)
           Just (missing, incomplete) ->
             ( if null (unWithdrawals missing) then Nothing else Just missing
-            , if null (unWithdrawals incomplete) then Nothing else Just incomplete
+            , if null incomplete then Nothing else Just incomplete
             )
   failOnJust missingWithdrawals $ injectFailure . ShelleyWithdrawalsMissingAccounts
   failOnJust incompleteWithdrawals $ injectFailure . ShelleyIncompleteWithdrawals

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -561,7 +561,7 @@ testWithdrawalWrongAmt =
       tx = MkShelleyTx $ ShelleyTx @ShelleyEra txb txwits SNothing
       errs =
         [ ShelleyIncompleteWithdrawals
-            [(raCredential rAccount, Mismatch (Coin 11) (Coin 10))]
+            [(rAccount, Mismatch (Coin 11) (Coin 10))]
         ]
    in testLEDGER (LedgerState utxoState dpState') tx ledgerEnv (Left errs)
 

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -44,7 +44,7 @@ import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert (..))
 import Cardano.Ledger.Shelley.TxOut (ShelleyTxOut (..))
 import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits, addrWits)
 import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Ledger.Val ((<+>), (<->))
+import Cardano.Ledger.Val (Val (..), (<+>), (<->))
 import Cardano.Protocol.Crypto (StandardCrypto, VRF, hashVerKeyVRF)
 import Cardano.Protocol.TPraos.BHeader (checkLeaderValue)
 import Control.DeepSeq (rnf)
@@ -559,7 +559,10 @@ testWithdrawalWrongAmt =
       rAccount = mkVKeyRewardAccount Testnet bobStake
       dpState' = addReward dpState (raCredential rAccount) (Coin 10)
       tx = MkShelleyTx $ ShelleyTx @ShelleyEra txb txwits SNothing
-      errs = [ShelleyIncompleteWithdrawals $ Withdrawals $ Map.singleton rAccount $ Coin 11]
+      errs =
+        [ ShelleyIncompleteWithdrawals
+            [(raCredential rAccount, Mismatch (Coin 11) (Coin 10))]
+        ]
    in testLEDGER (LedgerState utxoState dpState') tx ledgerEnv (Left errs)
 
 testOutputTooSmall :: Assertion

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Change the return type of `withdrawalsThatDoNotDrainAccounts` to `Maybe (Withdrawals, Map RewardAccount (Mismatch RelEQ Coin))`
 * Deprecate `StakeCredential` and `PaymentCredential` type synonyms
 * Add `positiveUnitIntervalRelaxToUnitInterval`, `positiveUnitIntervalRelaxToPositiveInterval` and  `positiveIntervalRelaxToNonNegativeInterval`
 * Changed the type of the following functions by adding `Network` argument:

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
@@ -201,7 +201,7 @@ withdrawalsThatDoNotDrainAccounts ::
   -- the wrong network.
   -- incomplete withdrawal = that which does not withdraw the exact account
   -- balance.
-  Maybe (Withdrawals, Map (Credential Staking) (Mismatch RelEQ Coin))
+  Maybe (Withdrawals, Map RewardAccount (Mismatch RelEQ Coin))
 withdrawalsThatDoNotDrainAccounts (Withdrawals withdrawals) networkId accounts
   -- @withdrawals@ is small and @accounts@ big, better to traverse the former than the latter.
   | Map.foldrWithKey checkBadWithdrawals True withdrawals = Nothing
@@ -212,14 +212,14 @@ withdrawalsThatDoNotDrainAccounts (Withdrawals withdrawals) networkId accounts
   where
     checkBadWithdrawals rewardAccount withdrawalAmount noBadWithdrawals =
       noBadWithdrawals && isGoodWithdrawal rewardAccount withdrawalAmount
-    collectBadWithdrawals rewardAccount@(RewardAccount _ cred) withdrawalAmount accum@(!_, !_) =
+    collectBadWithdrawals rewardAccount withdrawalAmount accum@(!_, !_) =
       case lookupAccount rewardAccount of
         Nothing -> first (Map.insert rewardAccount withdrawalAmount) accum
         Just account
           | isBalanceZero withdrawalAmount account -> accum
           | otherwise ->
               second
-                (Map.insert cred $ Mismatch withdrawalAmount (fromCompact $ account ^. balanceAccountStateL))
+                (Map.insert rewardAccount $ Mismatch withdrawalAmount (fromCompact $ account ^. balanceAccountStateL))
                 accum
     isGoodWithdrawal rewardAccount withdrawalAmount =
       maybe False (isBalanceZero withdrawalAmount) (lookupAccount rewardAccount)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
@@ -29,7 +29,7 @@ module Cardano.Ledger.State.Account (
 ) where
 
 import Cardano.Ledger.Address (RewardAccount (..), Withdrawals (..))
-import Cardano.Ledger.BaseTypes (Network)
+import Cardano.Ledger.BaseTypes (Mismatch (..), Network, Relation (..))
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
@@ -201,23 +201,26 @@ withdrawalsThatDoNotDrainAccounts ::
   -- the wrong network.
   -- incomplete withdrawal = that which does not withdraw the exact account
   -- balance.
-  Maybe (Withdrawals, Withdrawals)
+  Maybe (Withdrawals, Map (Credential Staking) (Mismatch RelEQ Coin))
 withdrawalsThatDoNotDrainAccounts (Withdrawals withdrawals) networkId accounts
   -- @withdrawals@ is small and @accounts@ big, better to traverse the former than the latter.
   | Map.foldrWithKey checkBadWithdrawals True withdrawals = Nothing
   | otherwise =
       Just $
-        bimap Withdrawals Withdrawals $
+        first Withdrawals $
           Map.foldrWithKey collectBadWithdrawals (Map.empty, Map.empty) withdrawals
   where
     checkBadWithdrawals rewardAccount withdrawalAmount noBadWithdrawals =
       noBadWithdrawals && isGoodWithdrawal rewardAccount withdrawalAmount
-    collectBadWithdrawals rewardAccount withdrawalAmount accum@(!_, !_) =
+    collectBadWithdrawals rewardAccount@(RewardAccount _ cred) withdrawalAmount accum@(!_, !_) =
       case lookupAccount rewardAccount of
         Nothing -> first (Map.insert rewardAccount withdrawalAmount) accum
         Just account
           | isBalanceZero withdrawalAmount account -> accum
-          | otherwise -> second (Map.insert rewardAccount withdrawalAmount) accum
+          | otherwise ->
+              second
+                (Map.insert cred $ Mismatch withdrawalAmount (fromCompact $ account ^. balanceAccountStateL))
+                accum
     isGoodWithdrawal rewardAccount withdrawalAmount =
       maybe False (isBalanceZero withdrawalAmount) (lookupAccount rewardAccount)
     isBalanceZero withdrawalAmount accountState =


### PR DESCRIPTION
# Description

This PR modifies `ShelleyIncompleteWithdrawals` and `ConwayIncompleteWithdrawals` predicate failures so that they also show the expected withdrawal amount.

close https://github.com/IntersectMBO/cardano-ledger/issues/5452

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
