### PR TITLE
Added Dijkstra `UTXO` rule and collateral `Ptr` check

### DIFF
--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `babbageUtxoTests`
 * Changed the type of the following fields to `CompactForm Coin` in `BabbagePParams`:
   - `bppMinFeeA`
   - `bppMinFeeB`

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `babbageUtxoValidation`
 * Add `babbageUtxoTests`
 * Changed the type of the following fields to `CompactForm Coin` in `BabbagePParams`:
   - `bppMinFeeA`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -19,7 +19,7 @@
 module Cardano.Ledger.Babbage.Rules.Utxo (
   BabbageUTXO,
   BabbageUtxoPredFailure (..),
-  babbageUtxoTests,
+  babbageUtxoValidation,
   utxoTransition,
   feesOK,
   validateTotalCollateral,
@@ -347,7 +347,7 @@ validateOutputTooSmallUTxO pp outs =
         )
         outs'
 
-babbageUtxoTests ::
+babbageUtxoValidation ::
   forall era.
   ( EraUTxO era
   , BabbageEraTxBody era
@@ -361,11 +361,10 @@ babbageUtxoTests ::
   , Signal (EraRule "UTXO" era) ~ Tx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
   , STS (EraRule "UTXO" era)
-  , -- In this function we we call the UTXOS rule, so we need some assumptions
-    EraCertState era
+  , EraCertState era
   ) =>
   TransitionRule (EraRule "UTXO" era)
-babbageUtxoTests = do
+babbageUtxoValidation = do
   TRC (Shelley.UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
   let utxo = utxosUtxo utxos
 
@@ -452,7 +451,7 @@ utxoTransition ::
   , Signal (EraRule "UTXO" era) ~ Tx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
   , STS (EraRule "UTXO" era)
-  , -- In this function we we call the UTXOS rule, so we need some assumptions
+  , -- In this function we call the UTXOS rule, so we need some assumptions
     Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
   , Environment (EraRule "UTXOS" era) ~ UtxoEnv era
   , State (EraRule "UTXOS" era) ~ UTxOState era
@@ -461,7 +460,7 @@ utxoTransition ::
   ) =>
   TransitionRule (EraRule "UTXO" era)
 utxoTransition = do
-  _ <- babbageUtxoTests
+  _ <- babbageUtxoValidation
   trans @(EraRule "UTXOS" era) =<< coerce <$> judgmentContext
 
 --------------------------------------------------------------------------------

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -81,6 +81,8 @@ import Control.Monad (unless, when)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended (
   Embed (..),
+  Rule,
+  RuleType (..),
   STS (..),
   TRC (..),
   TransitionRule,
@@ -363,7 +365,7 @@ babbageUtxoValidation ::
   , STS (EraRule "UTXO" era)
   , EraCertState era
   ) =>
-  TransitionRule (EraRule "UTXO" era)
+  Rule (EraRule "UTXO" era) 'Transition ()
 babbageUtxoValidation = do
   TRC (Shelley.UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
   let utxo = utxosUtxo utxos
@@ -434,7 +436,6 @@ babbageUtxoValidation = do
 
   {-   ‖collateral tx‖  ≤  maxCollInputs pp   -}
   runTest $ Alonzo.validateTooManyCollateralInputs pp txBody
-  pure utxos
 
 -- | The UTxO transition rule for the Babbage eras.
 utxoTransition ::
@@ -460,7 +461,7 @@ utxoTransition ::
   ) =>
   TransitionRule (EraRule "UTXO" era)
 utxoTransition = do
-  _ <- babbageUtxoValidation
+  babbageUtxoValidation
   trans @(EraRule "UTXOS" era) =<< coerce <$> judgmentContext
 
 --------------------------------------------------------------------------------

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxosSpec.hs
@@ -136,7 +136,7 @@ spec = describe "UTXOS" $ do
         mkBasicTx $
           mkBasicTxBody & outputsTxBodyL .~ [txOut]
     let txIn = txInAt 0 tx
-    addr <- freshKeyAddr_
+    addr <- freshKeyAddrNoPtr_
     coll <- sendCoinTo addr $ Coin 5_000_000
     let
       collReturn = mkBasicTxOut addr . inject $ Coin 2_000_000

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
@@ -121,8 +121,12 @@ spec = describe "Invalid" $ do
                 mkBasicTxOut (mkAddr scriptHash StakeRefNull) mempty
                   & datumTxOutL .~ DatumHash datumHash
               tx = mkBasicTx $ mkBasicTxBody & outputsTxBodyL .~ [txOut]
+          ProtVer pv _ <- getProtVer
           txIn <- txInAt 0 <$> submitTx tx
-          addr <- freshKeyAddr_
+          addr <-
+            if pv < natVersion @12
+              then freshKeyAddr_
+              else freshKeyAddrNoPtr_
           coll <- sendCoinTo addr $ Coin 5_000_000
           let collReturn = mkBasicTxOut addr . inject $ Coin 2_000_000
           submitPhase2Invalid_ $

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Re-export `UtxoEnv` from `Cardano.Ledger.Conway.Rules.Utxo`
 * Changed the type of the following fields to `CompactForm Coin` in `ConwayPParams`:
   - `cppMinFeeA`
   - `cppMinFeeB`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -20,6 +20,7 @@ module Cardano.Ledger.Conway.Rules.Utxo (
   babbageToConwayUtxoPredFailure,
   alonzoToConwayUtxoPredFailure,
   ConwayUtxoPredFailure (..),
+  UtxoEnv (..),
 ) where
 
 import Cardano.Ledger.Address (Addr, RewardAccount)
@@ -66,7 +67,7 @@ import Cardano.Ledger.Conway.Rules.Utxos (
  )
 import Cardano.Ledger.Plutus (ExUnits)
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley (UTxOState)
-import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure)
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, UtxoEnv (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley (UtxoEnv, validSizeComputationCheck)
 import Cardano.Ledger.State (EraCertState (..), EraUTxO, UTxO (..))
 import Cardano.Ledger.TxIn (TxIn)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -236,8 +236,12 @@ spec = do
     let scriptSize = originalBytesSize script
 
     -- prepare a txout with the succeeding script as reference script
+    ProtVer pv _ <- getProtVer
     collRefScriptTxOut <- do
-      addr <- freshKeyAddr_
+      addr <-
+        if pv < natVersion @12
+          then freshKeyAddr_
+          else freshKeyAddrNoPtr_
       pure $ mkBasicTxOut addr mempty & referenceScriptTxOutL .~ pure (fromNativeScript script)
 
     (txs :: [Tx TopTx era]) <- simulateThenRestore $ do

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -48,7 +48,6 @@
 
 ### `testlib`
 
-* Add `Arbitrary` and `ToExpr` instances to `DijkstraUtxoPredFailure`
 * Remove CDDL `certificate` redefinition to reuse from conway.
 * Add CDDL exports for `plutus_v4_script`, `dijkstra_native_script`, `script_require_guard`
 * Remove CDDL `protocol_version` redefinition

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0.0
 
+* Add `Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec`
 * Add `DijkstraUtxoPredFailure`
 * Add `DijkstraUTXO`
 * Changed the type of the following fields to `CompactForm Coin` in `DijkstraPParams`:

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.0.0
 
+* Add `DijkstraUtxoPredFailure`
+* Add `DijkstraUTXO`
 * Changed the type of the following fields to `CompactForm Coin` in `DijkstraPParams`:
   - `dppMinFeeA`
   - `dppMinFeeB`
@@ -45,6 +47,7 @@
 
 ### `testlib`
 
+* Add `Arbitrary` and `ToExpr` instances to `DijkstraUtxoPredFailure`
 * Remove CDDL `certificate` redefinition to reuse from conway.
 * Add CDDL exports for `plutus_v4_script`, `dijkstra_native_script`, `script_require_guard`
 * Remove CDDL `protocol_version` redefinition

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -103,7 +103,6 @@ library
     plutus-ledger-api,
     small-steps >=1.1.2,
     text,
-    validation-selective,
 
   if flag(asserts)
     ghc-options: -fno-ignore-asserts

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -103,6 +103,7 @@ library
     plutus-ledger-api,
     small-steps >=1.1.2,
     text,
+    validation-selective,
 
   if flag(asserts)
     ghc-options: -fno-ignore-asserts

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -121,6 +121,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Era
     Test.Cardano.Ledger.Dijkstra.Examples
     Test.Cardano.Ledger.Dijkstra.Imp
+    Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec
     Test.Cardano.Ledger.Dijkstra.ImpTest
     Test.Cardano.Ledger.Dijkstra.TreeDiff

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -282,7 +282,7 @@ utxoTransition ::
   TransitionRule (EraRule "UTXO" era)
 utxoTransition = do
   TRC (_, _, tx) <- judgmentContext
-  _ <- babbageUtxoValidation
+  babbageUtxoValidation
 
   validateNoPtrInCollateralReturn $ tx ^. bodyTxL
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -11,9 +11,11 @@ module Test.Cardano.Ledger.Dijkstra.Imp where
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
+import Cardano.Ledger.Dijkstra.Rules (DijkstraUtxoPredFailure)
 import Cardano.Ledger.Shelley.Rules
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp as ConwayImp
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 
@@ -24,6 +26,7 @@ spec ::
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
   , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
+  , InjectRuleFailure "LEDGER" DijkstraUtxoPredFailure era
   ) =>
   Spec
 spec = do
@@ -32,9 +35,12 @@ spec = do
 
 dijkstraEraGenericSpec ::
   forall era.
-  DijkstraEraImp era =>
+  ( DijkstraEraImp era
+  , InjectRuleFailure "LEDGER" DijkstraUtxoPredFailure era
+  ) =>
   SpecWith (ImpInit (LedgerSpec era))
 dijkstraEraGenericSpec = do
   describe "UTXOW" Utxow.spec
+  describe "UTXO" Utxo.spec
 
 instance EraSpecificSpec DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec (spec) where
+
+import Cardano.Ledger.Address (Addr (..))
+import Cardano.Ledger.BaseTypes (Inject (..), Network (..), StrictMaybe (..))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Dijkstra.Core (
+  BabbageEraTxBody (..),
+  EraTx (..),
+  EraTxBody (..),
+  EraTxOut (..),
+  InjectRuleFailure (..),
+ )
+import Cardano.Ledger.Dijkstra.Rules (DijkstraUtxoPredFailure (..))
+import Cardano.Ledger.Tools (ensureMinCoinTxOut)
+import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Dijkstra.ImpTest (
+  DijkstraEraImp,
+  ImpInit,
+  LedgerSpec,
+  freshKeyHash,
+  getsPParams,
+  submitFailingTx,
+ )
+import Test.Cardano.Ledger.Imp.Common (SpecWith, arbitrary, describe, it)
+
+spec ::
+  forall era.
+  ( DijkstraEraImp era
+  , InjectRuleFailure "LEDGER" DijkstraUtxoPredFailure era
+  ) =>
+  SpecWith (ImpInit (LedgerSpec era))
+spec =
+  describe "Collaterals" $ do
+    it "Fails to submit a transaction containing a Ptr in collateral return" $ do
+      cred <- KeyHashObj <$> freshKeyHash
+      ptr <- arbitrary
+      pp <- getsPParams id
+      let
+        ptrAddr = Addr Testnet cred (StakeRefPtr ptr)
+        ptrOutput = ensureMinCoinTxOut pp $ mkBasicTxOut ptrAddr . inject $ Coin 100
+        tx =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . collateralReturnTxBodyL .~ SJust ptrOutput
+      submitFailingTx tx [injectFailure $ PtrPresentInCollateral ptrOutput]

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -47,4 +47,4 @@ spec =
         tx =
           mkBasicTx mkBasicTxBody
             & bodyTxL . collateralReturnTxBodyL .~ SJust ptrOutput
-      submitFailingTx tx [injectFailure $ PtrPresentInCollateral ptrOutput]
+      submitFailingTx tx [injectFailure $ PtrPresentInCollateralReturn ptrOutput]

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -49,7 +49,6 @@
 
 ### `testlib`
 
-* Change the monad in `freshKeyAddr` and `freshKeyAddr_` to `ImpTestM era`
 * Renamed `impLastTick` to `impCurSlotNo` and `impLastTickG` to `impCurSlotNoG`
 * Add CDDL certificate definitions: `account_registration_cert`, `account_unregistration_cert`, `delegation_to_stake_pool_cert`
 * Add CDDL pool certificate definitions via `mkPoolRules`: `pool_registration_cert`, `pool_retirement_cert`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -49,6 +49,7 @@
 
 ### `testlib`
 
+* Change the monad in `freshKeyAddr` and `freshKeyAddr_` to `ImpTestM era`
 * Renamed `impLastTick` to `impCurSlotNo` and `impLastTickG` to `impCurSlotNoG`
 * Add CDDL certificate definitions: `account_registration_cert`, `account_unregistration_cert`, `delegation_to_stake_pool_cert`
 * Add CDDL pool certificate definitions via `mkPoolRules`: `pool_registration_cert`, `pool_retirement_cert`

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1492,23 +1492,20 @@ freshKeyPair = do
 
 -- | Generate a random `Addr` that uses a `KeyHash`, and add the corresponding `KeyPair`
 -- to the known keys in the Imp state.
-freshKeyAddr_ :: EraGov era => ImpTestM era Addr
+freshKeyAddr_ ::
+  (HasKeyPairs s, MonadState s m, HasStatefulGen g m, MonadGen m) => m Addr
 freshKeyAddr_ = snd <$> freshKeyAddr
 
 -- | Generate a random `Addr` that uses a `KeyHash`, add the corresponding `KeyPair`
 -- to the known keys in the Imp state, and return the `KeyHash` as well as the `Addr`.
-freshKeyAddr :: EraGov era => ImpTestM era (KeyHash Payment, Addr)
+freshKeyAddr ::
+  (HasKeyPairs s, MonadState s m, HasStatefulGen g m, MonadGen m) =>
+  m (KeyHash Payment, Addr)
 freshKeyAddr = do
-  ProtVer pv _ <- getProtVer
   paymentKeyHash <- freshKeyHash @Payment
   stakingKeyHash <-
-    oneof $
-      [ Just . mkStakeRef <$> freshKeyHash @Staking
-      , pure Nothing
-      ]
-        <> [ Just . mkStakeRef @Ptr <$> arbitrary
-           | pv < natVersion @12
-           ]
+    oneof
+      [Just . mkStakeRef <$> freshKeyHash @Staking, Just . mkStakeRef @Ptr <$> arbitrary, pure Nothing]
   pure (paymentKeyHash, mkAddr paymentKeyHash stakingKeyHash)
 
 -- | Looks up the keypair corresponding to the `BootstrapAddress`. The `BootstrapAddress`

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1492,20 +1492,23 @@ freshKeyPair = do
 
 -- | Generate a random `Addr` that uses a `KeyHash`, and add the corresponding `KeyPair`
 -- to the known keys in the Imp state.
-freshKeyAddr_ ::
-  (HasKeyPairs s, MonadState s m, HasStatefulGen g m, MonadGen m) => m Addr
+freshKeyAddr_ :: EraGov era => ImpTestM era Addr
 freshKeyAddr_ = snd <$> freshKeyAddr
 
 -- | Generate a random `Addr` that uses a `KeyHash`, add the corresponding `KeyPair`
 -- to the known keys in the Imp state, and return the `KeyHash` as well as the `Addr`.
-freshKeyAddr ::
-  (HasKeyPairs s, MonadState s m, HasStatefulGen g m, MonadGen m) =>
-  m (KeyHash Payment, Addr)
+freshKeyAddr :: EraGov era => ImpTestM era (KeyHash Payment, Addr)
 freshKeyAddr = do
+  ProtVer pv _ <- getProtVer
   paymentKeyHash <- freshKeyHash @Payment
   stakingKeyHash <-
-    oneof
-      [Just . mkStakeRef <$> freshKeyHash @Staking, Just . mkStakeRef @Ptr <$> arbitrary, pure Nothing]
+    oneof $
+      [ Just . mkStakeRef <$> freshKeyHash @Staking
+      , pure Nothing
+      ]
+        <> [ Just . mkStakeRef @Ptr <$> arbitrary
+           | pv < natVersion @12
+           ]
   pure (paymentKeyHash, mkAddr paymentKeyHash stakingKeyHash)
 
 -- | Looks up the keypair corresponding to the `BootstrapAddress`. The `BootstrapAddress`

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.Shelley.Rules (UtxoEnv (..), ledgerSlotNoL)
+import Cardano.Ledger.Shelley.Rules (ledgerSlotNoL)
 import Cardano.Ledger.TxIn (TxId)
 import Control.State.Transition
 import Data.Bifunctor (Bifunctor (..))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Rules/ValidationMode.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Rules.ValidationMode (
   Test,
   runTest,
   runTestOnSignal,
+  failOnJustStatic,
 ) where
 
 import Cardano.Ledger.BaseTypes (Inject (..))
@@ -86,3 +87,7 @@ runTest = validateTrans injectFailure
 
 runTestOnSignal :: InjectRuleFailure rule f era => Test (f era) -> Rule (EraRule rule era) ctx ()
 runTestOnSignal = validateTransLabeled injectFailure $ lblStatic NE.:| []
+
+failOnJustStatic :: Maybe a -> (a -> PredicateFailure sts) -> Rule sts ctx ()
+failOnJustStatic cond onJust =
+  validateTransLabeled id (lblStatic NE.:| []) $ failureOnJust cond onJust


### PR DESCRIPTION
# Description

This PR adds `DijkstraUTXO` together with a test that prevents using collateral return with a `Ptr`.

close https://github.com/IntersectMBO/cardano-ledger/issues/5454

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
