### PR TITLE
PlutusV3: Renamed fromGHC to fromHaskellRatio

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,7 +28,7 @@ source-repository-package
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
 index-state:
   , hackage.haskell.org 2025-09-30T00:00:00Z
-  , cardano-haskell-packages 2025-12-01T07:41:27Z
+  , cardano-haskell-packages 2025-12-10T11:48:32Z
 
 packages:
   -- == Byron era ==

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1764582977,
-        "narHash": "sha256-PeIEFK8P22ZsEst7wIow9cJqDaDpeM8BtNIV9isZJaU=",
+        "lastModified": 1765454725,
+        "narHash": "sha256-dtq0m4AmoQ5MLcMufMSJoNR2UFYylY02sjWdHLakBe0=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "80fdfffd6f59dda5025310b7b8e261fc5df202eb",
+        "rev": "68f4a94fbe8dfc0818503cf686fad0f92f71919b",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -130,7 +130,7 @@ library
     nothunks >=0.1.5 && <0.4,
     partial-order,
     plutus-core,
-    plutus-ledger-api,
+    plutus-ledger-api >= 1.56,
     prettyprinter,
     primitive,
     quiet,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/TxInfo.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/TxInfo.hs
@@ -116,7 +116,7 @@ txOutSourceToText = \case
   TxOutFromOutput txIx -> "Output: " <> T.pack (show txIx)
 
 transBoundedRational :: BoundedRational r => r -> PV3.Rational
-transBoundedRational = PV3.fromGHC . unboundRational
+transBoundedRational = PV3.fromHaskellRatio . unboundRational
 
 transDataHash :: DataHash -> PV1.DatumHash
 transDataHash safe = PV1.DatumHash (transSafeHash safe)


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
