### PR TITLE
Change all List to NonEmpty in predicate failures

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Change all lists into `NonEmpty` for `AllegraUtxoPredFailure`
 * Add `cddl` sub-library, and `generate-cddl` executable.
 * Remove deprecated type `Allegra`
 * Remove deprecated type `TimelockConstr`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.15.0.0
 
+* Change all lists into `NonEmpty` for `AlonzoUtxoPredFailure`, `AlonzoUtxosPredFailure`, `AlonzoUtxowPredFailure`
+* Change `collectPlutusScriptsWithContext` to return a `NonEmpty` list of failures
 * Changed the type of `dappMinUTxOValue` to `CompactForm Coin` in `DowngradeAlonzoPParams`
 * Changed the type of the following fields to `CompactForm Coin` in `AlonzoPParams`:
   - `appMinFeeA`

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec/Invalid.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Plutus (
  )
 import Cardano.Ledger.Shelley.LedgerState (epochStateStakePoolsL, nesEsL)
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map.Strict as Map
 import Data.Maybe (isJust)
 import Data.Sequence.Strict (StrictSeq ((:<|)))
@@ -214,7 +215,7 @@ spec = describe "Invalid transactions" $ do
                 txFixed <- fixupTx tx
                 -- The `Ix` of the redeemer may have been changed by `fixupRedeemerIndices`
                 let fixedRedeemers = txFixed ^. witsTxL . rdmrsTxWitsL . unRedeemersL
-                    extraRedeemers = Map.keys $ Map.filter (== redeemer) fixedRedeemers
+                    extraRedeemers = NonEmpty.fromList $ Map.keys $ Map.filter (== redeemer) fixedRedeemers
                 withNoFixup $
                   submitFailingTx
                     txFixed

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -93,6 +93,7 @@ import Cardano.Ledger.Shelley.LedgerState (
 import Cardano.Ledger.Shelley.UTxO (EraUTxO (..), ScriptsProvided (..), UTxO (..), txouts)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.Monad (forM)
+import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.MapExtras (fromElems)
@@ -473,7 +474,8 @@ impPlutusWithContexts tx = do
   utxo <- getUTxO
   case collectPlutusScriptsWithContext (epochInfo globals) (systemStart globals) pp tx utxo of
     Left errs ->
-      assertFailure $ "Did not expect to get context translation failures: " ++ unlines (map show errs)
+      assertFailure $
+        "Did not expect to get context translation failures: " ++ unlines (map show $ NonEmpty.toList errs)
     Right pwcs -> pure pwcs
 
 impScriptPredicateFailure ::

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Change all lists into `NonEmpty` for `BabbageUtxoPredFailure`
 * Add `babbageUtxoValidation`
 * Add `babbageUtxoTests`
 * Changed the type of the following fields to `CompactForm Coin` in `BabbagePParams`:

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -120,7 +120,7 @@ data BabbageUtxoPredFailure era
   | -- | list of supplied transaction outputs that are too small,
     -- together with the minimum value for the given output.
     BabbageOutputTooSmallUTxO
-      [(TxOut era, Coin)]
+      (NonEmpty (TxOut era, Coin))
   | -- | TxIns that appear in both inputs and reference inputs
     BabbageNonDisjointRefInputs
       (NonEmpty TxIn)
@@ -333,7 +333,7 @@ validateOutputTooSmallUTxO ::
   f (Sized (TxOut era)) ->
   Test (BabbageUtxoPredFailure era)
 validateOutputTooSmallUTxO pp outs =
-  failureUnless (null outputsTooSmall) $ BabbageOutputTooSmallUTxO outputsTooSmall
+  failureOnNonEmpty outputsTooSmall BabbageOutputTooSmallUTxO
   where
     outs' = map (\out -> (sizedValue out, getMinCoinSizedTxOut pp out)) (toList outs)
     outputsTooSmall =

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Change all lists into `NonEmpty` for `ConwayUtxoPredFailure`, `ConwayUtxosPredFailure`, `ConwayUtxowPredFailure`
 * Add `cddl` sub-library, and `generate-cddl` executable.
 * Re-export `UtxoEnv` from `Cardano.Ledger.Conway.Rules.Utxo`
 * Changed the type of the following fields to `CompactForm Coin` in `ConwayPParams`:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -113,13 +113,13 @@ data ConwayUtxoPredFailure era
       (Set RewardAccount)
   | -- | list of supplied transaction outputs that are too small
     OutputTooSmallUTxO
-      [TxOut era]
+      (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction outputs
     OutputBootAddrAttrsTooBig
-      [TxOut era]
+      (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
     OutputTooBigUTxO
-      [(Int, Int, TxOut era)]
+      (NonEmpty (Int, Int, TxOut era))
   | InsufficientCollateral
       -- | balance computed
       DeltaCoin
@@ -151,7 +151,7 @@ data ConwayUtxoPredFailure era
   | -- | list of supplied transaction outputs that are too small,
     -- together with the minimum value for the given output.
     BabbageOutputTooSmallUTxO
-      [(TxOut era, Coin)]
+      (NonEmpty (TxOut era, Coin))
   | -- | TxIns that appear in both inputs and reference inputs
     BabbageNonDisjointRefInputs
       (NonEmpty TxIn)
@@ -395,7 +395,7 @@ allegraToConwayUtxoPredFailure = \case
   Allegra.OutputTooSmallUTxO x -> OutputTooSmallUTxO x
   Allegra.UpdateFailure x -> absurdEraRule @"PPUP" @era x
   Allegra.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs
-  Allegra.OutputTooBigUTxO xs -> OutputTooBigUTxO (map (0,0,) xs)
+  Allegra.OutputTooBigUTxO xs -> OutputTooBigUTxO (fmap (0,0,) xs)
 
 instance InjectRuleFailure "UTXO" ConwayUtxosPredFailure ConwayEra where
   injectFailure = UtxosFailure

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -81,7 +81,7 @@ data ConwayUtxosPredFailure era
     -- consequences of not detecting this means scripts get dropped, so things
     -- might validate that shouldn't. So we double check in the function
     -- collectTwoPhaseScriptInputs, it should find data for every Script.
-    CollectErrors [CollectError era]
+    CollectErrors (NonEmpty (CollectError era))
   deriving
     (Generic)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -65,6 +65,7 @@ import Control.State.Transition.Extended (
   Embed (..),
   STS (..),
  )
+import Data.List.NonEmpty (NonEmpty)
 import Data.Set (Set)
 import GHC.Generics (Generic)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
@@ -74,8 +75,7 @@ import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 -- | Predicate failure type for the Conway Era
 data ConwayUtxowPredFailure era
   = UtxoFailure (PredicateFailure (EraRule "UTXO" era))
-  | InvalidWitnessesUTXOW
-      [VKey Witness]
+  | InvalidWitnessesUTXOW (NonEmpty (VKey Witness))
   | -- | witnesses which failed in verifiedWits function
     MissingVKeyWitnessesUTXOW
       -- | witnesses which were needed and not supplied
@@ -99,8 +99,7 @@ data ConwayUtxowPredFailure era
   | -- | extraneous scripts
     ExtraneousScriptWitnessesUTXOW
       (Set ScriptHash)
-  | MissingRedeemers
-      [(PlutusPurpose AsItem era, ScriptHash)]
+  | MissingRedeemers (NonEmpty (PlutusPurpose AsItem era, ScriptHash))
   | MissingRequiredDatums
       -- TODO: Make this NonEmpty #4066
 
@@ -122,7 +121,7 @@ data ConwayUtxowPredFailure era
       -- TODO: Make this NonEmpty #4066
       (Set TxIn)
   | -- | List of redeemers not needed
-    ExtraRedeemers [PlutusPurpose AsIx era]
+    ExtraRedeemers (NonEmpty (PlutusPurpose AsIx era))
   | -- | Embed UTXO rule failures
     MalformedScriptWitnesses
       (Set ScriptHash)

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0.0
 
+* Change all lists into `NonEmpty` for `DijkstraUtxoPredFailure`, `DijkstraUtxowPredFailure`
 * Add `cddl` sub-library, and `generate-cddl` executable.
 * Add `bhviewPrevEpochNonce` to `BHeaderView`
 * Change `makeHeaderView` to expect an additional `Maybe Nonce`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -136,11 +136,11 @@ data DijkstraUtxoPredFailure era
       -- | the set of reward addresses with incorrect network IDs
       (Set RewardAccount)
   | -- | list of supplied transaction outputs that are too small
-    OutputTooSmallUTxO [TxOut era]
+    OutputTooSmallUTxO (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction outputs
-    OutputBootAddrAttrsTooBig [TxOut era]
+    OutputBootAddrAttrsTooBig (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
-    OutputTooBigUTxO [(Int, Int, TxOut era)]
+    OutputTooBigUTxO (NonEmpty (Int, Int, TxOut era))
   | InsufficientCollateral
       -- | balance computed
       DeltaCoin
@@ -169,7 +169,7 @@ data DijkstraUtxoPredFailure era
       Coin
   | -- | list of supplied transaction outputs that are too small,
     -- together with the minimum value for the given output.
-    BabbageOutputTooSmallUTxO [(TxOut era, Coin)]
+    BabbageOutputTooSmallUTxO (NonEmpty (TxOut era, Coin))
   | -- | TxIns that appear in both inputs and reference inputs
     BabbageNonDisjointRefInputs (NonEmpty TxIn)
   | PtrPresentInCollateralReturn (TxOut era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -82,6 +82,7 @@ import Control.State.Transition.Extended (
   Embed (..),
   STS (..),
  )
+import Data.List.NonEmpty (NonEmpty)
 import Data.Set (Set)
 import GHC.Generics (Generic)
 import NoThunks.Class (
@@ -94,7 +95,7 @@ import NoThunks.Class (
 -- | Predicate failure type for the Conway Era
 data DijkstraUtxowPredFailure era
   = UtxoFailure (PredicateFailure (EraRule "UTXO" era))
-  | InvalidWitnessesUTXOW [VKey Witness]
+  | InvalidWitnessesUTXOW (NonEmpty (VKey Witness))
   | -- | witnesses which failed in verifiedWits function
     MissingVKeyWitnessesUTXOW
       -- | witnesses which were needed and not supplied
@@ -112,7 +113,7 @@ data DijkstraUtxowPredFailure era
     InvalidMetadata
   | -- | extraneous scripts
     ExtraneousScriptWitnessesUTXOW (Set ScriptHash)
-  | MissingRedeemers [(PlutusPurpose AsItem era, ScriptHash)]
+  | MissingRedeemers (NonEmpty (PlutusPurpose AsItem era, ScriptHash))
   | MissingRequiredDatums
       -- TODO: Make this NonEmpty #4066
 
@@ -134,7 +135,7 @@ data DijkstraUtxowPredFailure era
       -- TODO: Make this NonEmpty #4066
       (Set TxIn)
   | -- | List of redeemers not needed
-    ExtraRedeemers [PlutusPurpose AsIx era]
+    ExtraRedeemers (NonEmpty (PlutusPurpose AsIx era))
   | -- | Embed UTXO rule failures
     MalformedScriptWitnesses (Set ScriptHash)
   | -- | the set of malformed script witnesses

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -122,7 +122,7 @@ policyFailure p =
 outTooBigFailure ::
   ShelleyTxOut MaryEra -> Either (NonEmpty (PredicateFailure (ShelleyLEDGER MaryEra))) (UTxO MaryEra)
 outTooBigFailure out =
-  Left . pure . UtxowFailure . UtxoFailure $ OutputTooBigUTxO [out]
+  Left . pure . UtxowFailure . UtxoFailure $ OutputTooBigUTxO $ pure out
 
 ----------------------------------------------------
 -- Introduce a new Token Bundle, Purple Tokens

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Change all lists into `NonEmpty` for `ShelleyUtxoPredFailure`, `ShelleyUtxowPredFailure`
 * Changed the type of the following fields to `CompactForm Coin` in `ShelleyPParams`:
   - `sppMinFeeA`
   - `sppMinFeeB`

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -53,6 +53,7 @@ import Cardano.Ledger.Val (inject)
 import Cardano.Slotting.EpochInfo (EpochInfo, fixedEpochInfo)
 import Cardano.Slotting.Slot (EpochSize (..))
 import Cardano.Slotting.Time (SystemStart (..), mkSlotLength)
+import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Lens.Micro
@@ -175,7 +176,7 @@ collectInputs ::
   PParams era ->
   Tx TopTx era ->
   UTxO era ->
-  Either [CollectError era] [PlutusWithContext]
+  Either (NonEmpty (CollectError era)) [PlutusWithContext]
 collectInputs = collectPlutusScriptsWithContext
 
 testEpochInfo :: EpochInfo (Either Text)

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -79,7 +79,7 @@ main = do
       !globals = mkGlobals genesis
       !slotNo = SlotNo 55733343
       restrictError = \case
-        ApplyTxError (ConwayUtxowFailure (InvalidWitnessesUTXOW [_]) :| []) -> ()
+        ApplyTxError (ConwayUtxowFailure (InvalidWitnessesUTXOW _) :| []) -> ()
         otherErr -> error . show $ otherErr
       applyTx' mempoolEnv mempoolState =
         -- TODO: revert this to `either (error . show) seqTuple` after tx's are fixed


### PR DESCRIPTION
# Description

All Lists contained by predicate failures across all eras become `NonEmpty` for additional typesafety by preventing the possibility of reporting a failure with nothing in it.

Related ticket ~This is the first part of~ #5453
Resolves #4066 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
