### PR TITLE
Add Peras Certificate validation

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2.0.0
 
+* Change Dijkstra BBODY rule to validate Peras certificates when present
+* Add new block body predicate falures for Dijkstra:
+  - `PrevEpochNonceNotPresent` for missing optional nonce needed for validation
+  - `PerasCertValidationFailed` for certification validation failures
 * Change all lists into `NonEmpty` for `DijkstraUtxoPredFailure`, `DijkstraUtxowPredFailure`
 * Add `cddl` sub-library, and `generate-cddl` executable.
 * Add `bhviewPrevEpochNonce` to `BHeaderView`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.19.0.0
 
+* Add mocked-up `PerasKey` type
+* Add mocked-up `validatePerasCert` validation function
 * Changed name and type to `CompactForm Coin`:
   - `hkdMinFeeAL` -> `hkdMinFeeACompactL`
   - `hkdMinFeeBL` -> `hkdMinFeeBCompactL`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -93,6 +93,8 @@ module Cardano.Ledger.BaseTypes (
 
   -- * Peras-specific types
   PerasCert (..),
+  PerasKey (..),
+  validatePerasCert,
 ) where
 
 import Cardano.Crypto.Hash
@@ -1010,3 +1012,16 @@ instance DecCBOR PerasCert where
   decCBOR = do
     () <- decCBOR
     pure PerasCert
+
+-- | Placeholder for Peras public keys
+--
+-- NOTE: The real type will be brought from 'cardano-base' once it's ready.
+data PerasKey = PerasKey
+  deriving (Eq, Show, Generic, NoThunks)
+
+-- | Mocked-up Peras certificate validation routine
+--
+-- NOTE: this function will be replaced with the real implementation from
+-- 'cardano-base' once it's ready.
+validatePerasCert :: Nonce -> PerasKey -> PerasCert -> Bool
+validatePerasCert _ _ _ = True


### PR DESCRIPTION
# Description

This PR addresses #5438 by:

1. Defining a mocked-up `validatePerasCert` validation routine (along with an also mocked-up `PerasKey` data type), and
2. Enhancing the Dijkstra BBODY rule to validate Peras certificates using (1) when they appear in a block body.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
