### PR TITLE
Change all error Sets to NonEmptySets in predicate failures

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Change sets containing errors into `NonEmptySet` for `AllegraUtxoPredFailure`
 * Change all lists into `NonEmpty` for `AllegraUtxoPredFailure`
 * Add `cddl` sub-library, and `generate-cddl` executable.
 * Remove deprecated type `Allegra`

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -69,6 +69,7 @@ library
     aeson,
     base >=4.18 && <5,
     bytestring,
+    cardano-data,
     cardano-ledger-binary >=1.4,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.19,
     cardano-ledger-shelley ^>=1.18,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -60,7 +60,7 @@ import Data.Foldable (toList)
 import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
-import Data.Set (Set)
+import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
@@ -70,7 +70,7 @@ import Validation
 -- ==========================================================
 
 data AllegraUtxoPredFailure era
-  = BadInputsUTxO (Set TxIn) -- The bad transaction inputs
+  = BadInputsUTxO (NonEmptySet TxIn) -- The bad transaction inputs
   | OutsideValidityIntervalUTxO
       ValidityInterval -- transaction's validity interval
       SlotNo -- current slot
@@ -80,10 +80,10 @@ data AllegraUtxoPredFailure era
   | ValueNotConservedUTxO (Mismatch RelEQ (Value era)) -- Consumed, then produced
   | WrongNetwork
       Network -- the expected network id
-      (Set Addr) -- the set of addresses with incorrect network IDs
+      (NonEmptySet Addr) -- the set of addresses with incorrect network IDs
   | WrongNetworkWithdrawal
       Network -- the expected network id
-      (Set RewardAccount) -- the set of reward addresses with incorrect network IDs
+      (NonEmptySet RewardAccount) -- the set of reward addresses with incorrect network IDs
   | OutputTooSmallUTxO
       (NonEmpty (TxOut era)) -- list of supplied transaction outputs that are too small
   | UpdateFailure (EraRuleFailure "PPUP" era) -- Subtransition Failures

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.15.0.0
 
+* Change sets containing errors into `NonEmptySet` for `AlonzoUtxoPredFailure`, `AlonzoUtxowPredFailure`
 * Change all lists into `NonEmpty` for `AlonzoUtxoPredFailure`, `AlonzoUtxosPredFailure`, `AlonzoUtxowPredFailure`
 * Change `collectPlutusScriptsWithContext` to return a `NonEmpty` list of failures
 * Changed the type of `dappMinUTxOValue` to `CompactForm Coin` in `DowngradeAlonzoPParams`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -106,8 +106,8 @@ import Data.Either (isRight)
 import Data.Foldable as F (foldl', sequenceA_, toList)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
-import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
@@ -120,7 +120,7 @@ import Validation
 data AlonzoUtxoPredFailure era
   = -- | The bad transaction inputs
     BadInputsUTxO
-      (Set TxIn)
+      (NonEmptySet TxIn)
   | OutsideValidityIntervalUTxO
       -- | transaction's validity interval
       ValidityInterval
@@ -135,12 +135,12 @@ data AlonzoUtxoPredFailure era
       -- | the expected network id
       Network
       -- | the set of addresses with incorrect network IDs
-      (Set Addr)
+      (NonEmptySet Addr)
   | WrongNetworkWithdrawal
       -- | the expected network id
       Network
       -- | the set of reward addresses with incorrect network IDs
-      (Set RewardAccount)
+      (NonEmptySet RewardAccount)
   | -- | list of supplied transaction outputs that are too small
     OutputTooSmallUTxO
       (NonEmpty (TxOut era))

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Change sets containing errors into `NonEmptySet` for `BabbageUtxowPredFailure`
 * Change all lists into `NonEmpty` for `BabbageUtxoPredFailure`
 * Add `babbageUtxoValidation`
 * Add `babbageUtxoTests`

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -176,6 +176,7 @@ library testlib
     QuickCheck,
     base,
     bytestring,
+    cardano-data,
     cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
     cardano-ledger-babbage,
     cardano-ledger-binary:{cardano-ledger-binary, testlib},

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/UtxowSpec/Invalid.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Plutus (
  )
 import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (ExtraneousScriptWitnessesUTXOW))
 import qualified Data.Map.Strict as Map
+import qualified Data.Set.NonEmpty as NES
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Alonzo.ImpTest
@@ -68,7 +69,8 @@ spec = describe "Invalid" $ do
           submitFailingTx
             tx
             [ injectFailure $
-                MalformedScriptWitnesses [scriptHash]
+                MalformedScriptWitnesses $
+                  NES.singleton scriptHash
             ]
 
         it "MalformedReferenceScripts" $ do
@@ -84,7 +86,8 @@ spec = describe "Invalid" $ do
           submitFailingTx
             tx
             [ injectFailure $
-                MalformedReferenceScripts [scriptHash]
+                MalformedReferenceScripts $
+                  NES.singleton scriptHash
             ]
 
         -- There's already an ExtraRedeemers test for PlutusV1 in Alonzo, thus it's OK to start with PlutusV2
@@ -162,7 +165,8 @@ spec = describe "Invalid" $ do
                 & witsTxL . hashScriptTxWitsL .~ [script]
             )
             [ injectFailure $
-                ExtraneousScriptWitnessesUTXOW [scriptHash]
+                ExtraneousScriptWitnessesUTXOW $
+                  NES.singleton scriptHash
             ]
 
         it "Inline datum with redundant datum witness" $ do
@@ -179,7 +183,7 @@ spec = describe "Invalid" $ do
                 & witsTxL . hashDataTxWitsL .~ [redundantDatum]
             )
             [ injectFailure $
-                NotAllowedSupplementalDatums [hashData redundantDatum] mempty
+                NotAllowedSupplementalDatums (NES.singleton $ hashData redundantDatum) mempty
             ]
 
         -- There is no such thing as a "reference datum". In other words, you cannot
@@ -213,5 +217,5 @@ spec = describe "Invalid" $ do
                 & bodyTxL . inputsTxBodyL .~ [txInHash]
             )
             [ injectFailure $
-                MissingRequiredDatums [datumHash] mempty
+                MissingRequiredDatums (NES.singleton datumHash) mempty
             ]

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Change sets containing errors into `NonEmptySet` for `ConwayGovPredFailure`, `ConwayUtxoPredFailure`, `ConwayUtxowPredFailure`
 * Change all lists into `NonEmpty` for `ConwayUtxoPredFailure`, `ConwayUtxosPredFailure`, `ConwayUtxowPredFailure`
 * Add `cddl` sub-library, and `generate-cddl` executable.
 * Re-export `UtxoEnv` from `Cardano.Ledger.Conway.Rules.Utxo`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -74,7 +74,7 @@ import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (Embed (..), STS (..))
 import Data.List.NonEmpty (NonEmpty)
-import Data.Set (Set)
+import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import GHC.Natural (Natural)
@@ -88,7 +88,7 @@ data ConwayUtxoPredFailure era
     UtxosFailure (PredicateFailure (EraRule "UTXOS" era))
   | -- | The bad transaction inputs
     BadInputsUTxO
-      (Set TxIn)
+      (NonEmptySet TxIn)
   | OutsideValidityIntervalUTxO
       -- | transaction's validity interval
       ValidityInterval
@@ -105,12 +105,12 @@ data ConwayUtxoPredFailure era
       -- | the expected network id
       Network
       -- | the set of addresses with incorrect network IDs
-      (Set Addr)
+      (NonEmptySet Addr)
   | WrongNetworkWithdrawal
       -- | the expected network id
       Network
       -- | the set of reward addresses with incorrect network IDs
-      (Set RewardAccount)
+      (NonEmptySet RewardAccount)
   | -- | list of supplied transaction outputs that are too small
     OutputTooSmallUTxO
       (NonEmpty (TxOut era))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -67,6 +67,7 @@ import Control.State.Transition.Extended (
  )
 import Data.List.NonEmpty (NonEmpty)
 import Data.Set (Set)
+import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
@@ -79,13 +80,13 @@ data ConwayUtxowPredFailure era
   | -- | witnesses which failed in verifiedWits function
     MissingVKeyWitnessesUTXOW
       -- | witnesses which were needed and not supplied
-      (Set (KeyHash Witness))
+      (NonEmptySet (KeyHash Witness))
   | -- | missing scripts
     MissingScriptWitnessesUTXOW
-      (Set ScriptHash)
+      (NonEmptySet ScriptHash)
   | -- | failed scripts
     ScriptWitnessNotValidatingUTXOW
-      (Set ScriptHash)
+      (NonEmptySet ScriptHash)
   | -- | hash of the full metadata
     MissingTxBodyMetadataHash
       TxAuxDataHash
@@ -98,36 +99,31 @@ data ConwayUtxowPredFailure era
     InvalidMetadata
   | -- | extraneous scripts
     ExtraneousScriptWitnessesUTXOW
-      (Set ScriptHash)
+      (NonEmptySet ScriptHash)
   | MissingRedeemers (NonEmpty (PlutusPurpose AsItem era, ScriptHash))
   | MissingRequiredDatums
-      -- TODO: Make this NonEmpty #4066
-
       -- | Set of missing data hashes
-      (Set DataHash)
+      (NonEmptySet DataHash)
       -- | Set of received data hashes
       (Set DataHash)
   | NotAllowedSupplementalDatums
-      -- TODO: Make this NonEmpty #4066
-
       -- | Set of unallowed data hashes.
-      (Set DataHash)
+      (NonEmptySet DataHash)
       -- | Set of acceptable supplemental data hashes
       (Set DataHash)
   | PPViewHashesDontMatch
       (Mismatch RelEQ (StrictMaybe ScriptIntegrityHash))
   | -- | Set of transaction inputs that are TwoPhase scripts, and should have a DataHash but don't
     UnspendableUTxONoDatumHash
-      -- TODO: Make this NonEmpty #4066
-      (Set TxIn)
+      (NonEmptySet TxIn)
   | -- | List of redeemers not needed
     ExtraRedeemers (NonEmpty (PlutusPurpose AsIx era))
   | -- | Embed UTXO rule failures
     MalformedScriptWitnesses
-      (Set ScriptHash)
+      (NonEmptySet ScriptHash)
   | -- | the set of malformed script witnesses
     MalformedReferenceScripts
-      (Set ScriptHash)
+      (NonEmptySet ScriptHash)
   | -- | The computed script integrity hash does not match the provided script integrity hash
     ScriptIntegrityHashMismatch
       (Mismatch RelEQ (StrictMaybe ScriptIntegrityHash))

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -34,6 +34,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.OMap.Strict as OMap
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
 import Data.Tree
 import Lens.Micro
 import Test.Cardano.Ledger.Conway.Arbitrary ()
@@ -142,7 +143,7 @@ predicateFailuresSpec =
               (Set.singleton committeeC)
               (Map.singleton committeeC (addEpochInterval curEpochNo (EpochInterval 1)))
               (1 %! 1)
-      let expectedFailure = injectFailure $ ConflictingCommitteeUpdate $ Set.singleton committeeC
+      let expectedFailure = injectFailure $ ConflictingCommitteeUpdate $ NES.singleton committeeC
       proposal <- mkProposal action
       submitBootstrapAwareFailingProposal_ proposal $
         FailBootstrapAndPostBootstrap $
@@ -1089,7 +1090,7 @@ withdrawalsSpec =
         mkTreasuryWithdrawalsGovAction [(badRewardAccount, Coin 100_000_000)] >>= mkProposal
       let idMismatch =
             injectFailure $
-              TreasuryWithdrawalsNetworkIdMismatch (Set.singleton badRewardAccount) Testnet
+              TreasuryWithdrawalsNetworkIdMismatch (NES.singleton badRewardAccount) Testnet
           returnAddress =
             injectFailure $
               TreasuryWithdrawalReturnAccountsDoNotExist [badRewardAccount]

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -31,6 +31,7 @@ import Cardano.Ledger.Shelley.LedgerState
 import Control.Monad.Reader (asks)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
 import qualified Data.Text as T
 import Data.Word (Word32)
 import GHC.Exts (fromList)
@@ -237,6 +238,9 @@ spec = do
           sendCoinTo addr amount
 
       inputsCommon <- replicateM 5 newInput
+      inputsCommonNES <- case NES.fromFoldable inputsCommon of
+        Nothing -> error "Impossible empty set"
+        Just nes -> pure nes
       inputs1 <- replicateM 2 newInput
       inputs2 <- replicateM 3 newInput
 
@@ -256,7 +260,7 @@ spec = do
         submitFailingMempoolTx_
           "overlapping transaction"
           txOverlap
-          [injectFailure $ BadInputsUTxO $ fromList inputsCommon]
+          [injectFailure $ BadInputsUTxO inputsCommonNES]
 
     it "Unelected Committee voting" $ whenPostBootstrap $ do
       _ <- registerInitialCommittee

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -40,6 +40,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.OSet.Strict as OSet
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
 import Lens.Micro
 import qualified PlutusLedgerApi.V1 as P1
 import Test.Cardano.Ledger.Conway.ImpTest
@@ -74,7 +75,7 @@ spec = do
           else
             submitFailingTx
               tx
-              [ injectFailure $ UnspendableUTxONoDatumHash [txIn]
+              [ injectFailure $ UnspendableUTxONoDatumHash $ NES.singleton txIn
               ]
 
 datumAndReferenceInputsSpec ::
@@ -422,7 +423,7 @@ govPolicySpec = do
               mkBasicTx mkBasicTxBody
                 & bodyTxL . proposalProceduresTxBodyL .~ [proposal]
                 & bodyTxL . vldtTxBodyL .~ ValidityInterval SNothing SNothing
-        submitFailingTx tx [injectFailure $ ScriptWitnessNotValidatingUTXOW [scriptHash]]
+        submitFailingTx tx [injectFailure $ ScriptWitnessNotValidatingUTXOW $ NES.singleton scriptHash]
 
       impAnn "TreasuryWithdrawals" $ do
         rewardAccount <- registerRewardAccount
@@ -433,7 +434,7 @@ govPolicySpec = do
               mkBasicTx mkBasicTxBody
                 & bodyTxL . proposalProceduresTxBodyL .~ [proposal]
                 & bodyTxL . vldtTxBodyL .~ ValidityInterval SNothing SNothing
-        submitFailingTx tx [injectFailure $ ScriptWitnessNotValidatingUTXOW [scriptHash]]
+        submitFailingTx tx [injectFailure $ ScriptWitnessNotValidatingUTXOW $ NES.singleton scriptHash]
 
     it "alwaysSucceeds Plutus govPolicy validates" $ whenPostBootstrap $ do
       let alwaysSucceedsSh = hashPlutusScript (alwaysSucceedsNoDatum SPlutusV3)

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0.0
 
+* Change sets containing errors into `NonEmptySet` for `DijkstraGovPredFailure`, `DijkstraUtxoPredFailure`, `DijkstraUtxowPredFailure`
 * Change Dijkstra BBODY rule to validate Peras certificates when present
 * Add new block body predicate falures for Dijkstra:
   - `PrevEpochNonceNotPresent` for missing optional nonce needed for validation

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Gov.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Gov.hs
@@ -75,7 +75,7 @@ import Control.State.Transition.Extended (
  )
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
@@ -83,7 +83,7 @@ data DijkstraGovPredFailure era
   = GovActionsDoNotExist (NonEmpty GovActionId)
   | MalformedProposal (GovAction era)
   | ProposalProcedureNetworkIdMismatch RewardAccount Network
-  | TreasuryWithdrawalsNetworkIdMismatch (Set.Set RewardAccount) Network
+  | TreasuryWithdrawalsNetworkIdMismatch (NonEmptySet RewardAccount) Network
   | ProposalDepositIncorrect (Mismatch RelEQ Coin)
   | -- | Some governance actions are not allowed to be voted on by certain types of
     -- Voters. This failure lists all governance action ids with their respective voters
@@ -91,7 +91,7 @@ data DijkstraGovPredFailure era
     DisallowedVoters (NonEmpty (Voter, GovActionId))
   | ConflictingCommitteeUpdate
       -- | Credentials that are mentioned as members to be both removed and added
-      (Set.Set (Credential ColdCommitteeRole))
+      (NonEmptySet (Credential ColdCommitteeRole))
   | ExpirationEpochTooSmall
       -- | Members for which the expiration epoch has already been reached
       (Map.Map (Credential ColdCommitteeRole) EpochNo)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -98,7 +98,7 @@ import Control.State.Transition.Extended (
  )
 import Data.Coerce (coerce)
 import Data.List.NonEmpty (NonEmpty)
-import Data.Set (Set)
+import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import GHC.Natural (Natural)
@@ -112,7 +112,7 @@ data DijkstraUtxoPredFailure era
   = -- | Subtransition Failures
     UtxosFailure (PredicateFailure (EraRule "UTXOS" era))
   | -- | The bad transaction inputs
-    BadInputsUTxO (Set TxIn)
+    BadInputsUTxO (NonEmptySet TxIn)
   | OutsideValidityIntervalUTxO
       -- | transaction's validity interval
       ValidityInterval
@@ -129,12 +129,12 @@ data DijkstraUtxoPredFailure era
       -- | the expected network id
       Network
       -- | the set of addresses with incorrect network IDs
-      (Set Addr)
+      (NonEmptySet Addr)
   | WrongNetworkWithdrawal
       -- | the expected network id
       Network
       -- | the set of reward addresses with incorrect network IDs
-      (Set RewardAccount)
+      (NonEmptySet RewardAccount)
   | -- | list of supplied transaction outputs that are too small
     OutputTooSmallUTxO (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction outputs

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -84,6 +84,7 @@ import Control.State.Transition.Extended (
  )
 import Data.List.NonEmpty (NonEmpty)
 import Data.Set (Set)
+import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
 import NoThunks.Class (
   InspectHeapNamed (..),
@@ -99,11 +100,11 @@ data DijkstraUtxowPredFailure era
   | -- | witnesses which failed in verifiedWits function
     MissingVKeyWitnessesUTXOW
       -- | witnesses which were needed and not supplied
-      (Set (KeyHash Witness))
+      (NonEmptySet (KeyHash Witness))
   | -- | missing scripts
-    MissingScriptWitnessesUTXOW (Set ScriptHash)
+    MissingScriptWitnessesUTXOW (NonEmptySet ScriptHash)
   | -- | failed scripts
-    ScriptWitnessNotValidatingUTXOW (Set ScriptHash)
+    ScriptWitnessNotValidatingUTXOW (NonEmptySet ScriptHash)
   | -- | hash of the full metadata
     MissingTxBodyMetadataHash TxAuxDataHash
   | -- | hash of the metadata included in the transaction body
@@ -112,34 +113,29 @@ data DijkstraUtxowPredFailure era
   | -- | Contains out of range values (string`s too long)
     InvalidMetadata
   | -- | extraneous scripts
-    ExtraneousScriptWitnessesUTXOW (Set ScriptHash)
+    ExtraneousScriptWitnessesUTXOW (NonEmptySet ScriptHash)
   | MissingRedeemers (NonEmpty (PlutusPurpose AsItem era, ScriptHash))
   | MissingRequiredDatums
-      -- TODO: Make this NonEmpty #4066
-
       -- | Set of missing data hashes
-      (Set DataHash)
+      (NonEmptySet DataHash)
       -- | Set of received data hashes
       (Set DataHash)
   | NotAllowedSupplementalDatums
-      -- TODO: Make this NonEmpty #4066
-
       -- | Set of unallowed data hashes.
-      (Set DataHash)
+      (NonEmptySet DataHash)
       -- | Set of acceptable supplemental data hashes
       (Set DataHash)
   | PPViewHashesDontMatch
       (Mismatch RelEQ (StrictMaybe ScriptIntegrityHash))
   | -- | Set of transaction inputs that are TwoPhase scripts, and should have a DataHash but don't
     UnspendableUTxONoDatumHash
-      -- TODO: Make this NonEmpty #4066
-      (Set TxIn)
+      (NonEmptySet TxIn)
   | -- | List of redeemers not needed
     ExtraRedeemers (NonEmpty (PlutusPurpose AsIx era))
   | -- | Embed UTXO rule failures
-    MalformedScriptWitnesses (Set ScriptHash)
+    MalformedScriptWitnesses (NonEmptySet ScriptHash)
   | -- | the set of malformed script witnesses
-    MalformedReferenceScripts (Set ScriptHash)
+    MalformedReferenceScripts (NonEmptySet ScriptHash)
   | -- | The computed script integrity hash does not match the provided script integrity hash
     ScriptIntegrityHashMismatch
       (Mismatch RelEQ (StrictMaybe ScriptIntegrityHash))

--- a/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
+++ b/eras/shelley-ma/test-suite/test/Test/Cardano/Ledger/Mary/Examples/MultiAssets.hs
@@ -49,6 +49,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
 import GHC.Exts (fromString)
 import Lens.Micro
 import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkWitnessesVKey)
@@ -117,7 +118,7 @@ makeMaryTxBody ins outs interval minted =
 policyFailure ::
   PolicyID -> Either (NonEmpty (PredicateFailure (ShelleyLEDGER MaryEra))) (UTxO MaryEra)
 policyFailure p =
-  Left . pure . UtxowFailure . ScriptWitnessNotValidatingUTXOW $ Set.singleton (policyID p)
+  Left . pure . UtxowFailure . ScriptWitnessNotValidatingUTXOW $ NES.singleton (policyID p)
 
 outTooBigFailure ::
   ShelleyTxOut MaryEra -> Either (NonEmpty (PredicateFailure (ShelleyLEDGER MaryEra))) (UTxO MaryEra)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Change sets containing errors into `NonEmptySet` for `ShelleyUtxoPredFailure`, `ShelleyUtxowPredFailure`
 * Change all lists into `NonEmpty` for `ShelleyUtxoPredFailure`, `ShelleyUtxowPredFailure`
 * Changed the type of the following fields to `CompactForm Coin` in `ShelleyPParams`:
   - `sppMinFeeA`

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -218,7 +218,7 @@ library testlib
     cardano-crypto,
     cardano-crypto-class,
     cardano-crypto-wrapper,
-    cardano-data,
+    cardano-data:{cardano-data, testlib},
     cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-byron:{cardano-ledger-byron, testlib},
     cardano-ledger-core:{cardano-ledger-core, testlib},

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -92,6 +92,7 @@ import qualified Data.Text.Encoding as T (encodeUtf8)
 import Data.Word (Word64)
 import Generic.Random (genericArbitraryU)
 import Test.Cardano.Chain.UTxO.Gen (genCompactTxOut)
+import Test.Cardano.Data.Arbitrary ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Arbitrary ()
 import Test.Cardano.Ledger.Core.Utils (unsafeBoundRational)

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/UtxowSpec.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
 import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
 import Lens.Micro
 import Test.Cardano.Ledger.Core.KeyPair (ByronKeyPair (..))
 import Test.Cardano.Ledger.Imp.Common
@@ -62,7 +63,9 @@ spec = describe "UTXOW" $ do
       submitFailingTx
         tx
         [ injectFailure $
-            MissingVKeyWitnessesUTXOW [asWitness aliceKh]
+            MissingVKeyWitnessesUTXOW $
+              NES.singleton $
+                asWitness aliceKh
         ]
 
   it "MissingScriptWitnessesUTXOW" $ do
@@ -73,7 +76,8 @@ spec = describe "UTXOW" $ do
     submitFailingTx
       tx
       [ injectFailure $
-          MissingScriptWitnessesUTXOW [scriptHash]
+          MissingScriptWitnessesUTXOW $
+            NES.singleton scriptHash
       ]
 
   it "MissingTxBodyMetadataHash" $ do
@@ -125,9 +129,9 @@ spec = describe "UTXOW" $ do
       -- We dropped validating scripts when they are not needed, starting with Babbage
       if eraProtVerLow @era >= natVersion @6
         then
-          [ injectFailure $ ExtraneousScriptWitnessesUTXOW [scriptHash]
+          [ injectFailure $ ExtraneousScriptWitnessesUTXOW $ NES.singleton scriptHash
           ]
         else
-          [ injectFailure $ ScriptWitnessNotValidatingUTXOW [scriptHash]
-          , injectFailure $ ExtraneousScriptWitnessesUTXOW [scriptHash]
+          [ injectFailure $ ScriptWitnessNotValidatingUTXOW $ NES.singleton scriptHash
+          , injectFailure $ ExtraneousScriptWitnessesUTXOW $ NES.singleton scriptHash
           ]

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -30,6 +30,7 @@ import Cardano.Ledger.Shelley.TxOut
 import Cardano.Ledger.Shelley.TxWits
 import Cardano.Ledger.Shelley.UTxO
 import Data.TreeDiff.OMap as OMap
+import Test.Cardano.Data.TreeDiff ()
 import Test.Cardano.Ledger.TreeDiff
 
 -- PParams

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/RulesTests.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure (..))
 import Cardano.Ledger.Shelley.TxBody (RewardAccount (..), Withdrawals (..))
 import Data.Either (isRight)
 import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
 import Test.Cardano.Ledger.Core.KeyPair (vKey)
 import qualified Test.Cardano.Ledger.Shelley.Examples.Cast as Cast
 import Test.Cardano.Ledger.Shelley.Examples.Chain (testCHAINExample)
@@ -123,7 +123,7 @@ testAliceDoesntSign =
         (Withdrawals Map.empty)
         (Coin 0)
         [asWitness Cast.bobPay, asWitness Cast.carlPay, asWitness Cast.dariaPay]
-    wits = Set.singleton $ hashScript @ShelleyEra aliceOnly
+    wits = NES.singleton $ hashScript @ShelleyEra aliceOnly
 
 testEverybodySigns :: Assertion
 testEverybodySigns =
@@ -192,7 +192,7 @@ testAliceAndBob' =
         (Withdrawals Map.empty)
         (Coin 0)
         [asWitness Cast.alicePay]
-    wits = Set.singleton $ hashScript @ShelleyEra aliceAndBob
+    wits = NES.singleton $ hashScript @ShelleyEra aliceAndBob
 
 testAliceAndBob'' :: Assertion
 testAliceAndBob'' =
@@ -205,7 +205,7 @@ testAliceAndBob'' =
         (Withdrawals Map.empty)
         (Coin 0)
         [asWitness Cast.bobPay]
-    wits = Set.singleton $ hashScript @ShelleyEra aliceAndBob
+    wits = NES.singleton $ hashScript @ShelleyEra aliceAndBob
 
 testAliceAndBobOrCarl :: Assertion
 testAliceAndBobOrCarl =
@@ -332,7 +332,7 @@ testTwoScripts' =
         (Withdrawals Map.empty)
         (Coin 0)
         [asWitness Cast.bobPay, asWitness Cast.carlPay]
-    wits = Set.singleton $ hashScript @ShelleyEra aliceAndBob
+    wits = NES.singleton $ hashScript @ShelleyEra aliceAndBob
 
 -- script and skey locked
 
@@ -360,7 +360,7 @@ testScriptAndSKey' =
         (Withdrawals Map.empty)
         (Coin 1000)
         [asWitness Cast.bobPay]
-    wits = Set.singleton $ asWitness $ hashKey $ vKey Cast.alicePay
+    wits = NES.singleton $ asWitness $ hashKey $ vKey Cast.alicePay
 
 testScriptAndSKey'' :: Assertion
 testScriptAndSKey'' =
@@ -430,7 +430,7 @@ testRwdAliceSignsAlone' =
         )
         (Coin 0)
         [asWitness Cast.alicePay]
-    wits = Set.singleton $ hashScript @ShelleyEra bobOnly
+    wits = NES.singleton $ hashScript @ShelleyEra bobOnly
 
 testRwdAliceSignsAlone'' :: Assertion
 testRwdAliceSignsAlone'' =
@@ -469,4 +469,4 @@ testRwdAliceSignsAlone''' =
         )
         (Coin 0)
         [asWitness Cast.alicePay, asWitness Cast.bobPay]
-    wits = Set.singleton $ hashScript @ShelleyEra bobOnly
+    wits = NES.singleton $ hashScript @ShelleyEra bobOnly

--- a/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
+++ b/eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/UnitTests.hs
@@ -59,6 +59,7 @@ import Data.Ratio ((%))
 import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as StrictSeq
 import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
 import Data.Word (Word64)
 import GHC.Stack
 import Lens.Micro
@@ -329,7 +330,7 @@ testSpendNonexistentInput :: Assertion
 testSpendNonexistentInput =
   testInvalidTx
     [ UtxowFailure (UtxoFailure (ValueNotConservedUTxO $ Mismatch (Coin 0) (Coin 10000)))
-    , UtxowFailure (UtxoFailure $ BadInputsUTxO (Set.singleton $ mkGenesisTxIn 42))
+    , UtxowFailure (UtxoFailure $ BadInputsUTxO (NES.singleton $ mkGenesisTxIn 42))
     ]
     $ aliceGivesBobLovelace
     $ AliceToBob
@@ -360,7 +361,7 @@ testWitnessNotIncluded =
           SNothing
           SNothing
       tx = ShelleyTx @ShelleyEra txbody mempty SNothing
-      txwits = Set.singleton (asWitness $ hashKey $ vKey alicePay)
+      txwits = NES.singleton (asWitness $ hashKey $ vKey alicePay)
    in testInvalidTx
         [ UtxowFailure $
             MissingVKeyWitnessesUTXOW txwits
@@ -381,7 +382,7 @@ testSpendNotOwnedUTxO =
           SNothing
       aliceWit = mkWitnessVKey (hashAnnotated txbody) alicePay
       tx = MkShelleyTx $ ShelleyTx @ShelleyEra txbody mempty {addrWits = Set.fromList [aliceWit]} SNothing
-      txwits = Set.singleton (asWitness $ hashKey $ vKey bobPay)
+      txwits = NES.singleton (asWitness $ hashKey $ vKey bobPay)
    in testInvalidTx
         [ UtxowFailure $
             MissingVKeyWitnessesUTXOW txwits
@@ -412,7 +413,7 @@ testWitnessWrongUTxO =
           SNothing
       aliceWit = mkWitnessVKey (hashAnnotated tx2body) alicePay
       tx = ShelleyTx @ShelleyEra txbody mempty {addrWits = Set.fromList [aliceWit]} SNothing
-      txwits = Set.singleton (asWitness $ hashKey $ vKey bobPay)
+      txwits = NES.singleton (asWitness $ hashKey $ vKey bobPay)
    in testInvalidTx
         [ UtxowFailure $
             InvalidWitnessesUTXOW
@@ -526,7 +527,7 @@ testWithdrawalNoWit =
       txwits :: ShelleyTxWits ShelleyEra
       txwits = mempty {addrWits = Set.singleton $ mkWitnessVKey (hashAnnotated txb) alicePay}
       tx = ShelleyTx @ShelleyEra txb txwits SNothing
-      missing = Set.singleton (asWitness $ hashKey $ vKey bobStake)
+      missing = NES.singleton (asWitness $ hashKey $ vKey bobStake)
       errs =
         [ UtxowFailure $ MissingVKeyWitnessesUTXOW missing
         ]

--- a/libs/cardano-data/CHANGELOG.md
+++ b/libs/cardano-data/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.3.0.0
 
+* Add `Data.Set.NonEmpty`
 * Add `lookupInternMap`
 * Replace `okeyL` with `toOKey`
 

--- a/libs/cardano-data/cardano-data.cabal
+++ b/libs/cardano-data/cardano-data.cabal
@@ -24,6 +24,7 @@ library
     Data.OMap.Strict
     Data.OSet.Strict
     Data.Pulse
+    Data.Set.NonEmpty
     Data.Universe
 
   hs-source-dirs: src

--- a/libs/cardano-data/src/Data/Set/NonEmpty.hs
+++ b/libs/cardano-data/src/Data/Set/NonEmpty.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Data.Set.NonEmpty (
+  NonEmptySet,
+  fromFoldable,
+  fromSet,
+  singleton,
+  toList,
+  toSet,
+) where
+
+import Cardano.Ledger.Binary (DecCBOR (decCBOR), EncCBOR, decodeSet)
+import Control.DeepSeq (NFData)
+import qualified Data.Foldable as Foldable
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Typeable (Typeable)
+import NoThunks.Class (NoThunks)
+
+newtype NonEmptySet a = NonEmptySet (Set a)
+  deriving stock (Show, Eq)
+  deriving newtype (EncCBOR, NoThunks, NFData)
+
+instance (Typeable a, Ord a, DecCBOR a) => DecCBOR (NonEmptySet a) where
+  decCBOR = do
+    set <- decodeSet decCBOR
+    case fromSet set of
+      Nothing -> fail "Empty set found, expected non-empty"
+      Just nes -> pure nes
+  {-# INLINE decCBOR #-}
+
+-- | \(O(1)\).
+singleton :: a -> NonEmptySet a
+singleton = NonEmptySet . Set.singleton
+
+-- | \(O(1)\).
+fromSet :: Set a -> Maybe (NonEmptySet a)
+fromSet set = if Set.null set then Nothing else Just (NonEmptySet set)
+
+-- | \(O(1)\).
+toSet :: NonEmptySet a -> Set a
+toSet (NonEmptySet set) = set
+
+-- | \(O(n \log n)\).
+fromFoldable :: (Foldable f, Ord a) => f a -> Maybe (NonEmptySet a)
+fromFoldable = fromSet . Foldable.foldl' (flip Set.insert) Set.empty
+
+-- | \(O(n)\).
+toList :: NonEmptySet a -> [a]
+toList (NonEmptySet set) = Set.toList set

--- a/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
+++ b/libs/cardano-data/testlib/Test/Cardano/Data/Arbitrary.hs
@@ -5,8 +5,12 @@
 
 module Test.Cardano.Data.Arbitrary (genOSet) where
 
+import Data.Maybe (fromJust)
 import Data.OMap.Strict qualified as OMap
 import Data.OSet.Strict qualified as OSet
+import Data.Set qualified as Set
+import Data.Set.NonEmpty (NonEmptySet)
+import Data.Set.NonEmpty qualified as NES
 import Test.Cardano.Ledger.Binary.Arbitrary ()
 import Test.QuickCheck
 
@@ -18,3 +22,14 @@ genOSet = fmap OSet.fromFoldable . listOf
 
 instance (Arbitrary v, OMap.HasOKey k v, Arbitrary k) => Arbitrary (OMap.OMap k v) where
   arbitrary = OMap.fromFoldable @[] <$> arbitrary
+
+instance (Arbitrary a, Ord a) => Arbitrary (NonEmptySet a) where
+  arbitrary = do
+    el <- arbitrary
+    fromJust . NES.fromSet . Set.insert el <$> arbitrary
+
+  shrink nes =
+    [ fromJust $ NES.fromSet xs'
+    | xs' <- shrink $ NES.toSet nes
+    , not (Set.null xs')
+    ]

--- a/libs/cardano-data/testlib/Test/Cardano/Data/TreeDiff.hs
+++ b/libs/cardano-data/testlib/Test/Cardano/Data/TreeDiff.hs
@@ -9,6 +9,8 @@ import Data.Foldable (Foldable (..))
 import Data.Foldable qualified as F
 import Data.OMap.Strict
 import Data.OSet.Strict
+import Data.Set.NonEmpty (NonEmptySet)
+import Data.Set.NonEmpty qualified as NES
 import Test.Cardano.Ledger.Binary.TreeDiff (Expr (..), ToExpr (..))
 
 instance ToExpr a => ToExpr (OSet a) where
@@ -17,3 +19,6 @@ instance ToExpr a => ToExpr (OSet a) where
 instance (HasOKey k v, ToExpr v) => ToExpr (OMap k v) where
   listToExpr = listToExpr . F.toList
   toExpr = toExpr . F.toList
+
+instance ToExpr a => ToExpr (NonEmptySet a) where
+  toExpr = toExpr . NES.toList

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Trace.hs
@@ -57,6 +57,7 @@ import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Sequence.Strict (StrictSeq (..))
 import qualified Data.Sequence.Strict as SS
 import qualified Data.Set as Set
+import qualified Data.Set.NonEmpty as NES
 import Data.TreeDiff
 import Data.Vector (Vector, (!))
 import qualified Data.Vector as Vector
@@ -232,7 +233,7 @@ badScripts proof xs = Fold.foldl' (\s mcf -> Set.union s (getw proof mcf)) Set.e
                     )
                 )
             )
-        ) = set
+        ) = NES.toSet set
     getw
       Alonzo
       ( MockChainFromLedgersFailure
@@ -243,7 +244,7 @@ badScripts proof xs = Fold.foldl' (\s mcf -> Set.union s (getw proof mcf)) Set.e
                     )
                 )
             )
-        ) = set
+        ) = NES.toSet set
     getw
       Mary
       ( MockChainFromLedgersFailure
@@ -252,7 +253,7 @@ badScripts proof xs = Fold.foldl' (\s mcf -> Set.union s (getw proof mcf)) Set.e
                   (ScriptWitnessNotValidatingUTXOW set)
                 )
             )
-        ) = set
+        ) = NES.toSet set
     getw
       Allegra
       ( MockChainFromLedgersFailure
@@ -261,7 +262,7 @@ badScripts proof xs = Fold.foldl' (\s mcf -> Set.union s (getw proof mcf)) Set.e
                   (ScriptWitnessNotValidatingUTXOW set)
                 )
             )
-        ) = set
+        ) = NES.toSet set
     getw _ _ = Set.empty
 
 shortTxOut :: EraTxOut era => TxOut era -> Expr

--- a/libs/small-steps/CHANGELOG.md
+++ b/libs/small-steps/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `small-steps`
 
-## 1.1.2.1
+## 1.1.3.0
 
-*
+* Add `failOnNonEmptySet` and `failureOnNonEmptySet`
 
 ## 1.1.2.0
 

--- a/libs/small-steps/small-steps.cabal
+++ b/libs/small-steps/small-steps.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: small-steps
-version: 1.1.2.0
+version: 1.1.3.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -40,6 +40,7 @@ library
   build-depends:
     aeson,
     base >=4.18 && <5,
+    cardano-data >=1.3,
     cardano-strict-containers,
     containers,
     data-default,

--- a/libs/small-steps/src/Control/State/Transition/Extended.hs
+++ b/libs/small-steps/src/Control/State/Transition/Extended.hs
@@ -55,8 +55,10 @@ module Control.State.Transition.Extended (
   failBecause,
   failOnJust,
   failOnNonEmpty,
+  failOnNonEmptySet,
   failureOnJust,
   failureOnNonEmpty,
+  failureOnNonEmptySet,
   judgmentContext,
   trans,
   liftSTS,
@@ -107,6 +109,8 @@ import Data.Functor (($>), (<&>))
 import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
+import Data.Set.NonEmpty (NonEmptySet)
+import qualified Data.Set.NonEmpty as NES
 import Data.Typeable (typeRep)
 import Data.Void (Void)
 import NoThunks.Class (NoThunks (..))
@@ -414,6 +418,18 @@ failOnNonEmpty cond onNonEmpty = liftF $ Predicate (failureOnNonEmpty cond onNon
 -- converted to a NonEmpty list and theh can be used inside the  failure.
 failureOnNonEmpty :: Foldable f => f a -> (NonEmpty a -> e) -> Validation (NonEmpty e) ()
 failureOnNonEmpty cond = failureOnJust (NE.nonEmpty (F.toList cond))
+
+-- | Produce a predicate failure when supplied foldable is not an empty set, contents of which
+-- will be converted to a NonEmptySet and can be used inside the predicate failure.
+failOnNonEmptySet ::
+  (Foldable f, Ord a) => f a -> (NonEmptySet a -> PredicateFailure sts) -> Rule sts ctx ()
+failOnNonEmptySet cond onNonEmpty = liftF $ Predicate (failureOnNonEmptySet cond onNonEmpty) id ()
+
+-- | Produce a failure when supplied foldable is not an empty set, contents of which will be
+-- converted to a NonEmptySet and can then be used inside the failure constructor.
+failureOnNonEmptySet ::
+  (Foldable f, Ord a) => f a -> (NonEmptySet a -> e) -> Validation (NonEmpty e) ()
+failureOnNonEmptySet cond = failureOnJust (NES.fromFoldable cond)
 
 -- | Oh noes with an explanation
 --


### PR DESCRIPTION
# Description

Second part of #5453: all `Set`s containing errors in predicate failures across all eras become `NonEmptySet`s for additional typesafety by preventing the possibility of reporting a failure with nothing in it.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
