### PR TITLE
Dijkstra subtx produced and consumed

### DIFF
--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -120,6 +120,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Era
     Test.Cardano.Ledger.Dijkstra.Examples
     Test.Cardano.Ledger.Dijkstra.Imp
+    Test.Cardano.Ledger.Dijkstra.Imp.CertSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec
     Test.Cardano.Ledger.Dijkstra.ImpTest

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
@@ -54,7 +54,6 @@ import Cardano.Ledger.Conway.TxCert (
   Delegatee (..),
   conwayGovCertVKeyWitness,
   conwayTotalDepositsTxCerts,
-  conwayTotalRefundsTxCerts,
   conwayTxCertDelegDecoder,
  )
 import Cardano.Ledger.Core (
@@ -77,7 +76,7 @@ import Cardano.Ledger.Shelley.TxCert (
   encodeShelleyDelegCert,
   poolTxCertDecoder,
  )
-import Cardano.Ledger.Val (Val)
+import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson (KeyValue ((.=)), ToJSON (..))
 import GHC.Generics (Generic)
@@ -223,6 +222,17 @@ instance Era era => EncCBOR (DijkstraTxCert era) where
     DijkstraTxCertPool poolCert -> encodePoolCert poolCert
     DijkstraTxCertGov govCert -> encCBOR govCert
 
+dijkstraTotalRefundsTxCerts ::
+  ( Foldable f
+  , ConwayEraTxCert era
+  ) =>
+  f (TxCert era) ->
+  Coin
+dijkstraTotalRefundsTxCerts = foldMap $ \case
+  UnRegDepositTxCert _ deposit -> deposit
+  UnRegDRepTxCert _ deposit -> deposit
+  _ -> zero
+
 instance EraTxCert DijkstraEra where
   type TxCert DijkstraEra = DijkstraTxCert DijkstraEra
 
@@ -268,7 +278,7 @@ instance EraTxCert DijkstraEra where
     UnRegDepositTxCert c _ -> Just c
     _ -> Nothing
 
-  getTotalRefundsTxCerts = conwayTotalRefundsTxCerts
+  getTotalRefundsTxCerts _ _ _ = dijkstraTotalRefundsTxCerts
 
   getTotalDepositsTxCerts = conwayTotalDepositsTxCerts
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
@@ -79,6 +79,7 @@ import Cardano.Ledger.Shelley.TxCert (
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson (KeyValue ((.=)), ToJSON (..))
+import Data.Foldable (Foldable (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
@@ -222,13 +222,14 @@ instance Era era => EncCBOR (DijkstraTxCert era) where
     DijkstraTxCertPool poolCert -> encodePoolCert poolCert
     DijkstraTxCertGov govCert -> encCBOR govCert
 
+-- | Unlike previous eras, we no longer need to lookup refunds from the ledger state, since all of the certificates specify the actual refund and ledger rules will validate that they are accurate.
 dijkstraTotalRefundsTxCerts ::
   ( Foldable f
   , ConwayEraTxCert era
   ) =>
   f (TxCert era) ->
   Coin
-dijkstraTotalRefundsTxCerts = foldMap $ \case
+dijkstraTotalRefundsTxCerts = foldMap' $ \case
   UnRegDepositTxCert _ deposit -> deposit
   UnRegDRepTxCert _ deposit -> deposit
   _ -> zero

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -20,6 +21,7 @@ import Cardano.Ledger.Babbage.UTxO (
   getBabbageSupplementalDataHashes,
  )
 import Cardano.Ledger.BaseTypes (inject)
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.UTxO (
   conwayConsumed,
   conwayProducedValue,
@@ -27,7 +29,7 @@ import Cardano.Ledger.Conway.UTxO (
   getConwayScriptsNeeded,
   getConwayWitsVKeyNeeded,
  )
-import Cardano.Ledger.Credential (credScriptHash)
+import Cardano.Ledger.Credential (Credential, credScriptHash)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Scripts (DijkstraEraScript (..), pattern GuardingPurpose)
@@ -35,22 +37,78 @@ import Cardano.Ledger.Dijkstra.State
 import Cardano.Ledger.Dijkstra.Tx ()
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
 import Cardano.Ledger.Mary.UTxO (burnedMultiAssets, getConsumedMaryValue)
-import Cardano.Ledger.Mary.Value (MaryValue)
+import Cardano.Ledger.Mary.Value (MaryValue (..))
+import Cardano.Ledger.Val (Val (..))
 import Data.Maybe (catMaybes)
 import Lens.Micro ((^.))
+import Lens.Micro.Extras (view)
+
+getConsumedDijkstraValue ::
+  forall era l.
+  ( DijkstraEraTxBody era
+  , EraTx era
+  , Value era ~ MaryValue
+  , STxLevel l era ~ STxBothLevels l era
+  ) =>
+  PParams era ->
+  (Credential Staking -> Maybe Coin) ->
+  (Credential DRepRole -> Maybe Coin) ->
+  UTxO era ->
+  TxBody l era ->
+  Value era
+getConsumedDijkstraValue pp lookupStakingDeposit lookupDRepDeposit utxo txBody =
+  getConsumedMaryValue pp lookupStakingDeposit lookupDRepDeposit utxo txBody
+    <> subTransactionsConsumedValue
+  where
+    subTransactionsConsumedValue =
+      withBothTxLevels
+        txBody
+        ( \topTxBody ->
+            foldMap
+              (getConsumedMaryValue pp lookupStakingDeposit lookupDRepDeposit utxo . view bodyTxL)
+              $ topTxBody ^. subTransactionsTxBodyL
+        )
+        (const zero)
+
+dijkstraProducedValue ::
+  ( DijkstraEraTxBody era
+  , EraTx era
+  , Value era ~ MaryValue
+  ) =>
+  PParams era ->
+  (KeyHash StakePool -> Bool) ->
+  TxBody TopTx era ->
+  MaryValue
+dijkstraProducedValue pp isRegPoolId txBody =
+  conwayProducedValue pp isRegPoolId txBody
+    <> foldMap
+      (dijkstraSubTxProducedValue pp isRegPoolId . view bodyTxL)
+      (txBody ^. subTransactionsTxBodyL)
+
+getProducedDijkstraValue ::
+  ( STxLevel l era ~ STxBothLevels l era
+  , DijkstraEraTxBody era
+  , EraTx era
+  , Value era ~ MaryValue
+  ) =>
+  PParams era ->
+  (KeyHash StakePool -> Bool) ->
+  TxBody l era ->
+  MaryValue
+getProducedDijkstraValue pp isRegPoolId txBody =
+  withBothTxLevels
+    txBody
+    (dijkstraProducedValue pp isRegPoolId)
+    (dijkstraSubTxProducedValue pp isRegPoolId)
 
 instance EraUTxO DijkstraEra where
   type ScriptsNeeded DijkstraEra = AlonzoScriptsNeeded DijkstraEra
 
   consumed = conwayConsumed
 
-  getConsumedValue = getConsumedMaryValue
+  getConsumedValue = getConsumedDijkstraValue
 
-  getProducedValue pp isRegPoolId txBody =
-    withBothTxLevels
-      txBody
-      (conwayProducedValue pp isRegPoolId)
-      (dijkstraSubTxProducedValue pp isRegPoolId)
+  getProducedValue = getProducedDijkstraValue
 
   getScriptsProvided = getBabbageScriptsProvided
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -15,6 +15,7 @@ import Cardano.Ledger.Dijkstra.Rules (DijkstraUtxoPredFailure)
 import Cardano.Ledger.Shelley.Rules
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp as ConwayImp
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertSpec as Cert
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec as Utxo
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -40,6 +41,7 @@ dijkstraEraGenericSpec ::
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
 dijkstraEraGenericSpec = do
+  describe "CERTS" Cert.spec
   describe "UTXOW" Utxow.spec
   describe "UTXO" Utxo.spec
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertSpec.hs
@@ -9,14 +9,7 @@ module Test.Cardano.Ledger.Dijkstra.Imp.CertSpec (spec) where
 
 import Cardano.Ledger.Conway.Governance (Voter (..))
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Dijkstra.Core (
-  EraTx (..),
-  EraTxBody (..),
-  emptyPParamsUpdate,
-  ppKeyDepositL,
-  ppuKeyDepositL,
-  pattern UnRegDepositTxCert,
- )
+import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Maybe.Strict (StrictMaybe (..))
@@ -24,28 +17,8 @@ import qualified Data.OMap.Strict as OMap
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
 import Lens.Micro ((&), (.~))
-import Test.Cardano.Ledger.Dijkstra.ImpTest (
-  DijkstraEraImp,
-  ImpInit,
-  LedgerSpec,
-  expectStakeCredNotRegistered,
-  expectStakeCredRegistered,
-  freshKeyAddr,
-  freshKeyHash,
-  getsPParams,
-  impAnn,
-  passNEpochs,
-  registerInitialCommittee,
-  registerStakeCredential,
-  sendCoinTo,
-  setupSingleDRep,
-  submitFailingTx,
-  submitParameterChange,
-  submitTx_,
-  submitYesVoteCCs_,
-  submitYesVote_,
- )
-import Test.Cardano.Ledger.Imp.Common (SpecWith, arbitrary, shouldReturn, xit)
+import Test.Cardano.Ledger.Dijkstra.ImpTest
+import Test.Cardano.Ledger.Imp.Common
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
 spec = do

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertSpec.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Dijkstra.Imp.CertSpec (spec) where
+
+import Cardano.Ledger.Conway.Governance (Voter (..))
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Dijkstra.Core (
+  EraTx (..),
+  EraTxBody (..),
+  emptyPParamsUpdate,
+  ppKeyDepositL,
+  ppuKeyDepositL,
+  pattern UnRegDepositTxCert,
+ )
+import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
+import Data.Maybe.Strict (StrictMaybe (..))
+import qualified Data.OMap.Strict as OMap
+import qualified Data.Sequence.Strict as SSeq
+import Lens.Micro ((&), (.~))
+import Test.Cardano.Ledger.Dijkstra.ImpTest (
+  DijkstraEraImp,
+  ImpInit,
+  LedgerSpec,
+  expectStakeCredNotRegistered,
+  expectStakeCredRegistered,
+  freshKeyHash,
+  getsPParams,
+  impAnn,
+  passNEpochs,
+  registerInitialCommittee,
+  registerStakeCredential,
+  setupSingleDRep,
+  submitParameterChange,
+  submitTx_,
+  submitYesVoteCCs_,
+  submitYesVote_,
+ )
+import Test.Cardano.Ledger.Imp.Common (SpecWith, it, shouldReturn)
+
+spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
+spec = do
+  it "Subtransaction consumes correct refund after keyDeposit is changed" $ do
+    stakingCred <- KeyHashObj <$> freshKeyHash
+    _ <- registerStakeCredential stakingCred
+
+    initialKeyDeposit <- getsPParams ppKeyDepositL
+    impAnn "Change key deposit" $ do
+      (dRep, _, _) <- setupSingleDRep 100_000_000
+      ccHotCreds <- registerInitialCommittee
+      let newKeyDeposit = initialKeyDeposit <> initialKeyDeposit
+      ppChangeId <-
+        submitParameterChange SNothing $
+          emptyPParamsUpdate
+            & ppuKeyDepositL .~ SJust newKeyDeposit
+      submitYesVote_ (DRepVoter dRep) ppChangeId
+      submitYesVoteCCs_ ccHotCreds ppChangeId
+      getsPParams ppKeyDepositL `shouldReturn` initialKeyDeposit
+      passNEpochs 2
+      getsPParams ppKeyDepositL `shouldReturn` newKeyDeposit
+
+    impAnn "Unregister staking credential" $ do
+      expectStakeCredRegistered stakingCred
+      let
+        deRegCert = UnRegDepositTxCert stakingCred initialKeyDeposit
+        subTransaction =
+          mkBasicTx mkBasicTxBody
+            & bodyTxL . certsTxBodyL .~ SSeq.singleton deRegCert
+      submitTx_ $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . subTransactionsTxBodyL .~ OMap.singleton subTransaction
+      expectStakeCredNotRegistered stakingCred
+
+  -- it "Multiple subtransactions cannot get the same refund" $ do
+  --   undefined


### PR DESCRIPTION
# Description

This PR implements the consumed/produced computation for Dijkstra.

close https://github.com/IntersectMBO/cardano-ledger/issues/5401

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
