### PR TITLE
Changed CDDL test pending reasons

### DIFF
--- a/eras/conway/impl/test/Test/Cardano/Ledger/Conway/Binary/CddlSpec.hs
+++ b/eras/conway/impl/test/Test/Cardano/Ledger/Conway/Binary/CddlSpec.hs
@@ -81,7 +81,8 @@ spec = do
       -- TxBody
       huddleRoundTripAnnCborSpec @(TxBody TopTx ConwayEra) v "transaction_body"
       -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(TxBody TopTx ConwayEra) v "transaction_body"
+      xdescribe "fix certs" $
+        huddleRoundTripArbitraryValidate @(TxBody TopTx ConwayEra) v "transaction_body"
       huddleRoundTripCborSpec @(TxBody TopTx ConwayEra) v "transaction_body"
       -- AuxData
       huddleRoundTripAnnCborSpec @(TxAuxData ConwayEra) v "auxiliary_data"
@@ -119,7 +120,7 @@ spec = do
       -- PParamsUpdate
       huddleRoundTripCborSpec @(PParamsUpdate ConwayEra) v "protocol_param_update"
       -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $
+      xdescribe "fix unit_interval" $
         huddleRoundTripArbitraryValidate @(PParamsUpdate ConwayEra) v "protocol_param_update"
       -- CostModels
       huddleRoundTripCborSpec @CostModels v "cost_models"
@@ -132,7 +133,8 @@ spec = do
       -- Tx
       huddleRoundTripAnnCborSpec @(Tx TopTx ConwayEra) v "transaction"
       -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(Tx TopTx ConwayEra) v "transaction"
+      xdescribe "fix transaction_body" $
+        huddleRoundTripArbitraryValidate @(Tx TopTx ConwayEra) v "transaction"
       huddleRoundTripCborSpec @(Tx TopTx ConwayEra) v "transaction"
       -- VotingProcedure
       huddleRoundTripCborSpec @(VotingProcedure ConwayEra) v "voting_procedure"
@@ -145,7 +147,8 @@ spec = do
       -- GovAction
       huddleRoundTripCborSpec @(GovAction ConwayEra) v "gov_action"
       -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(GovAction ConwayEra) v "gov_action"
+      xdescribe "fix protocol_param_update" $
+        huddleRoundTripArbitraryValidate @(GovAction ConwayEra) v "gov_action"
       -- TxCert
       huddleRoundTripCborSpec @(TxCert ConwayEra) v "certificate"
       -- TODO this fails because of the hard-coded `unit_interval` in the CDDL

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -91,7 +91,7 @@ spec = do
         huddleRoundTripAnnCborSpec @(TxBody TopTx DijkstraEra) v "transaction_body"
         huddleRoundTripCborSpec @(TxBody TopTx DijkstraEra) v "transaction_body"
       -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $
+      xdescribe "fix certificate" $
         huddleRoundTripArbitraryValidate @(TxBody TopTx DijkstraEra) v "transaction_body"
       huddleRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
       -- TODO fails because of plutus scripts
@@ -126,7 +126,7 @@ spec = do
         huddleRoundTripArbitraryValidate @(TxWits DijkstraEra) v "transaction_witness_set"
       huddleRoundTripCborSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
       -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $ do
+      xdescribe "fix unit_interval" $
         huddleRoundTripArbitraryValidate @(PParamsUpdate DijkstraEra) v "protocol_param_update"
       huddleRoundTripCborSpec @CostModels v "cost_models"
       huddleRoundTripArbitraryValidate @CostModels v "cost_models"
@@ -138,7 +138,8 @@ spec = do
         huddleRoundTripAnnCborSpec @(Tx TopTx DijkstraEra) v "transaction"
         huddleRoundTripCborSpec @(Tx TopTx DijkstraEra) v "transaction"
       -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(Tx TopTx DijkstraEra) v "transaction"
+      xdescribe "fix transaction_body" $
+        huddleRoundTripArbitraryValidate @(Tx TopTx DijkstraEra) v "transaction"
       huddleRoundTripCborSpec @(VotingProcedure DijkstraEra) v "voting_procedure"
       huddleRoundTripArbitraryValidate @(VotingProcedure DijkstraEra) v "voting_procedure"
       huddleRoundTripCborSpec @(ProposalProcedure DijkstraEra) v "proposal_procedure"
@@ -147,7 +148,8 @@ spec = do
         huddleRoundTripArbitraryValidate @(ProposalProcedure DijkstraEra) v "proposal_procedure"
       huddleRoundTripCborSpec @(GovAction DijkstraEra) v "gov_action"
       -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(GovAction DijkstraEra) v "gov_action"
+      describe "fix protocol_param_update" $
+        huddleRoundTripArbitraryValidate @(GovAction DijkstraEra) v "gov_action"
       xdescribe "fix TxCert" $ do
         huddleRoundTripCborSpec @(TxCert DijkstraEra) v "certificate"
       -- TODO this fails because of the hard-coded `unit_interval` in the CDDL


### PR DESCRIPTION
# Description

This just changes the descriptions of the pending CDDL test cases. I tried to remove `xdescribe` from tests that said "hangs". While they finish instantly with the new version of `cuddle`, they are still failing due to bad generators.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
