### PR TITLE
MemoBytes avoid space leaks

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Scripts.hs
@@ -90,7 +90,7 @@ import Cardano.Ledger.MemoBytes (
   packMemoBytesM,
   unpackMemoBytesM,
  )
-import Cardano.Ledger.MemoBytes.Internal (mkMemoBytes)
+import Cardano.Ledger.MemoBytes.Internal (mkMemoBytesShort)
 import Cardano.Ledger.Shelley.Scripts (
   ShelleyEraScript (..),
   nativeMultiSigTag,
@@ -103,8 +103,6 @@ import Cardano.Slotting.Slot (SlotNo (..))
 import Control.DeepSeq (NFData (..))
 import Data.Aeson (ToJSON (..), (.=))
 import qualified Data.Aeson as Aeson
-import Data.ByteString.Lazy (fromStrict)
-import Data.ByteString.Short (fromShort)
 import Data.Foldable as F (foldl')
 import Data.MemPack
 import Data.Sequence.Strict as Seq (StrictSeq (Empty, (:<|)))
@@ -176,7 +174,7 @@ deriving instance Era era => NoThunks (TimelockRaw era)
 deriving instance Show (TimelockRaw era)
 
 -- | This function deconstructs and then reconstructs the timelock script
--- to prove the compiler that we can arbirarily switch out the eras as long
+-- to prove the compiler that we can arbitrarily switch out the eras as long
 -- as the cryptos for both eras are the same.
 translateTimelock ::
   forall era1 era2.
@@ -185,8 +183,8 @@ translateTimelock ::
   ) =>
   Timelock era1 ->
   Timelock era2
-translateTimelock (MkTimelock (Memo tl bs)) =
-  let rewrap rtl = MkTimelock $ mkMemoBytes rtl (fromStrict $ fromShort bs)
+translateTimelock (MkTimelock (Memo tl sbs)) =
+  let rewrap rtl = MkTimelock $ mkMemoBytesShort rtl sbs
    in case tl of
         TimelockSignature s -> rewrap $ TimelockSignature s
         TimelockAllOf l -> rewrap . TimelockAllOf $ translateTimelock <$> l

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -849,12 +849,12 @@ headerRewardAccountIsScript = (`testBit` 4)
 --
 -- ┏━━━━━━━━━━━━━━━━┳━┯━┯━┯━┯━┯━┯━┯━┓
 -- ┃ Reward Account ┃1┊1┊1┊x┊0┊0┊0┊x┃
--- ┗━━━━━━━━━━━━━━━━╋━┿━┿━┿━┿━┿━┿━┿━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
---                  ┃1┊1┊1┊0┊0┊0┊0┊0┃ Testnet PaymentKey    StakingKey    ┃
---                  ┃1┊1┊1┊0┊0┊0┊0┊1┃ Mainnet PaymentKey    StakingKey    ┃
---                  ┃1┊1┊1┊1┊0┊0┊0┊0┃ Testnet PaymentScript StakingKey    ┃
---                  ┃1┊1┊1┊1┊0┊0┊0┊1┃ Mainnet PaymentScript StakingKey    ┃
---                  ┗━┷━┷━┷━┷━┷━┷━┷━┻━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+-- ┗━━━━━━━━━━━━━━━━╋━┿━┿━┿━┿━┿━┿━┿━╋━━━━━━━━━━━━━━━━━━━━━━━┓
+--                  ┃1┊1┊1┊0┊0┊0┊0┊0┃ Testnet StakingKey    ┃
+--                  ┃1┊1┊1┊0┊0┊0┊0┊1┃ Mainnet StakingKey    ┃
+--                  ┃1┊1┊1┊1┊0┊0┊0┊0┃ Testnet StakingScript ┃
+--                  ┃1┊1┊1┊1┊0┊0┊0┊1┃ Mainnet StakingScript ┃
+--                  ┗━┷━┷━┷━┷━┷━┷━┷━┻━━━━━━━━━━━━━━━━━━━━━━━┛
 --                          \       \
 --                           \       `Is Mainnet Address
 --                            `Account Credential is a Script

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
@@ -209,8 +209,11 @@ mkMemoBytes t = mkMemoBytesStrict t . toStrict
 -- | Same as `mkMemoBytes`, but with strict bytes
 mkMemoBytesStrict :: forall t. t -> ByteString -> MemoBytes t
 mkMemoBytesStrict t bs =
-  MemoBytes t (toShort bs) $
-    makeHashWithExplicitProxys (Proxy @(MemoHashIndex t)) bs
+  MemoBytes t sbs hash
+  where
+    sbs = toShort bs
+    -- Ensure original `ByteString` can be garbage collected as soon as the hash is computed
+    hash = sbs `seq` makeHashWithExplicitProxys (Proxy @(MemoHashIndex t)) bs
 
 -- | Create MemoBytes from its CBOR encoding
 --

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/MemoBytes/Internal.hs
@@ -176,7 +176,7 @@ instance
   decCBOR = do
     (Annotator getT, Annotator getBytes) <- withSlice decCBOR
     pure $ Annotator $ \fullBytes ->
-      mkMemoBytes <$> getT fullBytes <*> getBytes fullBytes
+      mkMemoBytesForce <$> getT fullBytes <*> getBytes fullBytes
 
 -- | Both binary representation and Haskell types are compared.
 instance Eq t => Eq (MemoBytes t) where
@@ -223,6 +223,14 @@ mkMemoBytesShort t sbs =
   MemoBytes t sbs hash
   where
     hash = makeHashWithExplicitProxys (Proxy @(MemoHashIndex t)) (fromShort sbs)
+
+-- | Same as `mkMemoBytes`, but immediately makes a copy of the original bytes, in order to ensure
+-- that potentially much larger source `LazyByteString` is not retained in memory.
+mkMemoBytesForce :: t -> BSL.ByteString -> MemoBytes t
+mkMemoBytesForce t bsl =
+  -- Note: we cannot simply use `toStrict` here, since it does not guarantee a copy, which is why we
+  -- must convert it to a `ShortByteString` and ensure it is fully evaluated.
+  mkMemoBytesShort t $! toShort $ BSL.toStrict bsl
 
 -- | Create MemoBytes from its CBOR encoding
 --
@@ -289,7 +297,7 @@ mkMemoizedEra = mkMemoized (eraProtVerLow @era)
 decodeMemoized :: Decoder s t -> Decoder s (MemoBytes t)
 decodeMemoized rawTypeDecoder = do
   Annotated rawType lazyBytes <- decodeAnnotated rawTypeDecoder
-  pure $ mkMemoBytes rawType lazyBytes
+  pure $! mkMemoBytesForce rawType lazyBytes
 
 -- | Extract memoized SafeHash
 getMemoSafeHash :: Memoized t => t -> SafeHash (MemoHashIndex (RawType t))

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Data.hs
@@ -62,7 +62,7 @@ import Cardano.Ledger.MemoBytes (
   getMemoSafeHash,
   mkMemoizedEra,
  )
-import Cardano.Ledger.MemoBytes.Internal (mkMemoBytesStrict)
+import Cardano.Ledger.MemoBytes.Internal (mkMemoBytesShort)
 import qualified Codec.Serialise as Cborg (Serialise (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson (ToJSON (..), Value (Null))
@@ -170,7 +170,7 @@ decodeBinaryData :: forall era. Era era => BinaryData era -> Either DecoderError
 decodeBinaryData (BinaryData sbs) = do
   let bs = fromShort sbs
   plutusData <- decodeFull' (eraProtVerLow @era) bs
-  pure (MkData (mkMemoBytesStrict plutusData bs))
+  pure (MkData (mkMemoBytesShort plutusData sbs))
 
 -- | It is safe to convert `BinaryData` to `Data` because the only way to
 -- construct `BinaryData` is through the smart constructor `makeBinaryData` that


### PR DESCRIPTION
# Description

This PR prevents retention of larger bytestrings longer than necessary upon deserialization of MemoBytes. There is also slight reduction in copying for Plutus `BinaryData`

No user visible changes, since those are changes to internal interface only, so no changelog is needed.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
