### PR TITLE
CDDL: Remove header_body discrepancy

### DIFF
--- a/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
+++ b/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
@@ -188,7 +188,7 @@ instance HuddleGroup "operational_cert" AllegraEra where
   huddleGroupNamed = shelleyOperationalCertGroup
 
 instance HuddleRule "header_body" AllegraEra where
-  huddleRuleNamed = headerBodyRule
+  huddleRuleNamed = shelleyHeaderBodyRule
 
 instance HuddleRule "header" AllegraEra where
   huddleRuleNamed = headerRule

--- a/eras/alonzo/impl/cddl/data/alonzo.cddl
+++ b/eras/alonzo/impl/cddl/data/alonzo.cddl
@@ -18,14 +18,14 @@ header = [header_body, body_signature : kes_signature]
 
 header_body = 
   [ block_number      : block_number
-  , slot              : slot       
-  , prev_hash         : hash32/ nil
-  , issuer_vkey       : vkey       
-  , vrf_vkey          : vrf_vkey   
-  , nonce_vrf         : vrf_cert   
-  , leader_vrf        : vrf_cert   
-  , block_body_size   : uint       
-  , block_body_hash   : hash32      ; merkle triple root
+  , slot              : slot        
+  , prev_hash         : hash32/ nil 
+  , issuer_vkey       : vkey        
+  , vrf_vkey          : vrf_vkey    
+  , nonce_vrf         : vrf_cert    
+  , leader_vrf        : vrf_cert    
+  , block_body_size   : uint .size 4
+  , block_body_hash   : hash32      
   , operational_cert
   , protocol_version
   ]

--- a/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
+++ b/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
@@ -293,21 +293,7 @@ instance HuddleRule "header" AlonzoEra where
         ]
 
 instance HuddleRule "header_body" AlonzoEra where
-  huddleRuleNamed pname p =
-    pname
-      =.= arr
-        [ "block_number" ==> huddleRule @"block_number" p
-        , "slot" ==> huddleRule @"slot" p
-        , "prev_hash" ==> (huddleRule @"hash32" p / VNil)
-        , "issuer_vkey" ==> huddleRule @"vkey" p
-        , "vrf_vkey" ==> huddleRule @"vrf_vkey" p
-        , "nonce_vrf" ==> huddleRule @"vrf_cert" p
-        , "leader_vrf" ==> huddleRule @"vrf_cert" p
-        , "block_body_size" ==> VUInt
-        , "block_body_hash" ==> huddleRule @"hash32" p //- "merkle triple root"
-        , a $ huddleGroup @"operational_cert" p
-        , a $ huddleGroup @"protocol_version" p
-        ]
+  huddleRuleNamed = shelleyHeaderBodyRule
 
 instance HuddleGroup "protocol_version" AlonzoEra where
   huddleGroupNamed = shelleyProtocolVersionGroup

--- a/eras/babbage/impl/cddl/data/babbage.cddl
+++ b/eras/babbage/impl/cddl/data/babbage.cddl
@@ -16,15 +16,16 @@ block =
 
 header = [header_body, body_signature : kes_signature]
 
+; nonce_vrf and leader_vrf are replaced by vrf_result
 header_body = 
   [ block_number      : block_number
-  , slot              : slot       
-  , prev_hash         : hash32/ nil
-  , issuer_vkey       : vkey       
-  , vrf_vkey          : vrf_vkey   
-  , vrf_result        : vrf_cert    ; replaces nonce_vrf and leader_vrf
-  , block_body_size   : uint       
-  , block_body_hash   : hash32      ; merkle triple root
+  , slot              : slot        
+  , prev_hash         : hash32/ nil 
+  , issuer_vkey       : vkey        
+  , vrf_vkey          : vrf_vkey    
+  , vrf_result        : vrf_cert    
+  , block_body_size   : uint .size 4
+  , block_body_hash   : hash32       ; merkle triple root
   , operational_cert
   , protocol_version
   ]

--- a/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
+++ b/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
@@ -1271,20 +1271,7 @@ instance HuddleRule "update" ConwayEra where
   huddleRuleNamed = updateRule
 
 instance HuddleRule "header_body" ConwayEra where
-  huddleRuleNamed pname p =
-    pname
-      =.= arr
-        [ "block_number" ==> huddleRule @"block_number" p
-        , "slot" ==> huddleRule @"slot" p
-        , "prev_hash" ==> (huddleRule @"hash32" p / VNil)
-        , "issuer_vkey" ==> huddleRule @"vkey" p
-        , "vrf_vkey" ==> huddleRule @"vrf_vkey" p
-        , "vrf_result" ==> huddleRule @"vrf_cert" p
-        , "block_body_size" ==> VUInt `sized` (4 :: Word64)
-        , "block_body_hash" ==> huddleRule @"hash32" p //- "merkle triple root"
-        , a $ huddleRule @"operational_cert" p
-        , a $ huddleRule @"protocol_version" p
-        ]
+  huddleRuleNamed = babbageHeaderBodyRule
 
 instance HuddleRule "header" ConwayEra where
   huddleRuleNamed = headerRule

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -741,20 +741,7 @@ instance HuddleRule "update" DijkstraEra where
   huddleRuleNamed = updateRule
 
 instance HuddleRule "header_body" DijkstraEra where
-  huddleRuleNamed pname p =
-    pname
-      =.= arr
-        [ "block_number" ==> huddleRule @"block_number" p
-        , "slot" ==> huddleRule @"slot" p
-        , "prev_hash" ==> (huddleRule @"hash32" p / VNil)
-        , "issuer_vkey" ==> huddleRule @"vkey" p
-        , "vrf_vkey" ==> huddleRule @"vrf_vkey" p
-        , "vrf_result" ==> huddleRule @"vrf_cert" p
-        , "block_body_size" ==> VUInt `sized` (4 :: Word64)
-        , "block_body_hash" ==> huddleRule @"hash32" p //- "merkle triple root"
-        , a $ huddleRule @"operational_cert" p
-        , a $ huddleRule @"protocol_version" p
-        ]
+  huddleRuleNamed = babbageHeaderBodyRule
 
 instance HuddleRule "header" DijkstraEra where
   huddleRuleNamed = headerRule

--- a/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
+++ b/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
@@ -83,7 +83,7 @@ instance HuddleRule "header" MaryEra where
   huddleRuleNamed = headerRule
 
 instance HuddleRule "header_body" MaryEra where
-  huddleRuleNamed = headerBodyRule
+  huddleRuleNamed = shelleyHeaderBodyRule
 
 instance HuddleGroup "protocol_version" MaryEra where
   huddleGroupNamed = shelleyProtocolVersionGroup

--- a/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
+++ b/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
@@ -20,7 +20,7 @@ module Cardano.Ledger.Shelley.HuddleSpec (
   proposedProtocolParameterUpdatesRule,
   updateRule,
   protocolParamUpdateRule,
-  headerBodyRule,
+  shelleyHeaderBodyRule,
   transactionWitnessSetRule,
   vkeywitnessRule,
   bootstrapWitnessRule,
@@ -123,7 +123,7 @@ protocolParamUpdateRule pname p =
       , opt (idx 16 ==> huddleRule @"coin" p) //- "min pool cost"
       ]
 
-headerBodyRule ::
+shelleyHeaderBodyRule ::
   forall era.
   ( HuddleGroup "operational_cert" era
   , HuddleGroup "protocol_version" era
@@ -131,7 +131,7 @@ headerBodyRule ::
   Proxy "header_body" ->
   Proxy era ->
   Rule
-headerBodyRule pname p =
+shelleyHeaderBodyRule pname p =
   pname
     =.= arr
       [ "block_number" ==> huddleRule @"block_number" p
@@ -518,7 +518,7 @@ instance HuddleGroup "operational_cert" ShelleyEra where
   huddleGroupNamed = shelleyOperationalCertGroup
 
 instance HuddleRule "header_body" ShelleyEra where
-  huddleRuleNamed = headerBodyRule
+  huddleRuleNamed = shelleyHeaderBodyRule
 
 instance HuddleRule "header" ShelleyEra where
   huddleRuleNamed = headerRule


### PR DESCRIPTION
# Description

`block_body_size` was not sized only for `alonzo` and `babbage` due to a historical error. It is now sized for all eras. And the `header_body` rule now clearly distinguishes when `nonce_vrf` and `leader_vrf` were deprecated in favour of `vrf_result`.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] ~~Tests added or updated when needed.~~
- [ ] ~~`CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).~~
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
