### PR TITLE
Change Version from Word64 to Word32.

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -62,7 +62,7 @@ import Cardano.Ledger.BaseTypes (
   Inject (..),
   ProtVer (..),
   StrictMaybe (..),
-  getVersion64,
+  getVersion32,
   isSJust,
   kindObject,
   strictMaybe,
@@ -735,7 +735,7 @@ transPlutusPurposeV1V2 proxy pv = \case
 
 transProtVer :: ProtVer -> PV3.ProtocolVersion
 transProtVer (ProtVer major minor) =
-  PV3.ProtocolVersion (toInteger (getVersion64 major)) (toInteger minor)
+  PV3.ProtocolVersion (toInteger (getVersion32 major)) (toInteger minor)
 
 toPlutusV3Args ::
   EraPlutusTxInfo 'PlutusV3 era =>

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -98,6 +98,7 @@
 
 ### `cddl`
 
+* Constrain `protocol_version` minor field to `uint .size 4`.
 * Renamed `policy_hash` to `guardrails_script_hash` in governance actions to avoid confusion with multi-asset policy IDs
 * Move `cddl-files` to `cddl/data`.
 * Add full `HuddleSpec`.

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -97,7 +97,7 @@ kes_period = uint .size 8
 
 signature = bytes .size 64
 
-protocol_version = [major_protocol_version, uint]
+protocol_version = [major_protocol_version, uint .size 4]
 
 major_protocol_version = 0 .. 13
 

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -51,6 +51,13 @@ dijkstraCDDL =
     , HIRule $ huddleRule @"certificate" (Proxy @DijkstraEra)
     ]
 
+-- | Dijkstra constrains the minor protocol version to Word32 (uint .size 4).
+dijkstraProtocolVersionRule ::
+  forall era.
+  HuddleRule "major_protocol_version" era => Proxy "protocol_version" -> Proxy era -> Rule
+dijkstraProtocolVersionRule pname p =
+  pname =.= arr [a $ huddleRule @"major_protocol_version" p, a $ VUInt `sized` (4 :: Word64)]
+
 guardsRule ::
   forall era.
   ( HuddleRule "addr_keyhash" era
@@ -364,7 +371,7 @@ instance HuddleRule "operational_cert" DijkstraEra where
   huddleRuleNamed = babbageOperationalCertRule
 
 instance HuddleRule "protocol_version" DijkstraEra where
-  huddleRuleNamed = babbageProtocolVersionRule
+  huddleRuleNamed = dijkstraProtocolVersionRule
 
 instance HuddleRule "policy_id" DijkstraEra where
   huddleRuleNamed pname p = pname =.= huddleRule @"script_hash" p

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.8.0.0
 
+* Change `Version` from `Word64` to `Word32`
+  - Add `mkVersion32` and `getVersion32`
 * Remove `listLenBound` from `EncCBORGroup`
 * Change type of `listLen` in `EncCBORGroup` to accept a `Proxy` instead of a concrete value
 * Add `decodeNonEmptySetLikeEnforceNoDuplicatesAnn` to `Annotated` module

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -174,7 +174,7 @@ import Cardano.Ledger.Binary.Plain (
   toCborError,
  )
 import qualified Cardano.Ledger.Binary.Plain as Plain (assertTag, decodeTagMaybe)
-import Cardano.Ledger.Binary.Version (Version, mkVersion64, natVersion)
+import Cardano.Ledger.Binary.Version (Version, mkVersion32, natVersion)
 import Cardano.Slotting.Slot (WithOrigin, withOriginFromMaybe)
 import Codec.CBOR.ByteArray (ByteArray (..))
 import qualified Codec.CBOR.Decoding as C (
@@ -425,7 +425,7 @@ unlessDecoderVersionAtLeast atLeast decoder = do
 --------------------------------------------------------------------------------
 
 decodeVersion :: Decoder s Version
-decodeVersion = decodeWord64 >>= mkVersion64
+decodeVersion = decodeWord32 >>= mkVersion32
 {-# INLINE decodeVersion #-}
 
 -- | `Decoder` for `Rational`. Versions variance:
@@ -471,8 +471,8 @@ decodeRational =
 _decodeRationalFuture :: Decoder s Rational
 _decodeRationalFuture = do
   -- We are not using `natVersion` because these versions aren't yet supported.
-  v9 <- mkVersion64 9
-  v10 <- mkVersion64 10
+  v9 <- mkVersion32 9
+  v10 <- mkVersion32 10
   ifDecoderVersionAtLeast
     v10
     decodeRationalWithTag

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Encoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Encoder.hs
@@ -93,7 +93,7 @@ module Cardano.Ledger.Binary.Encoding.Encoder (
 
 import qualified Cardano.Binary as C
 import Cardano.Ledger.Binary.Decoding.Decoder (setTag)
-import Cardano.Ledger.Binary.Version (Version, getVersion64, natVersion)
+import Cardano.Ledger.Binary.Version (Version, getVersion32, natVersion)
 import Cardano.Slotting.Slot (WithOrigin, withOriginToMaybe)
 import Codec.CBOR.ByteArray.Sliced (SlicedByteArray)
 import qualified Codec.CBOR.Term as C (Term (..), encodeTerm)
@@ -275,7 +275,7 @@ encodeTerm = fromPlainEncoding . C.encodeTerm
 --------------------------------------------------------------------------------
 
 encodeVersion :: Version -> Encoding
-encodeVersion = encodeWord64 . getVersion64
+encodeVersion = encodeWord32 . getVersion32
 
 encodeRatioNoTag :: (t -> Encoding) -> Ratio t -> Encoding
 encodeRatioNoTag encodeNumeric r =

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Arbitrary.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Arbitrary.hs
@@ -209,12 +209,12 @@ instance Arbitrary Version where
 
 genVersion :: HasCallStack => Version -> Version -> Gen Version
 genVersion minVersion maxVersion =
-  genVersion64 (getVersion64 minVersion) (getVersion64 maxVersion)
+  genVersion32 (getVersion32 minVersion) (getVersion32 maxVersion)
   where
-    genVersion64 minVersion64 maxVersion64 = do
-      v64 <- choose (minVersion64, maxVersion64)
-      case mkVersion64 v64 of
-        Nothing -> error $ "Impossible: Invalid version generated: " ++ show v64
+    genVersion32 minVersion32 maxVersion32 = do
+      v32 <- choose (minVersion32, maxVersion32)
+      case mkVersion32 v32 of
+        Nothing -> error $ "Impossible: Invalid version generated: " ++ show v32
         Just v -> pure v
 
 genByteString :: Int -> Gen BS.ByteString

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/TreeDiff.hs
@@ -94,7 +94,7 @@ instance ToExpr a => ToExpr (StrictSeq a) where
 instance ToExpr a => ToExpr (StrictMaybe a)
 
 instance ToExpr Version where
-  toExpr v = App "Version" [toExpr (getVersion64 v)]
+  toExpr v = App "Version" [toExpr (getVersion32 v)]
 
 instance ToExpr a => ToExpr (Sized a)
 

--- a/libs/cardano-ledger-core/app/CLI.hs
+++ b/libs/cardano-ledger-core/app/CLI.hs
@@ -5,7 +5,7 @@ module CLI (
   optsParser,
 ) where
 
-import Cardano.Ledger.Binary (mkVersion64)
+import Cardano.Ledger.Binary (mkVersion32)
 import Cardano.Ledger.Plutus.Evaluate
 import Options.Applicative
 import Text.Read (readMaybe)
@@ -28,7 +28,7 @@ overridesParser =
           <> help "Plutus script hex without context"
       )
     <*> option
-      (mkVersion64 <$> auto)
+      (mkVersion32 <$> auto)
       ( long "protocol-version"
           <> short 'v'
           <> value Nothing

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -218,14 +218,14 @@ instance NoThunks ProtVer
 instance ToJSON ProtVer where
   toJSON (ProtVer major minor) =
     object
-      [ "major" .= getVersion64 major
+      [ "major" .= getVersion32 major
       , "minor" .= minor
       ]
 
 instance FromJSON ProtVer where
   parseJSON =
     withObject "ProtVer" $ \obj -> do
-      pvMajor <- mkVersion64 =<< obj .: "major"
+      pvMajor <- mkVersion32 =<< obj .: "major"
       pvMinor <- obj .: "minor"
       pure ProtVer {..}
 


### PR DESCRIPTION
# Description

* Add `mkVersion32` and `getVersion32`
* Constrain `dijkstra` `protocol_version` minor to `uint .size 4`

Closes #5414 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] ~~Tests added or updated when needed.~~
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] ~~Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).~~
- [ ] ~~Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).~~
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
