### PR TITLE
Implement events and failures in rules running nested transactions

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0.0
 
+* Add `DijkstraLedgerEvent`
 * Add `DirectDeposits` to transaction bodies at both (top and sub) levels.
   - Add `directDepositsTxBodyL` lens to the `DijkstraEraTxBody` typeclass.
 * Add `DijkstraSpendingOutputFromSameTx` to `DijkstraLedgerPredFailure`, to report when a sub-tx-id is being spent within the same transaction.

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## 0.2.0.0
 
+* Add:
+  - `DijkstraLedgerEvent`
+  - `DijkstraSubLedgersEvent`
+  - `DijkstraSubLedgerEvent`
+  - `DijkstraSubCertsEvent`
+  - `DijkstraSubCertEvent`
+  - `DijkstraSubPoolEvent`
+  - `DijkstraSubGovEvent`
+  - `DijkstraSubUtxowEvent`
+  - `DijkstraSubUtxoEvent`
+  - `DijkstraSubUtxosEvent`
 * Add `DijkstraLedgerEvent`
 * Add `DirectDeposits` to transaction bodies at both (top and sub) levels.
   - Add `directDepositsTxBodyL` lens to the `DijkstraEraTxBody` typeclass.

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Dijkstra.Rules.Ledger (
 import Cardano.Ledger.Address (RewardAccount (..))
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
 import Cardano.Ledger.Alonzo (AlonzoScript)
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
@@ -449,6 +450,7 @@ instance
   , AlonzoEraTx era
   , ConwayEraPParams era
   , DijkstraEraTxBody era
+  , EraPlutusContext era
   , GovState era ~ ConwayGovState era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
@@ -554,6 +556,7 @@ instance
   , ConwayEraTxBody era
   , ConwayEraGov era
   , ConwayEraCertState era
+  , EraPlutusContext era
   , EraRule "SUBLEDGERS" era ~ DijkstraSUBLEDGERS era
   , EraRule "SUBLEDGER" era ~ DijkstraSUBLEDGER era
   , EraRule "SUBGOV" era ~ DijkstraSUBGOV era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -125,7 +125,6 @@ import Data.Sequence (Seq)
 import qualified Data.Set as Set
 import Data.Set.NonEmpty (NonEmptySet)
 import qualified Data.Set.NonEmpty as NES
-import Data.Void (absurd)
 import GHC.Generics (Generic (..))
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
@@ -307,12 +306,14 @@ data DijkstraLedgerEvent era
   = UtxowEvent (Event (EraRule "UTXOW" era))
   | CertsEvent (Event (EraRule "CERTS" era))
   | GovEvent (Event (EraRule "GOV" era))
+  | SubLedgersEvent (Event (EraRule "SUBLEDGERS" era))
   deriving (Generic)
 
 deriving instance
   ( Eq (Event (EraRule "CERTS" era))
   , Eq (Event (EraRule "UTXOW" era))
   , Eq (Event (EraRule "GOV" era))
+  , Eq (Event (EraRule "SUBLEDGERS" era))
   ) =>
   Eq (DijkstraLedgerEvent era)
 
@@ -320,6 +321,7 @@ instance
   ( NFData (Event (EraRule "CERTS" era))
   , NFData (Event (EraRule "UTXOW" era))
   , NFData (Event (EraRule "GOV" era))
+  , NFData (Event (EraRule "SUBLEDGERS" era))
   ) =>
   NFData (DijkstraLedgerEvent era)
 
@@ -563,9 +565,10 @@ instance
   , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
   , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
   , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
+  , Event (EraRule "LEDGER" era) ~ DijkstraLedgerEvent era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGERS era) (DijkstraLEDGER era)
   where
   wrapFailed = DijkstraSubLedgersFailure
-  wrapEvent = absurd
+  wrapEvent = SubLedgersEvent

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Dijkstra.Rules.Mempool (
   DijkstraMempoolEvent (..),
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
@@ -223,6 +224,7 @@ instance
   , ConwayEraCertState era
   , DijkstraEraTxBody era
   , ConwayEraGov era
+  , EraPlutusContext era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "CERTS" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubDeleg.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubDeleg.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -24,7 +25,7 @@ import Cardano.Ledger.Binary (
   EncCBOR (..),
  )
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Rules (ConwayDelegEnv)
+import Cardano.Ledger.Conway.Rules (ConwayDelegEnv, ConwayDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
   DijkstraSUBDELEG,
@@ -45,23 +46,12 @@ import Control.State.Transition.Extended (
   judgmentContext,
   transitionRules,
  )
-import Data.Typeable (Typeable)
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
-data DijkstraSubDelegPredFailure era = DijkstraSubDelegPredFailure
-  deriving (Show, Eq, Generic)
-
-instance NoThunks (DijkstraSubDelegPredFailure era)
-
-instance NFData (DijkstraSubDelegPredFailure era)
-
-instance Era era => EncCBOR (DijkstraSubDelegPredFailure era) where
-  encCBOR _ = encCBOR ()
-
-instance Typeable era => DecCBOR (DijkstraSubDelegPredFailure era) where
-  decCBOR = decCBOR @() *> pure DijkstraSubDelegPredFailure
+newtype DijkstraSubDelegPredFailure era = DijkstraSubDelegPredFailure (ConwayDelegPredFailure era)
+  deriving (Generic, Eq, Show, NFData, NoThunks, EncCBOR, DecCBOR)
 
 type instance EraRuleFailure "SUBDELEG" DijkstraEra = DijkstraSubDelegPredFailure DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubGov.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubGov.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -32,6 +34,7 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
   DijkstraSUBGOV,
  )
+import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (
   BaseM,
@@ -46,22 +49,11 @@ import Control.State.Transition.Extended (
   judgmentContext,
   transitionRules,
  )
-import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
-data DijkstraSubGovPredFailure era = DijkstraSubGovPredFailure
-  deriving (Show, Eq, Generic)
-
-instance NoThunks (DijkstraSubGovPredFailure era)
-
-instance NFData (DijkstraSubGovPredFailure era)
-
-instance Era era => EncCBOR (DijkstraSubGovPredFailure era) where
-  encCBOR _ = encCBOR ()
-
-instance Typeable era => DecCBOR (DijkstraSubGovPredFailure era) where
-  decCBOR = decCBOR @() *> pure DijkstraSubGovPredFailure
+newtype DijkstraSubGovPredFailure era = DijkstraSubGovPredFailure (DijkstraGovPredFailure era)
+  deriving (Generic, Eq, Show, NoThunks, NFData, EncCBOR, DecCBOR)
 
 type instance EraRuleFailure "SUBGOV" DijkstraEra = DijkstraSubGovPredFailure DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubGovCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubGovCert.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -31,6 +32,7 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
   DijkstraSUBGOVCERT,
  )
+import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (
   BaseM,
@@ -45,23 +47,13 @@ import Control.State.Transition.Extended (
   judgmentContext,
   transitionRules,
  )
-import Data.Typeable (Typeable)
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
-data DijkstraSubGovCertPredFailure era = DijkstraSubGovCertPredFailure
-  deriving (Show, Eq, Generic)
-
-instance NoThunks (DijkstraSubGovCertPredFailure era)
-
-instance NFData (DijkstraSubGovCertPredFailure era)
-
-instance Era era => EncCBOR (DijkstraSubGovCertPredFailure era) where
-  encCBOR _ = encCBOR ()
-
-instance Typeable era => DecCBOR (DijkstraSubGovCertPredFailure era) where
-  decCBOR = decCBOR @() *> pure DijkstraSubGovCertPredFailure
+newtype DijkstraSubGovCertPredFailure era
+  = DijkstraSubGovCertPredFailure (DijkstraGovCertPredFailure era)
+  deriving (Show, Eq, Generic, NFData, NoThunks, EncCBOR, DecCBOR)
 
 type instance EraRuleFailure "SUBGOVCERT" DijkstraEra = DijkstraSubGovCertPredFailure DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedger (
   DijkstraSubLedgerEvent (..),
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
  )
@@ -302,6 +303,8 @@ instance
 instance
   ( ConwayEraGov era
   , ConwayEraCertState era
+  , ConwayEraTxBody era
+  , EraPlutusContext era
   , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , EraRule "SUBUTXOS" era ~ DijkstraSUBUTXOS era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -63,7 +63,6 @@ import Cardano.Ledger.Shelley.Rules (
   UtxoEnv (..),
   epochFromSlot,
  )
-import Cardano.Ledger.TxIn (TxId, TxIn (..))
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (
   BaseM,
@@ -84,7 +83,6 @@ import Control.State.Transition.Extended (
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.NonEmpty (NonEmptyMap)
 import qualified Data.Sequence.Strict as StrictSeq
-import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
@@ -98,7 +96,6 @@ data DijkstraSubLedgerPredFailure era
   | SubTxRefScriptsSizeTooBig (Mismatch RelLTEQ Int)
   | SubWithdrawalsMissingAccounts Withdrawals
   | SubIncompleteWithdrawals (NonEmptyMap RewardAccount (Mismatch RelEQ Coin))
-  | SubSpendingOutputFromSameTx (NonEmptyMap TxId (NonEmptySet TxIn))
   deriving (Generic)
 
 deriving stock instance
@@ -329,7 +326,6 @@ instance
       SubTxRefScriptsSizeTooBig mm -> Sum SubTxRefScriptsSizeTooBig 6 !> To mm
       SubWithdrawalsMissingAccounts w -> Sum SubWithdrawalsMissingAccounts 7 !> To w
       SubIncompleteWithdrawals w -> Sum SubIncompleteWithdrawals 8 !> To w
-      SubSpendingOutputFromSameTx txIds -> Sum SubSpendingOutputFromSameTx 9 !> To txIds
 
 instance
   ( Era era
@@ -348,5 +344,4 @@ instance
     6 -> SumD SubTxRefScriptsSizeTooBig <! From
     7 -> SumD SubWithdrawalsMissingAccounts <! From
     8 -> SumD SubIncompleteWithdrawals <! From
-    9 -> SumD SubSpendingOutputFromSameTx <! From
     n -> Invalid n

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -18,6 +18,7 @@
 module Cardano.Ledger.Dijkstra.Rules.SubLedger (
   DijkstraSUBLEDGER,
   DijkstraSubLedgerPredFailure (..),
+  DijkstraSubLedgerEvent (..),
 ) where
 
 import Cardano.Ledger.BaseTypes (
@@ -79,7 +80,6 @@ import Control.State.Transition.Extended (
   transitionRules,
  )
 import qualified Data.Sequence.Strict as StrictSeq
-import Data.Void (Void, absurd)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
@@ -148,7 +148,7 @@ instance
 
 type instance EraRuleFailure "SUBLEDGER" DijkstraEra = DijkstraSubLedgerPredFailure DijkstraEra
 
-type instance EraRuleEvent "SUBLEDGER" DijkstraEra = VoidEraRule "SUBLEDGER" DijkstraEra
+type instance EraRuleEvent "SUBLEDGER" DijkstraEra = DijkstraSubLedgerEvent DijkstraEra
 
 instance InjectRuleFailure "SUBLEDGER" DijkstraSubLedgerPredFailure DijkstraEra
 
@@ -160,6 +160,28 @@ instance InjectRuleFailure "SUBLEDGER" DijkstraSubUtxowPredFailure DijkstraEra w
 
 instance InjectRuleFailure "SUBLEDGER" DijkstraSubCertsPredFailure DijkstraEra where
   injectFailure = SubCertsFailure
+
+data DijkstraSubLedgerEvent era
+  = SubCertsEvent (Event (EraRule "SUBCERTS" era))
+  | SubGovEvent (Event (EraRule "SUBGOV" era))
+  | SubUtxowEvent (Event (EraRule "SUBUTXOW" era))
+  deriving (Generic)
+
+deriving instance
+  ( Eq (Event (EraRule "SUBCERTS" era))
+  , Eq (Event (EraRule "SUBGOV" era))
+  , Eq (Event (EraRule "SUBUTXOW" era))
+  ) =>
+  Eq (DijkstraSubLedgerEvent era)
+
+instance
+  ( NFData (Event (EraRule "SUBCERTS" era))
+  , NFData (Event (EraRule "SUBGOV" era))
+  , NFData (Event (EraRule "SUBUTXOW" era))
+  ) =>
+  NFData (DijkstraSubLedgerEvent era)
+
+instance InjectRuleEvent "SUBLEDGER" DijkstraSubLedgerEvent DijkstraEra
 
 instance
   ( EraTx era
@@ -188,7 +210,7 @@ instance
   type Environment (DijkstraSUBLEDGER era) = LedgerEnv era
   type BaseM (DijkstraSUBLEDGER era) = ShelleyBase
   type PredicateFailure (DijkstraSUBLEDGER era) = DijkstraSubLedgerPredFailure era
-  type Event (DijkstraSUBLEDGER era) = Void
+  type Event (DijkstraSUBLEDGER era) = DijkstraSubLedgerEvent era
 
   transitionRules = [dijkstraSubLedgersTransition @era]
 
@@ -275,7 +297,7 @@ instance
   Embed (DijkstraSUBGOV era) (DijkstraSUBLEDGER era)
   where
   wrapFailed = SubGovFailure
-  wrapEvent = absurd
+  wrapEvent = SubGovEvent
 
 instance
   ( ConwayEraGov era
@@ -287,7 +309,7 @@ instance
   Embed (DijkstraSUBUTXOW era) (DijkstraSUBLEDGER era)
   where
   wrapFailed = SubUtxowFailure
-  wrapEvent = absurd
+  wrapEvent = SubUtxowEvent
 
 instance
   ( ConwayEraGov era
@@ -302,4 +324,4 @@ instance
   Embed (DijkstraSUBCERTS era) (DijkstraSUBLEDGER era)
   where
   wrapFailed = SubCertsFailure
-  wrapEvent = absurd
+  wrapEvent = SubCertsEvent

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -19,6 +19,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedgers (
   DijkstraSubLedgersEvent (..),
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
  )
@@ -109,6 +110,7 @@ instance NFData (Event (EraRule "SUBLEDGER" era)) => NFData (DijkstraSubLedgersE
 instance
   ( ConwayEraGov era
   , ConwayEraCertState era
+  , EraPlutusContext era
   , EraRule "SUBLEDGERS" era ~ DijkstraSUBLEDGERS era
   , EraRule "SUBLEDGER" era ~ DijkstraSUBLEDGER era
   , Embed (EraRule "SUBLEDGER" era) (DijkstraSUBLEDGERS era)
@@ -145,6 +147,7 @@ instance
   , ConwayEraTxBody era
   , ConwayEraGov era
   , ConwayEraCertState era
+  , EraPlutusContext era
   , EraRule "SUBLEDGER" era ~ DijkstraSUBLEDGER era
   , EraRule "SUBGOV" era ~ DijkstraSUBGOV era
   , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubPool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubPool.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -32,7 +33,7 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBPOOL,
  )
 import Cardano.Ledger.Dijkstra.State
-import Cardano.Ledger.Shelley.Rules (PoolEnv, PoolEvent (..))
+import Cardano.Ledger.Shelley.Rules (PoolEnv, PoolEvent (..), ShelleyPoolPredFailure)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (
   BaseM,
@@ -47,22 +48,11 @@ import Control.State.Transition.Extended (
   judgmentContext,
   transitionRules,
  )
-import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 
-data DijkstraSubPoolPredFailure era = DijkstraSubPoolPredFailure
-  deriving (Show, Eq, Generic)
-
-instance NoThunks (DijkstraSubPoolPredFailure era)
-
-instance NFData (DijkstraSubPoolPredFailure era)
-
-instance Era era => EncCBOR (DijkstraSubPoolPredFailure era) where
-  encCBOR _ = encCBOR ()
-
-instance Typeable era => DecCBOR (DijkstraSubPoolPredFailure era) where
-  decCBOR = decCBOR @() *> pure DijkstraSubPoolPredFailure
+newtype DijkstraSubPoolPredFailure era = DijkstraSubPoolPredFailure (ShelleyPoolPredFailure era)
+  deriving (Eq, Show, Generic, DecCBOR, EncCBOR, NFData, NoThunks)
 
 type instance EraRuleFailure "SUBPOOL" DijkstraEra = DijkstraSubPoolPredFailure DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -19,6 +19,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubUtxo (
   DijkstraSubUtxoEvent (..),
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
  )
@@ -124,6 +125,8 @@ dijkstraSubUtxoTransition = do
 
 instance
   ( ConwayEraGov era
+  , ConwayEraTxBody era
+  , EraPlutusContext era
   , EraRule "SUBUTXOS" era ~ DijkstraSUBUTXOS era
   ) =>
   Embed (DijkstraSUBUTXOS era) (DijkstraSUBUTXO era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDeriving #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -19,14 +21,18 @@ module Cardano.Ledger.Dijkstra.Rules.SubUtxo (
   DijkstraSubUtxoEvent (..),
 ) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
-import Cardano.Ledger.BaseTypes (
-  ShelleyBase,
+import Cardano.Ledger.Address (
+  Addr (..),
+  RewardAccount,
  )
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
  )
+import Cardano.Ledger.Binary.Coders
+import Cardano.Ledger.Coin (Coin, DeltaCoin)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Dijkstra.Era (
@@ -35,46 +41,117 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBUTXOS,
  )
 import Cardano.Ledger.Dijkstra.Rules.SubUtxos (DijkstraSubUtxosPredFailure)
-import Cardano.Ledger.Shelley.LedgerState (UTxOState)
+import Cardano.Ledger.Plutus (ExUnits)
+import Cardano.Ledger.Shelley.LedgerState (UTxO (..), UTxOState)
 import Cardano.Ledger.Shelley.Rules (UtxoEnv)
+import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
+import Data.List.NonEmpty (NonEmpty)
+import Data.Set.NonEmpty (NonEmptySet)
+import Data.Word (Word32)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
+import GHC.Natural (Natural)
+import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
-newtype DijkstraSubUtxoPredFailure era
+data DijkstraSubUtxoPredFailure era
   = SubUtxosFailure (PredicateFailure (EraRule "SUBUTXOS" era))
+  | -- | The bad transaction inputs
+    SubBadInputsUTxO (NonEmptySet TxIn)
+  | SubOutsideValidityIntervalUTxO
+      -- | transaction's validity interval
+      ValidityInterval
+      -- | current slot
+      SlotNo
+  | SubMaxTxSizeUTxO (Mismatch RelLTEQ Word32)
+  | SubInputSetEmptyUTxO
+  | SubFeeTooSmallUTxO
+      (Mismatch RelGTEQ Coin)
+  | SubValueNotConservedUTxO
+      (Mismatch RelEQ (Value era)) -- Serialise consumed first, then produced
+  | -- | the set of addresses with incorrect network IDs
+    SubWrongNetwork
+      -- | the expected network id
+      Network
+      -- | the set of addresses with incorrect network IDs
+      (NonEmptySet Addr)
+  | SubWrongNetworkWithdrawal
+      -- | the expected network id
+      Network
+      -- | the set of reward addresses with incorrect network IDs
+      (NonEmptySet RewardAccount)
+  | -- | list of supplied transaction outputs that are too small
+    SubOutputTooSmallUTxO (NonEmpty (TxOut era))
+  | -- | list of supplied bad transaction outputs
+    SubOutputBootAddrAttrsTooBig (NonEmpty (TxOut era))
+  | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
+    SubOutputTooBigUTxO (NonEmpty (Int, Int, TxOut era))
+  | SubInsufficientCollateral
+      -- | balance computed
+      DeltaCoin
+      -- | the required collateral for the given fee
+      Coin
+  | -- | The UTxO entries which have the wrong kind of script
+    SubScriptsNotPaidUTxO (UTxO era)
+  | SubExUnitsTooBigUTxO
+      (Mismatch RelLTEQ ExUnits)
+  | -- | The inputs marked for use as fees contain non-ADA tokens
+    SubCollateralContainsNonADA (Value era)
+  | -- | Wrong Network ID in body
+    SubWrongNetworkInTxBody
+      (Mismatch RelEQ Network)
+  | -- | slot number outside consensus forecast range
+    SubOutsideForecast SlotNo
+  | -- | There are too many collateral inputs
+    SubTooManyCollateralInputs
+      (Mismatch RelLTEQ Natural)
+  | SubNoCollateralInputs
+  | -- | The collateral is not equivalent to the total collateral asserted by the transaction
+    SubIncorrectTotalCollateralField
+      -- | collateral provided
+      DeltaCoin
+      -- | collateral amount declared in transaction body
+      Coin
+  | -- | list of supplied transaction outputs that are too small,
+    -- together with the minimum value for the given output.
+    SubBabbageOutputTooSmallUTxO (NonEmpty (TxOut era, Coin))
+  | -- | TxIns that appear in both inputs and reference inputs
+    SubBabbageNonDisjointRefInputs (NonEmpty TxIn)
+  | SubPtrPresentInCollateralReturn (TxOut era)
   deriving (Generic)
 
 deriving stock instance
-  Eq (PredicateFailure (EraRule "SUBUTXOS" era)) => Eq (DijkstraSubUtxoPredFailure era)
+  ( Era era
+  , Eq (Value era)
+  , Eq (PredicateFailure (EraRule "SUBUTXOS" era))
+  , Eq (TxOut era)
+  , Eq (Script era)
+  , Eq TxIn
+  ) =>
+  Eq (DijkstraSubUtxoPredFailure era)
 
 deriving stock instance
-  Show (PredicateFailure (EraRule "SUBUTXOS" era)) => Show (DijkstraSubUtxoPredFailure era)
+  ( Era era
+  , Show (Value era)
+  , Show (PredicateFailure (EraRule "SUBUTXOS" era))
+  , Show (TxOut era)
+  , Show (Script era)
+  , Show TxIn
+  ) =>
+  Show (DijkstraSubUtxoPredFailure era)
+
+deriving via
+  InspectHeapNamed "DijkstraUtxosPred" (DijkstraSubUtxoPredFailure era)
+  instance
+    NoThunks (DijkstraSubUtxoPredFailure era)
 
 instance
-  NoThunks (PredicateFailure (EraRule "SUBUTXOS" era)) =>
-  NoThunks (DijkstraSubUtxoPredFailure era)
-
-instance
-  NFData (PredicateFailure (EraRule "SUBUTXOS" era)) =>
+  ( Era era
+  , NFData (Value era)
+  , NFData (TxOut era)
+  , NFData (PredicateFailure (EraRule "SUBUTXOS" era))
+  ) =>
   NFData (DijkstraSubUtxoPredFailure era)
-
-instance
-  ( Era era
-  , EncCBOR (PredicateFailure (EraRule "SUBUTXOS" era))
-  ) =>
-  EncCBOR (DijkstraSubUtxoPredFailure era)
-  where
-  encCBOR (SubUtxosFailure e) = encCBOR e
-
-instance
-  ( Era era
-  , DecCBOR (PredicateFailure (EraRule "SUBUTXOS" era))
-  ) =>
-  DecCBOR (DijkstraSubUtxoPredFailure era)
-  where
-  decCBOR = SubUtxosFailure <$> decCBOR
 
 type instance EraRuleFailure "SUBUTXO" DijkstraEra = DijkstraSubUtxoPredFailure DijkstraEra
 
@@ -99,6 +176,7 @@ instance
   , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
   , EraRule "SUBUTXOS" era ~ DijkstraSUBUTXOS era
   , Embed (EraRule "SUBUTXOS" era) (DijkstraSUBUTXO era)
+  , BabbageEraTxBody era
   ) =>
   STS (DijkstraSUBUTXO era)
   where
@@ -133,3 +211,74 @@ instance
   where
   wrapFailed = SubUtxosFailure
   wrapEvent = SubUtxosEvent
+
+instance
+  ( Era era
+  , EncCBOR (TxOut era)
+  , EncCBOR (Value era)
+  , EncCBOR (PredicateFailure (EraRule "SUBUTXOS" era))
+  ) =>
+  EncCBOR (DijkstraSubUtxoPredFailure era)
+  where
+  encCBOR =
+    encode . \case
+      SubUtxosFailure a -> Sum (SubUtxosFailure @era) 0 !> To a
+      SubBadInputsUTxO ins -> Sum (SubBadInputsUTxO @era) 1 !> To ins
+      SubOutsideValidityIntervalUTxO a b -> Sum SubOutsideValidityIntervalUTxO 2 !> To a !> To b
+      SubMaxTxSizeUTxO mm -> Sum SubMaxTxSizeUTxO 3 !> To mm
+      SubInputSetEmptyUTxO -> Sum SubInputSetEmptyUTxO 4
+      SubFeeTooSmallUTxO mm -> Sum SubFeeTooSmallUTxO 5 !> To mm
+      SubValueNotConservedUTxO mm -> Sum (SubValueNotConservedUTxO @era) 6 !> To mm
+      SubWrongNetwork right wrongs -> Sum (SubWrongNetwork @era) 7 !> To right !> To wrongs
+      SubWrongNetworkWithdrawal right wrongs -> Sum (SubWrongNetworkWithdrawal @era) 8 !> To right !> To wrongs
+      SubOutputTooSmallUTxO outs -> Sum (SubOutputTooSmallUTxO @era) 9 !> To outs
+      SubOutputBootAddrAttrsTooBig outs -> Sum (SubOutputBootAddrAttrsTooBig @era) 10 !> To outs
+      SubOutputTooBigUTxO outs -> Sum (SubOutputTooBigUTxO @era) 11 !> To outs
+      SubInsufficientCollateral a b -> Sum SubInsufficientCollateral 12 !> To a !> To b
+      SubScriptsNotPaidUTxO a -> Sum SubScriptsNotPaidUTxO 13 !> To a
+      SubExUnitsTooBigUTxO mm -> Sum SubExUnitsTooBigUTxO 14 !> To mm
+      SubCollateralContainsNonADA a -> Sum SubCollateralContainsNonADA 15 !> To a
+      SubWrongNetworkInTxBody mm -> Sum SubWrongNetworkInTxBody 16 !> To mm
+      SubOutsideForecast a -> Sum SubOutsideForecast 17 !> To a
+      SubTooManyCollateralInputs mm -> Sum SubTooManyCollateralInputs 18 !> To mm
+      SubNoCollateralInputs -> Sum SubNoCollateralInputs 19
+      SubIncorrectTotalCollateralField c1 c2 -> Sum SubIncorrectTotalCollateralField 20 !> To c1 !> To c2
+      SubBabbageOutputTooSmallUTxO x -> Sum SubBabbageOutputTooSmallUTxO 21 !> To x
+      SubBabbageNonDisjointRefInputs x -> Sum SubBabbageNonDisjointRefInputs 22 !> To x
+      SubPtrPresentInCollateralReturn x -> Sum SubPtrPresentInCollateralReturn 23 !> To x
+
+instance
+  ( Era era
+  , DecCBOR (TxOut era)
+  , EncCBOR (Value era)
+  , DecCBOR (Value era)
+  , DecCBOR (PredicateFailure (EraRule "SUBUTXOS" era))
+  ) =>
+  DecCBOR (DijkstraSubUtxoPredFailure era)
+  where
+  decCBOR = decode . Summands "DijkstraSubUtxoPredFailure" $ \case
+    0 -> SumD SubUtxosFailure <! From
+    1 -> SumD SubBadInputsUTxO <! From
+    2 -> SumD SubOutsideValidityIntervalUTxO <! From <! From
+    3 -> SumD SubMaxTxSizeUTxO <! From
+    4 -> SumD SubInputSetEmptyUTxO
+    5 -> SumD SubFeeTooSmallUTxO <! From
+    6 -> SumD SubValueNotConservedUTxO <! From
+    7 -> SumD SubWrongNetwork <! From <! From
+    8 -> SumD SubWrongNetworkWithdrawal <! From <! From
+    9 -> SumD SubOutputTooSmallUTxO <! From
+    10 -> SumD SubOutputBootAddrAttrsTooBig <! From
+    11 -> SumD SubOutputTooBigUTxO <! From
+    12 -> SumD SubInsufficientCollateral <! From <! From
+    13 -> SumD SubScriptsNotPaidUTxO <! From
+    14 -> SumD SubExUnitsTooBigUTxO <! From
+    15 -> SumD SubCollateralContainsNonADA <! From
+    16 -> SumD SubWrongNetworkInTxBody <! From
+    17 -> SumD SubOutsideForecast <! From
+    18 -> SumD SubTooManyCollateralInputs <! From
+    19 -> SumD SubNoCollateralInputs
+    20 -> SumD SubIncorrectTotalCollateralField <! From <! From
+    21 -> SumD SubBabbageOutputTooSmallUTxO <! From
+    22 -> SumD SubBabbageNonDisjointRefInputs <! From
+    23 -> SumD SubPtrPresentInCollateralReturn <! From
+    n -> Invalid n

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -32,7 +32,7 @@ import Cardano.Ledger.Binary (
   EncCBOR (..),
  )
 import Cardano.Ledger.Binary.Coders
-import Cardano.Ledger.Coin (Coin, DeltaCoin)
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Dijkstra.Era (
@@ -41,8 +41,7 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBUTXOS,
  )
 import Cardano.Ledger.Dijkstra.Rules.SubUtxos (DijkstraSubUtxosPredFailure)
-import Cardano.Ledger.Plutus (ExUnits)
-import Cardano.Ledger.Shelley.LedgerState (UTxO (..), UTxOState)
+import Cardano.Ledger.Shelley.LedgerState (UTxOState)
 import Cardano.Ledger.Shelley.Rules (UtxoEnv)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
@@ -51,7 +50,6 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
-import GHC.Natural (Natural)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 data DijkstraSubUtxoPredFailure era
@@ -65,10 +63,6 @@ data DijkstraSubUtxoPredFailure era
       SlotNo
   | SubMaxTxSizeUTxO (Mismatch RelLTEQ Word32)
   | SubInputSetEmptyUTxO
-  | SubFeeTooSmallUTxO
-      (Mismatch RelGTEQ Coin)
-  | SubValueNotConservedUTxO
-      (Mismatch RelEQ (Value era)) -- Serialise consumed first, then produced
   | -- | the set of addresses with incorrect network IDs
     SubWrongNetwork
       -- | the expected network id
@@ -86,38 +80,14 @@ data DijkstraSubUtxoPredFailure era
     SubOutputBootAddrAttrsTooBig (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
     SubOutputTooBigUTxO (NonEmpty (Int, Int, TxOut era))
-  | SubInsufficientCollateral
-      -- | balance computed
-      DeltaCoin
-      -- | the required collateral for the given fee
-      Coin
-  | -- | The UTxO entries which have the wrong kind of script
-    SubScriptsNotPaidUTxO (UTxO era)
-  | SubExUnitsTooBigUTxO
-      (Mismatch RelLTEQ ExUnits)
-  | -- | The inputs marked for use as fees contain non-ADA tokens
-    SubCollateralContainsNonADA (Value era)
   | -- | Wrong Network ID in body
     SubWrongNetworkInTxBody
       (Mismatch RelEQ Network)
   | -- | slot number outside consensus forecast range
     SubOutsideForecast SlotNo
-  | -- | There are too many collateral inputs
-    SubTooManyCollateralInputs
-      (Mismatch RelLTEQ Natural)
-  | SubNoCollateralInputs
-  | -- | The collateral is not equivalent to the total collateral asserted by the transaction
-    SubIncorrectTotalCollateralField
-      -- | collateral provided
-      DeltaCoin
-      -- | collateral amount declared in transaction body
-      Coin
   | -- | list of supplied transaction outputs that are too small,
     -- together with the minimum value for the given output.
     SubBabbageOutputTooSmallUTxO (NonEmpty (TxOut era, Coin))
-  | -- | TxIns that appear in both inputs and reference inputs
-    SubBabbageNonDisjointRefInputs (NonEmpty TxIn)
-  | SubPtrPresentInCollateralReturn (TxOut era)
   deriving (Generic)
 
 deriving stock instance
@@ -215,7 +185,6 @@ instance
 instance
   ( Era era
   , EncCBOR (TxOut era)
-  , EncCBOR (Value era)
   , EncCBOR (PredicateFailure (EraRule "SUBUTXOS" era))
   ) =>
   EncCBOR (DijkstraSubUtxoPredFailure era)
@@ -227,25 +196,14 @@ instance
       SubOutsideValidityIntervalUTxO a b -> Sum SubOutsideValidityIntervalUTxO 2 !> To a !> To b
       SubMaxTxSizeUTxO mm -> Sum SubMaxTxSizeUTxO 3 !> To mm
       SubInputSetEmptyUTxO -> Sum SubInputSetEmptyUTxO 4
-      SubFeeTooSmallUTxO mm -> Sum SubFeeTooSmallUTxO 5 !> To mm
-      SubValueNotConservedUTxO mm -> Sum (SubValueNotConservedUTxO @era) 6 !> To mm
-      SubWrongNetwork right wrongs -> Sum (SubWrongNetwork @era) 7 !> To right !> To wrongs
-      SubWrongNetworkWithdrawal right wrongs -> Sum (SubWrongNetworkWithdrawal @era) 8 !> To right !> To wrongs
-      SubOutputTooSmallUTxO outs -> Sum (SubOutputTooSmallUTxO @era) 9 !> To outs
-      SubOutputBootAddrAttrsTooBig outs -> Sum (SubOutputBootAddrAttrsTooBig @era) 10 !> To outs
-      SubOutputTooBigUTxO outs -> Sum (SubOutputTooBigUTxO @era) 11 !> To outs
-      SubInsufficientCollateral a b -> Sum SubInsufficientCollateral 12 !> To a !> To b
-      SubScriptsNotPaidUTxO a -> Sum SubScriptsNotPaidUTxO 13 !> To a
-      SubExUnitsTooBigUTxO mm -> Sum SubExUnitsTooBigUTxO 14 !> To mm
-      SubCollateralContainsNonADA a -> Sum SubCollateralContainsNonADA 15 !> To a
-      SubWrongNetworkInTxBody mm -> Sum SubWrongNetworkInTxBody 16 !> To mm
-      SubOutsideForecast a -> Sum SubOutsideForecast 17 !> To a
-      SubTooManyCollateralInputs mm -> Sum SubTooManyCollateralInputs 18 !> To mm
-      SubNoCollateralInputs -> Sum SubNoCollateralInputs 19
-      SubIncorrectTotalCollateralField c1 c2 -> Sum SubIncorrectTotalCollateralField 20 !> To c1 !> To c2
-      SubBabbageOutputTooSmallUTxO x -> Sum SubBabbageOutputTooSmallUTxO 21 !> To x
-      SubBabbageNonDisjointRefInputs x -> Sum SubBabbageNonDisjointRefInputs 22 !> To x
-      SubPtrPresentInCollateralReturn x -> Sum SubPtrPresentInCollateralReturn 23 !> To x
+      SubWrongNetwork right wrongs -> Sum (SubWrongNetwork @era) 5 !> To right !> To wrongs
+      SubWrongNetworkWithdrawal right wrongs -> Sum (SubWrongNetworkWithdrawal @era) 6 !> To right !> To wrongs
+      SubOutputTooSmallUTxO outs -> Sum (SubOutputTooSmallUTxO @era) 7 !> To outs
+      SubOutputBootAddrAttrsTooBig outs -> Sum (SubOutputBootAddrAttrsTooBig @era) 8 !> To outs
+      SubOutputTooBigUTxO outs -> Sum (SubOutputTooBigUTxO @era) 9 !> To outs
+      SubWrongNetworkInTxBody mm -> Sum SubWrongNetworkInTxBody 10 !> To mm
+      SubOutsideForecast a -> Sum SubOutsideForecast 11 !> To a
+      SubBabbageOutputTooSmallUTxO x -> Sum SubBabbageOutputTooSmallUTxO 12 !> To x
 
 instance
   ( Era era
@@ -262,23 +220,12 @@ instance
     2 -> SumD SubOutsideValidityIntervalUTxO <! From <! From
     3 -> SumD SubMaxTxSizeUTxO <! From
     4 -> SumD SubInputSetEmptyUTxO
-    5 -> SumD SubFeeTooSmallUTxO <! From
-    6 -> SumD SubValueNotConservedUTxO <! From
-    7 -> SumD SubWrongNetwork <! From <! From
-    8 -> SumD SubWrongNetworkWithdrawal <! From <! From
-    9 -> SumD SubOutputTooSmallUTxO <! From
-    10 -> SumD SubOutputBootAddrAttrsTooBig <! From
-    11 -> SumD SubOutputTooBigUTxO <! From
-    12 -> SumD SubInsufficientCollateral <! From <! From
-    13 -> SumD SubScriptsNotPaidUTxO <! From
-    14 -> SumD SubExUnitsTooBigUTxO <! From
-    15 -> SumD SubCollateralContainsNonADA <! From
-    16 -> SumD SubWrongNetworkInTxBody <! From
-    17 -> SumD SubOutsideForecast <! From
-    18 -> SumD SubTooManyCollateralInputs <! From
-    19 -> SumD SubNoCollateralInputs
-    20 -> SumD SubIncorrectTotalCollateralField <! From <! From
-    21 -> SumD SubBabbageOutputTooSmallUTxO <! From
-    22 -> SumD SubBabbageNonDisjointRefInputs <! From
-    23 -> SumD SubPtrPresentInCollateralReturn <! From
+    5 -> SumD SubWrongNetwork <! From <! From
+    6 -> SumD SubWrongNetworkWithdrawal <! From <! From
+    7 -> SumD SubOutputTooSmallUTxO <! From
+    8 -> SumD SubOutputBootAddrAttrsTooBig <! From
+    9 -> SumD SubOutputTooBigUTxO <! From
+    10 -> SumD SubWrongNetworkInTxBody <! From
+    11 -> SumD SubOutsideForecast <! From
+    12 -> SumD SubBabbageOutputTooSmallUTxO <! From
     n -> Invalid n

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -19,6 +19,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubUtxow (
   DijkstraSubUtxowEvent (..),
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
  )
@@ -98,6 +99,8 @@ instance NFData (Event (EraRule "SUBUTXO" era)) => NFData (DijkstraSubUtxowEvent
 
 instance
   ( ConwayEraGov era
+  , ConwayEraTxBody era
+  , EraPlutusContext era
   , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
   , EraRule "SUBUTXOS" era ~ DijkstraSUBUTXOS era
@@ -127,6 +130,8 @@ dijkstraSubUtxowTransition = do
 
 instance
   ( ConwayEraGov era
+  , ConwayEraTxBody era
+  , EraPlutusContext era
   , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
   , EraRule "SUBUTXOS" era ~ DijkstraSUBUTXOS era
   , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -251,8 +251,11 @@ instance
   where
   arbitrary = DijkstraSubGovPredFailure <$> arbitrary
 
-instance Arbitrary (DijkstraSubGovCertPredFailure era) where
-  arbitrary = pure DijkstraSubGovCertPredFailure
+instance
+  Arbitrary (DijkstraGovCertPredFailure era) =>
+  Arbitrary (DijkstraSubGovCertPredFailure era)
+  where
+  arbitrary = DijkstraSubGovCertPredFailure <$> arbitrary
 
 instance
   Arbitrary (ShelleyPoolPredFailure era) =>

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -21,6 +21,7 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeStart,
  )
 import Cardano.Ledger.BaseTypes (PerasCert (..), StrictMaybe)
+import Cardano.Ledger.Conway.Rules (ConwayUtxosPredFailure)
 import Cardano.Ledger.Dijkstra (ApplyTxError (DijkstraApplyTxError), DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
@@ -258,8 +259,11 @@ instance
   where
   arbitrary = genericArbitraryU
 
-instance Arbitrary (DijkstraSubUtxosPredFailure era) where
-  arbitrary = pure DijkstraSubUtxosPredFailure
+instance
+  Arbitrary (ConwayUtxosPredFailure era) =>
+  Arbitrary (DijkstraSubUtxosPredFailure era)
+  where
+  arbitrary = DijkstraSubUtxosPredFailure <$> arbitrary
 
 instance
   Arbitrary (PredicateFailure (EraRule "SUBUTXO" era)) =>

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeStart,
  )
 import Cardano.Ledger.BaseTypes (PerasCert (..), StrictMaybe)
-import Cardano.Ledger.Conway.Rules (ConwayUtxosPredFailure)
+import Cardano.Ledger.Conway.Rules (ConwayDelegPredFailure, ConwayUtxosPredFailure)
 import Cardano.Ledger.Dijkstra (ApplyTxError (DijkstraApplyTxError), DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
@@ -242,8 +242,11 @@ instance
   where
   arbitrary = genericArbitraryU
 
-instance Arbitrary (DijkstraSubDelegPredFailure era) where
-  arbitrary = pure DijkstraSubDelegPredFailure
+instance
+  Arbitrary (ConwayDelegPredFailure era) =>
+  Arbitrary (DijkstraSubDelegPredFailure era)
+  where
+  arbitrary = DijkstraSubDelegPredFailure <$> arbitrary
 
 instance
   Arbitrary (DijkstraGovPredFailure era) =>

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Dijkstra.Tx (DijkstraTx (..), Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError)
+import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
 import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
@@ -253,8 +254,11 @@ instance
 instance Arbitrary (DijkstraSubGovCertPredFailure era) where
   arbitrary = pure DijkstraSubGovCertPredFailure
 
-instance Arbitrary (DijkstraSubPoolPredFailure era) where
-  arbitrary = pure DijkstraSubPoolPredFailure
+instance
+  Arbitrary (ShelleyPoolPredFailure era) =>
+  Arbitrary (DijkstraSubPoolPredFailure era)
+  where
+  arbitrary = DijkstraSubPoolPredFailure <$> arbitrary
 
 instance
   ( EraTxOut era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -254,7 +254,11 @@ instance Arbitrary (DijkstraSubPoolPredFailure era) where
   arbitrary = pure DijkstraSubPoolPredFailure
 
 instance
-  Arbitrary (PredicateFailure (EraRule "SUBUTXOS" era)) =>
+  ( EraTxOut era
+  , Arbitrary (Value era)
+  , Arbitrary (TxOut era)
+  , Arbitrary (PredicateFailure (EraRule "SUBUTXOS" era))
+  ) =>
   Arbitrary (DijkstraSubUtxoPredFailure era)
   where
   arbitrary = genericArbitraryU

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -270,7 +270,12 @@ instance
   arbitrary = DijkstraSubUtxosPredFailure <$> arbitrary
 
 instance
-  Arbitrary (PredicateFailure (EraRule "SUBUTXO" era)) =>
+  ( Era era
+  , Arbitrary (PredicateFailure (EraRule "SUBUTXO" era))
+  , Arbitrary (TxCert era)
+  , Arbitrary (PlutusPurpose AsItem era)
+  , Arbitrary (PlutusPurpose AsIx era)
+  ) =>
   Arbitrary (DijkstraSubUtxowPredFailure era)
   where
   arbitrary = genericArbitraryU

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -244,8 +244,11 @@ instance
 instance Arbitrary (DijkstraSubDelegPredFailure era) where
   arbitrary = pure DijkstraSubDelegPredFailure
 
-instance Arbitrary (DijkstraSubGovPredFailure era) where
-  arbitrary = pure DijkstraSubGovPredFailure
+instance
+  Arbitrary (DijkstraGovPredFailure era) =>
+  Arbitrary (DijkstraSubGovPredFailure era)
+  where
+  arbitrary = DijkstraSubGovPredFailure <$> arbitrary
 
 instance Arbitrary (DijkstraSubGovCertPredFailure era) where
   arbitrary = pure DijkstraSubGovCertPredFailure

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -252,7 +252,9 @@ instance
   ToExpr (Event (EraRule "SUBLEDGER" era)) =>
   ToExpr (DijkstraSubLedgersEvent era)
 
-instance ToExpr (DijkstraSubGovPredFailure era)
+instance
+  ToExpr (DijkstraGovPredFailure era) =>
+  ToExpr (DijkstraSubGovPredFailure era)
 
 instance ToExpr (ConwayGovEvent era) => ToExpr (DijkstraSubGovEvent era)
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -176,6 +176,13 @@ instance
   ToExpr (DijkstraLedgerPredFailure era)
 
 instance
+  ( ToExpr (Event (EraRule "UTXOW" era))
+  , ToExpr (Event (EraRule "CERTS" era))
+  , ToExpr (Event (EraRule "GOV" era))
+  ) =>
+  ToExpr (DijkstraLedgerEvent era)
+
+instance
   ( ToExpr (Value era)
   , ToExpr (TxOut era)
   , ToExpr (PredicateFailure (EraRule "UTXOS" era))

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -280,7 +280,12 @@ instance
 instance ToExpr (TxOut era) => ToExpr (DijkstraSubUtxosEvent era)
 
 instance
-  ToExpr (PredicateFailure (EraRule "SUBUTXO" era)) =>
+  ( Era era
+  , ToExpr (PredicateFailure (EraRule "SUBUTXO" era))
+  , ToExpr (PlutusPurpose AsIx era)
+  , ToExpr (PlutusPurpose AsItem era)
+  , ToExpr (TxCert era)
+  ) =>
   ToExpr (DijkstraSubUtxowPredFailure era)
 
 instance

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -17,7 +17,7 @@ module Test.Cardano.Ledger.Dijkstra.TreeDiff (
 ) where
 
 import Cardano.Ledger.BaseTypes (PerasCert, StrictMaybe)
-import Cardano.Ledger.Conway.Rules (ConwayGovEvent)
+import Cardano.Ledger.Conway.Rules (ConwayGovEvent, ConwayUtxosPredFailure)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core (
   AlonzoEraScript (..),
@@ -270,7 +270,9 @@ instance
   ToExpr (Event (EraRule "SUBUTXOS" era)) =>
   ToExpr (DijkstraSubUtxoEvent era)
 
-instance ToExpr (DijkstraSubUtxosPredFailure era)
+instance
+  ToExpr (ConwayUtxosPredFailure era) =>
+  ToExpr (DijkstraSubUtxosPredFailure era)
 
 instance ToExpr (TxOut era) => ToExpr (DijkstraSubUtxosEvent era)
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -263,7 +263,10 @@ instance ToExpr (DijkstraSubPoolPredFailure era)
 instance ToExpr (DijkstraSubPoolEvent era)
 
 instance
-  ToExpr (PredicateFailure (EraRule "SUBUTXOS" era)) =>
+  ( ToExpr (Value era)
+  , ToExpr (TxOut era)
+  , ToExpr (PredicateFailure (EraRule "SUBUTXOS" era))
+  ) =>
   ToExpr (DijkstraSubUtxoPredFailure era)
 
 instance

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -17,6 +17,7 @@ module Test.Cardano.Ledger.Dijkstra.TreeDiff (
 ) where
 
 import Cardano.Ledger.BaseTypes (PerasCert, StrictMaybe)
+import Cardano.Ledger.Conway.Rules (ConwayGovEvent)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core (
   AlonzoEraScript (..),
@@ -179,6 +180,7 @@ instance
   ( ToExpr (Event (EraRule "UTXOW" era))
   , ToExpr (Event (EraRule "CERTS" era))
   , ToExpr (Event (EraRule "GOV" era))
+  , ToExpr (Event (EraRule "SUBLEDGERS" era))
   ) =>
   ToExpr (DijkstraLedgerEvent era)
 
@@ -215,8 +217,16 @@ instance
   ToExpr (DijkstraSubCertPredFailure era)
 
 instance
+  ToExpr (Event (EraRule "SUBPOOL" era)) =>
+  ToExpr (DijkstraSubCertEvent era)
+
+instance
   ToExpr (PredicateFailure (EraRule "SUBCERT" era)) =>
   ToExpr (DijkstraSubCertsPredFailure era)
+
+instance
+  ToExpr (Event (EraRule "SUBCERT" era)) =>
+  ToExpr (DijkstraSubCertsEvent era)
 
 instance ToExpr (DijkstraSubDelegPredFailure era)
 
@@ -228,21 +238,46 @@ instance
   ToExpr (DijkstraSubLedgerPredFailure era)
 
 instance
+  ( ToExpr (Event (EraRule "SUBGOV" era))
+  , ToExpr (Event (EraRule "SUBCERTS" era))
+  , ToExpr (Event (EraRule "SUBUTXOW" era))
+  ) =>
+  ToExpr (DijkstraSubLedgerEvent era)
+
+instance
   ToExpr (PredicateFailure (EraRule "SUBLEDGER" era)) =>
   ToExpr (DijkstraSubLedgersPredFailure era)
 
+instance
+  ToExpr (Event (EraRule "SUBLEDGER" era)) =>
+  ToExpr (DijkstraSubLedgersEvent era)
+
 instance ToExpr (DijkstraSubGovPredFailure era)
+
+instance ToExpr (ConwayGovEvent era) => ToExpr (DijkstraSubGovEvent era)
 
 instance ToExpr (DijkstraSubGovCertPredFailure era)
 
 instance ToExpr (DijkstraSubPoolPredFailure era)
 
+instance ToExpr (DijkstraSubPoolEvent era)
+
 instance
   ToExpr (PredicateFailure (EraRule "SUBUTXOS" era)) =>
   ToExpr (DijkstraSubUtxoPredFailure era)
 
+instance
+  ToExpr (Event (EraRule "SUBUTXOS" era)) =>
+  ToExpr (DijkstraSubUtxoEvent era)
+
 instance ToExpr (DijkstraSubUtxosPredFailure era)
+
+instance ToExpr (TxOut era) => ToExpr (DijkstraSubUtxosEvent era)
 
 instance
   ToExpr (PredicateFailure (EraRule "SUBUTXO" era)) =>
   ToExpr (DijkstraSubUtxowPredFailure era)
+
+instance
+  ToExpr (Event (EraRule "SUBUTXO" era)) =>
+  ToExpr (DijkstraSubUtxowEvent era)


### PR DESCRIPTION
# Description

Currently, all the predicate failures and events used in SUB* rules are stubs ( except for the propagation of a predicate failure to the caller of the rule). 

The first step of implementing these rules (https://github.com/IntersectMBO/cardano-ledger/issues/5500)  is to have predicate failures and events in place, so that the injection and hence the reuse  of the analogous top-level rules can work properly. 

Note that using the same event type  in a SUBRULE as the one used in a RULE doesn't work because of the injectivity in the definitions of Event and PredFailure, so: 
 * for "leaf" rules (that don't call other rules):  predicate failures in SUBRULE are just wrapping over the ones in RULE 
 * for rules that call other rules: the predicate failures in SUBRULE are redefined mirroring the  one in RULE  (basically copy-paste, and adding a `Sub` prefix  to them , to avoid conflicting exports.  If you have a suggestion on how to avoid this duplication, please let me know! ).  
  Wrapping over the RULE event doesn't work in this case, because these are referencing predicate failures of other RULES (whereas we need references to equivalent SUBRULES).


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
