### PR TITLE
Add more constraints on `ApplyTxError`

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -37,7 +37,7 @@ import Data.List.NonEmpty (NonEmpty)
 instance ApplyTx AllegraEra where
   newtype ApplyTxError AllegraEra = AllegraApplyTxError (NonEmpty (ShelleyLedgerPredFailure AllegraEra))
     deriving (Eq, Show)
-    deriving newtype (EncCBOR, DecCBOR)
+    deriving newtype (EncCBOR, DecCBOR, Semigroup)
   applyTxValidation validationPolicy globals env state tx =
     first AllegraApplyTxError $
       ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -48,7 +48,7 @@ import Data.List.NonEmpty (NonEmpty)
 instance ApplyTx AlonzoEra where
   newtype ApplyTxError AlonzoEra = AlonzoApplyTxError (NonEmpty (ShelleyLedgerPredFailure AlonzoEra))
     deriving (Eq, Show)
-    deriving newtype (EncCBOR, DecCBOR)
+    deriving newtype (EncCBOR, DecCBOR, Semigroup)
   applyTxValidation validationPolicy globals env state tx =
     first AlonzoApplyTxError $
       ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -41,7 +41,7 @@ import Data.List.NonEmpty (NonEmpty)
 instance ApplyTx BabbageEra where
   newtype ApplyTxError BabbageEra = BabbageApplyTxError (NonEmpty (ShelleyLedgerPredFailure BabbageEra))
     deriving (Eq, Show)
-    deriving newtype (EncCBOR, DecCBOR)
+    deriving newtype (EncCBOR, DecCBOR, Semigroup)
   applyTxValidation validationPolicy globals env state tx =
     first BabbageApplyTxError $
       ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Conway (
 
 import Cardano.Ledger.Babbage.TxBody ()
 import Cardano.Ledger.BaseTypes (Inject (..))
+import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Conway.BlockBody ()
 import Cardano.Ledger.Conway.Era (
   ConwayEra,
@@ -47,7 +48,7 @@ import Data.List.NonEmpty (NonEmpty)
 instance ApplyTx ConwayEra where
   newtype ApplyTxError ConwayEra = ConwayApplyTxError (NonEmpty (ConwayLedgerPredFailure ConwayEra))
     deriving (Eq, Show)
-    deriving newtype (Semigroup)
+    deriving newtype (EncCBOR, DecCBOR, Semigroup)
   applyTxValidation validationPolicy globals env state tx =
     first ConwayApplyTxError $
       ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state tx

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -45,6 +47,7 @@ import Data.List.NonEmpty (NonEmpty)
 instance ApplyTx ConwayEra where
   newtype ApplyTxError ConwayEra = ConwayApplyTxError (NonEmpty (ConwayLedgerPredFailure ConwayEra))
     deriving (Eq, Show)
+    deriving newtype (Semigroup)
   applyTxValidation validationPolicy globals env state tx =
     first ConwayApplyTxError $
       ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state tx

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -38,7 +38,7 @@ module Test.Cardano.Ledger.Conway.Arbitrary (
 
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import Cardano.Ledger.Conway (ConwayEra, Tx (..))
+import Cardano.Ledger.Conway (ApplyTxError (ConwayApplyTxError), ConwayEra, Tx (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
 import Cardano.Ledger.Conway.Governance
@@ -892,3 +892,5 @@ instance Arbitrary (TransitionConfig ConwayEra) where
   arbitrary = ConwayTransitionConfig <$> arbitrary <*> arbitrary
 
 deriving newtype instance Arbitrary (Tx TopTx ConwayEra)
+
+deriving newtype instance Arbitrary (ApplyTxError ConwayEra)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -35,6 +37,7 @@ import Data.List.NonEmpty (NonEmpty)
 instance ApplyTx DijkstraEra where
   newtype ApplyTxError DijkstraEra = DijkstraApplyTxError (NonEmpty (DijkstraMempoolPredFailure DijkstraEra))
     deriving (Eq, Show)
+    deriving newtype (Semigroup)
   applyTxValidation validationPolicy globals env state tx =
     first DijkstraApplyTxError $
       ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state tx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -11,6 +11,7 @@
 module Cardano.Ledger.Dijkstra (DijkstraEra, ApplyTxError (..)) where
 
 import Cardano.Ledger.BaseTypes (Inject (inject))
+import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Conway.Governance (RunConwayRatify)
 import Cardano.Ledger.Dijkstra.BlockBody ()
 import Cardano.Ledger.Dijkstra.Era
@@ -37,7 +38,7 @@ import Data.List.NonEmpty (NonEmpty)
 instance ApplyTx DijkstraEra where
   newtype ApplyTxError DijkstraEra = DijkstraApplyTxError (NonEmpty (DijkstraMempoolPredFailure DijkstraEra))
     deriving (Eq, Show)
-    deriving newtype (Semigroup)
+    deriving newtype (EncCBOR, DecCBOR, Semigroup)
   applyTxValidation validationPolicy globals env state tx =
     first DijkstraApplyTxError $
       ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state tx

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -21,7 +21,7 @@ import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeStart,
  )
 import Cardano.Ledger.BaseTypes (PerasCert (..), StrictMaybe)
-import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Dijkstra (ApplyTxError (DijkstraApplyTxError), DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams, UpgradeDijkstraPParams)
@@ -277,3 +277,8 @@ instance
   Arbitrary (DijkstraBlockBody era)
   where
   arbitrary = DijkstraBlockBody <$> arbitrary <*> arbitrary
+
+deriving newtype instance Arbitrary (ApplyTxError DijkstraEra)
+
+instance Arbitrary (DijkstraMempoolPredFailure DijkstraEra) where
+  arbitrary = genericArbitraryU

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -40,7 +40,7 @@ import Data.List.NonEmpty (NonEmpty)
 instance ApplyTx MaryEra where
   newtype ApplyTxError MaryEra = MaryApplyTxError (NonEmpty (ShelleyLedgerPredFailure MaryEra))
     deriving (Eq, Show)
-    deriving newtype (EncCBOR, DecCBOR)
+    deriving newtype (EncCBOR, DecCBOR, Semigroup)
   applyTxValidation validationPolicy globals env state tx =
     first MaryApplyTxError $
       ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/ShelleyMA/Serialisation/Roundtrip.hs
@@ -8,7 +8,6 @@
 module Test.Cardano.Ledger.ShelleyMA.Serialisation.Roundtrip where
 
 import Cardano.Ledger.Allegra (AllegraEra)
-import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API (ApplyTx, ApplyTxError)
@@ -29,8 +28,6 @@ eraRoundTripProps ::
   forall e.
   ( ApplyTx e
   , Arbitrary (ApplyTxError e)
-  , EncCBOR (ApplyTxError e)
-  , DecCBOR (ApplyTxError e)
   ) =>
   TestTree
 eraRoundTripProps =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -95,6 +95,7 @@ class
   , Eq (ApplyTxError era)
   , Show (ApplyTxError era)
   , Typeable (ApplyTxError era)
+  , Semigroup (ApplyTxError era)
   ) =>
   ApplyTx era
   where
@@ -141,7 +142,7 @@ ruleApplyTxValidation validationPolicy globals env state tx =
 instance ApplyTx ShelleyEra where
   newtype ApplyTxError ShelleyEra = ShelleyApplyTxError (NonEmpty (ShelleyLedgerPredFailure ShelleyEra))
     deriving (Eq, Show)
-    deriving newtype (EncCBOR, DecCBOR)
+    deriving newtype (EncCBOR, DecCBOR, Semigroup)
   applyTxValidation validationPolicy globals env state tx =
     first ShelleyApplyTxError $
       ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -96,6 +96,8 @@ class
   , Show (ApplyTxError era)
   , Typeable (ApplyTxError era)
   , Semigroup (ApplyTxError era)
+  , EncCBOR (ApplyTxError era)
+  , DecCBOR (ApplyTxError era)
   ) =>
   ApplyTx era
   where


### PR DESCRIPTION
# Description

This PR:
- adds `Semigroup`, `EncCBOR` and `DecCBOR` constraints on the `ApplyTxError era` associated type to the per-requisites of the `ApplyTx` type class
- adds the missing `Arbitrary` instances for the instances of `ApplyTxError era`

These changes are necessary for integration into Consensus

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
