### PR TITLE
SUBPOOL rule implementation

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Pool.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Pool.hs
@@ -7,8 +7,12 @@ module Cardano.Ledger.Allegra.Rules.Pool () where
 
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
+import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 
 type instance EraRuleFailure "POOL" AllegraEra = ShelleyPoolPredFailure AllegraEra
 
 instance InjectRuleFailure "POOL" ShelleyPoolPredFailure AllegraEra
+
+type instance EraRuleEvent "POOL" AllegraEra = PoolEvent AllegraEra
+
+instance InjectRuleEvent "POOL" PoolEvent AllegraEra

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Pool.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Pool.hs
@@ -7,8 +7,12 @@ module Cardano.Ledger.Alonzo.Rules.Pool () where
 
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
+import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 
 type instance EraRuleFailure "POOL" AlonzoEra = ShelleyPoolPredFailure AlonzoEra
 
 instance InjectRuleFailure "POOL" ShelleyPoolPredFailure AlonzoEra
+
+type instance EraRuleEvent "POOL" AlonzoEra = PoolEvent AlonzoEra
+
+instance InjectRuleEvent "POOL" PoolEvent AlonzoEra

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Pool.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Pool.hs
@@ -7,8 +7,12 @@ module Cardano.Ledger.Babbage.Rules.Pool () where
 
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
+import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 
 type instance EraRuleFailure "POOL" BabbageEra = ShelleyPoolPredFailure BabbageEra
 
 instance InjectRuleFailure "POOL" ShelleyPoolPredFailure BabbageEra
+
+type instance EraRuleEvent "POOL" BabbageEra = PoolEvent BabbageEra
+
+instance InjectRuleEvent "POOL" PoolEvent BabbageEra

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.Rules.Pool () where
 
 import Cardano.Ledger.Conway.Era (ConwayEra)
-import Cardano.Ledger.Core (EraRuleEvent, EraRuleFailure)
+import Cardano.Ledger.Core (EraRuleEvent, EraRuleFailure, InjectRuleFailure)
 import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 
 type instance EraRuleFailure "POOL" ConwayEra = ShelleyPoolPredFailure ConwayEra
 
 type instance EraRuleEvent "POOL" ConwayEra = PoolEvent ConwayEra
+
+instance InjectRuleFailure "POOL" ShelleyPoolPredFailure ConwayEra

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Pool.hs
@@ -6,7 +6,7 @@
 module Cardano.Ledger.Conway.Rules.Pool () where
 
 import Cardano.Ledger.Conway.Era (ConwayEra)
-import Cardano.Ledger.Core (EraRuleEvent, EraRuleFailure, InjectRuleFailure)
+import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 
 type instance EraRuleFailure "POOL" ConwayEra = ShelleyPoolPredFailure ConwayEra
@@ -14,3 +14,5 @@ type instance EraRuleFailure "POOL" ConwayEra = ShelleyPoolPredFailure ConwayEra
 type instance EraRuleEvent "POOL" ConwayEra = PoolEvent ConwayEra
 
 instance InjectRuleFailure "POOL" ShelleyPoolPredFailure ConwayEra
+
+instance InjectRuleEvent "POOL" PoolEvent ConwayEra

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -83,7 +83,6 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBDELEG,
   DijkstraSUBGOV,
   DijkstraSUBGOVCERT,
-  DijkstraSUBPOOL,
   DijkstraSUBUTXO,
   DijkstraSUBUTXOS,
   DijkstraSUBUTXOW,
@@ -94,6 +93,7 @@ import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedger
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers
+import Cardano.Ledger.Dijkstra.Rules.SubPool
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure)
 import Cardano.Ledger.Dijkstra.TxBody
@@ -104,6 +104,7 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
+  PoolEvent,
   ShelleyLEDGERS,
   ShelleyLedgerPredFailure (..),
   ShelleyLedgersEvent (LedgerEvent),
@@ -476,6 +477,10 @@ instance
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "LEDGER" DijkstraLedgerPredFailure era
   , InjectRuleFailure "LEDGER" DijkstraSubLedgersPredFailure era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (ShelleyLEDGERS era)
@@ -569,6 +574,10 @@ instance
   , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
   , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
   , Event (EraRule "LEDGER" era) ~ DijkstraLedgerEvent era
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGERS era) (DijkstraLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -65,12 +65,19 @@ import Cardano.Ledger.Dijkstra.Rules.Ledger (
   conwayToDijkstraLedgerPredFailure,
  )
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers (DijkstraSubLedgersPredFailure (..))
+import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
 import Cardano.Ledger.Dijkstra.State
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody)
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.Shelley.Rules (LedgerEnv (..), ShelleyLedgerPredFailure, UtxoEnv)
+import Cardano.Ledger.Shelley.Rules (
+  LedgerEnv (..),
+  PoolEvent,
+  ShelleyLedgerPredFailure,
+  ShelleyPoolPredFailure,
+  UtxoEnv,
+ )
 import Control.DeepSeq (NFData)
 import Control.State.Transition (
   BaseM,
@@ -253,6 +260,10 @@ instance
   , InjectRuleFailure "LEDGER" ShelleyLedgerPredFailure era
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "LEDGER" DijkstraLedgerPredFailure era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (DijkstraMEMPOOL era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Pool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Pool.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Dijkstra.Rules.Pool () where
 
-import Cardano.Ledger.Dijkstra.Core (EraRuleEvent, EraRuleFailure)
+import Cardano.Ledger.Dijkstra.Core (EraRuleEvent, EraRuleFailure, InjectRuleFailure)
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 
 type instance EraRuleFailure "POOL" DijkstraEra = ShelleyPoolPredFailure DijkstraEra
 
 type instance EraRuleEvent "POOL" DijkstraEra = PoolEvent DijkstraEra
+
+instance InjectRuleFailure "POOL" ShelleyPoolPredFailure DijkstraEra

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Pool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Pool.hs
@@ -5,7 +5,7 @@
 
 module Cardano.Ledger.Dijkstra.Rules.Pool () where
 
-import Cardano.Ledger.Dijkstra.Core (EraRuleEvent, EraRuleFailure, InjectRuleFailure)
+import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 
@@ -14,3 +14,5 @@ type instance EraRuleFailure "POOL" DijkstraEra = ShelleyPoolPredFailure Dijkstr
 type instance EraRuleEvent "POOL" DijkstraEra = PoolEvent DijkstraEra
 
 instance InjectRuleFailure "POOL" ShelleyPoolPredFailure DijkstraEra
+
+instance InjectRuleEvent "POOL" PoolEvent DijkstraEra

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCert.hs
@@ -46,9 +46,9 @@ import Cardano.Ledger.Dijkstra.Era (
  )
 import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
 import Cardano.Ledger.Dijkstra.TxCert
-import Cardano.Ledger.Shelley.Rules (PoolEnv (..))
+import Cardano.Ledger.Shelley.Rules (PoolEnv (..), PoolEvent, ShelleyPoolPredFailure)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
 import Data.Void (absurd)
@@ -210,6 +210,10 @@ instance
   ( ConwayEraGov era
   , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
   , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
   ) =>
   Embed (DijkstraSUBPOOL era) (DijkstraSUBCERT era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
@@ -43,7 +43,9 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBPOOL,
  )
 import Cardano.Ledger.Dijkstra.Rules.SubCert (DijkstraSubCertPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
 import Cardano.Ledger.Dijkstra.TxCert
+import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
 import qualified Data.Map.Strict as Map
@@ -148,6 +150,10 @@ instance
   , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
   , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
   , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBCERT era) (DijkstraSUBCERTS era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -55,11 +55,14 @@ import Cardano.Ledger.Dijkstra.Era (
  )
 import Cardano.Ledger.Dijkstra.Rules.SubCerts (DijkstraSubCertsPredFailure (..), SubCertsEnv (..))
 import Cardano.Ledger.Dijkstra.Rules.SubGov (DijkstraSubGovPredFailure (..))
+import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubUtxow (DijkstraSubUtxowPredFailure (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
+  PoolEvent,
+  ShelleyPoolPredFailure,
   UtxoEnv (..),
   epochFromSlot,
  )
@@ -181,6 +184,10 @@ instance
   , Embed (EraRule "SUBGOV" era) (DijkstraSUBLEDGER era)
   , Embed (EraRule "SUBUTXOW" era) (DijkstraSUBLEDGER era)
   , Embed (EraRule "SUBCERTS" era) (DijkstraSUBCERTS era)
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   STS (DijkstraSUBLEDGER era)
@@ -210,6 +217,10 @@ dijkstraSubLedgersTransition ::
   , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
   , Embed (EraRule "SUBGOV" era) (DijkstraSUBLEDGER era)
   , Embed (EraRule "SUBUTXOW" era) (DijkstraSUBLEDGER era)
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
   , STS (EraRule "SUBLEDGER" era)
   , TxCert era ~ DijkstraTxCert era
   ) =>
@@ -301,6 +312,10 @@ instance
   , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
   , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
   , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBCERTS era) (DijkstraSUBLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -45,9 +45,10 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBUTXOW,
  )
 import Cardano.Ledger.Dijkstra.Rules.SubLedger (DijkstraSubLedgerPredFailure (..))
+import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.Shelley.Rules (LedgerEnv)
+import Cardano.Ledger.Shelley.Rules (LedgerEnv, PoolEvent, ShelleyPoolPredFailure)
 import Cardano.Ledger.TxIn (TxId)
 import Control.DeepSeq (NFData)
 import Control.Monad (foldM)
@@ -114,6 +115,10 @@ instance
   , EraRule "SUBLEDGERS" era ~ DijkstraSUBLEDGERS era
   , EraRule "SUBLEDGER" era ~ DijkstraSUBLEDGER era
   , Embed (EraRule "SUBLEDGER" era) (DijkstraSUBLEDGERS era)
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
   ) =>
   STS (DijkstraSUBLEDGERS era)
   where
@@ -158,6 +163,10 @@ instance
   , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
   , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
   , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
+  , InjectRuleEvent "SUBPOOL" PoolEvent era
+  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
+  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
+  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGER era) (DijkstraSUBLEDGERS era)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Rules/Pool.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Rules/Pool.hs
@@ -7,8 +7,12 @@ module Cardano.Ledger.Mary.Rules.Pool () where
 
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
-import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
+import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
 
 type instance EraRuleFailure "POOL" MaryEra = ShelleyPoolPredFailure MaryEra
 
 instance InjectRuleFailure "POOL" ShelleyPoolPredFailure MaryEra
+
+type instance EraRuleEvent "POOL" MaryEra = PoolEvent MaryEra
+
+instance InjectRuleEvent "POOL" PoolEvent MaryEra

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.18.0.0
 
+* Expose `poolTransition` from `Pool`
 * Change the type `ApplyTxError era` to be a data family of the `ApplyTx era` class, with its constructor renamed to `ShelleyApplyTxError` for the Shelley era
 * Renamed:
   - `sppMinFeeA` -> `sppTxFeePerByte`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Shelley.Rules.Pool (
   PoolEnv (..),
   PredicateFailure,
   ShelleyPoolPredFailure (..),
+  poolTransition,
 ) where
 
 import Cardano.Crypto.Hash.Class (sizeHash)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -19,7 +19,13 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API (ApplyBlock, ShelleyPOOL)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (LedgerState, NewEpochState)
-import Cardano.Ledger.Shelley.Rules (BbodyEnv, LedgerEnv, ShelleyBbodyState, ShelleyLedgersEnv)
+import Cardano.Ledger.Shelley.Rules (
+  BbodyEnv,
+  LedgerEnv,
+  ShelleyBbodyState,
+  ShelleyLedgersEnv,
+  ShelleyPoolPredFailure,
+ )
 import Cardano.Ledger.Shelley.State
 import Cardano.Protocol.TPraos.API (GetLedgerView)
 import Cardano.Protocol.TPraos.Rules.Tickn (TicknEnv, TicknState)
@@ -88,6 +94,7 @@ commonTests ::
   , Signal (EraRule "TICK" era) ~ SlotNo
   , Signal (EraRule "BBODY" era) ~ Block BHeaderView era
   , EraRule "POOL" era ~ ShelleyPOOL era
+  , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
   ) =>
   [TestTree]
 commonTests =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.BHeaderView (BHeaderView)
 import Cardano.Ledger.BaseTypes (Globals, ShelleyBase, SlotNo)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.API (ApplyBlock)
+import Cardano.Ledger.Shelley.API (ApplyBlock, ShelleyPOOL)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (LedgerState, NewEpochState)
 import Cardano.Ledger.Shelley.Rules (BbodyEnv, LedgerEnv, ShelleyBbodyState, ShelleyLedgersEnv)
@@ -87,6 +87,7 @@ commonTests ::
   , Environment (EraRule "BBODY" era) ~ BbodyEnv era
   , Signal (EraRule "TICK" era) ~ SlotNo
   , Signal (EraRule "BBODY" era) ~ Block BHeaderView era
+  , EraRule "POOL" era ~ ShelleyPOOL era
   ) =>
   [TestTree]
 commonTests =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -22,6 +22,7 @@ import Cardano.Ledger.Shelley.LedgerState (LedgerState, NewEpochState)
 import Cardano.Ledger.Shelley.Rules (
   BbodyEnv,
   LedgerEnv,
+  PoolEvent,
   ShelleyBbodyState,
   ShelleyLedgersEnv,
   ShelleyPoolPredFailure,
@@ -95,6 +96,7 @@ commonTests ::
   , Signal (EraRule "BBODY" era) ~ Block BHeaderView era
   , EraRule "POOL" era ~ ShelleyPOOL era
   , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
+  , InjectRuleEvent "POOL" PoolEvent era
   ) =>
   [TestTree]
 commonTests =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState (..),
   curPParamsEpochStateL,
  )
-import Cardano.Ledger.Shelley.Rules (ShelleyPOOL, ShelleyPoolPredFailure)
+import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPOOL, ShelleyPoolPredFailure)
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Slot (EpochNo (..))
 import Cardano.Protocol.TPraos.BHeader (bhbody, bheaderSlotNo)
@@ -67,6 +67,7 @@ tests ::
   , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , EraRule "POOL" era ~ ShelleyPOOL era
   , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
+  , InjectRuleEvent "POOL" PoolEvent era
   ) =>
   TestTree
 tests =
@@ -85,6 +86,7 @@ poolRetirement ::
   ( ChainProperty era
   , EraRule "POOL" era ~ ShelleyPOOL era
   , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
+  , InjectRuleEvent "POOL" PoolEvent era
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -103,6 +105,7 @@ poolRegistration ::
   ( ChainProperty era
   , EraRule "POOL" era ~ ShelleyPOOL era
   , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
+  , InjectRuleEvent "POOL" PoolEvent era
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -118,6 +121,7 @@ poolStateIsInternallyConsistent ::
   ( ChainProperty era
   , EraRule "POOL" era ~ ShelleyPOOL era
   , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
+  , InjectRuleEvent "POOL" PoolEvent era
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState (..),
   curPParamsEpochStateL,
  )
-import Cardano.Ledger.Shelley.Rules (ShelleyPOOL)
+import Cardano.Ledger.Shelley.Rules (ShelleyPOOL, ShelleyPoolPredFailure)
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Slot (EpochNo (..))
 import Cardano.Protocol.TPraos.BHeader (bhbody, bheaderSlotNo)
@@ -66,6 +66,7 @@ tests ::
   , ChainProperty era
   , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , EraRule "POOL" era ~ ShelleyPOOL era
+  , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
   ) =>
   TestTree
 tests =
@@ -83,6 +84,7 @@ tests =
 poolRetirement ::
   ( ChainProperty era
   , EraRule "POOL" era ~ ShelleyPOOL era
+  , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -100,6 +102,7 @@ poolRetirement SourceSignalTarget {source = chainSt, signal = block} =
 poolRegistration ::
   ( ChainProperty era
   , EraRule "POOL" era ~ ShelleyPOOL era
+  , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
@@ -114,6 +117,7 @@ poolRegistration (SourceSignalTarget {source = chainSt, signal = block}) =
 poolStateIsInternallyConsistent ::
   ( ChainProperty era
   , EraRule "POOL" era ~ ShelleyPOOL era
+  , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
   ) =>
   SourceSignalTarget (CHAIN era) ->
   Property

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Shelley.Rules.Pool (
   tests,
@@ -64,6 +65,7 @@ tests ::
   , EraStake era
   , ChainProperty era
   , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
+  , EraRule "POOL" era ~ ShelleyPOOL era
   ) =>
   TestTree
 tests =
@@ -79,7 +81,9 @@ tests =
 -- | Check that a `RetirePool` certificate properly marks a stake pool for
 -- retirement.
 poolRetirement ::
-  ChainProperty era =>
+  ( ChainProperty era
+  , EraRule "POOL" era ~ ShelleyPOOL era
+  ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
 poolRetirement SourceSignalTarget {source = chainSt, signal = block} =
@@ -94,7 +98,9 @@ poolRetirement SourceSignalTarget {source = chainSt, signal = block} =
 -- | Check that a newly registered pool key is registered and not
 -- in the retiring map.
 poolRegistration ::
-  ChainProperty era =>
+  ( ChainProperty era
+  , EraRule "POOL" era ~ ShelleyPOOL era
+  ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
 poolRegistration (SourceSignalTarget {source = chainSt, signal = block}) =
@@ -106,7 +112,9 @@ poolRegistration (SourceSignalTarget {source = chainSt, signal = block}) =
 -- | Assert that PState maps are in sync with each other after each `Signal
 -- POOL` transition.
 poolStateIsInternallyConsistent ::
-  ChainProperty era =>
+  ( ChainProperty era
+  , EraRule "POOL" era ~ ShelleyPOOL era
+  ) =>
   SourceSignalTarget (CHAIN era) ->
   Property
 poolStateIsInternallyConsistent (SourceSignalTarget {source = chainSt, signal = block}) =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -44,6 +44,7 @@ import Cardano.Ledger.Shelley.Rules (
   DelegEnv (..),
   LedgerEnv (..),
   PoolEnv (..),
+  PoolEvent,
   ShelleyPOOL,
   ShelleyPoolPredFailure,
  )
@@ -192,6 +193,7 @@ poolTraceFromBlock ::
   ( ChainProperty era
   , EraRule "POOL" era ~ ShelleyPOOL era
   , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
+  , InjectRuleEvent "POOL" PoolEvent era
   ) =>
   ChainState era ->
   Block (BHeader MockCrypto) era ->

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -188,7 +188,9 @@ ledgerTraceFromBlockWithRestrictedUTxO chainSt block =
 -- | Reconstruct a POOL trace from the transactions in a Block and ChainState
 poolTraceFromBlock ::
   forall era.
-  ChainProperty era =>
+  ( ChainProperty era
+  , EraRule "POOL" era ~ ShelleyPOOL era
+  ) =>
   ChainState era ->
   Block (BHeader MockCrypto) era ->
   (ChainState era, Trace (ShelleyPOOL era))

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -45,6 +45,7 @@ import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
   PoolEnv (..),
   ShelleyPOOL,
+  ShelleyPoolPredFailure,
  )
 import Cardano.Ledger.Shelley.State
 import Cardano.Protocol.TPraos.API (GetLedgerView)
@@ -190,6 +191,7 @@ poolTraceFromBlock ::
   forall era.
   ( ChainProperty era
   , EraRule "POOL" era ~ ShelleyPOOL era
+  , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
   ) =>
   ChainState era ->
   Block (BHeader MockCrypto) era ->


### PR DESCRIPTION
# Description

This PR is based on https://github.com/IntersectMBO/cardano-ledger/pull/5522 and solves the SUBPOOL subtask from https://github.com/IntersectMBO/cardano-ledger/issues/5500.
It injects the failure and events for the SUBPOOL rule in the rules tree, to make it possible to implement SUBPOOL STS `transitionRules` by calling POOL transition.  

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
