### PR TITLE
SUBDELEG rule implementation

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -162,6 +162,7 @@ instance
   , Signal (EraRule "DELEG" era) ~ ConwayDelegCert
   , Environment (EraRule "DELEG" era) ~ ConwayDelegEnv era
   , EraRule "DELEG" era ~ ConwayDELEG era
+  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
   ) =>
   STS (ConwayDELEG era)
   where
@@ -181,7 +182,7 @@ conwayDelegTransition ::
   , Signal (EraRule rule era) ~ ConwayDelegCert
   , Environment (EraRule rule era) ~ ConwayDelegEnv era
   , State (EraRule rule era) ~ CertState era
-  , PredicateFailure (EraRule rule era) ~ ConwayDelegPredFailure era
+  , InjectRuleFailure rule ConwayDelegPredFailure era
   ) =>
   TransitionRule (EraRule rule era)
 conwayDelegTransition = do
@@ -201,24 +202,29 @@ conwayDelegTransition = do
         == ppKeyDeposit
           ?! if hardforkConwayDELEGIncorrectDepositsAndRefunds pv
             then
-              DepositIncorrectDELEG
-                Mismatch
-                  { mismatchSupplied = deposit
-                  , mismatchExpected = ppKeyDeposit
-                  }
-            else IncorrectDepositDELEG deposit
+              injectFailure
+                ( DepositIncorrectDELEG
+                    Mismatch
+                      { mismatchSupplied = deposit
+                      , mismatchExpected = ppKeyDeposit
+                      }
+                )
+            else injectFailure $ IncorrectDepositDELEG deposit
     checkStakeKeyNotRegistered stakeCred =
-      not (isAccountRegistered stakeCred accounts) ?! StakeKeyRegisteredDELEG stakeCred
+      not (isAccountRegistered stakeCred accounts)
+        ?! injectFailure (StakeKeyRegisteredDELEG stakeCred)
     checkStakeDelegateeRegistered =
       let checkPoolRegistered targetPool =
-            targetPool `Map.member` pools ?! DelegateeStakePoolNotRegisteredDELEG targetPool
+            targetPool
+              `Map.member` pools
+              ?! injectFailure (DelegateeStakePoolNotRegisteredDELEG targetPool)
           checkDRepRegistered = \case
             DRepAlwaysAbstain -> pure ()
             DRepAlwaysNoConfidence -> pure ()
             DRepCredential targetDRep -> do
               let dReps = certState ^. certVStateL . vsDRepsL
               unless (hardforkConwayBootstrapPhase (pp ^. ppProtocolVersionL)) $
-                targetDRep `Map.member` dReps ?! DelegateeDRepNotRegisteredDELEG targetDRep
+                targetDRep `Map.member` dReps ?! injectFailure (DelegateeDRepNotRegisteredDELEG targetDRep)
        in \case
             DelegStake targetPool -> checkPoolRegistered targetPool
             DelegStakeVote targetPool targetDRep ->
@@ -244,22 +250,26 @@ conwayDelegTransition = do
             Just $
               if hardforkConwayDELEGIncorrectDepositsAndRefunds pv
                 then
-                  RefundIncorrectDELEG
-                    Mismatch
-                      { mismatchSupplied = suppliedRefund
-                      , mismatchExpected = expectedRefund
-                      }
-                else IncorrectDepositDELEG suppliedRefund
+                  injectFailure
+                    ( RefundIncorrectDELEG
+                        Mismatch
+                          { mismatchSupplied = suppliedRefund
+                          , mismatchExpected = expectedRefund
+                          }
+                    )
+                else injectFailure $ IncorrectDepositDELEG suppliedRefund
           checkStakeKeyHasZeroRewardBalance = do
             accountState <- mAccountState
             let balanceCompact = accountState ^. balanceAccountStateL
             guard (balanceCompact /= mempty)
             Just $ fromCompact balanceCompact
       failOnJust checkInvalidRefund id
-      failOnJust checkStakeKeyHasZeroRewardBalance StakeKeyHasNonZeroAccountBalanceDELEG
+      failOnJust
+        checkStakeKeyHasZeroRewardBalance
+        (injectFailure . StakeKeyHasNonZeroAccountBalanceDELEG)
       case mAccountState of
         Nothing -> do
-          failBecause $ StakeKeyNotRegisteredDELEG stakeCred
+          failBecause $ injectFailure (StakeKeyNotRegisteredDELEG stakeCred)
           pure certState
         Just accountState ->
           pure $
@@ -271,7 +281,7 @@ conwayDelegTransition = do
       checkStakeDelegateeRegistered delegatee
       case lookupAccountStateIntern stakeCred accounts of
         Nothing -> do
-          failBecause $ StakeKeyNotRegisteredDELEG stakeCred
+          failBecause $ injectFailure (StakeKeyNotRegisteredDELEG stakeCred)
           pure certState
         Just (internedCred, accountState) -> do
           pure $

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -156,12 +156,12 @@ instance Era era => DecCBOR (ConwayDelegPredFailure era) where
 
 instance
   ( EraPParams era
+  , EraCertState era
+  , ConwayEraCertState era
   , State (EraRule "DELEG" era) ~ CertState era
   , Signal (EraRule "DELEG" era) ~ ConwayDelegCert
   , Environment (EraRule "DELEG" era) ~ ConwayDelegEnv era
   , EraRule "DELEG" era ~ ConwayDELEG era
-  , EraCertState era
-  , ConwayEraCertState era
   ) =>
   STS (ConwayDELEG era)
   where
@@ -172,10 +172,18 @@ instance
   type PredicateFailure (ConwayDELEG era) = ConwayDelegPredFailure era
   type Event (ConwayDELEG era) = Void
 
-  transitionRules = [conwayDelegTransition @era]
+  transitionRules = [conwayDelegTransition]
 
 conwayDelegTransition ::
-  (EraPParams era, ConwayEraCertState era) => TransitionRule (ConwayDELEG era)
+  forall rule era.
+  ( EraPParams era
+  , ConwayEraCertState era
+  , Signal (EraRule rule era) ~ ConwayDelegCert
+  , Environment (EraRule rule era) ~ ConwayDelegEnv era
+  , State (EraRule rule era) ~ CertState era
+  , PredicateFailure (EraRule rule era) ~ ConwayDelegPredFailure era
+  ) =>
+  TransitionRule (EraRule rule era)
 conwayDelegTransition = do
   TRC
     ( ConwayDelegEnv pp pools

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -19,6 +19,7 @@ module Cardano.Ledger.Conway.Rules.Deleg (
   ConwayDELEG,
   ConwayDelegPredFailure (..),
   ConwayDelegEnv (..),
+  conwayDelegTransition,
   processDelegation,
 ) where
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -618,6 +618,7 @@ instance
 instance
   ( EraPParams era
   , EraRule "DELEG" era ~ ConwayDELEG era
+  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
   , PredicateFailure (EraRule "CERTS" era) ~ ConwayCertsPredFailure era
   , PredicateFailure (EraRule "CERT" era) ~ ConwayCertPredFailure era
   , Event (EraRule "CERTS" era) ~ ConwayCertsEvent era

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.0.0
 
+* Add `dijkstraToConwayDelegCert`
 * Add:
   - `DijkstraLedgerEvent`
   - `DijkstraSubLedgersEvent`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Cert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Cert.hs
@@ -14,7 +14,7 @@ module Cardano.Ledger.Dijkstra.Rules.Cert (
   DijkstraCERT,
 ) where
 
-import Cardano.Ledger.BaseTypes (ShelleyBase, StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Conway.Rules (
   CertEnv (..),
   ConwayCertEvent,
@@ -106,13 +106,8 @@ certTransition = do
     pools = psStakePools certPState
   case c of
     DijkstraTxCertDeleg delegCert ->
-      let conwayDelegCert = case delegCert of
-            DijkstraRegCert cred coin -> ConwayRegCert cred (SJust coin)
-            DijkstraUnRegCert cred coin -> ConwayUnRegCert cred (SJust coin)
-            DijkstraDelegCert cred d -> ConwayDelegCert cred d
-            DijkstraRegDelegCert sc d coin -> ConwayRegDelegCert sc d coin
-       in trans @(EraRule "DELEG" era) $
-            TRC (ConwayDelegEnv pp pools, certState, conwayDelegCert)
+      trans @(EraRule "DELEG" era) $
+        TRC (ConwayDelegEnv pp pools, certState, dijkstraToConwayDelegCert delegCert)
     DijkstraTxCertPool poolCert -> do
       newPState <- trans @(EraRule "POOL" era) $ TRC (PoolEnv currentEpoch pp, certPState, poolCert)
       pure $ certState & certPStateL .~ newPState

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -91,6 +91,7 @@ import Cardano.Ledger.Dijkstra.Era (
 import Cardano.Ledger.Dijkstra.Rules.Certs ()
 import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedger
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers
@@ -485,6 +486,8 @@ instance
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
   , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (ShelleyLEDGERS era)
@@ -586,6 +589,8 @@ instance
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
   , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGERS era) (DijkstraLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -484,6 +484,7 @@ instance
   , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
+  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (ShelleyLEDGERS era)
@@ -553,6 +554,7 @@ instance
   , Event (EraRule "CERTS" era) ~ ConwayCertsEvent era
   , Event (EraRule "CERT" era) ~ ConwayCertEvent era
   , ConwayEraCertState era
+  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
   ) =>
   Embed (ConwayDELEG era) (DijkstraLEDGER era)
   where
@@ -583,6 +585,7 @@ instance
   , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
+  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGERS era) (DijkstraLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -39,6 +39,7 @@ import Cardano.Ledger.Conway.Governance (
  )
 import Cardano.Ledger.Conway.Rules (
   CertsEnv,
+  ConwayDelegPredFailure,
   ConwayGovCertPredFailure,
   ConwayLedgerPredFailure (ConwayMempoolFailure),
   GovEnv,
@@ -268,6 +269,7 @@ instance
   , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
+  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (DijkstraMEMPOOL era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -66,6 +66,7 @@ import Cardano.Ledger.Dijkstra.Rules.Ledger (
   DijkstraLedgerPredFailure (..),
   conwayToDijkstraLedgerPredFailure,
  )
+import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers (DijkstraSubLedgersPredFailure (..))
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
@@ -270,6 +271,8 @@ instance
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
   , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraLEDGER era) (DijkstraMEMPOOL era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCert.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Conway.Governance (ConwayEraGov)
 import Cardano.Ledger.Conway.Rules (
   CertEnv (..),
   ConwayDelegEnv (..),
+  ConwayDelegPredFailure,
   ConwayGovCertEnv (..),
   ConwayGovCertPredFailure,
  )
@@ -188,7 +189,7 @@ dijkstraSubCertTransition = do
   case c of
     DijkstraTxCertDeleg delegCert ->
       trans @(EraRule "SUBDELEG" era) $
-        TRC (ConwayDelegEnv pp pools, certState, delegCert)
+        TRC (ConwayDelegEnv pp pools, certState, dijkstraToConwayDelegCert delegCert)
     DijkstraTxCertPool poolCert -> do
       newPState <- trans @(EraRule "SUBPOOL" era) $ TRC (PoolEnv currentEpoch pp, certPState, poolCert)
       pure $ certState & certPStateL .~ newPState
@@ -201,6 +202,8 @@ instance
   , ConwayEraCertState era
   , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
   , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
+  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   ) =>
   Embed (DijkstraSUBDELEG era) (DijkstraSUBCERT era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
@@ -32,7 +32,7 @@ import Cardano.Ledger.Binary (
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
-import Cardano.Ledger.Conway.Rules (CertEnv (..), ConwayGovCertPredFailure)
+import Cardano.Ledger.Conway.Rules (CertEnv (..), ConwayDelegPredFailure, ConwayGovCertPredFailure)
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
@@ -43,6 +43,7 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBPOOL,
  )
 import Cardano.Ledger.Dijkstra.Rules.SubCert (DijkstraSubCertPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
 import Cardano.Ledger.Dijkstra.TxCert
@@ -158,6 +159,8 @@ instance
   , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
+  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBCERT era) (DijkstraSUBCERTS era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.Rules (
+  ConwayDelegPredFailure,
   ConwayGovCertPredFailure,
   GovEnv (..),
   GovSignal (..),
@@ -55,6 +56,7 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBUTXOW,
  )
 import Cardano.Ledger.Dijkstra.Rules.SubCerts (DijkstraSubCertsPredFailure (..), SubCertsEnv (..))
+import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGov (DijkstraSubGovPredFailure (..))
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
@@ -192,6 +194,8 @@ instance
   , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
+  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   STS (DijkstraSUBLEDGER era)
@@ -227,6 +231,8 @@ dijkstraSubLedgersTransition ::
   , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
+  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , STS (EraRule "SUBLEDGER" era)
   , TxCert era ~ DijkstraTxCert era
   ) =>
@@ -325,6 +331,8 @@ instance
   , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
+  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBCERTS era) (DijkstraSUBLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -29,7 +29,7 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
-import Cardano.Ledger.Conway.Rules (ConwayGovCertPredFailure)
+import Cardano.Ledger.Conway.Rules (ConwayDelegPredFailure, ConwayGovCertPredFailure)
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
@@ -45,6 +45,7 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBUTXOS,
   DijkstraSUBUTXOW,
  )
+import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedger (DijkstraSubLedgerPredFailure (..))
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure (..))
@@ -171,6 +172,8 @@ instance
   , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
+  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
+  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , TxCert era ~ DijkstraTxCert era
   ) =>
   Embed (DijkstraSUBLEDGER era) (DijkstraSUBLEDGERS era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
@@ -16,9 +16,10 @@ module Cardano.Ledger.Dijkstra.TxCert (
   DijkstraTxCertUpgradeError,
   DijkstraTxCert (..),
   DijkstraDelegCert (..),
+  dijkstraToConwayDelegCert,
 ) where
 
-import Cardano.Ledger.BaseTypes (kindObject)
+import Cardano.Ledger.BaseTypes (StrictMaybe (..), kindObject)
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
@@ -49,6 +50,7 @@ import Cardano.Ledger.Conway.Core (
   pattern UpdateDRepTxCert,
  )
 import Cardano.Ledger.Conway.TxCert (
+  ConwayDelegCert (..),
   ConwayEraTxCert (..),
   ConwayGovCert (..),
   Delegatee (..),
@@ -356,3 +358,10 @@ instance ConwayEraTxCert DijkstraEra where
   getUpdateDRepTxCert = \case
     DijkstraTxCertGov (ConwayUpdateDRep cred mAnchor) -> Just (cred, mAnchor)
     _ -> Nothing
+
+dijkstraToConwayDelegCert :: DijkstraDelegCert -> ConwayDelegCert
+dijkstraToConwayDelegCert = \case
+  DijkstraRegCert cred deposit -> ConwayRegCert cred (SJust deposit)
+  DijkstraUnRegCert cred deposit -> ConwayUnRegCert cred (SJust deposit)
+  DijkstraDelegCert cred d -> ConwayDelegCert cred d
+  DijkstraRegDelegCert sc d deposit -> ConwayRegDelegCert sc d deposit


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

This PR  solves the SUBDELEG subtask from https://github.com/IntersectMBO/cardano-ledger/issues/5500.
It injects the failure for the DELEG rule in the rules tree, to make it possible to implement SUBDELEG STS transitionRules by calling DELEG transition.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
