### PR TITLE
Fix laziness in `map` and `mapWithKey` for `VMap`

### DIFF
--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -104,6 +104,7 @@ import Cardano.Ledger.Slot (epochInfoSize)
 import Cardano.Ledger.Val (Val (..), invert, (<+>), (<->))
 import Cardano.Protocol.Crypto (VRF, hashVerKeyVRF)
 import Cardano.Slotting.Slot (EpochSize (..))
+import Control.DeepSeq
 import Control.Monad (replicateM)
 import Control.Monad.Trans.Reader (asks, runReader)
 import Data.Foldable as F (fold, foldl')
@@ -823,7 +824,7 @@ mkSnapShot activeStake delegs stakePools =
     , ssTotalActiveStake = totalActiveStake
     , ssDelegations = delegs
     , ssPoolParams = stakePools
-    , ssStakePoolsSnapShot = VMap.map snapShotFromStakePoolParams stakePools
+    , ssStakePoolsSnapShot = force $ VMap.map snapShotFromStakePoolParams stakePools
     }
   where
     snapShotFromStakePoolParams stakePoolParams =

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
@@ -129,7 +129,7 @@ internsFromMap m
             }
         ]
 
-internsFromVMap :: Ord k => VMap VB kv k a -> Interns k
+internsFromVMap :: (Ord k, VMap.Vector kv a) => VMap VB kv k a -> Interns k
 internsFromVMap m
   | VMap.size m == 0 = mempty
   | otherwise =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/SnapShots.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/SnapShots.hs
@@ -284,12 +284,10 @@ data SnapShot = SnapShot
   { ssStake :: !Stake -- TODO: rename to `ssActiveStake`
 
   -- ^ All of the stake for registered staking credentials that have a delegation to a stake pool.
-  , ssTotalActiveStake :: NonZero Coin -- Note: lazy on purpose
-
-  -- ^ Total active stake, which is the sum of all of the stake from `ssStake`, which is why it is
-  -- lazy.  It is primarily used in a denominator, therefore it cannot be zero and is defaulted to
-  -- 1. This is a reasonable assumption for a system that relies on non-zero active stake to produce
-  -- blocks.
+  , ssTotalActiveStake :: !(NonZero Coin)
+  -- ^ Total active stake, which is the sum of all of the stake from `ssStake`. It is primarily used
+  -- in a denominator, therefore it cannot be zero and is defaulted to 1. This is a reasonable
+  -- assumption for a system that relies on non-zero active stake to produce blocks.
   , ssDelegations :: VMap VB VB (Credential Staking) (KeyHash StakePool) -- TODO: remove (lazy on purpose)
   , ssPoolParams :: VMap VB VB (KeyHash StakePool) StakePoolParams -- TODO: remove (lazy on purpose)
   , ssStakePoolsSnapShot :: !(VMap VB VB (KeyHash StakePool) StakePoolSnapShot)
@@ -299,7 +297,7 @@ data SnapShot = SnapShot
   deriving (ToJSON) via KeyValuePairs SnapShot
   deriving
     (NoThunks)
-    via AllowThunksIn '["ssTotalActiveStake", "ssDelegations", "ssPoolParams"] SnapShot
+    via AllowThunksIn '["ssDelegations", "ssPoolParams"] SnapShot
 
 instance NFData SnapShot
 

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -85,6 +85,7 @@ import Cardano.Ledger.Plutus.Language (Language (..), nonNativeLanguages)
 import Cardano.Ledger.Rewards (Reward (..), RewardType (..))
 import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Control.DeepSeq
 import Control.Monad (replicateM)
 import Control.Monad.Identity (Identity)
 import Control.Monad.Trans.Fail.String (errorFail)
@@ -696,7 +697,7 @@ instance Arbitrary SnapShot where
         stakePoolSnapShotFromParams poolId =
           mkStakePoolSnapShot ssStake ssTotalActiveStake
             . mkStakePoolState deposit (Map.findWithDefault mempty poolId delegationsPerStakePool)
-        ssStakePoolsSnapShot = VMap.mapWithKey stakePoolSnapShotFromParams ssPoolParams
+        ssStakePoolsSnapShot = force $ VMap.mapWithKey stakePoolSnapShotFromParams ssPoolParams
     pure SnapShot {..}
 
 instance Arbitrary SnapShots where

--- a/libs/vector-map/src/Data/VMap.hs
+++ b/libs/vector-map/src/Data/VMap.hs
@@ -110,8 +110,8 @@ instance
 empty :: (VG.Vector kv k, VG.Vector vv v) => VMap kv vv k v
 empty = VMap VG.empty
 
-size :: VG.Vector kv k => VMap kv vv k v -> Int
-size = VG.length . KV.keysVector . unVMap
+size :: (VG.Vector kv k, VG.Vector vv v) => VMap kv vv k v -> Int
+size = VG.length . unVMap
 {-# INLINE size #-}
 
 lookup ::
@@ -230,11 +230,13 @@ fromDistinctAscListN n = VMap . KV.fromDistinctAscListN n
 {-# INLINE fromDistinctAscListN #-}
 
 map ::
-  (VG.Vector vv a, VG.Vector vv b) =>
+  (VG.Vector kv k, VG.Vector vv a, VG.Vector vv b) =>
   (a -> b) ->
   VMap kv vv k a ->
   VMap kv vv k b
-map f (VMap vec) = VMap (KV.mapValsKVVector f vec)
+map f (VMap vec) = VMap (VG.map (\(k, v) -> (k, f v)) vec)
+-- TODO: benchmark and switch to this implementation when we switch to Data.Vector.Strict
+-- VMap (KV.mapValsKVVector f vec)
 {-# INLINE map #-}
 
 mapMaybe ::
@@ -258,7 +260,9 @@ mapWithKey ::
   (k -> a -> b) ->
   VMap kv vv k a ->
   VMap kv vv k b
-mapWithKey f (VMap vec) = VMap (KV.mapWithKeyKVVector f vec)
+mapWithKey f (VMap vec) = VMap (VG.map (\(k, v) -> (k, f k v)) vec)
+-- TODO: benchmark and switch to this implementation when we switch to Data.Vector.Strict
+-- VMap (KV.mapWithKeyKVVector f vec)
 {-# INLINE mapWithKey #-}
 
 foldMapWithKey ::

--- a/libs/vector-map/test/Main.hs
+++ b/libs/vector-map/test/Main.hs
@@ -1,7 +1,33 @@
 module Main where
 
+import System.IO (
+  BufferMode (LineBuffering),
+  hSetBuffering,
+  hSetEncoding,
+  stdout,
+  utf8,
+ )
 import Test.Hspec
+import Test.Hspec.Core.Runner (ColorMode (ColorAlways), Config (..), defaultConfig, hspecWith)
 import Test.VMap
+
+-- ====================================================================================
+
+customSpecConfig :: Config
+customSpecConfig =
+  defaultConfig
+    { configTimes = True
+    , configColorMode = ColorAlways
+    }
+
+customSpecMainWithConfig :: Config -> Spec -> IO ()
+customSpecMainWithConfig conf spec = do
+  hSetBuffering stdout LineBuffering
+  hSetEncoding stdout utf8
+  hspecWith conf spec
+
+customSpecMain :: Spec -> IO ()
+customSpecMain = customSpecMainWithConfig customSpecConfig
 
 -- ====================================================================================
 
@@ -11,4 +37,4 @@ tests =
     vMapTests
 
 main :: IO ()
-main = hspec tests
+main = customSpecMain tests

--- a/libs/vector-map/vector-map.cabal
+++ b/libs/vector-map/vector-map.cabal
@@ -84,6 +84,7 @@ test-suite tests
     base,
     containers,
     hspec,
+    hspec-core,
     quickcheck-classes-base,
     vector-map,
 


### PR DESCRIPTION
# Description

This PR fixes lack of strictness on `map` and `mapWithKey` for `VMap`, which led to NoThunks tests to fail in Nightly CI

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
