### PR TITLE
Add AccountBalanceIntervals to DijkstraEraTxBody

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.0.0
 
+* Add `accountBalanceIntervalsTxBodyL` lens to `DijkstraEraTxBody` typeclass.
+  - Add the corresponding field to both `TopTx` and `SubTx` levels of `TxBody`.
+  - Add `AccountBalanceInterval` and `AccountBalanceIntervals` data types.
 * Add `Generic` instance for `ApplyTxError`
 * Change `ScriptsNotPaidUTxO` to use `NonEmptyMap TxIn (TxOut era)` instead of `UTxO era`
 * Add `dijkstraToConwayDelegCert`
@@ -115,6 +118,8 @@
 
 ### `cddl`
 
+* Add `account_balance_intervals` to `transaction_body` and `sub_transaction_body`.
+  - Add `accountBalanceInterval` and `accountBalanceIntervals` rules.
 * Remove `account_registration_cert` and `account_unregistration_cert`.
 * Add `directDepositsRule` to the transaction body.
 * Constrain `protocol_version` minor field to `uint .size 4`.

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -122,6 +122,7 @@ transaction_body =
   , ? 22 : positive_coin                    ; donation
   , ? 23 : sub_transactions                 ; sub-transactions (NEW)
   , ? 25 : direct_deposits                  ; direct deposits
+  , ? 26 : account_balance_intervals        ; account balance intervals
   }
 
 
@@ -723,12 +724,21 @@ sub_transaction_body =
   , ? 22 : positive_coin                   
   , ? 24 : required_top_level_guards       
   , ? 25 : direct_deposits                 
+  , ? 26 : account_balance_intervals       
   }
 
 
 required_top_level_guards = {+ credential => plutus_data/ nil}
 
 direct_deposits = {+ reward_account => coin}
+
+account_balance_intervals = {+ credential => account_balance_interval}
+
+account_balance_interval = 
+  [  inclusive_lower_bound : coin, exclusive_upper_bound : coin/ nil
+  // inclusive_lower_bound : coin/ nil, exclusive_upper_bound : coin
+  ]
+
 
 transaction_witness_set = 
   { ? 0 : nonempty_set<vkeywitness>      

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -13,6 +13,7 @@ import Cardano.Ledger.Conway.Governance (GovAction, ProposalProcedure, VotingPro
 import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.HuddleSpec (dijkstraCDDL)
+import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceInterval, AccountBalanceIntervals)
 import Cardano.Ledger.Plutus.Data (Data, Datum)
 import Test.Cardano.Ledger.Binary.Cuddle (
   huddleDecoderEquivalenceSpec,
@@ -30,16 +31,22 @@ spec = do
   describe "CDDL" $ do
     let v = eraProtVerHigh @DijkstraEra
     specWithHuddle dijkstraCDDL 100 $ do
+      huddleRoundTripCborSpec @(AccountBalanceInterval DijkstraEra) v "account_balance_interval"
+      huddleRoundTripCborSpec @(AccountBalanceIntervals DijkstraEra) v "account_balance_intervals"
+      huddleRoundTripArbitraryValidate @(AccountBalanceInterval DijkstraEra) v "account_balance_interval"
       huddleRoundTripCborSpec @(Value DijkstraEra) v "positive_coin"
       huddleRoundTripArbitraryValidate @(Value DijkstraEra) v "value"
       describe "MultiAsset" $ do
         huddleRoundTripCborSpec @(Value DijkstraEra) v "value"
-      xdescribe "fix TxBody" $ do
+      describe "fix TxBody" $ do
         huddleRoundTripAnnCborSpec @(TxBody TopTx DijkstraEra) v "transaction_body"
         huddleRoundTripCborSpec @(TxBody TopTx DijkstraEra) v "transaction_body"
+        huddleRoundTripAnnCborSpec @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
+        huddleRoundTripCborSpec @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
       -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $
+      xdescribe "hangs" $ do
         huddleRoundTripArbitraryValidate @(TxBody TopTx DijkstraEra) v "transaction_body"
+        huddleRoundTripArbitraryValidate @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
       huddleRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
       -- TODO fails because of plutus scripts
       xdescribe "fix plutus scripts" $ do
@@ -102,6 +109,7 @@ spec = do
         huddleRoundTripArbitraryValidate @(TxCert DijkstraEra) v "certificate"
       describe "DecCBOR instances equivalence via CDDL" $ do
         huddleDecoderEquivalenceSpec @(TxBody TopTx DijkstraEra) v "transaction_body"
+        huddleDecoderEquivalenceSpec @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
         xdescribe "Fix decoder equivalence of TxAuxData" $ do
           huddleDecoderEquivalenceSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
         huddleDecoderEquivalenceSpec @(NativeScript DijkstraEra) v "native_script"

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -34,9 +34,7 @@ import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError)
 import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
-import Cardano.Ledger.Shelley.Scripts (
-  pattern RequireSignature,
- )
+import Cardano.Ledger.Shelley.Scripts (pattern RequireSignature)
 import Data.Functor.Identity (Identity)
 import qualified Data.OMap.Strict as OMap
 import Data.Typeable (Typeable)
@@ -72,6 +70,7 @@ instance Arbitrary (TxBody SubTx DijkstraEra) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
 
 instance Arbitrary (TxBody TopTx DijkstraEra) where
   arbitrary =
@@ -96,6 +95,7 @@ instance Arbitrary (TxBody TopTx DijkstraEra) where
       <*> arbitrary
       <*> arbitrary
       <*> (choose (0, 4) >>= \n -> OMap.fromFoldable <$> vectorOf n arbitrary)
+      <*> arbitrary
       <*> arbitrary
 
 instance Arbitrary (UpgradeDijkstraPParams Identity DijkstraEra) where
@@ -310,3 +310,11 @@ deriving newtype instance Arbitrary (ApplyTxError DijkstraEra)
 
 instance Arbitrary (DijkstraMempoolPredFailure DijkstraEra) where
   arbitrary = genericArbitraryU
+
+instance Arbitrary (AccountBalanceIntervals era) where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
+
+instance Arbitrary (AccountBalanceInterval era) where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -134,6 +134,12 @@ instance Typeable l => DecCBOR (DijkstraTxBodyRaw l DijkstraEra) where
             (null . unDirectDeposits)
             (directDepositsDijkstraTxBodyRawL .~)
             From
+        26 ->
+          fieldGuarded
+            (emptyFailure "AccountBalanceIntervals" "non-empty")
+            (null . unAccountBalanceIntervals)
+            (accountBalanceIntervalsDijkstraTxBodyRawL .~)
+            From
         n -> invalidField n
       requiredFields :: STxBothLevels l DijkstraEra -> [(Word, String)]
       requiredFields sTxLevel

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
@@ -20,7 +20,7 @@ import Cardano.Ledger.Conway.Rules (ConwayDELEG, ConwayDelegPredFailure (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Dijkstra (ApplyTxError (..), DijkstraEra)
 import Cardano.Ledger.Dijkstra.Rules (DijkstraLEDGER, DijkstraMEMPOOL)
-import Cardano.Ledger.Dijkstra.Scripts (DijkstraPlutusPurpose (..))
+import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceIntervals (..), DijkstraPlutusPurpose (..))
 import Cardano.Ledger.Dijkstra.TxBody (TxBody (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Mary.Value (MaryValue (..))
@@ -114,6 +114,7 @@ exampleTxBodyDijkstra =
     mempty -- treasury donation
     mempty -- sub-transactions
     (DirectDeposits mempty)
+    (AccountBalanceIntervals mempty)
   where
     MaryValue _ exampleMultiAsset = exampleMultiAssetValue 3
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -38,6 +38,8 @@ import Cardano.Ledger.Dijkstra.Core (
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams)
 import Cardano.Ledger.Dijkstra.Rules
 import Cardano.Ledger.Dijkstra.Scripts (
+  AccountBalanceInterval,
+  AccountBalanceIntervals,
   DijkstraNativeScript,
   DijkstraNativeScriptRaw,
   DijkstraPlutusPurpose,
@@ -68,7 +70,7 @@ instance ToExpr (DijkstraPParams StrictMaybe DijkstraEra)
 
 instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
   toExpr = \case
-    txBody@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
+    txBody@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
       let DijkstraTxBodyRaw {..} = txBody
        in Rec "DijkstraTxBodyRaw" $
             OMap.fromList
@@ -93,8 +95,9 @@ instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
               , ("dtbrTreasuryDonation", toExpr dtbrTreasuryDonation)
               , ("dtbrSubTransactions", toExpr dtbrSubTransactions)
               , ("dtbrDirectDeposits", toExpr dtbrDirectDeposits)
+              , ("dtbrAccountBalanceIntervals", toExpr dtbrAccountBalanceIntervals)
               ]
-    txBody@(DijkstraSubTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
+    txBody@(DijkstraSubTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
       let DijkstraSubTxBodyRaw {..} = txBody
        in Rec "DijkstraSubTxBodyRaw" $
             OMap.fromList
@@ -115,6 +118,7 @@ instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
               , ("dstbrTreasuryDonation", toExpr dstbrTreasuryDonation)
               , ("dstbrRequiredTopLevelGuards", toExpr dstbrRequiredTopLevelGuards)
               , ("dstbrDirectDeposits", toExpr dstbrDirectDeposits)
+              , ("dstbrAccountBalanceIntervals", toExpr dstbrAccountBalanceIntervals)
               ]
 
 instance ToExpr (TxBody l DijkstraEra)
@@ -293,3 +297,7 @@ instance
 instance
   ToExpr (Event (EraRule "SUBUTXO" era)) =>
   ToExpr (DijkstraSubUtxowEvent era)
+
+instance ToExpr (AccountBalanceInterval era)
+
+instance ToExpr (AccountBalanceIntervals era)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Era.hs
@@ -642,6 +642,7 @@ instance EraApi DijkstraEra where
             , dtbTreasuryDonation = ctbrTreasuryDonation
             , dtbSubTransactions = mempty
             , dtbDirectDeposits = DirectDeposits mempty
+            , dtbAccountBalanceIntervals = AccountBalanceIntervals mempty
             }
 
   upgradeTxWits atw =

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Scripts.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -58,6 +57,8 @@ module Cardano.Ledger.Api.Scripts (
     toGuardingPurpose
   ),
   pattern GuardingPurpose,
+  AccountBalanceInterval (..),
+  AccountBalanceIntervals (..),
 ) where
 
 import Cardano.Ledger.Address (AccountAddress)
@@ -87,6 +88,8 @@ import Cardano.Ledger.Core (
   validateNativeScript,
  )
 import Cardano.Ledger.Dijkstra.Scripts (
+  AccountBalanceInterval (..),
+  AccountBalanceIntervals (..),
   DijkstraEraScript (..),
   pattern GuardingPurpose,
  )

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -5,12 +5,14 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -40,6 +42,8 @@ module Cardano.Ledger.BaseTypes (
   positiveUnitIntervalRelaxToUnitInterval,
   positiveUnitIntervalRelaxToPositiveInterval,
   positiveIntervalRelaxToNonNegativeInterval,
+  Inclusive (..),
+  Exclusive (..),
   BoundedRational (..),
   fpPrecision,
   integralToBounded,
@@ -760,6 +764,12 @@ newtype EpochErr = EpochErr Text
 deriving instance Show EpochErr
 
 instance Exception EpochErr
+
+newtype Inclusive a = Inclusive {unInclusive :: a}
+  deriving newtype (Generic, Show, Eq, Ord, NoThunks, NFData, EncCBOR, DecCBOR)
+
+newtype Exclusive a = Exclusive {unExclusive :: a}
+  deriving newtype (Generic, Show, Eq, Ord, NoThunks, NFData, EncCBOR, DecCBOR)
 
 -- | Relationship descriptor for the expectation in the 'Mismatch' type.
 type data Relation

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -41,7 +41,9 @@ import Cardano.Ledger.BaseTypes (
   CertIx (..),
   DnsName,
   EpochInterval (..),
+  Exclusive (..),
   HasZero,
+  Inclusive (..),
   Mismatch (..),
   Network (..),
   NonNegativeInterval,
@@ -340,6 +342,10 @@ instance Arbitrary GenDelegPair where
   arbitrary = GenDelegPair <$> arbitrary <*> arbitrary
 
 deriving instance Arbitrary GenDelegs
+
+deriving instance Arbitrary a => Arbitrary (Inclusive a)
+
+deriving instance Arbitrary a => Arbitrary (Exclusive a)
 
 ------------------------------------------------------------------------------------------
 -- Cardano.Ledger.Coin -------------------------------------------------------------------

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -50,6 +50,10 @@ instance ToExpr (CompactForm Coin) where
 
 deriving newtype instance ToExpr (CompactForm DeltaCoin)
 
+deriving newtype instance ToExpr a => ToExpr (Inclusive a)
+
+deriving newtype instance ToExpr a => ToExpr (Exclusive a)
+
 -- HKD
 instance ToExpr (NoUpdate a)
 


### PR DESCRIPTION
# Description

Add
* `accountBalanceIntervalsTxBodyL` lens to `DijkstraEraTxBody` typeclass.
* Corresponding fields to both top- and sub-level transaction bodies.
* `AccountBalanceInterval(s)` data-types.
* Corresponding rules in `HuddleSpec`.

Closes #5503 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
