### PR TITLE
Fix `sha256` of cardano-cls SRP stanza in cabal file

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -101,6 +101,5 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
+  --sha256: 1sprdlsgj0b4s9fw0hybl19yfnqdahkskkmw9mq5ng23f80qwbvs
   tag: 55d9af32aab35909a4f083797876d3e802835225
-
---sha256: 1sprdlsgj0b4s9fw0hybl19yfnqdahkskkmw9mq5ng23f80qwbvs


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

Without this change, entering `nix develop`  gives these warnings:

trace: WARNING: No sha256 found for source-repository-package https://github.com/tweag/cardano-cls.git ref=(unspecified) rev=55d9af32aab35909a4f083797876d3e802835225 download may fail in restricted mode (hydra)
trace: Consider adding `--sha256: 1sprdlsgj0b4s9fw0hybl19yfnqdahkskkmw9mq5ng23f80qwbvs` to the cabal.project file or passing in a sha256map argument

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
