### PR TITLE
Update `UTxOState` in `UTXO` rule rather than `UTXOS`

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.15.0.0
 
+* Move `TotalDeposits` and `TxUTxODiff` data constructors from `AlonzoUtxosEvent` to `AlonzoUtxoEvent`
+* Add `UtxosEnv`
+* Change `STS` instance of `AlonzoUTXOS`: use `UtxosEnv` as `Environment` and `ShelleyGovState` as `State`
 * Add `Generic` instance for `ApplyTxError`
 * Change `ScriptsNotPaidUTxO` to use `NonEmptyMap TxIn (TxOut era)` instead of `UTxO era`
 * Change `atadrPlutus`, `atadPlutus` and `atadPlutus'` to `atadrPlutusScripts`, `atadPlutusScripts` and `atadPlutusScripts'` respectively

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -184,11 +184,10 @@ instance
 
 instance ToExpr (Event (EraRule "UTXO" era)) => ToExpr (AlonzoUtxowEvent era)
 
-instance ToExpr (Event (EraRule "UTXOS" era)) => ToExpr (AlonzoUtxoEvent era)
+instance (ToExpr (TxOut era), ToExpr (Event (EraRule "UTXOS" era))) => ToExpr (AlonzoUtxoEvent era)
 
 instance
   ( ToExpr (EraRuleEvent "PPUP" era)
-  , ToExpr (TxOut era)
   , ToExpr PlutusWithContext
   ) =>
   ToExpr (AlonzoUtxosEvent era)

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Change `STS` instance of `BabbageUTXOS`: use `UtxosEnv` as `Environment` and `ShelleyGovState` as `State`
 * Add `Generic` instance for `ApplyTxError`
 * Add `BabbageApplyTxError` constructor for `ApplyTxError era`
 * Renamed:

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Change `babbageEvalScriptsTxInvalid` to return a `Rule` instead of `TransitionRule`
 * Change `STS` instance of `BabbageUTXOS`: use `UtxosEnv` as `Environment` and `ShelleyGovState` as `State`
 * Add `Generic` instance for `ApplyTxError`
 * Add `BabbageApplyTxError` constructor for `ApplyTxError era`

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.0.0
 
+* Add `updateUTxOStateByTxValidity`
 * Change `babbageEvalScriptsTxInvalid` to return a `Rule` instead of `TransitionRule`
 * Change `STS` instance of `BabbageUTXOS`: use `UtxosEnv` as `Environment` and `ShelleyGovState` as `State`
 * Add `Generic` instance for `ApplyTxError`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -36,6 +37,7 @@ import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoEvent (..),
   AlonzoUtxoPredFailure (..),
   AlonzoUtxosPredFailure (..),
+  UtxosEnv (..),
   allegraToAlonzoUtxoPredFailure,
  )
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (
@@ -48,7 +50,7 @@ import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (
   validateWrongNetworkInTxBody,
  )
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
-import Cardano.Ledger.Babbage.Collateral (collAdaBalance)
+import Cardano.Ledger.Babbage.Collateral (collAdaBalance, collOuts)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra, BabbageUTXO)
 import Cardano.Ledger.Babbage.Rules.Ppup ()
@@ -63,14 +65,19 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), Sized (..), natVersion)
 import Cardano.Ledger.Binary.Coders
-import Cardano.Ledger.Coin (Coin (..), DeltaCoin, toDeltaCoin)
+import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..), toDeltaCoin)
 import Cardano.Ledger.Rules.ValidationMode (
   Test,
   runTest,
   runTestOnSignal,
  )
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (utxosUtxo))
-import Cardano.Ledger.Shelley.Rules (ShelleyPpupPredFailure, ShelleyUtxoPredFailure, UtxoEnv)
+import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
+import Cardano.Ledger.Shelley.Rules (
+  ShelleyPpupPredFailure,
+  ShelleyUtxoPredFailure,
+  UtxoEnv (..),
+  updateUTxOState,
+ )
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxIn)
@@ -79,24 +86,12 @@ import qualified Cardano.Ledger.Val as Val (inject, isAdaOnly, pointwise)
 import Control.DeepSeq (NFData)
 import Control.Monad (unless, when)
 import Control.Monad.Trans.Reader (asks)
-import Control.State.Transition.Extended (
-  Embed (..),
-  Rule,
-  RuleType (..),
-  STS (..),
-  TRC (..),
-  TransitionRule,
-  failureOnNonEmpty,
-  judgmentContext,
-  liftSTS,
-  trans,
-  validate,
- )
+import Control.State.Transition.Extended
 import Data.Bifunctor (first)
-import Data.Coerce (coerce)
 import Data.Foldable (sequenceA_, toList)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
+import Data.MapExtras (extractKeys)
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -442,7 +437,10 @@ utxoTransition ::
   forall era.
   ( EraUTxO era
   , BabbageEraTxBody era
-  , AlonzoEraTxWits era
+  , AlonzoEraTx era
+  , EraCertState era
+  , EraStake era
+  , GovState era ~ ShelleyGovState era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
   , InjectRuleFailure "UTXO" AlonzoUtxoPredFailure era
@@ -451,18 +449,48 @@ utxoTransition ::
   , State (EraRule "UTXO" era) ~ UTxOState era
   , Signal (EraRule "UTXO" era) ~ Tx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
+  , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
   , STS (EraRule "UTXO" era)
   , -- In this function we call the UTXOS rule, so we need some assumptions
     Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
-  , Environment (EraRule "UTXOS" era) ~ UtxoEnv era
-  , State (EraRule "UTXOS" era) ~ UTxOState era
+  , Environment (EraRule "UTXOS" era) ~ UtxosEnv era
+  , State (EraRule "UTXOS" era) ~ ShelleyGovState era
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
-  , EraCertState era
   ) =>
   TransitionRule (EraRule "UTXO" era)
 utxoTransition = do
+  TRC (UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
   babbageUtxoValidation
-  trans @(EraRule "UTXOS" era) =<< coerce <$> judgmentContext
+  let utxo = utxosUtxo utxos
+  updatedGovState <-
+    trans @(EraRule "UTXOS" era) $
+      TRC (UtxosEnv slot pp certState utxo, utxosGovState utxos, tx)
+
+  let txBody = tx ^. bodyTxL
+  case tx ^. isValidTxL of
+    IsValid True ->
+      updateUTxOState
+        pp
+        utxos
+        txBody
+        certState
+        updatedGovState
+        (tellEvent . TotalDeposits (hashAnnotated txBody))
+        (\a b -> tellEvent $ TxUTxODiff a b)
+    IsValid False ->
+      {- utxoKeep = txBody ^. collateralInputsTxBodyL ⋪ utxo -}
+      {- utxoDel  = txBody ^. collateralInputsTxBodyL ◁ utxo -}
+      let !(utxoKeep, utxoDel) = extractKeys (unUTxO utxo) (txBody ^. collateralInputsTxBodyL)
+          UTxO collouts = collOuts txBody
+          DeltaCoin collateralFees = collAdaBalance txBody utxoDel -- NEW to Babbage
+       in pure $!
+            utxos {- (collInputs txb ⋪ utxo) ∪ collouts tx -}
+              { utxosUtxo = UTxO (Map.union utxoKeep collouts) -- NEW to Babbage
+              {- fees + collateralFees -}
+              , utxosFees = utxosFees utxos <> Coin collateralFees -- NEW to Babbage
+              , utxosInstantStake =
+                  deleteInstantStake (UTxO utxoDel) (addInstantStake (UTxO collouts) (utxos ^. instantStakeL))
+              }
 
 --------------------------------------------------------------------------------
 -- BabbageUTXO STS
@@ -473,7 +501,11 @@ instance
   ( EraTx era
   , EraUTxO era
   , BabbageEraTxBody era
+  , AlonzoEraTx era
   , AlonzoEraTxWits era
+  , EraCertState era
+  , EraStake era
+  , GovState era ~ ShelleyGovState era
   , EraRule "UTXO" era ~ BabbageUTXO era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
@@ -481,10 +513,9 @@ instance
   , InjectRuleFailure "UTXO" BabbageUtxoPredFailure era
   , -- instructions for calling UTXOS from BabbageUTXO
     Embed (EraRule "UTXOS" era) (BabbageUTXO era)
-  , Environment (EraRule "UTXOS" era) ~ UtxoEnv era
-  , State (EraRule "UTXOS" era) ~ UTxOState era
+  , Environment (EraRule "UTXOS" era) ~ UtxosEnv era
+  , State (EraRule "UTXOS" era) ~ ShelleyGovState era
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
-  , EraCertState era
   , SafeToHash (TxWits era)
   ) =>
   STS (BabbageUTXO era)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -27,6 +27,7 @@ import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxosEvent (..),
   AlonzoUtxosPredFailure (..),
   TagMismatchDescription (..),
+  UtxosEnv (..),
   invalidBegin,
   invalidEnd,
   scriptFailureToFailureDescription,
@@ -37,10 +38,6 @@ import Cardano.Ledger.Alonzo.Rules (
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
   AlonzoScriptsNeeded,
- )
-import Cardano.Ledger.Babbage.Collateral (
-  collAdaBalance,
-  collOuts,
  )
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra, BabbageUTXOS)
@@ -53,26 +50,20 @@ import Cardano.Ledger.BaseTypes (
   systemStart,
  )
 import Cardano.Ledger.Binary (EncCBOR (..))
-import Cardano.Ledger.Coin (Coin (..), DeltaCoin (..))
 import Cardano.Ledger.Plutus.Evaluate (
   ScriptFailure (..),
   ScriptResult (..),
  )
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules (
   PpupEnv (..),
   PpupEvent,
   ShelleyPPUP,
   ShelleyPpupPredFailure,
-  UtxoEnv (..),
-  updateUTxOState,
  )
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
 import Data.List.NonEmpty (nonEmpty)
-import qualified Data.Map.Strict as Map
-import Data.MapExtras (extractKeys)
 import qualified Debug.Trace as Debug
 import Lens.Micro
 
@@ -116,8 +107,8 @@ instance
   STS (BabbageUTXOS era)
   where
   type BaseM (BabbageUTXOS era) = ShelleyBase
-  type Environment (BabbageUTXOS era) = UtxoEnv era
-  type State (BabbageUTXOS era) = UTxOState era
+  type Environment (BabbageUTXOS era) = UtxosEnv era
+  type State (BabbageUTXOS era) = ShelleyGovState era
   type Signal (BabbageUTXOS era) = Tx TopTx era
   type PredicateFailure (BabbageUTXOS era) = AlonzoUtxosPredFailure era
   type Event (BabbageUTXOS era) = AlonzoUtxosEvent era
@@ -204,14 +195,12 @@ babbageEvalScriptsTxValid ::
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   , ShelleyEraTxBody era
-  , EraStake era
   , EraCertState era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , STS (BabbageUTXOS era)
   , Environment (EraRule "PPUP" era) ~ PpupEnv era
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , Embed (EraRule "PPUP" era) (BabbageUTXOS era)
-  , GovState era ~ ShelleyGovState era
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
   , EraPlutusContext era
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
@@ -220,7 +209,7 @@ babbageEvalScriptsTxValid ::
   ) =>
   TransitionRule (BabbageUTXOS era)
 babbageEvalScriptsTxValid = do
-  TRC (UtxoEnv slot pp certState, utxos@(UTxOState utxo _ _ pup _ _), tx) <-
+  TRC (UtxosEnv slot pp certState utxo, pup, tx) <-
     judgmentContext
   let txBody = tx ^. bodyTxL
       genDelegs = certState ^. certDStateL . dsGenDelegsL
@@ -228,7 +217,7 @@ babbageEvalScriptsTxValid = do
   -- We intentionally run the PPUP rule before evaluating any Plutus scripts.
   -- We do not want to waste computation running plutus scripts if the
   -- transaction will fail due to `PPUP`
-  ppup' <-
+  updatedGovState <-
     trans @(EraRule "PPUP" era) $
       TRC (PPUPEnv slot pp genDelegs, pup, txBody ^. updateTxBodyL)
 
@@ -236,36 +225,25 @@ babbageEvalScriptsTxValid = do
   expectScriptsToPass pp tx utxo
   () <- pure $! Debug.traceEvent validEnd ()
 
-  updateUTxOState
-    pp
-    utxos
-    txBody
-    certState
-    ppup'
-    (tellEvent . TotalDeposits (hashAnnotated txBody))
-    (\a b -> tellEvent $ TxUTxODiff a b)
+  pure updatedGovState
 
 babbageEvalScriptsTxInvalid ::
   forall era.
-  ( EraStake era
-  , AlonzoEraTx era
-  , BabbageEraTxBody era
+  ( AlonzoEraTx era
   , EraPlutusContext era
   , AlonzoEraUTxO era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , STS (EraRule "UTXOS" era)
-  , Environment (EraRule "UTXOS" era) ~ UtxoEnv era
+  , Environment (EraRule "UTXOS" era) ~ UtxosEnv era
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
-  , State (EraRule "UTXOS" era) ~ UTxOState era
+  , State (EraRule "UTXOS" era) ~ ShelleyGovState era
   , BaseM (EraRule "UTXOS" era) ~ ShelleyBase
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
   , InjectRuleEvent "UTXOS" AlonzoUtxosEvent era
   ) =>
   TransitionRule (EraRule "UTXOS" era)
 babbageEvalScriptsTxInvalid = do
-  TRC (UtxoEnv _ pp _, utxos@(UTxOState utxo _ fees _ _ _), tx) <- judgmentContext
-  {- txb := txbody tx -}
-  let txBody = tx ^. bodyTxL
+  TRC (UtxosEnv _ pp _ utxo, pup, tx) <- judgmentContext
   sysSt <- liftSTS $ asks systemStart
   ei <- liftSTS $ asks epochInfo
 
@@ -288,16 +266,4 @@ babbageEvalScriptsTxInvalid = do
 
   () <- pure $! Debug.traceEvent invalidEnd ()
 
-  {- utxoKeep = txBody ^. collateralInputsTxBodyL ⋪ utxo -}
-  {- utxoDel  = txBody ^. collateralInputsTxBodyL ◁ utxo -}
-  let !(utxoKeep, utxoDel) = extractKeys (unUTxO utxo) (txBody ^. collateralInputsTxBodyL)
-      UTxO collouts = collOuts txBody
-      DeltaCoin collateralFees = collAdaBalance txBody utxoDel -- NEW to Babbage
-  pure $!
-    utxos {- (collInputs txb ⋪ utxo) ∪ collouts tx -}
-      { utxosUtxo = UTxO (Map.union utxoKeep collouts) -- NEW to Babbage
-      {- fees + collateralFees -}
-      , utxosFees = fees <> Coin collateralFees -- NEW to Babbage
-      , utxosInstantStake =
-          deleteInstantStake (UTxO utxoDel) (addInstantStake (UTxO collouts) (utxos ^. instantStakeL))
-      }
+  pure pup

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.21.0.0
 
+* Change `STS` instance of `ConwayUTOXS`: use `PParams` as `Environment`
+* Remove `TotalDeposits` and `TxUTxODiff` data constructors from `ConwayUtxosEvent`
 * Add `Generic` instance for `ApplyTxError`
 * Change `ScriptsNotPaidUTxO` to use `NonEmptyMap TxIn (TxOut era)` instead of `UTxO era`
 * Add `conwayLedgerTransitionTRC`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxos.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxos.hs
@@ -88,7 +88,7 @@ instance InjectRuleFailure "SUBUTXOS" DijkstraSubUtxosPredFailure DijkstraEra
 newtype DijkstraSubUtxosEvent era = DijkstraSubUtxosEvent (ConwayUtxosEvent era)
   deriving (Generic)
 
-deriving instance Eq (ConwayUtxosEvent era) => Eq (DijkstraSubUtxosEvent era)
+deriving instance Eq (DijkstraSubUtxosEvent era)
 
 instance NFData (ConwayUtxosEvent era) => NFData (DijkstraSubUtxosEvent era)
 


### PR DESCRIPTION
# Description

At the moment,  changes to the UTxOState are done in the UTXOS rule - even though the UTXOS rule doesn't actually produce anything to change the state. 

In this PR, I'm updating UTXOS and UTXO rules for each era to update the state in UTXO.

Closes https://github.com/IntersectMBO/cardano-ledger/issues/5554

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
