### PR TITLE
Update CHaP

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1765454725,
-        "narHash": "sha256-dtq0m4AmoQ5MLcMufMSJoNR2UFYylY02sjWdHLakBe0=",
+        "lastModified": 1770251774,
+        "narHash": "sha256-R7bqXbzdKzaQrHdqFpZJdZRl87wRr/KNNdEn2vxV8K0=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "68f4a94fbe8dfc0818503cf686fad0f92f71919b",
+        "rev": "c765cd0d014285d8c9b2d379b1af89576b27f248",
         "type": "github"
       },
       "original": {
@@ -205,7 +205,7 @@
       "flake": false,
       "locked": {
         "lastModified": 1769576365,
-        "narHash": "sha256-OmxmlLlzaKVEYCjWe30AQqgBpBGVoO39rS79nh0vGiQ=",
+        "narHash": "sha256-kc9DbGbbyigV4XYFXMAn2CLPpXT93+xqLU7j0i/L6H0=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
         "rev": "ce149016c8294b9b91a9ee91fdbc449d6bb91a97",


### PR DESCRIPTION
# Description

Followup to #5561 - the `narHash` that was committed is now wrong for my local nix, which wanted to go back to the previous hash. We also upgrade CHaP to latest.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
