### PR TITLE
Tighten PParam lenses

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## 1.15.0.0
 
+* Change return type of lenses in `AlonzoEraPParams`:
+  - `hkdMaxValSizeL` to `Word32`
+  - `hkdCollateralPercentageL` to `Word16`
+  - `hkdMaxCollateralInputsL` to `Word16`
+* Change return type of `ppMaxValSizeL `to `Word32`
+* Change teturn type of `ppCollateralPercentageL` to `Word16`
+* Change return type of `ppMaxCollateralInputsL` to `Word16`
 * Move `TotalDeposits` and `TxUTxODiff` data constructors from `AlonzoUtxosEvent` to `AlonzoUtxoEvent`
 * Add `UtxosEnv`
 * Change `STS` instance of `AlonzoUTXOS`: use `UtxosEnv` as `Environment` and `ShelleyGovState` as `State`

--- a/eras/alonzo/impl/cddl/data/alonzo.cddl
+++ b/eras/alonzo/impl/cddl/data/alonzo.cddl
@@ -279,9 +279,9 @@ protocol_param_update =
   , ? 19 : ex_unit_prices         ; execution costs
   , ? 20 : ex_units               ; max tx ex units
   , ? 21 : ex_units               ; max block ex units
-  , ? 22 : uint                   ; max value size
-  , ? 23 : uint                   ; collateral percentage
-  , ? 24 : uint                   ; max collateral inputs
+  , ? 22 : uint .size 4           ; max value size
+  , ? 23 : uint .size 2           ; collateral percentage
+  , ? 24 : uint .size 2           ; max collateral inputs
   }
 
 

--- a/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
+++ b/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
@@ -382,9 +382,9 @@ instance HuddleRule "protocol_param_update" AlonzoEra where
         , opt (idx 19 ==> huddleRule @"ex_unit_prices" p) //- "execution costs"
         , opt (idx 20 ==> huddleRule @"ex_units" p) //- "max tx ex units"
         , opt (idx 21 ==> huddleRule @"ex_units" p) //- "max block ex units"
-        , opt (idx 22 ==> VUInt) //- "max value size"
-        , opt (idx 23 ==> VUInt) //- "collateral percentage"
-        , opt (idx 24 ==> VUInt) //- "max collateral inputs"
+        , opt (idx 22 ==> VUInt `sized` (4 :: Word64)) //- "max value size"
+        , opt (idx 23 ==> VUInt `sized` (2 :: Word64)) //- "collateral percentage"
+        , opt (idx 24 ==> VUInt `sized` (2 :: Word64)) //- "max collateral inputs"
         ]
 
 instance HuddleRule "transaction_witness_set" AlonzoEra where

--- a/eras/alonzo/impl/golden/pparams-update.json
+++ b/eras/alonzo/impl/golden/pparams-update.json
@@ -1,5 +1,5 @@
 {
-    "collateralPercentage": 51,
+    "collateralPercentage": 54880,
     "decentralization": 0.2,
     "executionUnitPrices": {
         "priceMemory": 6.137517258401616982e11,
@@ -15,9 +15,9 @@
         "steps": 4878948358509797471
     },
     "maxBlockHeaderSize": 34115,
-    "maxCollateralInputs": 45,
+    "maxCollateralInputs": 11954,
     "maxTxSize": 881284740,
-    "maxValueSize": 39,
+    "maxValueSize": 3392963155,
     "minPoolCost": 855261,
     "monetaryExpansion": 0.7810966919969065,
     "poolPledgeInfluence": 8.319022570290014789e16,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
@@ -68,9 +68,9 @@ import qualified Data.Aeson as Aeson
 import Data.Functor.Identity (Identity)
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
+import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
-import Numeric.Natural (Natural)
 
 -- | All configuration that is necessary to bootstrap AlonzoEra from ShelleyGenesis
 data AlonzoGenesis = AlonzoGenesisWrapper
@@ -123,9 +123,9 @@ pattern AlonzoGenesis ::
   Prices ->
   ExUnits ->
   ExUnits ->
-  Natural ->
-  Natural ->
-  Natural ->
+  Word32 ->
+  Word16 ->
+  Word16 ->
   Maybe AlonzoExtraConfig ->
   AlonzoGenesis
 pattern AlonzoGenesis

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -128,7 +128,6 @@ import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens, (^.))
 import NoThunks.Class (NoThunks (..))
-import Numeric.Natural (Natural)
 
 class EraPParams era => AlonzoEraPParams era where
   hkdCoinsPerUTxOWordL ::
@@ -143,11 +142,11 @@ class EraPParams era => AlonzoEraPParams era where
 
   hkdMaxBlockExUnitsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f ExUnits)
 
-  hkdMaxValSizeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
+  hkdMaxValSizeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Word32)
 
-  hkdCollateralPercentageL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
+  hkdCollateralPercentageL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Word16)
 
-  hkdMaxCollateralInputsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
+  hkdMaxCollateralInputsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Word16)
 
 ppCoinsPerUTxOWordL ::
   forall era.
@@ -167,13 +166,13 @@ ppMaxTxExUnitsL = ppLensHKD . hkdMaxTxExUnitsL @era @Identity
 ppMaxBlockExUnitsL :: forall era. AlonzoEraPParams era => Lens' (PParams era) ExUnits
 ppMaxBlockExUnitsL = ppLensHKD . hkdMaxBlockExUnitsL @era @Identity
 
-ppMaxValSizeL :: forall era. AlonzoEraPParams era => Lens' (PParams era) Natural
+ppMaxValSizeL :: forall era. AlonzoEraPParams era => Lens' (PParams era) Word32
 ppMaxValSizeL = ppLensHKD . hkdMaxValSizeL @era @Identity
 
-ppCollateralPercentageL :: forall era. AlonzoEraPParams era => Lens' (PParams era) Natural
+ppCollateralPercentageL :: forall era. AlonzoEraPParams era => Lens' (PParams era) Word16
 ppCollateralPercentageL = ppLensHKD . hkdCollateralPercentageL @era @Identity
 
-ppMaxCollateralInputsL :: forall era. AlonzoEraPParams era => Lens' (PParams era) Natural
+ppMaxCollateralInputsL :: forall era. AlonzoEraPParams era => Lens' (PParams era) Word16
 ppMaxCollateralInputsL = ppLensHKD . hkdMaxCollateralInputsL @era @Identity
 
 ppuCoinsPerUTxOWordL ::
@@ -209,19 +208,19 @@ ppuMaxBlockExUnitsL = ppuLensHKD . hkdMaxBlockExUnitsL @era @StrictMaybe
 ppuMaxValSizeL ::
   forall era.
   AlonzoEraPParams era =>
-  Lens' (PParamsUpdate era) (StrictMaybe Natural)
+  Lens' (PParamsUpdate era) (StrictMaybe Word32)
 ppuMaxValSizeL = ppuLensHKD . hkdMaxValSizeL @era @StrictMaybe
 
 ppuCollateralPercentageL ::
   forall era.
   AlonzoEraPParams era =>
-  Lens' (PParamsUpdate era) (StrictMaybe Natural)
+  Lens' (PParamsUpdate era) (StrictMaybe Word16)
 ppuCollateralPercentageL = ppuLensHKD . hkdCollateralPercentageL @era @StrictMaybe
 
 ppuMaxCollateralInputsL ::
   forall era.
   AlonzoEraPParams era =>
-  Lens' (PParamsUpdate era) (StrictMaybe Natural)
+  Lens' (PParamsUpdate era) (StrictMaybe Word16)
 ppuMaxCollateralInputsL = ppuLensHKD . hkdMaxCollateralInputsL @era @StrictMaybe
 
 -- | Protocol parameters.
@@ -274,12 +273,12 @@ data AlonzoPParams f era = AlonzoPParams
   -- ^ Max total script execution resources units allowed per tx
   , appMaxBlockExUnits :: !(HKD f OrdExUnits)
   -- ^ Max total script execution resources units allowed per block
-  , appMaxValSize :: !(HKD f Natural)
+  , appMaxValSize :: !(HKD f Word32)
   -- ^ Max size of a Value in an output
-  , appCollateralPercentage :: !(HKD f Natural)
+  , appCollateralPercentage :: !(HKD f Word16)
   -- ^ Percentage of the txfee which must be provided as collateral when
   -- including non-native scripts.
-  , appMaxCollateralInputs :: !(HKD f Natural)
+  , appMaxCollateralInputs :: !(HKD f Word16)
   -- ^ Maximum number of collateral inputs allowed in a transaction
   }
   deriving (Generic)
@@ -425,9 +424,9 @@ data UpgradeAlonzoPParams f = UpgradeAlonzoPParams
   , uappPrices :: !(HKD f Prices)
   , uappMaxTxExUnits :: !(HKD f ExUnits)
   , uappMaxBlockExUnits :: !(HKD f ExUnits)
-  , uappMaxValSize :: !(HKD f Natural)
-  , uappCollateralPercentage :: !(HKD f Natural)
-  , uappMaxCollateralInputs :: !(HKD f Natural)
+  , uappMaxValSize :: !(HKD f Word32)
+  , uappCollateralPercentage :: !(HKD f Word16)
+  , uappMaxCollateralInputs :: !(HKD f Word16)
   }
   deriving (Generic)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -117,11 +117,10 @@ import qualified Data.Map.Strict as Map
 import Data.MapExtras (extractKeys)
 import qualified Data.Set as Set
 import Data.Set.NonEmpty (NonEmptySet)
-import Data.Word (Word32)
+import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
-import Numeric.Natural (Natural)
 import Validation
 
 -- ==========================================================
@@ -178,7 +177,7 @@ data AlonzoUtxoPredFailure era
     OutsideForecast
       SlotNo
   | -- | There are too many collateral inputs
-    TooManyCollateralInputs (Mismatch RelLTEQ Natural)
+    TooManyCollateralInputs (Mismatch RelLTEQ Word16)
   | NoCollateralInputs
   deriving (Generic)
 
@@ -493,7 +492,7 @@ validateTooManyCollateralInputs pp txBody =
   failureUnless (numColl <= maxColl) $
     TooManyCollateralInputs Mismatch {mismatchSupplied = numColl, mismatchExpected = maxColl}
   where
-    maxColl, numColl :: Natural
+    maxColl, numColl :: Word16
     maxColl = pp ^. ppMaxCollateralInputsL
     numColl = fromIntegral . Set.size $ txBody ^. collateralInputsTxBodyL
 

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -355,7 +355,7 @@ genAlonzoPParamsUpdate constants pp = do
   maxBlockExUnits <- genM genMaxBlockExUnits
   -- Not too small for maxValSize, if this is too small then any Tx with Value
   -- that has lots of policyIds will fail. The Shelley Era uses hard coded 4000
-  maxValSize <- genM (genNatural 4000 5000)
+  maxValSize <- genM (choose (4000, 5000))
   let alonzoUpgrade =
         UpgradeAlonzoPParams
           { uappCoinsPerUTxOWord = coinPerWord
@@ -383,7 +383,7 @@ genAlonzoPParams constants = do
   -- prices <- Prices <$> (Coin <$> choose (100, 5000)) <*> (Coin <$> choose (100, 5000))
   maxTxExUnits <- genMaxTxExUnits
   maxBlockExUnits <- genMaxBlockExUnits
-  maxValSize <- genNatural 4000 10000 -- This can't be too small. Shelley uses Hard coded 4000
+  maxValSize <- choose (4000, 10000) -- This can't be too small. Shelley uses Hard coded 4000
   let alonzoUpgrade =
         UpgradeAlonzoPParams
           { uappCoinsPerUTxOWord = coinPerWord

--- a/eras/babbage/impl/cddl/data/babbage.cddl
+++ b/eras/babbage/impl/cddl/data/babbage.cddl
@@ -399,9 +399,9 @@ protocol_param_update =
   , ? 19 : ex_unit_prices       ; execution costs
   , ? 20 : ex_units             ; max tx ex units
   , ? 21 : ex_units             ; max block ex units
-  , ? 22 : uint                 ; max value size
-  , ? 23 : uint                 ; collateral percentage
-  , ? 24 : uint                 ; max collateral inputs
+  , ? 22 : uint .size 4         ; max value size
+  , ? 23 : uint .size 2         ; collateral percentage
+  , ? 24 : uint .size 2         ; max collateral inputs
   }
 
 

--- a/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
+++ b/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
@@ -574,9 +574,9 @@ instance HuddleRule "protocol_param_update" BabbageEra where
         , opt (idx 19 ==> huddleRule @"ex_unit_prices" p) //- "execution costs"
         , opt (idx 20 ==> huddleRule @"ex_units" p) //- "max tx ex units"
         , opt (idx 21 ==> huddleRule @"ex_units" p) //- "max block ex units"
-        , opt (idx 22 ==> VUInt) //- "max value size"
-        , opt (idx 23 ==> VUInt) //- "collateral percentage"
-        , opt (idx 24 ==> VUInt) //- "max collateral inputs"
+        , opt (idx 22 ==> VUInt `sized` (4 :: Word64)) //- "max value size"
+        , opt (idx 23 ==> VUInt `sized` (2 :: Word64)) //- "collateral percentage"
+        , opt (idx 24 ==> VUInt `sized` (2 :: Word64)) //- "max collateral inputs"
         ]
 
 instance HuddleRule "auxiliary_data" BabbageEra where

--- a/eras/babbage/impl/golden/pparams-update.json
+++ b/eras/babbage/impl/golden/pparams-update.json
@@ -1,5 +1,5 @@
 {
-    "collateralPercentage": 51,
+    "collateralPercentage": 54880,
     "executionUnitPrices": {
         "priceMemory": 6.137517258401616982e11,
         "priceSteps": {
@@ -13,8 +13,8 @@
         "steps": 4878948358509797471
     },
     "maxBlockHeaderSize": 7370,
-    "maxCollateralInputs": 45,
-    "maxValueSize": 39,
+    "maxCollateralInputs": 11954,
+    "maxValueSize": 3392963155,
     "minPoolCost": 855261,
     "monetaryExpansion": 0.2,
     "poolPledgeInfluence": 6.790200579626650307,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -72,7 +72,6 @@ import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
-import Numeric.Natural (Natural)
 
 class AlonzoEraPParams era => BabbageEraPParams era where
   hkdCoinsPerUTxOByteL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f CoinPerByte)
@@ -127,12 +126,12 @@ data BabbagePParams f era = BabbagePParams
   -- ^ Max total script execution resources units allowed per tx
   , bppMaxBlockExUnits :: !(HKD f OrdExUnits)
   -- ^ Max total script execution resources units allowed per block
-  , bppMaxValSize :: !(HKD f Natural)
+  , bppMaxValSize :: !(HKD f Word32)
   -- ^ Max size of a Value in an output
-  , bppCollateralPercentage :: !(HKD f Natural)
+  , bppCollateralPercentage :: !(HKD f Word16)
   -- ^ Percentage of the txfee which must be provided as collateral when
   -- including non-native scripts.
-  , bppMaxCollateralInputs :: !(HKD f Natural)
+  , bppMaxCollateralInputs :: !(HKD f Word16)
   -- ^ Maximum number of collateral inputs allowed in a transaction
   }
   deriving (Generic)

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Remove `asBoundedIntegralHKD`
 * Change lens type of `hkdCommitteeMinSizeL` and `ppCommitteeMinSize` from `Natural` to `Word16`
 * Add `HeaderProtVerTooHigh` predicate failure.
 * Change `STS` instance of `ConwayUTOXS`: use `PParams` as `Environment`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Change lens type of `hkdCommitteeMinSizeL` and `ppCommitteeMinSize` from `Natural` to `Word16`
 * Add `HeaderProtVerTooHigh` predicate failure.
 * Change `STS` instance of `ConwayUTOXS`: use `PParams` as `Environment`
 * Remove `TotalDeposits` and `TxUTxODiff` data constructors from `ConwayUtxosEvent`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -87,7 +87,6 @@ module Cardano.Ledger.Conway.PParams (
   emptyConwayPParams,
   emptyConwayPParamsUpdate,
   asNaturalHKD,
-  asBoundedIntegralHKD,
   ppGroup,
   asCompactCoinHKD,
 
@@ -116,7 +115,6 @@ import Cardano.Ledger.BaseTypes (
   ProtVer (..),
   ToKeyValuePairs (..),
   UnitInterval,
-  integralToBounded,
   knownNonZeroBounded,
   strictMaybeToMaybe,
  )
@@ -1263,24 +1261,6 @@ asCompactCoinHKD = hkdMap (Proxy @f) compactCoinOrError
 -- an `ArithmeticUnderflow` exception for negative numbers.
 asNaturalHKD :: forall f i. (HKDFunctor f, Integral i) => HKD f i -> HKD f Natural
 asNaturalHKD = hkdMap (Proxy @f) (fromIntegral @i @Natural)
-
-asBoundedIntegralHKD ::
-  forall f i b.
-  (HKDFunctor f, Integral i, Integral b, Bounded b, HasCallStack) =>
-  HKD f i ->
-  HKD f b
-asBoundedIntegralHKD = hkdMap (Proxy @f) $ \x ->
-  case integralToBounded @i @b @Maybe x of
-    Just b -> b
-    Nothing ->
-      error $
-        "Value: "
-          <> show (toInteger x)
-          <> " is out of the valid range: ["
-          <> show (toInteger (minBound @b))
-          <> ","
-          <> show (toInteger (maxBound @b))
-          <> "]"
 
 ppPoolVotingThresholds :: ConwayEraPParams era => PParam era
 ppPoolVotingThresholds =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -184,7 +184,7 @@ class BabbageEraPParams era => ConwayEraPParams era where
 
   hkdPoolVotingThresholdsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f PoolVotingThresholds)
   hkdDRepVotingThresholdsL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f DRepVotingThresholds)
-  hkdCommitteeMinSizeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Natural)
+  hkdCommitteeMinSizeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f Word16)
   hkdCommitteeMaxTermLengthL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochInterval)
   hkdGovActionLifetimeL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f EpochInterval)
   hkdGovActionDepositCompactL :: HKDFunctor f => Lens' (PParamsHKD f era) (HKD f (CompactForm Coin))
@@ -229,7 +229,7 @@ ppDRepVotingThresholdsL ::
   forall era. ConwayEraPParams era => Lens' (PParams era) DRepVotingThresholds
 ppDRepVotingThresholdsL = ppLensHKD . hkdDRepVotingThresholdsL @era @Identity
 
-ppCommitteeMinSizeL :: forall era. ConwayEraPParams era => Lens' (PParams era) Natural
+ppCommitteeMinSizeL :: forall era. ConwayEraPParams era => Lens' (PParams era) Word16
 ppCommitteeMinSizeL = ppLensHKD . hkdCommitteeMinSizeL @era @Identity
 
 ppCommitteeMaxTermLengthL :: forall era. ConwayEraPParams era => Lens' (PParams era) EpochInterval
@@ -267,7 +267,7 @@ ppuDRepVotingThresholdsL ::
 ppuDRepVotingThresholdsL = ppuLensHKD . hkdDRepVotingThresholdsL @era @StrictMaybe
 
 ppuCommitteeMinSizeL ::
-  forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Natural)
+  forall era. ConwayEraPParams era => Lens' (PParamsUpdate era) (StrictMaybe Word16)
 ppuCommitteeMinSizeL = ppuLensHKD . hkdCommitteeMinSizeL @era @StrictMaybe
 
 ppuCommitteeMaxTermLengthL ::
@@ -973,10 +973,8 @@ instance ConwayEraPParams ConwayEra where
     lens (unTHKD . cppPoolVotingThresholds) $ \pp x -> pp {cppPoolVotingThresholds = THKD x}
   hkdDRepVotingThresholdsL =
     lens (unTHKD . cppDRepVotingThresholds) $ \pp x -> pp {cppDRepVotingThresholds = THKD x}
-  hkdCommitteeMinSizeL :: forall f. HKDFunctor f => Lens' (PParamsHKD f ConwayEra) (HKD f Natural)
   hkdCommitteeMinSizeL =
-    lens (asNaturalHKD @f @Word16 . (unTHKD . cppCommitteeMinSize)) $
-      \pp x -> pp {cppCommitteeMinSize = THKD (asBoundedIntegralHKD @f @Natural @Word16 x)}
+    lens (unTHKD . cppCommitteeMinSize) $ \pp x -> pp {cppCommitteeMinSize = THKD x}
   hkdCommitteeMaxTermLengthL =
     lens (unTHKD . cppCommitteeMaxTermLength) $ \pp x -> pp {cppCommitteeMaxTermLength = THKD x}
   hkdGovActionLifetimeL =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -921,20 +921,12 @@ instance AlonzoEraPParams ConwayEra where
   hkdMaxBlockExUnitsL =
     lens (hkdMap (Proxy @f) unOrdExUnits . unTHKD . cppMaxBlockExUnits) $ \pp x ->
       pp {cppMaxBlockExUnits = THKD $ hkdMap (Proxy @f) OrdExUnits x}
-  hkdMaxValSizeL :: forall f. HKDFunctor f => Lens' (PParamsHKD f ConwayEra) (HKD f Natural)
   hkdMaxValSizeL =
-    lens (asNaturalHKD @f @Word32 . (unTHKD . cppMaxValSize)) $
-      \pp x -> pp {cppMaxValSize = THKD (asBoundedIntegralHKD @f @Natural @Word32 x)}
-  hkdCollateralPercentageL ::
-    forall f. HKDFunctor f => Lens' (PParamsHKD f ConwayEra) (HKD f Natural)
+    lens (unTHKD . cppMaxValSize) $ \pp x -> pp {cppMaxValSize = THKD x}
   hkdCollateralPercentageL =
-    lens (asNaturalHKD @f @Word16 . (unTHKD . cppCollateralPercentage)) $
-      \pp x -> pp {cppCollateralPercentage = THKD (asBoundedIntegralHKD @f @Natural @Word16 x)}
-  hkdMaxCollateralInputsL ::
-    forall f. HKDFunctor f => Lens' (PParamsHKD f ConwayEra) (HKD f Natural)
+    lens (unTHKD . cppCollateralPercentage) $ \pp x -> pp {cppCollateralPercentage = THKD x}
   hkdMaxCollateralInputsL =
-    lens (asNaturalHKD @f @Word16 . (unTHKD . cppMaxCollateralInputs)) $
-      \pp x -> pp {cppMaxCollateralInputs = THKD (asBoundedIntegralHKD @f @Natural @Word16 x)}
+    lens (unTHKD . cppMaxCollateralInputs) $ \pp x -> pp {cppMaxCollateralInputs = THKD x}
 
 instance BabbageEraPParams ConwayEra where
   hkdCoinsPerUTxOByteL =
@@ -1140,12 +1132,9 @@ upgradeConwayPParams UpgradeConwayPParams {..} BabbagePParams {..} =
     , cppPrices = THKD bppPrices
     , cppMaxTxExUnits = THKD bppMaxTxExUnits
     , cppMaxBlockExUnits = THKD bppMaxBlockExUnits
-    , cppMaxValSize =
-        THKD (asBoundedIntegralHKD @f @Natural @Word32 bppMaxValSize)
-    , cppCollateralPercentage =
-        THKD (asBoundedIntegralHKD @f @Natural @Word16 bppCollateralPercentage)
-    , cppMaxCollateralInputs =
-        THKD (asBoundedIntegralHKD @f @Natural @Word16 bppMaxCollateralInputs)
+    , cppMaxValSize = THKD bppMaxValSize
+    , cppCollateralPercentage = THKD bppCollateralPercentage
+    , cppMaxCollateralInputs = THKD bppMaxCollateralInputs
     , -- New for Conway
       cppPoolVotingThresholds = THKD ucppPoolVotingThresholds
     , cppDRepVotingThresholds = THKD ucppDRepVotingThresholds
@@ -1184,9 +1173,9 @@ downgradeConwayPParams ConwayPParams {..} =
     , bppPrices = unTHKD cppPrices
     , bppMaxTxExUnits = unTHKD cppMaxTxExUnits
     , bppMaxBlockExUnits = unTHKD cppMaxBlockExUnits
-    , bppMaxValSize = asNaturalHKD @f @Word32 (unTHKD cppMaxValSize)
-    , bppCollateralPercentage = asNaturalHKD @f @Word16 (unTHKD cppCollateralPercentage)
-    , bppMaxCollateralInputs = asNaturalHKD @f @Word16 (unTHKD cppMaxCollateralInputs)
+    , bppMaxValSize = unTHKD cppMaxValSize
+    , bppCollateralPercentage = unTHKD cppCollateralPercentage
+    , bppMaxCollateralInputs = unTHKD cppMaxCollateralInputs
     }
 
 -- | Functionality for updating protocol parameters in Conway era. Worth noting that, unlike previous

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -80,9 +80,8 @@ import Control.State.Transition.Extended
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.NonEmpty (NonEmptyMap)
 import Data.Set.NonEmpty (NonEmptySet)
-import Data.Word (Word32)
+import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
-import GHC.Natural (Natural)
 import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 -- ======================================================
@@ -145,7 +144,7 @@ data ConwayUtxoPredFailure era
       SlotNo
   | -- | There are too many collateral inputs
     TooManyCollateralInputs
-      (Mismatch RelLTEQ Natural) -- The values are serialised in reverse order
+      (Mismatch RelLTEQ Word16) -- The values are serialised in reverse order
   | NoCollateralInputs
   | -- | The collateral is not equivalent to the total collateral asserted by the transaction
     IncorrectTotalCollateralField

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/GenesisSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/GenesisSpec.hs
@@ -45,7 +45,7 @@ propConwayPParamsUpgrade ppu pp = property $ do
   let pp' = upgradePParams ppu pp :: PParams ConwayEra
   pp' ^. ppPoolVotingThresholdsL `shouldBe` ucppPoolVotingThresholds ppu
   pp' ^. ppDRepVotingThresholdsL `shouldBe` ucppDRepVotingThresholds ppu
-  fromIntegral (pp' ^. ppCommitteeMinSizeL) `shouldBe` ucppCommitteeMinSize ppu
+  pp' ^. ppCommitteeMinSizeL `shouldBe` ucppCommitteeMinSize ppu
   pp' ^. ppCommitteeMaxTermLengthL `shouldBe` ucppCommitteeMaxTermLength ppu
   pp' ^. ppGovActionLifetimeL `shouldBe` ucppGovActionLifetime ppu
   pp' ^. ppGovActionDepositL `shouldBe` ucppGovActionDeposit ppu

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
@@ -573,10 +573,8 @@ instance ConwayEraPParams DijkstraEra where
     lens (unTHKD . dppPoolVotingThresholds) $ \pp x -> pp {dppPoolVotingThresholds = THKD x}
   hkdDRepVotingThresholdsL =
     lens (unTHKD . dppDRepVotingThresholds) $ \pp x -> pp {dppDRepVotingThresholds = THKD x}
-  hkdCommitteeMinSizeL :: forall f. HKDFunctor f => Lens' (PParamsHKD f DijkstraEra) (HKD f Natural)
   hkdCommitteeMinSizeL =
-    lens (asNaturalHKD @f @Word16 . (unTHKD . dppCommitteeMinSize)) $
-      \pp x -> pp {dppCommitteeMinSize = THKD (asBoundedIntegralHKD @f @Natural @Word16 x)}
+    lens (unTHKD . dppCommitteeMinSize) $ \pp x -> pp {dppCommitteeMinSize = THKD x}
   hkdCommitteeMaxTermLengthL =
     lens (unTHKD . dppCommitteeMaxTermLength) $ \pp x -> pp {dppCommitteeMaxTermLength = THKD x}
   hkdGovActionLifetimeL =

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
@@ -74,7 +74,6 @@ import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens, to, (^.))
 import NoThunks.Class (NoThunks)
-import Numeric.Natural (Natural)
 
 -- | Dijkstra Protocol parameters. The following parameters have been added since Dijkstra:
 -- * @maxRefScriptSizePerBlock@
@@ -523,20 +522,11 @@ instance AlonzoEraPParams DijkstraEra where
   hkdMaxBlockExUnitsL =
     lens (hkdMap (Proxy @f) unOrdExUnits . unTHKD . dppMaxBlockExUnits) $ \pp x ->
       pp {dppMaxBlockExUnits = THKD $ hkdMap (Proxy @f) OrdExUnits x}
-  hkdMaxValSizeL :: forall f. HKDFunctor f => Lens' (PParamsHKD f DijkstraEra) (HKD f Natural)
-  hkdMaxValSizeL =
-    lens (asNaturalHKD @f @Word32 . (unTHKD . dppMaxValSize)) $
-      \pp x -> pp {dppMaxValSize = THKD (asBoundedIntegralHKD @f @Natural @Word32 x)}
-  hkdCollateralPercentageL ::
-    forall f. HKDFunctor f => Lens' (PParamsHKD f DijkstraEra) (HKD f Natural)
+  hkdMaxValSizeL = lens (unTHKD . dppMaxValSize) $ \pp x -> pp {dppMaxValSize = THKD x}
   hkdCollateralPercentageL =
-    lens (asNaturalHKD @f @Word16 . (unTHKD . dppCollateralPercentage)) $
-      \pp x -> pp {dppCollateralPercentage = THKD (asBoundedIntegralHKD @f @Natural @Word16 x)}
-  hkdMaxCollateralInputsL ::
-    forall f. HKDFunctor f => Lens' (PParamsHKD f DijkstraEra) (HKD f Natural)
+    lens (unTHKD . dppCollateralPercentage) $ \pp x -> pp {dppCollateralPercentage = THKD x}
   hkdMaxCollateralInputsL =
-    lens (asNaturalHKD @f @Word16 . (unTHKD . dppMaxCollateralInputs)) $
-      \pp x -> pp {dppMaxCollateralInputs = THKD (asBoundedIntegralHKD @f @Natural @Word16 x)}
+    lens (unTHKD . dppMaxCollateralInputs) $ \pp x -> pp {dppMaxCollateralInputs = THKD x}
 
 instance BabbageEraPParams DijkstraEra where
   hkdCoinsPerUTxOByteL =

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -95,9 +95,8 @@ import Control.State.Transition.Extended (
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.NonEmpty (NonEmptyMap)
 import Data.Set.NonEmpty (NonEmptySet)
-import Data.Word (Word32)
+import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
-import GHC.Natural (Natural)
 import Lens.Micro ((^.))
 import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
@@ -155,7 +154,7 @@ data DijkstraUtxoPredFailure era
     OutsideForecast SlotNo
   | -- | There are too many collateral inputs
     TooManyCollateralInputs
-      (Mismatch RelLTEQ Natural)
+      (Mismatch RelLTEQ Word16)
   | NoCollateralInputs
   | -- | The collateral is not equivalent to the total collateral asserted by the transaction
     IncorrectTotalCollateralField

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
@@ -285,15 +285,15 @@ data SimplePParams era = SimplePParams
   , prices :: Prices
   , maxTxExUnits :: ExUnits
   , maxBlockExUnits :: ExUnits
-  , maxValSize :: Natural
-  , collateralPercentage :: Natural
-  , maxCollateralInputs :: Natural
+  , maxValSize :: Word32
+  , collateralPercentage :: Word16
+  , maxCollateralInputs :: Word16
   -- ^  Babbage
   , coinsPerUTxOByte :: Coin
   -- ^ Conway
   , poolVotingThresholds :: PoolVotingThresholds
   , drepVotingThresholds :: DRepVotingThresholds
-  , committeeMinSize :: Natural
+  , committeeMinSize :: Word16
   , committeeMaxTermLength :: EpochInterval
   , govActionLifetime :: EpochInterval
   , govActionDeposit :: Coin
@@ -344,9 +344,9 @@ data SimplePPUpdate = SimplePPUpdate
   , uprices :: StrictMaybe Prices
   , umaxTxExUnits :: StrictMaybe ExUnits
   , umaxBlockExUnits :: StrictMaybe ExUnits
-  , umaxValSize :: StrictMaybe Natural
-  , ucollateralPercentage :: StrictMaybe Natural
-  , umaxCollateralInputs :: StrictMaybe Natural
+  , umaxValSize :: StrictMaybe Word32
+  , ucollateralPercentage :: StrictMaybe Word16
+  , umaxCollateralInputs :: StrictMaybe Word16
   , -- Babbage
     ucoinsPerUTxOByte :: StrictMaybe Coin
   , -- Conway

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Basic.hs
@@ -352,7 +352,7 @@ data SimplePPUpdate = SimplePPUpdate
   , -- Conway
     upoolVotingThresholds :: StrictMaybe PoolVotingThresholds
   , udrepVotingThresholds :: StrictMaybe DRepVotingThresholds
-  , ucommitteeMinSize :: StrictMaybe Natural
+  , ucommitteeMinSize :: StrictMaybe Word16
   , ucommitteeMaxTermLength :: StrictMaybe EpochInterval
   , ugovActionLifetime :: StrictMaybe EpochInterval
   , ugovActionDeposit :: StrictMaybe Coin

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/PParams.hs
@@ -83,7 +83,6 @@ import Cardano.Ledger.Shelley (ShelleyEra)
 import Constrained.API
 import Data.Word
 import Lens.Micro
-import Numeric.Natural (Natural)
 import Test.Cardano.Ledger.Allegra.Arbitrary ()
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
 import Test.Cardano.Ledger.Alonzo.TreeDiff ()
@@ -479,15 +478,15 @@ maxBlockExUnits_ ::
 maxBlockExUnits_ simplepp = sel @20 simplepp
 
 maxValSize_ ::
-  EraSpecPParams era => Term (SimplePParams era) -> Term Natural
+  EraSpecPParams era => Term (SimplePParams era) -> Term Word32
 maxValSize_ simplepp = sel @21 simplepp
 
 collateralPercentage_ ::
-  EraSpecPParams era => Term (SimplePParams era) -> Term Natural
+  EraSpecPParams era => Term (SimplePParams era) -> Term Word16
 collateralPercentage_ simplepp = sel @22 simplepp
 
 maxCollateralInputs_ ::
-  EraSpecPParams era => Term (SimplePParams era) -> Term Natural
+  EraSpecPParams era => Term (SimplePParams era) -> Term Word16
 maxCollateralInputs_ simplepp = sel @23 simplepp
 
 coinsPerUTxOByte_ ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/PParams.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/PParams.hs
@@ -503,7 +503,7 @@ drepVotingThresholds_ ::
 drepVotingThresholds_ simplepp = sel @26 simplepp
 
 committeeMinSize_ ::
-  EraSpecPParams era => Term (SimplePParams era) -> Term Natural
+  EraSpecPParams era => Term (SimplePParams era) -> Term Word16
 committeeMinSize_ simplepp = sel @27 simplepp
 
 committeeMaxTermLength_ ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -128,8 +128,8 @@ import qualified Data.Sequence.Strict as Seq
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.TreeDiff (Expr, ToExpr (toExpr))
+import Data.Word (Word16, Word32, Word64)
 import GHC.Generics (Generic)
-import GHC.Word (Word64)
 import Lens.Micro
 import Numeric.Natural
 import Test.Cardano.Ledger.Allegra.TreeDiff ()
@@ -181,9 +181,9 @@ class (EraTest era, Reflect era, EraModel era) => EraGenericGen era where
 
   -- Era generic "lenses" for testing
 
-  ppMaxCollateralInputsT :: Lens' (PParams era) Natural
+  ppMaxCollateralInputsT :: Lens' (PParams era) Word16
 
-  ppCollateralPercentageT :: Lens' (PParams era) Natural
+  ppCollateralPercentageT :: Lens' (PParams era) Word16
 
   ppCostModelsT :: Lens' (PParams era) CostModels
 
@@ -191,7 +191,7 @@ class (EraTest era, Reflect era, EraModel era) => EraGenericGen era where
 
   ppMaxBlockExUnitsT :: Lens' (PParams era) ExUnits
 
-  ppMaxValSizeT :: Lens' (PParams era) Natural
+  ppMaxValSizeT :: Lens' (PParams era) Word32
 
   -- Utils
 
@@ -206,7 +206,7 @@ data GenSize = GenSize
   , startSlot :: !Word64
   , slotDelta :: !(Word64, Word64)
   , blocksizeMax :: !Integer
-  , collInputsMax :: !Natural
+  , collInputsMax :: !Word16
   , spendInputsMax :: !Int
   , refInputsMax :: !Int
   , utxoChoicesMax :: !Int
@@ -350,7 +350,7 @@ getCertificateMax = certificateMax . geSize . gsGenEnv
 getUtxoChoicesMax :: GenState era -> Int
 getUtxoChoicesMax = utxoChoicesMax . geSize . gsGenEnv
 
-getCollInputsMax :: GenState era -> Natural
+getCollInputsMax :: GenState era -> Word16
 getCollInputsMax = collInputsMax . geSize . gsGenEnv
 
 getOldUtxoPercent :: GenState era -> Int


### PR DESCRIPTION
# Description

Some PParams are doing unnecessary conversions via lenses. This is an attempt to simplify and match were possible with the type, while maintaining the safety of the current version.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
