### PR TITLE
Fixup ledger for next release

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Add `HeaderProtVerTooHigh` predicate failure.
 * Change `STS` instance of `ConwayUTOXS`: use `PParams` as `Environment`
 * Remove `TotalDeposits` and `TxUTxODiff` data constructors from `ConwayUtxosEvent`
 * Add `Generic` instance for `ApplyTxError`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
@@ -389,6 +389,7 @@ conwayToDijkstraBbodyPredFailure = \case
   Conway.LedgersFailure f -> LedgersFailure f
   Conway.TooManyExUnits mm -> TooManyExUnits mm
   Conway.BodyRefScriptsSizeTooBig mm -> BodyRefScriptsSizeTooBig mm
+  Conway.HeaderProtVerTooHigh {} -> error "Impossible: HeaderProtVerTooHigh cannot be triggered in Dijkstra era"
 
 instance
   ( Era era

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1440,6 +1440,7 @@ tryTxsInBlock ::
 tryTxsInBlock txs finalState = do
   blockIssuer <- freshKeyHash
   slotNo <- use impCurSlotNoG
+  nes <- use impNESL
 
   let
     blockBody = mkBasicBlockBody @era & txSeqBlockBodyL .~ txs
@@ -1451,11 +1452,11 @@ tryTxsInBlock txs finalState = do
         , bhviewBHash = hashBlockBody blockBody
         , bhviewSlot = slotNo
         , bhviewPrevEpochNonce = Nothing
+        , bhviewProtVer = nes ^. nesEsL . curPParamsEpochStateL . ppProtocolVersionL
         }
     block = Block {blockHeader, blockBody}
 
   globals <- use impGlobalsL
-  nes <- use impNESL
 
   let res = applyBlockEither EPReturn ValidateAll globals nes block
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.13.0.0
 
+* Add `queryStakeSnapshots` and the types produced by it:
+  - `StakeSnapshot`
+  - `StakeSnapshots`
 * Re-export `DirectDeposits` and `directDepositsTxBodyL` from `Cardano.Ledger.Api.Tx.Body`.
 * Re-export `constitutionGuardrailsScriptHashL` from `Cardano.Ledger.Api.Governance`.
 * Changed the type of the following functions by adding `Network` argument:

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -75,7 +75,7 @@ library
     deepseq,
     microlens,
     transformers,
-    vector-map,
+    vector-map >=1.2,
 
 library testlib
   exposed-modules:

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -103,6 +103,7 @@ library testlib
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-dijkstra:testlib,
     data-default,
+    generic-random,
     prettyprinter,
 
 test-suite cardano-ledger-api-test
@@ -136,7 +137,7 @@ test-suite cardano-ledger-api-test
     cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
     cardano-ledger-api,
     cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
-    cardano-ledger-binary,
+    cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-byron,
     cardano-ledger-conway:{cardano-ledger-conway, testlib},
     cardano-ledger-core:{cardano-ledger-core, testlib},
@@ -150,3 +151,4 @@ test-suite cardano-ledger-api-test
     microlens,
     microlens-mtl,
     testlib,
+    vector-map,

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -72,8 +72,10 @@ library
     cardano-strict-containers,
     containers,
     data-default,
+    deepseq,
     microlens,
     transformers,
+    vector-map,
 
 library testlib
   exposed-modules:

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
+
 module Cardano.Ledger.Api.State.Query (
   -- * @GetFilteredDelegationsAndRewardAccounts@
   queryStakePoolDelegsAndRewards,
@@ -71,8 +72,10 @@ module Cardano.Ledger.Api.State.Query (
   QueryPoolStateResult (..),
   mkQueryPoolStateResult,
 
-    -- * @GetStakeSnapshots@
+  -- * @GetStakeSnapshots@
   queryStakeSnapshots,
+  StakeSnapshot (..),
+  StakeSnapshots (..),
 
   -- * For testing
   getNextEpochCommitteeMembers,
@@ -87,7 +90,6 @@ import Cardano.Ledger.Api.State.Query.CommitteeMembersState (
  )
 import Cardano.Ledger.BaseTypes (EpochNo, Network, strictMaybeToMaybe)
 import Cardano.Ledger.Binary
-import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.Governance (
@@ -518,25 +520,25 @@ data StakeSnapshot = StakeSnapshot
 
 instance NFData StakeSnapshot
 
-instance ToCBOR StakeSnapshot where
-  toCBOR
+instance EncCBOR StakeSnapshot where
+  encCBOR
     StakeSnapshot
       { ssMarkPool
       , ssSetPool
       , ssGoPool
       } =
-      Plain.encodeListLen 3
-        <> toCBOR ssMarkPool
-        <> toCBOR ssSetPool
-        <> toCBOR ssGoPool
+      encodeListLen 3
+        <> encCBOR ssMarkPool
+        <> encCBOR ssSetPool
+        <> encCBOR ssGoPool
 
-instance FromCBOR StakeSnapshot where
-  fromCBOR = do
-    Plain.enforceSize "StakeSnapshot" 3
+instance DecCBOR StakeSnapshot where
+  decCBOR = do
+    enforceSize "StakeSnapshot" 3
     StakeSnapshot
-      <$> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
+      <$> decCBOR
+      <*> decCBOR
+      <*> decCBOR
 
 data StakeSnapshots = StakeSnapshots
   { ssStakeSnapshots :: !(Map (KeyHash StakePool) StakeSnapshot)
@@ -548,28 +550,28 @@ data StakeSnapshots = StakeSnapshots
 
 instance NFData StakeSnapshots
 
-instance ToCBOR StakeSnapshots where
-  toCBOR
+instance EncCBOR StakeSnapshots where
+  encCBOR
     StakeSnapshots
       { ssStakeSnapshots
       , ssMarkTotal
       , ssSetTotal
       , ssGoTotal
       } =
-      Plain.encodeListLen 4
-        <> toCBOR ssStakeSnapshots
-        <> toCBOR ssMarkTotal
-        <> toCBOR ssSetTotal
-        <> toCBOR ssGoTotal
+      encodeListLen 4
+        <> encCBOR ssStakeSnapshots
+        <> encCBOR ssMarkTotal
+        <> encCBOR ssSetTotal
+        <> encCBOR ssGoTotal
 
-instance FromCBOR StakeSnapshots where
-  fromCBOR = do
-    Plain.enforceSize "StakeSnapshots" 4
+instance DecCBOR StakeSnapshots where
+  decCBOR = do
+    enforceSize "StakeSnapshots" 4
     StakeSnapshots
-      <$> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
-      <*> fromCBOR
+      <$> decCBOR
+      <*> decCBOR
+      <*> decCBOR
+      <*> decCBOR
 
 queryStakeSnapshots ::
   NewEpochState era ->

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
@@ -2,7 +2,8 @@
 
 module Test.Cardano.Ledger.Api.Arbitrary () where
 
-import Cardano.Ledger.Api.State.Query (MemberStatus, QueryPoolStateResult (..))
+import Cardano.Ledger.Api.State.Query
+import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Dijkstra.Arbitrary ()
 
@@ -11,3 +12,11 @@ instance Arbitrary MemberStatus where
 
 instance Arbitrary QueryPoolStateResult where
   arbitrary = QueryPoolStateResult <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+
+instance Arbitrary StakeSnapshot where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
+
+instance Arbitrary StakeSnapshots where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -85,7 +85,6 @@
 * Remove `Generic` instance from `BoundedRatio` type
 * Remove deprecated function `addrPtrNormalize`
 * Remove deprecated functions `mkTxIx`, `mkCertIx`, `hashAnchorData`
-* Remove deprecated functions `bheader`, `bbody`
 * Remove deprecated methods `fromTxSeq`, `toTxSeq`, `hashTxSeq` from `EraBlockBody` typeclass
 * Remove deprecated function `normalizePtr`
 * Remove deprecated functions `hashSignature`, `hashVerKeyVRF`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `bhviewProtVer` to `BHeaderView`
 * Remove re-exports of `Reward` and `RewardType` from `Cardano.Ledger.Core`
 * Add re-exports of `Addr`, `AccountAddress`, `Withdrawals` and `AccountId` from `Cardano.Ledger.Core`
 * Add `HasZero` instance for `CompactForm Coin`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BHeaderView.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BHeaderView.hs
@@ -4,7 +4,7 @@
 
 module Cardano.Ledger.BHeaderView where
 
-import Cardano.Ledger.BaseTypes (BoundedRational (..), Nonce, UnitInterval)
+import Cardano.Ledger.BaseTypes (BoundedRational (..), Nonce, ProtVer, UnitInterval)
 import Cardano.Ledger.Hashes (EraIndependentBlockBody, HASH, Hash, KeyHash, KeyRole (..))
 import Cardano.Ledger.Slot (SlotNo (..), (-*))
 import Control.DeepSeq (NFData)
@@ -35,6 +35,7 @@ data BHeaderView = BHeaderView
   , bhviewPrevEpochNonce :: Maybe Nonce
   -- ^ The previous epoch nonce, needed to validate Peras certificates
   -- contained in blocks.
+  , bhviewProtVer :: ProtVer
   }
   deriving (Generic)
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
@@ -16,6 +16,8 @@
 
 module Cardano.Ledger.Block (
   Block (..),
+  bheader,
+  bbody,
   neededTxInsForBlock,
 ) where
 
@@ -99,6 +101,16 @@ instance
     pure $ Block <$> header <*> txns
     where
       blockSize = 1 + fromIntegral (numSegComponents @era)
+
+bheader ::
+  Block h era ->
+  h
+bheader (Block bh _) = bh
+{-# DEPRECATED bheader "In favor of `blockHeader`" #-}
+
+bbody :: Block h era -> BlockBody era
+bbody (Block _ txs) = txs
+{-# DEPRECATED bbody "In favor of `blockBody`" #-}
 
 -- | The validity of any individual block depends only on a subset
 -- of the UTxO stored in the ledger state. This function returns

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -674,32 +674,35 @@ instance Arbitrary StakePoolSnapShot where
 
 instance Arbitrary SnapShot where
   arbitrary = do
-    ssStake@(Stake stake) <- arbitrary
-    let ssTotalActiveStake = sumAllStake ssStake `BaseTypes.nonZeroOr` (knownNonZeroCoin @1)
     ssPoolParams <- arbitrary
-    ssDelegations <-
+    credsWithStakeAndDelegations <-
       if VMap.null ssPoolParams
         then pure mempty
-        else fmap VMap.fromList $ listOf $ do
-          cred <-
-            if VMap.null stake
-              then arbitrary
-              else
-                let pickFromStake = do
-                      ix <- chooseInt (0, VMap.size stake - 1)
-                      pure $ fst $ VMap.elemAt ix stake
-                 in frequency [(1, arbitrary), (20, pickFromStake)]
-          ix <- chooseInt (0, VMap.size ssPoolParams - 1)
-          pure (cred, fst $ VMap.elemAt ix ssPoolParams)
+        else do
+          len <- sized $ \n -> chooseInt (0, n)
+          fmap Map.fromList $ vectorOf len $ do
+            cred <- arbitrary
+            !deleg <- do
+              ix <- chooseInt (0, VMap.size ssPoolParams - 1)
+              pure $ fst $ VMap.elemAt ix ssPoolParams
+            -- Make sure that the total sum does not overflow.
+            randomStake <- arbitrary
+            let stake
+                  | randomStake > CompactCoin 1000000 =
+                      CompactCoin (unCompactCoin randomStake `div` fromIntegral @Int @Word64 len)
+                  | otherwise = randomStake
+            pure (cred, (deleg, stake))
+    let
+      ssDelegations = VMap.fromMap $ Map.map fst credsWithStakeAndDelegations
+      ssStake = Stake $ VMap.fromMap $ Map.map snd credsWithStakeAndDelegations
+      ssTotalActiveStake = sumAllStake ssStake `BaseTypes.nonZeroOr` (knownNonZeroCoin @1)
     deposit <- arbitrary
     let delegationsPerStakePool :: Map (KeyHash StakePool) (Set (Credential Staking))
         delegationsPerStakePool =
-          VMap.foldlWithKey
-            ( \acc cred stakePool ->
-                Map.insertWith (<>) stakePool (Set.singleton cred) acc
-            )
+          Map.foldrWithKey'
+            (\cred (stakePool, _) -> Map.insertWith (<>) stakePool (Set.singleton cred))
             mempty
-            ssDelegations
+            credsWithStakeAndDelegations
         stakePoolSnapShotFromParams poolId =
           mkStakePoolSnapShot ssStake ssTotalActiveStake
             . mkStakePoolState deposit (Map.findWithDefault mempty poolId delegationsPerStakePool)

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs
@@ -463,3 +463,4 @@ makeHeaderView bh@(BHeader bhb _) nonce =
     (bhash bhb)
     (bheaderSlotNo bhb)
     nonce
+    (bprotver bhb)

--- a/libs/vector-map/CHANGELOG.md
+++ b/libs/vector-map/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.0.0
 
+* Add `keysSet`
 * Add `elemAt`
 * Add `mapMaybeWithKey`
 * Add `unionWithKey`, `unionWith` and `union`

--- a/libs/vector-map/src/Data/VMap.hs
+++ b/libs/vector-map/src/Data/VMap.hs
@@ -36,6 +36,7 @@ module Data.VMap (
   toList,
   toAscList,
   keys,
+  keysSet,
   elems,
   fromAscList,
   fromAscListN,
@@ -57,6 +58,7 @@ import Control.DeepSeq
 import Data.Aeson (FromJSON (..), FromJSONKey, ToJSON (..), ToJSONKey)
 import qualified Data.Map.Strict as Map
 import Data.Maybe as Maybe hiding (mapMaybe)
+import qualified Data.Set as Set
 import Data.VMap.KVVector (KVVector (..))
 import qualified Data.VMap.KVVector as KV
 import qualified Data.Vector as V
@@ -303,6 +305,10 @@ fold = VG.foldMap' id . valsVector . unVMap
 keys :: VG.Vector kv k => VMap kv vv k v -> [k]
 keys = VG.toList . keysVector . unVMap
 {-# INLINE keys #-}
+
+keysSet :: VG.Vector kv k => VMap kv vv k v -> Set.Set k
+keysSet = Set.fromDistinctAscList . VG.toList . keysVector . unVMap
+{-# INLINE keysSet #-}
 
 elems :: VG.Vector vv v => VMap kv vv k v -> [v]
 elems = VG.toList . valsVector . unVMap

--- a/libs/vector-map/test/Test/VMap.hs
+++ b/libs/vector-map/test/Test/VMap.hs
@@ -104,6 +104,9 @@ vMapTests =
           (\(m1, m2) -> VMap.fromMap m1 <> VMap.fromMap m2)
           (uncurry (<>))
           (Map.fromList xs1, Map.fromList xs2)
+      prop "keys" $ prop_AsMapTo VMap.keys Map.keys
+      prop "keysSet" $ prop_AsMapTo VMap.keysSet Map.keysSet
+      prop "elems" $ prop_AsMapTo VMap.elems Map.elems
       prop "toAscList" $ prop_AsMapTo VMap.toAscList Map.toAscList
       prop "foldMapWithKey" $ \f ->
         let f' k v = applyFun2 f k v :: String


### PR DESCRIPTION
# Description

This PR addresses a number of issues that are needed to be handled before the next 10.7 node release. All fixes are isolated in their own commits, as such it might be easier to review this PR commit-by-commit. Fixes included:

* `bheader` and `bbody` where deprecated and removed in the same version. This PR revers the removal and brings back deprecattions
* Move over GetStakeSnapshots query from Consensus over to cardano-ledger-api and adjust it to use new fields, instead of the old deprecated ones from the SnapShot type
* Add validation for DijkstraEra PV12
* Fix Arbitrary instance for `SnapShot`, it was previously incorrectly generating `Stake` with credentials that had no active delegations, which is not possible in the running system

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
