### PR TITLE
Fix preservation of a DRep delegation bug

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -354,9 +354,9 @@ processDelegationInternal preserveIncorrectDelegation stakeCred mAccountState ne
                 -- This is the case where we only add the new reverse delegation and do not remove
                 -- the old one, which is the behavior that we want:
                 --
-                -- - for new accounts, since there is no old reverse delegeation to remove
+                -- 1) for new accounts, since there is no old reverse delegation to remove
                 --
-                -- - in the bootstrap phase to preserve the incorrect behavior, where old reverse
+                -- 2) in the bootstrap phase, in order to preserve the incorrect behavior, where old reverse
                 --   delegation for the prior DRep was wrongfully retained. It is important to note
                 --   that in case when the new delegation was to a predefined DRep, the reverse
                 --   delegations where handled correctly even in the boostrap phase

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -76,6 +76,7 @@ import Control.State.Transition (
  )
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import Data.Maybe (isNothing)
 import Data.Set as Set
 import Data.Void (Void)
 import GHC.Generics (Generic)
@@ -345,14 +346,35 @@ processDelegationInternal preserveIncorrectDelegation stakeCred mAccountState ne
           (certPStateL . psStakePoolsL %~ Map.adjust (spsDelegatorsL %~ Set.insert stakeCred) stakePool)
           (\accountState -> certPStateL %~ unDelegReDelegStakePool stakeCred accountState (Just stakePool))
           mAccountState
+
     delegVote dRep cState =
-      cState
-        & certDStateL . accountsL %~ adjustAccountState (dRepDelegationAccountStateL ?~ dRep) stakeCred
-        & maybe
-          (certVStateL %~ insertDRepDeleg dRep)
-          (\accountState -> certVStateL %~ unDelegReDelegDRep stakeCred accountState (Just dRep))
-          (guard (not preserveIncorrectDelegation) >> mAccountState)
-    insertDRepDeleg dRep = case dRep of
-      DRepCredential dRepCred ->
-        vsDRepsL %~ Map.adjust (drepDelegsL %~ Set.insert stakeCred) dRepCred
-      _ -> id
+      let handleReverseDelegation =
+            case dRepToCred dRep of
+              Just dRepCred
+                -- This is the case where we only add the new reverse delegation and do not remove
+                -- the old one, which is the behavior that we want:
+                --
+                -- - for new accounts, since there is no old reverse delegeation to remove
+                --
+                -- - in the bootstrap phase to preserve the incorrect behavior, where old reverse
+                --   delegation for the prior DRep was wrongfully retained. It is important to note
+                --   that in case when the new delegation was to a predefined DRep, the reverse
+                --   delegations where handled correctly even in the boostrap phase
+                --
+                -- For reference here is the original bug report:
+                --   https://github.com/IntersectMBO/cardano-ledger/issues/4772
+                | isNothing mAccountState || preserveIncorrectDelegation ->
+                    certVStateL . vsDRepsL
+                      %~ Map.adjust (drepDelegsL %~ Set.insert stakeCred) dRepCred
+              _
+                -- AccountState existed before this delegation, therefore we need to properly handle
+                -- potential undelegation of the old DRep
+                | Just accountState <- mAccountState ->
+                    certVStateL %~ unDelegReDelegDRep stakeCred accountState (Just dRep)
+                -- If this is a fresh registration with delegation to a predefined DRep, there are
+                -- no extra steps that need to be done
+                | otherwise -> id
+       in cState
+            & certDStateL . accountsL
+              %~ adjustAccountState (dRepDelegationAccountStateL ?~ dRep) stakeCred
+            & handleReverseDelegation


### PR DESCRIPTION
# Description

A refactoring in this [commit](https://github.com/IntersectMBO/cardano-ledger/commit/7e5ab5d6b0ec3324fb4c2898985b1ca4675320d2/) has introduced a bug, affecting the logic preserving a buggy behaviour in boostrap phase, as follows:

Before the refactoring:
  * redelegate a stake credential SC from a DRep D to a new DRep credential  ->  preserves the reverse delegation  from D to SC 
  * redelegate SC from a DRep D to a a predefined DRep -> removes the reverse delegation from D to SC
  
After the refactoring: 
  * redelegate SC from a DRep D to any other DRep  (credential or predefined)-> preserves the reverse delegation from D to SC 

The problem with preserving the reverse delegation from D to SC  after redelegation of SC is that the unregistration of D will result into SC becoming undelegated.  

So, transactiions with this pattern:
 * delegate to drep D 
 * redelegate to AlwaysAbstain or AlwaysNoConfidence
 * D unregisters
 * SC withdraws 
 
were accepted before the refactoring, but failing after - because in the latter, the unregistration of D has rendered the stake credential undelegated.

This PR is fixing the error introduced in the ill-fated refactoring and adds a test for the case described above.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
