### PR TITLE
Use `AccountId` for stake pools

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -567,7 +567,7 @@ defaultStakePoolVote ::
 defaultStakePoolVote poolId poolParams accounts =
   toDefaultVote $ do
     spp <- Map.lookup poolId poolParams
-    accountState <- Map.lookup (spsAccountAddress spp) (accounts ^. accountsMapL)
+    accountState <- Map.lookup (unAccountId (spsAccountId spp)) (accounts ^. accountsMapL)
     accountState ^. dRepDelegationAccountStateL
   where
     toDefaultVote (Just DRepAlwaysAbstain) = DefaultAbstain

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -1028,7 +1028,7 @@ networkIdSpec =
       let badAccountAddress =
             AccountAddress
               { aaNetworkId = Mainnet -- Our network is Testnet
-              , aaAccountId = AccountId accountCredential
+              , aaId = AccountId accountCredential
               }
       proposal <- mkProposalWithAccountAddress InfoAction badAccountAddress
       submitBootstrapAwareFailingProposal_ proposal $
@@ -1084,7 +1084,7 @@ withdrawalsSpec =
       let badAccountAddress =
             AccountAddress
               { aaNetworkId = Mainnet -- Our network is Testnet
-              , aaAccountId = AccountId accountCredential
+              , aaId = AccountId accountCredential
               }
       proposal <-
         mkTreasuryWithdrawalsGovAction [(badAccountAddress, Coin 100_000_000)] >>= mkProposal

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -1904,7 +1904,7 @@ delegateSPORewardAddressToDRep_ kh stake drep = do
   sps <- getRatifyEnv >>= expectJust . Map.lookup kh . reStakePools
   void $
     delegateToDRep
-      (spsAccountAddress sps)
+      (unAccountId (spsAccountId sps))
       stake
       drep
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/SPORatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/SPORatifySpec.hs
@@ -275,7 +275,7 @@ genTestData Ratios {yes, no, abstain, alwaysAbstain, noConfidence} = do
       Map (KeyHash StakePool) StakePoolState ->
       Map (Credential Staking) DRep
     mkDelegatees drep =
-      fromKeys (const drep) . map spsAccountAddress . Map.elems
+      fromKeys (const drep) . map (unAccountId . spsAccountId) . Map.elems
 
     -- Create a map from each pool with the given value, where the key is the pool credential
     -- and take the union of all these maps.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/PulsingReward.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/PulsingReward.hs
@@ -175,7 +175,7 @@ startStep slotsPerEpoch b@(BlocksMade b') es@(EpochState acnt ls ss nm) maxSuppl
       newLikelihoods = VMap.map makeLikelihoods allPoolInfo
       -- We now compute the leader rewards for each stake pool.
       collectLRs acc poolRI =
-        let account = spssAccountId $ poolPs poolRI
+        let account = unAccountId $ spssAccountId $ poolPs poolRI
             packageLeaderReward = Set.singleton . leaderRewardToGeneral . poolLeaderReward
          in if hardforkBabbageForgoRewardPrefilter (pr ^. ppProtocolVersionL)
               || isAccountRegistered account accounts

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/PoolReap.hs
@@ -182,7 +182,7 @@ poolReapTransition = do
     accountRefunds =
       Map.fromListWith
         (<>)
-        [(spsAccountAddress sps, spsDeposit sps) | sps <- Map.elems retiringPools]
+        [(unAccountId $ spsAccountId sps, spsDeposit sps) | sps <- Map.elems retiringPools]
     accounts = ds ^. accountsL
     -- Deposits that can be refunded and those that are unclaimed (to be deposited into the treasury).
     refunds, unclaimedDeposits :: Map.Map (Credential Staking) (CompactForm Coin)
@@ -198,7 +198,7 @@ poolReapTransition = do
     let rewardAccountsWithPool =
           Map.foldrWithKey'
             ( \poolId sps ->
-                let cred = spsAccountAddress sps
+                let cred = unAccountId $ spsAccountId sps
                  in Map.insertWith (Map.unionWith (<>)) cred (Map.singleton poolId (spsDeposit sps))
             )
             Map.empty

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/PoolSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/PoolSpec.hs
@@ -41,7 +41,7 @@ spec = describe "POOL" $ do
       let badAccountAddress =
             AccountAddress
               { aaNetworkId = Mainnet
-              , aaAccountId = AccountId accountCredential
+              , aaId = AccountId accountCredential
               }
       kh <- freshKeyHash
       pps <- freshPoolParams kh badAccountAddress

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Utxo.hs
@@ -790,7 +790,7 @@ genWithdrawals
         let txwits =
               mkWithdrawalsWits @era ksIndexedStakeScripts ksIndexedStakingKeys
                 . unAccountId
-                . aaAccountId
+                . aaId
                 . fst
                 <$> selectedWrdls
         return (selectedWrdls, Either.partitionEithers txwits)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rewards.hs
@@ -435,7 +435,7 @@ rewardOnePool
           then Map.insertWith (<>)
           else Map.insert
       potentialRewards =
-        f (spssAccountId stakePoolSnapShot) lReward mRewards
+        f (unAccountId (spssAccountId stakePoolSnapShot)) lReward mRewards
       potentialRewards' =
         if hardforkBabbageForgoRewardPrefilter pv
           then potentialRewards

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -209,7 +209,7 @@ instance SpecTranslate ctx StakePoolSnapShot where
       <*> toSpecRep spssCost
       <*> toSpecRep spssMargin
       <*> toSpecRep spssPledge
-      <*> toSpecRep spssAccountId
+      <*> toSpecRep (unAccountId spssAccountId)
 
 instance SpecTranslate ctx Stake where
   type SpecRep Stake = Agda.HSMap Agda.Credential Agda.Coin

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -22,7 +22,7 @@ module Cardano.Ledger.Address (
   getNetwork,
   AccountAddress (..),
   AccountId (..),
-  accountAddressAccountIdL,
+  accountAddressIdL,
   accountAddressCredentialL,
   accountAddressNetworkIdL,
   serialiseAccountAddress,
@@ -182,7 +182,7 @@ instance NoThunks Addr
 -- | An account based address for rewards
 data AccountAddress = AccountAddress
   { aaNetworkId :: !Network
-  , aaAccountId :: !AccountId
+  , aaId :: !AccountId
   }
   deriving (Show, Eq, Generic, Ord, NFData, ToJSONKey, FromJSONKey)
 
@@ -197,15 +197,15 @@ pattern RewardAccount {raNetwork, raCredential} = AccountAddress raNetwork (Acco
 
 {-# DEPRECATED raNetwork "In favor of `aaNetworkId`" #-}
 
-{-# DEPRECATED raCredential "In favor of `aaAccountId`" #-}
+{-# DEPRECATED raCredential "In favor of `aaId`" #-}
 
 {-# COMPLETE RewardAccount #-}
 
-accountAddressAccountIdL :: Lens' AccountAddress AccountId
-accountAddressAccountIdL = lens aaAccountId $ \x y -> x {aaAccountId = y}
+accountAddressIdL :: Lens' AccountAddress AccountId
+accountAddressIdL = lens aaId $ \x y -> x {aaId = y}
 
 accountAddressCredentialL :: Lens' AccountAddress (Credential Staking)
-accountAddressCredentialL = lens (\(AccountAddress _ (AccountId c)) -> c) $ \x y -> x {aaAccountId = AccountId y}
+accountAddressCredentialL = lens (\(AccountAddress _ (AccountId c)) -> c) $ \x y -> x {aaId = AccountId y}
 
 accountAddressNetworkIdL :: Lens' AccountAddress Network
 accountAddressNetworkIdL = lens aaNetworkId $ \x y -> x {aaNetworkId = y}

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/SnapShots.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/SnapShots.hs
@@ -178,7 +178,7 @@ data StakePoolSnapShot = StakePoolSnapShot
   -- actual delegators, since at this point the actual stake has already been resolved.  This count
   -- is only needed to preserve older behavior where we filter out stake pools from `PoolDistr` that
   -- do not have any delegations.
-  , spssAccountId :: !(Credential Staking)
+  , spssAccountId :: !AccountId
   -- ^ This is the account where stake pools rewards will be deposited to. Corresponding field in
   -- the `StakePoolState` is `spsAccountAddress`.
   }
@@ -209,10 +209,10 @@ mkStakePoolSnapShot activeStake totalActiveStake stakePoolState =
     , spssCost = spsCost
     , spssMargin = spsMargin
     , spssNumDelegators = Set.size spsDelegators
-    , spssAccountId = spsAccountAddress
+    , spssAccountId = spsAccountId
     }
   where
-    StakePoolState {spsVrf, spsPledge, spsCost, spsMargin, spsAccountAddress, spsOwners, spsDelegators} =
+    StakePoolState {spsVrf, spsPledge, spsCost, spsMargin, spsAccountId, spsOwners, spsDelegators} =
       stakePoolState
     selfDelegatedOwners =
       Set.filter (\ownerKeyHash -> KeyHashObj ownerKeyHash `Set.member` spsDelegators) spsOwners
@@ -267,7 +267,7 @@ instance DecShareCBOR StakePoolSnapShot where
     spssCost <- lift decCBOR
     spssMargin <- lift decCBOR
     spssNumDelegators <- lift decCBOR
-    spssAccountId <- interns credInterns <$> lift decCBOR
+    spssAccountId <- AccountId . interns credInterns <$> lift decCBOR
     pure StakePoolSnapShot {..}
 
 -- | Snapshot of the stake distribution.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -43,7 +43,7 @@ coinToWord64 :: Coin -> Word64
 coinToWord64 (Coin n) = fromIntegral n
 
 wdrlCredentials :: Map AccountAddress Coin -> Set (Credential Staking)
-wdrlCredentials m = Set.map (unAccountId . aaAccountId) (Map.keysSet m)
+wdrlCredentials m = Set.map (unAccountId . aaId) (Map.keysSet m)
 
 keyHashWdrl :: Map AccountAddress Coin -> Set (Credential Staking)
 keyHashWdrl m = Set.filter isKeyHash (wdrlCredentials m)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -296,8 +296,6 @@ conwayDStateSpec univ (whoDelegates, wdrl) poolreg =
 
 -- | Specify the internal Map of ConwayAccounts ::  Map (Credential Staking) (ConwayAccountState era)
 --   Ensure that the Staking Credential is both staked to some Pool, and Delegated to some DRep
--- | Given a set of Withdrawals:: newtype Withdrawals = Withdrawals {unWithdrawals :: Map AccountAddress Coin}
---   where:: data AccountAddress = AccountAddress {aaNetworkId :: !Network, aaAccountId :: !(AccountId)}
 --   That ensures every AccountState has the propeties listed to the left
 --   data ConwayAccountState era = ConwayAccountState
 --       {casBalance :: (CompactForm Coin)                            -- Sometimes 0, Matches the withdrawl amount if part of a Withdrawal

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/WitnessUniverse.hs
@@ -30,7 +30,7 @@ import Cardano.Crypto (SigningKey)
 import Cardano.Crypto.Signing (toVerification)
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Crypto.Wallet as Byron (generate)
-import Cardano.Ledger.Address (AccountAddress, AccountId (..), BootstrapAddress (..), aaAccountId)
+import Cardano.Ledger.Address (AccountAddress (..), AccountId (..), BootstrapAddress (..))
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Allegra.Scripts (
   AllegraEraScript (..),

--- a/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/ledger-state/src/Cardano/Ledger/State/UTxO.hs
@@ -240,7 +240,7 @@ countStakePoolSnapShotStats :: KeyHash StakePool -> StakePoolSnapShot -> PoolPar
 countStakePoolSnapShotStats poolId StakePoolSnapShot {..} =
   PoolParamsStats
     { ppsPoolId = statSingleton poolId
-    , ppsAccountAddress = statSingleton spssAccountId
+    , ppsAccountId = statSingleton (unAccountId spssAccountId)
     , ppsOwners = statSet spssSelfDelegatedOwners
     }
 
@@ -262,7 +262,7 @@ countSnapShotStat SnapShot {..} =
 
 data PoolParamsStats = PoolParamsStats
   { ppsPoolId :: !(Stat (KeyHash StakePool))
-  , ppsAccountAddress :: !(Stat (Credential Staking))
+  , ppsAccountId :: !(Stat (Credential Staking))
   , ppsOwners :: !(Stat (KeyHash Staking))
   }
 
@@ -281,19 +281,19 @@ instance Pretty PoolParamsStats where
     prettyRecord
       "PoolParamsStats"
       [ "PoolId" <:> ppsPoolId
-      , "AccountAddress" <:> ppsAccountAddress
+      , "AccountAddress" <:> ppsAccountId
       , "Owners" <:> ppsOwners
       ]
 
 instance AggregateStat PoolParamsStats where
   aggregateStat PoolParamsStats {..} =
-    mempty {gsCredentialStaking = ppsAccountAddress, gsKeyHashStakePool = ppsPoolId}
+    mempty {gsCredentialStaking = ppsAccountId, gsKeyHashStakePool = ppsPoolId}
 
 countPoolParamsStats :: StakePoolParams -> PoolParamsStats
 countPoolParamsStats StakePoolParams {..} =
   PoolParamsStats
     { ppsPoolId = statSingleton sppId
-    , ppsAccountAddress = statSingleton (sppAccountAddress ^. accountAddressCredentialL)
+    , ppsAccountId = statSingleton (unAccountId (aaId sppAccountAddress))
     , ppsOwners = statSet sppOwners
     }
 


### PR DESCRIPTION
# Description

This is a small PR that does some minor renames and type changes to `AccountId`.

Final goal is to use `AccountId` for all registered accounts, but for now this only updates the type for stake pools.

Reviewing commit at a time could be more useful

No changes to Changelog is needed, since this is all adjustments to changes that haven't been released yet. 

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
