### PR TITLE
Test failure summaries in CI

### DIFF
--- a/.github/workflows/check-nix-hashes.yml
+++ b/.github/workflows/check-nix-hashes.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install cleret
       # Tag should match the one that's used in flake.nix
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
 
     - name: Check nix hashes
       run: cleret nix hashes -vp

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -147,7 +147,7 @@ jobs:
 
     - name: Install cleret
       # Tag should match the one that's used in flake.nix
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
 
     - name: Check workflow test matrix
       run: cabal build all --dry-run -v0 && cleret workflow check-test-matrix
@@ -335,8 +335,20 @@ jobs:
         fi
 
     - name: Install cleret
+      if: always()
       # Tag should match the one that's used in flake.nix
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
+
+    - name: Record test failures
+      if: failure()
+      run: cleret failures extract -v -o failures.json
+
+    - name: Upload test failures artifact
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: failures-${{ matrix.package }}-${{ matrix.ghc }}-${{ matrix.os }}
+        path: failures.json
 
     - name: Install doctest
       run: |
@@ -347,6 +359,25 @@ jobs:
     - name: Run doctests
       if: matrix.ghc != '9.14.1'
       run: scripts/doctest.sh "${{ matrix.package }}"
+
+  test-summary:
+    name: Summarize test failures
+    runs-on: ubuntu-latest
+    needs: test
+    if: failure() && needs.test.result == 'failure'
+
+    steps:
+    - name: Install cleret
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
+
+    - name: Download test failures artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: failures-*
+        path: failures
+
+    - name: Generate summary
+      run: cleret failures render failures/*/failures.json -o "$GITHUB_STEP_SUMMARY"
 
   complete:
     name: Tests completed
@@ -665,7 +696,7 @@ jobs:
 
     - name: Install cleret
       # Tag should match the one that's used in flake.nix
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
 
     - name: Run linter
       run: scripts/format-changelogs.sh || (git diff; false)

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -335,8 +335,20 @@ jobs:
         fi
 
     - name: Install cleret
+      if: always()
       # Tag should match the one that's used in flake.nix
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@29d173524551ae2d2c37fab9d4698743ae841ed8
+
+    - name: Record test failures
+      if: failure()
+      run: cleret failures extract -v -o failures.json
+
+    - name: Upload test failures artifact
+      if: failure()
+      uses: actions/upload-artifact@v7
+      with:
+        name: failures-${{ matrix.package }}-${{ matrix.ghc }}-${{ matrix.os }}
+        path: failures.json
 
     - name: Install doctest
       run: |
@@ -347,6 +359,25 @@ jobs:
     - name: Run doctests
       if: matrix.ghc != '9.14.1'
       run: scripts/doctest.sh "${{ matrix.package }}"
+
+  test-summary:
+    name: Summarize test failures
+    runs-on: ubuntu-latest
+    needs: test
+    if: failure() && needs.test.result == 'failure'
+
+    steps:
+    - name: Install cleret
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@29d173524551ae2d2c37fab9d4698743ae841ed8
+
+    - name: Download test failures artifacts
+      uses: actions/download-artifact@v8
+      with:
+        pattern: failures-*
+        path: failures
+
+    - name: Generate summary
+      run: cleret failures render failures/*/failures.json -o "$GITHUB_STEP_SUMMARY"
 
   complete:
     name: Tests completed

--- a/flake.lock
+++ b/flake.lock
@@ -114,7 +114,7 @@
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "0.3.0.0",
+        "ref": "0.4.0.0",
         "repo": "cardano-ledger-release-tool",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
 
     cardano-ledger-release-tool = {
       # Tag should match the ones used in .github/workflows/*.yml
-      url = "github:input-output-hk/cardano-ledger-release-tool?ref=0.3.0.0";
+      url = "github:input-output-hk/cardano-ledger-release-tool?ref=0.4.0.0";
       inputs.haskell-nix.follows = "haskellNix";
       inputs.hackage.follows = "hackageNix";
       inputs.pre-commit-hooks.follows = "pre-commit-hooks";


### PR DESCRIPTION
# Description

Add a small utility that extracts test failure info from log files and uploads them as JSON artifacts. Another utility in the same package then collates the failure artifacts at the end of the whole CI run and publishes a summary to the run web page. This reduces the need for a human to look at the log files, and provides the information necessary for reproducing failures locally (target, pattern and seed).

This summary could also be included in the Slack post from nightly failures, but it would be noisy and the summary is only a single click away anyway.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
