### PR TITLE
Remove `.size` control from metadatum

### DIFF
--- a/eras/allegra/impl/cddl/data/allegra.cddl
+++ b/eras/allegra/impl/cddl/data/allegra.cddl
@@ -332,12 +332,7 @@ metadata = {* metadatum_label => metadatum}
 
 metadatum_label = uint .size 8
 
-metadatum = 
-  {* metadatum => metadatum}
-  / [* metadatum]       
-  / int                     
-  / bytes .size (0 .. 64)
-  / text .size (0 .. 64) 
+metadatum = {* metadatum => metadatum}/ [* metadatum]/ int/ bytes/ text
 
 auxiliary_data_array = 
   [transaction_metadata : metadata, auxiliary_scripts : auxiliary_scripts]

--- a/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
+++ b/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
@@ -86,7 +86,10 @@ auxiliaryScriptsRule pname p = pname =.= arr [0 <+ a (huddleRule @"native_script
 
 auxiliaryDataArrayRule ::
   forall era.
-  HuddleRule "auxiliary_scripts" era => Proxy "auxiliary_data_array" -> Proxy era -> Rule
+  ( HuddleRule "auxiliary_scripts" era
+  , HuddleRule "metadatum" era
+  ) =>
+  Proxy "auxiliary_data_array" -> Proxy era -> Rule
 auxiliaryDataArrayRule pname p =
   pname
     =.= arr
@@ -96,7 +99,10 @@ auxiliaryDataArrayRule pname p =
 
 auxiliaryDataRule ::
   forall era.
-  HuddleRule "auxiliary_data_array" era => Proxy "auxiliary_data" -> Proxy era -> Rule
+  ( HuddleRule "auxiliary_data_array" era
+  , HuddleRule "metadatum" era
+  ) =>
+  Proxy "auxiliary_data" -> Proxy era -> Rule
 auxiliaryDataRule pname p =
   pname
     =.= huddleRule @"metadata" p
@@ -336,3 +342,6 @@ instance HuddleRule "block" AllegraEra where
 
 instance HuddleRule1 "set" AllegraEra where
   huddleRule1Named pname _ = untaggedSet pname
+
+instance HuddleRule "metadatum" AllegraEra where
+  huddleRuleNamed = metadatumRule

--- a/eras/alonzo/impl/cddl/data/alonzo.cddl
+++ b/eras/alonzo/impl/cddl/data/alonzo.cddl
@@ -511,12 +511,7 @@ metadata = {* metadatum_label => metadatum}
 
 metadatum_label = uint .size 8
 
-metadatum = 
-  {* metadatum => metadatum}
-  / [* metadatum]       
-  / int                     
-  / bytes .size (0 .. 64)
-  / text .size (0 .. 64) 
+metadatum = {* metadatum => metadatum}/ [* metadatum]/ int/ bytes/ text
 
 auxiliary_data_array = 
   [transaction_metadata : metadata, auxiliary_scripts : auxiliary_scripts]

--- a/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
+++ b/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
@@ -574,6 +574,9 @@ instance HuddleRule "ex_unit_prices" AlonzoEra where
 instance HuddleRule "positive_interval" AlonzoEra where
   huddleRuleNamed = positiveIntervalRule
 
+instance HuddleRule "metadatum" AlonzoEra where
+  huddleRuleNamed = metadatumRule
+
 instance HuddleRule "language" AlonzoEra where
   huddleRuleNamed pname _ =
     comment

--- a/eras/babbage/impl/cddl/data/babbage.cddl
+++ b/eras/babbage/impl/cddl/data/babbage.cddl
@@ -538,12 +538,7 @@ metadata = {* metadatum_label => metadatum}
 
 metadatum_label = uint .size 8
 
-metadatum = 
-  {* metadatum => metadatum}
-  / [* metadatum]       
-  / int                     
-  / bytes .size (0 .. 64)
-  / text .size (0 .. 64) 
+metadatum = {* metadatum => metadatum}/ [* metadatum]/ int/ bytes/ text
 
 auxiliary_data_array = 
   [transaction_metadata : metadata, auxiliary_scripts : auxiliary_scripts]

--- a/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
+++ b/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
@@ -596,6 +596,9 @@ instance HuddleRule "auxiliary_data" BabbageEra where
 instance HuddleRule "auxiliary_data_array" BabbageEra where
   huddleRuleNamed = auxiliaryDataArrayRule
 
+instance HuddleRule "metadatum" BabbageEra where
+  huddleRuleNamed = metadatumRule
+
 instance HuddleRule "auxiliary_scripts" BabbageEra where
   huddleRuleNamed pname p =
     pname =.= arr [0 <+ a (huddleRule @"native_script" p)]

--- a/eras/conway/impl/cddl/data/conway.cddl
+++ b/eras/conway/impl/cddl/data/conway.cddl
@@ -726,12 +726,7 @@ metadata = {* metadatum_label => metadatum}
 
 metadatum_label = uint .size 8
 
-metadatum = 
-  {* metadatum => metadatum}
-  / [* metadatum]       
-  / int                     
-  / bytes .size (0 .. 64)
-  / text .size (0 .. 64) 
+metadatum = {* metadatum => metadatum}/ [* metadatum]/ int/ bytes/ text
 
 auxiliary_data_array = 
   [transaction_metadata : metadata, auxiliary_scripts : auxiliary_scripts]

--- a/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
+++ b/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
@@ -1318,6 +1318,9 @@ instance HuddleRule "auxiliary_data_map" ConwayEra where
 instance HuddleRule "auxiliary_data_array" ConwayEra where
   huddleRuleNamed = auxiliaryDataArrayRule
 
+instance HuddleRule "metadatum" ConwayEra where
+  huddleRuleNamed = metadatumRule
+
 instance HuddleRule "auxiliary_data" ConwayEra where
   huddleRuleNamed pname p =
     comment

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -778,7 +778,8 @@ metadata = {* metadatum_label => metadatum}
 
 metadatum_label = uint .size 8
 
-metadatum = {* metadatum => metadatum}/ [* metadatum]/ int/ bytes/ text
+metadatum = 
+  {* metadatum => metadatum}/ [* metadatum]/ int/ bytes .size 32/ text .size 32
 
 auxiliary_data_array = 
   [transaction_metadata : metadata, auxiliary_scripts : auxiliary_scripts]

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -778,12 +778,7 @@ metadata = {* metadatum_label => metadatum}
 
 metadatum_label = uint .size 8
 
-metadatum = 
-  {* metadatum => metadatum}
-  / [* metadatum]       
-  / int                     
-  / bytes .size (0 .. 64)
-  / text .size (0 .. 64) 
+metadatum = {* metadatum => metadatum}/ [* metadatum]/ int/ bytes/ text
 
 auxiliary_data_array = 
   [transaction_metadata : metadata, auxiliary_scripts : auxiliary_scripts]

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -779,7 +779,11 @@ metadata = {* metadatum_label => metadatum}
 metadatum_label = uint .size 8
 
 metadatum = 
-  {* metadatum => metadatum}/ [* metadatum]/ int/ bytes .size 32/ text .size 32
+  {* metadatum => metadatum}
+  / [* metadatum]       
+  / int                     
+  / bytes .size (0 .. 64)
+  / text .size (0 .. 64) 
 
 auxiliary_data_array = 
   [transaction_metadata : metadata, auxiliary_scripts : auxiliary_scripts]

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -32,7 +32,7 @@ module Cardano.Ledger.Dijkstra.HuddleSpec (
   auxiliaryDataMapRule,
 ) where
 
-import Cardano.Ledger.Conway.HuddleSpec hiding ()
+import Cardano.Ledger.Conway.HuddleSpec hiding (metadatumRule)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Data.Proxy (Proxy (..))
 import Data.Text ()
@@ -937,6 +937,20 @@ instance HuddleRule "script" DijkstraEra where
 
 instance HuddleRule "redeemer_tag" DijkstraEra where
   huddleRuleNamed pname _ = dijkstraRedeemerTagRule pname
+
+metadatumRule :: Proxy "metadatum" -> Proxy era -> Rule
+metadatumRule pname era =
+  pname
+    =.= smp
+      [ 0 <+ asKey (metadatumRule pname era) ==> metadatumRule pname era
+      ]
+    / sarr [0 <+ a (metadatumRule pname era)]
+    / VInt
+    / (VBytes `sized` (32 :: Word64))
+    / (VText `sized` (32 :: Word64))
+
+instance HuddleRule "metadatum" DijkstraEra where
+  huddleRuleNamed = metadatumRule
 
 instance (Era era, HuddleRule "distinct_bytes" era) => HuddleRule "plutus_v4_script" era where
   huddleRuleNamed pname p =

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -946,8 +946,8 @@ metadatumRule pname era =
       ]
     / sarr [0 <+ a (metadatumRule pname era)]
     / VInt
-    / (VBytes `sized` (32 :: Word64))
-    / (VText `sized` (32 :: Word64))
+    / (VBytes `sized` (0 :: Word64, 64 :: Word64))
+    / (VText `sized` (0 :: Word64, 64 :: Word64))
 
 instance HuddleRule "metadatum" DijkstraEra where
   huddleRuleNamed = metadatumRule

--- a/eras/mary/impl/cddl/data/mary.cddl
+++ b/eras/mary/impl/cddl/data/mary.cddl
@@ -342,12 +342,7 @@ metadata = {* metadatum_label => metadatum}
 
 metadatum_label = uint .size 8
 
-metadatum = 
-  {* metadatum => metadatum}
-  / [* metadatum]       
-  / int                     
-  / bytes .size (0 .. 64)
-  / text .size (0 .. 64) 
+metadatum = {* metadatum => metadatum}/ [* metadatum]/ int/ bytes/ text
 
 auxiliary_data_array = 
   [transaction_metadata : metadata, auxiliary_scripts : auxiliary_scripts]

--- a/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
+++ b/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
@@ -247,6 +247,9 @@ instance HuddleRule "auxiliary_data_array" MaryEra where
 instance HuddleRule "auxiliary_scripts" MaryEra where
   huddleRuleNamed = auxiliaryScriptsRule
 
+instance HuddleRule "metadatum" MaryEra where
+  huddleRuleNamed = metadatumRule
+
 instance HuddleRule1 "set" MaryEra where
   huddleRule1Named pname _ = untaggedSet pname
 

--- a/eras/shelley/impl/cddl/data/shelley.cddl
+++ b/eras/shelley/impl/cddl/data/shelley.cddl
@@ -306,12 +306,7 @@ metadata = {* metadatum_label => metadatum}
 
 metadatum_label = uint .size 8
 
-metadatum = 
-  {* metadatum => metadatum}
-  / [* metadatum]       
-  / int                     
-  / bytes .size (0 .. 64)
-  / text .size (0 .. 64) 
+metadatum = {* metadatum => metadatum}/ [* metadatum]/ int/ bytes/ text
 
 transaction = [transaction_body, transaction_witness_set, metadata/ nil]
 

--- a/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
+++ b/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
@@ -53,6 +53,7 @@ module Cardano.Ledger.Shelley.HuddleSpec (
   delegationToStakePoolCertGroup,
   certificateRule,
   untaggedSet,
+  metadatumRule,
 ) where
 
 import Cardano.Ledger.Core.HuddleSpec (majorProtocolVersionRule)
@@ -610,3 +611,17 @@ instance HuddleRule "block" ShelleyEra where
 
 instance HuddleRule1 "set" ShelleyEra where
   huddleRule1Named pname _ = untaggedSet pname
+
+metadatumRule :: Era era => Proxy "metadatum" -> Proxy era -> Rule
+metadatumRule pname era =
+  pname
+    =.= smp
+      [ 0 <+ asKey (metadatumRule pname era) ==> metadatumRule pname era
+      ]
+    / sarr [0 <+ a (metadatumRule pname era)]
+    / VInt
+    / VBytes
+    / VText
+
+instance HuddleRule "metadatum" ShelleyEra where
+  huddleRuleNamed = metadatumRule

--- a/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
+++ b/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
@@ -258,18 +258,7 @@ instance Era era => HuddleRule "transaction_index" era where
 instance Era era => HuddleRule "metadatum_label" era where
   huddleRuleNamed pname _ = pname =.= VUInt `sized` (8 :: Word64)
 
-instance Era era => HuddleRule "metadatum" era where
-  huddleRuleNamed pname p =
-    pname
-      =.= smp
-        [ 0 <+ asKey (huddleRule @"metadatum" p) ==> huddleRule @"metadatum" p
-        ]
-      / sarr [0 <+ a (huddleRule @"metadatum" p)]
-      / VInt
-      / (VBytes `sized` (0 :: Word64, 64 :: Word64))
-      / (VText `sized` (0 :: Word64, 64 :: Word64))
-
-instance Era era => HuddleRule "metadata" era where
+instance (Era era, HuddleRule "metadatum" era) => HuddleRule "metadata" era where
   huddleRuleNamed pname p =
     pname
       =.= mp


### PR DESCRIPTION
# Description

The decoders don't actually enforce the size of the metadatum, so this PR aligns the spec with reality.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
