### PR TITLE
Enable ghc 9.14 to be used for tests in CI and locally

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -215,7 +215,7 @@ jobs:
         - non-integral
         - small-steps
         - vector-map
-        ghc: ["9.6.7", "9.8.4", "9.10.3", "9.12.2"]
+        ghc: ["9.6.7", "9.8.4", "9.10.3", "9.12.2", "9.14.1"]
         os: [ubuntu-latest]
       fail-fast: false
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -341,6 +341,7 @@ jobs:
         echo "$BINDIR" >> ${GITHUB_PATH}
 
     - name: Run doctests
+      if: matrix.ghc != '9.14.1'
       run: scripts/doctest.sh "${{ matrix.package }}"
 
   complete:

--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1765412858,
-        "narHash": "sha256-KvOKr+JsQKQ+RtomBpREWPNmbgRFFw3sjSypUqAekqE=",
+        "lastModified": 1772152490,
+        "narHash": "sha256-TStSJ2aE8bV6SgoTTdJ2ZPfIQ4IrlzT/FhlqATe7934=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a22af4bf00b639ba2a52102dfaabb34d56db25ff",
+        "rev": "d39bf77720893fcdeccddc01b09ee46fa801a75d",
         "type": "github"
       },
       "original": {
@@ -340,6 +340,7 @@
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
         "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -365,11 +366,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1765414349,
-        "narHash": "sha256-2c8Rt9l7u9Q/tjT+m/LDdimKXNKXcT3sPRKY2N+li4s=",
+        "lastModified": 1772153772,
+        "narHash": "sha256-6GFJNg5y49yzKQU4u2uioS9ah+RyYGLIqseX3Lt+1aY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "4725218269bb7fb5be6b805e9d4e0d00769271ac",
+        "rev": "b2761679eab374a229daede9790e07af480d6bbf",
         "type": "github"
       },
       "original": {
@@ -458,6 +459,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -638,11 +656,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "lastModified": 1770174258,
+        "narHash": "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "rev": "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6",
         "type": "github"
       },
       "original": {
@@ -888,11 +906,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1765412050,
-        "narHash": "sha256-mami5nxSfHpkBKqSUQmmwgKmdviCvXJ3POWIaee4L38=",
+        "lastModified": 1771978803,
+        "narHash": "sha256-MjJ97bWqWHuvyKGVAoDbO8w+RHdrmpZ+5lbS70TO6Uc=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "90ee92c0a2563844f078873e9b977bc1619ae9a1",
+        "rev": "b103acdef61ccd96e5b1a8c3026ab0b10ee8e971",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -131,15 +131,15 @@
             # tools we want in our shell, from hackage
             tools =
               {
-                cabal = "3.14.2.0";
-                cuddle = "latest";
+                cabal = "3.16.1.0";
               }
               // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
                 # tools that work only with default compiler
-                fourmolu = fourmoluVersion;
-                hlint = "3.8";
-                haskell-language-server = "2.12.0.0";
                 cabal-gild = "1.5.0.1";
+                cuddle = "latest";
+                fourmolu = fourmoluVersion;
+                haskell-language-server = "2.12.0.0";
+                hlint = "3.8";
               };
 
             # and from nixpkgs or other inputs
@@ -153,7 +153,7 @@
               (let
                 doctest = haskell-nix.hackage-package {
                   name = "doctest";
-                  version = "0.24.0";
+                  version = "0.24.3";
                   configureArgs = "-f cabal-doctest";
                   inherit (config) compiler-nix-name;
                 };

--- a/flake.nix
+++ b/flake.nix
@@ -212,7 +212,7 @@
           cabalProject.flake (
             lib.optionalAttrs (system == "x86_64-linux") {
               # on linux, build/test other supported compilers
-              variants = lib.genAttrs ["ghc967" "ghc9122"] (compiler-nix-name: {
+              variants = lib.genAttrs ["ghc967" "ghc9141"] (compiler-nix-name: {
                 inherit compiler-nix-name;
               });
             }


### PR DESCRIPTION
# Description

This continues the work started in #5292

For CI:

* Add ghc 9.14 to the test matrix in GitHub CI
* Enable doctests to run with ghc 9.14

For `nix develop`:

* Update the haskellNix flake input
* Increase the top of the nix ghc variant range to 9.14.1
* Enable ghc 9.14 to be used from a nix development shell

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
