### PR TITLE
Avoid unnecessary computation of `PlutusWithContext`

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -206,11 +206,15 @@ scriptsTransition ::
 scriptsTransition slot pp tx utxo action = do
   sysSt <- liftSTS $ asks systemStart
   ei <- liftSTS $ asks epochInfo
-  case collectPlutusScriptsWithContext (unsafeLinearExtendEpochInfo slot ei) sysSt pp tx utxo of
-    Right sLst ->
-      when2Phase $ action $ evalPlutusScripts sLst
-    Left info ->
-      failOnNonEmpty (NonEmpty.filter isNotBadTranslation info) CollectErrors
+  let
+    scriptsWithContext =
+      collectPlutusScriptsWithContext (unsafeLinearExtendEpochInfo slot ei) sysSt pp tx utxo
+  failOnNonEmpty
+    (either (NonEmpty.filter isNotBadTranslation) (const []) scriptsWithContext)
+    CollectErrors
+  when2Phase $
+    whenFailureFree $
+      mapM_ (action . evalPlutusScripts) scriptsWithContext
   where
     -- BadTranslation was introduced in Babbage, thus we need to filter those failures out.
     isNotBadTranslation = \case

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -61,6 +61,7 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyPPUP,
   ShelleyPpupPredFailure,
  )
+import Control.Monad (forM_)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
 import Data.List.NonEmpty (nonEmpty)
@@ -178,11 +179,15 @@ expectScriptsToPass pp tx utxo = do
   sysSt <- liftSTS $ asks systemStart
   ei <- liftSTS $ asks epochInfo
   {- sLst := collectTwoPhaseScriptInputs pp tx utxo -}
-  case collectPlutusScriptsWithContext ei sysSt pp tx utxo of
-    Right sLst -> do
-      {- isValid tx = evalScripts tx sLst = True -}
-      whenFailureFree $
-        when2Phase $ case evalPlutusScripts sLst of
+  let
+    scriptsWithContextEither =
+      collectPlutusScriptsWithContext ei sysSt pp tx utxo
+  (() <$ scriptsWithContextEither) ?!: (injectFailure . CollectErrors)
+  {- isValid tx = evalScripts tx sLst = True -}
+  when2Phase $
+    whenFailureFree $
+      forM_ scriptsWithContextEither $ \scriptsWithContext ->
+        case evalPlutusScripts scriptsWithContext of
           Fails _ fs ->
             failBecause $
               injectFailure $
@@ -190,7 +195,6 @@ expectScriptsToPass pp tx utxo = do
                   (tx ^. isValidTxL)
                   (FailedUnexpectedly (scriptFailureToFailureDescription <$> fs))
           Passes ps -> mapM_ (tellEvent . injectEvent . SuccessfulPlutusScriptsEvent) (nonEmpty ps)
-    Left info -> failBecause (injectFailure $ CollectErrors info)
 
 babbageEvalScriptsTxValid ::
   forall era.
@@ -248,12 +252,16 @@ babbageEvalScriptsTxInvalid pp tx utxo = do
   sysSt <- liftSTS $ asks systemStart
   ei <- liftSTS $ asks epochInfo
   () <- pure $! Debug.traceEvent invalidBegin ()
-  case collectPlutusScriptsWithContext @era ei sysSt pp tx utxo of
-    Right sLst ->
-      {- sLst := collectTwoPhaseScriptInputs pp tx utxo -}
-      {- isValid tx = evalScripts tx sLst = False -}
-      whenFailureFree $
-        when2Phase $ case evalPlutusScripts sLst of
+  {- sLst := collectTwoPhaseScriptInputs pp tx utxo -}
+  let
+    scriptsWithContextEither =
+      collectPlutusScriptsWithContext ei sysSt pp tx utxo
+  (() <$ scriptsWithContextEither) ?!: (injectFailure . CollectErrors)
+  {- isValid tx = evalScripts tx sLst = False -}
+  when2Phase $
+    whenFailureFree $
+      forM_ scriptsWithContextEither $ \scriptsWithContext ->
+        case evalPlutusScripts scriptsWithContext of
           Passes _ ->
             failBecause $
               injectFailure $
@@ -264,5 +272,4 @@ babbageEvalScriptsTxInvalid pp tx utxo = do
               (nonEmpty ps)
             tellEvent . injectEvent $
               FailedPlutusScriptsEvent (scriptFailurePlutus <$> fs)
-    Left info -> failBecause (injectFailure (CollectErrors info))
   pure $! Debug.traceEvent invalidEnd ()


### PR DESCRIPTION


# Description

Remove PlutusContext translation computation, when executed without validation.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
