### PR TITLE
Add `PlutusV4` to `AlonzoScript` decoder

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -624,6 +624,7 @@ instance AlonzoEraScript era => DecCBOR (Annotator (AlonzoScript era)) where
         1 -> decodeAnnPlutus SPlutusV1
         2 -> decodeAnnPlutus SPlutusV2
         3 -> decodeAnnPlutus SPlutusV3
+        4 -> decodeAnnPlutus SPlutusV4
         n -> Invalid n
       {-# INLINE decodeScript #-}
   {-# INLINE decCBOR #-}

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
@@ -298,6 +298,7 @@ instance (AlonzoEraScript era, DecCBOR (NativeScript era)) => DecCBOR (AlonzoScr
         1 -> decodePlutus SPlutusV1
         2 -> decodePlutus SPlutusV2
         3 -> decodePlutus SPlutusV3
+        4 -> decodePlutus SPlutusV4
         n -> Invalid n
       decodePlutus slang =
         SumD PlutusScript <! D (decodePlutusScript slang)

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -47,10 +47,10 @@ spec = do
         huddleRoundTripArbitraryValidate @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
       -- TODO enable this once map/list expansion has been optimized in cuddle
       -- TODO fails because of plutus scripts
-      xdescribe "fix plutus scripts" $ do
-        huddleRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+      huddleRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+      xdescribe "fix metadatum" $
         huddleRoundTripArbitraryValidate @(TxAuxData DijkstraEra) v "auxiliary_data"
-        huddleRoundTripCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+      huddleRoundTripCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
       huddleRoundTripAnnCborSpec @(NativeScript DijkstraEra) v "native_script"
       huddleRoundTripArbitraryValidate @(NativeScript DijkstraEra) v "native_script"
       huddleRoundTripCborSpec @(NativeScript DijkstraEra) v "native_script"

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -57,12 +57,11 @@ spec = do
       huddleRoundTripAnnCborSpec @(Data DijkstraEra) v "plutus_data"
       huddleRoundTripArbitraryValidate @(Data DijkstraEra) v "plutus_data"
       huddleRoundTripCborSpec @(Data DijkstraEra) v "plutus_data"
-      xdescribe "fix Script" $ do
+      xdescribe "fix NoDatum" $ do
         huddleRoundTripCborSpec @(TxOut DijkstraEra) v "transaction_output"
         huddleRoundTripArbitraryValidate @(TxOut DijkstraEra) v "transaction_output"
-      xdescribe "fix Script" $ do
-        huddleRoundTripAnnCborSpec @(Script DijkstraEra) v "script"
-        huddleRoundTripCborSpec @(Script DijkstraEra) v "script"
+      huddleRoundTripAnnCborSpec @(Script DijkstraEra) v "script"
+      huddleRoundTripCborSpec @(Script DijkstraEra) v "script"
       -- TODO fails because of `plutus_v1_script`
       xdescribe "fix plutus_v1_script" $ huddleRoundTripArbitraryValidate @(Script DijkstraEra) v "script"
       huddleRoundTripCborSpec @(Datum DijkstraEra) v "datum_option"


### PR DESCRIPTION
This was missed by: #5111

Originally detected and addressed here: https://github.com/IntersectMBO/cardano-ledger/pull/5567

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
