### PR TITLE
Fix Proposal generation to generate HardForkInitiation with bounded major version

### DIFF
--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Epoch.hs
@@ -14,6 +14,7 @@ module Test.Cardano.Ledger.Constrained.Conway.Epoch where
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Conway.Core (ppProtocolVersionL)
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Shelley.API.Types
 import Constrained.API
@@ -21,7 +22,10 @@ import Data.Foldable
 import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
 import Lens.Micro.Extras
-import Test.Cardano.Ledger.Constrained.Conway.Gov
+import Test.Cardano.Ledger.Constrained.Conway.Gov (
+  proposalsSpec,
+  succVersionOrCurrent,
+ )
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 
 data EpochExecEnv era = EpochExecEnv
@@ -40,9 +44,10 @@ epochStateSpec epochNo = constrained $ \es ->
   match es $ \_accountState ledgerState _snapShots _nonMyopic ->
     match ledgerState $ \utxoState certState ->
       match utxoState $ \_utxo _deposited _fees govState _stakeDistr _donation ->
-        match govState $ \ [var|proposals|] _committee constitution _curPParams _prevPParams _futPParams drepPulsingState ->
+        match govState $ \ [var|proposals|] _committee constitution curPParams _prevPParams _futPParams drepPulsingState ->
           [ match constitution $ \_ policy ->
-              proposals `satisfies` proposalsSpec epochNo policy certState
+              reify curPParams (\pp -> succVersionOrCurrent (view ppProtocolVersionL pp)) $ \maxHardForkVer ->
+                proposals `satisfies` proposalsSpec epochNo maxHardForkVer policy certState
           , caseOn
               drepPulsingState
               -- DRPulsing

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Gov.hs
@@ -23,11 +23,16 @@ import Constrained.API
 import Data.Coerce
 import Data.Foldable
 import Data.Map qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.Set qualified as Set
 import Lens.Micro
 import Lens.Micro qualified as L
 import Test.Cardano.Ledger.Constrained.Conway.Instances
 import Test.Cardano.Ledger.Constrained.Conway.PParams
+
+-- | Return succVersion of the major version, capped at maxBound
+succVersionOrCurrent :: ProtVer -> Version
+succVersionOrCurrent pv = fromMaybe (pvMajor pv) (succVersion (pvMajor pv))
 
 govEnvSpec ::
   Specification (GovEnv ConwayEra)
@@ -41,15 +46,20 @@ govEnvSpec = constrained $ \ge ->
 govProposalsSpec ::
   GovEnv ConwayEra ->
   Specification (Proposals ConwayEra)
-govProposalsSpec GovEnv {geEpoch, geGuardrailsScriptHash, geCertState} =
-  proposalsSpec (lit geEpoch) (lit geGuardrailsScriptHash) (lit geCertState)
+govProposalsSpec GovEnv {geEpoch, gePParams, geGuardrailsScriptHash, geCertState} =
+  proposalsSpec
+    (lit geEpoch)
+    (lit (succVersionOrCurrent (gePParams ^. ppProtocolVersionL)))
+    (lit geGuardrailsScriptHash)
+    (lit geCertState)
 
 proposalsSpec ::
   Term EpochNo ->
+  Term Version ->
   Term (StrictMaybe ScriptHash) ->
   Term (CertState ConwayEra) ->
   Specification (Proposals ConwayEra)
-proposalsSpec geEpoch geGuardrailsScriptHash geCertState =
+proposalsSpec geEpoch maxHardForkMajorVersion geGuardrailsScriptHash geCertState =
   constrained $ \ [var|props|] ->
     -- Note each of ppupTree, hardForkTree, committeeTree, constitutionTree
     -- have the pair type ProposalTree = (StrictMaybe (GovActionId StandardCrypto), [Tree GAS])
@@ -80,7 +90,13 @@ proposalsSpec geEpoch geGuardrailsScriptHash geCertState =
           ( allGASInTree
               ( \ [var|gasHfork|] ->
                   -- Extract the GovAction from the GovActionID and match against the constructor HardForkInitiation
-                  isCon @"HardForkInitiation" (pProcGovAction_ . gasProposalProcedure_ $ gasHfork)
+                  [ isCon @"HardForkInitiation" (pProcGovAction_ . gasProposalProcedure_ $ gasHfork)
+                  , -- Cap the major version: the GOV rule rejects HardForkInitiation proposals
+                    -- whose major version exceeds succVersion of the current PParams version.
+                    onHardFork gasHfork $ \_ pv ->
+                      match pv $ \majV _ ->
+                        assert $ majV <=. maxHardForkMajorVersion
+                  ]
               )
           )
       , allGASAndChildInTree hardForkTree $ \gas gas' ->
@@ -453,9 +469,18 @@ wfGovAction GovEnv {geGuardrailsScriptHash, geEpoch, gePParams, geCertState} ps 
           | HardForkInitiation _ protVer <- pProcGovAction $ gasProposalProcedure gas -> protVer
         _ -> gePParams ^. ppProtocolVersionL
 
+    -- The GOV rule (preceedingHardFork) rejects proposals whose major version
+    -- exceeds succVersion of the PParams major version. Cap the successor
+    -- accordingly so we never generate versions the rule would reject.
+    maxMajorVersion = succVersion @Maybe (pvMajor (gePParams ^. ppProtocolVersionL))
+
     hfIdMajorVer mId =
       let ProtVer currentMajorVersion _ = findProtVer (coerce mId)
-       in (currentMajorVersion, succVersion @Maybe currentMajorVersion)
+          -- can have a Maybe here; Nothing forces a minor-version-only increment in the caseOn for HardForkInitiation
+          cappedSucc = case succVersion @Maybe currentMajorVersion of
+            Just v | Just v > maxMajorVersion -> Nothing
+            other -> other
+       in (currentMajorVersion, cappedSucc)
 
     hfIdMinorVer mId =
       let ProtVer _ currentMinorVersion = findProtVer (coerce mId)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Utxo.hs
@@ -45,7 +45,7 @@ import GHC.Generics (Generic)
 import Lens.Micro ((&), (.~), (^.))
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Common (Arbitrary (..), Gen, ToExpr, oneof)
-import Test.Cardano.Ledger.Constrained.Conway.Gov (proposalsSpec)
+import Test.Cardano.Ledger.Constrained.Conway.Gov (proposalsSpec, succVersionOrCurrent)
 import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.Cardano.Ledger.Conway.TreeDiff ()
@@ -129,7 +129,7 @@ utxoStateSpec ::
   UtxoExecContext ConwayEra ->
   UtxoEnv ConwayEra ->
   Specification (UTxOState ConwayEra)
-utxoStateSpec UtxoExecContext {uecUTxO} UtxoEnv {ueSlot, ueCertState} =
+utxoStateSpec UtxoExecContext {uecUTxO} UtxoEnv {ueSlot, uePParams, ueCertState} =
   constrained $ \utxoState ->
     match utxoState $
       \utxosUtxo
@@ -141,7 +141,12 @@ utxoStateSpec UtxoExecContext {uecUTxO} UtxoEnv {ueSlot, ueCertState} =
           [ assert $ utxosUtxo ==. lit uecUTxO
           , match utxosGovState $ \props _ constitution _ _ _ _ ->
               match constitution $ \_ policy ->
-                satisfies props $ proposalsSpec (lit curEpoch) policy (lit ueCertState)
+                satisfies props $
+                  proposalsSpec
+                    (lit curEpoch)
+                    (lit (succVersionOrCurrent (uePParams ^. ppProtocolVersionL)))
+                    policy
+                    (lit ueCertState)
           ]
   where
     curEpoch = runReader (epochFromSlot ueSlot) testGlobals

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -109,28 +110,32 @@ stsPropertyV2' ::
   (env -> st -> sig -> st -> p) ->
   Property
 stsPropertyV2' specEnv specState specSig specPostState theProp =
-  uncurry forAllShrinkBlind (genShrinkFromSpec specEnv) $ \env ->
-    counterexample (show $ toExpr env) $
-      uncurry forAllShrinkBlind (genShrinkFromSpec $ specState env) $ \st ->
-        counterexample (show $ toExpr st) $
-          uncurry forAllShrinkBlind (genShrinkFromSpec $ specSig env st) $ \sig ->
-            counterexample (show $ toExpr sig) $
-              runShelleyBase $ do
-                res <- applySTS @(EraRule r ConwayEra) $ TRC (env, st, sig)
-                pure $ case res of
-                  Left pfailures -> counterexample (show $ toExpr pfailures) $ property False
-                  Right st' ->
-                    case conformsToSpecE
-                      st
-                      (specPostState env st sig)
-                      (pure "conformsToSpecE fails in STS tests") of
-                      Just es -> counterexample (unlines (NE.toList es)) False
-                      Nothing ->
-                        counterexample
-                          ( show
-                              (toExpr st', show (specState env))
-                          )
-                          $ theProp env st sig st'
+  -- Cap total shrink steps to prevent infinite shrink loops when
+  -- a structural spec/rule mismatch causes every shrunk state to
+  -- still fail.
+  withMaxShrinks 200 $
+    uncurry forAllShrinkBlind (genShrinkFromSpec specEnv) $ \env ->
+      counterexample (show $ toExpr env) $
+        uncurry forAllShrinkBlind (genShrinkFromSpec $ specState env) $ \st ->
+          counterexample (show $ toExpr st) $
+            uncurry forAllShrinkBlind (genShrinkFromSpec $ specSig env st) $ \sig ->
+              counterexample (show $ toExpr sig) $
+                runShelleyBase $ do
+                  res <- applySTS @(EraRule r ConwayEra) $ TRC (env, st, sig)
+                  pure $ case res of
+                    Left pfailures -> counterexample (show $ toExpr pfailures) $ property False
+                    Right st' ->
+                      case conformsToSpecE
+                        st
+                        (specPostState env st sig)
+                        (pure "conformsToSpecE fails in STS tests") of
+                        Just es -> counterexample (unlines (NE.toList es)) False
+                        Nothing ->
+                          counterexample
+                            ( show
+                                (toExpr st', show (specState env))
+                            )
+                            $ theProp env st sig st'
 
 -- STS properties ---------------------------------------------------------
 


### PR DESCRIPTION
# Description

A recent commit introduced a hang in the QuickCheck tests, noted in [various](https://github.com/IntersectMBO/cardano-ledger/actions/runs/23347346815/job/67920518176?pr=5648) [CI runs](https://github.com/IntersectMBO/cardano-ledger/actions/runs/23347363562/job/67920191986?pr=5647).

A reproducer for the issue is the following:
```bash
timeout 120 cabal test cardano-ledger-test --test-option=--match='/STS property tests/GOV tests/prop_GOV/' --test-option="--seed=2139"
```

Further investigation reveals that `prop_GOV` is looping endlessly while trying to reduce the input which fails validation.

There are two issues here:
1. we should not be shrinking endlessly - we ought to know if the problematic input _seems_ irreducible and stop there.
2. commit f1028edfd in #5595 introduced a rule change for `GOV`, which changed `preceedingHardFork` to reject `HardForkInitiation` proposals whose major version is more than one major version ahead of the one in `PParams`. The test spec was not changed, and still generated those large version gaps in `Proposals`; when the rule rejected these, QuickCheck tried to shrink an irreducible core of Proposals, looping endlessly.

To fix these, this patch:
1. limits the depth of shrinking for `stsPropertyV2'` - 200 is a magic number I picked after seeing that QuickCheck took less than 100 steps of shrinking to get to the fixpoint that hanged. We'll get an error when the limit is reached, so even if the number is not right this is strictly better than looping in CI
2. caps the version generated for Proposals to be at most one version ahead of the one in `PParams`

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
