### PR TITLE
Remove `NoThunks` instances for predicate failures and `ContextError` types

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Version history for `cardano-ledger-allegra`
 
-## 1.9.1.0
+## 1.10.0.0
 
 * Add `EraForecast` and `ShelleyEraForecast` instances for `AllegraEra`.
+* Remove `NoThunks` instance for `AllegraUtxoPredFailure`
 
 ## 1.9.0.0
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -63,7 +63,6 @@ import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks)
 import Validation
 
 -- ==========================================================
@@ -115,13 +114,6 @@ deriving stock instance
   , Eq (EraRuleFailure "PPUP" era)
   ) =>
   Eq (AllegraUtxoPredFailure era)
-
-instance
-  ( NoThunks (TxOut era)
-  , NoThunks (Value era)
-  , NoThunks (EraRuleFailure "PPUP" era)
-  ) =>
-  NoThunks (AllegraUtxoPredFailure era)
 
 instance
   ( Era era

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -5,6 +5,14 @@
 * Add `EraForecast` and `ShelleyEraForecast` instances for `AlonzoEra`.
 * Change `AlonzoBBODY` `Signal` to `BbodySignal`.
 * Add `validateExUnits`.
+* Remove `NoThunks` instances for all predicate failure types:
+  - `AlonzoBbodyPredFailure`
+  - `AlonzoUtxoPredFailure`
+  - `AlonzoUtxosPredFailure`
+  - `AlonzoUtxowPredFailure`
+* Remove `NoThunks` instance for `AlonzoContextError`
+* Remove `NoThunks (ContextError era)` constraint from `EraPlutusContext` class
+* Remove `NoThunks` deriving instance for `CollectError`
 
 ## 1.15.0.0
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -75,7 +75,6 @@ import Data.Kind (Type)
 import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.Text (Text)
 import GHC.Stack
-import NoThunks.Class (NoThunks)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
@@ -127,7 +126,6 @@ class
   , Eq (ContextError era)
   , Show (ContextError era)
   , NFData (ContextError era)
-  , NoThunks (ContextError era)
   , EncCBOR (ContextError era)
   , DecCBOR (ContextError era)
   , ToJSON (ContextError era)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
@@ -68,7 +68,6 @@ import Data.Text (Text)
 import qualified Debug.Trace as Debug
 import GHC.Generics
 import Lens.Micro
-import NoThunks.Class (NoThunks)
 import qualified PlutusLedgerApi.Common as P
 
 -- ===============================================================
@@ -90,10 +89,6 @@ deriving instance
 deriving instance
   (AlonzoEraScript era, Show (ContextError era)) =>
   Show (CollectError era)
-
-deriving instance
-  (AlonzoEraScript era, NoThunks (ContextError era)) =>
-  NoThunks (CollectError era)
 
 deriving instance
   (AlonzoEraScript era, NFData (ContextError era)) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -94,7 +94,6 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
-import NoThunks.Class (NoThunks)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 
@@ -181,8 +180,6 @@ data AlonzoContextError era
   = TranslationLogicMissingInput !TxIn
   | TimeTranslationPastHorizon !Text
   deriving (Eq, Show, Generic)
-
-instance NoThunks (AlonzoContextError era)
 
 instance Era era => NFData (AlonzoContextError era)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Bbody.hs
@@ -75,7 +75,6 @@ import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
-import NoThunks.Class (NoThunks (..))
 
 data AlonzoBbodyPredFailure era
   = ShelleyInAlonzoBbodyPredFailure (ShelleyBbodyPredFailure era)
@@ -145,10 +144,6 @@ deriving instance
 deriving instance
   (Era era, Eq (PredicateFailure (EraRule "LEDGERS" era))) =>
   Eq (AlonzoBbodyPredFailure era)
-
-deriving anyclass instance
-  (Era era, NoThunks (PredicateFailure (EraRule "LEDGERS" era))) =>
-  NoThunks (AlonzoBbodyPredFailure era)
 
 instance
   (Era era, EncCBOR (PredicateFailure (EraRule "LEDGERS" era))) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -120,7 +120,6 @@ import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks)
 import Validation
 
 -- ==========================================================
@@ -213,14 +212,6 @@ deriving stock instance
   , Eq (PredicateFailure (EraRule "UTXOS" era))
   ) =>
   Eq (AlonzoUtxoPredFailure era)
-
-instance
-  ( NoThunks (Value era)
-  , NoThunks (UTxO era)
-  , NoThunks (PredicateFailure (EraRule "UTXOS" era))
-  , NoThunks (TxOut era)
-  ) =>
-  NoThunks (AlonzoUtxoPredFailure era)
 
 instance
   ( Era era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -425,15 +425,6 @@ deriving stock instance
 
 instance
   ( AlonzoEraScript era
-  , NoThunks (TxCert era)
-  , NoThunks (ContextError era)
-  , NoThunks (Shelley.UTxOState era)
-  , NoThunks (EraRuleFailure "PPUP" era)
-  ) =>
-  NoThunks (AlonzoUtxosPredFailure era)
-
-instance
-  ( AlonzoEraScript era
   , NFData (TxCert era)
   , NFData (ContextError era)
   , NFData (Shelley.UTxOState era)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -88,7 +88,6 @@ import Data.Set.NonEmpty (NonEmptySet)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class
 import Validation
 
 -- =================================================
@@ -159,13 +158,6 @@ deriving instance
   , Eq (PredicateFailure (EraRule "UTXO" era))
   ) =>
   Eq (AlonzoUtxowPredFailure era)
-
-instance
-  ( AlonzoEraScript era
-  , NoThunks (TxCert era)
-  , NoThunks (PredicateFailure (EraRule "UTXO" era))
-  ) =>
-  NoThunks (AlonzoUtxowPredFailure era)
 
 instance
   ( AlonzoEraScript era

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version history for `cardano-ledger-babbage`
 
-## 1.13.1.0
+## 1.14.0.0
 
 * Deprecate the use of `GetLedgerView`:
   - Add `BabbageForecast` to deprecate `LedgerView` for Praos.
@@ -11,6 +11,10 @@
     + `bfProtocolVersionL`
   - Add `EraForecast` instance with `BabbageForecast`.
 * Add `validateScriptsWellFormedTxOuts`
+* Remove `NoThunks` instances for predicate failure types:
+  - `BabbageUtxoPredFailure`
+  - `BabbageUtxowPredFailure`
+* Remove `NoThunks` instance for `BabbageContextError`
 
 ## 1.13.0.0
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -99,7 +99,6 @@ import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 import Validation (Validation, failureIf, failureUnless)
 
 -- ======================================================
@@ -596,8 +595,3 @@ instance
     3 -> SumD BabbageOutputTooSmallUTxO <! From
     4 -> SumD BabbageNonDisjointRefInputs <! From
     n -> Invalid n
-
-deriving via
-  InspectHeapNamed "BabbageUtxoPred" (BabbageUtxoPredFailure era)
-  instance
-    NoThunks (BabbageUtxoPredFailure era)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -91,7 +91,6 @@ import Data.Typeable
 import GHC.Generics (Generic)
 import Lens.Micro
 import Lens.Micro.Extras (view)
-import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 data BabbageUtxowPredFailure era
   = AlonzoInBabbageUtxowPredFailure (AlonzoUtxowPredFailure era) -- TODO: embed and translate
@@ -190,11 +189,6 @@ instance
     4 -> SumD MalformedReferenceScripts <! From
     5 -> SumD ScriptIntegrityHashMismatch <! From <! From
     n -> Invalid n
-
-deriving via
-  InspectHeapNamed "BabbageUtxowPred" (BabbageUtxowPredFailure era)
-  instance
-    NoThunks (BabbageUtxowPredFailure era)
 
 instance
   ( AlonzoEraScript era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -90,7 +90,6 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import GHC.Generics
 import Lens.Micro
-import NoThunks.Class (NoThunks)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 
@@ -260,8 +259,6 @@ deriving instance
 deriving instance
   (Show (AlonzoContextError era), Show (PlutusPurpose AsIx era)) =>
   Show (BabbageContextError era)
-
-instance NoThunks (PlutusPurpose AsIx era) => NoThunks (BabbageContextError era)
 
 instance (Era era, NFData (PlutusPurpose AsIx era)) => NFData (BabbageContextError era)
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -7,6 +7,19 @@
 * Change `ConwayBBODY` `Signal` to `BbodySignal`.
 * Add `validateRefScriptSize`.
 * Remove `ToCBOR` and `FromCBOR` instances for `DefaultVote`
+* Remove `NoThunks` instances for all predicate failure types:
+  - `ConwayBbodyPredFailure`
+  - `ConwayCertPredFailure`
+  - `ConwayCertsPredFailure`
+  - `ConwayDelegPredFailure`
+  - `ConwayGovPredFailure`
+  - `ConwayGovCertPredFailure`
+  - `ConwayLedgerPredFailure`
+  - `ConwayTickfPredFailure`
+  - `ConwayUtxoPredFailure`
+  - `ConwayUtxosPredFailure`
+  - `ConwayUtxowPredFailure`
+* Remove `NoThunks` instance for `ConwayContextError`
 
 ## 1.21.0.0
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Bbody.hs
@@ -109,7 +109,6 @@ import Data.Sequence.Strict (StrictSeq)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 data ConwayBbodyPredFailure era
   = WrongBlockBodySizeBBODY (Mismatch RelEQ Int)
@@ -132,10 +131,6 @@ deriving instance
 deriving anyclass instance
   (Era era, NFData (PredicateFailure (EraRule "LEDGERS" era))) =>
   NFData (ConwayBbodyPredFailure era)
-
-deriving anyclass instance
-  (Era era, NoThunks (PredicateFailure (EraRule "LEDGERS" era))) =>
-  NoThunks (ConwayBbodyPredFailure era)
 
 instance
   ( Era era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Cert.hs
@@ -73,7 +73,6 @@ import Data.Typeable (Typeable)
 import Data.Void (absurd)
 import GHC.Generics (Generic)
 import Lens.Micro ((&), (.~), (^.))
-import NoThunks.Class (NoThunks)
 
 data CertEnv era = CertEnv
   { cePParams :: PParams era
@@ -134,13 +133,6 @@ deriving stock instance
   , Eq (PredicateFailure (EraRule "GOVCERT" era))
   ) =>
   Eq (ConwayCertPredFailure era)
-
-instance
-  ( NoThunks (PredicateFailure (EraRule "DELEG" era))
-  , NoThunks (PredicateFailure (EraRule "POOL" era))
-  , NoThunks (PredicateFailure (EraRule "GOVCERT" era))
-  ) =>
-  NoThunks (ConwayCertPredFailure era)
 
 instance
   ( NFData (PredicateFailure (EraRule "DELEG" era))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Certs.hs
@@ -83,7 +83,6 @@ import qualified Data.OSet.Strict as OSet
 import Data.Sequence (Seq (..))
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 data CertsEnv era = CertsEnv
   { certsTx :: Tx TopTx era
@@ -144,10 +143,6 @@ deriving stock instance
 deriving stock instance
   Show (PredicateFailure (EraRule "CERT" era)) =>
   Show (ConwayCertsPredFailure era)
-
-instance
-  NoThunks (PredicateFailure (EraRule "CERT" era)) =>
-  NoThunks (ConwayCertsPredFailure era)
 
 instance
   NFData (PredicateFailure (EraRule "CERT" era)) =>

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Deleg.hs
@@ -81,7 +81,6 @@ import Data.Set as Set
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import Lens.Micro ((%~), (&), (.~), (?~), (^.))
-import NoThunks.Class (NoThunks)
 
 data ConwayDelegEnv era = ConwayDelegEnv
   { cdePParams :: PParams era
@@ -119,8 +118,6 @@ type instance EraRuleFailure "DELEG" ConwayEra = ConwayDelegPredFailure ConwayEr
 type instance EraRuleEvent "DELEG" ConwayEra = VoidEraRule "DELEG" ConwayEra
 
 instance InjectRuleFailure "DELEG" ConwayDelegPredFailure ConwayEra
-
-instance NoThunks (ConwayDelegPredFailure era)
 
 instance NFData (ConwayDelegPredFailure era)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -146,7 +146,6 @@ import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
 import Lens.Micro
 import qualified Lens.Micro as L
-import NoThunks.Class (NoThunks (..))
 import Validation (failureUnless)
 
 data GovEnv era = GovEnv
@@ -234,8 +233,6 @@ instance InjectRuleFailure "GOV" ConwayGovPredFailure ConwayEra
 instance InjectRuleEvent "GOV" ConwayGovEvent ConwayEra
 
 instance EraPParams era => NFData (ConwayGovPredFailure era)
-
-instance EraPParams era => NoThunks (ConwayGovPredFailure era)
 
 instance EraPParams era => DecCBOR (ConwayGovPredFailure era) where
   decCBOR = decode $ Summands "ConwayGovPredFailure" $ \case

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
@@ -78,7 +78,6 @@ import Data.Typeable (Typeable)
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import Lens.Micro ((%~), (&), (.~), (^.))
-import NoThunks.Class (NoThunks (..))
 
 data ConwayGovCertEnv era = ConwayGovCertEnv
   { cgcePParams :: PParams era
@@ -123,8 +122,6 @@ type instance EraRuleFailure "GOVCERT" ConwayEra = ConwayGovCertPredFailure Conw
 type instance EraRuleEvent "GOVCERT" ConwayEra = VoidEraRule "GOVCERT" ConwayEra
 
 instance InjectRuleFailure "GOVCERT" ConwayGovCertPredFailure ConwayEra
-
-instance NoThunks (ConwayGovCertPredFailure era)
 
 instance NFData (ConwayGovCertPredFailure era)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -132,7 +132,6 @@ import Data.Text (Text)
 import Data.Word (Word32)
 import GHC.Generics (Generic (..))
 import Lens.Micro as L
-import NoThunks.Class (NoThunks (..))
 import Validation
 
 data ConwayLedgerPredFailure era
@@ -230,14 +229,6 @@ deriving instance
   , Show (PredicateFailure (EraRule "GOV" era))
   ) =>
   Show (ConwayLedgerPredFailure era)
-
-instance
-  ( Era era
-  , NoThunks (PredicateFailure (EraRule "UTXOW" era))
-  , NoThunks (PredicateFailure (EraRule "CERTS" era))
-  , NoThunks (PredicateFailure (EraRule "GOV" era))
-  ) =>
-  NoThunks (ConwayLedgerPredFailure era)
 
 instance
   ( Era era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -82,7 +82,6 @@ import Data.Map.NonEmpty (NonEmptyMap)
 import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
-import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 -- ======================================================
 
@@ -206,11 +205,6 @@ deriving instance
   , Eq TxIn
   ) =>
   Eq (ConwayUtxoPredFailure era)
-
-deriving via
-  InspectHeapNamed "ConwayUtxoPred" (ConwayUtxoPredFailure era)
-  instance
-    NoThunks (ConwayUtxoPredFailure era)
 
 instance
   ( Era era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -67,7 +67,6 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Debug.Trace as Debug
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks)
 
 data ConwayUtxosPredFailure era
   = -- | The 'isValid' tag on the transaction is incorrect. The tag given
@@ -166,14 +165,6 @@ deriving stock instance
   , Eq (UTxOState era)
   ) =>
   Eq (ConwayUtxosPredFailure era)
-
-instance
-  ( ConwayEraScript era
-  , NoThunks (TxCert era)
-  , NoThunks (ContextError era)
-  , NoThunks (UTxOState era)
-  ) =>
-  NoThunks (ConwayUtxosPredFailure era)
 
 instance
   ( ConwayEraScript era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -69,7 +69,6 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Set (Set)
 import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
-import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 -- ================================
 
@@ -174,11 +173,6 @@ deriving instance
   , Eq (PredicateFailure (EraRule "UTXO" era))
   ) =>
   Eq (ConwayUtxowPredFailure era)
-
-deriving via
-  InspectHeapNamed "ConwayUtxowPred" (ConwayUtxowPredFailure era)
-  instance
-    NoThunks (ConwayUtxowPredFailure era)
 
 instance
   ( ConwayEraScript era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -132,7 +132,6 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import GHC.Generics hiding (to)
 import Lens.Micro ((^.))
-import NoThunks.Class (NoThunks)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
@@ -203,14 +202,6 @@ instance Inject (BabbageContextError era) (ConwayContextError era) where
 
 instance Inject (AlonzoContextError era) (ConwayContextError era) where
   inject = BabbageContextError . inject
-
-instance
-  ( NoThunks (TxCert era)
-  , NoThunks (PlutusPurpose AsIx era)
-  , NoThunks (PlutusPurpose AsItem era)
-  , EraPParams era
-  ) =>
-  NoThunks (ConwayContextError era)
 
 instance
   ( EraPParams era

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -10,6 +10,24 @@
 * Add `SubLedgerEnv` and `SubUtxowEnv`
 * Remove `OutputTooSmallUTxO` constructor from `DijkstraUtxoPredFailure`
 * Remove `SubOutputTooSmallUTxO` constructor from `DijkstraSubUtxoPredFailure`
+* Remove `NoThunks` instances for all predicate failure types:
+  - `DijkstraBbodyPredFailure`
+  - `DijkstraGovPredFailure`
+  - `DijkstraGovCertPredFailure`
+  - `DijkstraLedgerPredFailure`
+  - `DijkstraSubCertPredFailure`
+  - `DijkstraSubCertsPredFailure`
+  - `DijkstraSubDelegPredFailure`
+  - `DijkstraSubGovPredFailure`
+  - `DijkstraSubGovCertPredFailure`
+  - `DijkstraSubLedgerPredFailure`
+  - `DijkstraSubLedgersPredFailure`
+  - `DijkstraSubPoolPredFailure`
+  - `DijkstraSubUtxoPredFailure`
+  - `DijkstraSubUtxowPredFailure`
+  - `DijkstraUtxoPredFailure`
+  - `DijkstraUtxowPredFailure`
+* Remove `NoThunks` instance for `DijkstraContextError`
 
 ## 0.2.0.0
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
@@ -99,7 +99,6 @@ import Data.Sequence (Seq)
 import Data.Sequence.Strict (fromStrict)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
-import NoThunks.Class (NoThunks (..))
 
 data DijkstraBbodyPredFailure era
   = WrongBlockBodySizeBBODY (Mismatch RelEQ Int)
@@ -120,10 +119,6 @@ deriving instance
 deriving instance
   (Era era, Eq (PredicateFailure (EraRule "LEDGERS" era))) =>
   Eq (DijkstraBbodyPredFailure era)
-
-deriving anyclass instance
-  (Era era, NoThunks (PredicateFailure (EraRule "LEDGERS" era))) =>
-  NoThunks (DijkstraBbodyPredFailure era)
 
 instance
   ( Era era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Gov.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Gov.hs
@@ -78,7 +78,6 @@ import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.NonEmpty (NonEmptyMap)
 import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 data DijkstraGovPredFailure era
   = GovActionsDoNotExist (NonEmpty GovActionId)
@@ -140,8 +139,6 @@ instance InjectRuleFailure "GOV" ConwayGovPredFailure DijkstraEra where
 instance InjectRuleEvent "GOV" ConwayGovEvent DijkstraEra
 
 instance EraPParams era => NFData (DijkstraGovPredFailure era)
-
-instance EraPParams era => NoThunks (DijkstraGovPredFailure era)
 
 instance EraPParams era => DecCBOR (DijkstraGovPredFailure era) where
   decCBOR = decode $ Summands "DijkstraGovPredFailure" $ \case

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/GovCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/GovCert.hs
@@ -50,7 +50,6 @@ import Control.State.Transition.Extended (
 import Data.Typeable (Typeable)
 import Data.Void (Void)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 data DijkstraGovCertPredFailure era
   = DijkstraDRepAlreadyRegistered (Credential DRepRole)
@@ -72,8 +71,6 @@ instance InjectRuleFailure "GOVCERT" DijkstraGovCertPredFailure DijkstraEra
 
 instance InjectRuleFailure "GOVCERT" ConwayGovCertPredFailure DijkstraEra where
   injectFailure = conwayToDijkstraGovCertPredFailure
-
-instance NoThunks (DijkstraGovCertPredFailure era)
 
 instance NFData (DijkstraGovCertPredFailure era)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -134,7 +134,6 @@ import Data.Set.NonEmpty (NonEmptySet)
 import qualified Data.Set.NonEmpty as NES
 import GHC.Generics (Generic (..))
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 data DijkstraLedgerPredFailure era
   = DijkstraUtxowFailure (PredicateFailure (EraRule "UTXOW" era))
@@ -246,15 +245,6 @@ deriving instance
   , Show (PredicateFailure (EraRule "SUBLEDGERS" era))
   ) =>
   Show (DijkstraLedgerPredFailure era)
-
-instance
-  ( Era era
-  , NoThunks (PredicateFailure (EraRule "UTXOW" era))
-  , NoThunks (PredicateFailure (EraRule "CERTS" era))
-  , NoThunks (PredicateFailure (EraRule "GOV" era))
-  , NoThunks (PredicateFailure (EraRule "SUBLEDGERS" era))
-  ) =>
-  NoThunks (DijkstraLedgerPredFailure era)
 
 instance
   ( Era era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCert.hs
@@ -58,7 +58,6 @@ import Control.State.Transition.Extended
 import Data.Void (absurd)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 data DijkstraSubCertPredFailure era
   = SubDelegFailure (PredicateFailure (EraRule "SUBDELEG" era))
@@ -79,13 +78,6 @@ deriving stock instance
   , Show (PredicateFailure (EraRule "SUBGOVCERT" era))
   ) =>
   Show (DijkstraSubCertPredFailure era)
-
-instance
-  ( NoThunks (PredicateFailure (EraRule "SUBDELEG" era))
-  , NoThunks (PredicateFailure (EraRule "SUBPOOL" era))
-  , NoThunks (PredicateFailure (EraRule "SUBGOVCERT" era))
-  ) =>
-  NoThunks (DijkstraSubCertPredFailure era)
 
 instance
   ( NFData (PredicateFailure (EraRule "SUBDELEG" era))

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
@@ -60,7 +60,6 @@ import Control.State.Transition.Extended
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq (..))
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 newtype DijkstraSubCertsPredFailure era = SubCertFailure (PredicateFailure (EraRule "SUBCERT" era))
   deriving (Generic)
@@ -70,10 +69,6 @@ deriving stock instance
 
 deriving stock instance
   Show (PredicateFailure (EraRule "SUBCERT" era)) => Show (DijkstraSubCertsPredFailure era)
-
-instance
-  NoThunks (PredicateFailure (EraRule "SUBCERT" era)) =>
-  NoThunks (DijkstraSubCertsPredFailure era)
 
 instance
   NFData (PredicateFailure (EraRule "SUBCERT" era)) =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubDeleg.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubDeleg.hs
@@ -49,10 +49,9 @@ import Control.State.Transition.Extended (
  )
 import Data.Void (Void)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 newtype DijkstraSubDelegPredFailure era = DijkstraSubDelegPredFailure (ConwayDelegPredFailure era)
-  deriving (Generic, Eq, Show, NFData, NoThunks, EncCBOR, DecCBOR)
+  deriving (Generic, Eq, Show, NFData, EncCBOR, DecCBOR)
 
 type instance EraRuleFailure "SUBDELEG" DijkstraEra = DijkstraSubDelegPredFailure DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubGov.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubGov.hs
@@ -45,10 +45,9 @@ import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure, conwayToDijkst
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 newtype DijkstraSubGovPredFailure era = DijkstraSubGovPredFailure (DijkstraGovPredFailure era)
-  deriving (Generic, Eq, Show, NoThunks, NFData, EncCBOR, DecCBOR)
+  deriving (Generic, Eq, Show, NFData, EncCBOR, DecCBOR)
 
 type instance EraRuleFailure "SUBGOV" DijkstraEra = DijkstraSubGovPredFailure DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubGovCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubGovCert.hs
@@ -53,11 +53,10 @@ import Control.State.Transition.Extended (
  )
 import Data.Void (Void)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 newtype DijkstraSubGovCertPredFailure era
   = DijkstraSubGovCertPredFailure (DijkstraGovCertPredFailure era)
-  deriving (Show, Eq, Generic, NFData, NoThunks, EncCBOR, DecCBOR)
+  deriving (Show, Eq, Generic, NFData, EncCBOR, DecCBOR)
 
 type instance EraRuleFailure "SUBGOVCERT" DijkstraEra = DijkstraSubGovCertPredFailure DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -101,7 +101,6 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Sequence.Strict as StrictSeq
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 data SubLedgerEnv era = SubLedgerEnv
   { sleSlotNo :: SlotNo
@@ -133,13 +132,6 @@ deriving stock instance
   , Show (PredicateFailure (EraRule "SUBUTXOW" era))
   ) =>
   Show (DijkstraSubLedgerPredFailure era)
-
-instance
-  ( NoThunks (PredicateFailure (EraRule "SUBGOV" era))
-  , NoThunks (PredicateFailure (EraRule "SUBCERTS" era))
-  , NoThunks (PredicateFailure (EraRule "SUBUTXOW" era))
-  ) =>
-  NoThunks (DijkstraSubLedgerPredFailure era)
 
 instance
   ( NFData (PredicateFailure (EraRule "SUBGOV" era))

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -74,7 +74,6 @@ import Control.Monad (foldM)
 import Control.State.Transition.Extended
 import Data.OMap.Strict (OMap)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 newtype DijkstraSubLedgersPredFailure era
   = SubLedgerFailure (PredicateFailure (EraRule "SUBLEDGER" era))
@@ -85,10 +84,6 @@ deriving stock instance
 
 deriving stock instance
   Show (PredicateFailure (EraRule "SUBLEDGER" era)) => Show (DijkstraSubLedgersPredFailure era)
-
-instance
-  NoThunks (PredicateFailure (EraRule "SUBLEDGER" era)) =>
-  NoThunks (DijkstraSubLedgersPredFailure era)
 
 instance NFData (PredicateFailure (EraRule "SUBLEDGER" era)) => NFData (DijkstraSubLedgersPredFailure era)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubPool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubPool.hs
@@ -51,10 +51,9 @@ import Control.State.Transition.Extended (
   transitionRules,
  )
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 newtype DijkstraSubPoolPredFailure era = DijkstraSubPoolPredFailure (ShelleyPoolPredFailure era)
-  deriving (Eq, Show, Generic, DecCBOR, EncCBOR, NFData, NoThunks)
+  deriving (Eq, Show, Generic, DecCBOR, EncCBOR, NFData)
 
 type instance EraRuleFailure "SUBPOOL" DijkstraEra = DijkstraSubPoolPredFailure DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -48,7 +48,6 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
-import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 data DijkstraSubUtxoPredFailure era
   = -- | The bad transaction inputs
@@ -102,11 +101,6 @@ deriving stock instance
   , Show TxIn
   ) =>
   Show (DijkstraSubUtxoPredFailure era)
-
-deriving via
-  InspectHeapNamed "DijkstraUtxosPred" (DijkstraSubUtxoPredFailure era)
-  instance
-    NoThunks (DijkstraSubUtxoPredFailure era)
 
 instance
   ( Era era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -80,10 +80,6 @@ import Data.Set (Set)
 import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (
-  InspectHeapNamed (..),
-  NoThunks (..),
- )
 
 data SubUtxowEnv era = SubUtxowEnv
   { sueSlot :: SlotNo
@@ -147,11 +143,6 @@ deriving stock instance
   , Show (PredicateFailure (EraRule "SUBUTXO" era))
   ) =>
   Show (DijkstraSubUtxowPredFailure era)
-
-deriving via
-  InspectHeapNamed "DijkstraSubUtxowPred" (DijkstraSubUtxowPredFailure era)
-  instance
-    NoThunks (DijkstraSubUtxowPredFailure era)
 
 instance
   ( ConwayEraScript era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -98,7 +98,6 @@ import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
-import NoThunks.Class (InspectHeapNamed (..), NoThunks (..))
 
 -- ======================================================
 
@@ -219,11 +218,6 @@ deriving instance
   , Eq TxIn
   ) =>
   Eq (DijkstraUtxoPredFailure era)
-
-deriving via
-  InspectHeapNamed "ConwayUtxoPred" (DijkstraUtxoPredFailure era)
-  instance
-    NoThunks (DijkstraUtxoPredFailure era)
 
 instance
   ( Era era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -87,10 +87,6 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Set (Set)
 import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
-import NoThunks.Class (
-  InspectHeapNamed (..),
-  NoThunks (..),
- )
 
 -- ================================
 
@@ -196,11 +192,6 @@ deriving instance
   , Eq (PredicateFailure (EraRule "UTXO" era))
   ) =>
   Eq (DijkstraUtxowPredFailure era)
-
-deriving via
-  InspectHeapNamed "ConwayUtxowPred" (DijkstraUtxowPredFailure era)
-  instance
-    NoThunks (DijkstraUtxowPredFailure era)
 
 instance
   ( ConwayEraScript era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -79,7 +79,6 @@ import Data.Proxy (Proxy (..))
 import qualified Data.Set as Set
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
-import NoThunks.Class (NoThunks)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
@@ -109,13 +108,6 @@ instance
   , EraTxOut era
   ) =>
   NFData (DijkstraContextError era)
-
-instance
-  ( AlonzoEraScript era
-  , EraTxCert era
-  , EraTxOut era
-  ) =>
-  NoThunks (DijkstraContextError era)
 
 instance
   ( ToJSON (TxCert era)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -22,6 +22,18 @@
   - Update `incrBlocks` to `:: SlotNo -> UnitInterval -> SlotNo -> KeyHash StakePool -> BlocksMake -> BlocksMade`.
   - Change `ShelleyBBODY` `Signal` to `BbodySignal`.
   - Add `validateBlockBodySize` and `validateBlockBodyHash`.
+* Remove `NoThunks` instances for all predicate failure types:
+  - `ShelleyUtxoPredFailure`
+  - `ShelleyUtxowPredFailure`
+  - `ShelleyBbodyPredFailure`
+  - `ShelleyDelegPredFailure`
+  - `ShelleyDelegsPredFailure`
+  - `ShelleyDelplPredFailure`
+  - `ShelleyLedgerPredFailure`
+  - `ShelleyLedgersPredFailure`
+  - `ShelleyPoolPredFailure`
+  - `ShelleyPpupPredFailure`
+  - `ChainPredicateFailure`
 
 ## 1.18.0.0
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
@@ -60,8 +60,6 @@ data ChainPredicateFailure
       Version -- max protocol version
   deriving (Generic, Show, Eq, Ord)
 
-instance NoThunks ChainPredicateFailure
-
 chainChecks ::
   (MonadError ChainPredicateFailure m, EraBlockHeader h era) =>
   Version ->

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
@@ -78,7 +78,6 @@ import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
-import NoThunks.Class (NoThunks (..))
 
 data ShelleyBbodyState era
   = BbodyState !(State (EraRule "LEDGERS" era)) !BlocksMade
@@ -179,12 +178,6 @@ deriving stock instance
   , Eq (PredicateFailure (EraRule "LEDGERS" era))
   ) =>
   Eq (ShelleyBbodyPredFailure era)
-
-instance
-  ( Era era
-  , NoThunks (PredicateFailure (EraRule "LEDGERS" era))
-  ) =>
-  NoThunks (ShelleyBbodyPredFailure era)
 
 instance
   ( EraBlockBody era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs
@@ -70,7 +70,6 @@ import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 data DelegEnv era = DelegEnv
   { slotNo :: SlotNo
@@ -149,8 +148,6 @@ instance
   type Event (ShelleyDELEG era) = ShelleyDelegEvent era
 
   transitionRules = [delegationTransition]
-
-instance NoThunks (ShelleyDelegPredFailure era)
 
 instance NFData (ShelleyDelegPredFailure era)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delegs.hs
@@ -63,7 +63,6 @@ import Data.Sequence (Seq (..))
 import Data.Typeable (Typeable)
 import Data.Word (Word16, Word32, Word64, Word8)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 data DelegsEnv era = DelegsEnv
   { delegsSlotNo :: SlotNo
@@ -140,10 +139,6 @@ instance
   type Event (ShelleyDELEGS era) = ShelleyDelegsEvent era
 
   transitionRules = [delegsTransition]
-
-instance
-  NoThunks (PredicateFailure (EraRule "DELPL" era)) =>
-  NoThunks (ShelleyDelegsPredFailure era)
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Delpl.hs
@@ -49,7 +49,6 @@ import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import Lens.Micro ((&), (.~), (^.))
-import NoThunks.Class (NoThunks (..))
 
 data DelplEnv era = DelplEnv
   { delplSlotNo :: SlotNo
@@ -102,12 +101,6 @@ deriving stock instance
   , Show (PredicateFailure (EraRule "POOL" era))
   ) =>
   Show (ShelleyDelplPredFailure era)
-
-instance
-  ( NoThunks (PredicateFailure (EraRule "DELEG" era))
-  , NoThunks (PredicateFailure (EraRule "POOL" era))
-  ) =>
-  NoThunks (ShelleyDelplPredFailure era)
 
 instance
   ( NFData (PredicateFailure (EraRule "DELEG" era))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -94,7 +94,6 @@ import qualified Data.Set as Set
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 -- ========================================================
 
@@ -203,13 +202,6 @@ deriving stock instance
   , Era era
   ) =>
   Eq (ShelleyLedgerPredFailure era)
-
-instance
-  ( NoThunks (PredicateFailure (EraRule "DELEGS" era))
-  , NoThunks (PredicateFailure (EraRule "UTXOW" era))
-  , Era era
-  ) =>
-  NoThunks (ShelleyLedgerPredFailure era)
 
 instance
   ( NFData (PredicateFailure (EraRule "DELEGS" era))

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -57,7 +57,6 @@ import Data.Foldable (toList)
 import Data.Functor.Identity (Identity)
 import Data.Sequence (Seq)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 data ShelleyLedgersEnv era = LedgersEnv
   { ledgersSlotNo :: SlotNo
@@ -140,12 +139,6 @@ deriving stock instance
   , Eq (PredicateFailure (EraRule "LEDGER" era))
   ) =>
   Eq (ShelleyLedgersPredFailure era)
-
-instance
-  ( Era era
-  , NoThunks (PredicateFailure (EraRule "LEDGER" era))
-  ) =>
-  NoThunks (ShelleyLedgersPredFailure era)
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Pool.hs
@@ -71,7 +71,6 @@ import Data.Primitive.ByteArray (sizeofByteArray)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 
 data PoolEnv era
   = PoolEnv EpochNo (PParams era)
@@ -122,8 +121,6 @@ instance InjectRuleFailure "POOL" ShelleyPoolPredFailure ShelleyEra
 type instance EraRuleEvent "POOL" ShelleyEra = PoolEvent ShelleyEra
 
 instance InjectRuleEvent "POOL" PoolEvent ShelleyEra
-
-instance NoThunks (ShelleyPoolPredFailure era)
 
 instance NFData (ShelleyPoolPredFailure era)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ppup.hs
@@ -111,8 +111,6 @@ type instance EraRuleFailure "PPUP" ShelleyEra = ShelleyPpupPredFailure ShelleyE
 
 instance InjectRuleFailure "PPUP" ShelleyPpupPredFailure ShelleyEra
 
-instance NoThunks (ShelleyPpupPredFailure era)
-
 instance NFData (ShelleyPpupPredFailure era)
 
 newtype PpupEvent era = PpupNewEpoch EpochNo

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -101,7 +101,6 @@ import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro
 import Lens.Micro.Extras (view)
-import NoThunks.Class (NoThunks (..))
 import Validation (failureUnless)
 
 data UtxoEnv era = UtxoEnv
@@ -208,13 +207,6 @@ deriving stock instance
   , Eq (EraRuleFailure "PPUP" era)
   ) =>
   Eq (ShelleyUtxoPredFailure era)
-
-instance
-  ( NoThunks (Value era)
-  , NoThunks (TxOut era)
-  , NoThunks (EraRuleFailure "PPUP" era)
-  ) =>
-  NoThunks (ShelleyUtxoPredFailure era)
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -107,7 +107,6 @@ import Data.Typeable (Typeable)
 import Data.Word (Word64, Word8)
 import GHC.Generics (Generic)
 import Lens.Micro
-import NoThunks.Class (NoThunks (..))
 import Validation
 
 -- =========================================
@@ -152,12 +151,6 @@ newtype ShelleyUtxowEvent era
 deriving instance Eq (Event (EraRule "UTXO" era)) => Eq (ShelleyUtxowEvent era)
 
 instance NFData (Event (EraRule "UTXO" era)) => NFData (ShelleyUtxowEvent era)
-
-instance
-  ( NoThunks (PredicateFailure (EraRule "UTXO" era))
-  , Era era
-  ) =>
-  NoThunks (ShelleyUtxowPredFailure era)
 
 instance
   ( NFData (PredicateFailure (EraRule "UTXO" era))

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-shelley-test`
 
-## 1.8.0.1
+## 1.9.0.0
 
-*
+* Remove `NoThunks` instance for `TestChainPredicateFailure`
 
 ## 1.8.0.0
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -108,7 +108,6 @@ import Data.Void (Void)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens, (&), (.~), (^.))
-import NoThunks.Class (NoThunks (..))
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.TreeDiff ()
 import Test.Cardano.Ledger.TreeDiff (ToExpr (toExpr), defaultExprViaShow)
@@ -166,14 +165,6 @@ deriving stock instance
   , Eq (PredicateFailure (EraRule "TICKN" era))
   ) =>
   Eq (TestChainPredicateFailure era)
-
-instance
-  ( Era era
-  , NoThunks (PredicateFailure (EraRule "BBODY" era))
-  , NoThunks (PredicateFailure (EraRule "TICK" era))
-  , NoThunks (PredicateFailure (EraRule "TICKN" era))
-  ) =>
-  NoThunks (TestChainPredicateFailure era)
 
 -- | Creates a valid initial chain state
 initialShelleyState ::

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -7,6 +7,10 @@
   - Update `tickChainDepState`, `updateChainDepState`, and `reupdateChainDepState` to use the new `TPraosLedgerView`.
   - Deprecate `mkInitialShelleyLedgerView`.
 * Remove `TicknPredicateFailure` and make `PredicateFailure TICKN` be `Void`.
+* Remove `NoThunks` instance for
+  - `UpdnPredicateFailure`
+  - `OverlayPredicateFailure`
+  - `ChainTransitionError`
 
 ### `testlib`
 

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -495,8 +495,6 @@ newtype ChainTransitionError c
   = ChainTransitionError (NonEmpty (PredicateFailure (STS.Prtcl.PRTCL c)))
   deriving (Generic)
 
-instance Crypto c => NoThunks (ChainTransitionError c)
-
 deriving instance Crypto c => Eq (ChainTransitionError c)
 
 deriving instance Crypto c => Show (ChainTransitionError c)

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
@@ -24,7 +24,6 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Word (Word64)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 data OCERT c
 
@@ -50,8 +49,6 @@ data OcertPredicateFailure
   | NoCounterForKeyHashOCERT
       (KeyHash BlockIssuer) -- stake pool key hash
   deriving (Show, Eq, Generic)
-
-instance NoThunks OcertPredicateFailure
 
 instance
   ( Crypto c

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
@@ -274,10 +274,6 @@ overlayTransition =
         trans @(OCERT c) $ TRC (oce, cs, bh)
 
 instance
-  VRF.VRFAlgorithm (VRF c) =>
-  NoThunks (OverlayPredicateFailure c)
-
-instance
   ( Crypto c
   , KES.Signable (KES c) (BHBody c)
   , VRF.Signable (VRF c) Seed

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Prtcl.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Prtcl.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -178,8 +177,6 @@ prtclTransition = do
       cs'
       etaV'
       etaC'
-
-instance Crypto c => NoThunks (PrtclPredicateFailure c)
 
 instance
   ( Crypto c

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Tickn.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Tickn.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
@@ -17,7 +17,6 @@ import Cardano.Protocol.Crypto
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks (..))
 
 data UPDN c
 
@@ -31,8 +30,6 @@ data UpdnState = UpdnState Nonce Nonce
 
 data UpdnPredicateFailure c -- No predicate failures
   deriving (Generic, Show, Eq)
-
-instance NoThunks (UpdnPredicateFailure c)
 
 newtype UpdnEvent c = NewEpoch EpochNo
 


### PR DESCRIPTION
# Description

`NoThunks` instances are used for memory leak detection during development, but predicate failures should never be retained in the ledger state, i.e. they are only used for validation results. Removing these instances reduces code maintenance burden and instance derivation overhead.

This change removes `NoThunks` instances from:

- All predicate failure types across Shelley, Allegra, Alonzo, Babbage, Conway, and Dijkstra eras
- All `ContextError` types (`AlonzoContextError`, `BabbageContextError`, `ConwayContextError`, `DijkstraContextError`)
- The `NoThunks (ContextError era)` constraint from the `EraPlutusContext` class
- The `NoThunks` deriving instance for `CollectError`

Closes #5643 

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
