### PR TITLE
Remove state update from UTXOS

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.22.0.0
 
+* Add `ConwayUtxosEnv`
+* Change `STS` instance of `ConwayUTXOS`: use `ConwayUtxosEnv` as `Environment` and `()` as `State`
 * Add `updateTreasuryDonation`
 * Add `checkReferenceInputsNotDisjointFromInputs`
 * Add `ConwayEraScript` superclass to `ConwayEraPlutusTxInfo`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.22.0.0
 
+* Add `updateTreasuryDonation`
 * Add `checkReferenceInputsNotDisjointFromInputs`
 * Add `ConwayEraScript` superclass to `ConwayEraPlutusTxInfo`
 * Change `transPlutusPurposeV1V2` to work only with `ScriptPurpose` for any era and change it from `AsItem` to `AsIxItem`.

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Conway.Rules.Utxo (
   alonzoToConwayUtxoPredFailure,
   ConwayUtxoPredFailure (..),
   UtxoEnv (..),
+  updateTreasuryDonation,
 ) where
 
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure, shelleyToAllegraUtxoPredFailure)
@@ -67,7 +68,7 @@ import Cardano.Ledger.Conway.Rules.Utxos (
   ConwayUtxosPredFailure (..),
  )
 import Cardano.Ledger.Plutus (ExUnits)
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState (UTxOState (..), utxosDonationL)
 import Cardano.Ledger.Shelley.Rules (
   ShelleyUtxoPredFailure,
   UtxoEnv (..),
@@ -82,6 +83,7 @@ import Data.Map.NonEmpty (NonEmptyMap)
 import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
+import Lens.Micro ((&), (<>~), (^.))
 
 -- ======================================================
 
@@ -214,12 +216,23 @@ instance
   ) =>
   NFData (ConwayUtxoPredFailure era)
 
+-- | Accumulate treasury donation for valid transactions
+updateTreasuryDonation ::
+  (AlonzoEraTx era, ConwayEraTxBody era) =>
+  Tx TopTx era ->
+  UTxOState era ->
+  UTxOState era
+updateTreasuryDonation tx utxos =
+  case tx ^. isValidTxL of
+    IsValid True -> utxos & utxosDonationL <>~ tx ^. bodyTxL . treasuryDonationTxBodyL
+    IsValid False -> utxos
+
 conwayUtxoTransition ::
   forall era.
   ( EraUTxO era
   , EraCertState era
-  , BabbageEraTxBody era
   , AlonzoEraTx era
+  , ConwayEraTxBody era
   , EraStake era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
@@ -242,7 +255,12 @@ conwayUtxoTransition = do
   TRC (UtxoEnv _ pp certState, utxos, tx) <- judgmentContext
   babbageUtxoValidation
   updatedUtxos <- trans @(EraRule "UTXOS" era) $ TRC (pp, utxos, tx)
-  updateUTxOStateByTxValidity pp certState (utxosGovState utxos) tx updatedUtxos
+  updateUTxOStateByTxValidity
+    pp
+    certState
+    (utxosGovState utxos)
+    tx
+    (updateTreasuryDonation tx updatedUtxos)
 
 --------------------------------------------------------------------------------
 -- ConwayUTXO STS

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -65,6 +65,7 @@ import Cardano.Ledger.Coin (Coin, DeltaCoin)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra, ConwayUTXO, ConwayUTXOS)
 import Cardano.Ledger.Conway.Rules.Utxos (
+  ConwayUtxosEnv (..),
   ConwayUtxosPredFailure (..),
  )
 import Cardano.Ledger.Plutus (ExUnits)
@@ -245,8 +246,8 @@ conwayUtxoTransition ::
   , STS (EraRule "UTXO" era)
   , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
   , -- In this function we we call the UTXOS rule, so we need some assumptions
-    Environment (EraRule "UTXOS" era) ~ PParams era
-  , State (EraRule "UTXOS" era) ~ UTxOState era
+    Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
+  , State (EraRule "UTXOS" era) ~ ()
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
   , Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
   ) =>
@@ -254,13 +255,13 @@ conwayUtxoTransition ::
 conwayUtxoTransition = do
   TRC (UtxoEnv _ pp certState, utxos, tx) <- judgmentContext
   babbageUtxoValidation
-  updatedUtxos <- trans @(EraRule "UTXOS" era) $ TRC (pp, utxos, tx)
+  () <- trans @(EraRule "UTXOS" era) $ TRC (ConwayUtxosEnv pp (utxosUtxo utxos), (), tx)
   updateUTxOStateByTxValidity
     pp
     certState
     (utxosGovState utxos)
     tx
-    (updateTreasuryDonation tx updatedUtxos)
+    (updateTreasuryDonation tx utxos)
 
 --------------------------------------------------------------------------------
 -- ConwayUTXO STS
@@ -280,8 +281,8 @@ instance
   , InjectRuleFailure "UTXO" BabbageUtxoPredFailure era
   , InjectRuleFailure "UTXO" ConwayUtxoPredFailure era
   , Embed (EraRule "UTXOS" era) (ConwayUTXO era)
-  , Environment (EraRule "UTXOS" era) ~ PParams era
-  , State (EraRule "UTXOS" era) ~ UTxOState era
+  , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
+  , State (EraRule "UTXOS" era) ~ ()
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
   , PredicateFailure (EraRule "UTXO" era) ~ ConwayUtxoPredFailure era
   , EraCertState era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -60,13 +60,13 @@ import Cardano.Ledger.Conway.Era (ConwayEra, ConwayUTXOS)
 import Cardano.Ledger.Conway.Governance (ConwayGovState)
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Plutus (PlutusWithContext)
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (..), utxosDonationL)
+import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
 import Data.List.NonEmpty (NonEmpty)
 import qualified Debug.Trace as Debug
 import GHC.Generics (Generic)
-import Lens.Micro
+import Lens.Micro ((^.))
 
 data ConwayUtxosPredFailure era
   = -- | The 'isValid' tag on the transaction is incorrect. The tag given
@@ -177,7 +177,7 @@ instance
 instance
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
-  , ConwayEraTxBody era
+  , ConwayEraScript era
   , ConwayEraPParams era
   , EraGov era
   , EraStake era
@@ -205,7 +205,7 @@ instance
 instance
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
-  , ConwayEraTxBody era
+  , ConwayEraScript era
   , ConwayEraPParams era
   , EraGov era
   , EraStake era
@@ -229,7 +229,6 @@ utxosTransition ::
   forall era.
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
-  , ConwayEraTxBody era
   , EraPlutusContext era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
@@ -253,7 +252,6 @@ conwayEvalScriptsTxValid ::
   forall era.
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
-  , ConwayEraTxBody era
   , EraPlutusContext era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
@@ -267,10 +265,9 @@ conwayEvalScriptsTxValid ::
   TransitionRule (EraRule "UTXOS" era)
 conwayEvalScriptsTxValid = do
   TRC (pp, utxos, tx) <- judgmentContext
-  let txBody = tx ^. bodyTxL
 
   () <- pure $! Debug.traceEvent validBegin ()
   expectScriptsToPass pp tx (utxosUtxo utxos)
   () <- pure $! Debug.traceEvent validEnd ()
 
-  pure $! utxos & utxosDonationL <>~ txBody ^. treasuryDonationTxBodyL
+  pure utxos

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -17,6 +17,7 @@
 
 module Cardano.Ledger.Conway.Rules.Utxos (
   ConwayUTXOS,
+  ConwayUtxosEnv (..),
   ConwayUtxosPredFailure (..),
   ConwayUtxosEvent (..),
   alonzoToConwayUtxosPredFailure,
@@ -60,13 +61,24 @@ import Cardano.Ledger.Conway.Era (ConwayEra, ConwayUTXOS)
 import Cardano.Ledger.Conway.Governance (ConwayGovState)
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Plutus (PlutusWithContext)
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
 import Data.List.NonEmpty (NonEmpty)
 import qualified Debug.Trace as Debug
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
+
+data ConwayUtxosEnv era = ConwayUtxosEnv
+  { cuePParams :: !(PParams era)
+  , cueUTxO :: !(UTxO era)
+  }
+  deriving (Generic)
+
+deriving instance (Show (PParams era), Show (UTxO era)) => Show (ConwayUtxosEnv era)
+
+deriving instance (Eq (PParams era), Eq (UTxO era)) => Eq (ConwayUtxosEnv era)
+
+instance (Era era, NFData (PParams era), NFData (UTxO era)) => NFData (ConwayUtxosEnv era)
 
 data ConwayUtxosPredFailure era
   = -- | The 'isValid' tag on the transaction is incorrect. The tag given
@@ -154,7 +166,6 @@ deriving stock instance
   ( ConwayEraScript era
   , Show (TxCert era)
   , Show (ContextError era)
-  , Show (UTxOState era)
   ) =>
   Show (ConwayUtxosPredFailure era)
 
@@ -162,7 +173,6 @@ deriving stock instance
   ( ConwayEraScript era
   , Eq (TxCert era)
   , Eq (ContextError era)
-  , Eq (UTxOState era)
   ) =>
   Eq (ConwayUtxosPredFailure era)
 
@@ -170,7 +180,6 @@ instance
   ( ConwayEraScript era
   , NFData (TxCert era)
   , NFData (ContextError era)
-  , NFData (UTxOState era)
   ) =>
   NFData (ConwayUtxosPredFailure era)
 
@@ -194,8 +203,8 @@ instance
   STS (ConwayUTXOS era)
   where
   type BaseM (ConwayUTXOS era) = Cardano.Ledger.BaseTypes.ShelleyBase
-  type Environment (ConwayUTXOS era) = PParams era
-  type State (ConwayUTXOS era) = UTxOState era
+  type Environment (ConwayUTXOS era) = ConwayUtxosEnv era
+  type State (ConwayUTXOS era) = ()
   type Signal (ConwayUTXOS era) = Tx TopTx era
   type PredicateFailure (ConwayUTXOS era) = ConwayUtxosPredFailure era
   type Event (ConwayUTXOS era) = ConwayUtxosEvent era
@@ -233,20 +242,19 @@ utxosTransition ::
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
   , STS (EraRule "UTXOS" era)
-  , Environment (EraRule "UTXOS" era) ~ PParams era
-  , State (EraRule "UTXOS" era) ~ UTxOState era
+  , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
+  , State (EraRule "UTXOS" era) ~ ()
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
   , BaseM (EraRule "UTXOS" era) ~ ShelleyBase
   , InjectRuleEvent "UTXOS" AlonzoUtxosEvent era
   ) =>
   TransitionRule (EraRule "UTXOS" era)
 utxosTransition =
-  judgmentContext >>= \(TRC (pp, utxos, tx)) -> do
+  judgmentContext >>= \(TRC (ConwayUtxosEnv pp utxo, (), tx)) -> do
     case tx ^. isValidTxL of
       IsValid True -> conwayEvalScriptsTxValid
       IsValid False -> do
-        babbageEvalScriptsTxInvalid @era pp tx (utxosUtxo utxos)
-        pure utxos
+        babbageEvalScriptsTxInvalid @era pp tx utxo
 
 conwayEvalScriptsTxValid ::
   forall era.
@@ -256,18 +264,16 @@ conwayEvalScriptsTxValid ::
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
   , STS (EraRule "UTXOS" era)
-  , State (EraRule "UTXOS" era) ~ UTxOState era
-  , Environment (EraRule "UTXOS" era) ~ PParams era
+  , State (EraRule "UTXOS" era) ~ ()
+  , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
   , BaseM (EraRule "UTXOS" era) ~ ShelleyBase
   , InjectRuleEvent "UTXOS" AlonzoUtxosEvent era
   ) =>
   TransitionRule (EraRule "UTXOS" era)
 conwayEvalScriptsTxValid = do
-  TRC (pp, utxos, tx) <- judgmentContext
+  TRC (ConwayUtxosEnv pp utxo, (), tx) <- judgmentContext
 
   () <- pure $! Debug.traceEvent validBegin ()
-  expectScriptsToPass pp tx (utxosUtxo utxos)
-  () <- pure $! Debug.traceEvent validEnd ()
-
-  pure utxos
+  expectScriptsToPass pp tx utxo
+  pure $! Debug.traceEvent validEnd ()

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -195,6 +195,8 @@ instance
   ) =>
   ToExpr (ConwayUtxosPredFailure era)
 
+instance (ToExpr (PParamsHKD Identity era), ToExpr (TxOut era)) => ToExpr (ConwayUtxosEnv era)
+
 -- TxBody
 instance ToExpr (ConwayTxBodyRaw TopTx ConwayEra) where
   toExpr ConwayTxBodyRaw {..} =

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -59,6 +59,7 @@ import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Rules (
   ConwayUTXOS,
   ConwayUtxoPredFailure,
+  ConwayUtxosEnv (..),
   ConwayUtxosPredFailure (..),
   allegraToConwayUtxoPredFailure,
   alonzoToConwayUtxoPredFailure,
@@ -264,8 +265,8 @@ dijkstraUtxoTransition ::
   , STS (EraRule "UTXO" era)
   , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
   , -- In this function we we call the UTXOS rule, so we need some assumptions
-    Environment (EraRule "UTXOS" era) ~ PParams era
-  , State (EraRule "UTXOS" era) ~ UTxOState era
+    Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
+  , State (EraRule "UTXOS" era) ~ ()
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
   , Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
   ) =>
@@ -274,13 +275,13 @@ dijkstraUtxoTransition = do
   TRC (UtxoEnv _ pp certState, utxos, tx) <- judgmentContext
   babbageUtxoValidation
   validateNoPtrInCollateralReturn $ tx ^. bodyTxL
-  updatedUtxos <- trans @(EraRule "UTXOS" era) $ TRC (pp, utxos, tx)
+  () <- trans @(EraRule "UTXOS" era) $ TRC (ConwayUtxosEnv pp (utxosUtxo utxos), (), tx)
   updateUTxOStateByTxValidity
     pp
     certState
     (utxosGovState utxos)
     tx
-    (updateTreasuryDonation tx updatedUtxos)
+    (updateTreasuryDonation tx utxos)
 
 instance
   forall era.
@@ -303,8 +304,8 @@ instance
   , STS (EraRule "UTXO" era)
   , -- In this function we we call the UTXOS rule, so we need some assumptions
     Embed (EraRule "UTXOS" era) (DijkstraUTXO era)
-  , Environment (EraRule "UTXOS" era) ~ PParams era
-  , State (EraRule "UTXOS" era) ~ UTxOState era
+  , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
+  , State (EraRule "UTXOS" era) ~ ()
   , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
   , EraCertState era
   , EraRule "UTXO" era ~ DijkstraUTXO era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -63,6 +63,7 @@ import Cardano.Ledger.Conway.Rules (
   allegraToConwayUtxoPredFailure,
   alonzoToConwayUtxoPredFailure,
   babbageToConwayUtxoPredFailure,
+  updateTreasuryDonation,
  )
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Credential (StakeReference (..))
@@ -248,8 +249,8 @@ dijkstraUtxoTransition ::
   forall era.
   ( EraUTxO era
   , EraCertState era
-  , BabbageEraTxBody era
   , AlonzoEraTx era
+  , ConwayEraTxBody era
   , EraStake era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" AllegraUtxoPredFailure era
@@ -274,7 +275,12 @@ dijkstraUtxoTransition = do
   babbageUtxoValidation
   validateNoPtrInCollateralReturn $ tx ^. bodyTxL
   updatedUtxos <- trans @(EraRule "UTXOS" era) $ TRC (pp, utxos, tx)
-  updateUTxOStateByTxValidity pp certState (utxosGovState utxos) tx updatedUtxos
+  updateUTxOStateByTxValidity
+    pp
+    certState
+    (utxosGovState utxos)
+    tx
+    (updateTreasuryDonation tx updatedUtxos)
 
 instance
   forall era.

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -1572,6 +1572,12 @@ instance
   (EraGov era, EraTxOut era, EraSpecPParams era, EraCertState era, HasSpec (CertState era)) =>
   HasSpec (UtxoEnv era)
 
+instance Era era => HasSimpleRep (ConwayUtxosEnv era)
+
+instance
+  (Era era, EraSpecPParams era, HasSpec (TxOut era), IsNormalType (TxOut era)) =>
+  HasSpec (ConwayUtxosEnv era)
+
 -- ================================================================
 -- All the Tx instances
 


### PR DESCRIPTION
# Description

At the moment, the UTXOState is updated with the treasury donations in UTXOS rule. 
This PR moves the update to UTXO, and makes UTXOS have no state. 

Closes https://github.com/IntersectMBO/cardano-ledger/issues/5642

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
