### PR TITLE
Add/refactor committee-related canonical namespaces

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -104,8 +104,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
-  --sha256: sha256-WCcC4P1edSGUV+F4KvTNy83GGRZjSEdmsSG4UUB+k6w=
-  tag: e4255f1d8a19897a21f7b68ccf92b3678739e25c
+  --sha256: sha256-BoAotLgxMipOIMcZrmlr6EtQzqC5HyEA0ZpK8nvCmJs=
+  tag: 5161deb34247a51160f2e8d58b6cc2d48044ea2c
 
 if impl(ghc >=9.14)
   source-repository-package

--- a/cabal.project
+++ b/cabal.project
@@ -104,8 +104,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
-  --sha256: sha256-y5T8XBVqhNWCpVNuVrcPDILOVd8M3e0QT6s2onBekPk=
-  tag: 108fc4701079d5da250eaba9547db930fcb1c1e2
+  --sha256: sha256-WCcC4P1edSGUV+F4KvTNy83GGRZjSEdmsSG4UUB+k6w=
+  tag: e4255f1d8a19897a21f7b68ccf92b3678739e25c
 
 if impl(ghc >=9.14)
   source-repository-package

--- a/libs/cardano-ledger-canonical-state/cardano-ledger-canonical-state.cabal
+++ b/libs/cardano-ledger-canonical-state/cardano-ledger-canonical-state.cabal
@@ -44,6 +44,7 @@ library
     Cardano.Ledger.CanonicalState.LedgerCBOR
     Cardano.Ledger.CanonicalState.Namespace
     Cardano.Ledger.CanonicalState.Namespace.Blocks.V0
+    Cardano.Ledger.CanonicalState.Namespace.EntitiesCommittee.V0
     Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0
     Cardano.Ledger.CanonicalState.Namespace.GovConstitution.V0
     Cardano.Ledger.CanonicalState.Namespace.GovPParams.V0

--- a/libs/cardano-ledger-canonical-state/conway/Cardano/Ledger/CanonicalState/Conway.hs
+++ b/libs/cardano-ledger-canonical-state/conway/Cardano/Ledger/CanonicalState/Conway.hs
@@ -62,6 +62,8 @@ import Lens.Micro
 
 type instance NamespaceEra "blocks/v0" = ConwayEra
 
+type instance NamespaceEra "entities/committee/v0" = ConwayEra
+
 type instance NamespaceEra "gov/committee/v0" = ConwayEra
 
 type instance NamespaceEra "gov/constitution/v0" = ConwayEra

--- a/libs/cardano-ledger-canonical-state/conway/Cardano/Ledger/CanonicalState/Conway.hs
+++ b/libs/cardano-ledger-canonical-state/conway/Cardano/Ledger/CanonicalState/Conway.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.CanonicalState.BasicTypes (
   mkOnChain,
  )
 import Cardano.Ledger.CanonicalState.Namespace
-import Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 ()
 import Cardano.Ledger.CanonicalState.Namespace.GovConstitution.V0
 import Cardano.Ledger.CanonicalState.Namespace.GovPParams.V0
 import Cardano.Ledger.CanonicalState.Namespace.GovProposals.V0

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/EntitiesCommittee/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/EntitiesCommittee/V0.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.CanonicalState.Namespace.EntitiesCommittee.V0 (
+  EntitiesCommitteeIn (..),
+  EntitiesCommitteeOut (..),
+  CanonicalCommitteeState (..),
+  CanonicalCommitteeAuthorization (..),
+  mkCanonicalCommitteeAuthorization,
+  fromCanonicalCommitteeAuthorization,
+) where
+
+import Cardano.Ledger.BaseTypes (Anchor (..), EpochNo (..), StrictMaybe (..))
+import Cardano.Ledger.CanonicalState.BasicTypes ()
+import Cardano.Ledger.CanonicalState.Namespace (Era, NamespaceEra)
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Keys (KeyRole (ColdCommitteeRole, HotCommitteeRole))
+import Cardano.Ledger.State (CommitteeAuthorization (..))
+import Cardano.SCLS.CBOR.Canonical.Decoder (FromCanonicalCBOR (..), decodeListLenCanonicalOf)
+import Cardano.SCLS.CBOR.Canonical.Encoder (ToCanonicalCBOR (..))
+import Cardano.SCLS.Entry.IsKey (IsKey (..))
+import Cardano.SCLS.NamespaceCodec (
+  CanonicalCBOREntryDecoder (..),
+  CanonicalCBOREntryEncoder (..),
+  KnownNamespace (..),
+  namespaceKeySize,
+ )
+import Cardano.SCLS.Versioned (Versioned (..))
+import qualified Data.Map.Strict as Map
+import Data.MemPack.ByteOrdered (packWord64beM, unpackBigEndianM)
+import Data.Proxy (Proxy (..))
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+
+instance (Era era, NamespaceEra "entities/committee/v0" ~ era) => KnownNamespace "entities/committee/v0" where
+  type NamespaceKey "entities/committee/v0" = EntitiesCommitteeIn
+  type NamespaceEntry "entities/committee/v0" = EntitiesCommitteeOut
+
+instance
+  (Era era, NamespaceEra "entities/committee/v0" ~ era) =>
+  CanonicalCBOREntryEncoder "entities/committee/v0" EntitiesCommitteeOut
+  where
+  encodeEntry (EntitiesCommitteeOut n) = toCanonicalCBOR (Proxy @"entities/committee/v0") n
+
+instance
+  (Era era, NamespaceEra "entities/committee/v0" ~ era) =>
+  CanonicalCBOREntryDecoder "entities/committee/v0" EntitiesCommitteeOut
+  where
+  decodeEntry = fmap EntitiesCommitteeOut <$> fromCanonicalCBOR
+
+data EntitiesCommitteeIn = EntitiesCommitteeIn EpochNo
+  deriving (Eq, Ord, Show)
+
+newtype EntitiesCommitteeOut = EntitiesCommitteeOut CanonicalCommitteeState
+  deriving (Eq, Show, Generic)
+
+instance IsKey EntitiesCommitteeIn where
+  keySize = namespaceKeySize @"entities/committee/v0"
+  packKeyM (EntitiesCommitteeIn (EpochNo no)) = do
+    packWord64beM no
+  unpackKeyM = do
+    no <- unpackBigEndianM
+    return $ EntitiesCommitteeIn (EpochNo no)
+
+newtype CanonicalCommitteeState = CanonicalCommitteeState
+  { csCommitteeCreds :: Map.Map (Credential ColdCommitteeRole) CanonicalCommitteeAuthorization
+  }
+  deriving (Eq, Show, Generic)
+
+instance (Era era, NamespaceEra v ~ era) => ToCanonicalCBOR v CanonicalCommitteeState where
+  toCanonicalCBOR v CanonicalCommitteeState {..} = toCanonicalCBOR v csCommitteeCreds
+
+instance (Era era, NamespaceEra v ~ era) => FromCanonicalCBOR v CanonicalCommitteeState where
+  fromCanonicalCBOR = do
+    st_ <- fromCanonicalCBOR
+    return $ CanonicalCommitteeState <$> st_
+
+instance (Era era, NamespaceEra v ~ era) => ToCanonicalCBOR v CanonicalCommitteeAuthorization where
+  toCanonicalCBOR v (CanonicalCommitteeHotCredential cred) =
+    toCanonicalCBOR v (0 :: Word8, cred)
+  toCanonicalCBOR v (CanonicalCommitteeMemberResigned ma) =
+    toCanonicalCBOR v (1 :: Word8, ma)
+
+instance (Era era, NamespaceEra v ~ era) => FromCanonicalCBOR v CanonicalCommitteeAuthorization where
+  fromCanonicalCBOR = do
+    decodeListLenCanonicalOf 2
+    Versioned (tag :: Word8) <- fromCanonicalCBOR
+    case tag of
+      0 -> fmap CanonicalCommitteeHotCredential <$> fromCanonicalCBOR @v
+      1 -> fmap CanonicalCommitteeMemberResigned <$> fromCanonicalCBOR @v
+      _ -> fail "Invalid CommitteeAuthorization tag"
+
+data CanonicalCommitteeAuthorization
+  = CanonicalCommitteeHotCredential (Credential HotCommitteeRole)
+  | CanonicalCommitteeMemberResigned (StrictMaybe Anchor)
+  deriving (Eq, Show, Ord, Generic)
+
+mkCanonicalCommitteeAuthorization :: CommitteeAuthorization -> CanonicalCommitteeAuthorization
+mkCanonicalCommitteeAuthorization (CommitteeHotCredential credential) = CanonicalCommitteeHotCredential credential
+mkCanonicalCommitteeAuthorization (CommitteeMemberResigned anchor) = CanonicalCommitteeMemberResigned anchor
+
+fromCanonicalCommitteeAuthorization :: CanonicalCommitteeAuthorization -> CommitteeAuthorization
+fromCanonicalCommitteeAuthorization (CanonicalCommitteeHotCredential credential) = CommitteeHotCredential credential
+fromCanonicalCommitteeAuthorization (CanonicalCommitteeMemberResigned anchor) = CommitteeMemberResigned anchor

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovCommittee/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovCommittee/V0.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -16,7 +20,7 @@ module Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 (
   CanonicalCommittee (..),
 ) where
 
-import Cardano.Ledger.BaseTypes (EpochNo (..), UnitInterval)
+import Cardano.Ledger.BaseTypes (EpochNo (..), StrictMaybe, UnitInterval)
 import Cardano.Ledger.CanonicalState.BasicTypes ()
 import Cardano.Ledger.CanonicalState.Namespace (Era, NamespaceEra)
 import Cardano.Ledger.Credential (Credential (..))
@@ -55,8 +59,16 @@ instance
 newtype GovCommitteeIn = GovCommitteeIn EpochNo
   deriving (Eq, Ord, Show)
 
-newtype GovCommitteeOut = GovCommitteeOut CanonicalCommittee
-  deriving (Eq, Show, Generic)
+newtype GovCommitteeOut = GovCommitteeOut (StrictMaybe CanonicalCommittee)
+  deriving (Generic, Eq, Show)
+
+deriving newtype instance
+  ToCanonicalCBOR "gov/committee/v0" (StrictMaybe CanonicalCommittee) =>
+  ToCanonicalCBOR "gov/committee/v0" GovCommitteeOut
+
+deriving newtype instance
+  FromCanonicalCBOR "gov/committee/v0" (StrictMaybe CanonicalCommittee) =>
+  FromCanonicalCBOR "gov/committee/v0" GovCommitteeOut
 
 instance IsKey GovCommitteeIn where
   keySize = namespaceKeySize @"gov/committee/v0"

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovCommittee/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovCommittee/V0.hs
@@ -1,14 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -18,19 +13,15 @@
 module Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 (
   GovCommitteeIn (..),
   GovCommitteeOut (..),
-  CanonicalCommitteeState (..),
-  CanonicalCommitteeAuthorization (..),
-  mkCanonicalCommitteeAuthorization,
-  fromCanonicalCommitteeAuthorization,
+  CanonicalCommittee (..),
 ) where
 
-import Cardano.Ledger.BaseTypes (Anchor (..), EpochNo (..), StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (EpochNo (..), UnitInterval)
 import Cardano.Ledger.CanonicalState.BasicTypes ()
 import Cardano.Ledger.CanonicalState.Namespace (Era, NamespaceEra)
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Keys (KeyRole (ColdCommitteeRole, HotCommitteeRole))
-import Cardano.Ledger.State (CommitteeAuthorization (..))
-import Cardano.SCLS.CBOR.Canonical.Decoder (FromCanonicalCBOR (..), decodeListLenCanonicalOf)
+import Cardano.Ledger.Keys (KeyRole (ColdCommitteeRole))
+import Cardano.SCLS.CBOR.Canonical.Decoder (FromCanonicalCBOR (..))
 import Cardano.SCLS.CBOR.Canonical.Encoder (ToCanonicalCBOR (..))
 import Cardano.SCLS.Entry.IsKey (IsKey (..))
 import Cardano.SCLS.NamespaceCodec (
@@ -39,11 +30,10 @@ import Cardano.SCLS.NamespaceCodec (
   KnownNamespace (..),
   namespaceKeySize,
  )
-import Cardano.SCLS.Versioned (Versioned (..))
+import Cardano.SCLS.Versioned (Versioned (Versioned))
 import qualified Data.Map.Strict as Map
 import Data.MemPack.ByteOrdered (packWord64beM, unpackBigEndianM)
 import Data.Proxy (Proxy (..))
-import Data.Word (Word8)
 import GHC.Generics (Generic)
 
 instance (Era era, NamespaceEra "gov/committee/v0" ~ era) => KnownNamespace "gov/committee/v0" where
@@ -62,57 +52,31 @@ instance
   where
   decodeEntry = fmap GovCommitteeOut <$> fromCanonicalCBOR
 
-data GovCommitteeIn = GovCommitteeIn EpochNo
+newtype GovCommitteeIn = GovCommitteeIn EpochNo
   deriving (Eq, Ord, Show)
 
-newtype GovCommitteeOut = GovCommitteeOut CanonicalCommitteeState
+newtype GovCommitteeOut = GovCommitteeOut CanonicalCommittee
   deriving (Eq, Show, Generic)
 
 instance IsKey GovCommitteeIn where
   keySize = namespaceKeySize @"gov/committee/v0"
-  packKeyM (GovCommitteeIn (EpochNo no)) = do
-    packWord64beM no
+  packKeyM (GovCommitteeIn (EpochNo no)) = packWord64beM no
   unpackKeyM = do
-    no <- unpackBigEndianM
-    return $ GovCommitteeIn (EpochNo no)
+    GovCommitteeIn . EpochNo <$> unpackBigEndianM
 
-newtype CanonicalCommitteeState = CanonicalCommitteeState
-  { csCommitteeCreds :: Map.Map (Credential ColdCommitteeRole) CanonicalCommitteeAuthorization
+data CanonicalCommittee = CanonicalCommittee
+  { committeeMembers :: !(Map.Map (Credential ColdCommitteeRole) EpochNo)
+  , committeeThreshold :: !UnitInterval
   }
   deriving (Eq, Show, Generic)
 
-instance (Era era, NamespaceEra v ~ era) => ToCanonicalCBOR v CanonicalCommitteeState where
-  toCanonicalCBOR v CanonicalCommitteeState {..} = toCanonicalCBOR v csCommitteeCreds
+instance (Era era, NamespaceEra v ~ era) => ToCanonicalCBOR v CanonicalCommittee where
+  toCanonicalCBOR v CanonicalCommittee {..} =
+    toCanonicalCBOR v (committeeMembers, committeeThreshold)
 
-instance (Era era, NamespaceEra v ~ era) => FromCanonicalCBOR v CanonicalCommitteeState where
+instance (Era era, NamespaceEra v ~ era) => FromCanonicalCBOR v CanonicalCommittee where
   fromCanonicalCBOR = do
-    st_ <- fromCanonicalCBOR
-    return $ CanonicalCommitteeState <$> st_
-
-instance (Era era, NamespaceEra v ~ era) => ToCanonicalCBOR v CanonicalCommitteeAuthorization where
-  toCanonicalCBOR v (CanonicalCommitteeHotCredential cred) =
-    toCanonicalCBOR v (0 :: Word8, cred)
-  toCanonicalCBOR v (CanonicalCommitteeMemberResigned ma) =
-    toCanonicalCBOR v (1 :: Word8, ma)
-
-instance (Era era, NamespaceEra v ~ era) => FromCanonicalCBOR v CanonicalCommitteeAuthorization where
-  fromCanonicalCBOR = do
-    decodeListLenCanonicalOf 2
-    Versioned (tag :: Word8) <- fromCanonicalCBOR
-    case tag of
-      0 -> fmap CanonicalCommitteeHotCredential <$> fromCanonicalCBOR @v
-      1 -> fmap CanonicalCommitteeMemberResigned <$> fromCanonicalCBOR @v
-      _ -> fail "Invalid CommitteeAuthorization tag"
-
-data CanonicalCommitteeAuthorization
-  = CanonicalCommitteeHotCredential (Credential HotCommitteeRole)
-  | CanonicalCommitteeMemberResigned (StrictMaybe Anchor)
-  deriving (Eq, Show, Ord, Generic)
-
-mkCanonicalCommitteeAuthorization :: CommitteeAuthorization -> CanonicalCommitteeAuthorization
-mkCanonicalCommitteeAuthorization (CommitteeHotCredential credential) = CanonicalCommitteeHotCredential credential
-mkCanonicalCommitteeAuthorization (CommitteeMemberResigned anchor) = CanonicalCommitteeMemberResigned anchor
-
-fromCanonicalCommitteeAuthorization :: CanonicalCommitteeAuthorization -> CommitteeAuthorization
-fromCanonicalCommitteeAuthorization (CanonicalCommitteeHotCredential credential) = CommitteeHotCredential credential
-fromCanonicalCommitteeAuthorization (CanonicalCommitteeMemberResigned anchor) = CommitteeMemberResigned anchor
+    Versioned (members, threshold) <- fromCanonicalCBOR @v
+    return $
+      Versioned $
+        CanonicalCommittee {committeeMembers = members, committeeThreshold = threshold}

--- a/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
+++ b/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.BaseTypes (EpochInterval, NonNegativeInterval, UnitInterva
 import Cardano.Ledger.CanonicalState.BasicTypes (CanonicalExUnits (..))
 import Cardano.Ledger.CanonicalState.Conway ()
 import qualified Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 as Blocks.V0
-import qualified Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 as Committee.V0
+import qualified Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 as GovCommittee.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovConstitution.V0 as GovConstitution.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovPParams.V0 as GovPParams.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.UTxO.V0 as UTxO.V0
@@ -41,11 +41,8 @@ spec = do
       isCanonical @"utxo/v0" @(UTxO.V0.UtxoOut ConwayEra)
       validateType @"utxo/v0" @(UTxO.V0.UtxoOut ConwayEra) "record_entry"
     describe "gov/committee/v0" $ do
-      isCanonical @"gov/committee/v0" @Committee.V0.CanonicalCommitteeState
-      validateType @"gov/committee/v0" @Committee.V0.CanonicalCommitteeState "committee"
-      isCanonical @"gov/committee/v0" @Committee.V0.CanonicalCommitteeAuthorization
-      validateType @"gov/committee/v0" @Committee.V0.CanonicalCommitteeAuthorization
-        "committee_authorization"
+      isCanonical @"gov/committee/v0" @GovCommittee.V0.CanonicalCommittee
+      validateType @"gov/committee/v0" @GovCommittee.V0.CanonicalCommittee "committee"
     describe "gov/constitution/v0" $ do
       isCanonical @"gov/constitution/v0" @GovConstitution.V0.CanonicalConstitution
       validateType @"gov/constitution/v0" @GovConstitution.V0.CanonicalConstitution "record_entry"

--- a/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
+++ b/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
@@ -17,6 +17,7 @@ import Cardano.Ledger.BaseTypes (EpochInterval, NonNegativeInterval, UnitInterva
 import Cardano.Ledger.CanonicalState.BasicTypes (CanonicalExUnits (..))
 import Cardano.Ledger.CanonicalState.Conway ()
 import qualified Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 as Blocks.V0
+import qualified Cardano.Ledger.CanonicalState.Namespace.EntitiesCommittee.V0 as Committee.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 as GovCommittee.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovConstitution.V0 as GovConstitution.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovPParams.V0 as GovPParams.V0
@@ -40,6 +41,12 @@ spec = do
     describe "utxo/v0" $ do
       isCanonical @"utxo/v0" @(UTxO.V0.UtxoOut ConwayEra)
       validateType @"utxo/v0" @(UTxO.V0.UtxoOut ConwayEra) "record_entry"
+    describe "entities/committee/v0" $ do
+      isCanonical @"entities/committee/v0" @Committee.V0.CanonicalCommitteeState
+      validateType @"entities/committee/v0" @Committee.V0.CanonicalCommitteeState "committee_state"
+      isCanonical @"entities/committee/v0" @Committee.V0.CanonicalCommitteeAuthorization
+      validateType @"entities/committee/v0" @Committee.V0.CanonicalCommitteeAuthorization
+        "committee_authorization"
     describe "gov/committee/v0" $ do
       isCanonical @"gov/committee/v0" @GovCommittee.V0.CanonicalCommittee
       validateType @"gov/committee/v0" @GovCommittee.V0.CanonicalCommittee "committee"
@@ -60,6 +67,7 @@ spec = do
   describe "namespaces" $ do
     testNS @"blocks/v0"
     testNS @"utxo/v0"
+    testNS @"entities/committee/v0"
     testNS @"gov/constitution/v0"
     testNS @"gov/committee/v0"
     testNS @"gov/pparams/v0"

--- a/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
+++ b/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
@@ -50,6 +50,8 @@ spec = do
     describe "gov/committee/v0" $ do
       isCanonical @"gov/committee/v0" @GovCommittee.V0.CanonicalCommittee
       validateType @"gov/committee/v0" @GovCommittee.V0.CanonicalCommittee "committee"
+      isCanonical @"gov/committee/v0" @GovCommittee.V0.GovCommitteeOut
+      validateType @"gov/committee/v0" @GovCommittee.V0.GovCommitteeOut "record_entry"
     describe "gov/constitution/v0" $ do
       isCanonical @"gov/constitution/v0" @GovConstitution.V0.CanonicalConstitution
       validateType @"gov/constitution/v0" @GovConstitution.V0.CanonicalConstitution "record_entry"

--- a/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
+++ b/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.CanonicalState.BasicTypes (
  )
 import Cardano.Ledger.CanonicalState.Conway ()
 import qualified Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 as Blocks.V0
-import qualified Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 as Committee.V0
+import qualified Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 as GovCommittee.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovPParams.V0 as GovPParams.V0 ()
 import qualified Cardano.Ledger.CanonicalState.Namespace.UTxO.V0 as UtxoOut.V0
 import Cardano.Ledger.Coin (CompactForm (CompactCoin))
@@ -34,13 +34,10 @@ instance (EraTxOut era, Arbitrary (TxOut era), Era era) => Arbitrary (UtxoOut.V0
 instance Arbitrary CanonicalCoin where
   arbitrary = CanonicalCoin . CompactCoin <$> arbitrary
 
-instance Arbitrary Committee.V0.GovCommitteeOut where
+instance Arbitrary GovCommittee.V0.GovCommitteeOut where
   arbitrary = genericArbitraryU
 
-instance Arbitrary Committee.V0.CanonicalCommitteeAuthorization where
-  arbitrary = fmap Committee.V0.mkCanonicalCommitteeAuthorization arbitrary
-
-instance Arbitrary Committee.V0.CanonicalCommitteeState where arbitrary = genericArbitraryU
+instance Arbitrary GovCommittee.V0.CanonicalCommittee where arbitrary = genericArbitraryU
 
 instance Arbitrary CanonicalExUnits where
   arbitrary = mkCanonicalExUnits <$> arbitrary

--- a/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
+++ b/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
@@ -37,7 +37,8 @@ instance Arbitrary CanonicalCoin where
 instance Arbitrary GovCommittee.V0.GovCommitteeOut where
   arbitrary = genericArbitraryU
 
-instance Arbitrary GovCommittee.V0.CanonicalCommittee where arbitrary = genericArbitraryU
+instance Arbitrary GovCommittee.V0.CanonicalCommittee where
+  arbitrary = genericArbitraryU
 
 instance Arbitrary CanonicalExUnits where
   arbitrary = mkCanonicalExUnits <$> arbitrary

--- a/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
+++ b/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/CanonicalState/Arbitrary.hs
@@ -14,6 +14,7 @@ import Cardano.Ledger.CanonicalState.BasicTypes (
  )
 import Cardano.Ledger.CanonicalState.Conway ()
 import qualified Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 as Blocks.V0
+import qualified Cardano.Ledger.CanonicalState.Namespace.EntitiesCommittee.V0 as EntitiesCommittee.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 as GovCommittee.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovPParams.V0 as GovPParams.V0 ()
 import qualified Cardano.Ledger.CanonicalState.Namespace.UTxO.V0 as UtxoOut.V0
@@ -33,6 +34,15 @@ instance (EraTxOut era, Arbitrary (TxOut era), Era era) => Arbitrary (UtxoOut.V0
 
 instance Arbitrary CanonicalCoin where
   arbitrary = CanonicalCoin . CompactCoin <$> arbitrary
+
+instance Arbitrary EntitiesCommittee.V0.EntitiesCommitteeOut where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary EntitiesCommittee.V0.CanonicalCommitteeState where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary EntitiesCommittee.V0.CanonicalCommitteeAuthorization where
+  arbitrary = fmap EntitiesCommittee.V0.mkCanonicalCommitteeAuthorization arbitrary
 
 instance Arbitrary GovCommittee.V0.GovCommitteeOut where
   arbitrary = genericArbitraryU


### PR DESCRIPTION
# Description

This PR refactors the `gov/committee/v0` canonical namespace to reflect the committee data from `GovState`. The previous implementation with the committee state data is now used to define the `entities/committee/v0` canonical namespace instead.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
