### PR TITLE
Consolidate ledger-state queries

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `Ord` instance for `RewardInfoPool` and `RewardParams`.
 * Add `updateUTxOStateNoFees`
 * Add `Shelley.API.Forecast` and `Shelley.Forecast`:
   - Add `EraForecast` and `ShelleyEraForecast` typeclasses to deprecate `GetLedgerView` from `cardano-ledger-tpraos`.

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 1.19.0.0
 
+* Export `currentSnapshot` from `Shelley.API.Wallet`.
+* Deprecate `Shelley.API.Wallet` query functions in favour of `Cardano.Ledger.Api.State.Query` sub-modules:
+  - `getUTxO`
+  - `getFilteredUTxO`
+  - `getUTxOSubset`
+  - `getPools`
+  - `getStakePools`
+  - `poolsByTotalStakeFraction`
+  - `getTotalStake`
+  - `getNonMyopicMemberRewards`
+  - `currentSnapshot`
+  - `getRewardInfoPools`
+  - `getRewardProvenance`.
 * Add `Ord` instance for `RewardInfoPool` and `RewardParams`.
 * Add `updateUTxOStateNoFees`
 * Add `Shelley.API.Forecast` and `Shelley.Forecast`:

--- a/eras/shelley/impl/CHANGELOG.md.orig
+++ b/eras/shelley/impl/CHANGELOG.md.orig
@@ -2,20 +2,11 @@
 
 ## 1.19.0.0
 
-* Remove query functions from `Shelley.API.Wallet` in favour of `Cardano.Ledger.Api.State.Query` sub-modules:
-  - `getUTxO` → `queryUTxOFull` in `Query.UTxO`
-  - `getFilteredUTxO` → `queryUTxOByAddress` in `Query.UTxO`
-  - `getUTxOSubset` → `queryUTxOByTxIn` in `Query.UTxO`
-  - `getPools` → `queryStakePools` in `Query.Pool`
-  - `getStakePools` → `queryPoolState` / `queryStakePoolParams` in `Query.Pool`
-  - `poolsByTotalStakeFraction` → `queryStakePoolDistrByTotalSupply` in `Query.Pool`
-  - `getTotalStake` → use `circulation` from `Cardano.Ledger.Shelley.LedgerState`
-  - `getNonMyopicMemberRewards` → `queryNonMyopicMemberRewards` in `Query.Reward`
-  - `currentSnapshot` → `queryCurrentSnapshot` in `Query.Snapshot`
-  - `getRewardInfoPools` → `queryRewardInfoPools` in `Query.Reward`
-  - `getRewardProvenance` → `queryRewardProvenance` in `Query.Reward`
-* Add `Ord` instance for `RewardInfoPool` and `RewardParams`.
+<<<<<<< HEAD
 * Add `updateUTxOStateNoFees`
+=======
+* Add `Ord` instance for `RewardInfoPool` and `RewardParams`.
+>>>>>>> 0b2a8412c (Add Query.Reward.)
 * Add `Shelley.API.Forecast` and `Shelley.Forecast`:
   - Add `EraForecast` and `ShelleyEraForecast` typeclasses to deprecate `GetLedgerView` from `cardano-ledger-tpraos`.
   - Add `currentForecast` and `futureForecast` functions to deprecate `currentLedgerView` and `futureLedgerView`.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -37,6 +37,9 @@ module Cardano.Ledger.Shelley.API.Wallet (
   totalAdaES,
   totalAdaPotsES,
   getStakePools,
+
+  -- * Snapshots
+  currentSnapshot,
 ) where
 
 import Cardano.Ledger.Address (compactAddr)
@@ -122,6 +125,10 @@ getUTxO ::
   NewEpochState era ->
   UTxO era
 getUTxO = utxosUtxo . lsUTxOState . esLState . nesEs
+{-# DEPRECATED
+  getUTxO
+  "Use queryUTxOFull from Cardano.Ledger.Api.State.Query.UTxO instead."
+  #-}
 
 -- | Get the UTxO filtered by address.
 getFilteredUTxO ::
@@ -139,12 +146,20 @@ getFilteredUTxO ss addrSet =
         Left addr -> addr `Set.member` addrSet
         Right cAddr -> cAddr `Set.member` compactAddrSet
 {-# INLINEABLE getFilteredUTxO #-}
+{-# DEPRECATED
+  getFilteredUTxO
+  "Use queryUTxOByAddress from Cardano.Ledger.Api.State.Query.UTxO instead."
+  #-}
 
 getUTxOSubset ::
   NewEpochState era ->
   Set TxIn ->
   UTxO era
 getUTxOSubset nes = txInsFilter (getUTxO nes)
+{-# DEPRECATED
+  getUTxOSubset
+  "Use queryUTxOByTxIn from Cardano.Ledger.Api.State.Query.UTxO instead."
+  #-}
 
 --------------------------------------------------------------------------------
 -- Stake pools and pool rewards
@@ -158,6 +173,10 @@ getPools ::
 getPools = Map.keysSet . f
   where
     f nes = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
+{-# DEPRECATED
+  getPools
+  "Use queryStakePools from Cardano.Ledger.Api.State.Query.Pool instead."
+  #-}
 
 -- | Get the /current/ registered stake pool state for a given set of
 -- stake pools. The result map will contain entries for all the given stake
@@ -170,6 +189,10 @@ getStakePools ::
 getStakePools = Map.restrictKeys . f
   where
     f nes = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
+{-# DEPRECATED
+  getStakePools
+  "Use queryPoolState or queryStakePoolParams from Cardano.Ledger.Api.State.Query.Pool instead."
+  #-}
 
 -- | Get pool sizes, but in terms of total stake
 --
@@ -200,6 +223,10 @@ poolsByTotalStakeFraction globals nes =
       IndividualPoolStake
     toTotalStakeFrac (IndividualPoolStake s c vrf) =
       IndividualPoolStake (s * stakeRatio) c vrf
+{-# DEPRECATED
+  poolsByTotalStakeFraction
+  "Use queryStakePoolDistrByTotalSupply from Cardano.Ledger.Api.State.Query.Pool instead"
+  #-}
 
 -- | Calculate the current total stake.
 getTotalStake :: Globals -> NewEpochState era -> Coin
@@ -207,6 +234,10 @@ getTotalStake globals ss =
   let supply = Coin . fromIntegral $ maxLovelaceSupply globals
       es = nesEs ss
    in circulation es supply
+{-# DEPRECATED
+  getTotalStake
+  "Use 'circulation' from Cardano.Ledger.Shelley.LedgerState instead."
+  #-}
 
 -- | Calculate the Non-Myopic Pool Member Rewards for a set of credentials.
 -- For each given credential, this function returns a map from each stake
@@ -252,6 +283,10 @@ getNonMyopicMemberRewards globals ss = Map.fromSet nmmRewards
       getTopRankedPools rPot totalStakeCoin pp $
         Map.intersectionWith (,) (VMap.toMap (VMap.map percentile' ls)) $
           VMap.toMap stakePoolsSnapShot
+{-# DEPRECATED
+  getNonMyopicMemberRewards
+  "Use queryNonMyopicMemberRewards from Cardano.Ledger.Api.State.Query.Reward instead"
+  #-}
 
 -- | Create a current snapshot of the ledger state.
 --
@@ -266,6 +301,10 @@ currentSnapshot nes =
     instantStake = ledgerState ^. instantStakeG
     dstate = ledgerState ^. lsCertStateL . certDStateL
     pstate = ledgerState ^. lsCertStateL . certPStateL
+{-# DEPRECATED
+  currentSnapshot
+  "Use queryCurrentSnapshot from Cardano.Ledger.Api.State.Query.Snapshot instead."
+  #-}
 
 -- | Information about a stake pool
 data RewardInfoPool = RewardInfoPool
@@ -359,6 +398,7 @@ getRewardInfoPools globals nes =
         , performanceEstimate =
             unPerformanceEstimate $ percentile' $ histLookup poolId
         }
+{-# DEPRECATED getRewardInfoPools "Use queryRewardInfoPools from Cardano.Ledger.Api.State.Query.Reward instead" #-}
 
 -- | Calculate stake pool rewards from the snapshot labeled `go`.
 -- Also includes information on how the rewards were calculated
@@ -366,10 +406,6 @@ getRewardInfoPools globals nes =
 --
 -- For a calculation of rewards based on the current stake distribution,
 -- see 'getRewardInfoPools'.
---
--- TODO: Deprecate 'getRewardProvenance', because wallets are more
--- likely to use 'getRewardInfoPools' for up-to-date information
--- on stake pool rewards.
 getRewardProvenance ::
   forall era.
   (EraGov era, EraCertState era) =>
@@ -391,6 +427,7 @@ getRewardProvenance globals newEpochState =
     slotsPerEpoch = epochInfoSize (epochInfoPure globals) epochNo
     asc = activeSlotCoeff globals
     secparam = securityParameter globals
+{-# DEPRECATED getRewardProvenance "Use queryRewardProvenance from Cardano.Ledger.Api.State.Query.Reward instead" #-}
 
 --------------------------------------------------------------------------------
 -- Transaction helpers

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -284,7 +284,7 @@ data RewardInfoPool = RewardInfoPool
   -- Can be larger than @1.0@ for pool that gets lucky.
   -- (If some pools get unlucky, some pools must get lucky.)
   }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance NoThunks RewardInfoPool
 
@@ -305,7 +305,7 @@ data RewardParams = RewardParams
   , totalStake :: Coin
   -- ^ Maximum lovelace supply minus treasury
   }
-  deriving (Eq, Show, Generic)
+  deriving (Eq, Ord, Show, Generic)
 
 instance NoThunks RewardParams
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs
@@ -1,33 +1,15 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 -- FIXME: use better names for record names
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Cardano.Ledger.Shelley.API.Wallet (
-  -- * UTxOs
-  getUTxO,
-  getUTxOSubset,
-  getFilteredUTxO,
-
-  -- * Stake Pools
-  getPools,
-  getTotalStake,
-  poolsByTotalStakeFraction,
+  -- * Reward types
   RewardInfoPool (..),
   RewardParams (..),
-  getRewardInfoPools,
-  getRewardProvenance,
-  getNonMyopicMemberRewards,
 
   -- * Transaction helpers
   addKeyWitnesses,
@@ -36,20 +18,11 @@ module Cardano.Ledger.Shelley.API.Wallet (
   AdaPots (..),
   totalAdaES,
   totalAdaPotsES,
-  getStakePools,
-
-  -- * Snapshots
-  currentSnapshot,
 ) where
 
-import Cardano.Ledger.Address (compactAddr)
 import Cardano.Ledger.BaseTypes (
-  Globals (..),
   NonNegativeInterval,
   UnitInterval,
-  epochInfoPure,
-  unNonZero,
-  (%?),
  )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -66,8 +39,6 @@ import Cardano.Ledger.Binary.Coders (
   (<!),
  )
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Compactible (fromCompact)
-import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Keys (WitVKey (..))
 import Cardano.Ledger.Shelley.AdaPots (
   AdaPots (..),
@@ -75,236 +46,14 @@ import Cardano.Ledger.Shelley.AdaPots (
   totalAdaPotsES,
  )
 import Cardano.Ledger.Shelley.Core
-import Cardano.Ledger.Shelley.LedgerState (
-  EpochState (..),
-  LedgerState (..),
-  NewEpochState (..),
-  RewardUpdate,
-  UTxOState (..),
-  circulation,
-  createRUpd,
-  curPParamsEpochStateL,
-  esLStateL,
-  lsCertStateL,
-  nesEsL,
- )
-import Cardano.Ledger.Shelley.PoolRank (
-  NonMyopic (..),
-  PerformanceEstimate (..),
-  calcNonMyopicMemberReward,
-  getTopRankedPools,
-  percentile',
- )
-import Cardano.Ledger.Shelley.RewardProvenance (RewardProvenance)
-import Cardano.Ledger.Shelley.Rewards (StakeShare (..))
-import Cardano.Ledger.Shelley.State
-import Cardano.Ledger.Slot (epochInfoSize)
-import qualified Cardano.Ledger.State as EB
-import Cardano.Ledger.TxIn (TxIn (..))
-import Cardano.Slotting.Slot (EpochSize)
 import Control.DeepSeq (NFData)
-import Control.Monad.Trans.Reader (runReader)
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Default (Default (def))
-import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
-import qualified Data.VMap as VMap
 import Data.Word (Word16)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks (..))
-
---------------------------------------------------------------------------------
--- UTxOs
---------------------------------------------------------------------------------
-
--- | Get the full UTxO.
-getUTxO ::
-  NewEpochState era ->
-  UTxO era
-getUTxO = utxosUtxo . lsUTxOState . esLState . nesEs
-{-# DEPRECATED
-  getUTxO
-  "Use queryUTxOFull from Cardano.Ledger.Api.State.Query.UTxO instead."
-  #-}
-
--- | Get the UTxO filtered by address.
-getFilteredUTxO ::
-  EraTxOut era =>
-  NewEpochState era ->
-  Set Addr ->
-  UTxO era
-getFilteredUTxO ss addrSet =
-  UTxO $ Map.filter checkAddr fullUTxO
-  where
-    UTxO fullUTxO = getUTxO ss
-    compactAddrSet = Set.map compactAddr addrSet
-    checkAddr out =
-      case out ^. addrEitherTxOutL of
-        Left addr -> addr `Set.member` addrSet
-        Right cAddr -> cAddr `Set.member` compactAddrSet
-{-# INLINEABLE getFilteredUTxO #-}
-{-# DEPRECATED
-  getFilteredUTxO
-  "Use queryUTxOByAddress from Cardano.Ledger.Api.State.Query.UTxO instead."
-  #-}
-
-getUTxOSubset ::
-  NewEpochState era ->
-  Set TxIn ->
-  UTxO era
-getUTxOSubset nes = txInsFilter (getUTxO nes)
-{-# DEPRECATED
-  getUTxOSubset
-  "Use queryUTxOByTxIn from Cardano.Ledger.Api.State.Query.UTxO instead."
-  #-}
-
---------------------------------------------------------------------------------
--- Stake pools and pool rewards
---------------------------------------------------------------------------------
-
--- | Get the /current/ registered stake pools.
-getPools ::
-  EraCertState era =>
-  NewEpochState era ->
-  Set (KeyHash StakePool)
-getPools = Map.keysSet . f
-  where
-    f nes = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
-{-# DEPRECATED
-  getPools
-  "Use queryStakePools from Cardano.Ledger.Api.State.Query.Pool instead."
-  #-}
-
--- | Get the /current/ registered stake pool state for a given set of
--- stake pools. The result map will contain entries for all the given stake
--- pools that are currently registered.
-getStakePools ::
-  EraCertState era =>
-  NewEpochState era ->
-  Set (KeyHash StakePool) ->
-  Map (KeyHash StakePool) StakePoolState
-getStakePools = Map.restrictKeys . f
-  where
-    f nes = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
-{-# DEPRECATED
-  getStakePools
-  "Use queryPoolState or queryStakePoolParams from Cardano.Ledger.Api.State.Query.Pool instead."
-  #-}
-
--- | Get pool sizes, but in terms of total stake
---
--- The stake distribution uses active stake (so that the leader schedule is not
--- affected by undelegated stake), but the wallet wants to display pool
--- saturation for rewards purposes. For that, it needs the fraction of total
--- stake.
---
--- The fields `individualTotalPoolStake` and `pdTotalActiveStake` continue to
--- remain based on active stake and not total stake.
---
--- This is not based on any snapshot, but uses the current ledger state.
-poolsByTotalStakeFraction ::
-  (EraStake era, EraCertState era) =>
-  Globals ->
-  NewEpochState era ->
-  PoolDistr
-poolsByTotalStakeFraction globals nes =
-  PoolDistr poolsByTotalStake totalActiveStake
-  where
-    snap = currentSnapshot nes
-    Coin totalStake = getTotalStake globals nes
-    stakeRatio = unCoin (unNonZero totalActiveStake) %? totalStake
-    PoolDistr poolsByActiveStake totalActiveStake = calculatePoolDistr snap
-    poolsByTotalStake = Map.map toTotalStakeFrac poolsByActiveStake
-    toTotalStakeFrac ::
-      IndividualPoolStake ->
-      IndividualPoolStake
-    toTotalStakeFrac (IndividualPoolStake s c vrf) =
-      IndividualPoolStake (s * stakeRatio) c vrf
-{-# DEPRECATED
-  poolsByTotalStakeFraction
-  "Use queryStakePoolDistrByTotalSupply from Cardano.Ledger.Api.State.Query.Pool instead"
-  #-}
-
--- | Calculate the current total stake.
-getTotalStake :: Globals -> NewEpochState era -> Coin
-getTotalStake globals ss =
-  let supply = Coin . fromIntegral $ maxLovelaceSupply globals
-      es = nesEs ss
-   in circulation es supply
-{-# DEPRECATED
-  getTotalStake
-  "Use 'circulation' from Cardano.Ledger.Shelley.LedgerState instead."
-  #-}
-
--- | Calculate the Non-Myopic Pool Member Rewards for a set of credentials.
--- For each given credential, this function returns a map from each stake
--- pool (identified by the key hash of the pool operator) to the
--- non-myopic pool member reward for that stake pool.
---
--- This is not based on any snapshot, but uses the current ledger state.
-getNonMyopicMemberRewards ::
-  (EraGov era, EraStake era, EraCertState era) =>
-  Globals ->
-  NewEpochState era ->
-  Set (Either Coin (Credential Staking)) ->
-  Map
-    (Either Coin (Credential Staking))
-    (Map (KeyHash StakePool) Coin)
-getNonMyopicMemberRewards globals ss = Map.fromSet nmmRewards
-  where
-    maxSupply = Coin . fromIntegral $ maxLovelaceSupply globals
-    totalStakeCoin@(Coin totalStake) = circulation es maxSupply
-    toShare (Coin x) = StakeShare $ x %? totalStake
-    memShare (Right cred) =
-      toShare $
-        maybe mempty (fromCompact . unNonZero . EB.swdStake) $
-          VMap.lookup cred (EB.unActiveStake activeStake)
-    memShare (Left coin) = toShare coin
-    es = nesEs ss
-    pp = es ^. curPParamsEpochStateL
-    NonMyopic {likelihoodsNM = ls, rewardPotNM = rPot} = esNonMyopic es
-    EB.SnapShot activeStake _ stakePoolsSnapShot = currentSnapshot ss
-    calcNMMRewards t poolId spss
-      | spssPledge <= spssSelfDelegatedOwnersStake =
-          calcNonMyopicMemberReward pp rPot poolId spssCost spssMargin s sigma t topPools hitRateEst
-      | otherwise = mempty
-      where
-        StakePoolSnapShot {spssSelfDelegatedOwnersStake, spssPledge, spssCost, spssMargin} = spss
-        s = toShare spssPledge
-        hitRateEst = percentile' (histLookup poolId)
-        sigma = toShare (fromCompact (spssStake spss))
-
-    nmmRewards cred = VMap.toMap $ VMap.mapWithKey (calcNMMRewards $ memShare cred) stakePoolsSnapShot
-    histLookup k = VMap.findWithDefault mempty k ls
-    topPools =
-      getTopRankedPools rPot totalStakeCoin pp $
-        Map.intersectionWith (,) (VMap.toMap (VMap.map percentile' ls)) $
-          VMap.toMap stakePoolsSnapShot
-{-# DEPRECATED
-  getNonMyopicMemberRewards
-  "Use queryNonMyopicMemberRewards from Cardano.Ledger.Api.State.Query.Reward instead"
-  #-}
-
--- | Create a current snapshot of the ledger state.
---
--- When ranking pools, and reporting their saturation level, in the wallet, we
--- do not want to use one of the regular snapshots, but rather the most recent
--- ledger state.
-currentSnapshot :: (EraStake era, EraCertState era) => NewEpochState era -> EB.SnapShot
-currentSnapshot nes =
-  snapShotFromInstantStake instantStake dstate pstate
-  where
-    ledgerState = esLState $ nesEs nes
-    instantStake = ledgerState ^. instantStakeG
-    dstate = ledgerState ^. lsCertStateL . certDStateL
-    pstate = ledgerState ^. lsCertStateL . certPStateL
-{-# DEPRECATED
-  currentSnapshot
-  "Use queryCurrentSnapshot from Cardano.Ledger.Api.State.Query.Snapshot instead."
-  #-}
 
 -- | Information about a stake pool
 data RewardInfoPool = RewardInfoPool
@@ -353,85 +102,6 @@ instance NFData RewardParams
 deriving instance FromJSON RewardParams
 
 deriving instance ToJSON RewardParams
-
--- | Retrieve the information necessary to calculate stake pool member rewards
--- from the /current/ stake distribution.
---
--- This information includes the current stake distribution aggregated
--- by stake pools and pool owners,
--- the `current` pool costs and margins,
--- and performance estimates.
--- Also included are global information such as
--- the total stake or protocol parameters.
-getRewardInfoPools ::
-  (EraGov era, EraStake era, EraCertState era) =>
-  Globals ->
-  NewEpochState era ->
-  (RewardParams, Map (KeyHash StakePool) RewardInfoPool)
-getRewardInfoPools globals nes =
-  (rewardParams, VMap.toMap $ VMap.mapWithKey mkRewardInfoPool ssStakePoolsSnapShot)
-  where
-    es = nesEs nes
-    pp = es ^. curPParamsEpochStateL
-    NonMyopic
-      { likelihoodsNM = ls
-      , rewardPotNM = rPot
-      } = esNonMyopic es
-    histLookup poolId = VMap.findWithDefault mempty poolId ls
-
-    EB.SnapShot {ssStakePoolsSnapShot} = currentSnapshot nes
-
-    rewardParams =
-      RewardParams
-        { a0 = pp ^. ppA0L
-        , nOpt = pp ^. ppNOptL
-        , totalStake = getTotalStake globals nes
-        , rPot = rPot
-        }
-    mkRewardInfoPool poolId StakePoolSnapShot {..} =
-      RewardInfoPool
-        { stake = fromCompact spssStake
-        , ownerStake = spssSelfDelegatedOwnersStake
-        , ownerPledge = spssPledge
-        , margin = spssMargin
-        , cost = spssCost
-        , performanceEstimate =
-            unPerformanceEstimate $ percentile' $ histLookup poolId
-        }
-{-# DEPRECATED getRewardInfoPools "Use queryRewardInfoPools from Cardano.Ledger.Api.State.Query.Reward instead" #-}
-
--- | Calculate stake pool rewards from the snapshot labeled `go`.
--- Also includes information on how the rewards were calculated
--- ('RewardProvenance').
---
--- For a calculation of rewards based on the current stake distribution,
--- see 'getRewardInfoPools'.
-getRewardProvenance ::
-  forall era.
-  (EraGov era, EraCertState era) =>
-  Globals ->
-  NewEpochState era ->
-  (RewardUpdate, RewardProvenance)
-getRewardProvenance globals newEpochState =
-  ( runReader
-      (createRUpd slotsPerEpoch blocksMade epochState maxSupply asc secparam)
-      globals
-  , def
-  )
-  where
-    epochState = nesEs newEpochState
-    maxSupply = Coin (fromIntegral (maxLovelaceSupply globals))
-    blocksMade = nesBprev newEpochState
-    epochNo = nesEL newEpochState
-    slotsPerEpoch :: EpochSize
-    slotsPerEpoch = epochInfoSize (epochInfoPure globals) epochNo
-    asc = activeSlotCoeff globals
-    secparam = securityParameter globals
-{-# DEPRECATED getRewardProvenance "Use queryRewardProvenance from Cardano.Ledger.Api.State.Query.Reward instead" #-}
-
---------------------------------------------------------------------------------
--- Transaction helpers
---------------------------------------------------------------------------------
 
 addKeyWitnesses :: EraTx era => Tx t era -> Set (WitVKey Witness) -> Tx t era
 addKeyWitnesses tx newWits = tx & witsTxL . addrTxWitsL %~ Set.union newWits

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.14.0.0
 
+* Add new queries to `Query` sub-modules:
+  - Add `queryEpochNo` to `Query.Epoch`.
+  - Add `queryDRepDelegatees` to `Query.Governance`.
+  - Add `queryStakeDelegDeposits` to `Query.StakeDelegation`.
+  - Add `queryCurrentSnapshot` to `Query.Snapshot`.
 * Refactor `Query` into sub-modules for consolidation.
   - `Query.Pool` - stake-pool queries and stake distribution.
   - `Query.Epoch` - chain account state.

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Add to `Query.Pool`: `queryStakePools`, `queryStakePoolDistrByTotalSupply`, `queryStakePoolDistrFromSnapshot`, `queryStakePoolRelays`.
 * Add new queries to `Query` sub-modules:
   - Add `queryEpochNo` to `Query.Epoch`.
   - Add `queryDRepDelegatees` to `Query.Governance`.

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.14.0.0
 
-* Refactor pool related queries into `Query.Pool` and re-export from `Query`.
+* Refactor `Query` into sub-modules for consolidation.
+  - `Query.Pool` - stake-pool queries and stake distribution
+  - `Query.Epoch` - chain account state
 
 ## 1.13.0.0
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -30,7 +30,7 @@
   - `Query.Pool` - stake pool queries and stake distribution
     + Rename `QueryPoolStateResult` to `QueryResultPoolState`.
     + Rename `queryPoolParameters` to `queryStakePoolParams`.
-    + `queryPoolState` now returns all pools states when give an empty set.
+    + `queryPoolState` now returns all pools states when given an empty set.
 
 ## 1.13.0.0
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Add new `Query.Reward` sub-module with `QueryResultRewardInfoPools`, `queryNonMyopicMemberRewards`, `queryRewardInfoPools`, `queryRewardProvenance` (deprecated).
 * Add new `Query.UTxO` sub-module with `queryUTxOFull`, `queryUTxOByAddress`, `queryUTxOByTxIn`.
 * Add new `Query.Debug` sub-module with `queryDebugEpochState`, `queryDebugNewEpochState`, `queryProposedPParamsUpdates` (deprecated).
 * Add to `Query.Pool`: `queryStakePools`, `queryStakePoolDistrByTotalSupply`, `queryStakePoolDistrFromSnapshot`, `queryStakePoolRelays`.

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.14.0.0
 
+* Add new `Query.UTxO` sub-module with `queryUTxOFull`, `queryUTxOByAddress`, `queryUTxOByTxIn`.
+* Add new `Query.Debug` sub-module with `queryDebugEpochState`, `queryDebugNewEpochState`, `queryProposedPParamsUpdates` (deprecated).
 * Add to `Query.Pool`: `queryStakePools`, `queryStakePoolDistrByTotalSupply`, `queryStakePoolDistrFromSnapshot`, `queryStakePoolRelays`.
 * Add new queries to `Query` sub-modules:
   - Add `queryEpochNo` to `Query.Epoch`.

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Refactor `Query` into sub-modules for consolidation.
   - `Query.Pool` - stake-pool queries and stake distribution
   - `Query.Epoch` - chain account state
+  - `Query.Governance` - governance, constitution, committee, and drep queries
+    + Rename `Query.CommitteeMembersState` module to `Query.Governance`.
+    + Add `QueryResultCommitteeMemberState` and `QueryResultCommitteeMembersState` stable query types and deprecate old ones.
 
 ## 1.13.0.0
 
@@ -34,6 +37,7 @@
 
 ### `testlib`
 
+* Add `CBOR` round-trip tests for `QueryResultCommittee*` types.
 * Remove the `State.Query` module and `getFilteredDelegationsAndRewardAccounts` function.
 
 ## 1.12.1.0

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -13,6 +13,9 @@
     + Move governance query functions over: `queryGovState`, `queryConstitution`, `queryConstitutionHash`, `queryProposals`, `queryRatifyState`, `queryCommitteeMembersState`, `queryDRepState`, `queryDRepDelegations`, `queryDRepStakeDistr`, `queryRegisteredDRepStakeDistr`, `getNextEpochCommitteeMembers`.
     + Change `queryConstitution` return type to `QueryResultConstitution`.
     + Change `queryDRepState` return type to `QueryResultDRepStates`.
+  - `Query.Snapshot` - mark/set/go stake snapshots
+    + Add `QueryResultStakeSnapshot(s)` stable types.
+    + `queryStakeSnapshots` now takes `Set (KeyHash StakePool)` where and empty set returns all pools.
 
 ## 1.13.0.0
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## 1.14.0.0
 
 * Refactor `Query` into sub-modules for consolidation.
-  - `Query.Pool` - stake-pool queries and stake distribution
-  - `Query.Epoch` - chain account state
-  - `Query.Governance` - governance, constitution, committee, and drep queries
+  - `Query.Pool` - stake-pool queries and stake distribution.
+  - `Query.Epoch` - chain account state.
+  - `Query.Governance` - governance, constitution, committee, and drep queries.
     + Rename `Query.CommitteeMembersState` module to `Query.Governance`.
     + Add `QueryResultCommitteeMemberState` and `QueryResultCommitteeMembersState` stable query types and deprecate old ones.
     + Add `QueryResultConstitution` stable query type with `toQueryResultConstitution`.
@@ -13,9 +13,11 @@
     + Move governance query functions over: `queryGovState`, `queryConstitution`, `queryConstitutionHash`, `queryProposals`, `queryRatifyState`, `queryCommitteeMembersState`, `queryDRepState`, `queryDRepDelegations`, `queryDRepStakeDistr`, `queryRegisteredDRepStakeDistr`, `getNextEpochCommitteeMembers`.
     + Change `queryConstitution` return type to `QueryResultConstitution`.
     + Change `queryDRepState` return type to `QueryResultDRepStates`.
-  - `Query.Snapshot` - mark/set/go stake snapshots
+  - `Query.Snapshot` - mark/set/go stake snapshots.
     + Add `QueryResultStakeSnapshot(s)` stable types.
     + `queryStakeSnapshots` now takes `Set (KeyHash StakePool)` where and empty set returns all pools.
+  - `Query.StakeDelegation` - stake pool delegations and reward accounts.
+    + Add `QueryResultDelegsAndRewards` stable type for `queryStakePoolDelegsAndRewards`. Returns all registered credentials when given an empty set.
 
 ## 1.13.0.0
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-api`
 
-## 1.13.0.1
+## 1.14.0.0
 
-*
+* Refactor pool related queries into `Query.Pool` and re-export from `Query`.
 
 ## 1.13.0.0
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,35 +2,52 @@
 
 ## 1.14.0.0
 
-* Add new `Query.Reward` sub-module with `QueryResultRewardInfoPools`, `queryNonMyopicMemberRewards`, `queryRewardInfoPools`, `queryRewardProvenance` (deprecated).
-* Add new `Query.UTxO` sub-module with `queryUTxOFull`, `queryUTxOByAddress`, `queryUTxOByTxIn`.
-* Add new `Query.Debug` sub-module with `queryDebugEpochState`, `queryDebugNewEpochState`, `queryProposedPParamsUpdates` (deprecated).
-* Add to `Query.Pool`: `queryStakePools`, `queryStakePoolDistrByTotalSupply`, `queryStakePoolDistrFromSnapshot`, `queryStakePoolRelays`.
+* Add new `Query.Reward` sub-module with:
+  - `QueryResultRewardInfoPools`
+  - `queryNonMyopicMemberRewards` (replaces `getNonMyopicMemberRewards`)
+  - `queryRewardInfoPools` (replaces `getRewardInfoPools`)
+  - `queryRewardProvenance` (replaces `getRewardProvenance`)
+* Add new `Query.UTxO` sub-module with:
+  - `queryUTxOFull` (replaces `getUTxO`)
+  - `queryUTxOByAddress` (replaces `getFilteredUTxO`)
+  - `queryUTxOByTxIn` (replaces `getUTxOSubset`)
+* Add new `Query.Debug` sub-module with `queryDebugEpochState`, `queryDebugNewEpochState`.
+* Add to `Query.Pool`:
+  - `queryStakePools` (replaces `getPools`)
+  - `queryStakePoolDistrByTotalSupply` (replaces `poolsByTotalStakeFraction`)
+  - `queryStakePoolDistrFromSnapshot`
+  - `queryStakePoolRelays`
 * Add new queries to `Query` sub-modules:
   - Add `queryEpochNo` to `Query.Epoch`.
   - Add `queryDRepDelegatees` to `Query.Governance`.
   - Add `queryStakeDelegDeposits` to `Query.StakeDelegation`.
-  - Add `queryCurrentSnapshot` to `Query.Snapshot`.
+  - Add `queryCurrentSnapshot` to `Query.Snapshot` (replaces `currentSnapshot`).
+* Remove deprecated `queryProposedPParamsUpdates` from `Query.Debug` (Shelley-era PParams update mechanism was replaced by Conway governance).
+* Remove deprecated type aliases:
+  - `CommitteeMemberState`, `CommitteeMembersState` from `Query.Governance`
+  - `QueryPoolStateResult`, `mkQueryPoolStateResult`, `queryPoolParameters` from `Query.Pool`
+  - `StakeSnapshot`, `StakeSnapshots` from `Query.Snapshot`
 * Refactor `Query` into sub-modules for consolidation.
   - `Query.Pool` - stake-pool queries and stake distribution.
   - `Query.Epoch` - chain account state.
   - `Query.Governance` - governance, constitution, committee, and drep queries.
     + Rename `Query.CommitteeMembersState` module to `Query.Governance`.
-    + Add `QueryResultCommitteeMemberState` and `QueryResultCommitteeMembersState` stable query types and deprecate old ones.
+    + Add `QueryResultCommitteeMemberState` and `QueryResultCommitteeMembersState` stable query types (replace `CommitteeMemberState` and `CommitteeMembersState`).
     + Add `QueryResultConstitution` stable query type with `toQueryResultConstitution`.
     + Add `QueryResultDRepState` and `QueryResultDRepStates` stable query types with `toQueryResultDRepState`.
     + Move governance query functions over: `queryGovState`, `queryConstitution`, `queryConstitutionHash`, `queryProposals`, `queryRatifyState`, `queryCommitteeMembersState`, `queryDRepState`, `queryDRepDelegations`, `queryDRepStakeDistr`, `queryRegisteredDRepStakeDistr`, `getNextEpochCommitteeMembers`.
     + Change `queryConstitution` return type to `QueryResultConstitution`.
     + Change `queryDRepState` return type to `QueryResultDRepStates`.
   - `Query.Snapshot` - mark/set/go stake snapshots.
-    + Add `QueryResultStakeSnapshot(s)` stable types.
-    + `queryStakeSnapshots` now takes `Set (KeyHash StakePool)` where and empty set returns all pools.
+    + Add `QueryResultStakeSnapshot(s)` stable types (replace `StakeSnapshot` and `StakeSnapshots`).
+    + `queryStakeSnapshots` now takes `Set (KeyHash StakePool)` where an empty set returns all pools.
   - `Query.StakeDelegation` - stake pool delegations and reward accounts.
     + Add `QueryResultDelegsAndRewards` stable type for `queryStakePoolDelegsAndRewards`. Returns all registered credentials when given an empty set.
   - `Query.Pool` - stake pool queries and stake distribution
-    + Rename `QueryPoolStateResult` to `QueryResultPoolState`.
-    + Rename `queryPoolParameters` to `queryStakePoolParams`.
-    + `queryPoolState` now returns all pools states when given an empty set.
+    + Rename `QueryPoolStateResult` to `QueryResultPoolState` (remove old alias).
+    + Rename `queryPoolParameters` to `queryStakePoolParams` (remove old alias).
+    + Rename `mkQueryPoolStateResult` to `toQueryResultPoolState` (remove old alias).
+    + `queryPoolState` (replaces `getStakePools`) now returns all pool states when given an empty set.
 
 ## 1.13.0.0
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -8,6 +8,11 @@
   - `Query.Governance` - governance, constitution, committee, and drep queries
     + Rename `Query.CommitteeMembersState` module to `Query.Governance`.
     + Add `QueryResultCommitteeMemberState` and `QueryResultCommitteeMembersState` stable query types and deprecate old ones.
+    + Add `QueryResultConstitution` stable query type with `toQueryResultConstitution`.
+    + Add `QueryResultDRepState` and `QueryResultDRepStates` stable query types with `toQueryResultDRepState`.
+    + Move governance query functions over: `queryGovState`, `queryConstitution`, `queryConstitutionHash`, `queryProposals`, `queryRatifyState`, `queryCommitteeMembersState`, `queryDRepState`, `queryDRepDelegations`, `queryDRepStakeDistr`, `queryRegisteredDRepStakeDistr`, `getNextEpochCommitteeMembers`.
+    + Change `queryConstitution` return type to `QueryResultConstitution`.
+    + Change `queryDRepState` return type to `QueryResultDRepStates`.
 
 ## 1.13.0.0
 
@@ -37,7 +42,7 @@
 
 ### `testlib`
 
-* Add `CBOR` round-trip tests for `QueryResultCommittee*` types.
+* Add `CBOR` round-trip tests for `QueryResult*` types.
 * Remove the `State.Query` module and `getFilteredDelegationsAndRewardAccounts` function.
 
 ## 1.12.1.0

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -18,6 +18,10 @@
     + `queryStakeSnapshots` now takes `Set (KeyHash StakePool)` where and empty set returns all pools.
   - `Query.StakeDelegation` - stake pool delegations and reward accounts.
     + Add `QueryResultDelegsAndRewards` stable type for `queryStakePoolDelegsAndRewards`. Returns all registered credentials when given an empty set.
+  - `Query.Pool` - stake pool queries and stake distribution
+    + Rename `QueryPoolStateResult` to `QueryResultPoolState`.
+    + Rename `queryPoolParameters` to `queryStakePoolParams`.
+    + `queryPoolState` now returns all pools states when give an empty set.
 
 ## 1.13.0.0
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -45,6 +45,7 @@ library
     Cardano.Ledger.Api.State.Query.Epoch
     Cardano.Ledger.Api.State.Query.Governance
     Cardano.Ledger.Api.State.Query.PParams
+    Cardano.Ledger.Api.State.Query.Snapshot
 
   default-language: Haskell2010
   ghc-options:

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -42,14 +42,15 @@ library
   hs-source-dirs: src
   other-modules:
     Cardano.Ledger.Api.Scripts.ExUnits
+    Cardano.Ledger.Api.State.Query.Debug
     Cardano.Ledger.Api.State.Query.Epoch
     Cardano.Ledger.Api.State.Query.Governance
     Cardano.Ledger.Api.State.Query.PParams
     Cardano.Ledger.Api.State.Query.Pool
+    Cardano.Ledger.Api.State.Query.Reward
     Cardano.Ledger.Api.State.Query.Snapshot
     Cardano.Ledger.Api.State.Query.StakeDelegation
     Cardano.Ledger.Api.State.Query.UTxO
-    Cardano.Ledger.Api.State.Query.Debug
 
   default-language: Haskell2010
   ghc-options:
@@ -114,6 +115,7 @@ library testlib
     cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-core:{cardano-ledger-core, testlib},
     cardano-ledger-dijkstra:testlib,
+    cardano-ledger-shelley,
     data-default,
     generic-random,
     prettyprinter,

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -42,8 +42,8 @@ library
   hs-source-dirs: src
   other-modules:
     Cardano.Ledger.Api.Scripts.ExUnits
-    Cardano.Ledger.Api.State.Query.CommitteeMembersState
     Cardano.Ledger.Api.State.Query.Epoch
+    Cardano.Ledger.Api.State.Query.Governance
     Cardano.Ledger.Api.State.Query.PParams
 
   default-language: Haskell2010
@@ -80,6 +80,7 @@ library
     data-default,
     deepseq,
     microlens,
+    nothunks,
     transformers,
     vector-map >=1.2,
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -45,6 +45,7 @@ library
     Cardano.Ledger.Api.State.Query.Epoch
     Cardano.Ledger.Api.State.Query.Governance
     Cardano.Ledger.Api.State.Query.PParams
+    Cardano.Ledger.Api.State.Query.Pool
     Cardano.Ledger.Api.State.Query.Snapshot
     Cardano.Ledger.Api.State.Query.StakeDelegation
 

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -48,6 +48,8 @@ library
     Cardano.Ledger.Api.State.Query.Pool
     Cardano.Ledger.Api.State.Query.Snapshot
     Cardano.Ledger.Api.State.Query.StakeDelegation
+    Cardano.Ledger.Api.State.Query.UTxO
+    Cardano.Ledger.Api.State.Query.Debug
 
   default-language: Haskell2010
   ghc-options:

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -43,6 +43,7 @@ library
   other-modules:
     Cardano.Ledger.Api.Scripts.ExUnits
     Cardano.Ledger.Api.State.Query.CommitteeMembersState
+    Cardano.Ledger.Api.State.Query.Epoch
     Cardano.Ledger.Api.State.Query.PParams
 
   default-language: Haskell2010

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-api
-version: 1.13.0.1
+version: 1.14.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -43,6 +43,7 @@ library
   other-modules:
     Cardano.Ledger.Api.Scripts.ExUnits
     Cardano.Ledger.Api.State.Query.CommitteeMembersState
+    Cardano.Ledger.Api.State.Query.PParams
 
   default-language: Haskell2010
   ghc-options:

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -46,6 +46,7 @@ library
     Cardano.Ledger.Api.State.Query.Governance
     Cardano.Ledger.Api.State.Query.PParams
     Cardano.Ledger.Api.State.Query.Snapshot
+    Cardano.Ledger.Api.State.Query.StakeDelegation
 
   default-language: Haskell2010
   ghc-options:

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -51,11 +51,8 @@ module Cardano.Ledger.Api.State.Query (
   MemberStatus (..),
   NextEpochChange (..),
 
-  -- * @GetCurrentPParams@
-  queryCurrentPParams,
-
-  -- * @GetFuturePParams@
-  queryFuturePParams,
+  -- * @GetCurrentPParams@ / @GetFuturePParams@
+  module Cardano.Ledger.Api.State.Query.PParams,
 
   -- * @GetProposals@
   queryProposals,
@@ -89,6 +86,7 @@ import Cardano.Ledger.Api.State.Query.CommitteeMembersState (
   MemberStatus (..),
   NextEpochChange (..),
  )
+import Cardano.Ledger.Api.State.Query.PParams
 import Cardano.Ledger.BaseTypes (EpochNo, Network, NonZero, ProtVer (..), strictMaybeToMaybe)
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
@@ -384,22 +382,6 @@ getNextEpochCommitteeMembers nes =
   let ratifyState = queryRatifyState nes
       committee = ratifyState ^. rsEnactStateL . ensCommitteeL
    in foldMap' committeeMembers committee
-
--- | This is a simple lookup into the state for the values of current protocol
--- parameters. These values can change on the epoch boundary. Use `queryFuturePParams` to
--- see if we are aware of any upcoming changes.
-queryCurrentPParams :: EraGov era => NewEpochState era -> PParams era
-queryCurrentPParams nes = queryGovState nes ^. curPParamsGovStateL
-
--- | This query will return values for protocol parameters that are likely to be adopted
--- at the next epoch boundary. It is only when we passed 2 stability windows before the
--- end of the epoch that users can rely on this query to produce stable results.
-queryFuturePParams :: EraGov era => NewEpochState era -> Maybe (PParams era)
-queryFuturePParams nes =
-  case queryGovState nes ^. futurePParamsGovStateL of
-    NoPParamsUpdate -> Nothing
-    PotentialPParamsUpdate mpp -> mpp
-    DefinitePParamsUpdate pp -> Just pp
 
 -- | Query proposals that are considered for ratification.
 queryProposals ::

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -1,5 +1,12 @@
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
+-- | Ledger state queries consolidated from @ouroboros-consensus@, @cardano-api@,
+-- @cardano-cli@, and @cardano-db-sync@.
+--
+-- Each query function includes @Source:@ comments pointing to the original
+-- call sites in these downstream packages. These are intended to guide
+-- downstream propagation of these queries. Once a downstream call site has been
+-- successfully migrated, the corresponding comment may be removed.
 module Cardano.Ledger.Api.State.Query (
   -- * @GetChainAccountState@
   module Cardano.Ledger.Api.State.Query.Epoch,

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -18,11 +18,19 @@ module Cardano.Ledger.Api.State.Query (
 
   -- * @GetFilteredDelegationsAndRewardAccounts@
   module Cardano.Ledger.Api.State.Query.StakeDelegation,
+
+  -- * UTxO queries
+  module Cardano.Ledger.Api.State.Query.UTxO,
+
+  -- * Debug queries
+  module Cardano.Ledger.Api.State.Query.Debug,
 ) where
 
+import Cardano.Ledger.Api.State.Query.Debug
 import Cardano.Ledger.Api.State.Query.Epoch
 import Cardano.Ledger.Api.State.Query.Governance
 import Cardano.Ledger.Api.State.Query.PParams
 import Cardano.Ledger.Api.State.Query.Pool
 import Cardano.Ledger.Api.State.Query.Snapshot
 import Cardano.Ledger.Api.State.Query.StakeDelegation
+import Cardano.Ledger.Api.State.Query.UTxO

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -13,6 +13,9 @@ module Cardano.Ledger.Api.State.Query (
   -- * Pool queries
   module Cardano.Ledger.Api.State.Query.Pool,
 
+  -- * Reward queries
+  module Cardano.Ledger.Api.State.Query.Reward,
+
   -- * @GetStakeSnapshots@
   module Cardano.Ledger.Api.State.Query.Snapshot,
 
@@ -31,6 +34,7 @@ import Cardano.Ledger.Api.State.Query.Epoch
 import Cardano.Ledger.Api.State.Query.Governance
 import Cardano.Ledger.Api.State.Query.PParams
 import Cardano.Ledger.Api.State.Query.Pool
+import Cardano.Ledger.Api.State.Query.Reward
 import Cardano.Ledger.Api.State.Query.Snapshot
 import Cardano.Ledger.Api.State.Query.StakeDelegation
 import Cardano.Ledger.Api.State.Query.UTxO

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-deprecations #-}
-
 -- | Ledger state queries consolidated from @ouroboros-consensus@, @cardano-api@,
 -- @cardano-cli@, and @cardano-db-sync@.
 --

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -1,19 +1,6 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Ledger.Api.State.Query (
-  -- * @GetFilteredDelegationsAndRewardAccounts@
-  module Cardano.Ledger.Api.State.Query.StakeDelegation,
-
-  -- * @GetSPOStakeDistr@
-  querySPOStakeDistr,
-
   -- * @GetChainAccountState@
   module Cardano.Ledger.Api.State.Query.Epoch,
 
@@ -23,130 +10,19 @@ module Cardano.Ledger.Api.State.Query (
   -- * @GetCurrentPParams@ / @GetFuturePParams@
   module Cardano.Ledger.Api.State.Query.PParams,
 
-  -- * @GetStakePoolDefaultVote@
-  queryStakePoolDefaultVote,
-  DefaultVote (..),
-
-  -- * @GetPoolState@
-  queryPoolParameters,
-  queryPoolState,
-  QueryPoolStateResult (..),
-  mkQueryPoolStateResult,
+  -- * Pool queries
+  module Cardano.Ledger.Api.State.Query.Pool,
 
   -- * @GetStakeSnapshots@
   module Cardano.Ledger.Api.State.Query.Snapshot,
+
+  -- * @GetFilteredDelegationsAndRewardAccounts@
+  module Cardano.Ledger.Api.State.Query.StakeDelegation,
 ) where
 
 import Cardano.Ledger.Api.State.Query.Epoch
 import Cardano.Ledger.Api.State.Query.Governance
 import Cardano.Ledger.Api.State.Query.PParams
+import Cardano.Ledger.Api.State.Query.Pool
 import Cardano.Ledger.Api.State.Query.Snapshot
 import Cardano.Ledger.Api.State.Query.StakeDelegation
-import Cardano.Ledger.BaseTypes (EpochNo, Network)
-import Cardano.Ledger.Binary
-import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Compactible (fromCompact)
-import Cardano.Ledger.Conway.Governance (
-  ConwayEraGov,
-  DefaultVote (..),
-  defaultStakePoolVote,
-  psPoolDistr,
- )
-import Cardano.Ledger.Conway.State
-import Cardano.Ledger.Core
-import Cardano.Ledger.Shelley.LedgerState
-import Data.Map (Map)
-import qualified Data.Map.Strict as Map
-import Data.Set (Set)
-import Lens.Micro
-
--- | Query pool stake distribution.
-querySPOStakeDistr ::
-  ConwayEraGov era =>
-  NewEpochState era ->
-  Set (KeyHash StakePool) ->
-  -- | Specify pool key hashes whose stake distribution should be returned. When this set is
-  -- empty, distributions for all of the pools will be returned.
-  Map (KeyHash StakePool) Coin
-querySPOStakeDistr nes keys
-  | null keys = Map.map fromCompact distr
-  | otherwise = Map.map fromCompact $ distr `Map.restrictKeys` keys
-  where
-    distr = psPoolDistr . fst $ finishedPulserState nes
-
--- | Query a stake pool's account address delegatee which determines the pool's default vote
--- in absence of an explicit vote. Note that this is different from the delegatee determined
--- by the credential of the stake pool itself.
-queryStakePoolDefaultVote ::
-  (EraCertState era, ConwayEraAccounts era) =>
-  NewEpochState era ->
-  -- | Specify the key hash of the pool whose default vote should be returned.
-  KeyHash StakePool ->
-  DefaultVote
-queryStakePoolDefaultVote nes poolId =
-  defaultStakePoolVote poolId (nes ^. nesEsL . epochStateStakePoolsL) $
-    nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL
-
--- | Used only for the `queryPoolState` query. This resembles the older way of
--- representing StakePoolState in Ledger.
-data QueryPoolStateResult = QueryPoolStateResult
-  { qpsrStakePoolParams :: !(Map (KeyHash StakePool) StakePoolParams)
-  , qpsrFutureStakePoolParams :: !(Map (KeyHash StakePool) StakePoolParams)
-  , qpsrRetiring :: !(Map (KeyHash StakePool) EpochNo)
-  , qpsrDeposits :: !(Map (KeyHash StakePool) Coin)
-  }
-  deriving (Show, Eq)
-
-instance EncCBOR QueryPoolStateResult where
-  encCBOR (QueryPoolStateResult a b c d) =
-    encodeListLen 4 <> encCBOR a <> encCBOR b <> encCBOR c <> encCBOR d
-
-instance DecCBOR QueryPoolStateResult where
-  decCBOR = decodeRecordNamed "QueryPoolStateResult" (const 4) $ do
-    qpsrStakePoolParams <- decCBOR
-    qpsrFutureStakePoolParams <- decCBOR
-    qpsrRetiring <- decCBOR
-    qpsrDeposits <- decCBOR
-    pure
-      QueryPoolStateResult {qpsrStakePoolParams, qpsrFutureStakePoolParams, qpsrRetiring, qpsrDeposits}
-
-mkQueryPoolStateResult ::
-  (forall x. Map.Map (KeyHash StakePool) x -> Map.Map (KeyHash StakePool) x) ->
-  PState era ->
-  Network ->
-  QueryPoolStateResult
-mkQueryPoolStateResult f ps network =
-  QueryPoolStateResult
-    { qpsrStakePoolParams =
-        Map.mapWithKey (stakePoolStateToStakePoolParams network) restrictedStakePools
-    , qpsrFutureStakePoolParams = f $ psFutureStakePoolParams ps
-    , qpsrRetiring = f $ psRetiring ps
-    , qpsrDeposits = Map.map (fromCompact . spsDeposit) restrictedStakePools
-    }
-  where
-    restrictedStakePools = f $ psStakePools ps
-
--- | Query the QueryPoolStateResult. This is slightly different from the internal
--- representation used by Ledger and is intended to resemble how the internal
--- representation used to be.
-queryPoolState ::
-  EraCertState era =>
-  NewEpochState era -> Maybe (Set (KeyHash StakePool)) -> Network -> QueryPoolStateResult
-queryPoolState nes mPoolKeys network =
-  let pstate = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL
-      f :: forall x. Map.Map (KeyHash StakePool) x -> Map.Map (KeyHash StakePool) x
-      f = case mPoolKeys of
-        Nothing -> id
-        Just keys -> (`Map.restrictKeys` keys)
-   in mkQueryPoolStateResult f pstate network
-
--- | Query the current StakePoolParams.
-queryPoolParameters ::
-  EraCertState era =>
-  Network ->
-  NewEpochState era ->
-  Set (KeyHash StakePool) ->
-  Map (KeyHash StakePool) StakePoolParams
-queryPoolParameters network nes poolKeys =
-  let pools = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
-   in Map.mapWithKey (stakePoolStateToStakePoolParams network) $ Map.restrictKeys pools poolKeys

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -9,7 +9,7 @@
 
 module Cardano.Ledger.Api.State.Query (
   -- * @GetFilteredDelegationsAndRewardAccounts@
-  queryStakePoolDelegsAndRewards,
+  module Cardano.Ledger.Api.State.Query.StakeDelegation,
 
   -- * @GetSPOStakeDistr@
   querySPOStakeDistr,
@@ -41,6 +41,7 @@ import Cardano.Ledger.Api.State.Query.Epoch
 import Cardano.Ledger.Api.State.Query.Governance
 import Cardano.Ledger.Api.State.Query.PParams
 import Cardano.Ledger.Api.State.Query.Snapshot
+import Cardano.Ledger.Api.State.Query.StakeDelegation
 import Cardano.Ledger.BaseTypes (EpochNo, Network)
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Coin (Coin (..))
@@ -53,27 +54,11 @@ import Cardano.Ledger.Conway.Governance (
  )
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Core
-import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Shelley.LedgerState
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Lens.Micro
-
--- | Implementation for @GetFilteredDelegationsAndRewardAccounts@ query.
-queryStakePoolDelegsAndRewards ::
-  EraCertState era =>
-  NewEpochState era ->
-  Set (Credential Staking) ->
-  ( Map (Credential Staking) (KeyHash StakePool)
-  , Map (Credential Staking) Coin
-  )
-queryStakePoolDelegsAndRewards nes creds =
-  let accountsMap = nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL . accountsMapL
-      accountsMapFiltered = accountsMap `Map.restrictKeys` creds
-   in ( Map.mapMaybe (^. stakePoolDelegationAccountStateL) accountsMapFiltered
-      , Map.map (fromCompact . (^. balanceAccountStateL)) accountsMapFiltered
-      )
 
 -- | Query pool stake distribution.
 querySPOStakeDistr ::

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -45,11 +45,9 @@ module Cardano.Ledger.Api.State.Query (
 
   -- * @GetChainAccountState@
   module Cardano.Ledger.Api.State.Query.Epoch,
-  CommitteeMemberState (..),
-  CommitteeMembersState (..),
-  HotCredAuthStatus (..),
-  MemberStatus (..),
-  NextEpochChange (..),
+
+  -- * Committee types
+  module Cardano.Ledger.Api.State.Query.Governance,
 
   -- * @GetCurrentPParams@ / @GetFuturePParams@
   module Cardano.Ledger.Api.State.Query.PParams,
@@ -79,14 +77,8 @@ module Cardano.Ledger.Api.State.Query (
   getNextEpochCommitteeMembers,
 ) where
 
-import Cardano.Ledger.Api.State.Query.CommitteeMembersState (
-  CommitteeMemberState (..),
-  CommitteeMembersState (..),
-  HotCredAuthStatus (..),
-  MemberStatus (..),
-  NextEpochChange (..),
- )
 import Cardano.Ledger.Api.State.Query.Epoch
+import Cardano.Ledger.Api.State.Query.Governance
 import Cardano.Ledger.Api.State.Query.PParams
 import Cardano.Ledger.BaseTypes (EpochNo, Network, NonZero, ProtVer (..), strictMaybeToMaybe)
 import Cardano.Ledger.Binary
@@ -286,7 +278,7 @@ queryCommitteeMembersState ::
   -- (useful, for discovering, for example, only active members)
   Set MemberStatus ->
   NewEpochState era ->
-  CommitteeMembersState
+  QueryResultCommitteeMembersState
 queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
   let
     committee = queryGovState nes ^. committeeGovStateL
@@ -326,7 +318,7 @@ queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
 
     mkMaybeMemberState ::
       Credential ColdCommitteeRole ->
-      Maybe CommitteeMemberState
+      Maybe QueryResultCommitteeMemberState
     mkMaybeMemberState coldCred = do
       let mbExpiry = Map.lookup coldCred comMembers
       let status = case mbExpiry of
@@ -340,7 +332,7 @@ queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
               Nothing -> MemberNotAuthorized
               Just (CommitteeMemberResigned anchor) -> MemberResigned (strictMaybeToMaybe anchor)
               Just (CommitteeHotCredential hk) -> MemberAuthorized hk
-      pure $ CommitteeMemberState hkStatus status mbExpiry (nextEpochChange coldCred)
+      pure $ QueryResultCommitteeMemberState hkStatus status mbExpiry (nextEpochChange coldCred)
 
     nextEpochChange :: Credential ColdCommitteeRole -> NextEpochChange
     nextEpochChange ck
@@ -363,10 +355,10 @@ queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
         expiringCurrent = lookupCurrent == Just currentEpoch
         expiringNext = lookupNext == Just currentEpoch
    in
-    CommitteeMembersState
-      { csCommittee = cms
-      , csThreshold = strictMaybeToMaybe $ (^. committeeThresholdL) <$> committee
-      , csEpochNo = currentEpoch
+    QueryResultCommitteeMembersState
+      { qrcmsCommittee = cms
+      , qrcmsThreshold = strictMaybeToMaybe $ (^. committeeThresholdL) <$> committee
+      , qrcmsEpochNo = currentEpoch
       }
 
 getNextEpochCommitteeMembers ::

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -1,11 +1,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -16,47 +14,17 @@ module Cardano.Ledger.Api.State.Query (
   -- * @GetFilteredDelegationsAndRewardAccounts@
   queryStakePoolDelegsAndRewards,
 
-  -- * @GetGovState@
-  queryGovState,
-
-  -- * @GetConstitution@
-  queryConstitution,
-
-  -- * @GetConstitutionHash@
-  queryConstitutionHash,
-
-  -- * @GetDRepState@
-  queryDRepState,
-
-  -- * @GetDRepDelegations@
-  queryDRepDelegations,
-
-  -- * @GetDRepStakeDistr@
-  queryDRepStakeDistr,
-
-  -- * @GetRegisteredDRepStakeDistr@
-  queryRegisteredDRepStakeDistr,
-
   -- * @GetSPOStakeDistr@
   querySPOStakeDistr,
-
-  -- * @GetCommitteeMembersState@
-  queryCommitteeMembersState,
 
   -- * @GetChainAccountState@
   module Cardano.Ledger.Api.State.Query.Epoch,
 
-  -- * Committee types
+  -- * Governance queries
   module Cardano.Ledger.Api.State.Query.Governance,
 
   -- * @GetCurrentPParams@ / @GetFuturePParams@
   module Cardano.Ledger.Api.State.Query.PParams,
-
-  -- * @GetProposals@
-  queryProposals,
-
-  -- * @GetRatifyState@
-  queryRatifyState,
 
   -- * @GetStakePoolDefaultVote@
   queryStakePoolDefaultVote,
@@ -72,56 +40,31 @@ module Cardano.Ledger.Api.State.Query (
   queryStakeSnapshots,
   StakeSnapshot (..),
   StakeSnapshots (..),
-
-  -- * For testing
-  getNextEpochCommitteeMembers,
 ) where
 
 import Cardano.Ledger.Api.State.Query.Epoch
 import Cardano.Ledger.Api.State.Query.Governance
 import Cardano.Ledger.Api.State.Query.PParams
-import Cardano.Ledger.BaseTypes (EpochNo, Network, NonZero, ProtVer (..), strictMaybeToMaybe)
+import Cardano.Ledger.BaseTypes (EpochNo, Network, NonZero, ProtVer (..))
 import Cardano.Ledger.Binary
-import Cardano.Ledger.Coin (Coin (..), CompactForm (..))
+import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.Governance (
-  Committee (committeeMembers),
-  Constitution (constitutionAnchor),
-  ConwayEraGov (..),
-  DRepPulser (..),
-  DRepPulsingState (..),
+  ConwayEraGov,
   DefaultVote (..),
-  GovActionId,
-  GovActionState (..),
-  PulsingSnapshot,
-  RatifyState,
-  committeeThresholdL,
   defaultStakePoolVote,
-  ensCommitteeL,
-  finishDRepPulser,
-  proposalsDeposits,
-  psDRepDistr,
   psPoolDistr,
-  psProposalsL,
-  rsEnactStateL,
  )
-import Cardano.Ledger.Conway.Rules (updateDormantDRepExpiry)
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.DRep (credToDRep, dRepToCred)
 import Cardano.Ledger.Shelley.LedgerState
 import Control.DeepSeq
 import Control.Monad (guard)
-import Data.Foldable (fold, foldMap')
+import Data.Foldable (fold)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
-import Data.Maybe (fromMaybe, isJust)
-import Data.Sequence (Seq (..))
-import qualified Data.Sequence as Seq
-import Data.Sequence.Strict (StrictSeq (..))
 import Data.Set (Set)
-import qualified Data.Set as Set
 import qualified Data.VMap as VMap
 import GHC.Generics
 import Lens.Micro
@@ -141,116 +84,6 @@ queryStakePoolDelegsAndRewards nes creds =
       , Map.map (fromCompact . (^. balanceAccountStateL)) accountsMapFiltered
       )
 
-queryConstitution :: ConwayEraGov era => NewEpochState era -> Constitution era
-queryConstitution = (^. constitutionGovStateL) . queryGovState
-
-queryConstitutionHash ::
-  ConwayEraGov era =>
-  NewEpochState era ->
-  SafeHash AnchorData
-queryConstitutionHash nes =
-  anchorDataHash . constitutionAnchor $ queryConstitution nes
-
--- | This query returns all of the state related to governance
-queryGovState :: NewEpochState era -> GovState era
-queryGovState nes = nes ^. nesEpochStateL . epochStateGovStateL
-
--- | Query DRep state.
-queryDRepState ::
-  ConwayEraCertState era =>
-  NewEpochState era ->
-  -- | Specify a set of DRep credentials whose state should be returned. When this set is
-  -- empty, states for all of the DReps will be returned.
-  Set (Credential DRepRole) ->
-  Map (Credential DRepRole) DRepState
-queryDRepState nes creds
-  | null creds = updateDormantDRepExpiry' vState ^. vsDRepsL
-  | otherwise = updateDormantDRepExpiry' vStateFiltered ^. vsDRepsL
-  where
-    vStateFiltered = vState & vsDRepsL %~ (`Map.restrictKeys` creds)
-    vState = nes ^. nesEsL . esLStateL . lsCertStateL . certVStateL
-    updateDormantDRepExpiry' = updateDormantDRepExpiry (nes ^. nesELL)
-
--- | Query the delegators delegated to each DRep, including
--- @AlwaysAbstain@ and @NoConfidence@.
-queryDRepDelegations ::
-  forall era.
-  ConwayEraCertState era =>
-  NewEpochState era ->
-  -- | Specify a set of DReps whose state should be returned. When this set is
-  -- empty, states for all of the DReps will be returned.
-  Set DRep ->
-  Map DRep (Set (Credential Staking))
-queryDRepDelegations nes dreps =
-  case getDRepCreds dreps of
-    Just creds ->
-      Map.map drepDelegs $
-        Map.mapKeys credToDRep ((vState ^. vsDRepsL) `Map.restrictKeys` creds)
-    Nothing ->
-      -- Whenever predefined `AlwaysAbstain` or `AlwaysNoConfidence` are
-      -- requested we are forced to iterate over all accounts and find those
-      -- delegations.
-      Map.foldlWithKey'
-        ( \m cred cas ->
-            case cas ^. dRepDelegationAccountStateL of
-              Just drep
-                | Set.null dreps || drep `Set.member` dreps ->
-                    Map.insertWith (<>) drep (Set.singleton cred) m
-              _ ->
-                m
-        )
-        Map.empty
-        (dState ^. accountsL . accountsMapL)
-  where
-    dState = nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL
-    vState = nes ^. nesEsL . esLStateL . lsCertStateL . certVStateL
-    -- Find all credentials for requested DReps, but only when we don't care
-    -- about predefined DReps
-    getDRepCreds ds = do
-      guard $ not $ Set.null ds
-      Set.fromList <$> traverse dRepToCred (Set.elems ds)
-
--- | Query DRep stake distribution. Note that this can be an expensive query because there
--- is a chance that current distribution has not been fully computed yet.
-queryDRepStakeDistr ::
-  ConwayEraGov era =>
-  NewEpochState era ->
-  -- | Specify DRep Ids whose stake distribution should be returned. When this set is
-  -- empty, distributions for all of the DReps will be returned.
-  Set DRep ->
-  Map DRep Coin
-queryDRepStakeDistr nes creds
-  | null creds = Map.map fromCompact distr
-  | otherwise = Map.map fromCompact $ distr `Map.restrictKeys` creds
-  where
-    distr = psDRepDistr . fst $ finishedPulserState nes
-
--- | Query the stake distribution of the registered DReps. This does not
--- include the @AlwaysAbstain@ and @NoConfidence@ DReps.
-queryRegisteredDRepStakeDistr ::
-  (ConwayEraGov era, ConwayEraCertState era) =>
-  NewEpochState era ->
-  -- | Specify DRep Ids whose stake distribution should be returned. When this set is
-  -- empty, distributions for all of the registered DReps will be returned.
-  Set (Credential DRepRole) ->
-  Map (Credential DRepRole) Coin
-queryRegisteredDRepStakeDistr nes creds =
-  Map.foldlWithKey' computeDistr mempty selectedDReps
-  where
-    selectedDReps
-      | null creds = registeredDReps
-      | otherwise = registeredDReps `Map.restrictKeys` creds
-    registeredDReps = nes ^. nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
-    computeDistr distrAcc dRepCred (DRepState {..}) =
-      Map.insert dRepCred (totalDelegations drepDelegs) distrAcc
-    totalDelegations =
-      fromCompact . foldMap stakeAndDeposits
-    instantStake = nes ^. instantStakeL . instantStakeCredentialsL
-    proposalDeposits = proposalsDeposits $ nes ^. newEpochStateGovStateL . proposalsGovStateL
-    stakeAndDeposits stakeCred =
-      fromMaybe (CompactCoin 0) $
-        Map.lookup stakeCred instantStake <> Map.lookup stakeCred proposalDeposits
-
 -- | Query pool stake distribution.
 querySPOStakeDistr ::
   ConwayEraGov era =>
@@ -264,139 +97,6 @@ querySPOStakeDistr nes keys
   | otherwise = Map.map fromCompact $ distr `Map.restrictKeys` keys
   where
     distr = psPoolDistr . fst $ finishedPulserState nes
-
--- | Query committee members. Whenever the system is in No Confidence mode this query will
--- return `Nothing`.
-queryCommitteeMembersState ::
-  forall era.
-  (ConwayEraGov era, ConwayEraCertState era) =>
-  -- | filter by cold credentials (don't filter when empty)
-  Set (Credential ColdCommitteeRole) ->
-  -- | filter by hot credentials (don't filter when empty)
-  Set (Credential HotCommitteeRole) ->
-  -- | filter by status (don't filter when empty)
-  -- (useful, for discovering, for example, only active members)
-  Set MemberStatus ->
-  NewEpochState era ->
-  QueryResultCommitteeMembersState
-queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
-  let
-    committee = queryGovState nes ^. committeeGovStateL
-    comMembers = foldMap' committeeMembers committee
-    nextComMembers = getNextEpochCommitteeMembers nes
-    comStateMembers =
-      csCommitteeCreds $
-        nes ^. nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
-
-    withFilteredColdCreds s
-      | Set.null coldCredsFilter = s
-      | otherwise = s `Set.intersection` coldCredsFilter
-
-    relevantColdKeys
-      | Set.null statusFilter || Set.member Unrecognized statusFilter =
-          withFilteredColdCreds $
-            Set.unions
-              [ Map.keysSet comMembers
-              , Map.keysSet comStateMembers
-              , Map.keysSet nextComMembers
-              ]
-      | otherwise = withFilteredColdCreds $ Map.keysSet comMembers
-
-    relevantHotKeys =
-      Set.fromList
-        [ ck
-        | (ck, CommitteeHotCredential hk) <- Map.toList comStateMembers
-        , hk `Set.member` hotCredsFilter
-        ]
-
-    relevant
-      | Set.null hotCredsFilter = relevantColdKeys
-      | otherwise = relevantColdKeys `Set.intersection` relevantHotKeys
-
-    cms = Map.mapMaybe id $ Map.fromSet mkMaybeMemberState relevant
-    currentEpoch = nes ^. nesELL
-
-    mkMaybeMemberState ::
-      Credential ColdCommitteeRole ->
-      Maybe QueryResultCommitteeMemberState
-    mkMaybeMemberState coldCred = do
-      let mbExpiry = Map.lookup coldCred comMembers
-      let status = case mbExpiry of
-            Nothing -> Unrecognized
-            Just expiry
-              | currentEpoch > expiry -> Expired
-              | otherwise -> Active
-      guard (null statusFilter || status `Set.member` statusFilter)
-      let hkStatus =
-            case Map.lookup coldCred comStateMembers of
-              Nothing -> MemberNotAuthorized
-              Just (CommitteeMemberResigned anchor) -> MemberResigned (strictMaybeToMaybe anchor)
-              Just (CommitteeHotCredential hk) -> MemberAuthorized hk
-      pure $ QueryResultCommitteeMemberState hkStatus status mbExpiry (nextEpochChange coldCred)
-
-    nextEpochChange :: Credential ColdCommitteeRole -> NextEpochChange
-    nextEpochChange ck
-      | not inCurrent && inNext = ToBeEnacted
-      | not inNext = ToBeRemoved
-      | Just curTerm <- lookupCurrent
-      , Just nextTerm <- lookupNext
-      , curTerm /= nextTerm
-      , -- if the term is adjusted such that it expires in the next epoch,
-        -- we set it to ToBeExpired instead of TermAdjusted
-        not expiringNext =
-          TermAdjusted nextTerm
-      | expiringCurrent || expiringNext = ToBeExpired
-      | otherwise = NoChangeExpected
-      where
-        lookupCurrent = Map.lookup ck comMembers
-        lookupNext = Map.lookup ck nextComMembers
-        inCurrent = isJust lookupCurrent
-        inNext = isJust lookupNext
-        expiringCurrent = lookupCurrent == Just currentEpoch
-        expiringNext = lookupNext == Just currentEpoch
-   in
-    QueryResultCommitteeMembersState
-      { qrcmsCommittee = cms
-      , qrcmsThreshold = strictMaybeToMaybe $ (^. committeeThresholdL) <$> committee
-      , qrcmsEpochNo = currentEpoch
-      }
-
-getNextEpochCommitteeMembers ::
-  ConwayEraGov era =>
-  NewEpochState era ->
-  Map (Credential ColdCommitteeRole) EpochNo
-getNextEpochCommitteeMembers nes =
-  let ratifyState = queryRatifyState nes
-      committee = ratifyState ^. rsEnactStateL . ensCommitteeL
-   in foldMap' committeeMembers committee
-
--- | Query proposals that are considered for ratification.
-queryProposals ::
-  ConwayEraGov era =>
-  NewEpochState era ->
-  -- | Specify a set of Governance Action IDs to filter the proposals. When this set is
-  -- empty, all the proposals considered for ratification will be returned.
-  Set GovActionId ->
-  Seq (GovActionState era)
-queryProposals nes gids
-  | null gids = proposals
-  -- TODO: Add `filter` to `cardano-strict-containers`
-  | otherwise =
-      Seq.filter (\GovActionState {..} -> gasId `Set.member` gids) proposals
-  where
-    proposals = fromStrict $ case nes ^. newEpochStateGovStateL . drepPulsingStateGovStateL of
-      DRComplete snap _rs -> snap ^. psProposalsL
-      DRPulsing DRepPulser {..} -> dpProposals
-
--- | Query ratification state.
-queryRatifyState :: ConwayEraGov era => NewEpochState era -> RatifyState era
-queryRatifyState = snd . finishedPulserState
-
-finishedPulserState ::
-  ConwayEraGov era =>
-  NewEpochState era ->
-  (PulsingSnapshot era, RatifyState era)
-finishedPulserState nes = finishDRepPulser (nes ^. newEpochStateGovStateL . drepPulsingStateGovStateL)
 
 -- | Query a stake pool's account address delegatee which determines the pool's default vote
 -- in absence of an explicit vote. Note that this is different from the delegatee determined

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -44,7 +44,7 @@ module Cardano.Ledger.Api.State.Query (
   queryCommitteeMembersState,
 
   -- * @GetChainAccountState@
-  queryChainAccountState,
+  module Cardano.Ledger.Api.State.Query.Epoch,
   CommitteeMemberState (..),
   CommitteeMembersState (..),
   HotCredAuthStatus (..),
@@ -86,6 +86,7 @@ import Cardano.Ledger.Api.State.Query.CommitteeMembersState (
   MemberStatus (..),
   NextEpochChange (..),
  )
+import Cardano.Ledger.Api.State.Query.Epoch
 import Cardano.Ledger.Api.State.Query.PParams
 import Cardano.Ledger.BaseTypes (EpochNo, Network, NonZero, ProtVer (..), strictMaybeToMaybe)
 import Cardano.Ledger.Binary
@@ -132,7 +133,6 @@ import qualified Data.Set as Set
 import qualified Data.VMap as VMap
 import GHC.Generics
 import Lens.Micro
-import Lens.Micro.Extras (view)
 
 -- | Implementation for @GetFilteredDelegationsAndRewardAccounts@ query.
 queryStakePoolDelegsAndRewards ::
@@ -368,11 +368,6 @@ queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
       , csThreshold = strictMaybeToMaybe $ (^. committeeThresholdL) <$> committee
       , csEpochNo = currentEpoch
       }
-
-queryChainAccountState ::
-  NewEpochState era ->
-  ChainAccountState
-queryChainAccountState = view chainAccountStateL
 
 getNextEpochCommitteeMembers ::
   ConwayEraGov era =>

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query.hs
@@ -1,13 +1,10 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Ledger.Api.State.Query (
@@ -37,15 +34,14 @@ module Cardano.Ledger.Api.State.Query (
   mkQueryPoolStateResult,
 
   -- * @GetStakeSnapshots@
-  queryStakeSnapshots,
-  StakeSnapshot (..),
-  StakeSnapshots (..),
+  module Cardano.Ledger.Api.State.Query.Snapshot,
 ) where
 
 import Cardano.Ledger.Api.State.Query.Epoch
 import Cardano.Ledger.Api.State.Query.Governance
 import Cardano.Ledger.Api.State.Query.PParams
-import Cardano.Ledger.BaseTypes (EpochNo, Network, NonZero, ProtVer (..))
+import Cardano.Ledger.Api.State.Query.Snapshot
+import Cardano.Ledger.BaseTypes (EpochNo, Network)
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Compactible (fromCompact)
@@ -59,14 +55,9 @@ import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Shelley.LedgerState
-import Control.DeepSeq
-import Control.Monad (guard)
-import Data.Foldable (fold)
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
-import qualified Data.VMap as VMap
-import GHC.Generics
 import Lens.Micro
 
 -- | Implementation for @GetFilteredDelegationsAndRewardAccounts@ query.
@@ -174,141 +165,3 @@ queryPoolParameters ::
 queryPoolParameters network nes poolKeys =
   let pools = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
    in Map.mapWithKey (stakePoolStateToStakePoolParams network) $ Map.restrictKeys pools poolKeys
-
--- | The stake snapshot returns information about the mark, set, go ledger snapshots for a pool,
--- plus the total active stake for each snapshot that can be used in a 'sigma' calculation.
---
--- Each snapshot is taken at the end of a different era. The go snapshot is the current one and
--- was taken two epochs earlier, set was taken one epoch ago, and mark was taken immediately
--- before the start of the current epoch.
-data StakeSnapshot = StakeSnapshot
-  { ssMarkPool :: !Coin
-  , ssSetPool :: !Coin
-  , ssGoPool :: !Coin
-  }
-  deriving (Eq, Show, Generic)
-
-instance NFData StakeSnapshot
-
-instance EncCBOR StakeSnapshot where
-  encCBOR
-    StakeSnapshot
-      { ssMarkPool
-      , ssSetPool
-      , ssGoPool
-      } =
-      encodeListLen 3
-        <> encCBOR ssMarkPool
-        <> encCBOR ssSetPool
-        <> encCBOR ssGoPool
-
-instance DecCBOR StakeSnapshot where
-  decCBOR = do
-    enforceSize "StakeSnapshot" 3
-    StakeSnapshot
-      <$> decCBOR
-      <*> decCBOR
-      <*> decCBOR
-
-data StakeSnapshots = StakeSnapshots
-  { ssStakeSnapshots :: !(Map (KeyHash StakePool) StakeSnapshot)
-  , ssMarkTotal :: !(NonZero Coin)
-  , ssSetTotal :: !(NonZero Coin)
-  , ssGoTotal :: !(NonZero Coin)
-  }
-  deriving (Eq, Show, Generic)
-
-instance NFData StakeSnapshots
-
-instance EncCBOR StakeSnapshots where
-  encCBOR
-    StakeSnapshots
-      { ssStakeSnapshots
-      , ssMarkTotal
-      , ssSetTotal
-      , ssGoTotal
-      } =
-      encodeListLen 4
-        <> encCBOR ssStakeSnapshots
-        <> encCBOR ssMarkTotal
-        <> encCBOR ssSetTotal
-        <> encCBOR ssGoTotal
-
-instance DecCBOR StakeSnapshots where
-  decCBOR = do
-    enforceSize "StakeSnapshots" 4
-    StakeSnapshots
-      <$> decCBOR
-      <*> decCBOR
-      <*> decCBOR
-      <*> decCBOR
-
--- | Report stake per pool per snapshot as well as total active stake per snapshot.
---
--- /Note/ - Whenever poolIds are not supplied, we collect all of the pools, even if they don't have
--- any delegations. Otherwise we filter out for exact poolIds that were supplied. In both cases it
--- means that there can be pools that have zero stake in all three snapshot, but the meaning of that
--- can be very different:
---
--- * either the pool has no delegations, or
--- * it was explicitly requested even though it has no stake or not even registered
---
--- However, starting with Protocol Version 11 we remove this strange inconsistency and only ever
--- report stake pools with non-zero stake, which means pools without delegations (hence without any stake in any of the three snapshots) are no longer included in the results.
-queryStakeSnapshots ::
-  EraGov era =>
-  NewEpochState era ->
-  Maybe (Set (KeyHash StakePool)) ->
-  StakeSnapshots
-queryStakeSnapshots nes mPoolIds =
-  let SnapShots
-        { ssStakeMark
-        , ssStakeSet
-        , ssStakeGo
-        } = esSnapshots $ nesEs nes
-
-      mkStakeSnapshotMaybe poolId = do
-        let
-          markPoolStake = spssStake <$> VMap.lookup poolId (ssStakePoolsSnapShot ssStakeMark)
-          setPoolStake = spssStake <$> VMap.lookup poolId (ssStakePoolsSnapShot ssStakeSet)
-          goPoolStake = spssStake <$> VMap.lookup poolId (ssStakePoolsSnapShot ssStakeGo)
-        -- Non-registered stake pools or ones that have no stake are of no interest to us.
-        guard (fold [markPoolStake, setPoolStake, goPoolStake] > Just mempty)
-        Just
-          StakeSnapshot
-            { ssMarkPool = maybe mempty fromCompact markPoolStake
-            , ssSetPool = maybe mempty fromCompact setPoolStake
-            , ssGoPool = maybe mempty fromCompact goPoolStake
-            }
-      mkStakeSnapshot poolId =
-        let
-          lookupStake =
-            maybe mempty (fromCompact . spssStake) . VMap.lookup poolId . ssStakePoolsSnapShot
-         in
-          StakeSnapshot
-            { ssMarkPool = lookupStake ssStakeMark
-            , ssSetPool = lookupStake ssStakeSet
-            , ssGoPool = lookupStake ssStakeGo
-            }
-      version = pvMajor (nes ^. nesEsL . curPParamsEpochStateL . ppProtocolVersionL)
-      poolIds =
-        case mPoolIds of
-          Nothing
-            | version < natVersion @11 ->
-                foldMap
-                  (VMap.keysSet . VMap.filter (\_ -> (> 0) . spssNumDelegators) . ssStakePoolsSnapShot)
-                  [ssStakeMark, ssStakeSet, ssStakeGo]
-            | otherwise ->
-                foldMap
-                  (VMap.keysSet . VMap.filter (\_ -> (> mempty) . spssStake) . ssStakePoolsSnapShot)
-                  [ssStakeMark, ssStakeSet, ssStakeGo]
-          Just ids -> ids
-   in StakeSnapshots
-        { ssStakeSnapshots =
-            if version < natVersion @11
-              then Map.fromSet mkStakeSnapshot poolIds
-              else Map.mapMaybe id $ Map.fromSet mkStakeSnapshotMaybe poolIds
-        , ssMarkTotal = ssTotalActiveStake ssStakeMark
-        , ssSetTotal = ssTotalActiveStake ssStakeSet
-        , ssGoTotal = ssTotalActiveStake ssStakeGo
-        }

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Debug.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Debug.hs
@@ -2,16 +2,12 @@ module Cardano.Ledger.Api.State.Query.Debug (
   -- * Debug queries
   queryDebugEpochState,
   queryDebugNewEpochState,
-
-  -- * Deprecated queries
-  queryProposedPParamsUpdates,
 ) where
 
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState,
   NewEpochState (nesEs),
  )
-import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates, emptyPPPUpdates)
 
 -- | Query the full 'EpochState' for debugging.
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:424
@@ -34,15 +30,3 @@ queryDebugEpochState = nesEs
 -- /O(1)/
 queryDebugNewEpochState :: NewEpochState era -> NewEpochState era
 queryDebugNewEpochState = id
-
--- | Query proposed protocol parameter updates.
--- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:420
---   answerPureBlockQuery case for GetProposedPParamsUpdates
---
--- /O(1)/
-queryProposedPParamsUpdates :: NewEpochState era -> ProposedPPUpdates era
-queryProposedPParamsUpdates _ = emptyPPPUpdates
-{-# DEPRECATED
-  queryProposedPParamsUpdates
-  "Shelley-era PParams update mechanism was replaced by Conway governance."
-  #-}

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Debug.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Debug.hs
@@ -19,6 +19,8 @@ import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates, emptyPPPUpdates)
 --
 -- __Warning:__ This returns internal, era-parameterized state that is not
 -- covered by CBOR stability guarantees. Use only for debugging and tooling.
+--
+-- /O(1)/
 queryDebugEpochState :: NewEpochState era -> EpochState era
 queryDebugEpochState = nesEs
 
@@ -28,12 +30,16 @@ queryDebugEpochState = nesEs
 --
 -- __Warning:__ This returns internal, era-parameterized state that is not
 -- covered by CBOR stability guarantees. Use only for debugging and tooling.
+--
+-- /O(1)/
 queryDebugNewEpochState :: NewEpochState era -> NewEpochState era
 queryDebugNewEpochState = id
 
 -- | Query proposed protocol parameter updates.
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:420
 --   answerPureBlockQuery case for GetProposedPParamsUpdates
+--
+-- /O(1)/
 queryProposedPParamsUpdates :: NewEpochState era -> ProposedPPUpdates era
 queryProposedPParamsUpdates _ = emptyPPPUpdates
 {-# DEPRECATED

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Debug.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Debug.hs
@@ -1,0 +1,42 @@
+module Cardano.Ledger.Api.State.Query.Debug (
+  -- * Debug queries
+  queryDebugEpochState,
+  queryDebugNewEpochState,
+
+  -- * Deprecated queries
+  queryProposedPParamsUpdates,
+) where
+
+import Cardano.Ledger.Shelley.LedgerState (
+  EpochState,
+  NewEpochState (nesEs),
+ )
+import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates, emptyPPPUpdates)
+
+-- | Query the full 'EpochState' for debugging.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:424
+--   answerPureBlockQuery case for DebugEpochState
+--
+-- __Warning:__ This returns internal, era-parameterized state that is not
+-- covered by CBOR stability guarantees. Use only for debugging and tooling.
+queryDebugEpochState :: NewEpochState era -> EpochState era
+queryDebugEpochState = nesEs
+
+-- | Query the full 'NewEpochState' for debugging.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:437
+--   answerPureBlockQuery case for DebugNewEpochState
+--
+-- __Warning:__ This returns internal, era-parameterized state that is not
+-- covered by CBOR stability guarantees. Use only for debugging and tooling.
+queryDebugNewEpochState :: NewEpochState era -> NewEpochState era
+queryDebugNewEpochState = id
+
+-- | Query proposed protocol parameter updates.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:420
+--   answerPureBlockQuery case for GetProposedPParamsUpdates
+queryProposedPParamsUpdates :: NewEpochState era -> ProposedPPUpdates era
+queryProposedPParamsUpdates _ = emptyPPPUpdates
+{-# DEPRECATED
+  queryProposedPParamsUpdates
+  "Shelley-era PParams update mechanism was replaced by Conway governance."
+  #-}

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Epoch.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Epoch.hs
@@ -1,0 +1,17 @@
+module Cardano.Ledger.Api.State.Query.Epoch (
+  queryChainAccountState,
+) where
+
+import Cardano.Ledger.Shelley.LedgerState (NewEpochState)
+import Cardano.Ledger.State (ChainAccountState, chainAccountStateL)
+import Lens.Micro ((^.))
+
+-- | Query chain account state (treasury and reserves).
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:475
+--   answerPureBlockQuery case for GetAccountState
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:484
+--   queryAccountState cardano-api wrapper (CLI via Convenience.hs:171)
+queryChainAccountState ::
+  NewEpochState era ->
+  ChainAccountState
+queryChainAccountState nes = nes ^. chainAccountStateL

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Epoch.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Epoch.hs
@@ -1,10 +1,18 @@
 module Cardano.Ledger.Api.State.Query.Epoch (
+  queryEpochNo,
   queryChainAccountState,
 ) where
 
-import Cardano.Ledger.Shelley.LedgerState (NewEpochState)
+import Cardano.Ledger.Shelley.LedgerState (NewEpochState (nesEL))
+import Cardano.Ledger.Slot (EpochNo)
 import Cardano.Ledger.State (ChainAccountState, chainAccountStateL)
 import Lens.Micro ((^.))
+
+-- | Query the current epoch number.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:413
+--   answerPureBlockQuery case for GetEpochNo
+queryEpochNo :: NewEpochState era -> EpochNo
+queryEpochNo = nesEL
 
 -- | Query chain account state (treasury and reserves).
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:475

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Epoch.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Epoch.hs
@@ -11,6 +11,8 @@ import Lens.Micro ((^.))
 -- | Query the current epoch number.
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:413
 --   answerPureBlockQuery case for GetEpochNo
+--
+-- /O(1)/
 queryEpochNo :: NewEpochState era -> EpochNo
 queryEpochNo = nesEL
 
@@ -19,6 +21,8 @@ queryEpochNo = nesEL
 --   answerPureBlockQuery case for GetAccountState
 -- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:484
 --   queryAccountState cardano-api wrapper (CLI via Convenience.hs:171)
+--
+-- /O(1)/
 queryChainAccountState ::
   NewEpochState era ->
   ChainAccountState

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
@@ -191,7 +191,7 @@ instance DecCBOR HotCredAuthStatus where
       k -> Invalid k
 
 data NextEpochChange
-  = --- | Member not enacted yet, but will be at the next epoch
+  = -- | Member not enacted yet, but will be at the next epoch
     ToBeEnacted
   | -- | Member will be removed
     ToBeRemoved

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
@@ -4,17 +4,19 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 
-module Cardano.Ledger.Api.State.Query.CommitteeMembersState (
-  CommitteeMemberState (..),
-  CommitteeMembersState (..),
+module Cardano.Ledger.Api.State.Query.Governance (
+  -- * Committee members state
+  QueryResultCommitteeMemberState (..),
+  QueryResultCommitteeMembersState (..),
   HotCredAuthStatus (..),
   MemberStatus (..),
   NextEpochChange (..),
+
+  -- * Deprecated
+  CommitteeMemberState,
+  CommitteeMembersState,
 ) where
 
 import Cardano.Ledger.BaseTypes (Anchor, KeyValuePairs (..), ToKeyValuePairs (..), UnitInterval)
@@ -28,12 +30,14 @@ import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Slot (EpochNo (..))
+import Control.DeepSeq (NFData)
 import Data.Aeson (ToJSON (..), (.=))
 import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
 
 data MemberStatus
-  = -- Votes of this member will count during ratification
+  = -- | Votes of this member will count during ratification
     Active
   | Expired
   | -- | This can happen when a hot credential for an unknown cold credential exists.
@@ -41,6 +45,10 @@ data MemberStatus
     -- epoch boundary or enacted as a new member.
     Unrecognized
   deriving (Show, Eq, Enum, Bounded, Generic, Ord, ToJSON)
+
+instance NFData MemberStatus
+
+instance NoThunks MemberStatus
 
 instance EncCBOR MemberStatus where
   encCBOR = encodeEnum
@@ -54,6 +62,10 @@ data HotCredAuthStatus
     MemberNotAuthorized
   | MemberResigned (Maybe Anchor)
   deriving (Show, Eq, Generic, Ord, ToJSON)
+
+instance NFData HotCredAuthStatus
+
+instance NoThunks HotCredAuthStatus
 
 instance EncCBOR HotCredAuthStatus where
   encCBOR =
@@ -80,6 +92,10 @@ data NextEpochChange
   | TermAdjusted EpochNo
   deriving (Show, Eq, Generic, Ord, ToJSON)
 
+instance NFData NextEpochChange
+
+instance NoThunks NextEpochChange
+
 instance EncCBOR NextEpochChange where
   encCBOR =
     encode . \case
@@ -99,78 +115,93 @@ instance DecCBOR NextEpochChange where
       4 -> SumD TermAdjusted <! From
       k -> Invalid k
 
-data CommitteeMemberState = CommitteeMemberState
-  { cmsHotCredAuthStatus :: !HotCredAuthStatus
-  , cmsStatus :: !MemberStatus
-  , cmsExpiration :: !(Maybe EpochNo)
+-- | Per-member committee state including authorization, member status, and expiration.
+data QueryResultCommitteeMemberState = QueryResultCommitteeMemberState
+  { qrcmsHotCredAuthStatus :: !HotCredAuthStatus
+  , qrcmsStatus :: !MemberStatus
+  , qrcmsExpiration :: !(Maybe EpochNo)
   -- ^ Absolute epoch number when the member expires
-  , cmsNextEpochChange :: !NextEpochChange
+  , qrcmsNextEpochChange :: !NextEpochChange
   -- ^ Changes to the member at the next epoch
   }
   deriving (Show, Eq, Generic)
-  deriving (ToJSON) via KeyValuePairs CommitteeMemberState
+  deriving (ToJSON) via KeyValuePairs QueryResultCommitteeMemberState
 
-deriving instance Ord CommitteeMemberState
+deriving instance Ord QueryResultCommitteeMemberState
 
-instance EncCBOR CommitteeMemberState where
-  encCBOR (CommitteeMemberState cStatus mStatus ex nec) =
+instance NFData QueryResultCommitteeMemberState
+
+instance NoThunks QueryResultCommitteeMemberState
+
+instance EncCBOR QueryResultCommitteeMemberState where
+  encCBOR (QueryResultCommitteeMemberState hotCredAuth status expiration nextEpoch) =
     encode $
-      Rec CommitteeMemberState
-        !> To cStatus
-        !> To mStatus
-        !> To ex
-        !> To nec
+      Rec QueryResultCommitteeMemberState
+        !> To hotCredAuth
+        !> To status
+        !> To expiration
+        !> To nextEpoch
 
-instance DecCBOR CommitteeMemberState where
+instance DecCBOR QueryResultCommitteeMemberState where
   decCBOR =
     decode $
-      RecD CommitteeMemberState
+      RecD QueryResultCommitteeMemberState
         <! From
         <! From
         <! From
         <! From
 
-instance ToKeyValuePairs CommitteeMemberState where
-  toKeyValuePairs c@(CommitteeMemberState _ _ _ _) =
-    let CommitteeMemberState {..} = c
-     in [ "hotCredsAuthStatus" .= cmsHotCredAuthStatus
-        , "status" .= cmsStatus
-        , "expiration" .= cmsExpiration
-        , "nextEpochChange" .= cmsNextEpochChange
-        ]
+instance ToKeyValuePairs QueryResultCommitteeMemberState where
+  toKeyValuePairs (QueryResultCommitteeMemberState hotCredAuth status expiration nextEpoch) =
+    [ "hotCredsAuthStatus" .= hotCredAuth
+    , "status" .= status
+    , "expiration" .= expiration
+    , "nextEpochChange" .= nextEpoch
+    ]
 
-data CommitteeMembersState = CommitteeMembersState
-  { csCommittee :: !(Map (Credential ColdCommitteeRole) CommitteeMemberState)
-  , csThreshold :: !(Maybe UnitInterval)
-  , csEpochNo :: !EpochNo
+type CommitteeMemberState = QueryResultCommitteeMemberState
+
+{-# DEPRECATED CommitteeMemberState "Use QueryResultCommitteeMemberState instead" #-}
+
+-- | Committee members state with the committee map, threshold, and current epoch.
+data QueryResultCommitteeMembersState = QueryResultCommitteeMembersState
+  { qrcmsCommittee :: !(Map (Credential ColdCommitteeRole) QueryResultCommitteeMemberState)
+  , qrcmsThreshold :: !(Maybe UnitInterval)
+  , qrcmsEpochNo :: !EpochNo
   -- ^ Current epoch number. This is necessary to interpret committee member states
   }
   deriving (Eq, Show, Generic)
-  deriving (ToJSON) via KeyValuePairs CommitteeMembersState
+  deriving (ToJSON) via KeyValuePairs QueryResultCommitteeMembersState
 
-deriving instance Ord CommitteeMembersState
+deriving instance Ord QueryResultCommitteeMembersState
 
-instance EncCBOR CommitteeMembersState where
-  encCBOR c@(CommitteeMembersState _ _ _) =
-    let CommitteeMembersState {..} = c
-     in encode $
-          Rec CommitteeMembersState
-            !> To csCommittee
-            !> To csThreshold
-            !> To csEpochNo
+instance NFData QueryResultCommitteeMembersState
 
-instance DecCBOR CommitteeMembersState where
+instance NoThunks QueryResultCommitteeMembersState
+
+instance EncCBOR QueryResultCommitteeMembersState where
+  encCBOR (QueryResultCommitteeMembersState committee threshold epoch) =
+    encode $
+      Rec QueryResultCommitteeMembersState
+        !> To committee
+        !> To threshold
+        !> To epoch
+
+instance DecCBOR QueryResultCommitteeMembersState where
   decCBOR =
     decode $
-      RecD CommitteeMembersState
+      RecD QueryResultCommitteeMembersState
         <! From
         <! From
         <! From
 
-instance ToKeyValuePairs CommitteeMembersState where
-  toKeyValuePairs c@(CommitteeMembersState _ _ _) =
-    let CommitteeMembersState {..} = c
-     in [ "committee" .= csCommittee
-        , "threshold" .= csThreshold
-        , "epoch" .= csEpochNo
-        ]
+instance ToKeyValuePairs QueryResultCommitteeMembersState where
+  toKeyValuePairs (QueryResultCommitteeMembersState committee threshold epoch) =
+    [ "committee" .= committee
+    , "threshold" .= threshold
+    , "epoch" .= epoch
+    ]
+
+type CommitteeMembersState = QueryResultCommitteeMembersState
+
+{-# DEPRECATED CommitteeMembersState "Use QueryResultCommitteeMembersState instead" #-}

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
@@ -382,6 +382,8 @@ instance DecCBOR QueryResultDRepStates where
 --   queryGovState cardano-api wrapper
 -- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1617
 --   CLI invocation
+--
+-- /O(1)/
 queryGovState :: NewEpochState era -> GovState era
 queryGovState nes = nes ^. nesEpochStateL . epochStateGovStateL
 
@@ -392,12 +394,16 @@ queryGovState nes = nes ^. nesEpochStateL . epochStateGovStateL
 --   queryConstitution cardano-api wrapper
 -- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1589
 --   CLI invocation
+--
+-- /O(1)/
 queryConstitution :: ConwayEraGov era => NewEpochState era -> QueryResultConstitution
 queryConstitution nes = toQueryResultConstitution $ queryGovState nes ^. constitutionGovStateL
 
 -- | Query the constitution hash.
 --
 -- Convenience extraction — no corresponding standalone query in @ouroboros-consensus@.
+--
+-- /O(1)/
 queryConstitutionHash ::
   ConwayEraGov era =>
   NewEpochState era ->
@@ -414,6 +420,8 @@ queryConstitutionHash nes =
 --   CLI invocation
 --
 -- Empty 'Set' returns all proposals.
+--
+-- /O(g)/ where (g) is the proposals considered for ratification, Seq.filter.
 queryProposals ::
   ConwayEraGov era =>
   NewEpochState era ->
@@ -438,6 +446,8 @@ queryProposals nes gids
 --   queryRatifyState cardano-api wrapper
 -- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1645
 --   CLI invocation
+--
+-- /O(P)/ where (P) is the DRep pulser completion cost, finishedPulserState.
 queryRatifyState :: ConwayEraGov era => NewEpochState era -> RatifyState era
 queryRatifyState = snd . finishedPulserState
 
@@ -445,12 +455,19 @@ queryRatifyState = snd . finishedPulserState
 -- return no committee members.
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:471
 --   answerPureBlockQuery case for GetCommitteeMembersState
--- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:452
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:454
 --   queryCommitteeMembersState cardano-api wrapper
 -- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1887
 --   CLI invocation
 --
 -- Empty 'Set' returns all matches (i.e. no filtering).
+--
+-- @
+--   O(P + m)
+-- @
+-- where,
+--   (P) is the DRep pulser completion cost, finishedPulserState
+--   (m) is the committee members (current + next + state), Map.union and Map.mapWithKey
 queryCommitteeMembersState ::
   forall era.
   (ConwayEraGov era, ConwayEraCertState era) =>
@@ -546,6 +563,8 @@ queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
       }
 
 -- | Get the committee members that will be in effect at the next epoch boundary.
+--
+-- /O(P)/ where (P) is the DRep pulser completion cost, finishedPulserState.
 getNextEpochCommitteeMembers ::
   ConwayEraGov era =>
   NewEpochState era ->
@@ -564,6 +583,13 @@ getNextEpochCommitteeMembers nes =
 --   CLI invocation
 --
 -- Empty 'Set' returns all DReps.
+--
+-- @
+--   O(d + k)
+-- @
+-- where,
+--   (d) is the total registered DReps, Map.restrictKeys and Map.map
+--   (k) is the requested DRep credential set, Map.restrictKeys
 queryDRepState ::
   ConwayEraCertState era =>
   NewEpochState era ->
@@ -590,6 +616,15 @@ queryDRepState nes creds =
 --   queryDRepDelegations cardano-api wrapper (not publicly exported)
 --
 -- Empty 'Set' returns all DReps.
+--
+-- @
+--   O(d + k)  when all requested DReps are DRepCredentials
+--   O(c)      when AlwaysAbstain or AlwaysNoConfidence are requested
+-- @
+-- where,
+--   (d) is the registered DReps, Map.restrictKeys
+--   (k) is the requested DRep set, Map.restrictKeys
+--   (c) is the total staking credentials, Map.foldlWithKey' (full accounts scan)
 queryDRepDelegations ::
   forall era.
   ConwayEraCertState era =>
@@ -637,6 +672,14 @@ queryDRepDelegations nes dreps =
 --   CLI invocation
 --
 -- Empty 'Set' returns all DReps.
+--
+-- @
+--   O(P + d + k)
+-- @
+-- where,
+--   (P) is the DRep pulser completion cost, finishedPulserState
+--   (d) is the total DReps in the distribution, Map.map
+--   (k) is the requested DRep set, Map.restrictKeys
 queryDRepStakeDistr ::
   ConwayEraGov era =>
   NewEpochState era ->
@@ -656,6 +699,15 @@ queryDRepStakeDistr nes creds
 --   No consensus BlockQuery constructor exists yet (GetRegisteredDRepStakeDistr was planned but not added).
 --
 -- Empty 'Set' returns all registered DReps.
+--
+-- @
+--   O(d + k + d * c_avg * log(c))
+-- @
+-- where,
+--   (d) is the registered DReps, Map.restrictKeys and Map.foldlWithKey'
+--   (k) is the requested DRep credential set, Map.restrictKeys
+--   (c_avg) is the average delegators per DRep, foldMap over drepDelegs
+--   (c) is the total staking credentials, Map.lookup in instantStake per delegator
 queryRegisteredDRepStakeDistr ::
   (ConwayEraGov era, ConwayEraCertState era) =>
   NewEpochState era ->
@@ -683,13 +735,20 @@ queryRegisteredDRepStakeDistr nes creds =
 -- | Query the DRep delegatee for each given staking credential.
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:457
 --   answerPureBlockQuery case for GetDRepStakeDistr (partial — delegatees extracted separately)
--- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:459
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:469
 --   queryStakeVoteDelegatees cardano-api wrapper
 -- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1042
 --   CLI invocation
 --
 -- Returns the DRep each credential has delegated to. Credentials with no
 -- DRep delegation are omitted from the result. Empty 'Set' returns all.
+--
+-- @
+--   O(c + k)
+-- @
+-- where,
+--   (c) is the total staking credentials, Map.restrictKeys
+--   (k) is the requested credential set, Map.restrictKeys
 queryDRepDelegatees ::
   (EraCertState era, ConwayEraAccounts era) =>
   NewEpochState era ->
@@ -704,6 +763,8 @@ queryDRepDelegatees nes creds =
 
 -- | Force the DRep pulser to completion and return the resulting snapshot and
 -- ratify state. Shared across governance query sub-modules.
+--
+-- /O(P)/ where (P) is the remaining DRep pulser work, amortised across the epoch.
 finishedPulserState ::
   ConwayEraGov era =>
   NewEpochState era ->

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
@@ -2,11 +2,21 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Ledger.Api.State.Query.Governance (
+  -- * Constitution
+  QueryResultConstitution (..),
+  toQueryResultConstitution,
+
   -- * Committee members state
   QueryResultCommitteeMemberState (..),
   QueryResultCommitteeMembersState (..),
@@ -14,27 +24,124 @@ module Cardano.Ledger.Api.State.Query.Governance (
   MemberStatus (..),
   NextEpochChange (..),
 
+  -- * DRep state
+  QueryResultDRepState (..),
+  QueryResultDRepStates (..),
+  toQueryResultDRepState,
+
+  -- * Queries
+  queryGovState,
+  queryConstitution,
+  queryConstitutionHash,
+  queryProposals,
+  queryRatifyState,
+  queryCommitteeMembersState,
+  queryDRepState,
+  queryDRepDelegations,
+  queryDRepStakeDistr,
+  queryRegisteredDRepStakeDistr,
+
+  -- * For testing
+  getNextEpochCommitteeMembers,
+
   -- * Deprecated
   CommitteeMemberState,
   CommitteeMembersState,
+
+  -- * Internal helpers (shared across Query sub-modules)
+  finishedPulserState,
 ) where
 
-import Cardano.Ledger.BaseTypes (Anchor, KeyValuePairs (..), ToKeyValuePairs (..), UnitInterval)
+import Cardano.Ledger.BaseTypes (
+  KeyValuePairs (..),
+  ToKeyValuePairs (..),
+  UnitInterval,
+  strictMaybeToMaybe,
+ )
 import Cardano.Ledger.Binary (
-  DecCBOR (decCBOR),
-  EncCBOR (encCBOR),
+  DecCBOR (..),
+  EncCBOR (..),
   decodeEnumBounded,
   encodeEnum,
  )
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
+import Cardano.Ledger.Coin (Coin, CompactForm (CompactCoin))
+import Cardano.Ledger.Compactible (fromCompact)
+import Cardano.Ledger.Conway.Governance (
+  Committee (committeeMembers),
+  Constitution (constitutionAnchor, constitutionGuardrailsScriptHash),
+  ConwayEraGov (..),
+  DRepPulser (..),
+  DRepPulsingState (..),
+  GovActionId,
+  GovActionState (..),
+  PulsingSnapshot,
+  RatifyState,
+  committeeThresholdL,
+  ensCommitteeL,
+  finishDRepPulser,
+  proposalsDeposits,
+  psDRepDistr,
+  psProposalsL,
+  rsEnactStateL,
+ )
+import Cardano.Ledger.Conway.Rules (updateDormantDRepExpiry)
+import Cardano.Ledger.Conway.State
+import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
-import Cardano.Ledger.Keys (KeyRole (..))
+import Cardano.Ledger.DRep (credToDRep, dRepToCred)
+import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Slot (EpochNo (..))
 import Control.DeepSeq (NFData)
+import Control.Monad (guard)
 import Data.Aeson (ToJSON (..), (.=))
+import Data.Foldable (foldMap')
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromMaybe, isJust)
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import Data.Sequence.Strict (StrictSeq (..))
+import Data.Set (Set)
+import qualified Data.Set as Set
 import GHC.Generics (Generic)
+import Lens.Micro
 import NoThunks.Class (NoThunks)
+
+-- | Stable query result for constitution data.
+data QueryResultConstitution = QueryResultConstitution
+  { qrcAnchor :: !Anchor
+  , qrcGuardrailsScript :: !(Maybe ScriptHash)
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+deriving instance ToJSON QueryResultConstitution
+
+instance NFData QueryResultConstitution
+
+instance NoThunks QueryResultConstitution
+
+instance EncCBOR QueryResultConstitution where
+  encCBOR (QueryResultConstitution anchor guardrailsScript) =
+    encode $
+      Rec QueryResultConstitution
+        !> To anchor
+        !> To guardrailsScript
+
+instance DecCBOR QueryResultConstitution where
+  decCBOR =
+    decode $
+      RecD QueryResultConstitution
+        <! From
+        <! From
+
+-- | Convert internal 'Constitution' to stable 'QueryResultConstitution'.
+toQueryResultConstitution :: Constitution era -> QueryResultConstitution
+toQueryResultConstitution con =
+  QueryResultConstitution
+    { qrcAnchor = constitutionAnchor con
+    , qrcGuardrailsScript = strictMaybeToMaybe (constitutionGuardrailsScriptHash con)
+    }
 
 data MemberStatus
   = -- | Votes of this member will count during ratification
@@ -205,3 +312,377 @@ instance ToKeyValuePairs QueryResultCommitteeMembersState where
 type CommitteeMembersState = QueryResultCommitteeMembersState
 
 {-# DEPRECATED CommitteeMembersState "Use QueryResultCommitteeMembersState instead" #-}
+
+-- | Stable query result for a single DRep's state.
+data QueryResultDRepState = QueryResultDRepState
+  { qrdrsExpiry :: !EpochNo
+  , qrdrsAnchor :: !(Maybe Anchor)
+  , qrdrsDeposit :: !Coin
+  , qrdrsDelegs :: !(Set (Credential Staking))
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+deriving instance ToJSON QueryResultDRepState
+
+instance NFData QueryResultDRepState
+
+instance NoThunks QueryResultDRepState
+
+instance EncCBOR QueryResultDRepState where
+  encCBOR (QueryResultDRepState expiry anchor deposit delegs) =
+    encode $
+      Rec QueryResultDRepState
+        !> To expiry
+        !> To anchor
+        !> To deposit
+        !> To delegs
+
+instance DecCBOR QueryResultDRepState where
+  decCBOR =
+    decode $
+      RecD QueryResultDRepState
+        <! From
+        <! From
+        <! From
+        <! From
+
+-- | Convert internal 'DRepState' to stable 'QueryResultDRepState'.
+toQueryResultDRepState :: DRepState -> QueryResultDRepState
+toQueryResultDRepState DRepState {..} =
+  QueryResultDRepState
+    { qrdrsExpiry = drepExpiry
+    , qrdrsAnchor = strictMaybeToMaybe drepAnchor
+    , qrdrsDeposit = fromCompact drepDeposit
+    , qrdrsDelegs = drepDelegs
+    }
+
+-- | Stable query result wrapping DRep states for all queried DReps.
+newtype QueryResultDRepStates = QueryResultDRepStates
+  { qrdrssStates :: Map (Credential DRepRole) QueryResultDRepState
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+deriving instance ToJSON QueryResultDRepStates
+
+instance NFData QueryResultDRepStates
+
+instance NoThunks QueryResultDRepStates
+
+instance EncCBOR QueryResultDRepStates where
+  encCBOR (QueryResultDRepStates states) = encCBOR states
+
+instance DecCBOR QueryResultDRepStates where
+  decCBOR = QueryResultDRepStates <$> decCBOR
+
+-- | This query returns all of the state related to governance.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:465
+--   answerPureBlockQuery case for GetGovState
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:371
+--   queryGovState cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1617
+--   CLI invocation
+queryGovState :: NewEpochState era -> GovState era
+queryGovState nes = nes ^. nesEpochStateL . epochStateGovStateL
+
+-- | Query the constitution.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:463
+--   answerPureBlockQuery case for GetConstitution
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:359
+--   queryConstitution cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1589
+--   CLI invocation
+queryConstitution :: ConwayEraGov era => NewEpochState era -> QueryResultConstitution
+queryConstitution nes = toQueryResultConstitution $ queryGovState nes ^. constitutionGovStateL
+
+-- | Query the constitution hash.
+--
+-- Convenience extraction — no corresponding standalone query in @ouroboros-consensus@.
+queryConstitutionHash ::
+  ConwayEraGov era =>
+  NewEpochState era ->
+  SafeHash AnchorData
+queryConstitutionHash nes =
+  anchorDataHash . constitutionAnchor $ queryGovState nes ^. constitutionGovStateL
+
+-- | Query proposals that are considered for ratification.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:479
+--   answerPureBlockQuery case for GetProposals
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:495
+--   queryProposals cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1045
+--   CLI invocation
+--
+-- Empty 'Set' returns all proposals.
+queryProposals ::
+  ConwayEraGov era =>
+  NewEpochState era ->
+  -- | Specify a set of Governance Action IDs to filter the proposals. When this set is
+  -- empty, all the proposals considered for ratification will be returned.
+  Set GovActionId ->
+  Seq (GovActionState era)
+queryProposals nes gids
+  | null gids = proposals
+  -- TODO: Add `filter` to `cardano-strict-containers`
+  | otherwise =
+      Seq.filter (\GovActionState {..} -> gasId `Set.member` gids) proposals
+  where
+    proposals = fromStrict $ case nes ^. newEpochStateGovStateL . drepPulsingStateGovStateL of
+      DRComplete snap _rs -> snap ^. psProposalsL
+      DRPulsing DRepPulser {..} -> dpProposals
+
+-- | Query ratification state.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:481
+--   answerPureBlockQuery case for GetRatifyState
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:383
+--   queryRatifyState cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1645
+--   CLI invocation
+queryRatifyState :: ConwayEraGov era => NewEpochState era -> RatifyState era
+queryRatifyState = snd . finishedPulserState
+
+-- | Query committee members. Whenever the system is in No Confidence mode this query will
+-- return no committee members.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:471
+--   answerPureBlockQuery case for GetCommitteeMembersState
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:452
+--   queryCommitteeMembersState cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1887
+--   CLI invocation
+--
+-- Empty 'Set' returns all matches (i.e. no filtering).
+queryCommitteeMembersState ::
+  forall era.
+  (ConwayEraGov era, ConwayEraCertState era) =>
+  -- | filter by cold credentials (don't filter when empty)
+  Set (Credential ColdCommitteeRole) ->
+  -- | filter by hot credentials (don't filter when empty)
+  Set (Credential HotCommitteeRole) ->
+  -- | filter by status (don't filter when empty)
+  -- (useful, for discovering, for example, only active members)
+  Set MemberStatus ->
+  NewEpochState era ->
+  QueryResultCommitteeMembersState
+queryCommitteeMembersState coldCredsFilter hotCredsFilter statusFilter nes =
+  let
+    committee = nes ^. nesEpochStateL . epochStateGovStateL . committeeGovStateL
+    comMembers = foldMap' committeeMembers committee
+    nextComMembers = getNextEpochCommitteeMembers nes
+    comStateMembers =
+      csCommitteeCreds $
+        nes ^. nesEpochStateL . esLStateL . lsCertStateL . certVStateL . vsCommitteeStateL
+
+    withFilteredColdCreds s
+      | Set.null coldCredsFilter = s
+      | otherwise = s `Set.intersection` coldCredsFilter
+
+    relevantColdKeys
+      | Set.null statusFilter || Set.member Unrecognized statusFilter =
+          withFilteredColdCreds $
+            Set.unions
+              [ Map.keysSet comMembers
+              , Map.keysSet comStateMembers
+              , Map.keysSet nextComMembers
+              ]
+      | otherwise = withFilteredColdCreds $ Map.keysSet comMembers
+
+    relevantHotKeys =
+      Set.fromList
+        [ ck
+        | (ck, CommitteeHotCredential hk) <- Map.toList comStateMembers
+        , hk `Set.member` hotCredsFilter
+        ]
+
+    relevant
+      | Set.null hotCredsFilter = relevantColdKeys
+      | otherwise = relevantColdKeys `Set.intersection` relevantHotKeys
+
+    cms = Map.mapMaybe id $ Map.fromSet mkMaybeMemberState relevant
+    currentEpoch = nes ^. nesELL
+
+    mkMaybeMemberState ::
+      Credential ColdCommitteeRole ->
+      Maybe QueryResultCommitteeMemberState
+    mkMaybeMemberState coldCred = do
+      let mbExpiry = Map.lookup coldCred comMembers
+      let status = case mbExpiry of
+            Nothing -> Unrecognized
+            Just expiry
+              | currentEpoch > expiry -> Expired
+              | otherwise -> Active
+      guard (null statusFilter || status `Set.member` statusFilter)
+      let hkStatus =
+            case Map.lookup coldCred comStateMembers of
+              Nothing -> MemberNotAuthorized
+              Just (CommitteeMemberResigned anchor) -> MemberResigned (strictMaybeToMaybe anchor)
+              Just (CommitteeHotCredential hk) -> MemberAuthorized hk
+      pure $ QueryResultCommitteeMemberState hkStatus status mbExpiry (nextEpochChange coldCred)
+
+    nextEpochChange :: Credential ColdCommitteeRole -> NextEpochChange
+    nextEpochChange ck
+      | not inCurrent && inNext = ToBeEnacted
+      | not inNext = ToBeRemoved
+      | Just curTerm <- lookupCurrent
+      , Just nextTerm <- lookupNext
+      , curTerm /= nextTerm
+      , -- if the term is adjusted such that it expires in the next epoch,
+        -- we set it to ToBeExpired instead of TermAdjusted
+        not expiringNext =
+          TermAdjusted nextTerm
+      | expiringCurrent || expiringNext = ToBeExpired
+      | otherwise = NoChangeExpected
+      where
+        lookupCurrent = Map.lookup ck comMembers
+        lookupNext = Map.lookup ck nextComMembers
+        inCurrent = isJust lookupCurrent
+        inNext = isJust lookupNext
+        expiringCurrent = lookupCurrent == Just currentEpoch
+        expiringNext = lookupNext == Just currentEpoch
+   in
+    QueryResultCommitteeMembersState
+      { qrcmsCommittee = cms
+      , qrcmsThreshold = strictMaybeToMaybe $ (^. committeeThresholdL) <$> committee
+      , qrcmsEpochNo = currentEpoch
+      }
+
+-- | Get the committee members that will be in effect at the next epoch boundary.
+getNextEpochCommitteeMembers ::
+  ConwayEraGov era =>
+  NewEpochState era ->
+  Map (Credential ColdCommitteeRole) EpochNo
+getNextEpochCommitteeMembers nes =
+  let (_, ratifyState) = finishedPulserState nes
+      committee = ratifyState ^. rsEnactStateL . ensCommitteeL
+   in foldMap' committeeMembers committee
+
+-- | Query DRep state.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:467
+--   answerPureBlockQuery case for GetDRepState
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:407
+--   queryDRepState cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1710
+--   CLI invocation
+--
+-- Empty 'Set' returns all DReps.
+queryDRepState ::
+  ConwayEraCertState era =>
+  NewEpochState era ->
+  -- | Specify a set of DRep credentials whose state should be returned. When this set is
+  -- empty, states for all of the DReps will be returned.
+  Set (Credential DRepRole) ->
+  QueryResultDRepStates
+queryDRepState nes creds =
+  QueryResultDRepStates $
+    Map.map toQueryResultDRepState $
+      if null creds
+        then updateDormantDRepExpiry' vState ^. vsDRepsL
+        else updateDormantDRepExpiry' vStateFiltered ^. vsDRepsL
+  where
+    vStateFiltered = vState & vsDRepsL %~ (`Map.restrictKeys` creds)
+    vState = nes ^. nesEsL . esLStateL . lsCertStateL . certVStateL
+    updateDormantDRepExpiry' = updateDormantDRepExpiry (nes ^. nesELL)
+
+-- | Query the delegators delegated to each DRep, including
+-- @AlwaysAbstain@ and @NoConfidence@.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:530
+--   answerPureBlockQuery case for GetDRepDelegations
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:529
+--   queryDRepDelegations cardano-api wrapper (not publicly exported)
+--
+-- Empty 'Set' returns all DReps.
+queryDRepDelegations ::
+  forall era.
+  ConwayEraCertState era =>
+  NewEpochState era ->
+  -- | Specify a set of DReps whose delegations should be returned. When this set is
+  -- empty, delegations for all DReps will be returned.
+  Set DRep ->
+  Map DRep (Set (Credential Staking))
+queryDRepDelegations nes dreps =
+  case getDRepCreds dreps of
+    Just creds ->
+      Map.map drepDelegs $
+        Map.mapKeys credToDRep ((vState ^. vsDRepsL) `Map.restrictKeys` creds)
+    Nothing ->
+      -- Whenever predefined `AlwaysAbstain` or `AlwaysNoConfidence` are
+      -- requested we are forced to iterate over all accounts and find those
+      -- delegations.
+      Map.foldlWithKey'
+        ( \m cred cas ->
+            case cas ^. dRepDelegationAccountStateL of
+              Just drep
+                | Set.null dreps || drep `Set.member` dreps ->
+                    Map.insertWith (<>) drep (Set.singleton cred) m
+              _ ->
+                m
+        )
+        Map.empty
+        (dState ^. accountsL . accountsMapL)
+  where
+    dState = nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL
+    vState = nes ^. nesEsL . esLStateL . lsCertStateL . certVStateL
+    -- Find all credentials for requested DReps, but only when we don't care
+    -- about predefined DReps
+    getDRepCreds ds = do
+      guard $ not $ Set.null ds
+      Set.fromList <$> traverse dRepToCred (Set.elems ds)
+
+-- | Query DRep stake distribution. Note that this can be an expensive query because there
+-- is a chance that current distribution has not been fully computed yet.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:469
+--   answerPureBlockQuery case for GetDRepStakeDistr
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:423
+--   queryDRepStakeDistribution cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1717
+--   CLI invocation
+--
+-- Empty 'Set' returns all DReps.
+queryDRepStakeDistr ::
+  ConwayEraGov era =>
+  NewEpochState era ->
+  -- | Specify DRep Ids whose stake distribution should be returned. When this set is
+  -- empty, distributions for all of the DReps will be returned.
+  Set DRep ->
+  Map DRep Coin
+queryDRepStakeDistr nes creds
+  | null creds = Map.map fromCompact distr
+  | otherwise = Map.map fromCompact $ distr `Map.restrictKeys` creds
+  where
+    distr = psDRepDistr . fst $ finishedPulserState nes
+
+-- | Query the stake distribution of the registered DReps. This does not
+-- include the @AlwaysAbstain@ and @NoConfidence@ DReps.
+-- Source: added by commit 18a08e4bb (Lucsanszky, Nov 2024) as a ledger-side query.
+--   No consensus BlockQuery constructor exists yet (GetRegisteredDRepStakeDistr was planned but not added).
+--
+-- Empty 'Set' returns all registered DReps.
+queryRegisteredDRepStakeDistr ::
+  (ConwayEraGov era, ConwayEraCertState era) =>
+  NewEpochState era ->
+  -- | Specify DRep Ids whose stake distribution should be returned. When this set is
+  -- empty, distributions for all of the registered DReps will be returned.
+  Set (Credential DRepRole) ->
+  Map (Credential DRepRole) Coin
+queryRegisteredDRepStakeDistr nes creds =
+  Map.foldlWithKey' computeDistr mempty selectedDReps
+  where
+    selectedDReps
+      | null creds = registeredDReps
+      | otherwise = registeredDReps `Map.restrictKeys` creds
+    registeredDReps = nes ^. nesEsL . esLStateL . lsCertStateL . certVStateL . vsDRepsL
+    computeDistr distrAcc dRepCred (DRepState {..}) =
+      Map.insert dRepCred (totalDelegations drepDelegs) distrAcc
+    totalDelegations =
+      fromCompact . foldMap stakeAndDeposits
+    instantStake = nes ^. instantStakeL . instantStakeCredentialsL
+    proposalDeposits = proposalsDeposits $ nes ^. newEpochStateGovStateL . proposalsGovStateL
+    stakeAndDeposits stakeCred =
+      fromMaybe (CompactCoin 0) $
+        Map.lookup stakeCred instantStake <> Map.lookup stakeCred proposalDeposits
+
+-- | Force the DRep pulser to completion and return the resulting snapshot and
+-- ratify state. Shared across governance query sub-modules.
+finishedPulserState ::
+  ConwayEraGov era =>
+  NewEpochState era ->
+  (PulsingSnapshot era, RatifyState era)
+finishedPulserState nes = finishDRepPulser (nes ^. newEpochStateGovStateL . drepPulsingStateGovStateL)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Ledger.Api.State.Query.Governance (
   -- * Constitution
@@ -44,10 +43,6 @@ module Cardano.Ledger.Api.State.Query.Governance (
 
   -- * For testing
   getNextEpochCommitteeMembers,
-
-  -- * Deprecated
-  CommitteeMemberState,
-  CommitteeMembersState,
 
   -- * Internal helpers (shared across Query sub-modules)
   finishedPulserState,
@@ -267,10 +262,6 @@ instance ToKeyValuePairs QueryResultCommitteeMemberState where
     , "nextEpochChange" .= nextEpoch
     ]
 
-type CommitteeMemberState = QueryResultCommitteeMemberState
-
-{-# DEPRECATED CommitteeMemberState "Use QueryResultCommitteeMemberState instead" #-}
-
 -- | Committee members state with the committee map, threshold, and current epoch.
 data QueryResultCommitteeMembersState = QueryResultCommitteeMembersState
   { qrcmsCommittee :: !(Map (Credential ColdCommitteeRole) QueryResultCommitteeMemberState)
@@ -309,10 +300,6 @@ instance ToKeyValuePairs QueryResultCommitteeMembersState where
     , "threshold" .= threshold
     , "epoch" .= epoch
     ]
-
-type CommitteeMembersState = QueryResultCommitteeMembersState
-
-{-# DEPRECATED CommitteeMembersState "Use QueryResultCommitteeMembersState instead" #-}
 
 -- | Stable query result for a single DRep's state.
 data QueryResultDRepState = QueryResultDRepState

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Governance.hs
@@ -40,6 +40,7 @@ module Cardano.Ledger.Api.State.Query.Governance (
   queryDRepDelegations,
   queryDRepStakeDistr,
   queryRegisteredDRepStakeDistr,
+  queryDRepDelegatees,
 
   -- * For testing
   getNextEpochCommitteeMembers,
@@ -678,6 +679,28 @@ queryRegisteredDRepStakeDistr nes creds =
     stakeAndDeposits stakeCred =
       fromMaybe (CompactCoin 0) $
         Map.lookup stakeCred instantStake <> Map.lookup stakeCred proposalDeposits
+
+-- | Query the DRep delegatee for each given staking credential.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:457
+--   answerPureBlockQuery case for GetDRepStakeDistr (partial — delegatees extracted separately)
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:459
+--   queryStakeVoteDelegatees cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1042
+--   CLI invocation
+--
+-- Returns the DRep each credential has delegated to. Credentials with no
+-- DRep delegation are omitted from the result. Empty 'Set' returns all.
+queryDRepDelegatees ::
+  (EraCertState era, ConwayEraAccounts era) =>
+  NewEpochState era ->
+  Set (Credential Staking) ->
+  Map (Credential Staking) DRep
+queryDRepDelegatees nes creds =
+  let accountsMap = nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL . accountsMapL
+      selected
+        | Set.null creds = accountsMap
+        | otherwise = accountsMap `Map.restrictKeys` creds
+   in Map.mapMaybe (^. dRepDelegationAccountStateL) selected
 
 -- | Force the DRep pulser to completion and return the resulting snapshot and
 -- ratify state. Shared across governance query sub-modules.

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/PParams.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/PParams.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Cardano.Ledger.Api.State.Query.PParams (
+  queryCurrentPParams,
+  queryFuturePParams,
+) where
+
+import Cardano.Ledger.Core (PParams)
+import Cardano.Ledger.Shelley.LedgerState (NewEpochState, epochStateGovStateL, nesEpochStateL)
+import Cardano.Ledger.State (
+  EraGov (curPParamsGovStateL, futurePParamsGovStateL),
+  FuturePParams (..),
+ )
+import Lens.Micro ((^.))
+
+-- | This is a simple lookup into the state for the values of current protocol
+-- parameters. These values can change on the epoch boundary. Use 'queryFuturePParams' to
+-- see if we are aware of any upcoming changes.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:418
+--   answerPureBlockQuery case for GetCurrentPParams
+queryCurrentPParams :: EraGov era => NewEpochState era -> PParams era
+queryCurrentPParams nes = nes ^. nesEpochStateL . epochStateGovStateL . curPParamsGovStateL
+
+-- | This query will return values for protocol parameters that are likely to be adopted
+-- at the next epoch boundary. It is only when we passed 2 stability windows before the
+-- end of the epoch that users can rely on this query to produce stable results.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:483
+--   answerPureBlockQuery case for GetFuturePParams
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:395
+--   queryFuturePParams cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1673
+--   CLI invocation
+queryFuturePParams :: EraGov era => NewEpochState era -> Maybe (PParams era)
+queryFuturePParams nes =
+  case nes ^. nesEpochStateL . epochStateGovStateL . futurePParamsGovStateL of
+    NoPParamsUpdate -> Nothing
+    PotentialPParamsUpdate mpp -> mpp
+    DefinitePParamsUpdate pp -> Just pp

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/PParams.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/PParams.hs
@@ -18,6 +18,8 @@ import Lens.Micro ((^.))
 -- see if we are aware of any upcoming changes.
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:418
 --   answerPureBlockQuery case for GetCurrentPParams
+--
+-- /O(1)/
 queryCurrentPParams :: EraGov era => NewEpochState era -> PParams era
 queryCurrentPParams nes = nes ^. nesEpochStateL . epochStateGovStateL . curPParamsGovStateL
 
@@ -30,6 +32,8 @@ queryCurrentPParams nes = nes ^. nesEpochStateL . epochStateGovStateL . curPPara
 --   queryFuturePParams cardano-api wrapper
 -- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1673
 --   CLI invocation
+--
+-- /O(1)/
 queryFuturePParams :: EraGov era => NewEpochState era -> Maybe (PParams era)
 queryFuturePParams nes =
   case nes ^. nesEpochStateL . epochStateGovStateL . futurePParamsGovStateL of

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Ledger.Api.State.Query.Pool (
   -- * Stable query result types
@@ -166,6 +165,13 @@ mkQueryPoolStateResult = toQueryResultPoolState
 --   CLI invocation
 --
 -- Empty 'Set' returns all pools.
+--
+-- @
+--   O(p + k)
+-- @
+-- where,
+--   (p) is the total registered stake pools, Map.restrictKeys and Map.mapWithKey
+--   (k) is the requested pool key set, Map.restrictKeys
 queryPoolState ::
   EraCertState era =>
   NewEpochState era ->
@@ -185,6 +191,13 @@ queryPoolState nes poolKeys network =
 --   queryStakePoolParameters cardano-api wrapper
 --
 -- Empty 'Set' returns all pools.
+--
+-- @
+--   O(p + k)
+-- @
+-- where,
+--   (p) is the total registered stake pools, Map.restrictKeys and Map.mapWithKey
+--   (k) is the requested pool key set, Map.restrictKeys
 queryStakePoolParams ::
   EraCertState era =>
   Network ->
@@ -218,6 +231,13 @@ queryPoolParameters = queryStakePoolParams
 --   queryStakePoolDefaultVote cardano-api wrapper
 -- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:2003
 --   CLI invocation
+--
+-- @
+--   O(log(p) + log(c))
+-- @
+-- where,
+--   (p) is the registered stake pools, Map.lookup
+--   (c) is the staking credentials, Map.lookup for reward account
 queryStakePoolDefaultVote ::
   (EraCertState era, ConwayEraAccounts era) =>
   NewEpochState era ->
@@ -237,6 +257,14 @@ queryStakePoolDefaultVote nes poolId =
 --   CLI invocation
 --
 -- Empty 'Set' returns all pools.
+--
+-- @
+--   O(P + p + k)
+-- @
+-- where,
+--   (P) is the DRep pulser completion cost, finishedPulserState
+--   (p) is the total pools in the distribution, Map.map
+--   (k) is the requested pool set, Map.restrictKeys
 querySPOStakeDistr ::
   ConwayEraGov era =>
   NewEpochState era ->
@@ -255,6 +283,8 @@ querySPOStakeDistr nes keys
 --   queryStakePools cardano-api wrapper (CLI via Convenience.hs:148)
 --
 -- Returns the key hashes of every pool in the current PState.
+--
+-- /O(p)/ where (p) is the registered stake pools, Map.keysSet.
 queryStakePools ::
   EraCertState era =>
   NewEpochState era ->
@@ -276,6 +306,13 @@ queryStakePools nes =
 -- memoized @nesPd@ (the __set__ snapshot computed at the last epoch boundary).
 --
 -- Needs @maxLovelaceSupply@ from genesis config.
+--
+-- @
+--   O(c + p)
+-- @
+-- where,
+--   (c) is the staking credentials, queryCurrentSnapshot
+--   (p) is the registered stake pools, calculatePoolDistr and Map.map
 queryStakePoolDistrByTotalSupply ::
   (EraStake era, EraCertState era) =>
   -- | maxLovelaceSupply from genesis config
@@ -325,6 +362,13 @@ queryStakePoolDistrByTotalSupply maxLovelaceSupply nes =
 -- This approach is more efficient: the expensive @calculatePoolDistr@
 -- computation happens once at the epoch boundary (ADR-7), and the query
 -- performs only an O(n+m) @Map.restrictKeys@.
+--
+-- @
+--   O(p + k)
+-- @
+-- where,
+--   (p) is the total pools in the memoized distribution, Map.restrictKeys
+--   (k) is the requested pool set, Map.restrictKeys
 queryStakePoolDistrFromSnapshot ::
   NewEpochState era ->
   Set (KeyHash StakePool) ->
@@ -346,6 +390,12 @@ queryStakePoolDistrFromSnapshot nes poolIds
 --
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs:32
 --   getPeers (LedgerSupportsPeerSelection instance)
+--
+-- @
+--   O(p * log(p))
+-- @
+-- where,
+--   (p) is the pools in the distribution, Map.mapMaybeWithKey with Map.lookup per pool
 queryStakePoolRelays ::
   EraCertState era =>
   NewEpochState era ->

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
@@ -10,11 +10,6 @@ module Cardano.Ledger.Api.State.Query.Pool (
   -- * Stable query result types
   QueryResultPoolState (..),
 
-  -- * Deprecated aliases
-  QueryPoolStateResult,
-  mkQueryPoolStateResult,
-  queryPoolParameters,
-
   -- * Conversion
   toQueryResultPoolState,
 
@@ -127,10 +122,6 @@ instance DecCBOR QueryResultPoolState where
         <! From
         <! From
 
-type QueryPoolStateResult = QueryResultPoolState
-
-{-# DEPRECATED QueryPoolStateResult "Use QueryResultPoolState instead" #-}
-
 -- | Convert 'PState' to 'QueryResultPoolState'.
 toQueryResultPoolState ::
   (forall x. Map (KeyHash StakePool) x -> Map (KeyHash StakePool) x) ->
@@ -148,15 +139,9 @@ toQueryResultPoolState f ps network =
   where
     restrictedStakePools = f $ psStakePools ps
 
-mkQueryPoolStateResult ::
-  (forall x. Map (KeyHash StakePool) x -> Map (KeyHash StakePool) x) ->
-  PState era ->
-  Network ->
-  QueryResultPoolState
-mkQueryPoolStateResult = toQueryResultPoolState
-{-# DEPRECATED mkQueryPoolStateResult "Use toQueryResultPoolState instead" #-}
-
 -- | Query stake pool state.
+-- Replaces @getStakePools@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:449
 --   answerPureBlockQuery case for GetPoolState
 -- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:202
@@ -185,6 +170,8 @@ queryPoolState nes poolKeys network =
    in toQueryResultPoolState f pstate network
 
 -- | Query stake pool parameters.
+-- Replaces @getStakePools@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:445
 --   answerPureBlockQuery case for GetStakePoolParams
 -- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:299
@@ -210,15 +197,6 @@ queryStakePoolParams network nes poolKeys =
         | Set.null poolKeys = pools
         | otherwise = Map.restrictKeys pools poolKeys
    in Map.mapWithKey (stakePoolStateToStakePoolParams network) filtered
-
-queryPoolParameters ::
-  EraCertState era =>
-  Network ->
-  NewEpochState era ->
-  Set (KeyHash StakePool) ->
-  Map (KeyHash StakePool) StakePoolParams
-queryPoolParameters = queryStakePoolParams
-{-# DEPRECATED queryPoolParameters "Use queryStakePoolParams instead" #-}
 
 -- | Query a stake pool's default vote, determined by the DRep delegatee of the
 -- pool's reward account. In the absence of an explicit vote, this default vote
@@ -277,6 +255,8 @@ querySPOStakeDistr nes keys
     distr = psPoolDistr . fst $ finishedPulserState nes
 
 -- | Query the set of all currently registered stake pools.
+-- Replaces @getPools@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:443
 --   answerPureBlockQuery case for GetStakePools
 -- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:325
@@ -293,6 +273,8 @@ queryStakePools nes =
   Map.keysSet $ nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
 
 -- | Query stake pool distribution with fractions relative to total ADA supply.
+-- Replaces @poolsByTotalStakeFraction@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:523
 --   answerPureBlockQuery case for GetStakeDistribution2
 --
@@ -301,7 +283,7 @@ queryStakePools nes =
 -- of the total supply including undelegated ADA. Used by wallets to display
 -- pool saturation.
 --
--- This query uses 'currentSnapshot' (the __mark__ snapshot computed from the
+-- This query uses 'queryCurrentSnapshot' (the __mark__ snapshot computed from the
 -- current ledger state), whereas 'queryStakePoolDistrFromSnapshot' reads the
 -- memoized @nesPd@ (the __set__ snapshot computed at the last epoch boundary).
 --

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
@@ -271,7 +271,7 @@ querySPOStakeDistr ::
   Set (KeyHash StakePool) ->
   Map (KeyHash StakePool) Coin
 querySPOStakeDistr nes keys
-  | null keys = Map.map fromCompact distr
+  | Set.null keys = Map.map fromCompact distr
   | otherwise = Map.map fromCompact $ distr `Map.restrictKeys` keys
   where
     distr = psPoolDistr . fst $ finishedPulserState nes

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
@@ -1,0 +1,233 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+module Cardano.Ledger.Api.State.Query.Pool (
+  -- * Stable query result types
+  QueryResultPoolState (..),
+
+  -- * Deprecated aliases
+  QueryPoolStateResult,
+  mkQueryPoolStateResult,
+  queryPoolParameters,
+
+  -- * Conversion
+  toQueryResultPoolState,
+
+  -- * Queries
+  queryPoolState,
+  queryStakePoolParams,
+  queryStakePoolDefaultVote,
+  querySPOStakeDistr,
+) where
+
+import Cardano.Ledger.Api.State.Query.Governance (finishedPulserState)
+import Cardano.Ledger.BaseTypes (Network)
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (fromCompact)
+import Cardano.Ledger.Conway.Governance (
+  ConwayEraGov (..),
+  DefaultVote (..),
+  defaultStakePoolVote,
+  psPoolDistr,
+ )
+import Cardano.Ledger.Conway.State (ConwayEraAccounts)
+import Cardano.Ledger.Keys (KeyHash, StakePool)
+import Cardano.Ledger.Shelley.LedgerState (
+  NewEpochState,
+  PState,
+  certDStateL,
+  certPStateL,
+  epochStateStakePoolsL,
+  esLStateL,
+  lsCertStateL,
+  nesEsL,
+  psStakePoolsL,
+ )
+import Cardano.Ledger.Slot (EpochNo)
+import Cardano.Ledger.State (
+  EraCertState,
+  StakePoolParams,
+  accountsL,
+  psFutureStakePoolParams,
+  psRetiring,
+  psStakePools,
+  spsDeposit,
+  stakePoolStateToStakePoolParams,
+ )
+import Control.DeepSeq (NFData)
+import Data.Aeson (ToJSON)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import GHC.Generics (Generic)
+import Lens.Micro ((^.))
+import NoThunks.Class (NoThunks)
+
+-- | Result of 'queryPoolState'. Stable query result type for pool state.
+data QueryResultPoolState = QueryResultPoolState
+  { qrpsStakePoolParams :: !(Map (KeyHash StakePool) StakePoolParams)
+  , qrpsFutureStakePoolParams :: !(Map (KeyHash StakePool) StakePoolParams)
+  , qrpsRetiring :: !(Map (KeyHash StakePool) EpochNo)
+  , qrpsDeposits :: !(Map (KeyHash StakePool) Coin)
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+deriving instance ToJSON QueryResultPoolState
+
+instance NFData QueryResultPoolState
+
+instance NoThunks QueryResultPoolState
+
+instance EncCBOR QueryResultPoolState where
+  encCBOR (QueryResultPoolState stakePoolParams futureStakePoolParams retiring deposits) =
+    encode $
+      Rec QueryResultPoolState
+        !> To stakePoolParams
+        !> To futureStakePoolParams
+        !> To retiring
+        !> To deposits
+
+instance DecCBOR QueryResultPoolState where
+  decCBOR =
+    decode $
+      RecD QueryResultPoolState
+        <! From
+        <! From
+        <! From
+        <! From
+
+type QueryPoolStateResult = QueryResultPoolState
+
+{-# DEPRECATED QueryPoolStateResult "Use QueryResultPoolState instead" #-}
+
+-- | Convert 'PState' to 'QueryResultPoolState'.
+toQueryResultPoolState ::
+  (forall x. Map (KeyHash StakePool) x -> Map (KeyHash StakePool) x) ->
+  PState era ->
+  Network ->
+  QueryResultPoolState
+toQueryResultPoolState f ps network =
+  QueryResultPoolState
+    { qrpsStakePoolParams =
+        Map.mapWithKey (stakePoolStateToStakePoolParams network) restrictedStakePools
+    , qrpsFutureStakePoolParams = f $ psFutureStakePoolParams ps
+    , qrpsRetiring = f $ psRetiring ps
+    , qrpsDeposits = Map.map (fromCompact . spsDeposit) restrictedStakePools
+    }
+  where
+    restrictedStakePools = f $ psStakePools ps
+
+mkQueryPoolStateResult ::
+  (forall x. Map (KeyHash StakePool) x -> Map (KeyHash StakePool) x) ->
+  PState era ->
+  Network ->
+  QueryResultPoolState
+mkQueryPoolStateResult = toQueryResultPoolState
+{-# DEPRECATED mkQueryPoolStateResult "Use toQueryResultPoolState instead" #-}
+
+-- | Query stake pool state.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:449
+--   answerPureBlockQuery case for GetPoolState
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:202
+--   queryPoolState cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:663
+--   CLI invocation
+--
+-- Empty 'Set' returns all pools.
+queryPoolState ::
+  EraCertState era =>
+  NewEpochState era ->
+  Set (KeyHash StakePool) ->
+  Network ->
+  QueryResultPoolState
+queryPoolState nes poolKeys network =
+  let pstate = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL
+      f :: forall x. Map (KeyHash StakePool) x -> Map (KeyHash StakePool) x
+      f = if Set.null poolKeys then id else (`Map.restrictKeys` poolKeys)
+   in toQueryResultPoolState f pstate network
+
+-- | Query stake pool parameters.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:445
+--   answerPureBlockQuery case for GetStakePoolParams
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:299
+--   queryStakePoolParameters cardano-api wrapper
+--
+-- Empty 'Set' returns all pools.
+queryStakePoolParams ::
+  EraCertState era =>
+  Network ->
+  NewEpochState era ->
+  Set (KeyHash StakePool) ->
+  Map (KeyHash StakePool) StakePoolParams
+queryStakePoolParams network nes poolKeys =
+  let pools = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
+      filtered
+        | Set.null poolKeys = pools
+        | otherwise = Map.restrictKeys pools poolKeys
+   in Map.mapWithKey (stakePoolStateToStakePoolParams network) filtered
+
+queryPoolParameters ::
+  EraCertState era =>
+  Network ->
+  NewEpochState era ->
+  Set (KeyHash StakePool) ->
+  Map (KeyHash StakePool) StakePoolParams
+queryPoolParameters = queryStakePoolParams
+{-# DEPRECATED queryPoolParameters "Use queryStakePoolParams instead" #-}
+
+-- | Query a stake pool's default vote, determined by the DRep delegatee of the
+-- pool's reward account. In the absence of an explicit vote, this default vote
+-- is used. Note that this is different from the delegatee determined by the
+-- credential of the stake pool itself.
+--
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:518
+--   answerPureBlockQuery case for QueryStakePoolDefaultVote
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:513
+--   queryStakePoolDefaultVote cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:2003
+--   CLI invocation
+queryStakePoolDefaultVote ::
+  (EraCertState era, ConwayEraAccounts era) =>
+  NewEpochState era ->
+  -- | Specify the key hash of the pool whose default vote should be returned.
+  KeyHash StakePool ->
+  DefaultVote
+queryStakePoolDefaultVote nes poolId =
+  defaultStakePoolVote poolId (nes ^. nesEsL . epochStateStakePoolsL) $
+    nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL
+
+-- | Query pool stake distribution.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:477
+--   answerPureBlockQuery case for GetSPOStakeDistr
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:436
+--   querySPOStakeDistribution cardano-api wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1811
+--   CLI invocation
+--
+-- Empty 'Set' returns all pools.
+querySPOStakeDistr ::
+  ConwayEraGov era =>
+  NewEpochState era ->
+  Set (KeyHash StakePool) ->
+  Map (KeyHash StakePool) Coin
+querySPOStakeDistr nes keys
+  | null keys = Map.map fromCompact distr
+  | otherwise = Map.map fromCompact $ distr `Map.restrictKeys` keys
+  where
+    distr = psPoolDistr . fst $ finishedPulserState nes

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Pool.hs
@@ -23,11 +23,16 @@ module Cardano.Ledger.Api.State.Query.Pool (
   queryPoolState,
   queryStakePoolParams,
   queryStakePoolDefaultVote,
+  queryStakePools,
   querySPOStakeDistr,
+  queryStakePoolDistrByTotalSupply,
+  queryStakePoolDistrFromSnapshot,
+  queryStakePoolRelays,
 ) where
 
 import Cardano.Ledger.Api.State.Query.Governance (finishedPulserState)
-import Cardano.Ledger.BaseTypes (Network)
+import Cardano.Ledger.Api.State.Query.Snapshot (queryCurrentSnapshot)
+import Cardano.Ledger.BaseTypes (Network, unNonZero, (%?))
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -37,7 +42,7 @@ import Cardano.Ledger.Binary.Coders (
   (!>),
   (<!),
  )
-import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Coin (Coin (..), unCoin)
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.Governance (
   ConwayEraGov (..),
@@ -48,33 +53,44 @@ import Cardano.Ledger.Conway.Governance (
 import Cardano.Ledger.Conway.State (ConwayEraAccounts)
 import Cardano.Ledger.Keys (KeyHash, StakePool)
 import Cardano.Ledger.Shelley.LedgerState (
-  NewEpochState,
+  NewEpochState (..),
   PState,
   certDStateL,
   certPStateL,
+  circulation,
   epochStateStakePoolsL,
   esLStateL,
   lsCertStateL,
+  nesEs,
   nesEsL,
   psStakePoolsL,
  )
 import Cardano.Ledger.Slot (EpochNo)
 import Cardano.Ledger.State (
   EraCertState,
+  EraStake,
+  IndividualPoolStake (..),
+  PoolDistr (..),
   StakePoolParams,
+  StakePoolRelay,
   accountsL,
+  calculatePoolDistr,
   psFutureStakePoolParams,
   psRetiring,
   psStakePools,
+  sppRelays,
   spsDeposit,
+  spsRelays,
   stakePoolStateToStakePoolParams,
  )
 import Control.DeepSeq (NFData)
 import Data.Aeson (ToJSON)
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks)
@@ -231,3 +247,119 @@ querySPOStakeDistr nes keys
   | otherwise = Map.map fromCompact $ distr `Map.restrictKeys` keys
   where
     distr = psPoolDistr . fst $ finishedPulserState nes
+
+-- | Query the set of all currently registered stake pools.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:443
+--   answerPureBlockQuery case for GetStakePools
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Expr.hs:325
+--   queryStakePools cardano-api wrapper (CLI via Convenience.hs:148)
+--
+-- Returns the key hashes of every pool in the current PState.
+queryStakePools ::
+  EraCertState era =>
+  NewEpochState era ->
+  Set (KeyHash StakePool)
+queryStakePools nes =
+  Map.keysSet $ nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL . psStakePoolsL
+
+-- | Query stake pool distribution with fractions relative to total ADA supply.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:523
+--   answerPureBlockQuery case for GetStakeDistribution2
+--
+-- Unlike 'queryStakePoolDistrFromSnapshot' (which gives fractions of active
+-- stake only), this adjusts each pool's fractional stake to reflect its share
+-- of the total supply including undelegated ADA. Used by wallets to display
+-- pool saturation.
+--
+-- This query uses 'currentSnapshot' (the __mark__ snapshot computed from the
+-- current ledger state), whereas 'queryStakePoolDistrFromSnapshot' reads the
+-- memoized @nesPd@ (the __set__ snapshot computed at the last epoch boundary).
+--
+-- Needs @maxLovelaceSupply@ from genesis config.
+queryStakePoolDistrByTotalSupply ::
+  (EraStake era, EraCertState era) =>
+  -- | maxLovelaceSupply from genesis config
+  Word64 ->
+  NewEpochState era ->
+  PoolDistr
+queryStakePoolDistrByTotalSupply maxLovelaceSupply nes =
+  PoolDistr poolsByTotalStake totalActiveStake
+  where
+    snap = queryCurrentSnapshot nes
+    Coin totalStake =
+      let supply = Coin (fromIntegral maxLovelaceSupply)
+       in circulation (nesEs nes) supply
+    stakeRatio = unCoin (unNonZero totalActiveStake) %? totalStake
+    PoolDistr poolsByActiveStake totalActiveStake = calculatePoolDistr snap
+    poolsByTotalStake = Map.map toTotalStakeFrac poolsByActiveStake
+    toTotalStakeFrac (IndividualPoolStake s c vrf) =
+      IndividualPoolStake (s * stakeRatio) c vrf
+
+-- | Query the pool distribution derived from the set-snapshot.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:520
+--   answerPureBlockQuery case for GetPoolDistr2
+--
+-- Returns the pre-computed 'PoolDistr' stored in 'NewEpochState' (@nesPd@),
+-- optionally filtered to the given set of pools. Empty set returns all pools.
+--
+-- ==== Equivalence with consensus
+--
+-- Consensus computes this on every query as:
+--
+-- @calculatePoolDistr' predicate (ssStakeSet (esSnapshots epochState))@
+--
+-- We instead read @nesPd@, which is set at the epoch boundary to
+-- @ssStakeMarkPoolDistr (esSnapshots es)@ where @es@ is the /pre-transition/
+-- epoch state (see @Shelley.Rules.NewEpoch:172-188@). Since SNAP rotates
+-- @ssStakeMark@ → @ssStakeSet@ (see @Shelley.Rules.Snap:100@), and
+-- @ssStakeMarkPoolDistr = calculatePoolDistr ssStakeMark@ (see
+-- @State.SnapShots:374@), the memoized @nesPd@ is identical to
+-- @calculatePoolDistr (ssStakeSet ...)@ on the post-transition epoch state.
+--
+-- Filtering is applied /after/ reading the memoized distribution rather than
+-- /during/ @calculatePoolDistr'@. This is equivalent because
+-- @calculatePoolDistr'@ sets @pdTotalActiveStake@ from the snapshot total
+-- independently of the filter, and each pool's @IndividualPoolStake@ values
+-- depend only on that pool's data (see @State.SnapShots:449-464@).
+--
+-- This approach is more efficient: the expensive @calculatePoolDistr@
+-- computation happens once at the epoch boundary (ADR-7), and the query
+-- performs only an O(n+m) @Map.restrictKeys@.
+queryStakePoolDistrFromSnapshot ::
+  NewEpochState era ->
+  Set (KeyHash StakePool) ->
+  PoolDistr
+queryStakePoolDistrFromSnapshot nes poolIds
+  | Set.null poolIds = nesPd nes
+  | otherwise =
+      let pd = nesPd nes
+       in pd {unPoolDistr = Map.restrictKeys (unPoolDistr pd) poolIds}
+
+-- | Query pool relay information with associated stake fractions.
+-- Returns pools that have at least one registered relay, combining
+-- relays from both current and pending (future) pool registrations.
+--
+-- This provides the ledger-side data needed by consensus for peer
+-- discovery (GetLedgerPeerSnapshot). Consensus applies networking-specific
+-- transformations (relay type conversion, big-peer stake accumulation)
+-- on top of this result.
+--
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/PeerSelection.hs:32
+--   getPeers (LedgerSupportsPeerSelection instance)
+queryStakePoolRelays ::
+  EraCertState era =>
+  NewEpochState era ->
+  Map (KeyHash StakePool) (Rational, StrictSeq StakePoolRelay)
+queryStakePoolRelays nes =
+  Map.mapMaybeWithKey getRelays (unPoolDistr (nesPd nes))
+  where
+    pstate = nes ^. nesEsL . esLStateL . lsCertStateL . certPStateL
+    pools = psStakePools pstate
+    futureParams = psFutureStakePoolParams pstate
+    getRelays poolId ips =
+      let curRelays = maybe mempty spsRelays (Map.lookup poolId pools)
+          futRelays = maybe mempty sppRelays (Map.lookup poolId futureParams)
+          allRelays = curRelays <> futRelays
+       in if null allRelays
+            then Nothing
+            else Just (individualPoolStake ips, allRelays)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Reward.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Reward.hs
@@ -1,0 +1,245 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Cardano.Ledger.Api.State.Query.Reward (
+  -- * Stable query result types
+  QueryResultRewardInfoPools (..),
+
+  -- * Queries
+  queryNonMyopicMemberRewards,
+  queryRewardInfoPools,
+  queryRewardProvenance,
+) where
+
+import Cardano.Ledger.Api.State.Query.Snapshot (queryCurrentSnapshot)
+import Cardano.Ledger.BaseTypes (Globals (..), epochInfoPure, unNonZero, (%?))
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (fromCompact)
+import Cardano.Ledger.Core (ppA0L, ppNOptL)
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (StakePool, Staking))
+import Cardano.Ledger.Shelley.API.Wallet (
+  RewardInfoPool (..),
+  RewardParams (..),
+ )
+import Cardano.Ledger.Shelley.LedgerState (
+  EpochState (..),
+  NewEpochState (..),
+  RewardUpdate,
+  circulation,
+  createRUpd,
+  curPParamsEpochStateL,
+ )
+import Cardano.Ledger.Shelley.PoolRank (
+  NonMyopic (..),
+  PerformanceEstimate (..),
+  calcNonMyopicMemberReward,
+  getTopRankedPools,
+  percentile',
+ )
+import Cardano.Ledger.Shelley.RewardProvenance (RewardProvenance)
+import Cardano.Ledger.Shelley.Rewards (StakeShare (..))
+import Cardano.Ledger.Slot (epochInfoSize)
+import Cardano.Ledger.State (
+  EraCertState,
+  EraGov,
+  EraStake,
+  spssCost,
+  spssMargin,
+  spssPledge,
+  spssSelfDelegatedOwnersStake,
+  spssStake,
+  ssStakePoolsSnapShot,
+ )
+import qualified Cardano.Ledger.State as LS
+import Control.DeepSeq (NFData)
+import Control.Monad.Trans.Reader (runReader)
+import Data.Aeson (ToJSON)
+import Data.Default (Default (def))
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.VMap as VMap
+import Data.Word (Word64)
+import GHC.Generics (Generic)
+import Lens.Micro ((^.))
+import NoThunks.Class (NoThunks)
+
+-- | Stable query result for per-pool reward information.
+data QueryResultRewardInfoPools = QueryResultRewardInfoPools
+  { qrripParams :: !RewardParams
+  , qrripPools :: !(Map (KeyHash StakePool) RewardInfoPool)
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+deriving instance ToJSON QueryResultRewardInfoPools
+
+instance NFData QueryResultRewardInfoPools
+
+instance NoThunks QueryResultRewardInfoPools
+
+instance EncCBOR QueryResultRewardInfoPools where
+  encCBOR (QueryResultRewardInfoPools params pools) =
+    encode $
+      Rec QueryResultRewardInfoPools
+        !> To params
+        !> To pools
+
+instance DecCBOR QueryResultRewardInfoPools where
+  decCBOR =
+    decode $
+      RecD QueryResultRewardInfoPools
+        <! From
+        <! From
+
+-- | Query non-myopic pool member rewards for a set of credentials.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:415
+--   answerPureBlockQuery case for GetNonMyopicMemberRewards
+--
+-- For each given credential (or hypothetical stake amount), returns a map from
+-- each stake pool to the estimated non-myopic member reward for that pool.
+-- Wallets use this to answer "how much would I earn if I delegated to pool X?".
+--
+-- "Non-myopic" means rewards are estimated under the assumption that stake
+-- will eventually converge to a Nash equilibrium across pools, rather than
+-- using today's distribution naively. This avoids overestimating rewards for
+-- currently under-saturated pools.
+--
+-- The input set contains @'Either' 'Coin' ('Credential' 'Staking')@ values:
+--
+-- * @'Left' coin@ — a hypothetical stake amount (for "what if I delegated
+--   this much?" queries).
+-- * @'Right' cred@ — an existing credential whose current active stake is
+--   looked up from the ledger state.
+--
+-- This uses a fresh snapshot derived from the current ledger state, not the
+-- stored mark\/set\/go snapshots.
+queryNonMyopicMemberRewards ::
+  (EraGov era, EraStake era, EraCertState era) =>
+  -- | maxLovelaceSupply from genesis config
+  Word64 ->
+  NewEpochState era ->
+  Set (Either Coin (Credential Staking)) ->
+  Map
+    (Either Coin (Credential Staking))
+    (Map (KeyHash StakePool) Coin)
+queryNonMyopicMemberRewards maxLovelaceSupply ss = Map.fromSet nmmRewards
+  where
+    maxSupply = Coin . fromIntegral $ maxLovelaceSupply
+    totalStakeCoin@(Coin totalStake) = circulation es maxSupply
+    toShare (Coin x) = StakeShare $ x %? totalStake
+    memShare (Right cred) =
+      toShare $
+        maybe mempty (fromCompact . unNonZero . LS.swdStake) $
+          VMap.lookup cred (LS.unActiveStake activeStake)
+    memShare (Left coin) = toShare coin
+    es = nesEs ss
+    pp = es ^. curPParamsEpochStateL
+    NonMyopic {likelihoodsNM = ls, rewardPotNM = rPot} = esNonMyopic es
+    LS.SnapShot {LS.ssActiveStake = activeStake, LS.ssStakePoolsSnapShot = stakePoolsSnapShot} = queryCurrentSnapshot ss
+    calcNMMRewards t poolId spss
+      | spssPledge <= spssSelfDelegatedOwnersStake =
+          calcNonMyopicMemberReward pp rPot poolId spssCost spssMargin s sigma t topPools hitRateEst
+      | otherwise = mempty
+      where
+        LS.StakePoolSnapShot {spssSelfDelegatedOwnersStake, spssPledge, spssCost, spssMargin} = spss
+        s = toShare spssPledge
+        hitRateEst = percentile' (histLookup poolId)
+        sigma = toShare (fromCompact (LS.spssStake spss))
+
+    nmmRewards cred = VMap.toMap $ VMap.mapWithKey (calcNMMRewards $ memShare cred) stakePoolsSnapShot
+    histLookup k = VMap.findWithDefault mempty k ls
+    topPools =
+      getTopRankedPools rPot totalStakeCoin pp $
+        Map.intersectionWith (,) (VMap.toMap (VMap.map percentile' ls)) $
+          VMap.toMap stakePoolsSnapShot
+
+-- | Query per-pool reward information from the current stake distribution.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:447
+--   answerPureBlockQuery case for GetRewardInfoPools
+--
+-- This is the primary query for wallets and tools that display pool ranking,
+-- saturation levels, and estimated returns. It returns per-pool data (stake,
+-- pledge, costs, margins, performance estimates) together with global reward
+-- parameters (a0, nOpt, totalStake, rPot).
+--
+-- Uses a fresh snapshot from 'queryCurrentSnapshot' rather than the stored
+-- epoch-boundary snapshots, so the data reflects the most recent ledger state.
+queryRewardInfoPools ::
+  (EraGov era, EraStake era, EraCertState era) =>
+  -- | maxLovelaceSupply from genesis config
+  Word64 ->
+  NewEpochState era ->
+  QueryResultRewardInfoPools
+queryRewardInfoPools maxLovelaceSupply nes =
+  QueryResultRewardInfoPools rewardParams poolInfos
+  where
+    es = nesEs nes
+    pp = es ^. curPParamsEpochStateL
+    NonMyopic {likelihoodsNM = ls, rewardPotNM = rPot} = esNonMyopic es
+    histLookup poolId = VMap.findWithDefault mempty poolId ls
+
+    LS.SnapShot {ssStakePoolsSnapShot} = queryCurrentSnapshot nes
+
+    rewardParams =
+      RewardParams
+        { a0 = pp ^. ppA0L
+        , nOpt = pp ^. ppNOptL
+        , totalStake =
+            let supply = Coin (fromIntegral maxLovelaceSupply)
+             in circulation es supply
+        , rPot = rPot
+        }
+    poolInfos = VMap.toMap $ VMap.mapWithKey mkRewardInfoPool ssStakePoolsSnapShot
+    mkRewardInfoPool poolId LS.StakePoolSnapShot {spssStake, spssSelfDelegatedOwnersStake, spssPledge, spssMargin, spssCost} =
+      RewardInfoPool
+        { stake = fromCompact spssStake
+        , ownerStake = spssSelfDelegatedOwnersStake
+        , ownerPledge = spssPledge
+        , margin = spssMargin
+        , cost = spssCost
+        , performanceEstimate =
+            unPerformanceEstimate $ percentile' $ histLookup poolId
+        }
+
+-- | Query reward provenance by computing a reward update (internally based on the go snapshot).
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:441
+--   answerPureBlockQuery case for GetRewardProvenance
+--
+-- __Note:__ The 'RewardProvenance' component of the result is always 'def'
+-- (empty\/default). Only the 'RewardUpdate' is meaningful. This matches the
+-- consensus implementation, which also discards provenance.
+--
+-- This function requires the full 'Globals' because it internally runs
+-- 'createRUpd' in a 'Reader' monad that needs access to 'epochInfo',
+-- 'activeSlotCoeff', 'securityParameter', and 'maxLovelaceSupply'.
+queryRewardProvenance ::
+  (EraGov era, EraCertState era) =>
+  Globals ->
+  NewEpochState era ->
+  (RewardUpdate, RewardProvenance)
+queryRewardProvenance globals newEpochState =
+  ( runReader
+      (createRUpd slotsPerEpoch blocksMade epochState maxSupply asc secparam)
+      globals
+  , def
+  )
+  where
+    epochState = nesEs newEpochState
+    maxSupply = Coin (fromIntegral (maxLovelaceSupply globals))
+    blocksMade = nesBprev newEpochState
+    epochNo = nesEL newEpochState
+    slotsPerEpoch = epochInfoSize (epochInfoPure globals) epochNo
+    asc = activeSlotCoeff globals
+    secparam = securityParameter globals
+{-# DEPRECATED
+  queryRewardProvenance
+  "Wallets should prefer 'queryRewardInfoPools' for up-to-date reward information based on the current stake distribution."
+  #-}

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Reward.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Reward.hs
@@ -100,6 +100,8 @@ instance DecCBOR QueryResultRewardInfoPools where
         <! From
 
 -- | Query non-myopic pool member rewards for a set of credentials.
+-- Replaces @getNonMyopicMemberRewards@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:415
 --   answerPureBlockQuery case for GetNonMyopicMemberRewards
 --
@@ -170,6 +172,8 @@ queryNonMyopicMemberRewards maxLovelaceSupply ss = Map.fromSet nmmRewards
           VMap.toMap stakePoolsSnapShot
 
 -- | Query per-pool reward information from the current stake distribution.
+-- Replaces @getRewardInfoPools@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:447
 --   answerPureBlockQuery case for GetRewardInfoPools
 --
@@ -225,6 +229,8 @@ queryRewardInfoPools maxLovelaceSupply nes =
         }
 
 -- | Query reward provenance by computing a reward update (internally based on the go snapshot).
+-- Replaces @getRewardProvenance@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:441
 --   answerPureBlockQuery case for GetRewardProvenance
 --
@@ -261,7 +267,3 @@ queryRewardProvenance globals newEpochState =
     slotsPerEpoch = epochInfoSize (epochInfoPure globals) epochNo
     asc = activeSlotCoeff globals
     secparam = securityParameter globals
-{-# DEPRECATED
-  queryRewardProvenance
-  "Wallets should prefer 'queryRewardInfoPools' for up-to-date reward information based on the current stake distribution."
-  #-}

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Reward.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Reward.hs
@@ -121,6 +121,14 @@ instance DecCBOR QueryResultRewardInfoPools where
 --
 -- This uses a fresh snapshot derived from the current ledger state, not the
 -- stored mark\/set\/go snapshots.
+--
+-- @
+--   O(c + k * p)
+-- @
+-- where,
+--   (c) is the staking credentials, queryCurrentSnapshot
+--   (k) is the input credential\/coin set, iterate over
+--   (p) is the registered stake pools, VMap.mapWithKey per credential
 queryNonMyopicMemberRewards ::
   (EraGov era, EraStake era, EraCertState era) =>
   -- | maxLovelaceSupply from genesis config
@@ -172,6 +180,13 @@ queryNonMyopicMemberRewards maxLovelaceSupply ss = Map.fromSet nmmRewards
 --
 -- Uses a fresh snapshot from 'queryCurrentSnapshot' rather than the stored
 -- epoch-boundary snapshots, so the data reflects the most recent ledger state.
+--
+-- @
+--   O(c + p)
+-- @
+-- where,
+--   (c) is the staking credentials, queryCurrentSnapshot
+--   (p) is the registered stake pools, VMap.mapWithKey
 queryRewardInfoPools ::
   (EraGov era, EraStake era, EraCertState era) =>
   -- | maxLovelaceSupply from genesis config
@@ -220,6 +235,13 @@ queryRewardInfoPools maxLovelaceSupply nes =
 -- This function requires the full 'Globals' because it internally runs
 -- 'createRUpd' in a 'Reader' monad that needs access to 'epochInfo',
 -- 'activeSlotCoeff', 'securityParameter', and 'maxLovelaceSupply'.
+--
+-- @
+--   O(c * log(p))
+-- @
+-- where,
+--   (c) is the staking credentials, createRUpd reward computation
+--   (p) is the registered stake pools, reward calculation per credential
 queryRewardProvenance ::
   (EraGov era, EraCertState era) =>
   Globals ->

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Snapshot.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Snapshot.hs
@@ -18,6 +18,7 @@ module Cardano.Ledger.Api.State.Query.Snapshot (
 
   -- * Queries
   queryStakeSnapshots,
+  queryCurrentSnapshot,
 ) where
 
 import Cardano.Ledger.BaseTypes (NonZero, natVersion, pvMajor)
@@ -36,14 +37,23 @@ import Cardano.Ledger.Core (ppProtocolVersionL)
 import Cardano.Ledger.Keys (KeyHash, StakePool)
 import Cardano.Ledger.Shelley.LedgerState (
   NewEpochState,
+  certDStateL,
+  certPStateL,
   curPParamsEpochStateL,
+  esLStateL,
   esSnapshots,
+  lsCertStateL,
   nesEs,
   nesEsL,
  )
 import Cardano.Ledger.State (
+  EraCertState,
   EraGov,
+  EraStake,
+  SnapShot,
   SnapShots (..),
+  instantStakeG,
+  snapShotFromInstantStake,
   spssNumDelegators,
   spssStake,
   ssStakePoolsSnapShot,
@@ -215,3 +225,23 @@ queryStakeSnapshots nes requestedPoolIds =
         , qrssSetTotal = ssTotalActiveStake ssStakeSet
         , qrssGoTotal = ssTotalActiveStake ssStakeGo
         }
+
+-- | Compute a snapshot from the current (live) ledger state, rather than
+-- from one of the stored epoch-boundary snapshots (mark / set / go).
+--
+-- Used when ranking pools and reporting their saturation level: the most
+-- recent state is more relevant than a potentially stale snapshot.
+--
+-- Source: eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs:296
+--   currentSnapshot (now deprecated)
+queryCurrentSnapshot ::
+  (EraStake era, EraCertState era) =>
+  NewEpochState era ->
+  SnapShot
+queryCurrentSnapshot nes =
+  snapShotFromInstantStake instantStake dstate pstate
+  where
+    ledgerState = nesEs nes ^. esLStateL
+    instantStake = ledgerState ^. instantStakeG
+    dstate = ledgerState ^. lsCertStateL . certDStateL
+    pstate = ledgerState ^. lsCertStateL . certPStateL

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Snapshot.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Snapshot.hs
@@ -11,10 +11,6 @@ module Cardano.Ledger.Api.State.Query.Snapshot (
   QueryResultStakeSnapshot (..),
   QueryResultStakeSnapshots (..),
 
-  -- * Deprecated aliases
-  StakeSnapshot,
-  StakeSnapshots,
-
   -- * Queries
   queryStakeSnapshots,
   queryCurrentSnapshot,
@@ -101,10 +97,6 @@ instance DecCBOR QueryResultStakeSnapshot where
         <! From
         <! From
 
-type StakeSnapshot = QueryResultStakeSnapshot
-
-{-# DEPRECATED StakeSnapshot "Use QueryResultStakeSnapshot instead" #-}
-
 -- | Stake snapshots for all pools plus total active stake per snapshot.
 data QueryResultStakeSnapshots = QueryResultStakeSnapshots
   { qrssStakeSnapshots :: !(Map (KeyHash StakePool) QueryResultStakeSnapshot)
@@ -137,10 +129,6 @@ instance DecCBOR QueryResultStakeSnapshots where
         <! From
         <! From
         <! From
-
-type StakeSnapshots = QueryResultStakeSnapshots
-
-{-# DEPRECATED StakeSnapshots "Use QueryResultStakeSnapshots instead" #-}
 
 -- | Report stake per pool per snapshot as well as total active stake per snapshot.
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:451
@@ -234,12 +222,10 @@ queryStakeSnapshots nes requestedPoolIds =
 
 -- | Compute a snapshot from the current (live) ledger state, rather than
 -- from one of the stored epoch-boundary snapshots (mark / set / go).
+-- Replaces @currentSnapshot@ from @Cardano.Ledger.Shelley.API.Wallet@.
 --
 -- Used when ranking pools and reporting their saturation level: the most
 -- recent state is more relevant than a potentially stale snapshot.
---
--- Source: eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs:296
---   currentSnapshot (now deprecated)
 --
 -- @
 --   O(c + p)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Snapshot.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Snapshot.hs
@@ -1,0 +1,217 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+module Cardano.Ledger.Api.State.Query.Snapshot (
+  -- * Stable query result types
+  QueryResultStakeSnapshot (..),
+  QueryResultStakeSnapshots (..),
+
+  -- * Deprecated aliases
+  StakeSnapshot,
+  StakeSnapshots,
+
+  -- * Queries
+  queryStakeSnapshots,
+) where
+
+import Cardano.Ledger.BaseTypes (NonZero, natVersion, pvMajor)
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
+import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Compactible (fromCompact)
+import Cardano.Ledger.Core (ppProtocolVersionL)
+import Cardano.Ledger.Keys (KeyHash, StakePool)
+import Cardano.Ledger.Shelley.LedgerState (
+  NewEpochState,
+  curPParamsEpochStateL,
+  esSnapshots,
+  nesEs,
+  nesEsL,
+ )
+import Cardano.Ledger.State (
+  EraGov,
+  SnapShots (..),
+  spssNumDelegators,
+  spssStake,
+  ssStakePoolsSnapShot,
+  ssTotalActiveStake,
+ )
+import Control.DeepSeq (NFData)
+import Control.Monad (guard)
+import Data.Aeson (ToJSON)
+import Data.Foldable (fold)
+import Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Data.VMap as VMap
+import GHC.Generics (Generic)
+import Lens.Micro ((^.))
+import NoThunks.Class (NoThunks)
+
+-- | Per-pool stake snapshot across mark, set, and go ledger snapshots.
+data QueryResultStakeSnapshot = QueryResultStakeSnapshot
+  { qrssMarkPool :: !Coin
+  , qrssSetPool :: !Coin
+  , qrssGoPool :: !Coin
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+deriving instance ToJSON QueryResultStakeSnapshot
+
+instance NFData QueryResultStakeSnapshot
+
+instance NoThunks QueryResultStakeSnapshot
+
+instance EncCBOR QueryResultStakeSnapshot where
+  encCBOR (QueryResultStakeSnapshot markPool setPool goPool) =
+    encode $
+      Rec QueryResultStakeSnapshot
+        !> To markPool
+        !> To setPool
+        !> To goPool
+
+instance DecCBOR QueryResultStakeSnapshot where
+  decCBOR =
+    decode $
+      RecD QueryResultStakeSnapshot
+        <! From
+        <! From
+        <! From
+
+type StakeSnapshot = QueryResultStakeSnapshot
+
+{-# DEPRECATED StakeSnapshot "Use QueryResultStakeSnapshot instead" #-}
+
+-- | Stake snapshots for all pools plus total active stake per snapshot.
+data QueryResultStakeSnapshots = QueryResultStakeSnapshots
+  { qrssStakeSnapshots :: !(Map (KeyHash StakePool) QueryResultStakeSnapshot)
+  , qrssMarkTotal :: !(NonZero Coin)
+  , qrssSetTotal :: !(NonZero Coin)
+  , qrssGoTotal :: !(NonZero Coin)
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+deriving instance ToJSON QueryResultStakeSnapshots
+
+instance NFData QueryResultStakeSnapshots
+
+instance NoThunks QueryResultStakeSnapshots
+
+instance EncCBOR QueryResultStakeSnapshots where
+  encCBOR (QueryResultStakeSnapshots stakeSnapshots markTotal setTotal goTotal) =
+    encode $
+      Rec QueryResultStakeSnapshots
+        !> To stakeSnapshots
+        !> To markTotal
+        !> To setTotal
+        !> To goTotal
+
+instance DecCBOR QueryResultStakeSnapshots where
+  decCBOR =
+    decode $
+      RecD QueryResultStakeSnapshots
+        <! From
+        <! From
+        <! From
+        <! From
+
+type StakeSnapshots = QueryResultStakeSnapshots
+
+{-# DEPRECATED StakeSnapshots "Use QueryResultStakeSnapshots instead" #-}
+
+-- | Report stake per pool per snapshot as well as total active stake per snapshot.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:451
+--   answerPureBlockQuery case for GetStakeSnapshots
+--
+-- Each snapshot is taken at an epoch boundary. The mark snapshot is the most recent, taken
+-- immediately before the start of the current epoch. The set snapshot is one epoch older,
+-- and the go snapshot is the oldest (two epochs back), used for reward calculation and
+-- leader election.
+--
+-- /Note/ - The behavior of this function depends on the protocol version:
+--
+-- __Protocol Version < 11:__
+--
+-- * Empty 'Set': collects pools that have at least one delegator in any of the three
+--   snapshots. Pools with delegators but zero stake are still included (with zero-valued
+--   entries).
+-- * Specific pool IDs: results are returned for exactly those pools, even if they have
+--   no stake or are not registered (with zero-valued entries).
+--
+-- __Protocol Version >= 11:__
+--
+-- * Empty 'Set': collects pools with non-zero stake in any of the three snapshots.
+-- * Specific pool IDs: pools with zero stake across all three snapshots are filtered out
+--   and will not appear in the result, even if explicitly requested.
+queryStakeSnapshots ::
+  EraGov era =>
+  NewEpochState era ->
+  Set (KeyHash StakePool) ->
+  QueryResultStakeSnapshots
+queryStakeSnapshots nes requestedPoolIds =
+  let SnapShots
+        { ssStakeMark
+        , ssStakeSet
+        , ssStakeGo
+        } = esSnapshots $ nesEs nes
+
+      mkStakeSnapshotMaybe poolId = do
+        let
+          markPoolStake = spssStake <$> VMap.lookup poolId (ssStakePoolsSnapShot ssStakeMark)
+          setPoolStake = spssStake <$> VMap.lookup poolId (ssStakePoolsSnapShot ssStakeSet)
+          goPoolStake = spssStake <$> VMap.lookup poolId (ssStakePoolsSnapShot ssStakeGo)
+        -- Non-registered stake pools or ones that have no stake are of no interest to us.
+        guard (fold [markPoolStake, setPoolStake, goPoolStake] > Just mempty)
+        Just
+          QueryResultStakeSnapshot
+            { qrssMarkPool = maybe mempty fromCompact markPoolStake
+            , qrssSetPool = maybe mempty fromCompact setPoolStake
+            , qrssGoPool = maybe mempty fromCompact goPoolStake
+            }
+      mkStakeSnapshot poolId =
+        let
+          lookupStake =
+            maybe mempty (fromCompact . spssStake) . VMap.lookup poolId . ssStakePoolsSnapShot
+         in
+          QueryResultStakeSnapshot
+            { qrssMarkPool = lookupStake ssStakeMark
+            , qrssSetPool = lookupStake ssStakeSet
+            , qrssGoPool = lookupStake ssStakeGo
+            }
+      version = pvMajor (nes ^. nesEsL . curPParamsEpochStateL . ppProtocolVersionL)
+      poolIds =
+        if Set.null requestedPoolIds
+          then
+            if version < natVersion @11
+              then
+                foldMap
+                  (VMap.keysSet . VMap.filter (\_ -> (> 0) . spssNumDelegators) . ssStakePoolsSnapShot)
+                  [ssStakeMark, ssStakeSet, ssStakeGo]
+              else
+                foldMap
+                  (VMap.keysSet . VMap.filter (\_ -> (> mempty) . spssStake) . ssStakePoolsSnapShot)
+                  [ssStakeMark, ssStakeSet, ssStakeGo]
+          else requestedPoolIds
+   in QueryResultStakeSnapshots
+        { qrssStakeSnapshots =
+            if version < natVersion @11
+              then Map.fromSet mkStakeSnapshot poolIds
+              else Map.mapMaybe id $ Map.fromSet mkStakeSnapshotMaybe poolIds
+        , qrssMarkTotal = ssTotalActiveStake ssStakeMark
+        , qrssSetTotal = ssTotalActiveStake ssStakeSet
+        , qrssGoTotal = ssTotalActiveStake ssStakeGo
+        }

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Snapshot.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Snapshot.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Cardano.Ledger.Api.State.Query.Snapshot (
   -- * Stable query result types
@@ -167,6 +166,13 @@ type StakeSnapshots = QueryResultStakeSnapshots
 -- * Empty 'Set': collects pools with non-zero stake in any of the three snapshots.
 -- * Specific pool IDs: pools with zero stake across all three snapshots are filtered out
 --   and will not appear in the result, even if explicitly requested.
+--
+-- @
+--   O(v + k * log(v))
+-- @
+-- where,
+--   (v) is the size of the snapshot VMaps, VMap.filter and VMap.keysSet
+--   (k) is the number of result pools, VMap.lookup (×3 snapshots per pool)
 queryStakeSnapshots ::
   EraGov era =>
   NewEpochState era ->
@@ -234,6 +240,13 @@ queryStakeSnapshots nes requestedPoolIds =
 --
 -- Source: eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Wallet.hs:296
 --   currentSnapshot (now deprecated)
+--
+-- @
+--   O(c + p)
+-- @
+-- where,
+--   (c) is the total staking credentials, instantStake traversal
+--   (p) is the number of registered stake pools, snapShotFromInstantStake
 queryCurrentSnapshot ::
   (EraStake era, EraCertState era) =>
   NewEpochState era ->

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/StakeDelegation.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/StakeDelegation.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.Ledger.Api.State.Query.StakeDelegation (
+  -- * Stable query result type
+  QueryResultDelegsAndRewards (..),
+
+  -- * Queries
+  queryStakePoolDelegsAndRewards,
+) where
+
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
+import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Compactible (fromCompact)
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (StakePool, Staking))
+import Cardano.Ledger.Shelley.LedgerState (
+  NewEpochState,
+  certDStateL,
+  esLStateL,
+  lsCertStateL,
+  nesEsL,
+ )
+import Cardano.Ledger.State (
+  EraCertState,
+  accountsL,
+  accountsMapL,
+  balanceAccountStateL,
+  stakePoolDelegationAccountStateL,
+ )
+import Control.DeepSeq (NFData)
+import Data.Aeson (ToJSON)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import GHC.Generics (Generic)
+import Lens.Micro ((^.))
+import NoThunks.Class (NoThunks)
+
+-- | Stable query result for filtered delegations and reward accounts.
+data QueryResultDelegsAndRewards = QueryResultDelegsAndRewards
+  { qrdarDelegations :: !(Map (Credential Staking) (KeyHash StakePool))
+  , qrdarRewards :: !(Map (Credential Staking) Coin)
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+deriving instance ToJSON QueryResultDelegsAndRewards
+
+instance NFData QueryResultDelegsAndRewards
+
+instance NoThunks QueryResultDelegsAndRewards
+
+instance EncCBOR QueryResultDelegsAndRewards where
+  encCBOR (QueryResultDelegsAndRewards delegations rewards) =
+    encode $
+      Rec QueryResultDelegsAndRewards
+        !> To delegations
+        !> To rewards
+
+instance DecCBOR QueryResultDelegsAndRewards where
+  decCBOR =
+    decode $
+      RecD QueryResultDelegsAndRewards
+        <! From
+        <! From
+
+-- | Query stake pool delegations and reward balances for registered credentials.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:433
+--   answerPureBlockQuery case for GetFilteredDelegationsAndRewardAccounts
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1034
+--   CLI invocation (as queryStakeAddresses)
+--
+-- The two result fields have different coverage: 'qrdarDelegations' contains only
+-- credentials that are actually delegated to a stake pool, while 'qrdarRewards'
+-- contains all selected registered credentials regardless of delegation status.
+--
+-- Empty 'Set' returns all registered credentials.
+queryStakePoolDelegsAndRewards ::
+  EraCertState era =>
+  NewEpochState era ->
+  Set (Credential Staking) ->
+  QueryResultDelegsAndRewards
+queryStakePoolDelegsAndRewards nes creds =
+  let accountsMap = nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL . accountsMapL
+      accountsMapFiltered
+        | Set.null creds = accountsMap
+        | otherwise = accountsMap `Map.restrictKeys` creds
+   in QueryResultDelegsAndRewards
+        { qrdarDelegations = Map.mapMaybe (^. stakePoolDelegationAccountStateL) accountsMapFiltered
+        , qrdarRewards = Map.map (fromCompact . (^. balanceAccountStateL)) accountsMapFiltered
+        }

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/StakeDelegation.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/StakeDelegation.hs
@@ -83,6 +83,13 @@ instance DecCBOR QueryResultDelegsAndRewards where
 -- contains all selected registered credentials regardless of delegation status.
 --
 -- Empty 'Set' returns all registered credentials.
+--
+-- @
+--   O(c + k)
+-- @
+-- where,
+--   (c) is the total staking credentials, Map.restrictKeys
+--   (k) is the requested credential set, Map.restrictKeys
 queryStakePoolDelegsAndRewards ::
   EraCertState era =>
   NewEpochState era ->
@@ -108,6 +115,13 @@ queryStakePoolDelegsAndRewards nes creds =
 --
 -- Returns the deposit for each given credential that is currently registered.
 -- Empty 'Set' returns all registered credentials.
+--
+-- @
+--   O(c + k)
+-- @
+-- where,
+--   (c) is the total staking credentials, Map.restrictKeys
+--   (k) is the requested credential set, Map.restrictKeys
 queryStakeDelegDeposits ::
   EraCertState era =>
   NewEpochState era ->

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/StakeDelegation.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/StakeDelegation.hs
@@ -11,6 +11,7 @@ module Cardano.Ledger.Api.State.Query.StakeDelegation (
 
   -- * Queries
   queryStakePoolDelegsAndRewards,
+  queryStakeDelegDeposits,
 ) where
 
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
@@ -31,6 +32,7 @@ import Cardano.Ledger.State (
   accountsL,
   accountsMapL,
   balanceAccountStateL,
+  depositAccountStateL,
   stakePoolDelegationAccountStateL,
  )
 import Control.DeepSeq (NFData)
@@ -95,3 +97,25 @@ queryStakePoolDelegsAndRewards nes creds =
         { qrdarDelegations = Map.mapMaybe (^. stakePoolDelegationAccountStateL) accountsMapFiltered
         , qrdarRewards = Map.map (fromCompact . (^. balanceAccountStateL)) accountsMapFiltered
         }
+
+-- | Query staking delegation deposits.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:455
+--   answerPureBlockQuery case for GetStakeDelegDeposits
+-- Also: cardano-api:cardano-api/src/Cardano/Api/Query/Internal/Convenience.hs:154
+--   queryStakeDelegDeposits cardano-api convenience wrapper
+-- Also: cardano-cli:cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs:1036
+--   CLI invocation
+--
+-- Returns the deposit for each given credential that is currently registered.
+-- Empty 'Set' returns all registered credentials.
+queryStakeDelegDeposits ::
+  EraCertState era =>
+  NewEpochState era ->
+  Set (Credential Staking) ->
+  Map (Credential Staking) Coin
+queryStakeDelegDeposits nes creds =
+  let accountsMap = nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL . accountsMapL
+      selected
+        | Set.null creds = accountsMap
+        | otherwise = accountsMap `Map.restrictKeys` creds
+   in Map.map (fromCompact . (^. depositAccountStateL)) selected

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/UTxO.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/UTxO.hs
@@ -1,0 +1,65 @@
+module Cardano.Ledger.Api.State.Query.UTxO (
+  queryUTxOFull,
+  queryUTxOByAddress,
+  queryUTxOByTxIn,
+) where
+
+import Cardano.Ledger.Address (Addr, compactAddr)
+import Cardano.Ledger.Core (EraTxOut, addrEitherTxOutL)
+import Cardano.Ledger.Shelley.LedgerState (
+  CanSetUTxO (utxoL),
+  NewEpochState,
+  esLStateL,
+  lsUTxOStateL,
+  nesEsL,
+ )
+import Cardano.Ledger.State (UTxO (..), txInsFilter)
+import Cardano.Ledger.TxIn (TxIn)
+import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Lens.Micro ((^.))
+
+-- | Query the full UTxO set.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:1259
+--   answerShelleyTraversingQueries case for GetUTxOWhole
+--
+-- __Warning:__ This is an expensive query — it returns the entire UTxO map.
+-- Prefer 'queryUTxOByAddress' or 'queryUTxOByTxIn' when possible.
+queryUTxOFull ::
+  NewEpochState era ->
+  UTxO era
+queryUTxOFull nes = nes ^. nesEsL . esLStateL . lsUTxOStateL . utxoL
+
+-- | Query UTxO entries filtered by address.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:1258
+--   answerShelleyTraversingQueries case for GetUTxOByAddress
+--
+-- Returns only UTxO entries whose address is in the given set.
+-- An empty set returns an empty UTxO (use 'queryUTxOFull' for everything).
+queryUTxOByAddress ::
+  EraTxOut era =>
+  NewEpochState era ->
+  Set Addr ->
+  UTxO era
+queryUTxOByAddress nes addrSet =
+  UTxO $ Map.filter checkAddr fullUTxO
+  where
+    UTxO fullUTxO = queryUTxOFull nes
+    compactAddrSet = Set.map compactAddr addrSet
+    checkAddr out =
+      case out ^. addrEitherTxOutL of
+        Left addr -> addr `Set.member` addrSet
+        Right cAddr -> cAddr `Set.member` compactAddrSet
+
+-- | Query UTxO entries filtered by transaction input.
+-- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:1180
+--   answerShelleyLookupQueries case for GetUTxOByTxIn
+--
+-- Returns only UTxO entries whose 'TxIn' is in the given set.
+-- An empty set returns an empty UTxO (use 'queryUTxOFull' for everything).
+queryUTxOByTxIn ::
+  NewEpochState era ->
+  Set TxIn ->
+  UTxO era
+queryUTxOByTxIn nes = txInsFilter (queryUTxOFull nes)

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/UTxO.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/UTxO.hs
@@ -26,6 +26,8 @@ import Lens.Micro ((^.))
 --
 -- __Warning:__ This is an expensive query — it returns the entire UTxO map.
 -- Prefer 'queryUTxOByAddress' or 'queryUTxOByTxIn' when possible.
+--
+-- /O(1)/
 queryUTxOFull ::
   NewEpochState era ->
   UTxO era
@@ -37,6 +39,13 @@ queryUTxOFull nes = nes ^. nesEsL . esLStateL . lsUTxOStateL . utxoL
 --
 -- Returns only UTxO entries whose address is in the given set.
 -- An empty set returns an empty UTxO (use 'queryUTxOFull' for everything).
+--
+-- @
+--   O(u * log(k))
+-- @
+-- where,
+--   (u) is the size of the full UTxO map, Map.filter with Set.member per entry
+--   (k) is the size of the address set, Set.member lookup per UTxO entry
 queryUTxOByAddress ::
   EraTxOut era =>
   NewEpochState era ->
@@ -58,6 +67,13 @@ queryUTxOByAddress nes addrSet =
 --
 -- Returns only UTxO entries whose 'TxIn' is in the given set.
 -- An empty set returns an empty UTxO (use 'queryUTxOFull' for everything).
+--
+-- @
+--   O(u + k)
+-- @
+-- where,
+--   (u) is the size of the full UTxO map, Map.restrictKeys
+--   (k) is the size of the TxIn set, Map.restrictKeys
 queryUTxOByTxIn ::
   NewEpochState era ->
   Set TxIn ->

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/UTxO.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/UTxO.hs
@@ -52,7 +52,10 @@ queryUTxOByAddress ::
   Set Addr ->
   UTxO era
 queryUTxOByAddress nes addrSet =
-  UTxO $ Map.filter checkAddr fullUTxO
+  UTxO $
+    if Set.null addrSet
+      then mempty
+      else Map.filter checkAddr fullUTxO
   where
     UTxO fullUTxO = queryUTxOFull nes
     compactAddrSet = Set.map compactAddr addrSet
@@ -78,4 +81,6 @@ queryUTxOByTxIn ::
   NewEpochState era ->
   Set TxIn ->
   UTxO era
-queryUTxOByTxIn nes = txInsFilter (queryUTxOFull nes)
+queryUTxOByTxIn nes txIns
+  | Set.null txIns = UTxO mempty
+  | otherwise = txInsFilter (queryUTxOFull nes) txIns

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/UTxO.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/UTxO.hs
@@ -21,6 +21,8 @@ import qualified Data.Set as Set
 import Lens.Micro ((^.))
 
 -- | Query the full UTxO set.
+-- Replaces @getUTxO@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:1259
 --   answerShelleyTraversingQueries case for GetUTxOWhole
 --
@@ -34,6 +36,8 @@ queryUTxOFull ::
 queryUTxOFull nes = nes ^. nesEsL . esLStateL . lsUTxOStateL . utxoL
 
 -- | Query UTxO entries filtered by address.
+-- Replaces @getFilteredUTxO@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:1258
 --   answerShelleyTraversingQueries case for GetUTxOByAddress
 --
@@ -65,6 +69,8 @@ queryUTxOByAddress nes addrSet =
         Right cAddr -> cAddr `Set.member` compactAddrSet
 
 -- | Query UTxO entries filtered by transaction input.
+-- Replaces @getUTxOSubset@ from @Cardano.Ledger.Shelley.API.Wallet@.
+--
 -- Source: ouroboros-consensus:ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs:1180
 --   answerShelleyLookupQueries case for GetUTxOByTxIn
 --

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -10,11 +10,11 @@
 module Test.Cardano.Ledger.Api.State.Imp.QuerySpec where
 
 import Cardano.Ledger.Api.State.Query (
-  CommitteeMemberState (..),
-  CommitteeMembersState (..),
   HotCredAuthStatus (..),
   MemberStatus (..),
   NextEpochChange (..),
+  QueryResultCommitteeMemberState (..),
+  QueryResultCommitteeMembersState (..),
   queryCommitteeMembersState,
   queryDRepDelegations,
   queryDRepState,
@@ -172,7 +172,7 @@ spec = withEachEraVersion @era $ do
           UpdateCommittee SNothing mempty (Map.singleton c1 (EpochNo 4321)) (1 %! 1)
         hk1 <- registerCommitteeHotKey c1
         expectQueryResult (Set.singleton c1) mempty mempty $
-          [(c1, CommitteeMemberState (MemberAuthorized hk1) Unrecognized Nothing ToBeRemoved)]
+          [(c1, QueryResultCommitteeMemberState (MemberAuthorized hk1) Unrecognized Nothing ToBeRemoved)]
         passEpoch
         expectQueryResult (Set.singleton c1) mempty mempty Map.empty
 
@@ -196,10 +196,11 @@ spec = withEachEraVersion @era $ do
         passEpoch
         hk1 <- registerCommitteeHotKey c1
         expectQueryResult (Set.singleton c1) mempty mempty $
-          [(c1, CommitteeMemberState (MemberAuthorized hk1) Unrecognized Nothing ToBeEnacted)]
+          [(c1, QueryResultCommitteeMemberState (MemberAuthorized hk1) Unrecognized Nothing ToBeEnacted)]
         passEpoch
         expectQueryResult (Set.singleton c1) mempty mempty $
-          [(c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) NoChangeExpected)]
+          [ (c1, QueryResultCommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) NoChangeExpected)
+          ]
 
   it "queryDRepDelegationState" $ do
     (credDrep, delegator, _) <- setupSingleDRep 1_000_000
@@ -272,26 +273,26 @@ spec = withEachEraVersion @era $ do
     expectMembers $ Map.keysSet newMembers
     -- members for which the expiration epoch is the current epoch are `ToBeExpired`
     expectNoFilterQueryResult
-      [ (c1, CommitteeMemberState MemberNotAuthorized Active (Just c1Expiry) NoChangeExpected)
-      , (c2, CommitteeMemberState MemberNotAuthorized Active (Just c2Expiry) ToBeExpired)
-      , (c3, CommitteeMemberState MemberNotAuthorized Active (Just c3Expiry) NoChangeExpected)
-      , (c4, CommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) NoChangeExpected)
+      [ (c1, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c1Expiry) NoChangeExpected)
+      , (c2, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c2Expiry) ToBeExpired)
+      , (c3, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c3Expiry) NoChangeExpected)
+      , (c4, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) NoChangeExpected)
       ]
     -- hot cred status of members with registered hot keys becomes `MemberAuthorized`
     hk1 <- registerCommitteeHotKey c1
     hk2 <- registerCommitteeHotKey c2
     expectNoFilterQueryResult
-      [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) NoChangeExpected)
-      , (c2, CommitteeMemberState (MemberAuthorized hk2) Active (Just c2Expiry) ToBeExpired)
-      , (c3, CommitteeMemberState MemberNotAuthorized Active (Just c3Expiry) NoChangeExpected)
-      , (c4, CommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) NoChangeExpected)
+      [ (c1, QueryResultCommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) NoChangeExpected)
+      , (c2, QueryResultCommitteeMemberState (MemberAuthorized hk2) Active (Just c2Expiry) ToBeExpired)
+      , (c3, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c3Expiry) NoChangeExpected)
+      , (c4, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) NoChangeExpected)
       ]
     expectQueryResult
       [c2, c3, c5]
       mempty
       [Active, Unrecognized]
-      [ (c3, CommitteeMemberState MemberNotAuthorized Active (Just c3Expiry) NoChangeExpected)
-      , (c2, CommitteeMemberState (MemberAuthorized hk2) Active (Just c2Expiry) ToBeExpired)
+      [ (c3, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c3Expiry) NoChangeExpected)
+      , (c2, QueryResultCommitteeMemberState (MemberAuthorized hk2) Active (Just c2Expiry) ToBeExpired)
       ]
 
     c3Anchor <- arbitrary
@@ -309,11 +310,18 @@ spec = withEachEraVersion @era $ do
     -- registering a hot key for a credential that's not part of the committee will yield `Unrecognized` member status
     -- and expected change of `ToBeRemoved`
     expectNoFilterQueryResult
-      [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) NoChangeExpected)
-      , (c2, CommitteeMemberState (MemberAuthorized hk2) Active (Just c2Expiry) ToBeExpired)
-      , (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just c3Expiry) NoChangeExpected)
-      , (c4, CommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) NoChangeExpected)
-      , (c5, CommitteeMemberState (MemberAuthorized hk5) Unrecognized Nothing ToBeRemoved)
+      [ (c1, QueryResultCommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) NoChangeExpected)
+      , (c2, QueryResultCommitteeMemberState (MemberAuthorized hk2) Active (Just c2Expiry) ToBeExpired)
+      ,
+        ( c3
+        , QueryResultCommitteeMemberState
+            (MemberResigned (Just c3Anchor))
+            Active
+            (Just c3Expiry)
+            NoChangeExpected
+        )
+      , (c4, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) NoChangeExpected)
+      , (c5, QueryResultCommitteeMemberState (MemberAuthorized hk5) Unrecognized Nothing ToBeRemoved)
       ]
     expectQueryResult
       [c2, c3, c5]
@@ -321,17 +329,27 @@ spec = withEachEraVersion @era $ do
       [Unrecognized]
       ( Map.singleton
           c5
-          (CommitteeMemberState (MemberAuthorized hk5) Unrecognized Nothing ToBeRemoved)
+          (QueryResultCommitteeMemberState (MemberAuthorized hk5) Unrecognized Nothing ToBeRemoved)
       )
 
     passEpoch -- epoch 3
     -- the `Unrecognized` member gets removed from the query result
     -- the member which in the previous epoch was expected `ToBeEpired`, has now MemberStatus `Expired` and `NoChangeExpected`
     expectNoFilterQueryResult
-      [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) NoChangeExpected)
-      , (c2, CommitteeMemberState (MemberAuthorized hk2) Expired (Just c2Expiry) NoChangeExpected)
-      , (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just c3Expiry) NoChangeExpected)
-      , (c4, CommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) NoChangeExpected)
+      [ (c1, QueryResultCommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) NoChangeExpected)
+      ,
+        ( c2
+        , QueryResultCommitteeMemberState (MemberAuthorized hk2) Expired (Just c2Expiry) NoChangeExpected
+        )
+      ,
+        ( c3
+        , QueryResultCommitteeMemberState
+            (MemberResigned (Just c3Anchor))
+            Active
+            (Just c3Expiry)
+            NoChangeExpected
+        )
+      , (c4, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) NoChangeExpected)
       ]
 
     -- elect new committee to be: c1 (term extended ), c3 (no changes), c4 (term shortened, expiring next epoch), c6, c7 (new)
@@ -361,20 +379,41 @@ spec = withEachEraVersion @era $ do
     -- members that are part of both current and next committee have `NoChangeExpected` or `TermAdjusted`
     -- members that part of only next committee are `ToBeEnacted`
     expectNoFilterQueryResult
-      [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) (TermAdjusted c1NewExpiry))
-      , (c2, CommitteeMemberState (MemberAuthorized hk2) Expired (Just c2Expiry) ToBeRemoved)
-      , (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just c3Expiry) NoChangeExpected)
+      [
+        ( c1
+        , QueryResultCommitteeMemberState
+            (MemberAuthorized hk1)
+            Active
+            (Just c1Expiry)
+            (TermAdjusted c1NewExpiry)
+        )
+      , (c2, QueryResultCommitteeMemberState (MemberAuthorized hk2) Expired (Just c2Expiry) ToBeRemoved)
+      ,
+        ( c3
+        , QueryResultCommitteeMemberState
+            (MemberResigned (Just c3Anchor))
+            Active
+            (Just c3Expiry)
+            NoChangeExpected
+        )
       , -- though its term was adjusted, `ToBeExpired` takes precedence
-        (c4, CommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) ToBeExpired)
-      , (c6, CommitteeMemberState (MemberAuthorized hk6) Unrecognized Nothing ToBeEnacted)
-      , (c7, CommitteeMemberState MemberNotAuthorized Unrecognized Nothing ToBeEnacted)
-      , (c8, CommitteeMemberState (MemberAuthorized hk8) Unrecognized Nothing ToBeRemoved)
+        (c4, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c4Expiry) ToBeExpired)
+      , (c6, QueryResultCommitteeMemberState (MemberAuthorized hk6) Unrecognized Nothing ToBeEnacted)
+      , (c7, QueryResultCommitteeMemberState MemberNotAuthorized Unrecognized Nothing ToBeEnacted)
+      , (c8, QueryResultCommitteeMemberState (MemberAuthorized hk8) Unrecognized Nothing ToBeRemoved)
       ]
     expectQueryResult
       [c1]
       mempty
       mempty
-      [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just c1Expiry) (TermAdjusted c1NewExpiry))
+      [
+        ( c1
+        , QueryResultCommitteeMemberState
+            (MemberAuthorized hk1)
+            Active
+            (Just c1Expiry)
+            (TermAdjusted c1NewExpiry)
+        )
       ]
     expectQueryResult
       [c2]
@@ -382,18 +421,31 @@ spec = withEachEraVersion @era $ do
       [Expired]
       ( Map.singleton
           c2
-          (CommitteeMemberState (MemberAuthorized hk2) Expired (Just c2Expiry) ToBeRemoved)
+          (QueryResultCommitteeMemberState (MemberAuthorized hk2) Expired (Just c2Expiry) ToBeRemoved)
       )
 
     passNEpochs 2 -- epoch 6
     -- the new committee is in place with the adjusted terms
     expectMembers [c1, c3, c4, c6, c7]
     expectNoFilterQueryResult
-      [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just c1NewExpiry) NoChangeExpected)
-      , (c3, CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just c3Expiry) NoChangeExpected)
-      , (c4, CommitteeMemberState MemberNotAuthorized Expired (Just c4NewExpiry) NoChangeExpected)
-      , (c6, CommitteeMemberState (MemberAuthorized hk6) Active (Just c6Expiry) ToBeExpired)
-      , (c7, CommitteeMemberState MemberNotAuthorized Active (Just c7Expiry) NoChangeExpected)
+      [
+        ( c1
+        , QueryResultCommitteeMemberState (MemberAuthorized hk1) Active (Just c1NewExpiry) NoChangeExpected
+        )
+      ,
+        ( c3
+        , QueryResultCommitteeMemberState
+            (MemberResigned (Just c3Anchor))
+            Active
+            (Just c3Expiry)
+            NoChangeExpected
+        )
+      ,
+        ( c4
+        , QueryResultCommitteeMemberState MemberNotAuthorized Expired (Just c4NewExpiry) NoChangeExpected
+        )
+      , (c6, QueryResultCommitteeMemberState (MemberAuthorized hk6) Active (Just c6Expiry) ToBeExpired)
+      , (c7, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c7Expiry) NoChangeExpected)
       ]
     expectQueryResult
       Set.empty
@@ -422,10 +474,10 @@ spec = withEachEraVersion @era $ do
     passEpoch -- epoch 7
     -- members whose term changed have next epoch change `TermAdjusted`
     expectNoFilterQueryResult
-      [ (c1, CommitteeMemberState (MemberAuthorized hk1) Active (Just c1NewExpiry) ToBeRemoved)
+      [ (c1, QueryResultCommitteeMemberState (MemberAuthorized hk1) Active (Just c1NewExpiry) ToBeRemoved)
       ,
         ( c3
-        , CommitteeMemberState
+        , QueryResultCommitteeMemberState
             (MemberResigned (Just c3Anchor))
             Active
             (Just c3Expiry)
@@ -433,21 +485,42 @@ spec = withEachEraVersion @era $ do
         )
       ,
         ( c4
-        , CommitteeMemberState MemberNotAuthorized Expired (Just c4NewExpiry) (TermAdjusted c4NewNewExpiry)
+        , QueryResultCommitteeMemberState
+            MemberNotAuthorized
+            Expired
+            (Just c4NewExpiry)
+            (TermAdjusted c4NewNewExpiry)
         )
-      , (c6, CommitteeMemberState (MemberAuthorized hk6) Expired (Just c6Expiry) (TermAdjusted c6NewExpiry))
-      , (c7, CommitteeMemberState MemberNotAuthorized Active (Just c7Expiry) ToBeExpired)
+      ,
+        ( c6
+        , QueryResultCommitteeMemberState
+            (MemberAuthorized hk6)
+            Expired
+            (Just c6Expiry)
+            (TermAdjusted c6NewExpiry)
+        )
+      , (c7, QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c7Expiry) ToBeExpired)
       ]
     passEpoch -- epoch 8
     expectMembers [c3, c4, c6, c7]
     expectNoFilterQueryResult
       [
         ( c3
-        , CommitteeMemberState (MemberResigned (Just c3Anchor)) Active (Just c3NewExpiry) NoChangeExpected
+        , QueryResultCommitteeMemberState
+            (MemberResigned (Just c3Anchor))
+            Active
+            (Just c3NewExpiry)
+            NoChangeExpected
         )
-      , (c4, CommitteeMemberState MemberNotAuthorized Active (Just c4NewNewExpiry) NoChangeExpected)
-      , (c6, CommitteeMemberState (MemberAuthorized hk6) Active (Just c6NewExpiry) NoChangeExpected)
-      , (c7, CommitteeMemberState MemberNotAuthorized Expired (Just c7Expiry) NoChangeExpected)
+      ,
+        ( c4
+        , QueryResultCommitteeMemberState MemberNotAuthorized Active (Just c4NewNewExpiry) NoChangeExpected
+        )
+      ,
+        ( c6
+        , QueryResultCommitteeMemberState (MemberAuthorized hk6) Active (Just c6NewExpiry) NoChangeExpected
+        )
+      , (c7, QueryResultCommitteeMemberState MemberNotAuthorized Expired (Just c7Expiry) NoChangeExpected)
       ]
   where
     expectQueryResult ::
@@ -455,22 +528,22 @@ spec = withEachEraVersion @era $ do
       Set.Set (Credential ColdCommitteeRole) ->
       Set.Set (Credential HotCommitteeRole) ->
       Set.Set MemberStatus ->
-      Map.Map (Credential ColdCommitteeRole) CommitteeMemberState ->
+      Map.Map (Credential ColdCommitteeRole) QueryResultCommitteeMemberState ->
       ImpTestM era ()
     expectQueryResult ckFilter hkFilter statusFilter expResult = do
       nes <- use impNESL
-      let CommitteeMembersState {csCommittee} =
+      let QueryResultCommitteeMembersState {qrcmsCommittee} =
             queryCommitteeMembersState
               ckFilter
               hkFilter
               statusFilter
               nes
       impAnn "Expecting query result" $
-        csCommittee `shouldBe` expResult
+        qrcmsCommittee `shouldBe` expResult
 
     expectNoFilterQueryResult ::
       HasCallStack =>
-      Map.Map (Credential ColdCommitteeRole) CommitteeMemberState ->
+      Map.Map (Credential ColdCommitteeRole) QueryResultCommitteeMemberState ->
       ImpTestM era ()
     expectNoFilterQueryResult =
       expectQueryResult mempty mempty mempty

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -15,6 +15,8 @@ import Cardano.Ledger.Api.State.Query (
   NextEpochChange (..),
   QueryResultCommitteeMemberState (..),
   QueryResultCommitteeMembersState (..),
+  QueryResultDRepState (..),
+  QueryResultDRepStates (..),
   queryCommitteeMembersState,
   queryDRepDelegations,
   queryDRepState,
@@ -51,9 +53,9 @@ spec = withEachEraVersion @era $ do
             (HasCallStack, Monad m) =>
             Credential DRepRole ->
             NewEpochState era ->
-            m DRepState
+            m QueryResultDRepState
           drepStateFromQuery drep nes =
-            case Map.lookup drep (queryDRepState nes mempty) of
+            case Map.lookup drep (qrdrssStates (queryDRepState nes mempty)) of
               Nothing -> error $ "Expected for DRep " ++ show drep ++ " to be present in the query result"
               Just state -> pure state
       it "simple expiry" $ do
@@ -63,7 +65,7 @@ spec = withEachEraVersion @era $ do
         (drep, _, _) <- setupSingleDRep 1_000_000
         nes <- getsNES id
         drepState <- drepStateFromQuery drep nes
-        drepState ^. drepExpiryL `shouldBe` addEpochInterval curEpochNo (EpochInterval drepActivity)
+        qrdrsExpiry drepState `shouldBe` addEpochInterval curEpochNo (EpochInterval drepActivity)
         let n = 4
         passNEpochsChecking n $
           isDRepExpired drep `shouldReturn` False
@@ -96,7 +98,7 @@ spec = withEachEraVersion @era $ do
 
         expectedExpiry >>= expectDRepExpiry drep
         drepState <- drepStateFromQuery drep nes
-        expectedExpiry >>= shouldBe (drepState ^. drepExpiryL)
+        expectedExpiry >>= shouldBe (qrdrsExpiry drepState)
 
       it "proposals are made and numDormantEpochs are added" $ do
         curEpochNo <- getsNES nesELL
@@ -105,7 +107,7 @@ spec = withEachEraVersion @era $ do
         (drep, _, _) <- setupSingleDRep 1_000_000
         nes <- getsNES id
         drepState <- drepStateFromQuery drep nes
-        drepState ^. drepExpiryL `shouldBe` addEpochInterval curEpochNo (EpochInterval drepActivity)
+        qrdrsExpiry drepState `shouldBe` addEpochInterval curEpochNo (EpochInterval drepActivity)
         let n = 2
             actualExpiry = addEpochInterval curEpochNo $ EpochInterval (drepActivity + fromIntegral n)
         passNEpochsChecking n $
@@ -116,7 +118,7 @@ spec = withEachEraVersion @era $ do
         expectDRepExpiry drep actualExpiry
         nes1 <- getsNES id
         drepState1 <- drepStateFromQuery drep nes1
-        drepState1 ^. drepExpiryL `shouldBe` actualExpiry
+        qrdrsExpiry drepState1 `shouldBe` actualExpiry
         passNEpochsChecking (fromIntegral drepActivity) $
           isDRepExpired drep `shouldReturn` False
         passEpoch
@@ -128,7 +130,7 @@ spec = withEachEraVersion @era $ do
         (drep, _, _) <- setupSingleDRep 1_000_000
         nes <- getsNES id
         drepState <- drepStateFromQuery drep nes
-        drepState ^. drepExpiryL `shouldBe` addEpochInterval curEpochNo (EpochInterval drepActivity)
+        qrdrsExpiry drepState `shouldBe` addEpochInterval curEpochNo (EpochInterval drepActivity)
         let n = 3
         passNEpochsChecking n $
           isDRepExpired drep `shouldReturn` False
@@ -145,11 +147,10 @@ spec = withEachEraVersion @era $ do
         expectNumDormantEpochs $ EpochNo (fromIntegral n)
         nes1 <- getsNES id
         drepState1 <- drepStateFromQuery drep nes1
-        drepState1
-          ^. drepExpiryL
-            `shouldBe` addEpochInterval
-              curEpochNo
-              (EpochInterval (drepActivity + fromIntegral n))
+        qrdrsExpiry drepState1
+          `shouldBe` addEpochInterval
+            curEpochNo
+            (EpochInterval (drepActivity + fromIntegral n))
         expectDRepExpiry drep $ addEpochInterval curEpochNo $ EpochInterval drepActivity
         passEpoch
         expectNumDormantEpochs $ EpochNo (fromIntegral n + 1)
@@ -158,7 +159,7 @@ spec = withEachEraVersion @era $ do
         nes2 <- getsNES id
         drepState2 <- drepStateFromQuery drep nes2
         let drepExpiry2 = addEpochInterval curEpochNo $ EpochInterval (drepActivity + fromIntegral n + 1)
-        drepState2 ^. drepExpiryL `shouldBe` drepExpiry2
+        qrdrsExpiry drepState2 `shouldBe` drepExpiry2
         expectActualDRepExpiry drep drepExpiry2
         passNEpochsChecking (fromIntegral drepActivity) $ do
           isDRepExpired drep `shouldReturn` False

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -71,6 +71,12 @@ latestErasSpec =
           roundTripEraExpectation @era @QueryResultCommitteeMemberState
         prop "QueryResultCommitteeMembersState" $
           roundTripEraExpectation @era @QueryResultCommitteeMembersState
+        prop "QueryResultConstitution" $
+          roundTripEraExpectation @era @QueryResultConstitution
+        prop "QueryResultDRepState" $
+          roundTripEraExpectation @era @QueryResultDRepState
+        prop "QueryResultDRepStates" $
+          roundTripEraExpectation @era @QueryResultDRepStates
       describe "Queries" $ do
         committeeMembersStateSpec @era
         queryStakeSnapshotsSpec @era

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -13,12 +13,16 @@ import Cardano.Ledger.Api.Era
 import Cardano.Ledger.Api.State.Query
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.Governance (
   Committee (..),
+  Constitution,
   ConwayEraGov (..),
   ConwayGovState,
   DRepPulsingState (..),
   RatifyState (..),
+  constitutionAnchor,
+  constitutionGuardrailsScriptHash,
   ensCommitteeL,
   newEpochStateDRepPulsingStateL,
   rsEnactStateL,
@@ -80,6 +84,22 @@ latestErasSpec =
         prop "QueryResultDRepStates" $
           roundTripEraExpectation @era @QueryResultDRepStates
         prop "QueryResultRewardInfoPools" $ roundTripEraExpectation @era @QueryResultRewardInfoPools
+      describe "Extraction functions" $ do
+        describe "toQueryResultConstitution" $ do
+          prop "preserves anchor" $ \(c :: Constitution ConwayEra) ->
+            qrcAnchor (toQueryResultConstitution c) === constitutionAnchor c
+          prop "converts guardrails script" $ \(c :: Constitution ConwayEra) ->
+            qrcGuardrailsScript (toQueryResultConstitution c)
+              === strictMaybeToMaybe (constitutionGuardrailsScriptHash c)
+        describe "toQueryResultDRepState" $ do
+          prop "preserves expiry" $ \(d :: DRepState) ->
+            qrdrsExpiry (toQueryResultDRepState d) === drepExpiry d
+          prop "converts anchor" $ \(d :: DRepState) ->
+            qrdrsAnchor (toQueryResultDRepState d) === strictMaybeToMaybe (drepAnchor d)
+          prop "converts deposit" $ \(d :: DRepState) ->
+            qrdrsDeposit (toQueryResultDRepState d) === fromCompact (drepDeposit d)
+          prop "preserves delegations" $ \(d :: DRepState) ->
+            qrdrsDelegs (toQueryResultDRepState d) === drepDelegs d
       describe "Queries" $ do
         committeeMembersStateSpec @era
         queryStakeSnapshotsSpec @era

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -74,6 +74,7 @@ latestErasSpec =
           roundTripEraExpectation @era @QueryResultCommitteeMembersState
         prop "QueryResultConstitution" $
           roundTripEraExpectation @era @QueryResultConstitution
+        prop "QueryResultDelegsAndRewards" $ roundTripEraExpectation @era @QueryResultDelegsAndRewards
         prop "QueryResultDRepState" $
           roundTripEraExpectation @era @QueryResultDRepState
         prop "QueryResultDRepStates" $

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -66,7 +66,8 @@ latestErasSpec =
     describe (eraName @era) $ do
       describe "Roundtrip" $ do
         prop "QueryPoolStateResult" $ roundTripEraExpectation @era @QueryPoolStateResult
-        prop "StakeSnapshots" $ roundTripEraExpectation @era @StakeSnapshots
+        prop "QueryResultStakeSnapshot" $ roundTripEraExpectation @era @QueryResultStakeSnapshot
+        prop "QueryResultStakeSnapshots" $ roundTripEraExpectation @era @QueryResultStakeSnapshots
         prop "QueryResultCommitteeMemberState" $
           roundTripEraExpectation @era @QueryResultCommitteeMemberState
         prop "QueryResultCommitteeMembersState" $
@@ -475,10 +476,10 @@ queryStakeSnapshotsSpec ::
   Spec
 queryStakeSnapshotsSpec =
   describe "GetStakeSnapshots" $ do
-    prop "ssStakeSnapshots has all poolIds" $ \ss -> do
+    prop "qrssStakeSnapshots has all poolIds" $ \ss -> do
       let
         nes = (def :: NewEpochState era) & nesEsL . esSnapshotsL .~ ss
-        result = queryStakeSnapshots nes Nothing
+        result = queryStakeSnapshots nes Set.empty
         getPoolIdsWithNonZeroDelegators =
           Map.filter ((> 0) . spssNumDelegators) . VMap.toMap . ssStakePoolsSnapShot
         getPoolIdsWithNonZeroStake =
@@ -493,22 +494,24 @@ queryStakeSnapshotsSpec =
           | otherwise = allPoolIdsFiltered getPoolIdsWithNonZeroDelegators
         nonZeroTotal = ssTotalActiveStake
         nonZeroSubTotal ssWhich =
-          nonZeroOr (foldMap ssWhich (ssStakeSnapshots result)) (knownNonZeroCoin @1)
+          nonZeroOr (foldMap ssWhich (qrssStakeSnapshots result)) (knownNonZeroCoin @1)
       subPoolIds <- uniformSubSet Nothing allPoolIds QC
       -- Tricky bit about the query is when all pool ids are requested then ones that do not have
       -- delegations are filtered out, while when poolIds are specified, then they are retained even
       -- if they don't have any delegations
       let
-        subResult = queryStakeSnapshots nes (Just subPoolIds)
+        subResult = queryStakeSnapshots nes subPoolIds
       pure @Gen $
         conjoin
           [ counterexample "AllPoolIds" $
-              Map.keysSet (ssStakeSnapshots result) === allPoolIds
-          , counterexample "SubTotal Mark" $ nonZeroSubTotal ssMarkPool === ssMarkTotal result
-          , counterexample "SubTotal Set" $ nonZeroSubTotal ssSetPool === ssSetTotal result
-          , counterexample "SubTotal Go" $ nonZeroSubTotal ssGoPool === ssGoTotal result
-          , counterexample "Total Mark" $ ssMarkTotal result === nonZeroTotal (ssStakeMark ss)
-          , counterexample "Total Set" $ ssSetTotal result === nonZeroTotal (ssStakeSet ss)
-          , counterexample "Total Go" $ ssGoTotal result === nonZeroTotal (ssStakeGo ss)
-          , counterexample "subPoolIds" $ Map.keysSet (ssStakeSnapshots subResult) === subPoolIds
+              Map.keysSet (qrssStakeSnapshots result) === allPoolIds
+          , counterexample "SubTotal Mark" $ nonZeroSubTotal qrssMarkPool === qrssMarkTotal result
+          , counterexample "SubTotal Set" $ nonZeroSubTotal qrssSetPool === qrssSetTotal result
+          , counterexample "SubTotal Go" $ nonZeroSubTotal qrssGoPool === qrssGoTotal result
+          , counterexample "Total Mark" $ qrssMarkTotal result === nonZeroTotal (ssStakeMark ss)
+          , counterexample "Total Set" $ qrssSetTotal result === nonZeroTotal (ssStakeSet ss)
+          , counterexample "Total Go" $ qrssGoTotal result === nonZeroTotal (ssStakeGo ss)
+          , counterexample "subPoolIds" $
+              Map.keysSet (qrssStakeSnapshots subResult)
+                === if Set.null subPoolIds then allPoolIds else subPoolIds
           ]

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -67,6 +67,10 @@ latestErasSpec =
       describe "Roundtrip" $ do
         prop "QueryPoolStateResult" $ roundTripEraExpectation @era @QueryPoolStateResult
         prop "StakeSnapshots" $ roundTripEraExpectation @era @StakeSnapshots
+        prop "QueryResultCommitteeMemberState" $
+          roundTripEraExpectation @era @QueryResultCommitteeMemberState
+        prop "QueryResultCommitteeMembersState" $
+          roundTripEraExpectation @era @QueryResultCommitteeMembersState
       describe "Queries" $ do
         committeeMembersStateSpec @era
         queryStakeSnapshotsSpec @era
@@ -80,7 +84,7 @@ committeeMembersStateSpec ::
   ) =>
   Spec
 committeeMembersStateSpec =
-  prop "GetCommitteeMembersState" $ \statusFilter -> do
+  prop "GetQueryResultCommitteeMembersState" $ \statusFilter -> do
     forAll genCommittee $ \committee ->
       -- half of the committee members in the next epoch will overlap with the current ones
       forAll (genNextCommittee @era committee) $ \nextCommittee ->
@@ -121,7 +125,7 @@ propEmpty ::
 propEmpty nes = do
   withCommitteeInfo nes $
     \comMembers (CommitteeState comStateMembers) nextComMembers noFilterResult -> do
-      Map.null (csCommittee noFilterResult)
+      Map.null (qrcmsCommittee noFilterResult)
         `shouldBe` (Map.null comMembers && Map.null comStateMembers && Map.null nextComMembers)
 
 propComplete ::
@@ -135,7 +139,7 @@ propComplete nes = do
       -- if a credential appears in either Committee or CommitteeState, it should appear
       -- in the result
       Set.unions [Map.keysSet comMembers, Map.keysSet nextComMembers, Map.keysSet comStateMembers]
-        `shouldBe` Map.keysSet (csCommittee noFilterResult)
+        `shouldBe` Map.keysSet (qrcmsCommittee noFilterResult)
 
 propNotAuthorized ::
   forall era.
@@ -148,10 +152,10 @@ propNotAuthorized nes = do
       let notAuthorized =
             Map.filter
               ( \case
-                  CommitteeMemberState MemberNotAuthorized _ _ _ -> True
+                  QueryResultCommitteeMemberState MemberNotAuthorized _ _ _ -> True
                   _ -> False
               )
-              (csCommittee noFilterResult)
+              (qrcmsCommittee noFilterResult)
       -- if the member is NotAuthorized, it should not have an associated hot credential in the committeeState
       Map.intersection comStateMembers notAuthorized `shouldBe` Map.empty
 
@@ -165,7 +169,8 @@ propAuthorized nes = do
     \_ (CommitteeState comStateMembers) _ noFilterResult -> do
       let ckHk =
             [ (ck, hk)
-            | (ck, CommitteeMemberState (MemberAuthorized hk) _ _ _) <- Map.toList (csCommittee noFilterResult)
+            | (ck, QueryResultCommitteeMemberState (MemberAuthorized hk) _ _ _) <-
+                Map.toList (qrcmsCommittee noFilterResult)
             ]
       -- if the member is Authorized, it should appear in the committeeState
       ckHk `shouldBe` [(ck, hk) | (ck, CommitteeHotCredential hk) <- Map.toList comStateMembers]
@@ -180,7 +185,8 @@ propResigned nes = do
     \_ (CommitteeState comStateMembers) _ noFilterResult -> do
       let resigned =
             [ ck
-            | (ck, CommitteeMemberState (MemberResigned _) _ _ _) <- Map.toList (csCommittee noFilterResult)
+            | (ck, QueryResultCommitteeMemberState (MemberResigned _) _ _ _) <-
+                Map.toList (qrcmsCommittee noFilterResult)
             ]
       -- if the member is Resignd, it should appear in the committeeState as Nothing
       resigned `shouldBe` [ck | (ck, CommitteeMemberResigned _) <- Map.toList comStateMembers]
@@ -196,10 +202,10 @@ propUnrecognized nes = do
       let unrecognized =
             Map.filter
               ( \case
-                  CommitteeMemberState _ Unrecognized _ _ -> True
+                  QueryResultCommitteeMemberState _ Unrecognized _ _ -> True
                   _ -> False
               )
-              (csCommittee noFilterResult)
+              (qrcmsCommittee noFilterResult)
       let nextComMembers = Map.keysSet nextComMembers'
       -- if the member is Unrecognized, it should not be in the committe, but it should be
       -- in the committeeState or in the nextCommittee
@@ -207,11 +213,11 @@ propUnrecognized nes = do
       Map.keysSet unrecognized
         `shouldSatisfy` (`Set.isSubsetOf` (Map.keysSet comStateMembers `Set.union` nextComMembers))
       -- all Unrecognized members will be either enacted or removed in the next epoch
-      Set.fromList (cmsNextEpochChange <$> Map.elems unrecognized)
+      Set.fromList (qrcmsNextEpochChange <$> Map.elems unrecognized)
         `shouldSatisfy` (`Set.isSubsetOf` Set.fromList [ToBeEnacted, ToBeRemoved])
-      Map.keysSet (Map.filter (\x -> cmsNextEpochChange x == ToBeEnacted) unrecognized)
+      Map.keysSet (Map.filter (\x -> qrcmsNextEpochChange x == ToBeEnacted) unrecognized)
         `shouldSatisfy` (`Set.isSubsetOf` nextComMembers)
-      Map.keysSet (Map.filter (\x -> cmsNextEpochChange x == ToBeRemoved) unrecognized)
+      Map.keysSet (Map.filter (\x -> qrcmsNextEpochChange x == ToBeRemoved) unrecognized)
         `shouldSatisfy` (\s -> Set.null s || not (s `Set.isSubsetOf` nextComMembers))
 
 propActiveAuthorized ::
@@ -225,10 +231,10 @@ propActiveAuthorized nes = do
       let activeAuthorized =
             Map.mapMaybe
               ( \case
-                  CommitteeMemberState (MemberAuthorized hk) Active _ _ -> Just hk
+                  QueryResultCommitteeMemberState (MemberAuthorized hk) Active _ _ -> Just hk
                   _ -> Nothing
               )
-              (csCommittee noFilterResult)
+              (qrcmsCommittee noFilterResult)
       let epochNo = nes ^. nesELL
 
       -- if a member is active and authorized, then it should be:
@@ -247,7 +253,7 @@ propActiveAuthorized nes = do
               _ -> False
           )
 
-      csEpochNo noFilterResult `shouldBe` epochNo
+      qrcmsEpochNo noFilterResult `shouldBe` epochNo
 
 propFilters ::
   forall era.
@@ -258,13 +264,13 @@ propFilters ::
   NewEpochState era ->
   Expectation
 propFilters ckFilter hkFilter statusFilter nes = do
-  let (CommitteeMembersState result _ _) = queryCommitteeMembersState @era ckFilter hkFilter statusFilter nes
+  let (QueryResultCommitteeMembersState result _ _) = queryCommitteeMembersState @era ckFilter hkFilter statusFilter nes
   let allCks = Map.keysSet result
   let (allHks, allMemberStatuses) =
         foldMap'
           ( \case
-              CommitteeMemberState (MemberAuthorized hk) ms _ _ -> (Set.singleton hk, Set.singleton ms)
-              CommitteeMemberState _ ms _ _ -> (Set.empty, Set.singleton ms)
+              QueryResultCommitteeMemberState (MemberAuthorized hk) ms _ _ -> (Set.singleton hk, Set.singleton ms)
+              QueryResultCommitteeMemberState _ ms _ _ -> (Set.empty, Set.singleton ms)
           )
           result
   unless (Set.null ckFilter) $
@@ -300,7 +306,7 @@ propNextEpoch nes = do
         ]
         `shouldSatisfy` (== (comMembers `Set.intersection` nextComMembers))
 
-      let currentEpoch = csEpochNo noFilterResult
+      let currentEpoch = qrcmsEpochNo noFilterResult
       let expiring =
             Map.keysSet $
               Map.union
@@ -311,25 +317,25 @@ propNextEpoch nes = do
       Map.keysSet (filterNext ToBeExpired noFilterResult)
         `shouldSatisfy` (`Set.isSubsetOf` expiring)
 
-      cmsExpiration
+      qrcmsExpiration
         <$> filterNext NoChangeExpected noFilterResult
           `shouldSatisfy` all (all (>= currentEpoch + 1))
   where
     filterNext nextEpochChange cms =
       Map.filter
         ( \case
-            CommitteeMemberState _ _ _ nextEpochChange' ->
+            QueryResultCommitteeMemberState _ _ _ nextEpochChange' ->
               nextEpochChange == nextEpochChange'
         )
-        (csCommittee cms)
+        (qrcmsCommittee cms)
     termAdjusted cms =
       Map.mapMaybeWithKey
         ( \k cm ->
             case cm of
-              CommitteeMemberState _ _ _ (TermAdjusted _) -> Just k
+              QueryResultCommitteeMemberState _ _ _ (TermAdjusted _) -> Just k
               _ -> Nothing
         )
-        (csCommittee cms)
+        (qrcmsCommittee cms)
 
 propNoExpiration ::
   forall era.
@@ -339,10 +345,10 @@ propNoExpiration ::
 propNoExpiration nes =
   withCommitteeInfo nes $
     \_ _ _ noFilterResult -> do
-      let noExpiration = Map.filter (isNothing . cmsExpiration) (csCommittee noFilterResult)
+      let noExpiration = Map.filter (isNothing . qrcmsExpiration) (qrcmsCommittee noFilterResult)
       unless (Map.null noExpiration) $
         -- only Unrecognized members should have no expiration
-        Set.fromList (cmsStatus <$> Map.elems noExpiration) `shouldBe` Set.singleton Unrecognized
+        Set.fromList (qrcmsStatus <$> Map.elems noExpiration) `shouldBe` Set.singleton Unrecognized
 
 genCommittee ::
   forall era.
@@ -415,7 +421,7 @@ withCommitteeInfo ::
   ( Map.Map (Credential ColdCommitteeRole) EpochNo -> -- current committee members
     CommitteeState era ->
     Map.Map (Credential ColdCommitteeRole) EpochNo -> -- next epoch committee members
-    CommitteeMembersState ->
+    QueryResultCommitteeMembersState ->
     Expectation
   ) ->
   Expectation
@@ -446,7 +452,7 @@ queryCommitteeMembersStateNoFilters ::
   forall era.
   (ConwayEraGov era, ConwayEraCertState era) =>
   NewEpochState era ->
-  CommitteeMembersState
+  QueryResultCommitteeMembersState
 queryCommitteeMembersStateNoFilters =
   queryCommitteeMembersState @era
     Set.empty

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -79,6 +79,7 @@ latestErasSpec =
           roundTripEraExpectation @era @QueryResultDRepState
         prop "QueryResultDRepStates" $
           roundTripEraExpectation @era @QueryResultDRepStates
+        prop "QueryResultRewardInfoPools" $ roundTripEraExpectation @era @QueryResultRewardInfoPools
       describe "Queries" $ do
         committeeMembersStateSpec @era
         queryStakeSnapshotsSpec @era

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -65,7 +65,7 @@ latestErasSpec =
   describe "QuerySpec" $ do
     describe (eraName @era) $ do
       describe "Roundtrip" $ do
-        prop "QueryPoolStateResult" $ roundTripEraExpectation @era @QueryPoolStateResult
+        prop "QueryResultPoolState" $ roundTripEraExpectation @era @QueryResultPoolState
         prop "QueryResultStakeSnapshot" $ roundTripEraExpectation @era @QueryResultStakeSnapshot
         prop "QueryResultStakeSnapshots" $ roundTripEraExpectation @era @QueryResultStakeSnapshots
         prop "QueryResultCommitteeMemberState" $

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
@@ -3,6 +3,7 @@
 module Test.Cardano.Ledger.Api.Arbitrary () where
 
 import Cardano.Ledger.Api.State.Query
+import Cardano.Ledger.Shelley.API.Wallet (RewardInfoPool, RewardParams)
 import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Dijkstra.Arbitrary ()
@@ -32,6 +33,15 @@ instance Arbitrary QueryResultDelegsAndRewards where
   arbitrary = genericArbitraryU
 
 instance Arbitrary QueryResultDRepStates where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary QueryResultRewardInfoPools where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary RewardInfoPool where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary RewardParams where
   arbitrary = genericArbitraryU
 
 instance Arbitrary QueryResultPoolState where

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
@@ -28,6 +28,9 @@ instance Arbitrary QueryResultConstitution where
 instance Arbitrary QueryResultDRepState where
   arbitrary = genericArbitraryU
 
+instance Arbitrary QueryResultDelegsAndRewards where
+  arbitrary = genericArbitraryU
+
 instance Arbitrary QueryResultDRepStates where
   arbitrary = genericArbitraryU
 

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
@@ -34,10 +34,10 @@ instance Arbitrary QueryResultDRepStates where
 instance Arbitrary QueryPoolStateResult where
   arbitrary = QueryPoolStateResult <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
-instance Arbitrary StakeSnapshot where
+instance Arbitrary QueryResultStakeSnapshot where
   arbitrary = genericArbitraryU
   shrink = genericShrink
 
-instance Arbitrary StakeSnapshots where
+instance Arbitrary QueryResultStakeSnapshots where
   arbitrary = genericArbitraryU
   shrink = genericShrink

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
@@ -34,8 +34,8 @@ instance Arbitrary QueryResultDelegsAndRewards where
 instance Arbitrary QueryResultDRepStates where
   arbitrary = genericArbitraryU
 
-instance Arbitrary QueryPoolStateResult where
-  arbitrary = QueryPoolStateResult <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+instance Arbitrary QueryResultPoolState where
+  arbitrary = QueryResultPoolState <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary QueryResultStakeSnapshot where
   arbitrary = genericArbitraryU

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
@@ -10,6 +10,18 @@ import Test.Cardano.Ledger.Dijkstra.Arbitrary ()
 instance Arbitrary MemberStatus where
   arbitrary = arbitraryBoundedEnum
 
+instance Arbitrary HotCredAuthStatus where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary NextEpochChange where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary QueryResultCommitteeMemberState where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary QueryResultCommitteeMembersState where
+  arbitrary = genericArbitraryU
+
 instance Arbitrary QueryPoolStateResult where
   arbitrary = QueryPoolStateResult <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
@@ -22,6 +22,15 @@ instance Arbitrary QueryResultCommitteeMemberState where
 instance Arbitrary QueryResultCommitteeMembersState where
   arbitrary = genericArbitraryU
 
+instance Arbitrary QueryResultConstitution where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary QueryResultDRepState where
+  arbitrary = genericArbitraryU
+
+instance Arbitrary QueryResultDRepStates where
+  arbitrary = genericArbitraryU
+
 instance Arbitrary QueryPoolStateResult where
   arbitrary = QueryPoolStateResult <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -143,7 +143,7 @@ main = do
          in bgroup
               "MinMaxTxId"
               [ env (pure setAddr) $
-                  bench "getFilteredNewUTxO" . nf (queryUTxOByAddress newEpochState)
+                  bench "queryUTxOByAddress" . nf (queryUTxOByAddress newEpochState)
               , env (pure setAddr) $
                   bench "getFilteredOldUTxO" . nf (getFilteredOldUTxO newEpochState)
               ]

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -9,6 +9,7 @@ module Main where
 
 import Cardano.Ledger.Address
 import Cardano.Ledger.Api.Era
+import Cardano.Ledger.Api.State.Query (queryUTxOByAddress, queryUTxOFull)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Conway
@@ -18,7 +19,6 @@ import Cardano.Ledger.Conway.Rules (
  )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API.Mempool
-import Cardano.Ledger.Shelley.API.Wallet (getFilteredUTxO, getUTxO)
 import Cardano.Ledger.Shelley.Genesis (
   ShelleyGenesis (..),
   fromNominalDiffTimeMicro,
@@ -143,7 +143,7 @@ main = do
          in bgroup
               "MinMaxTxId"
               [ env (pure setAddr) $
-                  bench "getFilteredNewUTxO" . nf (getFilteredUTxO newEpochState)
+                  bench "getFilteredNewUTxO" . nf (queryUTxOByAddress newEpochState)
               , env (pure setAddr) $
                   bench "getFilteredOldUTxO" . nf (getFilteredOldUTxO newEpochState)
               ]
@@ -270,7 +270,7 @@ getFilteredOldUTxO ss addrs =
   UTxO $
     Map.filter (\txOut -> (txOut ^. compactAddrTxOutL) `Set.member` addrSBSs) fullUTxO
   where
-    UTxO fullUTxO = getUTxO ss
+    UTxO fullUTxO = queryUTxOFull ss
     addrSBSs = Set.map compactAddr addrs
 
 seqTuple :: (a, b) -> (a, b)


### PR DESCRIPTION
# Description

Reorganise `Ledger.Api.State.Query` into domain-specific sub-modules, and re-export everything.
- Consolidate ledger state queries from `consensus`, `api`, and `cli`.
- Add stable `QueryResult*` types to decouple downstream from ledger-internal representation.
- Wherever it made sense: `filter ~ empty set -> return all`.
- Contains breaking changes, some tests.
- CBOR codecs are preserved.

Closes #5659 and #5660

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
