### PR TITLE
Turn `ScriptsProvided` into an associated type family of `EraUTxO`

### DIFF
--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-allegra
-version: 1.9.1.0
+version: 1.10.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
@@ -11,6 +11,7 @@ import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.State ()
 import Cardano.Ledger.Shelley.UTxO (
   ShelleyScriptsNeeded (..),
+  ShelleyScriptsProvided (..),
   getConsumedCoin,
   getShelleyMinFeeTxUtxo,
   getShelleyScriptsNeeded,
@@ -18,11 +19,12 @@ import Cardano.Ledger.Shelley.UTxO (
   shelleyConsumed,
   shelleyProducedValue,
  )
-import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided (..))
+import Cardano.Ledger.State (EraUTxO (..))
 import Lens.Micro
 
 instance EraUTxO AllegraEra where
   type ScriptsNeeded AllegraEra = ShelleyScriptsNeeded AllegraEra
+  type ScriptsProvided AllegraEra = ShelleyScriptsProvided AllegraEra
 
   consumed = shelleyConsumed
 
@@ -31,7 +33,9 @@ instance EraUTxO AllegraEra where
   getProducedValue pp isRegPoolId txBody =
     withTopTxLevelOnly txBody (shelleyProducedValue pp isRegPoolId)
 
-  getScriptsProvided _ tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
+  getScriptsProvided _ tx = ShelleyScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
+
+  getScriptsProvidedMap = unShelleyScriptsProvided
 
   getScriptsNeeded = getShelleyScriptsNeeded
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -95,7 +95,7 @@ library
     cardano-base >=0.1.1.0,
     cardano-crypto-class,
     cardano-data ^>=1.3,
-    cardano-ledger-allegra ^>=1.9.1,
+    cardano-ledger-allegra ^>=1.10,
     cardano-ledger-binary ^>=1.9,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.20,
     cardano-ledger-mary ^>=1.10.1,

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
@@ -50,7 +50,7 @@ import Cardano.Ledger.Plutus.Evaluate (
 import Cardano.Ledger.Plutus.ExUnits
 import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.Plutus.TxInfo (exBudgetToExUnits)
-import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided (..), UTxO (..))
+import Cardano.Ledger.State (EraUTxO (..), UTxO (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
@@ -168,7 +168,7 @@ collectPlutusScriptsWithContext epochInfo systemStart pp tx utxo =
         }
     txInfoResult = mkTxInfoResult ledgerTxInfo
 
-    ScriptsProvided scriptsProvided = getScriptsProvided utxo tx
+    scriptsProvided = getScriptsProvidedMap $ getScriptsProvided utxo tx
     AlonzoScriptsNeeded scriptsNeeded = getScriptsNeeded utxo (tx ^. bodyTxL)
     neededPlutusScripts =
       mapMaybe (\(sp, sh) -> (,) (sh, sp) <$> lookupPlutusScript sh scriptsProvided) scriptsNeeded
@@ -375,7 +375,7 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo systemStart = Map.mapWithKey findAndC
     rdmrs = wits ^. rdmrsTxWitsL . unRedeemersL
     protVer = pp ^. ppProtocolVersionL
     costModels = costModelsValid $ pp ^. ppCostModelsL
-    ScriptsProvided scriptsProvided = getScriptsProvided utxo tx
+    scriptsProvided = getScriptsProvidedMap $ getScriptsProvided utxo tx
     AlonzoScriptsNeeded scriptsNeeded = getScriptsNeeded utxo txBody
     findAndCount pointer (redeemerData, exUnits) = do
       (plutusPurpose, plutusScriptHash) <-

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -70,7 +70,6 @@ import Cardano.Ledger.Shelley.UTxO (ShelleyScriptsNeeded (..))
 import Cardano.Ledger.State (
   EraCertState (..),
   EraUTxO (..),
-  ScriptsProvided (..),
   UTxO (..),
   dsGenDelegsL,
  )
@@ -246,15 +245,16 @@ missingRequiredDatums utxo tx = do
                            h ↦ s ∈ txscripts txw, s ∈ Scriptph2}     -}
 hasExactSetOfRedeemers ::
   forall era l.
-  AlonzoEraTx era =>
+  (AlonzoEraTx era, EraUTxO era) =>
   Tx l era ->
   ScriptsProvided era ->
   AlonzoScriptsNeeded era ->
   Test (AlonzoUtxowPredFailure era)
-hasExactSetOfRedeemers tx (ScriptsProvided scriptsProvided) (AlonzoScriptsNeeded scriptsNeeded) = do
-  let redeemersNeeded =
-        [ (hoistPlutusPurpose toAsIx sp, (hoistPlutusPurpose toAsItem sp, sh))
-        | (sp, sh) <- scriptsNeeded
+hasExactSetOfRedeemers tx sp (AlonzoScriptsNeeded scriptsNeeded) = do
+  let scriptsProvided = getScriptsProvidedMap sp
+      redeemersNeeded =
+        [ (hoistPlutusPurpose toAsIx sp', (hoistPlutusPurpose toAsItem sp', sh))
+        | (sp', sh) <- scriptsNeeded
         , Just script <- [Map.lookup sh scriptsProvided]
         , not (isNativeScript script)
         ]

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -116,7 +116,7 @@ import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Cardano.Ledger.Plutus.Data (Data, hashData)
 import Cardano.Ledger.Plutus.Language (nonNativeLanguages)
 import Cardano.Ledger.Shelley.Tx (shelleyTxEqRaw)
-import Cardano.Ledger.State (EraUTxO, ScriptsProvided (..))
+import Cardano.Ledger.State (EraUTxO (..))
 import qualified Cardano.Ledger.State as Shelley
 import Cardano.Ledger.Val (Val ((<+>), (<×>)))
 import Control.DeepSeq (NFData (..), deepseq)
@@ -327,14 +327,14 @@ mkScriptIntegrity ::
   ScriptsProvided era ->
   Set ScriptHash ->
   StrictMaybe (ScriptIntegrity era)
-mkScriptIntegrity pp tx (ScriptsProvided scriptsProvided) scriptsNeeded
+mkScriptIntegrity pp tx sp scriptsNeeded
   | null (txRedeemers ^. unRedeemersL)
   , null langViews
   , null (txDats ^. unTxDatsL) =
       SNothing
   | otherwise = SJust $ ScriptIntegrity txRedeemers txDats langViews
   where
-    scriptsUsed = Map.elems $ Map.restrictKeys scriptsProvided scriptsNeeded
+    scriptsUsed = Map.elems $ Map.restrictKeys (getScriptsProvidedMap sp) scriptsNeeded
     langs = Set.fromList $ plutusScriptLanguage <$> mapMaybe toPlutusScript scriptsUsed
     langViews = Set.map (getLanguageView pp) langs
     txWits = tx ^. witsTxL

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -48,6 +48,7 @@ import Cardano.Ledger.Mary.Value (PolicyID (..))
 import Cardano.Ledger.Plutus (Language (..))
 import Cardano.Ledger.Plutus.Data (Data, Datum (..))
 import Cardano.Ledger.Shelley.UTxO (
+  ShelleyScriptsProvided (..),
   getShelleyMinFeeTxUtxo,
   getShelleyWitsVKeyNeeded,
   shelleyConsumed,
@@ -55,7 +56,6 @@ import Cardano.Ledger.Shelley.UTxO (
 import Cardano.Ledger.State (
   EraCertState (..),
   EraUTxO (..),
-  ScriptsProvided (..),
   UTxO (..),
   getScriptHash,
  )
@@ -80,6 +80,7 @@ deriving instance AlonzoEraScript era => Show (AlonzoScriptsNeeded era)
 
 instance EraUTxO AlonzoEra where
   type ScriptsNeeded AlonzoEra = AlonzoScriptsNeeded AlonzoEra
+  type ScriptsProvided AlonzoEra = ShelleyScriptsProvided AlonzoEra
 
   consumed = shelleyConsumed
 
@@ -88,7 +89,9 @@ instance EraUTxO AlonzoEra where
   getProducedValue pp isRegPoolId txBody =
     withTopTxLevelOnly txBody (getProducedMaryValue pp isRegPoolId)
 
-  getScriptsProvided _ tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
+  getScriptsProvided _ tx = ShelleyScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
+
+  getScriptsProvidedMap = unShelleyScriptsProvided
 
   getScriptsNeeded = getAlonzoScriptsNeeded
 
@@ -163,14 +166,15 @@ getAlonzoScriptsHashesNeeded (AlonzoScriptsNeeded sn) = Set.fromList (map snd sn
 --
 -- @{ h | (_ → (a,_,h)) ∈ txins tx ◁ utxo, isNonNativeScriptAddress tx a}@
 getInputDataHashesTxBody ::
-  (EraTxBody era, AlonzoEraTxOut era, AlonzoEraScript era) =>
+  (EraUTxO era, AlonzoEraTxOut era, AlonzoEraScript era) =>
   UTxO era ->
   TxBody l era ->
   ScriptsProvided era ->
   (Set.Set DataHash, Set.Set TxIn)
-getInputDataHashesTxBody (UTxO utxo) txBody (ScriptsProvided scriptsProvided) =
+getInputDataHashesTxBody (UTxO utxo) txBody sp =
   Map.foldlWithKey' accum (Set.empty, Set.empty) spendUTxO
   where
+    scriptsProvided = getScriptsProvidedMap sp
     spendingPlutusScriptLanguage addr = do
       scriptHash <- getScriptHash addr
       plutusScript <- lookupPlutusScript scriptHash scriptsProvided

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -92,7 +92,7 @@ import Cardano.Ledger.Shelley.LedgerState (
   nesEsL,
   utxoL,
  )
-import Cardano.Ledger.Shelley.UTxO (EraUTxO (..), ScriptsProvided (..), UTxO (..), txouts)
+import Cardano.Ledger.Shelley.UTxO (EraUTxO (..), UTxO (..), txouts)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.Monad (forM)
 import qualified Data.List.NonEmpty as NonEmpty
@@ -258,7 +258,7 @@ fixupScriptWits ::
 fixupScriptWits tx = impAnn "fixupScriptWits" $ do
   contexts <- impGetPlutusContexts tx
   utxo <- getUTxO
-  let ScriptsProvided provided = getScriptsProvided utxo tx
+  let provided = getScriptsProvidedMap $ getScriptsProvided utxo tx
   let contextsToAdd = filter (\(_, sh, _) -> not (Map.member sh provided)) contexts
   scriptWits <- forM contextsToAdd $ \(_, sh, ScriptTestContext plutus _) ->
     (sh,) . fromPlutusScript <$> mkPlutusScript plutus

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.14.0.0
 
+* Add `BabbageScriptsProvided` type
+* Add `mkBabbageScriptsProvided`
 * `BabbageTxInfoResult` changed its content type to `PlutusTxInfoResult`
 * Deprecate the use of `GetLedgerView`:
   - Add `BabbageForecast` to deprecate `LedgerView` for Praos.

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -90,7 +90,7 @@ library
     base >=4.18 && <5,
     bytestring,
     cardano-data >=1.2,
-    cardano-ledger-allegra ^>=1.9.1,
+    cardano-ledger-allegra ^>=1.10,
     cardano-ledger-alonzo ^>=1.16,
     cardano-ledger-binary >=1.6,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.20,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -41,7 +41,7 @@ import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra, BabbageUTXOW)
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUTXO, BabbageUtxoPredFailure (..))
 import Cardano.Ledger.Babbage.Tx (mkScriptIntegrity)
-import Cardano.Ledger.Babbage.UTxO (getReferenceScripts)
+import Cardano.Ledger.Babbage.UTxO (BabbageScriptsProvided (..))
 import Cardano.Ledger.BaseTypes (Mismatch, Relation (..), ShelleyBase, quorum, strictMaybeToMaybe)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
@@ -318,6 +318,7 @@ babbageUtxowTransition ::
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   , BabbageEraTxBody era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
@@ -342,7 +343,6 @@ babbageUtxowTransition = do
   let utxo = utxosUtxo u
       txBody = tx ^. bodyTxL
       witsKeyHashes = keyHashWitnessesTxWits (tx ^. witsTxL)
-      inputs = (txBody ^. referenceInputsTxBodyL) `Set.union` (txBody ^. inputsTxBodyL)
 
   -- check scripts
   {- neededHashes := {h | ( , h) ∈ scriptsNeeded utxo txb} -}
@@ -355,8 +355,8 @@ babbageUtxowTransition = do
   runTest $ validateFailedBabbageScripts tx scriptsProvided scriptHashesNeeded
 
   {- neededHashes − dom(refScripts tx utxo) = dom(txwitscripts txw) -}
-  let sReceived = Map.keysSet $ tx ^. witsTxL . scriptTxWitsL
-      sRefs = Map.keysSet $ getReferenceScripts utxo inputs
+  let sReceived = Map.keysSet $ bspWitnessScripts scriptsProvided
+      sRefs = Map.keysSet $ bspReferenceScripts scriptsProvided
   runTest $ babbageMissingScripts pp scriptHashesNeeded sRefs sReceived
 
   {-  inputHashes ⊆  dom(txdats txw) ⊆  allowed -}
@@ -404,6 +404,7 @@ instance
   , AlonzoEraUTxO era
   , ShelleyEraTxBody era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   , BabbageEraTxBody era
   , EraRule "UTXOW" era ~ BabbageUTXOW era
   , InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -63,7 +63,7 @@ import Cardano.Ledger.Shelley.Rules (
   validateNeededWitnesses,
  )
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import Cardano.Ledger.State (EraCertState (..), EraUTxO (..), ScriptsProvided (..))
+import Cardano.Ledger.State (EraCertState (..), EraUTxO (..))
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended (
@@ -224,13 +224,14 @@ babbageMissingScripts _ sNeeded sRefs sReceived =
 
 {-  ∀ s ∈ (txscripts txw utxo ∩ Scriptnative), validateScript s tx   -}
 validateFailedBabbageScripts ::
-  EraTx era =>
+  EraUTxO era =>
   Tx l era ->
   ScriptsProvided era ->
   Set ScriptHash ->
   Test (ShelleyUtxowPredFailure era)
-validateFailedBabbageScripts tx (ScriptsProvided scriptsProvided) neededHashes =
-  let failedScripts =
+validateFailedBabbageScripts tx sp neededHashes =
+  let scriptsProvided = getScriptsProvidedMap sp
+      failedScripts =
         Map.filterWithKey
           ( \scriptHash script ->
               case getNativeScript script of

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Babbage.UTxO (
+  BabbageScriptsProvided (..),
+  mkBabbageScriptsProvided,
   getBabbageSupplementalDataHashes,
   getBabbageSpendingDatum,
   getBabbageScriptsProvided,
@@ -27,17 +32,46 @@ import Cardano.Ledger.Binary (sizedValue)
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue, getProducedMaryValue)
 import Cardano.Ledger.Plutus.Data (Data)
 import Cardano.Ledger.Shelley.UTxO (getShelleyMinFeeTxUtxo, shelleyConsumed)
-import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided (..), UTxO (..))
+import Cardano.Ledger.State (EraUTxO (..), UTxO (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.Applicative
+import Control.DeepSeq (NFData)
 import Data.Foldable (toList)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
+import GHC.Generics (Generic)
 import Lens.Micro
+
+data BabbageScriptsProvided era = BabbageScriptsProvided
+  { bspWitnessScripts :: !(Map.Map ScriptHash (Script era))
+  , bspReferenceScripts :: !(Map.Map ScriptHash (Script era))
+  , bspAllScripts :: !(Map.Map ScriptHash (Script era)) -- cached union
+  }
+  deriving (Generic)
+
+mkBabbageScriptsProvided ::
+  Map.Map ScriptHash (Script era) ->
+  Map.Map ScriptHash (Script era) ->
+  BabbageScriptsProvided era
+mkBabbageScriptsProvided witnessScripts referenceScripts =
+  BabbageScriptsProvided
+    { bspWitnessScripts = witnessScripts
+    , bspReferenceScripts = referenceScripts
+    , bspAllScripts = referenceScripts `Map.union` witnessScripts
+    }
+
+deriving instance (Era era, Eq (Script era)) => Eq (BabbageScriptsProvided era)
+
+deriving instance (Era era, Ord (Script era)) => Ord (BabbageScriptsProvided era)
+
+deriving instance (Era era, Show (Script era)) => Show (BabbageScriptsProvided era)
+
+instance (Era era, NFData (Script era)) => NFData (BabbageScriptsProvided era)
 
 instance EraUTxO BabbageEra where
   type ScriptsNeeded BabbageEra = AlonzoScriptsNeeded BabbageEra
+  type ScriptsProvided BabbageEra = BabbageScriptsProvided BabbageEra
 
   consumed = shelleyConsumed
 
@@ -47,6 +81,8 @@ instance EraUTxO BabbageEra where
     withTopTxLevelOnly txBody (getProducedMaryValue pp isRegPoolId)
 
   getScriptsProvided = getBabbageScriptsProvided
+
+  getScriptsProvidedMap = bspAllScripts
 
   getScriptsNeeded = getAlonzoScriptsNeeded
   {-# INLINEABLE getScriptsNeeded #-}
@@ -130,12 +166,13 @@ getBabbageScriptsProvided ::
   ) =>
   UTxO era ->
   Tx l era ->
-  ScriptsProvided era
-getBabbageScriptsProvided utxo tx = ScriptsProvided ans
+  BabbageScriptsProvided era
+getBabbageScriptsProvided utxo tx = mkBabbageScriptsProvided witnessScripts referenceScripts
   where
     txBody = tx ^. bodyTxL
     ins = (txBody ^. referenceInputsTxBodyL) `Set.union` (txBody ^. inputsTxBodyL)
-    ans = getReferenceScripts utxo ins `Map.union` (tx ^. witsTxL . scriptTxWitsL)
+    referenceScripts = getReferenceScripts utxo ins
+    witnessScripts = tx ^. witsTxL . scriptTxWitsL
 
 -- | Collect all the reference scripts found in the TxOuts, pointed to by some input.
 getReferenceScripts ::

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -106,7 +106,7 @@ library
     base >=4.18 && <5,
     cardano-crypto-class,
     cardano-data >=1.3,
-    cardano-ledger-allegra ^>=1.9.1,
+    cardano-ledger-allegra ^>=1.10,
     cardano-ledger-alonzo ^>=1.16,
     cardano-ledger-babbage ^>=1.14,
     cardano-ledger-binary ^>=1.9,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -40,6 +40,7 @@ import Cardano.Ledger.Babbage.Rules (
   babbageUtxowTransition,
  )
 import qualified Cardano.Ledger.Babbage.Rules as Babbage (BabbageUtxowPredFailure (..))
+import Cardano.Ledger.Babbage.UTxO (BabbageScriptsProvided)
 import Cardano.Ledger.BaseTypes (Mismatch (..), Relation (..), ShelleyBase, StrictMaybe (..))
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
@@ -190,6 +191,7 @@ instance
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   , ConwayEraTxBody era
   , EraRule "UTXOW" era ~ ConwayUTXOW era
   , InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -28,6 +28,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   zipAsIxItem,
  )
 import Cardano.Ledger.Babbage.UTxO (
+  BabbageScriptsProvided (..),
   getBabbageScriptsProvided,
   getBabbageSpendingDatum,
   getBabbageSupplementalDataHashes,
@@ -128,6 +129,7 @@ conwayProducedValue pp isStakePool txBody =
 
 instance EraUTxO ConwayEra where
   type ScriptsNeeded ConwayEra = AlonzoScriptsNeeded ConwayEra
+  type ScriptsProvided ConwayEra = BabbageScriptsProvided ConwayEra
 
   consumed = conwayConsumed
 
@@ -137,6 +139,8 @@ instance EraUTxO ConwayEra where
     withTopTxLevelOnly txBody (conwayProducedValue pp isRegPoolId)
 
   getScriptsProvided = getBabbageScriptsProvided
+
+  getScriptsProvidedMap = bspAllScripts
 
   getScriptsNeeded = getConwayScriptsNeeded
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -626,6 +626,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   ) =>
   Embed (DijkstraSUBLEDGERS era) (DijkstraLEDGER era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -37,6 +37,7 @@ import Cardano.Ledger.Babbage.Rules (
   BabbageUtxoPredFailure,
   BabbageUtxowPredFailure,
  )
+import Cardano.Ledger.Babbage.UTxO (BabbageScriptsProvided (..), mkBabbageScriptsProvided)
 import Cardano.Ledger.BaseTypes (
   Mismatch (..),
   Relation (..),
@@ -328,6 +329,7 @@ instance
   , ConwayEraGov era
   , DijkstraEraTxBody era
   , EraUTxO era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
@@ -387,6 +389,7 @@ dijkstraLedgerTransition ::
   , ConwayEraGov era
   , DijkstraEraTxBody era
   , EraUTxO era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
@@ -416,11 +419,11 @@ dijkstraLedgerTransition = do
 
   let utxo = utxosUtxo (ledgerState ^. lsUTxOStateL)
       subTxs = tx ^. bodyTxL . subTransactionsTxBodyL
+      allProvided = getScriptsProvided utxo tx : map (getScriptsProvided utxo) (OMap.elems subTxs)
       scriptsProvided =
-        ScriptsProvided $
-          Map.unions $
-            unScriptsProvided (getScriptsProvided utxo tx)
-              : map (unScriptsProvided . getScriptsProvided utxo) (OMap.elems subTxs)
+        mkBabbageScriptsProvided
+          (Map.unions $ map bspWitnessScripts allProvided)
+          (Map.unions $ map bspReferenceScripts allProvided)
 
   ledgerStateAfterSubledgers <-
     trans @(EraRule "SUBLEDGERS" era) $
@@ -462,6 +465,7 @@ instance
   , ConwayEraPParams era
   , DijkstraEraTxBody era
   , EraPlutusContext era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   , GovState era ~ ConwayGovState era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
+import Cardano.Ledger.Babbage.UTxO (BabbageScriptsProvided)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
@@ -244,6 +245,7 @@ instance
   , DijkstraEraTxBody era
   , ConwayEraGov era
   , EraPlutusContext era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "CERTS" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -26,6 +26,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
+import Cardano.Ledger.Babbage.UTxO (BabbageScriptsProvided)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -339,6 +340,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   ) =>
   Embed (DijkstraSUBUTXOW era) (DijkstraSUBLEDGER era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -23,6 +23,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
+import Cardano.Ledger.Babbage.UTxO (BabbageScriptsProvided)
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
  )
@@ -197,6 +198,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , TxCert era ~ DijkstraTxCert era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   ) =>
   Embed (DijkstraSUBLEDGER era) (DijkstraSUBLEDGERS era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -71,7 +71,7 @@ import qualified Cardano.Ledger.Shelley.Rules as Shelley (
   validateNeededWitnesses,
   validateVerifiedWits,
  )
-import Cardano.Ledger.State (CertState, EraUTxO (..), ScriptsProvided (..))
+import Cardano.Ledger.State (CertState, EraUTxO (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -37,6 +37,7 @@ import qualified Cardano.Ledger.Babbage.Rules as Babbage (
   validateScriptsWellFormedTxOuts,
  )
 import Cardano.Ledger.Babbage.Tx (mkScriptIntegrity)
+import Cardano.Ledger.Babbage.UTxO (BabbageScriptsProvided (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -207,6 +208,7 @@ instance
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   ) =>
   STS (DijkstraSUBUTXOW era)
   where
@@ -231,6 +233,7 @@ dijkstraSubUtxowTransition ::
   , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
   , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
 dijkstraSubUtxowTransition = do
@@ -265,7 +268,7 @@ dijkstraSubUtxowTransition = do
   runTest $
     Babbage.validateScriptsWellFormedTxOuts
       pp
-      (tx ^. witsTxL . scriptTxWitsL)
+      (bspWitnessScripts scriptsProvided)
       (tx ^. bodyTxL . outputsTxBodyL)
 
   trans @(EraRule "SUBUTXO" era) $ TRC (UtxoEnv slot pp certState, utxoState, tx)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -39,6 +39,7 @@ import Cardano.Ledger.Babbage.Rules (
   BabbageUtxowPredFailure,
   babbageUtxowTransition,
  )
+import Cardano.Ledger.Babbage.UTxO (BabbageScriptsProvided)
 import Cardano.Ledger.BaseTypes (
   Mismatch (..),
   Relation (..),
@@ -209,6 +210,7 @@ instance
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , ScriptsProvided era ~ BabbageScriptsProvided era
   , ConwayEraTxBody era
   , EraRule "UTXOW" era ~ DijkstraUTXOW era
   , InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -17,6 +17,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   zipAsIxItem,
  )
 import Cardano.Ledger.Babbage.UTxO (
+  BabbageScriptsProvided (..),
   getBabbageScriptsProvided,
   getBabbageSpendingDatum,
   getBabbageSupplementalDataHashes,
@@ -105,6 +106,7 @@ getProducedDijkstraValue pp isRegPoolId txBody =
 
 instance EraUTxO DijkstraEra where
   type ScriptsNeeded DijkstraEra = AlonzoScriptsNeeded DijkstraEra
+  type ScriptsProvided DijkstraEra = BabbageScriptsProvided DijkstraEra
 
   consumed = conwayConsumed
 
@@ -113,6 +115,8 @@ instance EraUTxO DijkstraEra where
   getProducedValue = getProducedDijkstraValue
 
   getScriptsProvided = getBabbageScriptsProvided
+
+  getScriptsProvidedMap = bspAllScripts
 
   getScriptsNeeded = getDijkstraScriptsNeeded
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -83,7 +83,7 @@ library
     bytestring,
     cardano-crypto-class ^>=2.3,
     cardano-data ^>=1.3,
-    cardano-ledger-allegra ^>=1.9.1,
+    cardano-ledger-allegra ^>=1.10,
     cardano-ledger-binary >=1.4,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.20,
     cardano-ledger-shelley ^>=1.19,

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -19,6 +19,7 @@ import Cardano.Ledger.Mary.State ()
 import Cardano.Ledger.Mary.Value (MaryValue (..), filterMultiAsset, mapMaybeMultiAsset, policyID)
 import Cardano.Ledger.Shelley.UTxO (
   ShelleyScriptsNeeded (..),
+  ShelleyScriptsProvided (..),
   getShelleyMinFeeTxUtxo,
   getShelleyScriptsNeeded,
   getShelleyWitsVKeyNeeded,
@@ -27,7 +28,6 @@ import Cardano.Ledger.Shelley.UTxO (
  )
 import Cardano.Ledger.State (
   EraUTxO (..),
-  ScriptsProvided (..),
   UTxO,
   sumUTxO,
   txInsFilter,
@@ -39,6 +39,7 @@ import Lens.Micro
 
 instance EraUTxO MaryEra where
   type ScriptsNeeded MaryEra = ShelleyScriptsNeeded MaryEra
+  type ScriptsProvided MaryEra = ShelleyScriptsProvided MaryEra
 
   consumed = shelleyConsumed
 
@@ -47,7 +48,9 @@ instance EraUTxO MaryEra where
   getProducedValue pp isRegPoolId txBody =
     withTopTxLevelOnly txBody (getProducedMaryValue pp isRegPoolId)
 
-  getScriptsProvided _ tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
+  getScriptsProvided _ tx = ShelleyScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
+
+  getScriptsProvidedMap = unShelleyScriptsProvided
 
   getScriptsNeeded = getMaryScriptsNeeded
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `ShelleyScriptsProvided` type
 * Add `Shelley.API.Forecast` and `Shelley.Forecast`:
   - Add `EraForecast` and `ShelleyEraForecast` typeclasses to deprecate `GetLedgerView` from `cardano-ledger-tpraos`.
   - Add `currentForecast` and `futureForecast` functions to deprecate `currentLedgerView` and `futureLedgerView`.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -71,7 +71,6 @@ import qualified Cardano.Ledger.Shelley.SoftForks as SoftForks
 import Cardano.Ledger.Shelley.TxCert (isInstantaneousRewards)
 import Cardano.Ledger.Shelley.UTxO (
   EraUTxO (..),
-  ScriptsProvided (..),
   ShelleyScriptsNeeded (..),
   UTxO,
   verifyWitVKey,
@@ -366,28 +365,29 @@ instance
 
 {-  ∀ s ∈ range(txscripts txw) ∩ Scriptnative), runNativeScript s tx   -}
 validateFailedNativeScripts ::
-  EraTx era => ScriptsProvided era -> Tx l era -> Test (ShelleyUtxowPredFailure era)
-validateFailedNativeScripts (ScriptsProvided scriptsProvided) tx = do
+  EraUTxO era => ScriptsProvided era -> Tx l era -> Test (ShelleyUtxowPredFailure era)
+validateFailedNativeScripts sp tx = do
   let failedScripts =
         Map.filter -- we keep around only non-validating native scripts
           (maybe False (not . validateNativeScript tx) . getNativeScript)
-          scriptsProvided
+          (getScriptsProvidedMap sp)
   failureOnNonEmptySet (Map.keysSet failedScripts) ScriptWitnessNotValidatingUTXOW
 
 {-  { s | (_,s) ∈ scriptsNeeded utxo tx} = dom(txscripts txw)    -}
 {-  sNeeded := scriptsNeeded utxo tx                             -}
 {-  sProvided := Map.keysSet (tx ^. witsTxL . scriptTxWitsL)     -}
 validateMissingScripts ::
+  EraUTxO era =>
   ShelleyScriptsNeeded era ->
   ScriptsProvided era ->
   Test (ShelleyUtxowPredFailure era)
-validateMissingScripts (ShelleyScriptsNeeded sNeeded) scriptsprovided =
+validateMissingScripts (ShelleyScriptsNeeded sNeeded) sp =
   sequenceA_
     [ failureOnNonEmptySet (sNeeded `Set.difference` sProvided) MissingScriptWitnessesUTXOW
     , failureOnNonEmptySet (sProvided `Set.difference` sNeeded) ExtraneousScriptWitnessesUTXOW
     ]
   where
-    sProvided = Map.keysSet $ unScriptsProvided scriptsprovided
+    sProvided = Map.keysSet $ getScriptsProvidedMap sp
 
 -- | Determine if the UTxO witnesses in a given transaction are correct.
 validateVerifiedWits :: EraTx era => Tx l era -> Test (ShelleyUtxowPredFailure era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -18,6 +19,7 @@
 module Cardano.Ledger.Shelley.UTxO (
   EraUTxO (..),
   ShelleyScriptsNeeded (..),
+  ShelleyScriptsProvided (..),
   getShelleyScriptsNeeded,
   getConsumedCoin,
   shelleyProducedValue,
@@ -53,7 +55,6 @@ import Cardano.Ledger.State as UTxO (
   CanGetUTxO (..),
   CanSetUTxO (..),
   EraUTxO (..),
-  ScriptsProvided (..),
   UTxO (..),
   areAllAdaOnly,
   getScriptHash,
@@ -70,6 +71,7 @@ import Cardano.Ledger.State as UTxO (
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Ledger.Val ((<+>))
 import qualified Cardano.Ledger.Val as Val
+import Control.DeepSeq (NFData)
 import Data.Foldable (Foldable (fold), foldr', toList)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
@@ -170,8 +172,22 @@ getConsumedCoin pp lookupRefund utxo txBody =
 newtype ShelleyScriptsNeeded era = ShelleyScriptsNeeded (Set ScriptHash)
   deriving (Eq, Show, Generic)
 
+newtype ShelleyScriptsProvided era = ShelleyScriptsProvided
+  { unShelleyScriptsProvided :: Map.Map ScriptHash (Script era)
+  }
+  deriving (Generic)
+
+deriving instance (Era era, Eq (Script era)) => Eq (ShelleyScriptsProvided era)
+
+deriving instance (Era era, Ord (Script era)) => Ord (ShelleyScriptsProvided era)
+
+deriving instance (Era era, Show (Script era)) => Show (ShelleyScriptsProvided era)
+
+instance (Era era, NFData (Script era)) => NFData (ShelleyScriptsProvided era)
+
 instance EraUTxO ShelleyEra where
   type ScriptsNeeded ShelleyEra = ShelleyScriptsNeeded ShelleyEra
+  type ScriptsProvided ShelleyEra = ShelleyScriptsProvided ShelleyEra
 
   consumed = shelleyConsumed
 
@@ -180,7 +196,9 @@ instance EraUTxO ShelleyEra where
   getProducedValue pp isRegPoolId txBody =
     withTopTxLevelOnly txBody (shelleyProducedValue pp isRegPoolId)
 
-  getScriptsProvided _ tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
+  getScriptsProvided _ tx = ShelleyScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
+
+  getScriptsProvidedMap = unShelleyScriptsProvided
 
   getScriptsNeeded = getShelleyScriptsNeeded
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1050,7 +1050,7 @@ addNativeScriptTxWits ::
 addNativeScriptTxWits tx = impAnn "addNativeScriptTxWits" $ do
   scriptsRequired <- impNativeScriptsRequired tx
   utxo <- getUTxO
-  let ScriptsProvided provided = getScriptsProvided utxo tx
+  let provided = getScriptsProvidedMap $ getScriptsProvided utxo tx
       scriptsToAdd = scriptsRequired Map.\\ provided
   pure $
     tx

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -64,7 +64,7 @@ library
     base >=4.18 && <5,
     bytestring,
     cardano-data,
-    cardano-ledger-allegra ^>=1.9,
+    cardano-ledger-allegra ^>=1.10,
     cardano-ledger-alonzo >=1.12,
     cardano-ledger-babbage >=1.13,
     cardano-ledger-binary >=1.4,

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.20.0.0
 
+* Convert `ScriptsProvided` from a concrete newtype to an associated type family on `EraUTxO`
+* Add `getScriptsProvidedMap` method to `EraUTxO`
 * Deprecate `BHeaderView` in favour `*EraBlockHeader` typeclasses.
   - Move `isOverlaySlot` to `Cardano.Ledger.Slot`.
   - Remove `PerasCert`, `PerasKey` and `validatePerasCert` to `dijkstra`.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
@@ -23,7 +23,6 @@ module Cardano.Ledger.State.UTxO (
   -- * Primitives
   UTxO (..),
   EraUTxO (..),
-  ScriptsProvided (..),
 
   -- * Functions
   txins,
@@ -223,26 +222,13 @@ getScriptHash :: Addr -> Maybe ScriptHash
 getScriptHash (Addr _ (ScriptHashObj hs) _) = Just hs
 getScriptHash _ = Nothing
 
--- | The only reason it is a newtype instead of just a Map is becuase for later eras is
--- expensive to compute the actual map, so we want to use the type safety guidance to
--- avoid redundant work.
-newtype ScriptsProvided era = ScriptsProvided
-  { unScriptsProvided :: Map.Map ScriptHash (Script era)
-  }
-  deriving (Generic)
-
-deriving instance (Era era, Eq (Script era)) => Eq (ScriptsProvided era)
-
-deriving instance (Era era, Ord (Script era)) => Ord (ScriptsProvided era)
-
-deriving instance (Era era, Show (Script era)) => Show (ScriptsProvided era)
-
-deriving instance (Era era, NFData (Script era)) => NFData (ScriptsProvided era)
-
 class EraTx era => EraUTxO era where
   -- | A customizable type on per era basis for the information required to find all
   -- scripts needed for the transaction.
   type ScriptsNeeded era = (r :: Type) | r -> era
+
+  -- | A customizable type on per era basis for the scripts provided by a transaction.
+  type ScriptsProvided era = (r :: Type) | r -> era
 
   consumed :: PParams era -> CertState era -> UTxO era -> TxBody t era -> Value era
 
@@ -273,6 +259,9 @@ class EraTx era => EraUTxO era where
     UTxO era ->
     Tx t era ->
     ScriptsProvided era
+
+  -- | Extract the combined map of all provided scripts, regardless of source.
+  getScriptsProvidedMap :: ScriptsProvided era -> Map.Map ScriptHash (Script era)
 
   -- | Produce all the information required for figuring out which scripts are required
   -- for the transaction to be valid, once those scripts are evaluated

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -268,8 +268,6 @@ instance ToExpr CommitteeAuthorization
 instance ToExpr (CommitteeState era)
 
 -- UTxO
-deriving instance (Era era, ToExpr (Script era)) => ToExpr (ScriptsProvided era)
-
 instance ToExpr (TxOut era) => ToExpr (UTxO era)
 
 instance ToExpr TxOutSource

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Functions.hs
@@ -291,7 +291,7 @@ languages ::
   Set Language
 languages tx utxo sNeeded = Map.foldl' accum Set.empty allScripts
   where
-    allScripts = Map.restrictKeys (unScriptsProvided $ getScriptsProvided utxo tx) sNeeded
+    allScripts = Map.restrictKeys (getScriptsProvidedMap $ getScriptsProvided utxo tx) sNeeded
     accum ans script =
       case toPlutusScript script of
         Nothing -> ans

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -45,7 +45,7 @@ library
     cardano-base >=0.1.2,
     cardano-crypto-class ^>=2.3,
     cardano-crypto-praos ^>=2.2,
-    cardano-ledger-allegra >=1.9.1,
+    cardano-ledger-allegra >=1.10,
     cardano-ledger-alonzo >=1.16,
     cardano-ledger-babbage >=1.13.1,
     cardano-ledger-binary >=1.8,


### PR DESCRIPTION
# Description

`ScriptsProvided` is a map of scripts, provided as : 
   * witnesses (pre-babbage) 
   *  witnesses and references (babbage +) 

At the moment in master, `ScriptsProvided` is just a wrapper over the Map, so whenever we call `getScriptsProvided` we lose the information of the source of the returned scripts.
In some cases, we have to repeat parts of what `getScriptsProvided` does,  (namely: `getReferenceScripts`), because we need to differentiate between the two sets of scripts .

This PR turns `ScriptsProvided` into an associated type family, similar to `ScriptsNeeded`, with two implementations: ShelleyScriptsProvided and BabbageScriptsProvided, the latter with fields for the two different sources (plus the cached union, to avoid its recomputation). 
The `getScriptsProvidedMap`  plays the same role like `getScriptsHashesNeeded` to `getScriptsNeeded` - necessary for functions that use this across era and need to unwrap the type internally.

The removed redundancy is small atm, but with the top level UTXOW rule for nested transactions, it becomes more problematic (with ScriptsProvided being passed in environments for the rules). 



<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
