### PR TITLE
Remove 5 redundant NativeScript era ~ Timelock era constraints (#5319)

### DIFF
--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Examples.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Examples.hs
@@ -101,5 +101,5 @@ exampleTimelock =
       ]
 
 exampleAllegraTxAuxData ::
-  (AllegraEraScript era, NativeScript era ~ Timelock era) => AllegraTxAuxData era
+  AllegraEraScript era => AllegraTxAuxData era
 exampleAllegraTxAuxData = AllegraTxAuxData exampleAuxDataMap (StrictSeq.fromList [exampleTimelock])

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -15,7 +15,6 @@ module Test.Cardano.Ledger.Alonzo.AlonzoEraGen where
 
 import Cardano.Ledger.Allegra.Scripts (
   AllegraEraScript,
-  Timelock (..),
   translateTimelock,
   pattern RequireTimeExpire,
   pattern RequireTimeStart,

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/AlonzoEraGen.hs
@@ -618,9 +618,7 @@ addMaybeDataHashToTxOut txout = txout & dataHashTxOutL .~ dataFromAddr (txout ^.
 
 someLeaf ::
   forall era.
-  ( AllegraEraScript era
-  , NativeScript era ~ Timelock era
-  ) =>
+  AllegraEraScript era =>
   Proxy era ->
   KeyHash Witness ->
   AlonzoScript era

--- a/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
+++ b/eras/shelley-ma/test-suite/src/Test/Cardano/Ledger/AllegraEraGen.hs
@@ -187,7 +187,7 @@ genValidityInterval cs@(SlotNo currentSlot) =
 -- valid sub-branch of script.
 someLeaf ::
   forall era.
-  (AllegraEraScript era, NativeScript era ~ Timelock era) =>
+  AllegraEraScript era =>
   KeyHash Witness ->
   NativeScript era
 someLeaf x =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -110,7 +110,6 @@ instance
 
 instance
   ( AlonzoEraScript era
-  , NativeScript era ~ Timelock era
   , Script era ~ AlonzoScript era
   ) =>
   SpecTranslate ctx (PlutusScript era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/GenState.hs
@@ -82,7 +82,6 @@ module Test.Cardano.Ledger.Generic.GenState (
 
 import Cardano.Ledger.Allegra.Scripts (
   AllegraEraScript,
-  Timelock (..),
   ValidityInterval (..),
   pattern RequireTimeExpire,
   pattern RequireTimeStart,
@@ -742,7 +741,7 @@ genScript tag = case reify @era of
 -- Adds to gsScripts
 genTimelockScript ::
   forall era.
-  (AllegraEraScript era, NativeScript era ~ Timelock era) =>
+  AllegraEraScript era =>
   GenRS era ScriptHash
 genTimelockScript = do
   vi@(ValidityInterval mBefore mAfter) <- gets gsValidityInterval
@@ -753,7 +752,7 @@ genTimelockScript = do
             elementsT $
               nonRecTimelocks ++ [requireAllOf k, requireAnyOf k, requireMOf k]
         | otherwise = elementsT nonRecTimelocks
-      nonRecTimelocks :: [GenRS era (Timelock era)]
+      nonRecTimelocks :: [GenRS era (NativeScript era)]
       nonRecTimelocks =
         [ r
         | SJust r <-


### PR DESCRIPTION
# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
