### PR TITLE
Add a CI workflow for checking nix hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  open-pull-requests-limit: 5
+  groups:
+    actions:
+      patterns:
+      - "*"

--- a/.github/workflows/check-nix-hashes.yml
+++ b/.github/workflows/check-nix-hashes.yml
@@ -1,0 +1,34 @@
+name: Check nix hashes
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - flake.lock
+    - cabal.project
+  pull_request:
+    paths:
+    - flake.lock
+    - cabal.project
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+
+    - name: Install nix
+      uses: cachix/install-nix-action@v31
+
+    - name: Install cleret
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
+
+    - name: Check nix hashes
+      run: cleret nix hashes -vp

--- a/.github/workflows/check-nix-hashes.yml
+++ b/.github/workflows/check-nix-hashes.yml
@@ -28,6 +28,7 @@ jobs:
       uses: cachix/install-nix-action@v31
 
     - name: Install cleret
+      # Tag should match the one that's used in flake.nix
       uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
 
     - name: Check nix hashes

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -146,7 +146,8 @@ jobs:
           ${{ env.cache-name }}-${{ runner.os }}-${{ matrix.ghc }}-${{ env.CABAL_CACHE_VERSION }}-
 
     - name: Install cleret
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.2.0.2
+      # Tag should match the one that's used in flake.nix
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
 
     - name: Check workflow test matrix
       run: cabal build all --dry-run -v0 && cleret workflow check-test-matrix
@@ -332,7 +333,8 @@ jobs:
         fi
 
     - name: Install cleret
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.2.0.2
+      # Tag should match the one that's used in flake.nix
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
 
     - name: Install doctest
       run: |
@@ -661,7 +663,8 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install cleret
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.2.0.2
+      # Tag should match the one that's used in flake.nix
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.3.0.0
 
     - name: Run linter
       run: scripts/format-changelogs.sh || (git diff; false)

--- a/flake.lock
+++ b/flake.lock
@@ -122,16 +122,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1774040590,
-        "narHash": "sha256-hgGRPVtciAAsT96ATgWjEDnmCHP/MthQ23TBwxuDtUo=",
+        "lastModified": 1775087180,
+        "narHash": "sha256-eAwb3ZXkcRO83gP9/fiiWxC05eAhSZ4ntkLVxpv7qEY=",
         "owner": "input-output-hk",
         "repo": "cardano-ledger-release-tool",
-        "rev": "1c6bd73fc43993112cb47a728d4a72465a66d998",
+        "rev": "e8011391f49e927f1b69878b75b69cc656e6b9cb",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "0.2.0.2",
+        "ref": "0.3.0.0",
         "repo": "cardano-ledger-release-tool",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,8 @@
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
 
     cardano-ledger-release-tool = {
-      # Tag should match the one used in .github/workflows/haskell.yml
-      url = "github:input-output-hk/cardano-ledger-release-tool?ref=0.2.0.2";
+      # Tag should match the ones used in .github/workflows/*.yml
+      url = "github:input-output-hk/cardano-ledger-release-tool?ref=0.3.0.0";
       inputs.haskell-nix.follows = "haskellNix";
       inputs.hackage.follows = "hackageNix";
       inputs.pre-commit-hooks.follows = "pre-commit-hooks";


### PR DESCRIPTION
# Description

Sometimes the nix hashes of srp's in `cabal.project` are missing or incorrect, and sometimes the hashes in `flake.lock` are incorrect. `cleret` now has the ability to check these, so this PR adds a new workflow that's triggered by a change to either of those files. (It can also be triggered manually.)

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
