### PR TITLE
Add serialisation tests for query result types

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### `testlib`
 
+* Add `Arbitrary` instances for `RewardInfoPool` and `RewardParams`
 * Add `withIssuerAndTxsInBlock_` and `withIssuerAndTxsInBlock`
 * Add a `Maybe (KeyHash BlockIssuer)` parameter to `withTxsInBlockEither`
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -39,6 +39,7 @@ import Cardano.Ledger.Shelley.API (
   ShelleyTx (ShelleyTx),
   TxBody (ShelleyTxBody),
  )
+import Cardano.Ledger.Shelley.API.Wallet (RewardInfoPool (..), RewardParams (..))
 import Cardano.Ledger.Shelley.BlockBody
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Genesis
@@ -767,3 +768,18 @@ instance
   Arbitrary (ShelleyBlockBody era)
   where
   arbitrary = ShelleyBlockBody <$> arbitrary
+
+instance Arbitrary RewardInfoPool where
+  arbitrary =
+    RewardInfoPool
+      <$> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+  shrink = genericShrink
+
+instance Arbitrary RewardParams where
+  arbitrary = RewardParams <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+  shrink = genericShrink

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *
 
+### `testlib`
+
+* Add `Arbitrary` instances for `HotCredAuthStatus`, `NextEpochChange`, `CommitteeMemberState`, `CommitteeMembersState`, and `DefaultVote`
+
 ## 1.13.0.0
 
 * Add `queryStakeSnapshots` and the types produced by it:

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -116,6 +116,7 @@ test-suite cardano-ledger-api-test
   hs-source-dirs: test
   other-modules:
     Test.Cardano.Ledger.Api.State.Imp.QuerySpec
+    Test.Cardano.Ledger.Api.State.Query.GoldenSpec
     Test.Cardano.Ledger.Api.State.QuerySpec
     Test.Cardano.Ledger.Api.Tx
     Test.Cardano.Ledger.Api.Tx.Body
@@ -135,6 +136,7 @@ test-suite cardano-ledger-api-test
 
   build-depends:
     base,
+    base16-bytestring,
     bytestring,
     cardano-data,
     cardano-ledger-allegra:{cardano-ledger-allegra, testlib},

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Query/GoldenSpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Query/GoldenSpec.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cardano.Ledger.Api.State.Query.GoldenSpec (spec) where
+
+import Cardano.Ledger.Api.State.Query
+import Cardano.Ledger.BaseTypes (EpochNo (..), unsafeNonZero)
+import Cardano.Ledger.Binary (DecCBOR, EncCBOR, Version, decodeFull)
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Core (eraProtVerHigh)
+import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.Shelley.API.Wallet (RewardInfoPool (..), RewardParams (..))
+import Cardano.Ledger.State (ChainAccountState (..))
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as BS16
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Map.Strict as Map
+import Data.Ratio ((%))
+import Test.Cardano.Ledger.Binary.Plain.Golden (DiffView (..), Enc (..), expectGoldenEncHexBytes)
+import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.KeyPair (mkKeyHash)
+import Test.Cardano.Ledger.Core.Utils (unsafeBoundRational)
+
+-- | Pin all golden tests to Conway's highest protocol version
+goldenVersion :: Version
+goldenVersion = eraProtVerHigh @ConwayEra
+
+-- | Bidirectional golden test: encoding produces expected hex, decoding expected hex
+-- produces the value. This catches both encoder changes and decoder incompatibilities.
+goldenRoundTrip ::
+  forall a.
+  (HasCallStack, EncCBOR a, DecCBOR a, Show a, Eq a) =>
+  a ->
+  BS.ByteString ->
+  Spec
+goldenRoundTrip val expectedHex = do
+  it "encoding matches golden" $
+    expectGoldenEncHexBytes DiffCBOR (Ev goldenVersion val) expectedHex
+  it "decoding matches golden" $
+    case BS16.decode expectedHex of
+      Left err -> expectationFailure $ "Bad hex in test: " ++ err
+      Right bs ->
+        case decodeFull goldenVersion (BSL.fromStrict bs) of
+          Left err -> expectationFailure $ "Decode failed: " ++ show err
+          Right (decoded :: a) -> decoded `shouldBe` val
+
+spec :: Spec
+spec = describe "Query Golden" $ do
+  describe "MemberStatus" $ do
+    describe "Active" $ goldenRoundTrip Active "00"
+    describe "Expired" $ goldenRoundTrip Expired "01"
+    describe "Unrecognized" $ goldenRoundTrip Unrecognized "02"
+
+  describe "HotCredAuthStatus" $ do
+    describe "MemberAuthorized" $
+      goldenRoundTrip
+        (MemberAuthorized (KeyHashObj (mkKeyHash 0)))
+        "82008200581c73dedba5efd33678f941c6ee48cdf2b35ff4f40653e9ed01d6c5e3c0"
+    describe "MemberNotAuthorized" $
+      goldenRoundTrip MemberNotAuthorized "8101"
+    describe "MemberResigned Nothing" $
+      goldenRoundTrip (MemberResigned Nothing) "820280"
+
+  describe "NextEpochChange" $ do
+    describe "ToBeEnacted" $ goldenRoundTrip ToBeEnacted "8100"
+    describe "ToBeRemoved" $ goldenRoundTrip ToBeRemoved "8101"
+    describe "NoChangeExpected" $ goldenRoundTrip NoChangeExpected "8102"
+    describe "ToBeExpired" $ goldenRoundTrip ToBeExpired "8103"
+    describe "TermAdjusted" $ goldenRoundTrip (TermAdjusted (EpochNo 42)) "8204182a"
+
+  describe "DefaultVote" $ do
+    describe "DefaultNo" $ goldenRoundTrip DefaultNo "00"
+    describe "DefaultAbstain" $ goldenRoundTrip DefaultAbstain "01"
+    describe "DefaultNoConfidence" $ goldenRoundTrip DefaultNoConfidence "02"
+
+  describe "CommitteeMemberState" $
+    describe "canonical" $
+      goldenRoundTrip
+        (CommitteeMemberState MemberNotAuthorized Active (Just (EpochNo 100)) NoChangeExpected)
+        "848101008118648102"
+
+  describe "CommitteeMembersState" $
+    describe "canonical" $
+      goldenRoundTrip
+        (CommitteeMembersState Map.empty Nothing (EpochNo 5))
+        "83a08005"
+
+  describe "RewardInfoPool" $
+    describe "canonical" $
+      goldenRoundTrip
+        (RewardInfoPool (Coin 1000) (Coin 500) (Coin 300) (Coin 100) (unsafeBoundRational (1 % 2)) 1.5)
+        "861903e81901f419012c1864d81e820102fb3ff8000000000000"
+
+  describe "RewardParams" $
+    describe "canonical" $
+      goldenRoundTrip
+        (RewardParams 500 (unsafeBoundRational (3 % 10)) (Coin 10000) (Coin 1000000))
+        "841901f4d81e82030a1927101a000f4240"
+
+  describe "ChainAccountState" $
+    describe "canonical" $
+      goldenRoundTrip
+        (ChainAccountState (Coin 5000000) (Coin 3000000))
+        "821a004c4b401a002dc6c0"
+
+  describe "QueryPoolStateResult" $
+    describe "canonical" $
+      goldenRoundTrip
+        (QueryPoolStateResult Map.empty Map.empty Map.empty Map.empty)
+        "84a0a0a0a0"
+
+  describe "StakeSnapshot" $
+    describe "canonical" $
+      goldenRoundTrip
+        (StakeSnapshot (Coin 100) (Coin 200) (Coin 300))
+        "83186418c819012c"
+
+  describe "StakeSnapshots" $
+    describe "canonical" $
+      goldenRoundTrip
+        ( StakeSnapshots
+            Map.empty
+            (unsafeNonZero (Coin 1000))
+            (unsafeNonZero (Coin 2000))
+            (unsafeNonZero (Coin 3000))
+        )
+        "84a01903e81907d0190bb8"

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/QuerySpec.hs
@@ -28,6 +28,7 @@ import Cardano.Ledger.Conway.State (
   vsCommitteeStateL,
  )
 import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.Shelley.API.Wallet (RewardInfoPool, RewardParams)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.State
@@ -67,6 +68,16 @@ latestErasSpec =
       describe "Roundtrip" $ do
         prop "QueryPoolStateResult" $ roundTripEraExpectation @era @QueryPoolStateResult
         prop "StakeSnapshots" $ roundTripEraExpectation @era @StakeSnapshots
+        prop "StakeSnapshot" $ roundTripEraExpectation @era @StakeSnapshot
+        prop "MemberStatus" $ roundTripEraExpectation @era @MemberStatus
+        prop "HotCredAuthStatus" $ roundTripEraExpectation @era @HotCredAuthStatus
+        prop "NextEpochChange" $ roundTripEraExpectation @era @NextEpochChange
+        prop "CommitteeMemberState" $ roundTripEraExpectation @era @CommitteeMemberState
+        prop "CommitteeMembersState" $ roundTripEraExpectation @era @CommitteeMembersState
+        prop "RewardInfoPool" $ roundTripEraExpectation @era @RewardInfoPool
+        prop "RewardParams" $ roundTripEraExpectation @era @RewardParams
+        prop "ChainAccountState" $ roundTripEraExpectation @era @ChainAccountState
+        prop "DefaultVote" $ roundTripEraExpectation @era @DefaultVote
       describe "Queries" $ do
         committeeMembersStateSpec @era
         queryStakeSnapshotsSpec @era

--- a/libs/cardano-ledger-api/test/Tests.hs
+++ b/libs/cardano-ledger-api/test/Tests.hs
@@ -13,6 +13,7 @@ import Data.Default (def)
 import Test.Cardano.Ledger.Allegra.Binary.Annotator ()
 import Test.Cardano.Ledger.Alonzo.Binary.Annotator ()
 import qualified Test.Cardano.Ledger.Api.State.Imp.QuerySpec as ImpQuery (spec)
+import qualified Test.Cardano.Ledger.Api.State.Query.GoldenSpec as QueryGolden (spec)
 import qualified Test.Cardano.Ledger.Api.State.QuerySpec as StateQuery (spec)
 import qualified Test.Cardano.Ledger.Api.Tx as Tx (spec)
 import qualified Test.Cardano.Ledger.Api.Tx.Body as TxBody (spec)
@@ -37,6 +38,7 @@ apiSpec =
       TxBody.spec
     describe "State" $ do
       StateQuery.spec
+      QueryGolden.spec
     describe "Imp" $
       ImpQuery.spec @ConwayEra
     describe "Upgrade" $ do

--- a/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
+++ b/libs/cardano-ledger-api/testlib/Test/Cardano/Ledger/Api/Arbitrary.hs
@@ -20,3 +20,34 @@ instance Arbitrary StakeSnapshot where
 instance Arbitrary StakeSnapshots where
   arbitrary = genericArbitraryU
   shrink = genericShrink
+
+instance Arbitrary HotCredAuthStatus where
+  arbitrary =
+    oneof
+      [ MemberAuthorized <$> arbitrary
+      , pure MemberNotAuthorized
+      , MemberResigned <$> arbitrary
+      ]
+  shrink = genericShrink
+
+instance Arbitrary NextEpochChange where
+  arbitrary =
+    oneof
+      [ pure ToBeEnacted
+      , pure ToBeRemoved
+      , pure NoChangeExpected
+      , pure ToBeExpired
+      , TermAdjusted <$> arbitrary
+      ]
+  shrink = genericShrink
+
+instance Arbitrary CommitteeMemberState where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
+
+instance Arbitrary CommitteeMembersState where
+  arbitrary = genericArbitraryU
+  shrink = genericShrink
+
+instance Arbitrary DefaultVote where
+  arbitrary = elements [DefaultNo, DefaultAbstain, DefaultNoConfidence]


### PR DESCRIPTION
# Description

Arbitrary instances, CBOR round-trip tests, and bidirectional golden tests for all query result types.

All the changes from #5690 are going to be re-based on top of this so that we can verify that the golden tests continue to pass. Also created #5722 as the broader scope for exhaustive testing. We could choose to cover *all or just a subset* of points from there as per our priorities.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
