### PR TITLE
Backport of fixes for `cardano-node-10.7.1`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -28,7 +28,7 @@ source-repository-package
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
 index-state:
   , hackage.haskell.org 2026-02-24T18:41:42Z
-  , cardano-haskell-packages 2026-02-19T00:52:30Z
+  , cardano-haskell-packages 2026-04-12T17:25:56Z
 
 packages:
   -- == Byron era ==

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-alonzo
-version: 1.15.0.0
+version: 1.15.0.1
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -96,7 +96,7 @@ library
     cardano-data ^>=1.3,
     cardano-ledger-allegra ^>=1.9,
     cardano-ledger-binary ^>=1.8,
-    cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.19,
+    cardano-ledger-core:{cardano-ledger-core, internal} >=1.19 && <1.21,
     cardano-ledger-mary ^>=1.10,
     cardano-ledger-shelley ^>=1.18,
     cardano-slotting,

--- a/eras/byron/chain/executable-spec/byron-spec-chain.cabal
+++ b/eras/byron/chain/executable-spec/byron-spec-chain.cabal
@@ -38,7 +38,7 @@ library
     containers,
     hashable,
     hedgehog >=1.0.4,
-    microlens,
+    microlens <0.5,
     microlens-th,
     small-steps:{small-steps, testlib} >=1.1,
 

--- a/eras/byron/ledger/executable-spec/byron-spec-ledger.cabal
+++ b/eras/byron/ledger/executable-spec/byron-spec-ledger.cabal
@@ -50,7 +50,7 @@ library
     crypton,
     hashable,
     hedgehog >=1.0.4,
-    microlens,
+    microlens <0.5,
     microlens-th,
     nothunks,
     small-steps:{small-steps, testlib} >=1.1,

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.22.0.0
+
+* Switch `ConwayAccountState` to use `Maybe` instead of `StrictMaybe`
+* Add `balanceConwayAccountStateL`, `depositConwayAccountStateL`, `stakePoolDelegationConwayAccountStateL` and `dRepDelegationConwayAccountStateL`.
+
 ## 1.21.0.0
 
 * Add `validateTreasuryValue`, `validateWithdrawalsDelegated`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-conway
-version: 1.21.0.1
+version: 1.22.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-conway
-version: 1.21.0.0
+version: 1.21.0.1
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -109,7 +109,7 @@ library
     cardano-ledger-alonzo ^>=1.15,
     cardano-ledger-babbage ^>=1.13,
     cardano-ledger-binary ^>=1.8,
-    cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.19,
+    cardano-ledger-core:{cardano-ledger-core, internal} >=1.19 && <1.21,
     cardano-ledger-mary ^>=1.10,
     cardano-ledger-shelley ^>=1.18,
     cardano-slotting,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -24,6 +25,10 @@ module Cardano.Ledger.Conway.State.Account (
     casStakePoolDelegation,
     casDRepDelegation
   ),
+  balanceConwayAccountStateL,
+  depositConwayAccountStateL,
+  stakePoolDelegationConwayAccountStateL,
+  dRepDelegationConwayAccountStateL,
   ConwayAccounts (..),
   ConwayEraAccounts (..),
   accountStateDelegatee,
@@ -174,14 +179,93 @@ instance EraAccounts ConwayEra where
 
   accountsMapL = lens caStates $ \cas asMap -> cas {caStates = asMap}
 
-  balanceAccountStateL = lens casBalance $ \cas b -> cas {casBalance = b}
+  balanceAccountStateL = balanceConwayAccountStateL
 
-  depositAccountStateL = lens casDeposit $ \cas d -> cas {casDeposit = d}
+  depositAccountStateL = depositConwayAccountStateL
 
-  stakePoolDelegationAccountStateL =
-    lens casStakePoolDelegation $ \cas d -> cas {casStakePoolDelegation = d}
+  stakePoolDelegationAccountStateL = stakePoolDelegationConwayAccountStateL
 
   unregisterAccount = unregisterConwayAccount
+
+balanceConwayAccountStateL :: Lens' (ConwayAccountState era) (CompactForm Coin)
+balanceConwayAccountStateL =
+  lens
+    ( \case
+        CASNoDelegation balance _ -> balance
+        CASStakePool balance _ _ -> balance
+        CASDRep balance _ _ -> balance
+        CASStakePoolAndDRep balance _ _ _ -> balance
+    )
+    $ \cas balance ->
+      case cas of
+        CASNoDelegation _ deposit -> CASNoDelegation balance deposit
+        CASStakePool _ deposit stakePool -> CASStakePool balance deposit stakePool
+        CASDRep _ deposit dRep -> CASDRep balance deposit dRep
+        CASStakePoolAndDRep _ deposit stakePool dRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+
+depositConwayAccountStateL :: Lens' (ConwayAccountState era) (CompactForm Coin)
+depositConwayAccountStateL =
+  lens
+    ( \case
+        CASNoDelegation _ deposit -> deposit
+        CASStakePool _ deposit _ -> deposit
+        CASDRep _ deposit _ -> deposit
+        CASStakePoolAndDRep _ deposit _ _ -> deposit
+    )
+    $ \cas deposit ->
+      case cas of
+        CASNoDelegation balance _ -> CASNoDelegation balance deposit
+        CASStakePool balance _ stakePool -> CASStakePool balance deposit stakePool
+        CASDRep balance _ dRep -> CASDRep balance deposit dRep
+        CASStakePoolAndDRep balance _ stakePool dRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+
+stakePoolDelegationConwayAccountStateL :: Lens' (ConwayAccountState era) (Maybe (KeyHash StakePool))
+stakePoolDelegationConwayAccountStateL =
+  lens
+    ( \case
+        CASNoDelegation _ _ -> Nothing
+        CASStakePool _ _ stakePool -> Just stakePool
+        CASDRep _ _ _ -> Nothing
+        CASStakePoolAndDRep _ _ stakePool _ -> Just stakePool
+    )
+    $ \cas mStakePool ->
+      case cas of
+        CASNoDelegation balance deposit
+          | Just stakePool <- mStakePool -> CASStakePool balance deposit stakePool
+          | otherwise -> CASNoDelegation balance deposit
+        CASStakePool balance deposit _
+          | Just stakePool <- mStakePool -> CASStakePool balance deposit stakePool
+          | otherwise -> CASNoDelegation balance deposit
+        CASDRep balance deposit dRep
+          | Just stakePool <- mStakePool -> CASStakePoolAndDRep balance deposit stakePool dRep
+          | otherwise -> CASDRep balance deposit dRep
+        CASStakePoolAndDRep balance deposit _ dRep
+          | Just stakePool <- mStakePool -> CASStakePoolAndDRep balance deposit stakePool dRep
+          | otherwise -> CASDRep balance deposit dRep
+
+dRepDelegationConwayAccountStateL :: Lens' (ConwayAccountState era) (Maybe DRep)
+dRepDelegationConwayAccountStateL =
+  lens
+    ( \case
+        CASNoDelegation _ _ -> Nothing
+        CASStakePool _ _ _ -> Nothing
+        CASDRep _ _ dRep -> Just dRep
+        CASStakePoolAndDRep _ _ _ dRep -> Just dRep
+    )
+    $ \cas mDRep ->
+      case cas of
+        CASNoDelegation balance deposit
+          | Just dRep <- mDRep -> CASDRep balance deposit dRep
+          | otherwise -> CASNoDelegation balance deposit
+        CASStakePool balance deposit stakePool
+          | Just dRep <- mDRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+          | otherwise -> CASStakePool balance deposit stakePool
+        CASDRep balance deposit _
+          | Just dRep <- mDRep -> CASDRep balance deposit dRep
+          | otherwise -> CASNoDelegation balance deposit
+        CASStakePoolAndDRep balance deposit stakePool _
+          | Just dRep <- mDRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+          | otherwise -> CASStakePool balance deposit stakePool
 
 class EraAccounts era => ConwayEraAccounts era where
   mkConwayAccountState :: CompactForm Coin -> AccountState era
@@ -200,8 +284,7 @@ class EraAccounts era => ConwayEraAccounts era where
   dRepDelegationAccountStateL :: Lens' (AccountState era) (Maybe DRep)
 
 instance ConwayEraAccounts ConwayEra where
-  dRepDelegationAccountStateL =
-    lens casDRepDelegation $ \cas d -> cas {casDRepDelegation = d}
+  dRepDelegationAccountStateL = dRepDelegationConwayAccountStateL
 
 lookupDRepDelegation :: ConwayEraAccounts era => Credential Staking -> Accounts era -> Maybe DRep
 lookupDRepDelegation cred accounts = do

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
@@ -85,17 +85,17 @@ data ConwayAccountState era
 
 viewConwayAccountState ::
   ConwayAccountState era ->
-  (CompactForm Coin, CompactForm Coin, StrictMaybe (KeyHash StakePool), StrictMaybe DRep)
-viewConwayAccountState (CASNoDelegation x y) = (x, y, SNothing, SNothing)
-viewConwayAccountState (CASStakePool x y z) = (x, y, SJust z, SNothing)
-viewConwayAccountState (CASDRep x y w) = (x, y, SNothing, SJust w)
-viewConwayAccountState (CASStakePoolAndDRep x y z w) = (x, y, SJust z, SJust w)
+  (CompactForm Coin, CompactForm Coin, Maybe (KeyHash StakePool), Maybe DRep)
+viewConwayAccountState (CASNoDelegation x y) = (x, y, Nothing, Nothing)
+viewConwayAccountState (CASStakePool x y z) = (x, y, Just z, Nothing)
+viewConwayAccountState (CASDRep x y w) = (x, y, Nothing, Just w)
+viewConwayAccountState (CASStakePoolAndDRep x y z w) = (x, y, Just z, Just w)
 
 pattern ConwayAccountState ::
   CompactForm Coin ->
   CompactForm Coin ->
-  StrictMaybe (KeyHash StakePool) ->
-  StrictMaybe DRep ->
+  Maybe (KeyHash StakePool) ->
+  Maybe DRep ->
   ConwayAccountState era
 pattern ConwayAccountState
   { casBalance
@@ -105,10 +105,10 @@ pattern ConwayAccountState
   } <-
   (viewConwayAccountState -> (casBalance, casDeposit, casStakePoolDelegation, casDRepDelegation))
   where
-    ConwayAccountState x y SNothing SNothing = CASNoDelegation x y
-    ConwayAccountState x y (SJust z) SNothing = CASStakePool x y z
-    ConwayAccountState x y SNothing (SJust w) = CASDRep x y w
-    ConwayAccountState x y (SJust z) (SJust w) = CASStakePoolAndDRep x y z w
+    ConwayAccountState x y Nothing Nothing = CASNoDelegation x y
+    ConwayAccountState x y (Just z) Nothing = CASStakePool x y z
+    ConwayAccountState x y Nothing (Just w) = CASDRep x y w
+    ConwayAccountState x y (Just z) (Just w) = CASStakePoolAndDRep x y z w
 
 {-# COMPLETE ConwayAccountState #-}
 
@@ -123,8 +123,8 @@ instance EncCBOR (ConwayAccountState era) where
      in encodeListLen 4
           <> encCBOR casBalance
           <> encCBOR casDeposit
-          <> encodeNullStrictMaybe encCBOR casStakePoolDelegation
-          <> encodeNullStrictMaybe encCBOR casDRepDelegation
+          <> encodeNullMaybe encCBOR casStakePoolDelegation
+          <> encodeNullMaybe encCBOR casDRepDelegation
 
 instance Typeable era => DecShareCBOR (ConwayAccountState era) where
   type
@@ -135,8 +135,8 @@ instance Typeable era => DecShareCBOR (ConwayAccountState era) where
       ConwayAccountState
         <$> decCBOR
         <*> decCBOR
-        <*> decodeNullStrictMaybe (interns ks <$> decCBOR)
-        <*> decodeNullStrictMaybe (decShareCBOR cd)
+        <*> decodeNullMaybe (interns ks <$> decCBOR)
+        <*> decodeNullMaybe (decShareCBOR cd)
 
 instance ToKeyValuePairs (ConwayAccountState era) where
   toKeyValuePairs cas@ConwayAccountState {..} =
@@ -179,8 +179,7 @@ instance EraAccounts ConwayEra where
   depositAccountStateL = lens casDeposit $ \cas d -> cas {casDeposit = d}
 
   stakePoolDelegationAccountStateL =
-    lens (strictMaybeToMaybe . casStakePoolDelegation) $ \cas d ->
-      cas {casStakePoolDelegation = maybeToStrictMaybe d}
+    lens casStakePoolDelegation $ \cas d -> cas {casStakePoolDelegation = d}
 
   unregisterAccount = unregisterConwayAccount
 
@@ -194,16 +193,15 @@ class EraAccounts era => ConwayEraAccounts era where
     ConwayAccountState
       { casBalance = mempty
       , casDeposit = deposit
-      , casStakePoolDelegation = SNothing
-      , casDRepDelegation = SNothing
+      , casStakePoolDelegation = Nothing
+      , casDRepDelegation = Nothing
       }
 
   dRepDelegationAccountStateL :: Lens' (AccountState era) (Maybe DRep)
 
 instance ConwayEraAccounts ConwayEra where
   dRepDelegationAccountStateL =
-    lens (strictMaybeToMaybe . casDRepDelegation) $ \cas d ->
-      cas {casDRepDelegation = maybeToStrictMaybe d}
+    lens casDRepDelegation $ \cas d -> cas {casDRepDelegation = d}
 
 lookupDRepDelegation :: ConwayEraAccounts era => Credential Staking -> Accounts era -> Maybe DRep
 lookupDRepDelegation cred accounts = do

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
@@ -117,6 +117,8 @@ pattern ConwayAccountState
 
 {-# COMPLETE ConwayAccountState #-}
 
+{-# INLINE ConwayAccountState #-}
+
 instance NoThunks (ConwayAccountState era)
 
 instance NFData (ConwayAccountState era) where
@@ -180,10 +182,13 @@ instance EraAccounts ConwayEra where
   accountsMapL = lens caStates $ \cas asMap -> cas {caStates = asMap}
 
   balanceAccountStateL = balanceConwayAccountStateL
+  {-# INLINE balanceAccountStateL #-}
 
   depositAccountStateL = depositConwayAccountStateL
+  {-# INLINE depositAccountStateL #-}
 
   stakePoolDelegationAccountStateL = stakePoolDelegationConwayAccountStateL
+  {-# INLINE stakePoolDelegationAccountStateL #-}
 
   unregisterAccount = unregisterConwayAccount
 
@@ -202,6 +207,7 @@ balanceConwayAccountStateL =
         CASStakePool _ deposit stakePool -> CASStakePool balance deposit stakePool
         CASDRep _ deposit dRep -> CASDRep balance deposit dRep
         CASStakePoolAndDRep _ deposit stakePool dRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+{-# INLINE balanceConwayAccountStateL #-}
 
 depositConwayAccountStateL :: Lens' (ConwayAccountState era) (CompactForm Coin)
 depositConwayAccountStateL =
@@ -218,6 +224,7 @@ depositConwayAccountStateL =
         CASStakePool balance _ stakePool -> CASStakePool balance deposit stakePool
         CASDRep balance _ dRep -> CASDRep balance deposit dRep
         CASStakePoolAndDRep balance _ stakePool dRep -> CASStakePoolAndDRep balance deposit stakePool dRep
+{-# INLINE depositConwayAccountStateL #-}
 
 stakePoolDelegationConwayAccountStateL :: Lens' (ConwayAccountState era) (Maybe (KeyHash StakePool))
 stakePoolDelegationConwayAccountStateL =
@@ -242,6 +249,7 @@ stakePoolDelegationConwayAccountStateL =
         CASStakePoolAndDRep balance deposit _ dRep
           | Just stakePool <- mStakePool -> CASStakePoolAndDRep balance deposit stakePool dRep
           | otherwise -> CASDRep balance deposit dRep
+{-# INLINE stakePoolDelegationConwayAccountStateL #-}
 
 dRepDelegationConwayAccountStateL :: Lens' (ConwayAccountState era) (Maybe DRep)
 dRepDelegationConwayAccountStateL =
@@ -266,6 +274,7 @@ dRepDelegationConwayAccountStateL =
         CASStakePoolAndDRep balance deposit stakePool _
           | Just dRep <- mDRep -> CASStakePoolAndDRep balance deposit stakePool dRep
           | otherwise -> CASStakePool balance deposit stakePool
+{-# INLINE dRepDelegationConwayAccountStateL #-}
 
 class EraAccounts era => ConwayEraAccounts era where
   mkConwayAccountState :: CompactForm Coin -> AccountState era
@@ -285,6 +294,7 @@ class EraAccounts era => ConwayEraAccounts era where
 
 instance ConwayEraAccounts ConwayEra where
   dRepDelegationAccountStateL = dRepDelegationConwayAccountStateL
+  {-# INLINE dRepDelegationAccountStateL #-}
 
 lookupDRepDelegation :: ConwayEraAccounts era => Credential Staking -> Accounts era -> Maybe DRep
 lookupDRepDelegation cred accounts = do

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/Account.hs
@@ -12,7 +12,9 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
+-- `unused-pattern-binds` warning is disabled to preserve safety of `RecordWildCards` "trick" while
+-- avoiding unnecessary pattern matching that is not zero cost with pattern synonyms.
+{-# OPTIONS_GHC -Wno-orphans -Wno-unused-pattern-binds #-}
 
 module Cardano.Ledger.Conway.State.Account (
   ConwayAccountState (
@@ -116,8 +118,8 @@ instance NFData (ConwayAccountState era) where
   rnf = rwhnf
 
 instance EncCBOR (ConwayAccountState era) where
-  encCBOR cas@(ConwayAccountState _ _ _ _) =
-    let ConwayAccountState {..} = cas
+  encCBOR cas@ConwayAccountState {..} =
+    let ConwayAccountState _ _ _ _ = cas
      in encodeListLen 4
           <> encCBOR casBalance
           <> encCBOR casDeposit
@@ -137,8 +139,8 @@ instance Typeable era => DecShareCBOR (ConwayAccountState era) where
         <*> decodeNullStrictMaybe (decShareCBOR cd)
 
 instance ToKeyValuePairs (ConwayAccountState era) where
-  toKeyValuePairs cas@(ConwayAccountState _ _ _ _) =
-    let ConwayAccountState {..} = cas
+  toKeyValuePairs cas@ConwayAccountState {..} =
+    let ConwayAccountState _ _ _ _ = cas
      in [ "reward" .= casBalance -- deprecated
         , "balance" .= casBalance
         , "deposit" .= casDeposit

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -15,6 +15,7 @@
 module Cardano.Ledger.Conway.Translation () where
 
 import Cardano.Ledger.Babbage (BabbageEra)
+import Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra)
@@ -134,8 +135,8 @@ instance TranslateEra ConwayEra DState where
         ConwayAccountState
           { casBalance = sasBalance
           , casDeposit = sasDeposit
-          , casStakePoolDelegation = sasStakePoolDelegation
-          , casDRepDelegation = SNothing
+          , casStakePoolDelegation = strictMaybeToMaybe sasStakePoolDelegation
+          , casDRepDelegation = Nothing
           }
 
 instance TranslateEra ConwayEra PState where

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-dijkstra
-version: 0.2.0.0
+version: 0.2.0.1
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -109,7 +109,7 @@ library
     cardano-ledger-alonzo ^>=1.15,
     cardano-ledger-babbage,
     cardano-ledger-binary ^>=1.8,
-    cardano-ledger-conway,
+    cardano-ledger-conway ^>=1.22,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.19,
     cardano-ledger-mary,
     cardano-ledger-shelley,

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
@@ -16,15 +16,13 @@ instance EraAccounts DijkstraEra where
 
   accountsMapL = lens caStates $ \cas asMap -> cas {caStates = asMap}
 
-  balanceAccountStateL = lens casBalance $ \cas b -> cas {casBalance = b}
+  balanceAccountStateL = balanceConwayAccountStateL
 
-  depositAccountStateL = lens casDeposit $ \cas d -> cas {casDeposit = d}
+  depositAccountStateL = depositConwayAccountStateL
 
-  stakePoolDelegationAccountStateL =
-    lens casStakePoolDelegation $ \cas d -> cas {casStakePoolDelegation = d}
+  stakePoolDelegationAccountStateL = stakePoolDelegationConwayAccountStateL
 
   unregisterAccount = unregisterConwayAccount
 
 instance ConwayEraAccounts DijkstraEra where
-  dRepDelegationAccountStateL =
-    lens casDRepDelegation $ \cas d -> cas {casDRepDelegation = d}
+  dRepDelegationAccountStateL = dRepDelegationConwayAccountStateL

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
@@ -17,12 +17,16 @@ instance EraAccounts DijkstraEra where
   accountsMapL = lens caStates $ \cas asMap -> cas {caStates = asMap}
 
   balanceAccountStateL = balanceConwayAccountStateL
+  {-# INLINE balanceAccountStateL #-}
 
   depositAccountStateL = depositConwayAccountStateL
+  {-# INLINE depositAccountStateL #-}
 
   stakePoolDelegationAccountStateL = stakePoolDelegationConwayAccountStateL
+  {-# INLINE stakePoolDelegationAccountStateL #-}
 
   unregisterAccount = unregisterConwayAccount
 
 instance ConwayEraAccounts DijkstraEra where
   dRepDelegationAccountStateL = dRepDelegationConwayAccountStateL
+  {-# INLINE dRepDelegationAccountStateL #-}

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/Account.hs
@@ -3,7 +3,6 @@
 
 module Cardano.Ledger.Dijkstra.State.Account () where
 
-import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era
 import qualified Data.Map.Strict as Map
@@ -22,12 +21,10 @@ instance EraAccounts DijkstraEra where
   depositAccountStateL = lens casDeposit $ \cas d -> cas {casDeposit = d}
 
   stakePoolDelegationAccountStateL =
-    lens (strictMaybeToMaybe . casStakePoolDelegation) $ \cas d ->
-      cas {casStakePoolDelegation = maybeToStrictMaybe d}
+    lens casStakePoolDelegation $ \cas d -> cas {casStakePoolDelegation = d}
 
   unregisterAccount = unregisterConwayAccount
 
 instance ConwayEraAccounts DijkstraEra where
   dRepDelegationAccountStateL =
-    lens (strictMaybeToMaybe . casDRepDelegation) $ \cas d ->
-      cas {casDRepDelegation = maybeToStrictMaybe d}
+    lens casDRepDelegation $ \cas d -> cas {casDRepDelegation = d}

--- a/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
+++ b/eras/shelley-ma/test-suite/cardano-ledger-shelley-ma-test.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-shelley-ma-test
-version: 1.4.0.1
+version: 1.4.0.2
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -50,7 +50,7 @@ library
     bytestring,
     cardano-ledger-allegra:{cardano-ledger-allegra, testlib} ^>=1.9,
     cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.7,
-    cardano-ledger-core:{cardano-ledger-core, tasty-compat} ^>=1.19,
+    cardano-ledger-core:{cardano-ledger-core, tasty-compat} >=1.19 && <1.21,
     cardano-ledger-mary:{cardano-ledger-mary, testlib} ^>=1.10,
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.12,
     cardano-ledger-shelley-test >=1.6,

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -120,7 +120,7 @@ library
     cardano-data ^>=1.3,
     cardano-ledger-binary ^>=1.8,
     cardano-ledger-byron,
-    cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.19,
+    cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.20,
     cardano-slotting,
     cardano-strict-containers >=0.1.5,
     containers,

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-shelley
-version: 1.18.0.0
+version: 1.18.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardUpdate.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/RewardUpdate.hs
@@ -286,7 +286,7 @@ data RewardPulser (m :: Type -> Type) ans where
     (ans ~ RewardAns, m ~ ShelleyBase) =>
     !Int ->
     !FreeVars ->
-    !(VMap.VMap VMap.VB VMap.VB (Credential Staking) StakeWithDelegation) ->
+    !(VMap.VMap VMap.VB VMap.VS (Credential Staking) StakeWithDelegation) ->
     !ans ->
     RewardPulser m ans
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1771562591,
-        "narHash": "sha256-y1tKTheSvtSi00SC0QjX7ApRHwQ7P2a7EmWmu5AnC2o=",
+        "lastModified": 1776017924,
+        "narHash": "sha256-bXkPNE8uV2Lp5cALoPwet1dVmAPpfpKQ0G9Y5+/HQYE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "b0bc8819feca37f6db6f6ad750c782dfda89e245",
+        "rev": "5b6428d9460eb41e00cb6162efe08af110f2de8a",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-binary`
 
+## 1.8.1.0
+
+* Add `DecShareCBOR` instance for `VMap VB VS`
+
 ## 1.8.0.0
 
 * Add `Uniform`, `UniformRange` instances and fix `Random` instance

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-binary
-version: 1.8.0.0
+version: 1.8.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Sharing.hs
@@ -38,8 +38,9 @@ import Data.Map.Strict.Internal (Map (..))
 import Data.Primitive.Types (Prim)
 import qualified Data.Set as Set (size)
 import qualified Data.Set.Internal as Set (Set (..))
-import Data.VMap (VB, VMap, VP)
+import Data.VMap (VB, VMap, VP, VS)
 import qualified Data.VMap as VMap
+import Foreign.Storable (Storable)
 import Lens.Micro
 
 -- =======================================
@@ -230,6 +231,12 @@ instance (Ord k, DecCBOR k, DecCBOR v) => DecShareCBOR (VMap VB VB k v) where
 
 instance (Ord k, DecCBOR k, DecCBOR v, Prim v) => DecShareCBOR (VMap VB VP k v) where
   type Share (VMap VB VP k v) = Interns k
+  decShareCBOR kis = do
+    decodeVMap (interns kis <$> decCBOR) decCBOR
+  getShare !m = internsFromVMap m
+
+instance (Ord k, DecCBOR k, DecCBOR v, Storable v) => DecShareCBOR (VMap VB VS k v) where
+  type Share (VMap VB VS k v) = Interns k
   decShareCBOR kis = do
     decodeVMap (interns kis <$> decCBOR) decCBOR
   getShare !m = internsFromVMap m

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Version history for `cardano-ledger-core`
 
+## 1.20.0.0
+
+* Add `Storable` instance for `NonZero`, `CompactForm Coin`, `KeyHash`, `ScriptHash`, `Credential` and `StakeWithDelegation`
+* Switch `ActiveStake` to use `VS` for the value in the `VMap`
+
 ## 1.19.0.0
 
 * In `SnapShot`, subsume `ssDelegations` into `ssActiveStake`.

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-core
-version: 1.19.0.0
+version: 1.20.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -119,10 +119,10 @@ library
     bytestring >=0.10 && <0.11.3 || >=0.11.4,
     cardano-base >=0.1.1.0,
     cardano-crypto,
-    cardano-crypto-class ^>=2.3,
+    cardano-crypto-class >=2.3.2 && <2.5,
     cardano-crypto-wrapper,
     cardano-data >=1.3,
-    cardano-ledger-binary ^>=1.8,
+    cardano-ledger-binary ^>=1.8.1,
     cardano-ledger-byron,
     cardano-ledger-core:internal,
     cardano-slotting,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes/NonZero.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes/NonZero.hs
@@ -47,6 +47,7 @@ import Data.Proxy (Proxy (..))
 import Data.Ratio (Ratio, numerator, (%))
 import Data.Typeable (Typeable)
 import Data.Word (Word16, Word32, Word64, Word8)
+import Foreign.Storable (Storable)
 import GHC.TypeLits
 import NoThunks.Class (NoThunks)
 
@@ -73,8 +74,8 @@ instance KnownBounds Word64 where
 type WithinBounds n a = (MinBound a <= n, n <= MaxBound a)
 
 newtype NonZero a = NonZero {unNonZero :: a}
-  deriving (Eq, Ord, Show, NoThunks, NFData)
-  deriving newtype (EncCBOR, ToCBOR, ToJSON)
+  deriving (Show)
+  deriving newtype (Eq, Ord, EncCBOR, ToCBOR, ToJSON, NoThunks, NFData, Storable)
 
 class HasZero a where
   isZero :: a -> Bool

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs
@@ -78,6 +78,7 @@ import Data.PartialOrd (PartialOrd)
 import Data.Primitive.Types
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
+import Foreign.Storable
 import GHC.Generics (Generic)
 import GHC.Stack
 import GHC.TypeLits
@@ -141,7 +142,8 @@ rationalToCoinViaCeiling = Coin . ceiling
 
 instance Compactible Coin where
   newtype CompactForm Coin = CompactCoin {unCompactCoin :: Word64}
-    deriving (Eq, Show, NoThunks, NFData, Prim, Ord, ToCBOR, ToJSON, FromJSON, HasZero, Generic)
+    deriving stock (Show, Generic)
+    deriving newtype (Eq, NoThunks, NFData, Prim, Ord, ToCBOR, ToJSON, FromJSON, HasZero, Storable)
     deriving (Semigroup, Monoid, Group, Abelian) via Sum Word64
 
   toCompact (Coin c) = CompactCoin <$> integerToWord64 c

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Credential.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Cardano.Ledger.Credential (
   Credential (KeyHashObj, ScriptHashObj),
@@ -48,7 +49,7 @@ import Cardano.Ledger.Binary (
   natVersion,
  )
 import qualified Cardano.Ledger.Binary.Plain as Plain
-import Cardano.Ledger.Hashes (ScriptHash (..))
+import Cardano.Ledger.Hashes (ADDRHASH, Hash, ScriptHash (..))
 import Cardano.Ledger.Keys (
   HasKeyRole (..),
   KeyHash (..),
@@ -76,6 +77,8 @@ import Data.MemPack
 import qualified Data.Text as T
 import Data.Typeable (Typeable)
 import Data.Word
+import Foreign.Ptr (castPtr)
+import Foreign.Storable (Storable (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import System.Random.Stateful (Random, Uniform (..), UniformRange (..))
@@ -107,6 +110,29 @@ instance Typeable kr => MemPack (Credential kr) where
       1 -> KeyHashObj <$> unpackM
       n -> unknownTagM @(Credential kr) n
   {-# INLINE unpackM #-}
+
+-- Format: [8:8:8:4 - Hash, 1: tag (0/1)]
+--
+-- Tag goes after the hash, because that will work better for alignment of reading first 8 byte
+-- chunks
+instance Storable (Credential r) where
+  sizeOf _ = sizeOf (undefined :: Hash ADDRHASH ()) + 1
+  alignment _ = 32 -- ADDRHASH is 28 bytes + 1 byte for the Tag. Next power of 2 is 32
+  poke ptr = \case
+    ScriptHashObj hash -> do
+      poke (castPtr ptr) hash
+      pokeByteOff (castPtr ptr) (sizeOf hash) (0 :: Word8)
+    KeyHashObj hash -> do
+      poke (castPtr ptr) hash
+      pokeByteOff (castPtr ptr) (sizeOf hash) (1 :: Word8)
+  {-# INLINE poke #-}
+  peek ptr = do
+    hash :: Hash ADDRHASH () <- peek (castPtr ptr)
+    t :: Word8 <- peekByteOff (castPtr ptr) (sizeOf hash)
+    pure $! case t of
+      0 -> ScriptHashObj $ ScriptHash $ coerce hash
+      _ -> KeyHashObj $ KeyHash $ coerce hash
+  {-# INLINE peek #-}
 
 instance Default (Credential r) where
   def = KeyHashObj def

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
@@ -109,6 +110,7 @@ import Data.Default (Default (..))
 import Data.Map.Strict (Map)
 import Data.MemPack
 import Data.Typeable
+import Foreign.Storable (Storable)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Quiet
@@ -174,6 +176,7 @@ newtype KeyHash (r :: KeyRole) = KeyHash
     , FromJSON
     , Default
     , MemPack
+    , Storable
     )
 
 instance HasKeyRole KeyHash
@@ -208,6 +211,7 @@ newtype ScriptHash
     , ToJSONKey
     , FromJSONKey
     , MemPack
+    , Storable
     )
 
 --------------------------------------------------------------------------------

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Stake.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Stake.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
@@ -60,8 +61,10 @@ import Data.Kind (Type)
 import qualified Data.Map.Merge.Strict as Map
 import Data.Map.Strict (Map)
 import Data.Maybe (fromMaybe)
-import Data.VMap (VB, VMap, VP)
+import Data.VMap (VB, VMap, VP, VS)
 import qualified Data.VMap as VMap
+import Foreign.Ptr (castPtr)
+import Foreign.Storable (Storable (..))
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -122,17 +125,33 @@ instance DecShareCBOR StakeWithDelegation where
   type Share StakeWithDelegation = Interns (Credential Staking)
   decShareCBOR _si = decCBOR
 
+instance Storable StakeWithDelegation where
+  sizeOf _ =
+    sizeOf (undefined :: (NonZero (CompactForm Coin)))
+      + sizeOf (undefined :: KeyHash StakePool)
+  alignment _ = 8
+  poke ptr swd@(StakeWithDelegation _ _) = do
+    let StakeWithDelegation {..} = swd
+    poke (castPtr ptr) swdStake
+    pokeByteOff (castPtr ptr) (sizeOf swdStake) swdDelegation
+  {-# INLINE poke #-}
+  peek ptr = do
+    swdStake <- peek (castPtr ptr)
+    swdDelegation <- peekByteOff (castPtr ptr) (sizeOf swdStake)
+    pure StakeWithDelegation {..}
+  {-# INLINE peek #-}
+
 -- | Active stake: maps staking credentials to their non-zero stake paired with delegation.
 -- Only credentials that are registered, delegated, and have non-zero stake appear here.
 newtype ActiveStake = ActiveStake
-  { unActiveStake :: VMap VB VB (Credential Staking) StakeWithDelegation
+  { unActiveStake :: VMap VB VS (Credential Staking) StakeWithDelegation
   }
   deriving (Show, Eq, NFData, Generic, ToJSON, NoThunks, EncCBOR)
 
 instance DecShareCBOR ActiveStake where
   type Share ActiveStake = Interns (Credential Staking)
-  getShare (ActiveStake m) = fst (getShare m)
-  decShareCBOR si = ActiveStake <$> decShareCBOR (si, mempty)
+  getShare (ActiveStake m) = getShare m
+  decShareCBOR si = ActiveStake <$> decShareCBOR si
 
 -- | Sum all active stake. Returns @NonZero Coin@, defaulting to 1 lovelace if empty.
 sumAllActiveStake :: ActiveStake -> NonZero Coin

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Deleg.hs
@@ -94,7 +94,7 @@ conwayAccountsSpec univ poolreg = constrained $ \ [var|conwayAccounts|] ->
           , witness univ accountstate
           , match accountstate $ \ [var|_rewardbal|] [var|_depositbal|] [var|mStakeDelegKeyhash|] [var|mDRep|] ->
               [ ( caseOn
-                    (mStakeDelegKeyhash :: Term (StrictMaybe (KeyHash StakePool)))
+                    (mStakeDelegKeyhash :: Term (Maybe (KeyHash StakePool)))
                     (branchW 1 $ \_ -> True)
                     (branchW 3 $ \ [var|stakekeyhash|] -> mapMember_ stakekeyhash poolreg)
                 )

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -1914,7 +1914,7 @@ instance HasSpec RewardUpdate
 type PulserTypes =
   '[ Int
    , FreeVars
-   , VMap VMap.VB VMap.VB (Credential Staking) StakeWithDelegation
+   , VMap VMap.VB VMap.VS (Credential Staking) StakeWithDelegation
    , RewardAns
    ]
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -1092,8 +1092,8 @@ instance Typeable era => HasSpec (ShelleyAccounts era)
 type ConwayAccountStateTypes era =
   '[ CompactForm Coin
    , CompactForm Coin
-   , StrictMaybe (KeyHash StakePool)
-   , StrictMaybe DRep
+   , Maybe (KeyHash StakePool)
+   , Maybe DRep
    ]
 
 instance HasSimpleRep (ConwayAccountState era) where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/LedgerTypes/Specs.hs
@@ -341,8 +341,8 @@ conwayAccountMapSpec univ whoDelegates poolreg wdrl =
                   [ dependsOn deposit cred
                   , dependsOn bal cred
                   , satisfies deposit (geqSpec 0)
-                  , onCon @"SJust" mpool $ \ [var|khashStakePool|] -> member_ khashStakePool (dom_ poolreg)
-                  , reify cred isKeyHash $ \bool -> whenTrue bool [assert $ onCon @"SJust" mdrep $ \x -> member_ x (lit (dRepsOf whoDelegates))]
+                  , onCon @"Just" mpool $ \ [var|khashStakePool|] -> member_ khashStakePool (dom_ poolreg)
+                  , reify cred isKeyHash $ \bool -> whenTrue bool [assert $ onCon @"Just" mdrep $ \x -> member_ x (lit (dRepsOf whoDelegates))]
                   , (caseOn (lookup_ cred (lit withdrawalMap)))
                       -- Nothing
                       ( branch $ \_ ->
@@ -363,15 +363,15 @@ conwayAccountMapSpec univ whoDelegates poolreg wdrl =
                       (member_ cred (lit withdrawalKeys))
                       ( satisfies
                           mdrep
-                          ( constrained $ \(x :: Term (StrictMaybe DRep)) ->
+                          ( constrained $ \(x :: Term (Maybe DRep)) ->
                               (caseOn x)
-                                -- SNothing
+                                -- Sothing
                                 (branch $ \_ -> False)
-                                -- SJust
+                                -- Just
                                 (branch $ \drep -> member_ drep (lit (dRepsOf whoDelegates)))
                           )
                       )
-                      (onCon @"SJust" mdrep $ \ [var|drep|] -> member_ drep (lit (dRepsOf whoDelegates)))
+                      (onCon @"Just" mdrep $ \ [var|drep|] -> member_ drep (lit (dRepsOf whoDelegates)))
                   ]
               ]
         ]


### PR DESCRIPTION
# Description

This is backport of fixes from #5727 (which includes all relevant tests) and #5729

We have ran benchmarks with these changes, which confirmed a fix for the space leak that observed in `cardano-node-10.7.0`. Currently it is unclear which change specifically fixed the issue, whether it was changes in this PR or in consensus-3.0 release: https://github.com/IntersectMBO/cardano-haskell-packages/pull/1334

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
