### PR TITLE
Add negative tests for Metadatum int decoding range

### DIFF
--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
@@ -13,15 +13,16 @@ module Test.Cardano.Ledger.Shelley.Binary.RoundTrip (
 
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Core
-import Cardano.Ledger.Metadata (Metadatum)
+import Cardano.Ledger.Metadata (Metadatum (I))
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.State
 import qualified Data.Text as T
 import Test.Cardano.Base.Bytes (genByteString)
 import Test.Cardano.Ledger.Binary.RoundTrip (
-  roundTripCborRangeExpectation,
-  roundTripCborRangeFailureExpectation,
+  embedTrip,
+  embedTripRangeFailureExpectation,
+  mkTrip,
  )
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary.RoundTrip
@@ -107,17 +108,48 @@ metadatumIntRangeSpec fromVersion toVersion = do
     maxInt = 2 ^ (64 :: Int) - 1
     minInt :: Integer
     minInt = -(2 ^ (64 :: Int))
+    intToMetadatum = mkTrip (encCBOR @Integer) (decCBOR @Metadatum)
+    expectAccepted n =
+      forM_ [fromVersion .. toVersion] $ \v ->
+        case embedTrip v v intToMetadatum n of
+          Left err -> expectationFailure $ "Failed to deserialize: " ++ show err
+          Right m -> m `shouldBe` I n
+    expectRejected = embedTripRangeFailureExpectation intToMetadatum fromVersion toVersion
+    -- Test the binary decoder directly, bypassing FlatTerm.
+    -- This is needed because cborg's FlatTerm has an off-by-one bug in
+    -- tokenTypeOf that misclassifies -(2^64) as TypeInteger instead of
+    -- TypeNInt64 (https://github.com/well-typed/cborg/issues/377)
+    --
+    -- This bug only affect the tests, not the actual decoder, because the
+    -- actual decoder does not go through FlatTerm
+    expectBinaryAccepted n =
+      forM_ [fromVersion .. toVersion] $ \v ->
+        decodeFull @Metadatum v (serialize v n) `shouldBe` Right (I n)
+    expectBinaryRejected n =
+      forM_ [fromVersion .. toVersion] $ \v ->
+        case decodeFull @Metadatum v (serialize v n) of
+          Left _ -> pure ()
+          Right _ -> expectationFailure $ "Should not have deserialized: " ++ show n
   it "Accepts max int (2^64-1)" $
-    roundTripCborRangeExpectation fromVersion toVersion maxInt
-  it "Accepts min int (-(2^64))" $
-    roundTripCborRangeExpectation fromVersion toVersion minInt
+    expectAccepted maxInt
+  it "Accepts max int (2^64-1) (binary)" $
+    expectBinaryAccepted maxInt
+  -- TODO: enable this once the cborg FlatTerm bug is fixed
+  xit "Accepts min int (-(2^64))" $
+    expectAccepted minInt
+  it "Accepts min int (-(2^64)) (binary)" $
+    expectBinaryAccepted minInt
   it "Rejects positive big integer (2^64)" $
-    roundTripCborRangeFailureExpectation fromVersion toVersion (maxInt + 1)
+    expectRejected (maxInt + 1)
+  it "Rejects positive big integer (2^64) (binary)" $
+    expectBinaryRejected (maxInt + 1)
   it "Rejects negative big integer (-(2^64+1))" $
-    roundTripCborRangeFailureExpectation fromVersion toVersion (minInt - 1)
+    expectRejected (minInt - 1)
+  it "Rejects negative big integer (-(2^64+1)) (binary)" $
+    expectBinaryRejected (minInt - 1)
   prop "Accepts any int in CBOR range" $
     forAll (choose (minInt, maxInt)) $ \n ->
-      property $ roundTripCborRangeExpectation fromVersion toVersion n
+      property $ expectBinaryAccepted n
 
 instance RuleListEra ShelleyEra where
   type

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
@@ -19,6 +19,10 @@ import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.State
 import qualified Data.Text as T
 import Test.Cardano.Base.Bytes (genByteString)
+import Test.Cardano.Ledger.Binary.RoundTrip (
+  roundTripCborRangeExpectation,
+  roundTripCborRangeFailureExpectation,
+ )
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Binary.RoundTrip
 import Test.Cardano.Ledger.Shelley.Arbitrary ()
@@ -37,6 +41,8 @@ roundTripShelleyCommonSpec = do
   roundTripAllPredicateFailures @era
   describe "Metadatum size limits" $
     forEachEraVersion @era metadatumSizeLimitSpec
+  describe "Metadatum int range" $
+    metadatumIntRangeSpec (eraProtVerLow @era) (eraProtVerHigh @era)
 
 roundTripStateEraTypesSpec ::
   forall era.
@@ -92,6 +98,26 @@ metadatumSizeLimitSpec v = do
       prop "Accepts text exceeding 64 bytes" $
         forAll (choose (65, 1000) >>= genAsciiText) $ \txt ->
           expectRightDeepExpr_ $ dec txt
+
+metadatumIntRangeSpec :: Version -> Version -> Spec
+metadatumIntRangeSpec fromVersion toVersion = do
+  let
+    -- CBOR int range: -2^64 .. 2^64-1
+    maxInt :: Integer
+    maxInt = 2 ^ (64 :: Int) - 1
+    minInt :: Integer
+    minInt = -(2 ^ (64 :: Int))
+  it "Accepts max int (2^64-1)" $
+    roundTripCborRangeExpectation fromVersion toVersion maxInt
+  it "Accepts min int (-(2^64))" $
+    roundTripCborRangeExpectation fromVersion toVersion minInt
+  it "Rejects positive big integer (2^64)" $
+    roundTripCborRangeFailureExpectation fromVersion toVersion (maxInt + 1)
+  it "Rejects negative big integer (-(2^64+1))" $
+    roundTripCborRangeFailureExpectation fromVersion toVersion (minInt - 1)
+  prop "Accepts any int in CBOR range" $
+    forAll (choose (minInt, maxInt)) $ \n ->
+      property $ roundTripCborRangeExpectation fromVersion toVersion n
 
 instance RuleListEra ShelleyEra where
   type

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Metadata.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Metadata.hs
@@ -109,7 +109,7 @@ decodeMetadatum = do
   let checkSizes = dv > natVersion @2
   tkty <- peekTokenType
   case tkty of
-    -- We support -(2^64-1) .. 2^64-1, but not big integers
+    -- We support -(2^64) .. 2^64-1, but not big integers
     -- not even big integer representation of values within range
     TypeUInt -> I <$> decodeInteger
     TypeUInt64 -> I <$> decodeInteger


### PR DESCRIPTION
Verify that the decoder rejects big integers (CBOR tags 2/3) outside the valid CBOR int range of `-2^64 .. 2^64-1`, and accepts values at the boundaries. Also fix an off-by-one in the comment documenting the supported range.

resolve https://github.com/IntersectMBO/cardano-ledger/issues/5638

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
