### PR TITLE
Dijkstra era CDDL for `block`, add `block_body`

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/BlockBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/BlockBody.hs
@@ -11,6 +11,8 @@ module Cardano.Ledger.Allegra.BlockBody () where
 
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.Tx ()
+import Cardano.Ledger.BaseTypes (ProtVer (..))
+import Cardano.Ledger.Binary (EncCBORGroup (..), serialize')
 import Cardano.Ledger.Core (EraBlockBody (..))
 import Cardano.Ledger.Shelley.BlockBody (
   ShelleyBlockBody,
@@ -18,6 +20,7 @@ import Cardano.Ledger.Shelley.BlockBody (
   shelleyBlockBodyHash,
   txSeqBlockBodyShelleyL,
  )
+import qualified Data.ByteString as BS
 
 instance EraBlockBody AllegraEra where
   type BlockBody AllegraEra = ShelleyBlockBody AllegraEra
@@ -25,3 +28,4 @@ instance EraBlockBody AllegraEra where
   txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = shelleyBlockBodyHash
   numSegComponents = 3
+  blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/BlockBody/Internal.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/BlockBody/Internal.hs
@@ -34,6 +34,7 @@ module Cardano.Ledger.Alonzo.BlockBody.Internal (
 import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Alonzo.Era
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsValid (..))
+import Cardano.Ledger.BaseTypes (ProtVer (..))
 import Cardano.Ledger.Binary (
   Annotator (..),
   DecCBOR (..),
@@ -43,6 +44,7 @@ import Cardano.Ledger.Binary (
   encodeFoldableMapEncoder,
   encodePreEncoded,
   serialize,
+  serialize',
   withSlice,
  )
 import Cardano.Ledger.Core
@@ -50,6 +52,7 @@ import Cardano.Ledger.Shelley.BlockBody (auxDataSeqDecoder)
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import Data.ByteString.Builder (Builder, shortByteString, toLazyByteString)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Coerce (coerce)
@@ -97,6 +100,7 @@ instance EraBlockBody AlonzoEra where
   txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = abbHash
   numSegComponents = 4
+  blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
 
 mkBasicBlockBodyAlonzo ::
   ( SafeToHash (TxWits era)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/BlockBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/BlockBody.hs
@@ -6,7 +6,10 @@ module Cardano.Ledger.Babbage.BlockBody where
 import Cardano.Ledger.Alonzo.BlockBody
 import Cardano.Ledger.Babbage.Era
 import Cardano.Ledger.Babbage.Tx ()
+import Cardano.Ledger.BaseTypes (ProtVer (..))
+import Cardano.Ledger.Binary (EncCBORGroup (..), serialize')
 import Cardano.Ledger.Core
+import qualified Data.ByteString as BS
 
 instance EraBlockBody BabbageEra where
   type BlockBody BabbageEra = AlonzoBlockBody BabbageEra
@@ -14,3 +17,4 @@ instance EraBlockBody BabbageEra where
   txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = alonzoBlockBodyHash
   numSegComponents = 4
+  blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -104,6 +104,7 @@ library
   build-depends:
     aeson >=2.2,
     base >=4.18 && <5,
+    bytestring,
     cardano-crypto-class,
     cardano-data >=1.3,
     cardano-ledger-allegra ^>=1.10,

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/BlockBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/BlockBody.hs
@@ -4,9 +4,12 @@
 module Cardano.Ledger.Conway.BlockBody where
 
 import Cardano.Ledger.Alonzo.BlockBody
+import Cardano.Ledger.BaseTypes (ProtVer (..))
+import Cardano.Ledger.Binary (EncCBORGroup (..), serialize')
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Conway.Tx ()
 import Cardano.Ledger.Core
+import qualified Data.ByteString as BS
 
 instance EraBlockBody ConwayEra where
   type BlockBody ConwayEra = AlonzoBlockBody ConwayEra
@@ -14,3 +17,4 @@ instance EraBlockBody ConwayEra where
   txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = alonzoBlockBodyHash
   numSegComponents = 4
+  blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -54,8 +54,14 @@
 * Remove `NoThunks` instance for `DijkstraContextError`
 * Make `DijkstraContextError` constructors lazy
 
+### cddl
+
+* Add `peras_certificate`, `block_body`
+
 ### testlib
 
+* Add `ToExpr` instance for `DijkstraBlockBody`
+* Add `DecCBOR` instance for `DijkstraBlockBodyRaw`
 * Add `genNonEmptyAccountBalanceIntervals`
 * In `Test.Cardano.Ledger.Dijkstra.Examples`:
   - Remove `mkDijkstraBasedExampleTx`, `mkDijkstraBasedExampleTxBody`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Add `getDijkstraScriptsProvided`
 * Add `MissingRequiredGuards` constructor to `DijkstraUtxowPredFailure`
 * Add `DijkstraUtxoEnv` and use it as `Environemnt` in `STS` instance of `UTXOW`
+* Refactor `DijkstraBlockBody` to use `MemoBytes` for memoized serialization
+* Add `blockBodySize` implementation for `DijkstraEra`
+* Add `DijkstraBlockBodyRaw`, `MkDijkstraBlockBody`
 * Add `ApplyTick` instance for `DijkstraEra`
 * Add `WrongNetworkInDirectDeposit` constructor to `DijkstraUtxoPredFailure`
 * Add `SubWrongNetworkInDirectDeposit` constructor to `DijkstraSubUtxoPredFailure`

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -30,6 +30,7 @@ library
   exposed-modules:
     Cardano.Ledger.Dijkstra
     Cardano.Ledger.Dijkstra.BlockBody
+    Cardano.Ledger.Dijkstra.BlockBody.Internal
     Cardano.Ledger.Dijkstra.Core
     Cardano.Ledger.Dijkstra.Era
     Cardano.Ledger.Dijkstra.Genesis
@@ -49,7 +50,6 @@ library
     Cardano.Ledger.Dijkstra.UTxO
 
   other-modules:
-    Cardano.Ledger.Dijkstra.BlockBody.Internal
     Cardano.Ledger.Dijkstra.Forecast
     Cardano.Ledger.Dijkstra.Rules.Bbody
     Cardano.Ledger.Dijkstra.Rules.Cert
@@ -111,7 +111,7 @@ library
     cardano-ledger-babbage ^>=1.14,
     cardano-ledger-binary ^>=1.9,
     cardano-ledger-conway ^>=1.23,
-    cardano-ledger-core:{cardano-ledger-core, internal} >=1.20,
+    cardano-ledger-core:{cardano-ledger-core, internal} >=1.21,
     cardano-ledger-mary,
     cardano-ledger-shelley,
     cardano-slotting,

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -210,10 +210,16 @@ library cddl
     -Wunused-packages
 
   build-depends:
+    QuickCheck,
+    antigen,
     base,
     cardano-ledger-conway:cddl,
+    cardano-ledger-core:cddl,
     cardano-ledger-dijkstra,
+    cborg,
+    cuddle,
     heredoc,
+    quickcheck-transformer,
     text,
 
 executable generate-cddl

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -1,10 +1,5 @@
 ; This file was auto-generated using generate-cddl. Please do not modify it directly!
 
-; Valid blocks must also satisfy the following two constraints:
-;   1) the length of transaction_bodies and transaction_witness_sets must be
-;      the same
-;   2) every transaction_index must be strictly smaller than the length of
-;      transaction_bodies
 block = [header, block_body]
 
 transaction = 
@@ -92,6 +87,7 @@ protocol_version = [major_protocol_version, uint .size 4]
 
 major_protocol_version = 0 .. 13
 
+; Note that every transaction_index must be strictly smaller than the length of transaction_bodies
 block_body = 
   [ invalid_transactions : [* transaction_index]
   , transactions      : [* transaction]

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -89,11 +89,15 @@ major_protocol_version = 0 .. 13
 
 ; Note that every transaction_index must be strictly smaller than the length of transaction_bodies
 block_body = 
-  [ invalid_transactions : [* transaction_index]
+  [ invalid_transactions : invalid_transactions/ nil
   , transactions      : [* transaction]
   , peras_certificate : peras_certificate  
   ]
 
+
+invalid_transactions = nonempty_set<transaction_index>
+
+nonempty_set<a0> = #6.258([+ a0])/ [+ a0]
 
 transaction_index = uint .size 2
 
@@ -501,8 +505,6 @@ positive_int64 = 1 .. max_int64
 ; therefore there is no way to override this behavior by providing a custom
 ; representation for empty redeemers.
 script_data_hash = hash32
-
-nonempty_set<a0> = #6.258([+ a0])/ [+ a0]
 
 guards = nonempty_set<addr_keyhash>/ nonempty_oset<credential>
 

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -5,14 +5,7 @@
 ;      the same
 ;   2) every transaction_index must be strictly smaller than the length of
 ;      transaction_bodies
-block = 
-  [ header                 
-  , transaction_bodies       : [* transaction_body]                   
-  , transaction_witness_sets : [* transaction_witness_set]            
-  , auxiliary_data_set       : {* transaction_index => auxiliary_data}
-  , invalid_transactions     : [* transaction_index]                  
-  ]
-
+block = [header, block_body]
 
 transaction = 
   [  transaction_body, transaction_witness_set, true, auxiliary_data/ nil
@@ -98,6 +91,15 @@ signature = bytes .size 64
 protocol_version = [major_protocol_version, uint .size 4]
 
 major_protocol_version = 0 .. 13
+
+block_body = 
+  [ invalid_transactions : [* transaction_index]
+  , transactions      : [* transaction]
+  , peras_certificate : peras_certificate  
+  ]
+
+
+transaction_index = uint .size 2
 
 transaction_body = 
   {   0  : set<transaction_input>         
@@ -783,5 +785,5 @@ auxiliary_data_map =
   )
 
 
-transaction_index = uint .size 2
+peras_certificate = bytes/ nil
 

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -864,26 +864,22 @@ instance HuddleRule "header" DijkstraEra where
 
 instance HuddleRule "block" DijkstraEra where
   huddleRuleNamed pname p =
-    comment
-      [str|Valid blocks must also satisfy the following two constraints:
-          |  1) the length of transaction_bodies and transaction_witness_sets must be
-          |     the same
-          |  2) every transaction_index must be strictly smaller than the length of
-          |     transaction_bodies
-          |]
-      $ pname
-        =.= arr
-          [ a $ huddleRule @"header" p
-          , a $ huddleRule @"block_body" p
-          ]
+    pname
+      =.= arr
+        [ a $ huddleRule @"header" p
+        , a $ huddleRule @"block_body" p
+        ]
 
 instance HuddleRule "peras_certificate" DijkstraEra where
   huddleRuleNamed pname _era = pname =.= VBytes / VNil
 
 instance HuddleRule "block_body" DijkstraEra where
   huddleRuleNamed pname era =
-    withCBORGen blockBodyGen $
-      pname
+    comment
+      [str|Note that every transaction_index must be strictly smaller than the length of transaction_bodies
+          |]
+      $ withCBORGen blockBodyGen
+      $ pname
         =.= arr
           [ "invalid_transactions" ==> arr [0 <+ a (huddleRule @"transaction_index" era)]
           , "transactions" ==> arr [0 <+ a (huddleRule @"transaction" era)]

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -34,9 +34,19 @@ module Cardano.Ledger.Dijkstra.HuddleSpec (
 
 import Cardano.Ledger.Conway.HuddleSpec hiding ()
 import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Huddle.Gen (genArrayTerm)
+import Codec.CBOR.Cuddle.CBOR.Gen (generateFromName)
+import Codec.CBOR.Cuddle.CDDL.CBORGenerator (CBORGen, WrappedTerm (..), liftAntiGen, withAntiGen)
+import Codec.CBOR.Term (Term (..))
+import Control.Monad (zipWithM)
 import Data.Proxy (Proxy (..))
 import Data.Text ()
-import Data.Word (Word64)
+import Data.Text qualified as T
+import Data.Word (Word16, Word64)
+import Test.AntiGen (withAnnotation, (|!))
+import Test.QuickCheck (choose, shuffle)
+import Test.QuickCheck qualified as QC
+import Test.QuickCheck.GenT (liftGen)
 import Text.Heredoc
 import Prelude hiding ((/))
 
@@ -864,16 +874,52 @@ instance HuddleRule "block" DijkstraEra where
       $ pname
         =.= arr
           [ a $ huddleRule @"header" p
-          , "transaction_bodies" ==> arr [0 <+ a (huddleRule @"transaction_body" p)]
-          , "transaction_witness_sets" ==> arr [0 <+ a (huddleRule @"transaction_witness_set" p)]
-          , "auxiliary_data_set"
-              ==> mp
-                [ 0
-                    <+ asKey (huddleRule @"transaction_index" p)
-                    ==> huddleRule @"auxiliary_data" p
-                ]
-          , "invalid_transactions" ==> arr [0 <+ a (huddleRule @"transaction_index" p)]
+          , a $ huddleRule @"block_body" p
           ]
+
+instance HuddleRule "peras_certificate" DijkstraEra where
+  huddleRuleNamed pname _era = pname =.= VBytes / VNil
+
+instance HuddleRule "block_body" DijkstraEra where
+  huddleRuleNamed pname era =
+    withCBORGen blockBodyGen $
+      pname
+        =.= arr
+          [ "invalid_transactions" ==> arr [0 <+ a (huddleRule @"transaction_index" era)]
+          , "transactions" ==> arr [0 <+ a (huddleRule @"transaction" era)]
+          , "peras_certificate" ==> huddleRule @"peras_certificate" era
+          ]
+
+blockBodyGen :: CBORGen WrappedTerm
+blockBodyGen = do
+  numTxs <- liftGen . QC.sized $ \s -> choose (0 :: Int, s)
+  txs <-
+    mapM
+      (\i -> withAntiGen (withAnnotation (T.pack $ show i)) $ generateFromName "transaction")
+      [0 .. numTxs - 1]
+  invalidIxIxs <-
+    if numTxs == 0
+      then pure []
+      else do
+        n <-
+          liftAntiGen $
+            choose (0, numTxs) |! choose (numTxs + 1, 2 * numTxs)
+        txIndices <- liftGen $ shuffle [0 .. toInteger numTxs - 1]
+        -- We need this so that a zapped `n` still produces indices
+        txIndicesOverflow <- liftGen $ shuffle txIndices
+        let
+          txIndicesWithOverflow = take n $ txIndices <> txIndicesOverflow
+          faultyIndex pos i =
+            withAnnotation (T.pack $ show pos) $
+              pure i
+                |! choose (toInteger numTxs + 1, toInteger $ maxBound @Word16)
+        liftAntiGen $
+          withAnnotation "invalid_transactions" $
+            zipWithM faultyIndex [0 :: Int ..] txIndicesWithOverflow
+  invalidTxIxsTerm <- genArrayTerm $ TInteger . toInteger <$> invalidIxIxs
+  txsTerm <- withAntiGen (withAnnotation "transactions") $ genArrayTerm txs
+  perasCertTerm <- generateFromName "peras_certificate"
+  S <$> liftGen (genArrayTerm [invalidTxIxsTerm, txsTerm, perasCertTerm])
 
 instance HuddleRule "auxiliary_scripts" DijkstraEra where
   huddleRuleNamed = auxiliaryScriptsRule

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -873,6 +873,9 @@ instance HuddleRule "block" DijkstraEra where
 instance HuddleRule "peras_certificate" DijkstraEra where
   huddleRuleNamed pname _era = pname =.= VBytes / VNil
 
+instance HuddleRule "invalid_transactions" DijkstraEra where
+  huddleRuleNamed pname era = pname =.= huddleRule1 @"nonempty_set" era (huddleRule @"transaction_index" era)
+
 instance HuddleRule "block_body" DijkstraEra where
   huddleRuleNamed pname era =
     comment
@@ -881,7 +884,7 @@ instance HuddleRule "block_body" DijkstraEra where
       $ withCBORGen blockBodyGen
       $ pname
         =.= arr
-          [ "invalid_transactions" ==> arr [0 <+ a (huddleRule @"transaction_index" era)]
+          [ "invalid_transactions" ==> huddleRule @"invalid_transactions" era / VNil
           , "transactions" ==> arr [0 <+ a (huddleRule @"transaction" era)]
           , "peras_certificate" ==> huddleRule @"peras_certificate" era
           ]

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -66,7 +67,7 @@ import Cardano.Ledger.MemoBytes (
   mkMemoizedEra,
  )
 import Control.DeepSeq (NFData)
-import Control.Monad (unless)
+import Control.Monad (forM_, unless)
 import qualified Data.ByteString as BS
 import qualified Data.IntSet as IntSet
 import Data.Maybe.Strict (StrictMaybe (..))
@@ -74,6 +75,7 @@ import qualified Data.Sequence as Seq
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Typeable (Typeable)
+import Data.Word (Word16)
 import GHC.Generics (Generic)
 import Lens.Micro
 import NoThunks.Class (NoThunks)
@@ -184,7 +186,7 @@ instance
     case mLen of
       Just len | len /= 3 -> fail "expected 3 elements"
       _ -> pure ()
-    invalidTxs <- decCBOR
+    invalidTxs :: [Word16] <- decCBOR
     txs <- decCBOR
     perasCert <- decodeNullStrictMaybe decCBOR
     case mLen of
@@ -194,15 +196,12 @@ instance
       _ -> pure ()
     let txsLength = Seq.length txs
         inRange x = 0 <= x && x < txsLength
-    unless (all inRange invalidTxs) $
-      fail $
-        "Some IsValid index is not in the range: 0 .. "
-          ++ show (txsLength - 1)
-          ++ ", "
-          ++ show invalidTxs
+    forM_ invalidTxs $ \i ->
+      unless (inRange $ fromIntegral @Word16 @Int i) . fail $
+        "index is out of range: " <> show i
     let
       setValidityFlag tx isValid = set isValidTxL isValid <$> tx
-      validityFlags = alignedValidFlags txsLength invalidTxs
+      validityFlags = alignedValidFlags txsLength (fromIntegral <$> invalidTxs)
       txsWithIsValid = Seq.zipWith setValidityFlag txs validityFlags
     pure $
       DijkstraBlockBodyRaw

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -39,11 +38,13 @@ module Cardano.Ledger.Dijkstra.BlockBody.Internal (
 ) where
 
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsValid (..))
-import Cardano.Ledger.BaseTypes (Nonce, ProtVer (..))
+import Cardano.Ledger.BaseTypes (Nonce, ProtVer (..), maybeToStrictMaybe)
 import Cardano.Ledger.Binary (
   Annotator (..),
   DecCBOR (..),
   EncCBOR,
+  decodeNonEmptySetLikeEnforceNoDuplicates,
+  decodeNullMaybe,
   decodeNullStrictMaybe,
   decodeRecordNamed,
   encCBOR,
@@ -68,11 +69,14 @@ import Cardano.Ledger.MemoBytes (
 import Control.DeepSeq (NFData)
 import Control.Monad (forM_, unless)
 import qualified Data.ByteString as BS
+import Data.Foldable (Foldable (..))
+import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
 import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.Sequence as Seq
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
+import qualified Data.Set.NonEmpty as NonEmptySet
 import Data.Typeable (Typeable)
 import Data.Word (Word16)
 import GHC.Generics (Generic)
@@ -165,12 +169,13 @@ instance
   where
   encCBOR (DijkstraBlockBodyRaw txs perasCert) =
     encodeListLen 3
-      <> encCBOR invalidIndices
+      <> encodeNullStrictMaybe encCBOR invalidIndices
       <> encCBOR txs
       <> encodeNullStrictMaybe encCBOR perasCert
     where
       invalidIndices =
-        StrictSeq.findIndicesL (\tx -> tx ^. isValidTxL == IsValid False) txs
+        maybeToStrictMaybe . NonEmptySet.fromFoldable $
+          StrictSeq.findIndicesL (\tx -> tx ^. isValidTxL == IsValid False) txs
 
 instance
   ( AlonzoEraTx era
@@ -181,17 +186,23 @@ instance
   DecCBOR (Annotator (DijkstraBlockBodyRaw era))
   where
   decCBOR = decodeRecordNamed "DijkstraBlockBodyRaw" (const 3) $ do
-    invalidTxs :: [Word16] <- decCBOR
+    let
+      decodeInvalidTxs =
+        decodeNonEmptySetLikeEnforceNoDuplicates
+          (IntSet.insert . fromIntegral @Word16 @Int)
+          (\x -> (IntSet.size x, x))
+          (decCBOR @Word16)
+    invalidTxs :: IntSet <- fold <$> decodeNullMaybe decodeInvalidTxs
     txs <- decCBOR
     perasCert <- decodeNullStrictMaybe decCBOR
     let txsLength = Seq.length txs
         inRange x = 0 <= x && x < txsLength
-    forM_ invalidTxs $ \i ->
-      unless (inRange $ fromIntegral @Word16 @Int i) . fail $
+    forM_ (IntSet.toList invalidTxs) $ \i ->
+      unless (inRange i) . fail $
         "index is out of range: " <> show i
     let
       setValidityFlag tx isValid = set isValidTxL isValid <$> tx
-      validityFlags = alignedValidFlags txsLength (fromIntegral <$> invalidTxs)
+      validityFlags = alignedValidFlags txsLength invalidTxs
       txsWithIsValid = Seq.zipWith setValidityFlag txs validityFlags
     pure $
       DijkstraBlockBodyRaw
@@ -215,12 +226,9 @@ deriving via
 -- | Given the number of transactions, and the set of indices for which these
 -- transactions do not validate, create an aligned sequence of `IsValid`
 -- flags.
-alignedValidFlags :: Int -> [Int] -> Seq.Seq IsValid
-alignedValidFlags n idxs =
-  Seq.fromFunction n $ \i ->
-    IsValid (i `IntSet.notMember` invalidSet)
-  where
-    invalidSet = IntSet.fromList idxs
+alignedValidFlags :: Int -> IntSet -> Seq.Seq IsValid
+alignedValidFlags n invalidSet =
+  Seq.fromFunction n $ \i -> IsValid (i `IntSet.notMember` invalidSet)
 
 -- | Placeholder for Peras certificates
 --

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -44,9 +44,8 @@ import Cardano.Ledger.Binary (
   Annotator (..),
   DecCBOR (..),
   EncCBOR,
-  decodeBreakOr,
-  decodeListLenOrIndef,
   decodeNullStrictMaybe,
+  decodeRecordNamed,
   encCBOR,
   encodeListLen,
   encodeNullStrictMaybe,
@@ -181,19 +180,10 @@ instance
   ) =>
   DecCBOR (Annotator (DijkstraBlockBodyRaw era))
   where
-  decCBOR = do
-    mLen <- decodeListLenOrIndef
-    case mLen of
-      Just len | len /= 3 -> fail "expected 3 elements"
-      _ -> pure ()
+  decCBOR = decodeRecordNamed "DijkstraBlockBodyRaw" (const 3) $ do
     invalidTxs :: [Word16] <- decCBOR
     txs <- decCBOR
     perasCert <- decodeNullStrictMaybe decCBOR
-    case mLen of
-      Nothing -> do
-        isBreak <- decodeBreakOr
-        unless isBreak $ fail "expected break"
-      _ -> pure ()
     let txsLength = Seq.length txs
         inRange x = 0 <= x && x < txsLength
     forM_ invalidTxs $ \i ->

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -1,20 +1,21 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-pattern-binds #-}
 {-# OPTIONS_HADDOCK not-home #-}
 
 -- | Provides BlockBody internals
@@ -26,8 +27,8 @@
 -- The contents of this module may change __in any way whatsoever__
 -- and __without any warning__ between minor versions of this package.
 module Cardano.Ledger.Dijkstra.BlockBody.Internal (
-  DijkstraBlockBody (DijkstraBlockBody, ..),
-  hashDijkstraSegWits,
+  DijkstraBlockBody (DijkstraBlockBody, MkDijkstraBlockBody),
+  DijkstraBlockBodyRaw (..),
   alignedValidFlags,
   mkBasicBlockBodyDijkstra,
   DijkstraEraBlockBody (..),
@@ -36,47 +37,46 @@ module Cardano.Ledger.Dijkstra.BlockBody.Internal (
   validatePerasCert,
 ) where
 
-import qualified Cardano.Crypto.Hash as Hash
 import Cardano.Ledger.Alonzo.Tx (AlonzoEraTx (..), IsValid (..))
-import Cardano.Ledger.BaseTypes (Nonce)
+import Cardano.Ledger.BaseTypes (Nonce, ProtVer (..))
 import Cardano.Ledger.Binary (
   Annotator (..),
   DecCBOR (..),
   EncCBOR,
-  EncCBORGroup (..),
-  decodeListLen,
+  decodeBreakOr,
+  decodeListLenOrIndef,
+  decodeNullStrictMaybe,
   encCBOR,
-  encodeFoldableEncoder,
-  encodeFoldableMapEncoder,
-  encodePreEncoded,
-  serialize,
-  withSlice,
+  encodeListLen,
+  encodeNullStrictMaybe,
+  serialize',
  )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra.Era
 import Cardano.Ledger.Dijkstra.Tx ()
-import Cardano.Ledger.Shelley.BlockBody (auxDataSeqDecoder)
+import Cardano.Ledger.MemoBytes (
+  Mem,
+  MemoBytes,
+  MemoHashIndex,
+  Memoized (..),
+  getMemoBytesHash,
+  getMemoRawType,
+  lensMemoRawType,
+  mkMemoized,
+  mkMemoizedEra,
+ )
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
-import Data.Bifunctor (Bifunctor (..))
-import Data.ByteString (ByteString)
-import Data.ByteString.Builder (Builder, shortByteString, toLazyByteString)
-import qualified Data.ByteString.Lazy as BSL
-import Data.Coerce (coerce)
-import Data.Maybe (fromMaybe)
-import Data.Maybe.Strict (
-  StrictMaybe (..),
-  maybeToStrictMaybe,
-  strictMaybeToMaybe,
- )
+import qualified Data.ByteString as BS
+import qualified Data.IntSet as IntSet
+import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.Sequence as Seq
 import Data.Sequence.Strict (StrictSeq)
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro
-import Lens.Micro.Extras (view)
-import NoThunks.Class (AllowThunksIn (..), NoThunks)
+import NoThunks.Class (NoThunks)
 
 -- =================================================
 
@@ -87,43 +87,27 @@ import NoThunks.Class (AllowThunksIn (..), NoThunks)
 -- BlockBody provides an alternate way of formatting transactions in a block, in
 -- order to support segregated witnessing.
 
-data DijkstraBlockBody era = DijkstraBlockBodyInternal
-  { dbbTxs :: !(StrictSeq (Tx TopTx era))
-  , dbbPerasCert :: !(StrictMaybe PerasCert)
+data DijkstraBlockBodyRaw era = DijkstraBlockBodyRaw
+  { dbbrTxs :: !(StrictSeq (Tx TopTx era))
+  , dbbrPerasCert :: !(StrictMaybe PerasCert)
   -- ^ Optional Peras certificate
-  , dbbHash :: Hash.Hash HASH EraIndependentBlockBody
-  -- ^ Memoized hash to avoid recomputation. Lazy on purpose.
-  , dbbTxsBodyBytes :: BSL.ByteString
-  -- ^ Bytes encoding @Seq ('TxBody' era)@
-  , dbbTxsWitsBytes :: BSL.ByteString
-  -- ^ Bytes encoding @Seq ('TxWits' era)@
-  , dbbTxsAuxDataBytes :: BSL.ByteString
-  -- ^ Bytes encoding a @'TxAuxData')@. Missing indices have
-  -- 'SNothing' for metadata
-  , dbbTxsIsValidBytes :: BSL.ByteString
-  -- ^ Bytes representing a set of integers. These are the indices of
-  -- transactions with 'isValid' == False.
-  , dbbPerasCertBytes :: Maybe BSL.ByteString
-  -- ^ Bytes encoding the optional Peras certificate
   }
   deriving (Generic)
 
-instance (NFData (Tx TopTx era), NFData PerasCert) => NFData (DijkstraBlockBody era)
+instance (NFData (Tx TopTx era), NFData PerasCert) => NFData (DijkstraBlockBodyRaw era)
+
+type instance MemoHashIndex (DijkstraBlockBodyRaw era) = EraIndependentBlockBody
 
 instance EraBlockBody DijkstraEra where
   type BlockBody DijkstraEra = DijkstraBlockBody DijkstraEra
   mkBasicBlockBody = mkBasicBlockBodyDijkstra
-  txSeqBlockBodyL = lens dbbTxs (\bb p -> bb {dbbTxs = p})
-  hashBlockBody = dbbHash
+  txSeqBlockBodyL = lensMemoRawType @DijkstraEra dbbrTxs (\bb p -> bb {dbbrTxs = p})
+  hashBlockBody (MkDijkstraBlockBody m) = extractHash $ getMemoBytesHash m
   numSegComponents = 5
+  blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBOR
 
-mkBasicBlockBodyDijkstra ::
-  ( SafeToHash (TxWits era)
-  , BlockBody era ~ DijkstraBlockBody era
-  , AlonzoEraTx era
-  ) =>
-  BlockBody era
-mkBasicBlockBodyDijkstra = DijkstraBlockBody mempty SNothing
+mkBasicBlockBodyDijkstra :: forall era. AlonzoEraTx era => DijkstraBlockBody era
+mkBasicBlockBodyDijkstra = mkMemoized (eraProtVerLow @era) $ DijkstraBlockBodyRaw mempty SNothing
 {-# INLINEABLE mkBasicBlockBodyDijkstra #-}
 
 -- | Dijkstra-specific extensions to 'EraBlockBody'
@@ -132,116 +116,60 @@ class EraBlockBody era => DijkstraEraBlockBody era where
   -- ^ Lens to access the optional Peras certificate in the block body
 
 instance DijkstraEraBlockBody DijkstraEra where
-  perasCertBlockBodyL = lens dbbPerasCert (\bb c -> bb {dbbPerasCert = c})
+  perasCertBlockBodyL = lensMemoRawType @DijkstraEra dbbrPerasCert (\bb c -> bb {dbbrPerasCert = c})
+
+deriving instance (Typeable era, NoThunks (Tx TopTx era)) => NoThunks (DijkstraBlockBodyRaw era)
+
+deriving stock instance Show (Tx TopTx era) => Show (DijkstraBlockBodyRaw era)
+
+deriving stock instance Eq (Tx TopTx era) => Eq (DijkstraBlockBodyRaw era)
+
+newtype DijkstraBlockBody era = MkDijkstraBlockBody (MemoBytes (DijkstraBlockBodyRaw era))
+  deriving (Generic)
+
+deriving instance Eq (Tx TopTx era) => Eq (DijkstraBlockBody era)
+
+deriving instance Show (Tx TopTx era) => Show (DijkstraBlockBody era)
+
+deriving newtype instance
+  (NFData (Tx TopTx era), NFData PerasCert) => NFData (DijkstraBlockBody era)
+
+deriving newtype instance EncCBOR (DijkstraBlockBody era)
+
+instance Memoized (DijkstraBlockBody era) where
+  type RawType (DijkstraBlockBody era) = DijkstraBlockBodyRaw era
 
 pattern DijkstraBlockBody ::
-  forall era.
-  ( AlonzoEraTx era
-  , SafeToHash (TxWits era)
-  ) =>
+  AlonzoEraTx era =>
   StrictSeq (Tx TopTx era) ->
   StrictMaybe PerasCert ->
   DijkstraBlockBody era
-pattern DijkstraBlockBody xs mbPerasCert <-
-  DijkstraBlockBodyInternal xs mbPerasCert _ _ _ _ _ _
+pattern DijkstraBlockBody txs perasCert <- (getMemoRawType -> DijkstraBlockBodyRaw txs perasCert)
   where
-    DijkstraBlockBody txns mbPerasCert =
-      let version = eraProtVerLow @era
-          serializeFoldablePreEncoded x =
-            serialize version $
-              encodeFoldableEncoder encodePreEncoded x
-          metaChunk index m = encodeIndexed <$> strictMaybeToMaybe m
-            where
-              encodeIndexed metadata = encCBOR index <> encodePreEncoded metadata
-          txSeqBodies =
-            serializeFoldablePreEncoded $ originalBytes . view bodyTxL <$> txns
-          txSeqWits =
-            serializeFoldablePreEncoded $ originalBytes . view witsTxL <$> txns
-          txSeqAuxDatas =
-            serialize version . encodeFoldableMapEncoder metaChunk $
-              fmap originalBytes . view auxDataTxL <$> txns
-          txSeqIsValids =
-            serialize version $ encCBOR $ nonValidatingIndices txns
-          mbPerasCertBytes =
-            fmap (serialize version) (strictMaybeToMaybe mbPerasCert)
-       in DijkstraBlockBodyInternal
-            { dbbTxs = txns
-            , dbbPerasCert = mbPerasCert
-            , dbbHash =
-                hashDijkstraSegWits
-                  txSeqBodies
-                  txSeqWits
-                  txSeqAuxDatas
-                  txSeqIsValids
-                  mbPerasCertBytes
-            , dbbTxsBodyBytes = txSeqBodies
-            , dbbTxsWitsBytes = txSeqWits
-            , dbbTxsAuxDataBytes = txSeqAuxDatas
-            , dbbTxsIsValidBytes = txSeqIsValids
-            , dbbPerasCertBytes = mbPerasCertBytes
-            }
+    DijkstraBlockBody txs perasCert =
+      mkMemoizedEra @DijkstraEra $
+        DijkstraBlockBodyRaw txs perasCert
 
 {-# COMPLETE DijkstraBlockBody #-}
-
-deriving via
-  AllowThunksIn
-    '[ "dbbHash"
-     , "dbbTxsBodyBytes"
-     , "dbbTxsWitsBytes"
-     , "dbbTxsAuxDataBytes"
-     , "dbbTxsIsValidBytes"
-     , "dbbPerasCertBytes"
-     ]
-    (DijkstraBlockBody era)
-  instance
-    (Typeable era, NoThunks (Tx TopTx era)) => NoThunks (DijkstraBlockBody era)
-
-deriving stock instance Show (Tx TopTx era) => Show (DijkstraBlockBody era)
-
-deriving stock instance Eq (Tx TopTx era) => Eq (DijkstraBlockBody era)
 
 --------------------------------------------------------------------------------
 -- Serialisation and hashing
 --------------------------------------------------------------------------------
 
-instance Era era => EncCBORGroup (DijkstraBlockBody era) where
-  encCBORGroup blockBody =
-    encodePreEncoded $
-      BSL.toStrict $
-        dbbTxsBodyBytes blockBody
-          <> dbbTxsWitsBytes blockBody
-          <> dbbTxsAuxDataBytes blockBody
-          <> dbbTxsIsValidBytes blockBody
-          <> fromMaybe BSL.empty (dbbPerasCertBytes blockBody)
-  listLen _ = 5
-
-hashDijkstraSegWits ::
-  BSL.ByteString ->
-  -- | Bytes for transaction bodies
-  BSL.ByteString ->
-  -- | Bytes for transaction witnesses
-  BSL.ByteString ->
-  -- | Bytes for transaction auxiliary datas
-  BSL.ByteString ->
-  -- | Bytes for transaction isValid flags
-  Maybe BSL.ByteString ->
-  -- | Bytes for optional Peras certificate
-  Hash HASH EraIndependentBlockBody
-hashDijkstraSegWits txSeqBodies txSeqWits txAuxData txSeqIsValids mbPerasCert =
-  coerce . hashLazy . toLazyByteString $
-    hashPart txSeqBodies
-      <> hashPart txSeqWits
-      <> hashPart txAuxData
-      <> hashPart txSeqIsValids
-      <> maybe mempty hashPart mbPerasCert
+instance
+  ( AlonzoEraTx era
+  , EncCBOR (Tx TopTx era)
+  ) =>
+  EncCBOR (DijkstraBlockBodyRaw era)
   where
-    hashLazy :: BSL.ByteString -> Hash HASH ByteString
-    hashLazy = Hash.hashWith id . BSL.toStrict
-    {-# INLINE hashLazy #-}
-    hashPart :: BSL.ByteString -> Builder
-    hashPart = shortByteString . Hash.hashToBytesShort . hashLazy
-    {-# INLINE hashPart #-}
-{-# INLINE hashDijkstraSegWits #-}
+  encCBOR (DijkstraBlockBodyRaw txs perasCert) =
+    encodeListLen 3
+      <> encCBOR invalidIndices
+      <> encCBOR txs
+      <> encodeNullStrictMaybe encCBOR perasCert
+    where
+      invalidIndices =
+        StrictSeq.findIndicesL (\tx -> tx ^. isValidTxL == IsValid False) txs
 
 instance
   ( AlonzoEraTx era
@@ -249,114 +177,61 @@ instance
   , DecCBOR (Annotator (TxBody TopTx era))
   , DecCBOR (Annotator (TxWits era))
   ) =>
-  DecCBOR (Annotator (DijkstraBlockBody era))
+  DecCBOR (Annotator (DijkstraBlockBodyRaw era))
   where
   decCBOR = do
-    len <- decodeListLen
-
-    (bodies, bodiesAnn) <- withSlice decCBOR
-    (wits, witsAnn) <- withSlice decCBOR
-    let bodiesLength = length bodies
-        inRange x = (0 <= x) && (x <= (bodiesLength - 1))
-        witsLength = length wits
-    (auxData, auxDataAnn) <- withSlice $ do
-      auxDataMap <- decCBOR
-      auxDataSeqDecoder bodiesLength auxDataMap
-
-    (isValIdxs, isValAnn) <- withSlice decCBOR
-    let validFlags = alignedValidFlags bodiesLength isValIdxs
-    unless (bodiesLength == witsLength) $
-      fail $
-        "different number of transaction bodies ("
-          <> show bodiesLength
-          <> ") and witness sets ("
-          <> show witsLength
-          <> ")"
-    unless (all inRange isValIdxs) $
+    mLen <- decodeListLenOrIndef
+    case mLen of
+      Just len | len /= 3 -> fail "expected 3 elements"
+      _ -> pure ()
+    invalidTxs <- decCBOR
+    txs <- decCBOR
+    perasCert <- decodeNullStrictMaybe decCBOR
+    case mLen of
+      Nothing -> do
+        isBreak <- decodeBreakOr
+        unless isBreak $ fail "expected break"
+      _ -> pure ()
+    let txsLength = Seq.length txs
+        inRange x = 0 <= x && x < txsLength
+    unless (all inRange invalidTxs) $
       fail $
         "Some IsValid index is not in the range: 0 .. "
-          ++ show (bodiesLength - 1)
+          ++ show (txsLength - 1)
           ++ ", "
-          ++ show isValIdxs
-
-    let txns =
-          sequenceA $
-            StrictSeq.forceToStrict $
-              Seq.zipWith4 dijkstraSegwitTx bodies wits validFlags auxData
-
-    (mbPerasCert, mbPerasCertAnn) <-
-      case len of
-        4 -> return (pure SNothing, pure Nothing)
-        5 -> bimap (pure . SJust) (fmap Just) <$> withSlice decCBOR
-        _ -> fail $ "unexpected body length: " <> show len
-
+          ++ show invalidTxs
+    let
+      setValidityFlag tx isValid = set isValidTxL isValid <$> tx
+      validityFlags = alignedValidFlags txsLength invalidTxs
+      txsWithIsValid = Seq.zipWith setValidityFlag txs validityFlags
     pure $
-      DijkstraBlockBodyInternal
-        <$> txns
-        <*> mbPerasCert
-        <*> ( hashDijkstraSegWits
-                <$> bodiesAnn
-                <*> witsAnn
-                <*> auxDataAnn
-                <*> isValAnn
-                <*> mbPerasCertAnn
-            )
-        <*> bodiesAnn
-        <*> witsAnn
-        <*> auxDataAnn
-        <*> isValAnn
-        <*> mbPerasCertAnn
+      DijkstraBlockBodyRaw
+        <$> sequenceA (StrictSeq.forceToStrict txsWithIsValid)
+        <*> pure perasCert
+
+deriving via
+  Mem (DijkstraBlockBodyRaw era)
+  instance
+    ( AlonzoEraTx era
+    , DecCBOR (Annotator (TxAuxData era))
+    , DecCBOR (Annotator (TxBody TopTx era))
+    , DecCBOR (Annotator (TxWits era))
+    ) =>
+    DecCBOR (Annotator (DijkstraBlockBody era))
 
 --------------------------------------------------------------------------------
 -- Internal utility functions
 --------------------------------------------------------------------------------
 
--- | Given a sequence of transactions, return the indices of those which do not
--- validate. We store the indices of the non-validating transactions because we
--- expect this to be a much smaller set than the validating transactions.
-nonValidatingIndices :: AlonzoEraTx era => StrictSeq (Tx TopTx era) -> [Int]
-nonValidatingIndices (StrictSeq.fromStrict -> xs) =
-  Seq.foldrWithIndex
-    ( \idx tx acc ->
-        if tx ^. isValidTxL == IsValid False
-          then idx : acc
-          else acc
-    )
-    []
-    xs
-
 -- | Given the number of transactions, and the set of indices for which these
 -- transactions do not validate, create an aligned sequence of `IsValid`
 -- flags.
 alignedValidFlags :: Int -> [Int] -> Seq.Seq IsValid
-alignedValidFlags = alignedValidFlags' (-1)
+alignedValidFlags n idxs =
+  Seq.fromFunction n $ \i ->
+    IsValid (i `IntSet.notMember` invalidSet)
   where
-    alignedValidFlags' _ n [] = Seq.replicate n $ IsValid True
-    alignedValidFlags' prev n (x : xs) =
-      Seq.replicate (x - prev - 1) (IsValid True)
-        Seq.>< IsValid False
-        Seq.<| alignedValidFlags' x (n - (x - prev)) xs
-
--- | Construct an annotated Dijkstra style transaction.
-dijkstraSegwitTx ::
-  AlonzoEraTx era =>
-  Annotator (TxBody TopTx era) ->
-  Annotator (TxWits era) ->
-  IsValid ->
-  Maybe (Annotator (TxAuxData era)) ->
-  Annotator (Tx TopTx era)
-dijkstraSegwitTx txBodyAnn txWitsAnn txIsValid txAuxDataAnn = Annotator $ \bytes -> do
-  txBody <- runAnnotator txBodyAnn bytes
-  txWits <- runAnnotator txWitsAnn bytes
-  txAuxData <- mapM (`runAnnotator` bytes) txAuxDataAnn
-  pure $
-    mkBasicTx txBody
-      & witsTxL
-        .~ txWits
-      & auxDataTxL
-        .~ maybeToStrictMaybe txAuxData
-      & isValidTxL
-        .~ txIsValid
+    invalidSet = IntSet.fromList idxs
 
 -- | Placeholder for Peras certificates
 --
@@ -367,12 +242,11 @@ data PerasCert = PerasCert
 instance NFData PerasCert
 
 instance EncCBOR PerasCert where
-  encCBOR PerasCert =
-    encCBOR ()
+  encCBOR PerasCert = encCBOR BS.empty
 
 instance DecCBOR PerasCert where
   decCBOR = do
-    () <- decCBOR
+    (_ :: BS.ByteString) <- decCBOR
     pure PerasCert
 
 -- | Placeholder for Peras public keys

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -47,6 +47,7 @@ import Cardano.Ledger.Binary (
   decodeNullMaybe,
   decodeNullStrictMaybe,
   decodeRecordNamed,
+  decodeSeq,
   encCBOR,
   encodeListLen,
   encodeNullStrictMaybe,
@@ -54,7 +55,7 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra.Era
-import Cardano.Ledger.Dijkstra.Tx ()
+import Cardano.Ledger.Dijkstra.Tx (DijkstraTx, Tx (..), decDijkstraTopTxCBORAnn)
 import Cardano.Ledger.MemoBytes (
   Mem,
   MemoBytes,
@@ -69,6 +70,7 @@ import Cardano.Ledger.MemoBytes (
 import Control.DeepSeq (NFData)
 import Control.Monad (forM_, unless)
 import qualified Data.ByteString as BS
+import Data.Coerce (Coercible, coerce)
 import Data.Foldable (Foldable (..))
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
@@ -182,6 +184,7 @@ instance
   , DecCBOR (Annotator (TxAuxData era))
   , DecCBOR (Annotator (TxBody TopTx era))
   , DecCBOR (Annotator (TxWits era))
+  , Coercible (DijkstraTx TopTx era) (Tx TopTx era)
   ) =>
   DecCBOR (Annotator (DijkstraBlockBodyRaw era))
   where
@@ -193,7 +196,7 @@ instance
           (\x -> (IntSet.size x, x))
           (decCBOR @Word16)
     invalidTxs :: IntSet <- fold <$> decodeNullMaybe decodeInvalidTxs
-    txs <- decCBOR
+    txs <- decodeSeq (decDijkstraTopTxCBORAnn @era False)
     perasCert <- decodeNullStrictMaybe decCBOR
     let txsLength = Seq.length txs
         inRange x = 0 <= x && x < txsLength
@@ -203,7 +206,7 @@ instance
     let
       setValidityFlag tx isValid = set isValidTxL isValid <$> tx
       validityFlags = alignedValidFlags txsLength invalidTxs
-      txsWithIsValid = Seq.zipWith setValidityFlag txs validityFlags
+      txsWithIsValid = Seq.zipWith setValidityFlag (coerce txs) validityFlags
     pure $
       DijkstraBlockBodyRaw
         <$> sequenceA (StrictSeq.forceToStrict txsWithIsValid)
@@ -213,6 +216,7 @@ deriving via
   Mem (DijkstraBlockBodyRaw era)
   instance
     ( AlonzoEraTx era
+    , Coercible (DijkstraTx TopTx era) (Tx TopTx era)
     , DecCBOR (Annotator (TxAuxData era))
     , DecCBOR (Annotator (TxBody TopTx era))
     , DecCBOR (Annotator (TxWits era))

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -67,8 +67,10 @@ import Cardano.Ledger.MemoBytes (
   mkMemoized,
   mkMemoizedEra,
  )
+import Cardano.Ledger.Orphans ()
 import Control.DeepSeq (NFData)
 import Control.Monad (forM_, unless)
+import Data.Array.Byte (ByteArray)
 import qualified Data.ByteString as BS
 import Data.Coerce (Coercible, coerce)
 import Data.Foldable (Foldable (..))
@@ -237,18 +239,13 @@ alignedValidFlags n invalidSet =
 -- | Placeholder for Peras certificates
 --
 -- NOTE: The real type will be brought from 'cardano-base' once it's ready.
-data PerasCert = PerasCert
-  deriving (Eq, Show, Generic, NoThunks)
+newtype PerasCert = PerasCert ByteArray
+  deriving (Eq, Show, Generic)
+  deriving newtype (EncCBOR, DecCBOR)
+
+instance NoThunks PerasCert
 
 instance NFData PerasCert
-
-instance EncCBOR PerasCert where
-  encCBOR PerasCert = encCBOR BS.empty
-
-instance DecCBOR PerasCert where
-  decCBOR = do
-    (_ :: BS.ByteString) <- decCBOR
-    pure PerasCert
 
 -- | Placeholder for Peras public keys
 --

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -105,7 +105,7 @@ instance EraBlockBody DijkstraEra where
   mkBasicBlockBody = mkBasicBlockBodyDijkstra
   txSeqBlockBodyL = lensMemoRawType @DijkstraEra dbbrTxs (\bb p -> bb {dbbrTxs = p})
   hashBlockBody (MkDijkstraBlockBody m) = extractHash $ getMemoBytesHash m
-  numSegComponents = 5
+  numSegComponents = 1
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBOR
 
 mkBasicBlockBodyDijkstra :: forall era. AlonzoEraTx era => DijkstraBlockBody era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -328,8 +328,6 @@ nonValidatingIndices (StrictSeq.fromStrict -> xs) =
 -- | Given the number of transactions, and the set of indices for which these
 -- transactions do not validate, create an aligned sequence of `IsValid`
 -- flags.
---
--- This function operates much as the inverse of 'nonValidatingIndices'.
 alignedValidFlags :: Int -> [Int] -> Seq.Seq IsValid
 alignedValidFlags = alignedValidFlags' (-1)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -23,6 +23,7 @@ module Cardano.Ledger.Dijkstra.Tx (
   Tx (..),
   DijkstraStAnnTx (..),
   validateDijkstraNativeScript,
+  decDijkstraTopTxCBORAnn,
 ) where
 
 import Cardano.Ledger.Allegra.TxBody (AllegraEraTxBody (..), StrictMaybe)
@@ -35,6 +36,7 @@ import Cardano.Ledger.BaseTypes (ProtVer, StrictMaybe (..), integralToBounded)
 import Cardano.Ledger.Binary (
   Annotator,
   DecCBOR (..),
+  Decoder,
   EncCBOR (..),
   Encoding,
   ToCBOR (..),
@@ -124,37 +126,40 @@ instance (EraTx era, Typeable l) => ToCBOR (DijkstraTx l era) where
 instance EraTx era => EncCBOR (DijkstraTx l era) where
   encCBOR = toCBORForMempoolSubmission
 
+decDijkstraTopTxCBORAnn :: EraTx era => Bool -> Decoder s (Annotator (DijkstraTx TopTx era))
+decDijkstraTopTxCBORAnn allowIsValid = do
+  decodeListLen >>= \case
+    4 | allowIsValid -> do
+      bodyAnn <- decCBOR
+      witsAnn <- decCBOR
+      isValid <-
+        decCBOR
+          >>= \case
+            True -> pure (IsValid True)
+            False -> fail "value `false` not allowed for `isValid`"
+      auxAnn <- decodeNullStrictMaybe decCBOR
+      pure $
+        DijkstraTx
+          <$> bodyAnn
+          <*> witsAnn
+          <*> pure isValid
+          <*> sequence auxAnn
+    3 -> do
+      bodyAnn <- decCBOR
+      witsAnn <- decCBOR
+      auxAnn <- decodeNullStrictMaybe decCBOR
+      pure $
+        DijkstraTx
+          <$> bodyAnn
+          <*> witsAnn
+          <*> pure (IsValid True)
+          <*> sequence auxAnn
+    n ->
+      fail $ "Unexpected list length: " <> show n <> ". Expected: 4 or 3."
+
 instance (EraTx era, Typeable l) => DecCBOR (Annotator (DijkstraTx l era)) where
   decCBOR = withSTxBothLevels @l $ \case
-    STopTx -> do
-      decodeListLen >>= \case
-        4 -> do
-          bodyAnn <- decCBOR
-          witsAnn <- decCBOR
-          isValid <-
-            decCBOR
-              >>= \case
-                True -> pure (IsValid True)
-                False -> fail "value `false` not allowed for `isValid`"
-          auxAnn <- decodeNullStrictMaybe decCBOR
-          pure $
-            DijkstraTx
-              <$> bodyAnn
-              <*> witsAnn
-              <*> pure isValid
-              <*> sequence auxAnn
-        3 -> do
-          bodyAnn <- decCBOR
-          witsAnn <- decCBOR
-          auxAnn <- decodeNullStrictMaybe decCBOR
-          pure $
-            DijkstraTx
-              <$> bodyAnn
-              <*> witsAnn
-              <*> pure (IsValid True)
-              <*> sequence auxAnn
-        n ->
-          fail $ "Unexpected list length: " <> show n <> ". Expected: 4 or 3."
+    STopTx -> decDijkstraTopTxCBORAnn True
     SSubTx ->
       decode $
         Ann (RecD DijkstraSubTx)

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -35,6 +35,9 @@ spec = do
   describe "CDDL" $ do
     let v = eraProtVerHigh @DijkstraEra
     describe "Huddle" $ specWithHuddle dijkstraCDDL . noTwiddle $ do
+      -- BlockBody
+      xdescribe "fix transaction" $
+        fullAnnCddlSpec @(BlockBody DijkstraEra) v "block_body"
       -- AccountBalanceInterval
       fullCddlSpec @(AccountBalanceInterval DijkstraEra) v "account_balance_interval"
       -- AccountBalanceIntervals

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -14,6 +14,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.HuddleSpec (dijkstraCDDL)
 import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceInterval, AccountBalanceIntervals)
+import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Cardano.Ledger.Plutus.Data (Data, Datum)
 import Test.Cardano.Ledger.Alonzo.Arbitrary (genDatumPresent, genNonEmptyRedeemers)
 import Test.Cardano.Ledger.Binary.Cuddle (

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -291,7 +291,7 @@ instance
   arbitrary = genericArbitraryU
 
 instance Arbitrary PerasCert where
-  arbitrary = pure PerasCert
+  arbitrary = PerasCert <$> arbitrary
 
 instance
   ( EraBlockBody era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -211,19 +211,11 @@ instance Typeable l => DecCBOR (DijkstraTx l DijkstraEra) where
 deriving newtype instance Typeable l => DecCBOR (Tx l DijkstraEra)
 
 instance DecCBOR (DijkstraBlockBodyRaw DijkstraEra) where
-  decCBOR = do
-    mLen <- decodeListLenOrIndef
-    case mLen of
-      Just len | len /= 3 -> fail "expected 3 elements"
-      _ -> pure ()
+  decCBOR = decodeRecordNamed "DijkstraBlockBodyRaw" (const 3) $ do
     invalidTxs <- decCBOR
     txs <- decCBOR
     perasCert <- decodeNullStrictMaybe decCBOR
-    case mLen of
-      Nothing -> do
-        isBreak <- decodeBreakOr
-        unless isBreak $ fail "expected break"
-      _ -> pure ()
+
     let txsLength = Seq.length txs
         inRange x = 0 <= x && x <= txsLength - 1
     unless (all inRange invalidTxs) $

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -34,6 +34,7 @@ import Cardano.Ledger.Dijkstra.TxBody
 import Cardano.Ledger.MemoBytes (decodeMemoized)
 import Cardano.Ledger.Val (Val (..))
 import Control.Monad (forM_, unless)
+import Data.Coerce (coerce)
 import Data.Foldable (Foldable (..))
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
@@ -185,25 +186,7 @@ instance Era era => DecCBOR (DijkstraNativeScript era) where
 instance Typeable l => DecCBOR (DijkstraTx l DijkstraEra) where
   decCBOR =
     withSTxBothLevels @l $ \case
-      STopTx ->
-        decodeListLen >>= \case
-          4 -> do
-            body <- decCBOR
-            wits <- decCBOR
-            isValid <-
-              decCBOR
-                >>= \case
-                  True -> pure (IsValid True)
-                  False -> fail "value `false` not allowed for `isValid`"
-            aux <- decodeNullStrictMaybe decCBOR
-            pure $ DijkstraTx body wits isValid aux
-          3 -> do
-            DijkstraTx
-              <$> decCBOR
-              <*> decCBOR
-              <*> pure (IsValid True)
-              <*> decodeNullStrictMaybe decCBOR
-          n -> fail $ "Unexpected list length: " <> show n <> ". Expected: 4 or 3."
+      STopTx -> decDijkstraTopTxCBOR True
       SSubTx ->
         decode $
           RecD DijkstraSubTx
@@ -214,6 +197,32 @@ instance Typeable l => DecCBOR (DijkstraTx l DijkstraEra) where
 
 deriving newtype instance Typeable l => DecCBOR (Tx l DijkstraEra)
 
+decDijkstraTopTxCBOR ::
+  ( DecCBOR (TxBody TopTx era)
+  , DecCBOR (TxWits era)
+  , DecCBOR (TxAuxData era)
+  ) =>
+  Bool -> Decoder s (DijkstraTx TopTx era)
+decDijkstraTopTxCBOR allowIsValid =
+  decodeListLen >>= \case
+    4 | allowIsValid -> do
+      body <- decCBOR
+      wits <- decCBOR
+      isValid <-
+        decCBOR
+          >>= \case
+            True -> pure (IsValid True)
+            False -> fail "value `false` not allowed for `isValid`"
+      aux <- decodeNullStrictMaybe decCBOR
+      pure $ DijkstraTx body wits isValid aux
+    3 -> do
+      DijkstraTx
+        <$> decCBOR
+        <*> decCBOR
+        <*> pure (IsValid True)
+        <*> decodeNullStrictMaybe decCBOR
+    n -> fail $ "Unexpected list length: " <> show n <> ". Expected: 4 or 3."
+
 instance DecCBOR (DijkstraBlockBodyRaw DijkstraEra) where
   decCBOR = decodeRecordNamed "DijkstraBlockBodyRaw" (const 3) $ do
     let
@@ -223,7 +232,7 @@ instance DecCBOR (DijkstraBlockBodyRaw DijkstraEra) where
           (\x -> (IntSet.size x, x))
           (decCBOR @Word16)
     invalidTxs :: IntSet <- fold <$> decodeNullMaybe decodeInvalidTxs
-    txs <- decCBOR
+    txs <- decodeSeq (decDijkstraTopTxCBOR @DijkstraEra False)
     perasCert <- decodeNullStrictMaybe decCBOR
 
     let txsLength = Seq.length txs
@@ -232,9 +241,8 @@ instance DecCBOR (DijkstraBlockBodyRaw DijkstraEra) where
       unless (inRange i) . fail $
         "index is out of range: " <> show i
     let
-      setValidityFlag tx isValid = tx & isValidTxL .~ isValid
       validityFlags = alignedValidFlags txsLength invalidTxs
-      txsWithIsValid = Seq.zipWith setValidityFlag txs validityFlags
+      txsWithIsValid = Seq.zipWith (set isValidTxL) validityFlags (coerce <$> txs)
     pure $ DijkstraBlockBodyRaw (StrictSeq.forceToStrict txsWithIsValid) perasCert
 
 instance DecCBOR (DijkstraBlockBody DijkstraEra) where

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -33,13 +33,17 @@ import Cardano.Ledger.Dijkstra.Tx (DijkstraTx (..), Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody
 import Cardano.Ledger.MemoBytes (decodeMemoized)
 import Cardano.Ledger.Val (Val (..))
-import Control.Monad (unless)
+import Control.Monad (forM_, unless)
+import Data.Foldable (Foldable (..))
+import Data.IntSet (IntSet)
+import qualified Data.IntSet as IntSet
 import qualified Data.Map.Strict as Map
 import qualified Data.OMap.Strict as OMap
 import qualified Data.OSet.Strict as OSet
 import qualified Data.Sequence as Seq
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Typeable (Typeable)
+import Data.Word (Word16)
 import Lens.Micro
 import Test.Cardano.Ledger.Conway.Binary.Annotator ()
 
@@ -212,18 +216,21 @@ deriving newtype instance Typeable l => DecCBOR (Tx l DijkstraEra)
 
 instance DecCBOR (DijkstraBlockBodyRaw DijkstraEra) where
   decCBOR = decodeRecordNamed "DijkstraBlockBodyRaw" (const 3) $ do
-    invalidTxs <- decCBOR
+    let
+      decodeInvalidTxs =
+        decodeNonEmptySetLikeEnforceNoDuplicates
+          (IntSet.insert . fromIntegral @Word16 @Int)
+          (\x -> (IntSet.size x, x))
+          (decCBOR @Word16)
+    invalidTxs :: IntSet <- fold <$> decodeNullMaybe decodeInvalidTxs
     txs <- decCBOR
     perasCert <- decodeNullStrictMaybe decCBOR
 
     let txsLength = Seq.length txs
         inRange x = 0 <= x && x <= txsLength - 1
-    unless (all inRange invalidTxs) $
-      fail $
-        "Some IsValid index is not in the range: 0 .. "
-          ++ show (txsLength - 1)
-          ++ ", "
-          ++ show invalidTxs
+    forM_ (IntSet.toList invalidTxs) $ \i ->
+      unless (inRange i) . fail $
+        "index is out of range: " <> show i
     let
       setValidityFlag tx isValid = tx & isValidTxL .~ isValid
       validityFlags = alignedValidFlags txsLength invalidTxs

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -22,15 +22,23 @@ import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin (decodePositiveCoin)
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
 import Cardano.Ledger.Dijkstra (DijkstraEra)
+import Cardano.Ledger.Dijkstra.BlockBody.Internal (
+  DijkstraBlockBody (..),
+  DijkstraBlockBodyRaw (..),
+  alignedValidFlags,
+ )
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Scripts
 import Cardano.Ledger.Dijkstra.Tx (DijkstraTx (..), Tx (..))
 import Cardano.Ledger.Dijkstra.TxBody
 import Cardano.Ledger.MemoBytes (decodeMemoized)
 import Cardano.Ledger.Val (Val (..))
+import Control.Monad (unless)
 import qualified Data.Map.Strict as Map
 import qualified Data.OMap.Strict as OMap
 import qualified Data.OSet.Strict as OSet
+import qualified Data.Sequence as Seq
+import qualified Data.Sequence.Strict as StrictSeq
 import Data.Typeable (Typeable)
 import Lens.Micro
 import Test.Cardano.Ledger.Conway.Binary.Annotator ()
@@ -201,3 +209,34 @@ instance Typeable l => DecCBOR (DijkstraTx l DijkstraEra) where
   {-# INLINE decCBOR #-}
 
 deriving newtype instance Typeable l => DecCBOR (Tx l DijkstraEra)
+
+instance DecCBOR (DijkstraBlockBodyRaw DijkstraEra) where
+  decCBOR = do
+    mLen <- decodeListLenOrIndef
+    case mLen of
+      Just len | len /= 3 -> fail "expected 3 elements"
+      _ -> pure ()
+    invalidTxs <- decCBOR
+    txs <- decCBOR
+    perasCert <- decodeNullStrictMaybe decCBOR
+    case mLen of
+      Nothing -> do
+        isBreak <- decodeBreakOr
+        unless isBreak $ fail "expected break"
+      _ -> pure ()
+    let txsLength = Seq.length txs
+        inRange x = 0 <= x && x <= txsLength - 1
+    unless (all inRange invalidTxs) $
+      fail $
+        "Some IsValid index is not in the range: 0 .. "
+          ++ show (txsLength - 1)
+          ++ ", "
+          ++ show invalidTxs
+    let
+      setValidityFlag tx isValid = tx & isValidTxL .~ isValid
+      validityFlags = alignedValidFlags txsLength invalidTxs
+      txsWithIsValid = Seq.zipWith setValidityFlag txs validityFlags
+    pure $ DijkstraBlockBodyRaw (StrictSeq.forceToStrict txsWithIsValid) perasCert
+
+instance DecCBOR (DijkstraBlockBody DijkstraEra) where
+  decCBOR = MkDijkstraBlockBody <$> decodeMemoized decCBOR

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -21,8 +21,10 @@ import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Conway.Rules (ConwayGovEvent)
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.BlockBody (PerasCert)
+import Cardano.Ledger.Dijkstra.BlockBody.Internal (DijkstraBlockBodyRaw)
 import Cardano.Ledger.Dijkstra.Core (
   AlonzoEraScript (..),
+  AlonzoEraTx,
   AsItem,
   AsIx,
   DijkstraBlockBody,
@@ -127,7 +129,9 @@ instance ToExpr (TxBody l DijkstraEra)
 
 instance ToExpr PerasCert
 
-instance (ToExpr (Tx TopTx era), ToExpr PerasCert) => ToExpr (DijkstraBlockBody era)
+instance ToExpr (Tx TopTx era) => ToExpr (DijkstraBlockBodyRaw era)
+
+instance (AlonzoEraTx era, ToExpr (Tx TopTx era), ToExpr PerasCert) => ToExpr (DijkstraBlockBody era)
 
 instance ToExpr (DijkstraTx l DijkstraEra) where
   toExpr = \case

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Dijkstra.Core (
   AlonzoEraTx,
   AsItem,
   AsIx,
-  DijkstraBlockBody,
+  DijkstraBlockBody (..),
   Era,
   EraPParams (..),
   EraRule,

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/BlockBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/BlockBody.hs
@@ -9,6 +9,8 @@
 
 module Cardano.Ledger.Mary.BlockBody () where
 
+import Cardano.Ledger.BaseTypes (ProtVer (..))
+import Cardano.Ledger.Binary (EncCBORGroup (..), serialize')
 import Cardano.Ledger.Core (EraBlockBody (..))
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Tx ()
@@ -18,6 +20,7 @@ import Cardano.Ledger.Shelley.BlockBody (
   shelleyBlockBodyHash,
   txSeqBlockBodyShelleyL,
  )
+import qualified Data.ByteString as BS
 
 instance EraBlockBody MaryEra where
   type BlockBody MaryEra = ShelleyBlockBody MaryEra
@@ -25,3 +28,4 @@ instance EraBlockBody MaryEra where
   txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = shelleyBlockBodyHash
   numSegComponents = 3
+  blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody.hs
@@ -6,7 +6,6 @@ module Cardano.Ledger.Shelley.BlockBody (
   shelleyBlockBodyTxs,
   auxDataSeqDecoder,
   hashShelleySegWits,
-  bBodySize,
   slotToNonce,
   incrBlocks,
   coreAuxDataBytes,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody/Internal.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody/Internal.hs
@@ -31,7 +31,6 @@ module Cardano.Ledger.Shelley.BlockBody.Internal (
   txSeqBlockBodyShelleyL,
   auxDataSeqDecoder,
   hashShelleySegWits,
-  bBodySize,
   slotToNonce,
   --
   incrBlocks,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody/Internal.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody/Internal.hs
@@ -41,6 +41,7 @@ import qualified Cardano.Crypto.Hash.Class as Hash
 import Cardano.Ledger.BaseTypes (
   BlocksMade (..),
   Nonce (..),
+  ProtVer (..),
   StrictMaybe (..),
   UnitInterval,
   maybeToStrictMaybe,
@@ -57,6 +58,7 @@ import Cardano.Ledger.Binary (
   encodeFoldableMapEncoder,
   encodePreEncoded,
   serialize,
+  serialize',
   withSlice,
  )
 import Cardano.Ledger.Block (Block, EraBlockHeader (..))
@@ -68,6 +70,7 @@ import Cardano.Ledger.Slot (SlotNo (..), isOverlaySlot)
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import Data.ByteString.Builder (Builder, shortByteString, toLazyByteString)
 import qualified Data.ByteString.Lazy as BSL
 import Data.Coerce (coerce)
@@ -106,6 +109,7 @@ instance EraBlockBody ShelleyEra where
   txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = sbbHash
   numSegComponents = 3
+  blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
 
 mkBasicBlockBodyShelley ::
   ( EraBlockBody era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Bbody.hs
@@ -76,6 +76,7 @@ import Control.State.Transition (
  )
 import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
+import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
 
@@ -258,8 +259,8 @@ validateBlockBodySize block protVer =
               }
         )
   where
-    actualSize = bBodySize protVer $ blockBody block
-    sizeInBlockHeader = fromIntegral $ block ^. blockBodySizeBlockHeaderL
+    actualSize = blockBodySize protVer $ blockBody block
+    sizeInBlockHeader = fromIntegral @Word32 @Int $ block ^. blockBodySizeBlockHeaderL
 
 -- | Validate that actual block body hash matches claimed hash in block header.
 validateBlockBodyHash ::

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1493,7 +1493,7 @@ tryTxsInBlock' txs finalState blockIssuer = do
     blockHeader =
       TestBlockHeader
         { tbhIssuer = blockIssuer
-        , tbhBSize = fromIntegral $ bBodySize (ProtVer (eraProtVerLow @era) 0) blockBody
+        , tbhBSize = fromIntegral $ blockBodySize (ProtVer (eraProtVerLow @era) 0) blockBody
         , tbhHSize = 0
         , tbhBHash = hashBlockBody blockBody
         , tbhSlot = slotNo

--- a/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
+++ b/eras/shelley/test-suite/cardano-ledger-shelley-test.cabal
@@ -87,7 +87,7 @@ library
     cardano-data >=1.2,
     cardano-ledger-binary:{cardano-ledger-binary, testlib} >=1.7,
     cardano-ledger-byron,
-    cardano-ledger-core:{cardano-ledger-core, tasty-compat, testlib} >=1.20,
+    cardano-ledger-core:{cardano-ledger-core, tasty-compat, testlib} >=1.21,
     cardano-ledger-shelley:{cardano-ledger-shelley, testlib} >=1.19,
     cardano-protocol-tpraos:{cardano-protocol-tpraos, testlib} >=1.4,
     cardano-slotting:{cardano-slotting, testlib},

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
@@ -146,9 +146,9 @@ genPParams c@Constants {maxTxFeePerByte, maxTxFeeFixed} = do
   where
     szGen :: Gen (Word32, Word32, Word16)
     szGen = do
-      blockBodySize <- choose (low, hi)
-      (blockBodySize,,)
-        <$> choose (blockBodySize, blockBodySize `div` 2)
+      bbSize <- choose (low, hi)
+      (bbSize,,)
+        <$> choose (bbSize, bbSize `div` 2)
         <*> choose (25000, maxBound :: Word16) -- Must stay in the range of Word16, but can't be too small
 
 -- Note: we keep the lower bound high enough so that we can more likely

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -13,6 +13,7 @@ module Test.Cardano.Ledger.Shelley.PropertyTests (
 ) where
 
 import Cardano.Ledger.BaseTypes (Globals, ShelleyBase, SlotNo)
+import Cardano.Ledger.Binary (EncCBORGroup)
 import Cardano.Ledger.Block (BbodySignal)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API (ApplyBlock, ShelleyEraForecast, ShelleyPOOL)
@@ -95,6 +96,7 @@ commonTests ::
   , EraRule "POOL" era ~ ShelleyPOOL era
   , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
   , InjectRuleEvent "POOL" PoolEvent era
+  , EncCBORGroup (BlockBody era)
   ) =>
   [TestTree]
 commonTests =

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Add `toPackageGolden` and `itGolden`
 * Add `goldenForToJSON`, `itGoldenToJSON`, `aesonGoldenSpec` and `roundTripAesonProperty`
 * Add `fullAnnCddlSpec`, `fullAnnGenCddlSpec`, `fullCddlSpec` and `fullGenCddlSpec`
+* Generalize the type of `genArrayTerm`
 * Add `TestBlockHeader` and `mkTestBlockHeaderNoNonce` as a replacement to deprecated `BHeaderView` and `makeHeaderView`.
 * Modify `ToExpr` instance for `Mismatch` to display type-level `r` parameter using `Typeable`
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Remove `ToCBOR` and `FromCBOR` instances for `PlutusWithContext`
   - Add `EncCBOR` and `DecCBOR` instances as replacement
 * Remove `ToCBOR (TxOut era)` superclass constraint from `EraTxOut`
+* Remove `EncCBORGroup (BlockBody era)` superclass constraint from `EraBlockBody`
+* Remove `bBodySize` in favour of the new `blockBodySize` method on `EraBlockBody`
 * Remove `validMetadatum`
 * Deprecate `BHeaderView` in favour `*EraBlockHeader` typeclasses.
   - Move `isOverlaySlot` to `Cardano.Ledger.Slot`.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -63,7 +63,6 @@ module Cardano.Ledger.Core (
   module Cardano.Ledger.Core.Era,
   -- $erablockbody
   EraBlockBody (..),
-  bBodySize,
 
   -- * Re-exports
   Addr (..),
@@ -626,7 +625,6 @@ class
   , Eq (BlockBody era)
   , Show (BlockBody era)
   , Typeable (BlockBody era)
-  , EncCBORGroup (BlockBody era)
   , DecCBOR (Annotator (BlockBody era))
   ) =>
   EraBlockBody era
@@ -645,8 +643,9 @@ class
   -- | The number of segregated components
   numSegComponents :: Word64
 
-bBodySize :: forall era. EraBlockBody era => ProtVer -> BlockBody era -> Int
-bBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
+  blockBodySize :: ProtVer -> BlockBody era -> Int
+  default blockBodySize :: EncCBORGroup (BlockBody era) => ProtVer -> BlockBody era -> Int
+  blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
 
 txIdTx :: EraTx era => Tx l era -> TxId
 txIdTx tx = txIdTxBody (tx ^. bodyTxL)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -94,14 +94,11 @@ import Cardano.Ledger.Binary (
   DecShareCBOR (Share),
   DecoderError,
   EncCBOR (..),
-  EncCBORGroup,
   Interns,
   Sized (sizedValue),
   ToCBOR,
-  encCBORGroup,
   mkSized,
   serialize,
-  serialize',
   translateViaCBORAnnotator,
  )
 import Cardano.Ledger.Coin (Coin)
@@ -644,8 +641,8 @@ class
   numSegComponents :: Word64
 
   blockBodySize :: ProtVer -> BlockBody era -> Int
-  default blockBodySize :: EncCBORGroup (BlockBody era) => ProtVer -> BlockBody era -> Int
-  blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
+  default blockBodySize :: SafeToHash (BlockBody era) => ProtVer -> BlockBody era -> Int
+  blockBodySize _ = originalBytesSize
 
 txIdTx :: EraTx era => Tx l era -> TxId
 txIdTx tx = txIdTxBody (tx ^. bodyTxL)

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -50,7 +50,7 @@ library
     cardano-ledger-babbage >=1.13.1,
     cardano-ledger-binary >=1.8,
     cardano-ledger-conway >=1.22,
-    cardano-ledger-core >=1.19,
+    cardano-ledger-core >=1.21,
     cardano-ledger-dijkstra >=0.3,
     cardano-ledger-mary >=1.10.1,
     cardano-ledger-shelley >=1.19,

--- a/libs/cardano-protocol-tpraos/test/Test/Cardano/Protocol/Binary/BinarySpec.hs
+++ b/libs/cardano-protocol-tpraos/test/Test/Cardano/Protocol/Binary/BinarySpec.hs
@@ -8,6 +8,7 @@ module Test.Cardano.Protocol.Binary.BinarySpec (spec) where
 
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Alonzo (AlonzoEra)
+import Cardano.Ledger.Binary (EncCBORGroup)
 import Cardano.Ledger.Block
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary (MaryEra)
@@ -38,6 +39,7 @@ blockEraSpec ::
   ( EraBlockBody era
   , Arbitrary (Tx TopTx era)
   , Arbitrary (BlockBody era)
+  , EncCBORGroup (BlockBody era)
   ) =>
   Spec
 blockEraSpec =

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
@@ -6,7 +6,7 @@
 
 module Test.Cardano.Protocol.Binary.RoundTrip (roundTripBlockSpec) where
 
-import Cardano.Ledger.Binary (Annotator, DecCBOR, EncCBOR)
+import Cardano.Ledger.Binary (Annotator, DecCBOR, EncCBOR, EncCBORGroup)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
 import Data.Typeable
@@ -26,6 +26,7 @@ roundTripBlockSpec ::
   , EraBlockBody era
   , Arbitrary (Block h era)
   , DecCBOR (BlockBody era)
+  , EncCBORGroup (BlockBody era)
   ) =>
   Spec
 roundTripBlockSpec =

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/TPraos/Create.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/TPraos/Create.hs
@@ -277,7 +277,7 @@ mkBlock ::
 mkBlock prev pKeys txns slotNo blockNo enonce kesPeriod keyRegKesPeriod oCert =
   let protVer = ProtVer (eraProtVerHigh @era) 0
       blockBody = mkBasicBlockBody & txSeqBlockBodyL .~ StrictSeq.fromList txns
-      bodySize = fromIntegral $ bBodySize protVer blockBody
+      bodySize = fromIntegral $ blockBodySize protVer blockBody
       bodyHash = hashBlockBody @era blockBody
       bhBody = mkBHBody protVer prev pKeys slotNo blockNo enonce oCert bodySize bodyHash
       blockHeader = mkBHeader pKeys kesPeriod keyRegKesPeriod bhBody
@@ -317,7 +317,7 @@ mkBlockFakeVRF ::
 mkBlockFakeVRF prev pKeys txns slotNo blockNo enonce bnonce l kesPeriod keyRegKesPeriod oCert =
   let protVer = ProtVer (eraProtVerHigh @era) 0
       blockBody = mkBasicBlockBody & txSeqBlockBodyL .~ StrictSeq.fromList txns
-      bodySize = fromIntegral $ bBodySize protVer blockBody
+      bodySize = fromIntegral $ blockBodySize protVer blockBody
       bodyHash = hashBlockBody blockBody
       bhBody =
         mkBHBodyFakeVRF bnonce l protVer prev pKeys slotNo blockNo enonce oCert bodySize bodyHash


### PR DESCRIPTION
# Description

This PR updates the CDDL for `block` to what is specified in CIP-0176. `DijkstraBlockBody` no longer uses segmented fields, now it only has fields for transactions, invalid transaction indices and one for praos certificate. This simplifies the memoization and hash computation of the block body significantly.

Resolves #5380 

Related to https://github.com/cardano-foundation/CIPs/tree/master/CIP-0176

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
