### PR TITLE
Fix DecCBOR instances to reject `ProtVer` values exceeding the era maximum

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Fix `ex_unit_prices` CDDL to use `nonnegative_interval` instead of `positive_interval`
 * Remove `ToCBOR` and `FromCBOR` instances for `AlonzoExtraConfig` and `AlonzoTxOut`
 * Add `ApplyTick` instance for `AlonzoEra`
 * Add `mkPlutusTxInfoFromResult` and `toPlutusTxInfoForPurpose` helpers

--- a/eras/alonzo/impl/cddl/data/alonzo.cddl
+++ b/eras/alonzo/impl/cddl/data/alonzo.cddl
@@ -316,9 +316,8 @@ min_int64 = -9223372036854775808
 
 max_int64 = 9223372036854775807
 
-ex_unit_prices = [mem_price : positive_interval, step_price : positive_interval]
-
-positive_interval = #6.30([positive_int, positive_int])
+ex_unit_prices = 
+  [mem_price : nonnegative_interval, step_price : nonnegative_interval]
 
 ex_units = [mem : 0 .. max_int64, steps : 0 .. max_int64]
 

--- a/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
+++ b/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
@@ -107,12 +107,12 @@ boundedBytesRule pname =
 
 exUnitPricesRule ::
   forall era.
-  HuddleRule "positive_interval" era => Proxy "ex_unit_prices" -> Proxy era -> Rule
+  HuddleRule "nonnegative_interval" era => Proxy "ex_unit_prices" -> Proxy era -> Rule
 exUnitPricesRule pname p =
   pname
     =.= arr
-      [ "mem_price" ==> huddleRule @"positive_interval" p
-      , "step_price" ==> huddleRule @"positive_interval" p
+      [ "mem_price" ==> huddleRule @"nonnegative_interval" p
+      , "step_price" ==> huddleRule @"nonnegative_interval" p
       ]
 
 requiredSignersRule ::

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -660,6 +660,7 @@ ppCoinsPerUTxOWord =
   PParam
     { ppName = "utxoCostPerByte"
     , ppLens = ppCoinsPerUTxOWordL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 17 ppuCoinsPerUTxOWordL
     }
 
@@ -668,6 +669,7 @@ ppCostModels =
   PParam
     { ppName = "costModels"
     , ppLens = ppCostModelsL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 18 ppuCostModelsL
     }
 
@@ -676,6 +678,7 @@ ppPrices =
   PParam
     { ppName = "executionUnitPrices"
     , ppLens = ppPricesL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 19 ppuPricesL
     }
 
@@ -684,6 +687,7 @@ ppMaxTxExUnits =
   PParam
     { ppName = "maxTxExecutionUnits"
     , ppLens = ppMaxTxExUnitsL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 20 ppuMaxTxExUnitsL
     }
 
@@ -692,6 +696,7 @@ ppMaxBlockExUnits =
   PParam
     { ppName = "maxBlockExecutionUnits"
     , ppLens = ppMaxBlockExUnitsL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 21 ppuMaxBlockExUnitsL
     }
 
@@ -700,6 +705,7 @@ ppMaxValSize =
   PParam
     { ppName = "maxValueSize"
     , ppLens = ppMaxValSizeL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 22 ppuMaxValSizeL
     }
 
@@ -708,6 +714,7 @@ ppCollateralPercentage =
   PParam
     { ppName = "collateralPercentage"
     , ppLens = ppCollateralPercentageL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 23 ppuCollateralPercentageL
     }
 
@@ -716,5 +723,6 @@ ppMaxCollateralInputs =
   PParam
     { ppName = "maxCollateralInputs"
     , ppLens = ppMaxCollateralInputsL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 24 ppuMaxCollateralInputsL
     }

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -98,6 +98,7 @@ import Numeric.Natural (Natural)
 import Test.Cardano.Data (genNonEmptyMap)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Arbitrary (
+  genEraProtVer,
   genValidAndUnknownCostModels,
   genValidCostModel,
   genValidCostModels,
@@ -247,7 +248,7 @@ genPlutusScript lang =
     , (5, alwaysFailsLang lang <$> elements [1, 2, 3])
     ]
 
-instance Arbitrary (AlonzoPParams Identity era) where
+instance Era era => Arbitrary (AlonzoPParams Identity era) where
   arbitrary =
     AlonzoPParams
       <$> arbitrary
@@ -264,7 +265,7 @@ instance Arbitrary (AlonzoPParams Identity era) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> genEraProtVer @era
       <*> arbitrary
       <*> arbitrary
       <*> genValidCostModels [PlutusV1, PlutusV2]
@@ -277,7 +278,7 @@ instance Arbitrary (AlonzoPParams Identity era) where
 
 deriving instance Arbitrary OrdExUnits
 
-instance Arbitrary (AlonzoPParams StrictMaybe era) where
+instance Era era => Arbitrary (AlonzoPParams StrictMaybe era) where
   arbitrary =
     AlonzoPParams
       <$> arbitrary
@@ -294,7 +295,7 @@ instance Arbitrary (AlonzoPParams StrictMaybe era) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> oneof [pure SNothing, SJust <$> genEraProtVer @era]
       <*> arbitrary
       <*> arbitrary
       <*> oneof [pure SNothing, SJust <$> genValidCostModels [PlutusV1, PlutusV2]]

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Fix `ex_unit_prices` CDDL to use `nonnegative_interval` instead of `positive_interval`
 * Remove `ToCBOR` and `FromCBOR` instances for `BabbageTxOut`
 * Add `ApplyTick` instance for `BabbageEra`
 * `BabbageTxInfoResult` changed its content type to `PlutusTxInfoResult`

--- a/eras/babbage/impl/cddl/data/babbage.cddl
+++ b/eras/babbage/impl/cddl/data/babbage.cddl
@@ -407,9 +407,8 @@ max_word64 = 18446744073709551615
 
 cost_models = {? 0 : [166*166 int64], ? 1 : [175*175 int64]}
 
-ex_unit_prices = [mem_price : positive_interval, step_price : positive_interval]
-
-positive_interval = #6.30([positive_int, positive_int])
+ex_unit_prices = 
+  [mem_price : nonnegative_interval, step_price : nonnegative_interval]
 
 ex_units = [mem : 0 .. max_int64, steps : 0 .. max_int64]
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -407,5 +407,6 @@ ppCoinsPerUTxOByte =
   PParam
     { ppName = "utxoCostPerByte"
     , ppLens = ppCoinsPerUTxOByteL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 17 ppuCoinsPerUTxOByteL
     }

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Arbitrary.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -24,10 +25,10 @@ import Control.State.Transition (STS (PredicateFailure))
 import Data.Functor.Identity (Identity)
 import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Alonzo.Arbitrary ()
-import Test.Cardano.Ledger.Core.Arbitrary (genValidCostModels)
+import Test.Cardano.Ledger.Core.Arbitrary (genEraProtVer, genValidCostModels)
 import Test.QuickCheck
 
-instance Arbitrary (BabbagePParams Identity era) where
+instance Era era => Arbitrary (BabbagePParams Identity era) where
   arbitrary =
     BabbagePParams
       <$> arbitrary
@@ -42,7 +43,7 @@ instance Arbitrary (BabbagePParams Identity era) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> genEraProtVer @era
       <*> arbitrary
       <*> arbitrary
       <*> genValidCostModels [PlutusV1, PlutusV2]
@@ -53,7 +54,7 @@ instance Arbitrary (BabbagePParams Identity era) where
       <*> arbitrary
       <*> arbitrary
 
-instance Arbitrary (BabbagePParams StrictMaybe era) where
+instance Era era => Arbitrary (BabbagePParams StrictMaybe era) where
   arbitrary =
     BabbagePParams
       <$> arbitrary
@@ -68,7 +69,7 @@ instance Arbitrary (BabbagePParams StrictMaybe era) where
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
+      <*> oneof [pure SNothing, SJust <$> genEraProtVer @era]
       <*> arbitrary
       <*> arbitrary
       <*> oneof [pure SNothing, SJust <$> genValidCostModels [PlutusV1, PlutusV2]]

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -90,6 +90,7 @@ import Cardano.Ledger.BaseTypes (
   ProtVer,
   ToKeyValuePairs (..),
   UnitInterval,
+  decodeProtVer,
   maybeToStrictMaybe,
  )
 import Cardano.Ledger.Binary (
@@ -860,7 +861,10 @@ instance EraPParams era => DecCBOR (GovAction era) where
           <! D (decodeNullStrictMaybe decCBOR)
           <! From
           <! D (decodeNullStrictMaybe decCBOR)
-      1 -> SumD HardForkInitiation <! D (decodeNullStrictMaybe decCBOR) <! From
+      1 ->
+        SumD HardForkInitiation
+          <! D (decodeNullStrictMaybe decCBOR)
+          <! D (decodeProtVer @era)
       2 -> SumD TreasuryWithdrawals <! From <! D (decodeNullStrictMaybe decCBOR)
       3 -> SumD NoConfidence <! D (decodeNullStrictMaybe decCBOR)
       4 -> SumD UpdateCommittee <! D (decodeNullStrictMaybe decCBOR) <! From <! From <! From

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs
@@ -1267,6 +1267,7 @@ ppPoolVotingThresholds =
   PParam
     { ppName = "poolVotingThresholds"
     , ppLens = ppPoolVotingThresholdsL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 25 ppuPoolVotingThresholdsL
     }
 
@@ -1275,6 +1276,7 @@ ppDRepVotingThresholds =
   PParam
     { ppName = "dRepVotingThresholds"
     , ppLens = ppDRepVotingThresholdsL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 26 ppuDRepVotingThresholdsL
     }
 
@@ -1283,6 +1285,7 @@ ppCommitteeMinSize =
   PParam
     { ppName = "committeeMinSize"
     , ppLens = ppCommitteeMinSizeL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 27 ppuCommitteeMinSizeL
     }
 
@@ -1291,6 +1294,7 @@ ppCommitteeMaxTermLength =
   PParam
     { ppName = "committeeMaxTermLength"
     , ppLens = ppCommitteeMaxTermLengthL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 28 ppuCommitteeMaxTermLengthL
     }
 
@@ -1299,6 +1303,7 @@ ppGovActionLifetime =
   PParam
     { ppName = "govActionLifetime"
     , ppLens = ppGovActionLifetimeL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 29 ppuGovActionLifetimeL
     }
 
@@ -1307,6 +1312,7 @@ ppGovActionDeposit =
   PParam
     { ppName = "govActionDeposit"
     , ppLens = ppGovActionDepositCompactL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 30 ppuGovActionDepositCompactL
     }
 
@@ -1315,6 +1321,7 @@ ppDRepDeposit =
   PParam
     { ppName = "dRepDeposit"
     , ppLens = ppDRepDepositCompactL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 31 ppuDRepDepositCompactL
     }
 
@@ -1323,6 +1330,7 @@ ppDRepActivity =
   PParam
     { ppName = "dRepActivity"
     , ppLens = ppDRepActivityL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 32 ppuDRepActivityL
     }
 
@@ -1331,6 +1339,7 @@ ppMinFeeRefScriptCostPerByte =
   PParam
     { ppName = "minFeeRefScriptCostPerByte"
     , ppLens = ppMinFeeRefScriptCostPerByteL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 33 ppuMinFeeRefScriptCostPerByteL
     }
 
@@ -1339,5 +1348,6 @@ ppGovProtocolVersion =
   PParam
     { ppName = "protocolVersion"
     , ppLens = ppProtocolVersionL
+    , ppEraDecoder = Nothing
     , ppUpdate = Nothing
     }

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -37,7 +37,7 @@ module Test.Cardano.Ledger.Conway.Arbitrary (
 ) where
 
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (CollectError)
-import Cardano.Ledger.BaseTypes (ProtVer (..), StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Conway (ApplyTxError (ConwayApplyTxError), ConwayEra, Tx (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Genesis (ConwayGenesis (..))
@@ -76,7 +76,7 @@ import Test.Cardano.Ledger.Alonzo.Arbitrary (genValidAndUnknownCostModels, genVa
 import Test.Cardano.Ledger.Babbage.Arbitrary ()
 import Test.Cardano.Ledger.Binary.Random (QC (..))
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Arbitrary (uniformSubMap)
+import Test.Cardano.Ledger.Core.Arbitrary (genEraProtVer, uniformSubMap)
 
 instance
   (Era era, Arbitrary (PParamsUpdate era)) =>
@@ -453,9 +453,11 @@ genPParamUpdateGovAction ::
 genPParamUpdateGovAction parent = ParameterChange parent <$> arbitrary <*> arbitrary
 
 genHardForkGovAction ::
+  forall era.
+  Era era =>
   StrictMaybe (GovPurposeId 'HardForkPurpose) ->
   Gen (GovAction era)
-genHardForkGovAction parent = HardForkInitiation parent <$> arbitrary
+genHardForkGovAction parent = HardForkInitiation parent <$> genEraProtVer @era
 
 genCommitteeGovAction ::
   StrictMaybe (GovPurposeId 'CommitteePurpose) ->
@@ -506,10 +508,7 @@ genParameterChange :: Arbitrary (PParamsUpdate era) => Gen (GovAction era)
 genParameterChange = ParameterChange <$> arbitrary <*> arbitrary <*> arbitrary
 
 genHardForkInitiation :: forall era. Era era => Gen (GovAction era)
-genHardForkInitiation =
-  HardForkInitiation
-    <$> arbitrary
-    <*> (ProtVer <$> elements [eraProtVerLow @era .. succ $ eraProtVerHigh @era] <*> arbitrary)
+genHardForkInitiation = genHardForkGovAction @era =<< arbitrary
 
 genTreasuryWithdrawals :: Gen (GovAction era)
 genTreasuryWithdrawals = TreasuryWithdrawals <$> arbitrary <*> arbitrary

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
@@ -462,6 +462,7 @@ ppMaxRefScriptSizePerBlock =
   PParam
     { ppName = "maxRefScriptSizePerBlock"
     , ppLens = ppMaxRefScriptSizePerBlockL
+    , ppEraDecoder = Nothing
     , ppUpdate =
         Just
           PParamUpdate
@@ -475,6 +476,7 @@ ppMaxRefScriptSizePerTx =
   PParam
     { ppName = "maxRefScriptSizePerTx"
     , ppLens = ppMaxRefScriptSizePerTxL
+    , ppEraDecoder = Nothing
     , ppUpdate =
         Just
           PParamUpdate
@@ -488,6 +490,7 @@ ppRefScriptCostStride =
   PParam
     { ppName = "refScriptCostStride"
     , ppLens = ppRefScriptCostStrideL
+    , ppEraDecoder = Nothing
     , ppUpdate =
         Just
           PParamUpdate
@@ -501,6 +504,7 @@ ppRefScriptCostMultiplier =
   PParam
     { ppName = "refScriptCostMultiplier"
     , ppLens = ppRefScriptCostMultiplierL
+    , ppEraDecoder = Nothing
     , ppUpdate =
         Just
           PParamUpdate

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -16,6 +16,7 @@ import Cardano.Ledger.Dijkstra.HuddleSpec (dijkstraCDDL)
 import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceInterval, AccountBalanceIntervals)
 import Cardano.Ledger.Plutus.Data (Data, Datum)
 import Test.Cardano.Ledger.Binary.Cuddle (
+  huddleAntiCborSpec,
   huddleDecoderEquivalenceSpec,
   huddleRoundTripAnnCborSpec,
   huddleRoundTripArbitraryValidate,
@@ -72,6 +73,7 @@ spec = do
       huddleRoundTripArbitraryValidate @(TxWits DijkstraEra) v "transaction_witness_set"
       huddleRoundTripCborSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
       huddleRoundTripArbitraryValidate @(PParamsUpdate DijkstraEra) v "protocol_param_update"
+      huddleAntiCborSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
       huddleRoundTripCborSpec @CostModels v "cost_models"
       huddleRoundTripArbitraryValidate @CostModels v "cost_models"
       huddleRoundTripAnnCborSpec @(Redeemers DijkstraEra) v "redeemers"

--- a/eras/shelley/impl/golden/pparams-update.json
+++ b/eras/shelley/impl/golden/pparams-update.json
@@ -1,16 +1,18 @@
 {
-    "decentralization": 0.79,
-    "extraPraosEntropy": null,
-    "maxBlockBodySize": 292445202,
-    "maxBlockHeaderSize": 53249,
-    "minPoolCost": 794548,
-    "monetaryExpansion": 0.8855156,
-    "poolPledgeInfluence": 3.8777413926852632e7,
-    "poolRetireMaxEpoch": 2414041002,
-    "stakeAddressDeposit": 9604294329594137974,
-    "stakePoolDeposit": 4729380140346080457,
-    "stakePoolTargetNum": 52993,
-    "treasuryCut": 0.3,
-    "txFeeFixed": 29,
-    "txFeePerByte": 360044
+    "decentralization": 0.68265,
+    "extraPraosEntropy": "0eecc0f627fcac2a4b9bb53d3661496f9f0ab83d860653945f64708094344d57",
+    "maxBlockBodySize": 938825652,
+    "maxBlockHeaderSize": 7400,
+    "maxTxSize": 1863034707,
+    "minUTxOValue": 851497,
+    "monetaryExpansion": 0.78,
+    "poolRetireMaxEpoch": 3903347188,
+    "protocolVersion": {
+        "major": 2,
+        "minor": 46
+    },
+    "stakePoolDeposit": 751882,
+    "stakePoolTargetNum": 31910,
+    "treasuryCut": 2.3e-3,
+    "txFeePerByte": 4197483115719285921
 }

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/PParams.hs
@@ -62,6 +62,7 @@ import Cardano.Ledger.BaseTypes (
   ProtVer (..),
   StrictMaybe (..),
   UnitInterval,
+  decodeProtVer,
   succVersion,
  )
 import Cardano.Ledger.Binary (
@@ -339,6 +340,7 @@ ppTxFeePerByte =
   PParam
     { ppName = "txFeePerByte"
     , ppLens = ppTxFeePerByteL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 0 ppuTxFeePerByteL
     }
 
@@ -351,6 +353,7 @@ ppTxFeeFixed =
   PParam
     { ppName = "txFeeFixed"
     , ppLens = ppTxFeeFixedCompactL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 1 ppuTxFeeFixedCompactL
     }
 
@@ -363,6 +366,7 @@ ppMaxBBSize =
   PParam
     { ppName = "maxBlockBodySize"
     , ppLens = ppMaxBBSizeL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 2 ppuMaxBBSizeL
     }
 
@@ -371,6 +375,7 @@ ppMaxTxSize =
   PParam
     { ppName = "maxTxSize"
     , ppLens = ppMaxTxSizeL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 3 ppuMaxTxSizeL
     }
 
@@ -379,6 +384,7 @@ ppMaxBHSize =
   PParam
     { ppName = "maxBlockHeaderSize"
     , ppLens = ppMaxBHSizeL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 4 ppuMaxBHSizeL
     }
 
@@ -387,6 +393,7 @@ ppKeyDeposit =
   PParam
     { ppName = "stakeAddressDeposit"
     , ppLens = ppKeyDepositCompactL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 5 ppuKeyDepositCompactL
     }
 
@@ -395,6 +402,7 @@ ppPoolDeposit =
   PParam
     { ppName = "stakePoolDeposit"
     , ppLens = ppPoolDepositCompactL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 6 ppuPoolDepositCompactL
     }
 
@@ -403,6 +411,7 @@ ppEMax =
   PParam
     { ppName = "poolRetireMaxEpoch"
     , ppLens = ppEMaxL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 7 ppuEMaxL
     }
 
@@ -411,6 +420,7 @@ ppNOpt =
   PParam
     { ppName = "stakePoolTargetNum"
     , ppLens = ppNOptL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 8 ppuNOptL
     }
 
@@ -419,6 +429,7 @@ ppA0 =
   PParam
     { ppName = "poolPledgeInfluence"
     , ppLens = ppA0L
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 9 ppuA0L
     }
 
@@ -427,6 +438,7 @@ ppRho =
   PParam
     { ppName = "monetaryExpansion"
     , ppLens = ppRhoL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 10 ppuRhoL
     }
 
@@ -435,6 +447,7 @@ ppTau =
   PParam
     { ppName = "treasuryCut"
     , ppLens = ppTauL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 11 ppuTauL
     }
 
@@ -443,6 +456,7 @@ ppD =
   PParam
     { ppName = "decentralization"
     , ppLens = ppDL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 12 ppuDL
     }
 
@@ -451,14 +465,16 @@ ppExtraEntropy =
   PParam
     { ppName = "extraPraosEntropy"
     , ppLens = ppExtraEntropyL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 13 ppuExtraEntropyL
     }
 
-ppProtocolVersion :: (EraPParams era, AtMostEra "Babbage" era) => PParam era
+ppProtocolVersion :: forall era. (EraPParams era, AtMostEra "Babbage" era) => PParam era
 ppProtocolVersion =
   PParam
     { ppName = "protocolVersion"
     , ppLens = ppProtocolVersionL
+    , ppEraDecoder = Just (EraDecoder (decodeProtVer @era))
     , ppUpdate = Just $ PParamUpdate 14 ppuProtocolVersionL
     }
 
@@ -467,6 +483,7 @@ ppMinUTxOValue =
   PParam
     { ppName = "minUTxOValue"
     , ppLens = ppMinUTxOValueCompactL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 15 ppuMinUTxOValueCompactL
     }
 
@@ -475,6 +492,7 @@ ppMinPoolCost =
   PParam
     { ppName = "minPoolCost"
     , ppLens = ppMinPoolCostCompactL
+    , ppEraDecoder = Nothing
     , ppUpdate = Just $ PParamUpdate 16 ppuMinPoolCostCompactL
     }
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -95,7 +95,7 @@ import Test.Cardano.Base.Bytes (genByteArray)
 import Test.Cardano.Chain.UTxO.Gen (genCompactTxOut)
 import Test.Cardano.Data.Arbitrary ()
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Arbitrary ()
+import Test.Cardano.Ledger.Core.Arbitrary (genEraProtVer)
 import Test.Cardano.Ledger.Core.Utils (unsafeBoundRational)
 import Test.QuickCheck.Hedgehog (hedgehog)
 
@@ -104,11 +104,17 @@ import Test.QuickCheck.Hedgehog (hedgehog)
 ------------------------------------------------------------------------------------------
 
 instance Era era => Arbitrary (ShelleyPParams Identity era) where
-  arbitrary = genericArbitraryU
+  arbitrary = do
+    p <- genericArbitraryU @(ShelleyPParams Identity era)
+    pv <- genEraProtVer @era
+    pure (p {sppProtocolVersion = pv})
   shrink = genericShrink
 
 instance Era era => Arbitrary (ShelleyPParams StrictMaybe era) where
-  arbitrary = genericArbitraryU
+  arbitrary = do
+    p <- genericArbitraryU @(ShelleyPParams StrictMaybe era)
+    pv <- oneof [pure SNothing, SJust <$> genEraProtVer @era]
+    pure (p {sppProtocolVersion = pv})
   shrink = genericShrink
 
 instance (Era era, Arbitrary (PParamsUpdate era)) => Arbitrary (ProposedPPUpdates era) where

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Add `decodeIntegralRational`
 * Add `decodeNonEmptySetLikeEnforceNoDuplicates`
 * Change `decodeIPv4`, `decodeIPv6`, `encodeIPv4`, `encodeIPv6`, `ipv4ToBytes`, `ipv6ToBytes` to work on `Cardano.Base.IP.IPv4/IPv6`
 * Remove default implementation for `DecCBOR` class

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -16,6 +17,7 @@ module Cardano.Ledger.Binary.Decoding.DecCBOR (
   DecCBOR (..),
   fromByronCBOR,
   decodeScriptContextFromData,
+  decodeIntegralRational,
 ) where
 
 import qualified Cardano.Binary as Plain (Decoder)
@@ -64,6 +66,7 @@ import Data.ByteString.Short (ShortByteString(SBS))
 import Data.ByteString.Short.Internal (ShortByteString(SBS))
 #endif
 import Cardano.Base.IP (IPv4, IPv6)
+import Control.Monad (when)
 import Data.Fixed (Fixed (..))
 import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.IntMap as IntMap
@@ -71,6 +74,7 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import qualified Data.Maybe.Strict as SMaybe
 import qualified Data.Primitive.ByteArray as Prim
+import Data.Ratio ((%))
 import qualified Data.Sequence as Seq
 import qualified Data.Sequence.Strict as SSeq
 import qualified Data.Set as Set
@@ -206,6 +210,17 @@ instance DecCBOR IPv4 where
 instance DecCBOR IPv6 where
   decCBOR = decodeIPv6
   {-# INLINE decCBOR #-}
+
+decodeIntegralRational :: forall a s. (DecCBOR a, Integral a) => Decoder s Rational
+decodeIntegralRational = do
+  assertTag 30
+  values <- decodeList (decCBOR @a)
+  case values of
+    [n, d] -> do
+      when (d == 0) $ fail "Denominator cannot be zero"
+      pure $! toInteger n % toInteger d
+    xs ->
+      cborError $ DecoderErrorSizeMismatch "Rational" 2 (length xs)
 
 --------------------------------------------------------------------------------
 -- Tagged

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.21.0.0
 
+* Add `decodeProtVer` to `Cardano.Ledger.BaseTypes`
+* Add `EraDecoder` type and `ppEraDecoder` field to `PParam`
+* Fix `DecCBOR` instance for `PParamsUpdate` to reject `ProtVer` values exceeding the era maximum
 * Remove `ToCBOR` and `FromCBOR` instances for `TxIx`, `CertIx`, `SlotNo32`, `Ptr`, `VRFVerKeyHash`, `SafeHash`, `VoidEraRule`, `Language`, `SLanguage`
 * Remove `FromCBOR` instances for `ScriptHash`, `ChainCode`, `PlutusBinary`, `BootstrapWitness`, `WitVKey`
 * Remove `ToCBOR` and `FromCBOR` instances for `PlutusWithContext`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
@@ -26,6 +27,7 @@ module Cardano.Ledger.BaseTypes (
   module Slotting,
   module NonZero,
   ProtVer (..),
+  decodeProtVer,
   module Cardano.Ledger.Binary.Version,
   FixedPoint,
   (==>),
@@ -111,6 +113,7 @@ import Cardano.Ledger.Binary (
   FromCBOR,
   ToCBOR,
   cborError,
+  decodeIntegralRational,
   encodeListLen,
   fromPlainDecoder,
   ifDecoderVersionAtLeast,
@@ -130,6 +133,7 @@ import Cardano.Ledger.Binary.Plain (
  )
 import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Binary.Version
+import Cardano.Ledger.Core.Era (Era (..))
 import Cardano.Ledger.Hashes (HashAnnotated, SafeHash, SafeToHash)
 import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.NonIntegral (ln')
@@ -239,6 +243,25 @@ instance DecCBORGroup ProtVer where
         (natVersion @12)
         (fromIntegral @Word32 @Natural <$> decCBOR @Word32)
         (decCBOR @Natural)
+
+-- | Decoder for `ProtVer` that only accepts versions where the major fits in
+-- the bounds of what's allowed for the provided Era.
+--
+-- /Note/ - Thanks to the Ledger rules, only the current major protocol version
+-- and the very next major protocol version from the current one will be accepted
+-- by the Ledger anywhere in the block, regardless that this decoder allows a
+-- broader range.
+decodeProtVer :: forall era s. Era era => Decoder s ProtVer
+decodeProtVer = do
+  maxMajorVersion <- succVersion (natVersion @(ProtVerHigh era))
+  pv@(ProtVer major _) <- decCBOR
+  when (major > maxMajorVersion) $
+    fail $
+      "Protocol version "
+        <> show major
+        <> " exceeds the maximum expected version of "
+        <> show maxMajorVersion
+  pure pv
 
 data E34
 
@@ -382,11 +405,27 @@ instance
 instance (ToCBOR (BoundedRatio b a), Typeable b, Typeable a) => EncCBOR (BoundedRatio b a)
 
 instance
-  (FromCBOR (BoundedRatio b a), Typeable b, Typeable a, Typeable (BoundedRatio b a)) =>
+  ( FromCBOR (BoundedRatio b a)
+  , Bounded (BoundedRatio b a)
+  , Bounded a
+  , Integral a
+  , DecCBOR a
+  , Typeable b
+  , Typeable a
+  , Typeable (BoundedRatio b a)
+  ) =>
   DecCBOR (BoundedRatio b a)
   where
-  decCBOR = fromPlainDecoder fromCBOR
-  {-# INLINE decCBOR #-}
+  decCBOR =
+    ifDecoderVersionAtLeast
+      (natVersion @12)
+      ( do
+          r <- decodeIntegralRational @a
+          case boundRational r of
+            Nothing -> cborError $ DecoderErrorCustom "BoundedRatio" (Text.pack $ show r)
+            Just u -> pure u
+      )
+      (fromPlainDecoder fromCBOR)
 
 instance Bounded (BoundedRatio b Word64) => ToJSON (BoundedRatio b Word64) where
   toJSON :: BoundedRatio b Word64 -> Value

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/PParams.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Core.PParams (
   PParams (..),
   PParam (..),
   PParamUpdate (..),
+  EraDecoder (..),
   emptyPParams,
   PParamsUpdate (..),
   emptyPParamsUpdate,
@@ -109,6 +110,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
+  Decoder,
   EncCBOR (..),
   FromCBOR (..),
   ToCBOR (..),
@@ -117,7 +119,7 @@ import Cardano.Ledger.Binary (
   encodeMapLen,
   encodeWord,
  )
-import Cardano.Ledger.Binary.Coders (Decode (..), Field, decode, field, invalidField)
+import Cardano.Ledger.Binary.Coders (Decode (..), Field (..), decode, field, invalidField)
 import Cardano.Ledger.Coin (
   Coin (..),
   CoinPerByte (..),
@@ -128,7 +130,13 @@ import Cardano.Ledger.Coin (
   partialCompactCoinL,
  )
 import Cardano.Ledger.Compactible (Compactible (..), partialCompactFL)
-import Cardano.Ledger.Core.Era (AtMostEra, Era (..), PreviousEra, fromEraCBOR, toEraCBOR)
+import Cardano.Ledger.Core.Era (
+  AtMostEra,
+  Era (..),
+  PreviousEra,
+  fromEraCBOR,
+  toEraCBOR,
+ )
 import Cardano.Ledger.HKD (HKD, HKDApplicative, HKDFunctor (..), NoUpdate (..))
 import Cardano.Ledger.Plutus.ToPlutusData (ToPlutusData (..))
 import Control.DeepSeq (NFData)
@@ -259,9 +267,17 @@ instance EraPParams era => DecCBOR (PParamsUpdate era) where
       updateFieldMap :: IntMap (Field (PParamsUpdate era))
       updateFieldMap =
         IntMap.fromList
-          [ (fromIntegral ppuTag, field (set ppuLens . SJust) From)
-          | PParam {ppUpdate = Just PParamUpdate {ppuTag, ppuLens}} <- eraPParams @era
+          [ (fromIntegral ppuTag, mkField ppEraDecoder ppuLens)
+          | PParam {ppEraDecoder, ppUpdate = Just PParamUpdate {ppuTag, ppuLens}} <- eraPParams @era
           ]
+      mkField ::
+        forall t.
+        DecCBOR t =>
+        Maybe (EraDecoder t) ->
+        Lens' (PParamsUpdate era) (StrictMaybe t) ->
+        Field (PParamsUpdate era)
+      mkField Nothing ppuLens = field (set ppuLens . SJust) From
+      mkField (Just (EraDecoder d)) ppuLens = Field (set ppuLens . SJust) d
 
 instance EraPParams era => ToCBOR (PParamsUpdate era) where
   toCBOR = toEraCBOR @era
@@ -749,6 +765,11 @@ downgradePParamsUpdate ::
 downgradePParamsUpdate args (PParamsUpdate pphkd) =
   PParamsUpdate (downgradePParamsHKD @_ @StrictMaybe args pphkd)
 
+-- | A CBOR decoder with universally quantified state type, suitable for
+-- storage inside a GADT. Used when a protocol parameter needs an era-aware
+-- decoder instead of the default 'decCBOR'.
+newtype EraDecoder t = EraDecoder (forall s. Decoder s t)
+
 -- | Represents a single protocol parameter and the data required to serialize it.
 data PParam era where
   PParam ::
@@ -756,6 +777,9 @@ data PParam era where
     { ppName :: Text
     -- ^ Used as JSON key
     , ppLens :: Lens' (PParams era) t
+    , ppEraDecoder :: Maybe (EraDecoder t)
+    -- ^ When present, this decoder will be used instead of 'decCBOR', which is
+    -- helpful when a decoder needs access to the @era@ parameter, like 'ProtVer'.
     , ppUpdate :: Maybe (PParamUpdate era t)
     -- ^ Not all protocol parameters have an update functionality in all eras
     } ->

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -32,6 +32,9 @@ module Test.Cardano.Ledger.Core.Arbitrary (
   uniformSubSet,
   uniformSubMap,
   uniformSubMapElems,
+
+  -- * Era-aware generators
+  genEraProtVer,
 ) where
 
 import qualified Cardano.Chain.Common as Byron
@@ -261,6 +264,13 @@ instance Arbitrary CertIx where
 
 instance Arbitrary ProtVer where
   arbitrary = ProtVer <$> arbitrary <*> arbitrary
+
+-- | Generate a 'ProtVer' whose major version falls within the era's accepted range.
+genEraProtVer :: forall era. Era era => Gen ProtVer
+genEraProtVer =
+  ProtVer
+    <$> elements [eraProtVerLow @era .. succ (eraProtVerHigh @era)]
+    <*> arbitrary
 
 instance Arbitrary Nonce where
   arbitrary =


### PR DESCRIPTION
# Description

fix #5707, fix #5646, fix #5631 

Re-enable some tests that were disabled due to CDDL mismatches:
- the Alonzo and Babbage CDDL used `positive_interval` instead of `nonnegative_interval` when decoding `Price`s, unlike Conway
- the `ProtVer` in `HardForkInitiation` and `PParamsUpdate` could be higher than the maximum for the era. We now prevent that explicitly in the `DecCBOR` instances.

All the reproducers listed in the tickets mentioned above pass with this patch.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
