### PR TITLE
Refactor gov/proposals/v0 namespace to include the proposals order

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -104,8 +104,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
-  --sha256: sha256-DSftURPyJsLdW16EGNhUX/+FuGL2CGHMiz497OOBm6A=
-  tag: 6442f9d8512eeeadc8edbc3d064ff198084f66a0
+  --sha256: sha256-02j6m1UBYiZrdgAzGFb5yO+tFf8pN6DmykZjk9tdOUg=
+  tag: 940f6ad992382e856082f73c437a162211e50ba8
 
 constraints:
   -- Happy version 2.2.1 fails to compile haskell-src-exts

--- a/cabal.project
+++ b/cabal.project
@@ -104,8 +104,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
-  --sha256: sha256-02j6m1UBYiZrdgAzGFb5yO+tFf8pN6DmykZjk9tdOUg=
-  tag: 940f6ad992382e856082f73c437a162211e50ba8
+  --sha256: sha256-RFJKaPudu+Iog+CJQM1XwCXPpaadrq7zkdUtr96nI2Y=
+  tag: ba6dae91820425e53a65858aee495de23aa87ce5
 
 constraints:
   -- Happy version 2.2.1 fails to compile haskell-src-exts

--- a/cabal.project
+++ b/cabal.project
@@ -104,8 +104,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
-  --sha256: sha256-BoAotLgxMipOIMcZrmlr6EtQzqC5HyEA0ZpK8nvCmJs=
-  tag: 5161deb34247a51160f2e8d58b6cc2d48044ea2c
+  --sha256: sha256-DSftURPyJsLdW16EGNhUX/+FuGL2CGHMiz497OOBm6A=
+  tag: 6442f9d8512eeeadc8edbc3d064ff198084f66a0
 
 constraints:
   -- Happy version 2.2.1 fails to compile haskell-src-exts

--- a/cabal.project
+++ b/cabal.project
@@ -104,8 +104,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
-  --sha256: sha256-royx20JbIku5U6/mybyt8jk30f4uV0U8IrCgzV2hDM8=
-  tag: 346e145996629bab539c480b73209d2090ecdec6
+  --sha256: sha256-eA30oxMOyrmMkXGDZA6M6niE7nFBo420RVq8WLGMiLQ=
+  tag: 30bb9316d8929a570e52a04337fef8ab134a5fb2
 
 constraints:
   -- Happy version 2.2.1 fails to compile haskell-src-exts

--- a/libs/cardano-ledger-canonical-state/conway/Cardano/Ledger/CanonicalState/Conway.hs
+++ b/libs/cardano-ledger-canonical-state/conway/Cardano/Ledger/CanonicalState/Conway.hs
@@ -57,7 +57,7 @@ import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Encoding as E
 import Data.Map (Map)
 import Data.Text (Text)
-import Data.Word (Word8)
+import Data.Word (Word64, Word8)
 import Lens.Micro
 
 type instance NamespaceEra "blocks/v0" = ConwayEra
@@ -245,24 +245,28 @@ instance KnownNamespace "gov/proposals/v0" where
   type NamespaceEntry "gov/proposals/v0" = GovProposalOut CanonicalGovActionState
 
 fromGovActionState ::
-  GovActionState ConwayEra -> (GovProposalIn, GovProposalOut CanonicalGovActionState)
-fromGovActionState GovActionState {..} =
+  Word64 -> GovActionState ConwayEra -> (GovProposalIn, GovProposalOut CanonicalGovActionState)
+fromGovActionState n GovActionState {..} =
   ( mkGovProposalIn gasId
-  , GovProposalOut $
-      CanonicalGovActionState
-        { gasProposalProcedure = mkOnChain @ConwayEra gasProposalProcedure
-        , ..
-        }
+  , GovProposalOut
+      ( n
+      , CanonicalGovActionState
+          { gasProposalProcedure = mkOnChain @ConwayEra gasProposalProcedure
+          , ..
+          }
+      )
   )
 
 toGovActionState ::
-  (GovProposalIn, GovProposalOut CanonicalGovActionState) -> GovActionState ConwayEra
-toGovActionState (govIn, GovProposalOut CanonicalGovActionState {..}) =
-  GovActionState
-    { gasProposalProcedure = getValue gasProposalProcedure
-    , gasId = fromGovProposalIn govIn
-    , ..
-    }
+  (GovProposalIn, GovProposalOut CanonicalGovActionState) -> (Word64, GovActionState ConwayEra)
+toGovActionState (govIn, GovProposalOut (n, CanonicalGovActionState {..})) =
+  ( n
+  , GovActionState
+      { gasProposalProcedure = getValue gasProposalProcedure
+      , gasId = fromGovProposalIn govIn
+      , ..
+      }
+  )
 
 mkGovProposalIn :: GovActionId -> GovProposalIn
 mkGovProposalIn GovActionId {gaidGovActionIx = GovActionIx idx, gaidTxId} =

--- a/libs/cardano-ledger-canonical-state/conway/Cardano/Ledger/CanonicalState/Conway.hs
+++ b/libs/cardano-ledger-canonical-state/conway/Cardano/Ledger/CanonicalState/Conway.hs
@@ -57,7 +57,7 @@ import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Encoding as E
 import Data.Map (Map)
 import Data.Text (Text)
-import Data.Word (Word8)
+import Data.Word (Word64, Word8)
 import Lens.Micro
 
 type instance NamespaceEra "blocks/v0" = ConwayEra
@@ -253,24 +253,29 @@ instance KnownNamespace "gov/proposals/v0" where
   type NamespaceEntry "gov/proposals/v0" = GovProposalOut CanonicalGovActionState
 
 fromGovActionState ::
-  GovActionState ConwayEra -> (GovProposalIn, GovProposalOut CanonicalGovActionState)
-fromGovActionState GovActionState {..} =
+  Word64 -> GovActionState ConwayEra -> (GovProposalIn, GovProposalOut CanonicalGovActionState)
+fromGovActionState gpoProposalOrder GovActionState {..} =
   ( mkGovProposalIn gasId
-  , GovProposalOut $
-      CanonicalGovActionState
-        { gasProposalProcedure = mkOnChain @ConwayEra gasProposalProcedure
-        , ..
-        }
+  , GovProposalOut
+      { gpoProposalOrder
+      , gpoProposal =
+          CanonicalGovActionState
+            { gasProposalProcedure = mkOnChain @ConwayEra gasProposalProcedure
+            , ..
+            }
+      }
   )
 
 toGovActionState ::
-  (GovProposalIn, GovProposalOut CanonicalGovActionState) -> GovActionState ConwayEra
-toGovActionState (govIn, GovProposalOut CanonicalGovActionState {..}) =
-  GovActionState
-    { gasProposalProcedure = getValue gasProposalProcedure
-    , gasId = fromGovProposalIn govIn
-    , ..
-    }
+  (GovProposalIn, GovProposalOut CanonicalGovActionState) -> (Word64, GovActionState ConwayEra)
+toGovActionState (govIn, GovProposalOut {gpoProposalOrder, gpoProposal = CanonicalGovActionState {..}}) =
+  ( gpoProposalOrder
+  , GovActionState
+      { gasProposalProcedure = getValue gasProposalProcedure
+      , gasId = fromGovProposalIn govIn
+      , ..
+      }
+  )
 
 mkGovProposalIn :: GovActionId -> GovProposalIn
 mkGovProposalIn GovActionId {gaidGovActionIx = GovActionIx idx, gaidTxId} =

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovProposals/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovProposals/V0.hs
@@ -41,7 +41,7 @@ import Cardano.SCLS.Versioned (Versioned (..))
 import Data.MemPack
 import Data.MemPack.ByteOrdered
 import Data.Proxy (Proxy (..))
-import Data.Word (Word16)
+import Data.Word (Word16, Word64)
 import GHC.Generics (Generic)
 
 newtype CanonicalGovActionIx = CanonicalGovActionIx Word16
@@ -76,9 +76,7 @@ instance IsKey GovProposalIn where
     gaidGovActionIx <- unpackM
     return $ GovProposalIn CanonicalGovActionId {..}
 
--- | Canonical wrapper over gov action state. Because this is on-chain data
--- we create a wrapper for that.
-newtype GovProposalOut v = GovProposalOut v
+newtype GovProposalOut v = GovProposalOut (Word64, v)
   deriving (Eq, Show, Generic)
   deriving newtype (ToCanonicalCBOR "gov/proposals/v0")
   deriving newtype (FromCanonicalCBOR "gov/proposals/v0")

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovProposals/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovProposals/V0.hs
@@ -41,7 +41,7 @@ import Cardano.SCLS.Versioned (Versioned (..))
 import Data.MemPack
 import Data.MemPack.ByteOrdered
 import Data.Proxy (Proxy (..))
-import Data.Word (Word16)
+import Data.Word (Word16, Word64)
 import GHC.Generics (Generic)
 
 newtype CanonicalGovActionIx = CanonicalGovActionIx Word16
@@ -76,20 +76,30 @@ instance IsKey GovProposalIn where
     gaidGovActionIx <- unpackM
     return $ GovProposalIn CanonicalGovActionId {..}
 
--- | Canonical wrapper over gov action state. Because this is on-chain data
--- we create a wrapper for that.
-newtype GovProposalOut v = GovProposalOut v
+-- | Canonical wrapper over proposal order and gov action state. Because this
+-- is on-chain data we create a wrapper for that.
+data GovProposalOut v = GovProposalOut
+  { gpoProposalOrder :: !Word64
+  , gpoProposal :: !v
+  }
   deriving (Eq, Show, Generic)
-  deriving newtype (ToCanonicalCBOR "gov/proposals/v0")
-  deriving newtype (FromCanonicalCBOR "gov/proposals/v0")
 
 type instance NamespaceKeySize "gov/proposals/v0" = 34
+
+instance ToCanonicalCBOR v p => ToCanonicalCBOR v (GovProposalOut p) where
+  toCanonicalCBOR v (GovProposalOut {..}) =
+    toCanonicalCBOR v (gpoProposalOrder, gpoProposal)
+
+instance FromCanonicalCBOR v p => FromCanonicalCBOR v (GovProposalOut p) where
+  fromCanonicalCBOR = do
+    Versioned (gpoProposalOrder, gpoProposal) <- fromCanonicalCBOR @v
+    return $ Versioned $ GovProposalOut {..}
 
 instance
   ToCanonicalCBOR "gov/proposals/v0" v =>
   CanonicalCBOREntryEncoder "gov/proposals/v0" (GovProposalOut v)
   where
-  encodeEntry (GovProposalOut n) = toCanonicalCBOR (Proxy @"gov/proposals/v0") n
+  encodeEntry = toCanonicalCBOR (Proxy @"gov/proposals/v0")
 
 instance
   FromCanonicalCBOR "gov/proposals/v0" v =>

--- a/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
+++ b/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
@@ -15,12 +15,13 @@ module Test.Cardano.Ledger.CanonicalState.Spec (spec) where
 
 import Cardano.Ledger.BaseTypes (EpochInterval, NonNegativeInterval, UnitInterval)
 import Cardano.Ledger.CanonicalState.BasicTypes (CanonicalExUnits (..))
-import Cardano.Ledger.CanonicalState.Conway ()
+import Cardano.Ledger.CanonicalState.Conway (CanonicalGovActionState)
 import qualified Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 as Blocks.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.EntitiesCommittee.V0 as Committee.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovCommittee.V0 as GovCommittee.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovConstitution.V0 as GovConstitution.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovPParams.V0 as GovPParams.V0
+import qualified Cardano.Ledger.CanonicalState.Namespace.GovProposals.V0 as GovProposals.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.UTxO.V0 as UTxO.V0
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core (PParams)
@@ -66,6 +67,10 @@ spec = do
       validateType @"gov/pparams/v0" @CanonicalExUnits "ex_units"
       isCanonical @"gov/pparams/v0" @(PParams ConwayEra)
       validateType @"gov/pparams/v0" @(GovPParams.V0.GovPParamsOut ConwayEra) "gov_pparams_out"
+    describe "gov/proposals/v0" $ do
+      isCanonical @"gov/proposals/v0" @(GovProposals.V0.GovProposalOut CanonicalGovActionState)
+      validateType @"gov/proposals/v0" @(GovProposals.V0.GovProposalOut CanonicalGovActionState)
+        "record_entry"
   describe "namespaces" $ do
     testNS @"blocks/v0"
     testNS @"utxo/v0"

--- a/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
+++ b/libs/cardano-ledger-canonical-state/test/Test/Cardano/Ledger/CanonicalState/Spec.hs
@@ -15,7 +15,7 @@ module Test.Cardano.Ledger.CanonicalState.Spec (spec) where
 
 import Cardano.Ledger.BaseTypes (EpochInterval, NonNegativeInterval, NonZero, UnitInterval)
 import Cardano.Ledger.CanonicalState.BasicTypes (CanonicalExUnits (..))
-import Cardano.Ledger.CanonicalState.Conway ()
+import Cardano.Ledger.CanonicalState.Conway (CanonicalGovActionState)
 import qualified Cardano.Ledger.CanonicalState.Namespace.Blocks.V0 as Blocks.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.EntitiesCommittee.V0 as Committee.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.EntitiesDReps.V0 as EntitiesDReps.V0
@@ -142,6 +142,10 @@ spec = do
       validateType @"gov/proposals/roots/v0" @GovProposals.V0.CanonicalGovActionId "gov_action_id"
       isCanonical @"gov/proposals/roots/v0" @GovProposals.Roots.V0.GovProposalsRootsOut
       validateType @"gov/proposals/roots/v0" @GovProposals.Roots.V0.GovProposalsRootsOut "record_entry"
+    describe "gov/proposals/v0" $ do
+      isCanonical @"gov/proposals/v0" @(GovProposals.V0.GovProposalOut CanonicalGovActionState)
+      validateType @"gov/proposals/v0" @(GovProposals.V0.GovProposalOut CanonicalGovActionState)
+        "record_entry"
   describe "namespaces" $ do
     testNS @"blocks/v0"
     testNS @"utxo/v0"

--- a/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/Conway/CanonicalState/Arbitrary.hs
+++ b/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/Conway/CanonicalState/Arbitrary.hs
@@ -16,7 +16,7 @@ import qualified Cardano.Ledger.CanonicalState.Namespace.GovConstitution.V0 as G
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovPParams.V0 as GovPParams.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovProposals.V0 as GovProposals.V0
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Governance (Constitution, GovActionState)
+import Cardano.Ledger.Conway.Governance (Constitution)
 import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.QuickCheck (Arbitrary (..))
@@ -31,4 +31,4 @@ instance Arbitrary (GovPParams.V0.GovPParamsOut ConwayEra) where
   arbitrary = genericArbitraryU
 
 instance Arbitrary (GovProposals.V0.GovProposalOut CanonicalGovActionState) where
-  arbitrary = snd . fromGovActionState <$> arbitrary @(GovActionState ConwayEra)
+  arbitrary = snd . fromGovActionState 0 <$> arbitrary

--- a/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/Conway/CanonicalState/Arbitrary.hs
+++ b/libs/cardano-ledger-canonical-state/testlib/Test/Cardano/Ledger/Conway/CanonicalState/Arbitrary.hs
@@ -18,7 +18,7 @@ import qualified Cardano.Ledger.CanonicalState.Namespace.GovPParams.V0 as GovPPa
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovProposals.Roots.V0 as GovProposals.Roots.V0
 import qualified Cardano.Ledger.CanonicalState.Namespace.GovProposals.V0 as GovProposals.V0
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Governance (Constitution, GovActionState)
+import Cardano.Ledger.Conway.Governance (Constitution)
 import Generic.Random (genericArbitraryU)
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 import Test.QuickCheck (Arbitrary (..))
@@ -33,7 +33,9 @@ instance Arbitrary (GovPParams.V0.GovPParamsOut ConwayEra) where
   arbitrary = genericArbitraryU
 
 instance Arbitrary (GovProposals.V0.GovProposalOut CanonicalGovActionState) where
-  arbitrary = snd . fromGovActionState <$> arbitrary @(GovActionState ConwayEra)
+  arbitrary = do
+    orderIx <- arbitrary
+    snd . fromGovActionState orderIx <$> arbitrary
 
 instance Arbitrary GovProposals.V0.CanonicalGovActionIx where
   arbitrary = genericArbitraryU


### PR DESCRIPTION
# Description

The order in which proposals were added must be preserved to properly reconstruct the ledger state.
This PR refactors the `gov/proposals/v0` canonical namespace definition to also encode the order of each proposal.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
