### PR TITLE
Fix nix build failure in `plutus-preprocessor`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -70,7 +70,7 @@ program-options
   ghc-options: -Werror
 
 package plutus-preprocessor
-  haddock-options: "--optghc=-fplugin-opt PlutusTx.Plugin:defer-errors"
+  haddock-options: "--optghc=-fplugin-opt=PlutusTx.Plugin:defer-errors"
 
 package cardano-ledger-core
   flags: +asserts


### PR DESCRIPTION
# Description

This has been happening consistently since the `haskell.nix` flake input was updated:

```
Error: [Cabal-5504]
Unrecognised build target 'PlutusTx.Plugin:defer-errors'.
Expected a module name, rather than 'defer-errors'.
```

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.