### PR TITLE
Refactor namespaces with singleton keys

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -104,8 +104,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
-  --sha256: sha256-DSftURPyJsLdW16EGNhUX/+FuGL2CGHMiz497OOBm6A=
-  tag: 6442f9d8512eeeadc8edbc3d064ff198084f66a0
+  --sha256: sha256-02j6m1UBYiZrdgAzGFb5yO+tFf8pN6DmykZjk9tdOUg=
+  tag: 940f6ad992382e856082f73c437a162211e50ba8
 
 constraints:
   -- Happy version 2.2.1 fails to compile haskell-src-exts

--- a/cabal.project
+++ b/cabal.project
@@ -104,8 +104,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
-  --sha256: sha256-BoAotLgxMipOIMcZrmlr6EtQzqC5HyEA0ZpK8nvCmJs=
-  tag: 5161deb34247a51160f2e8d58b6cc2d48044ea2c
+  --sha256: sha256-DSftURPyJsLdW16EGNhUX/+FuGL2CGHMiz497OOBm6A=
+  tag: 6442f9d8512eeeadc8edbc3d064ff198084f66a0
 
 constraints:
   -- Happy version 2.2.1 fails to compile haskell-src-exts

--- a/cabal.project
+++ b/cabal.project
@@ -104,8 +104,8 @@ source-repository-package
   type: git
   location: https://github.com/tweag/cardano-cls.git
   subdir: merkle-tree-incremental mempack-scls scls-cbor scls-cardano scls-format scls-core
-  --sha256: sha256-02j6m1UBYiZrdgAzGFb5yO+tFf8pN6DmykZjk9tdOUg=
-  tag: 940f6ad992382e856082f73c437a162211e50ba8
+  --sha256: sha256-ewiH4VzDoBYpwKKFMbc5AwhkdgYtymvPKTJv+wxpfOA=
+  tag: a5c60155922819b6421a2606ebbc358c78c0ea1b
 
 constraints:
   -- Happy version 2.2.1 fails to compile haskell-src-exts

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/EntitiesCommittee/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/EntitiesCommittee/V0.hs
@@ -3,12 +3,10 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -24,7 +22,7 @@ module Cardano.Ledger.CanonicalState.Namespace.EntitiesCommittee.V0 (
   fromCanonicalCommitteeAuthorization,
 ) where
 
-import Cardano.Ledger.BaseTypes (Anchor (..), EpochNo (..), StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (Anchor (..), StrictMaybe (..))
 import Cardano.Ledger.CanonicalState.BasicTypes ()
 import Cardano.Ledger.CanonicalState.Namespace (Era, NamespaceEra)
 import Cardano.Ledger.Credential (Credential (..))
@@ -41,7 +39,7 @@ import Cardano.SCLS.NamespaceCodec (
  )
 import Cardano.SCLS.Versioned (Versioned (..))
 import qualified Data.Map.Strict as Map
-import Data.MemPack.ByteOrdered (packWord64beM, unpackBigEndianM)
+import Data.MemPack (MemPack (packM, unpackM))
 import Data.Proxy (Proxy (..))
 import Data.Word (Word8)
 import GHC.Generics (Generic)
@@ -62,19 +60,18 @@ instance
   where
   decodeEntry = fmap EntitiesCommitteeOut <$> fromCanonicalCBOR
 
-data EntitiesCommitteeIn = EntitiesCommitteeIn EpochNo
-  deriving (Eq, Ord, Show)
+data EntitiesCommitteeIn = EntitiesCommitteeIn
+  deriving (Eq, Ord, Show, Enum)
 
 newtype EntitiesCommitteeOut = EntitiesCommitteeOut CanonicalCommitteeState
   deriving (Eq, Show, Generic)
 
 instance IsKey EntitiesCommitteeIn where
   keySize = namespaceKeySize @"entities/committee/v0"
-  packKeyM (EntitiesCommitteeIn (EpochNo no)) = do
-    packWord64beM no
-  unpackKeyM = do
-    no <- unpackBigEndianM
-    return $ EntitiesCommitteeIn (EpochNo no)
+  packKeyM = do
+    packM . fromIntegral @_ @Word8 . fromEnum
+  unpackKeyM =
+    toEnum . fromIntegral @Word8 <$> unpackM
 
 newtype CanonicalCommitteeState = CanonicalCommitteeState
   { csCommitteeCreds :: Map.Map (Credential ColdCommitteeRole) CanonicalCommitteeAuthorization

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovCommittee/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovCommittee/V0.hs
@@ -36,8 +36,9 @@ import Cardano.SCLS.NamespaceCodec (
  )
 import Cardano.SCLS.Versioned (Versioned (Versioned))
 import qualified Data.Map.Strict as Map
-import Data.MemPack.ByteOrdered (packWord64beM, unpackBigEndianM)
+import Data.MemPack (MemPack (unpackM), packM)
 import Data.Proxy (Proxy (..))
+import Data.Word (Word8)
 import GHC.Generics (Generic)
 
 instance (Era era, NamespaceEra "gov/committee/v0" ~ era) => KnownNamespace "gov/committee/v0" where
@@ -56,8 +57,8 @@ instance
   where
   decodeEntry = fmap GovCommitteeOut <$> fromCanonicalCBOR
 
-newtype GovCommitteeIn = GovCommitteeIn EpochNo
-  deriving (Eq, Ord, Show)
+data GovCommitteeIn = GovCommitteeIn
+  deriving (Eq, Ord, Show, Enum)
 
 newtype GovCommitteeOut = GovCommitteeOut (StrictMaybe CanonicalCommittee)
   deriving (Generic, Eq, Show)
@@ -72,9 +73,10 @@ deriving newtype instance
 
 instance IsKey GovCommitteeIn where
   keySize = namespaceKeySize @"gov/committee/v0"
-  packKeyM (GovCommitteeIn (EpochNo no)) = packWord64beM no
-  unpackKeyM = do
-    GovCommitteeIn . EpochNo <$> unpackBigEndianM
+  packKeyM =
+    packM . fromIntegral @_ @Word8 . fromEnum
+  unpackKeyM =
+    toEnum . fromIntegral @Word8 <$> unpackM
 
 data CanonicalCommittee = CanonicalCommittee
   { committeeMembers :: !(Map.Map (Credential ColdCommitteeRole) EpochNo)

--- a/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovConstitution/V0.hs
+++ b/libs/cardano-ledger-canonical-state/src/Cardano/Ledger/CanonicalState/Namespace/GovConstitution/V0.hs
@@ -2,12 +2,9 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -20,7 +17,7 @@ module Cardano.Ledger.CanonicalState.Namespace.GovConstitution.V0 (
   GovConstitutionOut (..),
 ) where
 
-import Cardano.Ledger.BaseTypes (Anchor (..), EpochNo (..), StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (Anchor (..), StrictMaybe (..))
 import Cardano.Ledger.CanonicalState.BasicTypes ()
 import Cardano.Ledger.CanonicalState.Namespace (Era, NamespaceEra)
 import Cardano.Ledger.Hashes (ScriptHash (..))
@@ -34,23 +31,23 @@ import Cardano.SCLS.NamespaceCodec (
   namespaceKeySize,
  )
 import Cardano.SCLS.Versioned (Versioned (..))
-import Data.MemPack.ByteOrdered (packWord64beM, unpackBigEndianM)
+import Data.MemPack (MemPack (packM, unpackM))
 import Data.Proxy (Proxy (..))
+import Data.Word (Word8)
 import GHC.Generics (Generic)
 
-newtype GovConstitutionIn = GovConstitutionIn EpochNo
-  deriving (Eq, Ord, Show)
+data GovConstitutionIn = GovConstitutionIn
+  deriving (Eq, Ord, Show, Enum)
 
 newtype GovConstitutionOut = GovConstitutionOut CanonicalConstitution
   deriving (Eq, Show, Generic)
 
 instance IsKey GovConstitutionIn where
   keySize = namespaceKeySize @"gov/constitution/v0"
-  packKeyM (GovConstitutionIn (EpochNo epochNo)) = do
-    packWord64beM epochNo
-  unpackKeyM = do
-    epochNo <- unpackBigEndianM
-    return $ GovConstitutionIn (EpochNo epochNo)
+  packKeyM =
+    packM . fromIntegral @_ @Word8 . fromEnum
+  unpackKeyM =
+    toEnum . fromIntegral @Word8 <$> unpackM
 
 data CanonicalConstitution = CanonicalConstitution
   { constitutionAnchor :: !Anchor


### PR DESCRIPTION
# Description

The following namespaces should only have a single entry:

- `entities/committee/v0`
- `gov/committee/v0`
- `gov/constitution/v0`

For these namespaces, `epochNo` was used as each entry key, which doesn't make sense (especially when  `DELTA` records are supported, which would result in new entries being added instead of updating the previous ones).
This PR refactors such namespaces to use a singleton value (`0 :: Word8`) for the key.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
