### PR TITLE
Clean up CddlSpec, fix `Datum` and `AccountBalanceIntervals` generators

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### `testlib`
 
+* Add `genDatumPresent`
 * Added `Proxy era` argument to `exUnitsRule`
 * `TranslationInstance` has a new field `tiPlutusPurpose`
 

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Arbitrary.hs
@@ -30,6 +30,7 @@ module Test.Cardano.Ledger.Alonzo.Arbitrary (
   genValidCostModel,
   genValidAndUnknownCostModels,
   genAlonzoPlutusPurposePointer,
+  genDatumPresent,
 ) where
 
 import Cardano.Ledger.Alonzo (AlonzoEra, ApplyTxError (..), Tx (..))
@@ -78,7 +79,7 @@ import Cardano.Ledger.Alonzo.TxWits (
   TxDats (TxDats),
  )
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
-import Cardano.Ledger.Plutus.Data (hashData)
+import Cardano.Ledger.Plutus.Data (Datum (..), hashData)
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
 import Cardano.Ledger.Plutus.Language (
   Language (..),
@@ -485,3 +486,6 @@ instance Arbitrary LangDepView where
   arbitrary = LangDepView <$> arbitrary <*> arbitrary
 
 deriving instance Arbitrary AlonzoExtraConfig
+
+genDatumPresent :: Era era => Gen (Datum era)
+genDatumPresent = oneof [DatumHash <$> arbitrary, Datum <$> arbitrary]

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -42,6 +42,10 @@
 * Remove `NoThunks` instance for `DijkstraContextError`
 * Make `DijkstraContextError` constructors lazy
 
+### testlib
+
+* Add `genNonEmptyAccountBalanceIntervals`
+
 ## 0.2.0.0
 
 * Expose `conwayToDijkstraUtxowPredFailure`

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -255,7 +255,7 @@ test-suite tests
 
   build-depends:
     base,
-    cardano-ledger-alonzo,
+    cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
     cardano-ledger-babbage:testlib,
     cardano-ledger-binary:testlib,
     cardano-ledger-conway:{cardano-ledger-conway, testlib},

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -66,8 +66,7 @@ spec = do
       xdescribe "fix plutus_v4_script" $ do
         fullAnnCddlSpec @(TxWits DijkstraEra) v "transaction_witness_set"
       -- PParamsUpdate
-      xdescribe "fix pparamupdate" $
-        fullCddlSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
+      fullCddlSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
       -- CostModels
       xdescribe "not enough decision points" $ do
         fullCddlSpec @CostModels v "cost_models"
@@ -81,7 +80,6 @@ spec = do
       -- ProposalProcedure
       fullCddlSpec @(ProposalProcedure DijkstraEra) v "proposal_procedure"
       -- GovAction
-      xdescribe "fix pparamupdate" $
-        fullCddlSpec @(GovAction DijkstraEra) v "gov_action"
+      fullCddlSpec @(GovAction DijkstraEra) v "gov_action"
       -- TxCert
       fullCddlSpec @(TxCert DijkstraEra) v "certificate"

--- a/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
+++ b/eras/dijkstra/impl/test/Test/Cardano/Ledger/Dijkstra/Binary/CddlSpec.hs
@@ -15,17 +15,19 @@ import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.HuddleSpec (dijkstraCDDL)
 import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceInterval, AccountBalanceIntervals)
 import Cardano.Ledger.Plutus.Data (Data, Datum)
+import Test.Cardano.Ledger.Alonzo.Arbitrary (genDatumPresent, genNonEmptyRedeemers)
 import Test.Cardano.Ledger.Binary.Cuddle (
-  huddleAntiCborSpec,
-  huddleDecoderEquivalenceSpec,
-  huddleRoundTripAnnCborSpec,
-  huddleRoundTripArbitraryValidate,
-  huddleRoundTripCborSpec,
   noTwiddle,
   specWithHuddle,
  )
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Dijkstra.Arbitrary ()
+import Test.Cardano.Ledger.Core.Binary (
+  fullAnnCddlSpec,
+  fullAnnGenCddlSpec,
+  fullCddlSpec,
+  fullGenCddlSpec,
+ )
+import Test.Cardano.Ledger.Dijkstra.Arbitrary (genNonEmptyAccountBalanceIntervals)
 import Test.Cardano.Ledger.Dijkstra.Binary.Annotator ()
 
 spec :: Spec
@@ -33,75 +35,53 @@ spec = do
   describe "CDDL" $ do
     let v = eraProtVerHigh @DijkstraEra
     describe "Huddle" $ specWithHuddle dijkstraCDDL . noTwiddle $ do
-      huddleRoundTripCborSpec @(AccountBalanceInterval DijkstraEra) v "account_balance_interval"
-      huddleRoundTripCborSpec @(AccountBalanceIntervals DijkstraEra) v "account_balance_intervals"
-      huddleRoundTripArbitraryValidate @(AccountBalanceInterval DijkstraEra) v "account_balance_interval"
-      huddleRoundTripCborSpec @(Value DijkstraEra) v "positive_coin"
-      huddleRoundTripArbitraryValidate @(Value DijkstraEra) v "value"
-      describe "MultiAsset" $ do
-        huddleRoundTripCborSpec @(Value DijkstraEra) v "value"
+      -- AccountBalanceInterval
+      fullCddlSpec @(AccountBalanceInterval DijkstraEra) v "account_balance_interval"
+      -- AccountBalanceIntervals
+      fullGenCddlSpec @(AccountBalanceIntervals DijkstraEra)
+        genNonEmptyAccountBalanceIntervals
+        v
+        "account_balance_intervals"
+      -- Value
+      fullCddlSpec @(Value DijkstraEra) v "value"
+      -- TxBody TopTx
       xdescribe "fix TxBody" $ do
-        huddleRoundTripAnnCborSpec @(TxBody TopTx DijkstraEra) v "transaction_body"
-        huddleRoundTripCborSpec @(TxBody TopTx DijkstraEra) v "transaction_body"
-        huddleRoundTripArbitraryValidate @(TxBody TopTx DijkstraEra) v "transaction_body"
-        huddleRoundTripAnnCborSpec @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
-        huddleRoundTripCborSpec @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
-        huddleRoundTripArbitraryValidate @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
-      -- AuxData
-      huddleRoundTripAnnCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
-      huddleRoundTripArbitraryValidate @(TxAuxData DijkstraEra) v "auxiliary_data"
-      huddleRoundTripCborSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
-      huddleRoundTripAnnCborSpec @(NativeScript DijkstraEra) v "native_script"
-      huddleRoundTripArbitraryValidate @(NativeScript DijkstraEra) v "native_script"
-      huddleRoundTripCborSpec @(NativeScript DijkstraEra) v "native_script"
-      huddleRoundTripAnnCborSpec @(Data DijkstraEra) v "plutus_data"
-      huddleRoundTripArbitraryValidate @(Data DijkstraEra) v "plutus_data"
-      huddleRoundTripCborSpec @(Data DijkstraEra) v "plutus_data"
-      xdescribe "fix NoDatum" $ do
-        huddleRoundTripCborSpec @(TxOut DijkstraEra) v "transaction_output"
-        huddleRoundTripArbitraryValidate @(TxOut DijkstraEra) v "transaction_output"
-      huddleRoundTripAnnCborSpec @(Script DijkstraEra) v "script"
-      huddleRoundTripCborSpec @(Script DijkstraEra) v "script"
-      huddleRoundTripArbitraryValidate @(Script DijkstraEra) v "script"
-      huddleRoundTripCborSpec @(Datum DijkstraEra) v "datum_option"
-      -- TODO NoDatum is encoded as an empty bytestring
-      xdescribe "fix NoDatum" $ huddleRoundTripArbitraryValidate @(Datum DijkstraEra) v "datum_option"
+        fullAnnCddlSpec @(TxBody TopTx DijkstraEra) v "transaction_body"
+      -- TxBody SubTx
+      xdescribe "fix TxBody" $ do
+        fullAnnCddlSpec @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
+      -- TxAuxData
+      fullAnnCddlSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
+      -- NativeScript
+      fullAnnCddlSpec @(NativeScript DijkstraEra) v "native_script"
+      -- Data
+      fullAnnCddlSpec @(Data DijkstraEra) v "plutus_data"
+      -- TxOut
+      fullCddlSpec @(TxOut DijkstraEra) v "transaction_output"
+      -- Script
+      fullAnnCddlSpec @(Script DijkstraEra) v "script"
+      -- Datum
+      fullGenCddlSpec @(Datum DijkstraEra) genDatumPresent v "datum_option"
       -- TxWits
       xdescribe "fix plutus_v4_script" $ do
-        huddleRoundTripAnnCborSpec @(TxWits DijkstraEra) v "transaction_witness_set"
-        huddleRoundTripCborSpec @(TxWits DijkstraEra) v "transaction_witness_set"
-      huddleRoundTripArbitraryValidate @(TxWits DijkstraEra) v "transaction_witness_set"
-      huddleRoundTripCborSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
-      huddleRoundTripArbitraryValidate @(PParamsUpdate DijkstraEra) v "protocol_param_update"
-      huddleAntiCborSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
-      huddleRoundTripCborSpec @CostModels v "cost_models"
-      huddleRoundTripArbitraryValidate @CostModels v "cost_models"
-      huddleRoundTripAnnCborSpec @(Redeemers DijkstraEra) v "redeemers"
-      -- TODO arbitrary can generate empty redeemers, which is not allowed in the CDDL
-      xdescribe "fix empty redeemers" $
-        huddleRoundTripArbitraryValidate @(Redeemers DijkstraEra) v "redeemers"
-      huddleRoundTripCborSpec @(Redeemers DijkstraEra) v "redeemers"
+        fullAnnCddlSpec @(TxWits DijkstraEra) v "transaction_witness_set"
+      -- PParamsUpdate
+      xdescribe "fix pparamupdate" $
+        fullCddlSpec @(PParamsUpdate DijkstraEra) v "protocol_param_update"
+      -- CostModels
+      xdescribe "not enough decision points" $ do
+        fullCddlSpec @CostModels v "cost_models"
+      -- Redeemers
+      fullAnnGenCddlSpec @(Redeemers DijkstraEra) genNonEmptyRedeemers v "redeemers"
+      -- Tx
       xdescribe "fix Transaction" $ do
-        huddleRoundTripAnnCborSpec @(Tx TopTx DijkstraEra) v "transaction"
-        huddleRoundTripCborSpec @(Tx TopTx DijkstraEra) v "transaction"
-      -- TODO enable this once map/list expansion has been optimized in cuddle
-      xdescribe "hangs" $ huddleRoundTripArbitraryValidate @(Tx TopTx DijkstraEra) v "transaction"
-      huddleRoundTripCborSpec @(VotingProcedure DijkstraEra) v "voting_procedure"
-      huddleRoundTripArbitraryValidate @(VotingProcedure DijkstraEra) v "voting_procedure"
-      huddleRoundTripCborSpec @(ProposalProcedure DijkstraEra) v "proposal_procedure"
-      huddleRoundTripArbitraryValidate @(ProposalProcedure DijkstraEra) v "proposal_procedure"
-      huddleRoundTripCborSpec @(GovAction DijkstraEra) v "gov_action"
-      huddleRoundTripArbitraryValidate @(GovAction DijkstraEra) v "gov_action"
-      huddleRoundTripCborSpec @(TxCert DijkstraEra) v "certificate"
-      huddleRoundTripArbitraryValidate @(TxCert DijkstraEra) v "certificate"
-      describe "DecCBOR instances equivalence via CDDL" $ do
-        huddleDecoderEquivalenceSpec @(TxBody TopTx DijkstraEra) v "transaction_body"
-        huddleDecoderEquivalenceSpec @(TxBody SubTx DijkstraEra) v "sub_transaction_body"
-        huddleDecoderEquivalenceSpec @(TxAuxData DijkstraEra) v "auxiliary_data"
-        huddleDecoderEquivalenceSpec @(NativeScript DijkstraEra) v "native_script"
-        huddleDecoderEquivalenceSpec @(Data DijkstraEra) v "plutus_data"
-        huddleDecoderEquivalenceSpec @(Script DijkstraEra) v "script"
-        huddleDecoderEquivalenceSpec @(TxWits DijkstraEra) v "transaction_witness_set"
-        huddleDecoderEquivalenceSpec @(Redeemers DijkstraEra) v "redeemers"
-        xdescribe "Fix decoder equivalence of Tx" $ do
-          huddleDecoderEquivalenceSpec @(Tx TopTx DijkstraEra) v "transaction"
+        fullAnnCddlSpec @(Tx TopTx DijkstraEra) v "transaction"
+      -- VotingProcedure
+      fullCddlSpec @(VotingProcedure DijkstraEra) v "voting_procedure"
+      -- ProposalProcedure
+      fullCddlSpec @(ProposalProcedure DijkstraEra) v "proposal_procedure"
+      -- GovAction
+      xdescribe "fix pparamupdate" $
+        fullCddlSpec @(GovAction DijkstraEra) v "gov_action"
+      -- TxCert
+      fullCddlSpec @(TxCert DijkstraEra) v "certificate"

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -14,7 +14,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Dijkstra.Arbitrary () where
+module Test.Cardano.Ledger.Dijkstra.Arbitrary (genNonEmptyAccountBalanceIntervals) where
 
 import Cardano.Ledger.Allegra.Scripts (
   pattern RequireTimeExpire,
@@ -37,6 +37,7 @@ import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError)
 import Cardano.Ledger.Shelley.Rules (ShelleyPoolPredFailure)
 import Cardano.Ledger.Shelley.Scripts (pattern RequireSignature)
 import Data.Functor.Identity (Identity)
+import qualified Data.Map.Strict as Map
 import qualified Data.OMap.Strict as OMap
 import Data.Typeable (Typeable)
 import Generic.Random (genericArbitraryU)
@@ -308,6 +309,9 @@ instance Arbitrary (DijkstraMempoolPredFailure DijkstraEra) where
 instance Arbitrary (AccountBalanceIntervals era) where
   arbitrary = genericArbitraryU
   shrink = genericShrink
+
+genNonEmptyAccountBalanceIntervals :: Gen (AccountBalanceIntervals era)
+genNonEmptyAccountBalanceIntervals = AccountBalanceIntervals . Map.fromList . getNonEmpty <$> arbitrary
 
 instance Arbitrary (AccountBalanceInterval era) where
   arbitrary = genericArbitraryU

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### `testlib`
 
+* Add `fullAnnCddlSpec`, `fullAnnGenCddlSpec`, `fullCddlSpec` and `fullGenCddlSpec`
 * Add `TestBlockHeader` and `mkTestBlockHeaderNoNonce` as a replacement to deprecated `BHeaderView` and `makeHeaderView`.
 * Modify `ToExpr` instance for `Mismatch` to display type-level `r` parameter using `Typeable`
 

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -12,12 +11,26 @@ module Test.Cardano.Ledger.Core.Binary (
   txSizeSpec,
   decoderEquivalenceCoreEraTypesSpec,
   Mem,
+  fullAnnCddlSpec,
+  fullAnnGenCddlSpec,
+  fullCddlSpec,
+  fullGenCddlSpec,
 ) where
 
+import Cardano.Ledger.Binary (Annotator, DecCBOR, EncCBOR, Version)
 import Cardano.Ledger.Core
 import Cardano.Ledger.MemoBytes (Mem)
+import qualified Data.Text as T
 import Lens.Micro
 import Test.Cardano.Ledger.Binary (decoderEquivalenceSpec)
+import Test.Cardano.Ledger.Binary.Cuddle (
+  HuddleEnv,
+  huddleAntiCborSpec,
+  huddleDecoderEquivalenceSpec,
+  huddleRoundTripAnnCborSpec,
+  huddleRoundTripCborSpec,
+  huddleRoundTripGenValidate,
+ )
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Arbitrary ()
 import Test.Cardano.Ledger.Core.Binary.Annotator
@@ -34,3 +47,71 @@ txSizeSpec =
     prop "should match the size of the cbor encoding" $ \(tx :: Tx TopTx era) -> do
       let txSize = sizeTxForFeeCalculation tx
       txSize `shouldBe` tx ^. sizeTxF
+
+-- | Like 'fullAnnCddlSpec' but with a custom generator.
+fullAnnGenCddlSpec ::
+  forall a.
+  ( Eq a
+  , Show a
+  , EncCBOR a
+  , DecCBOR a
+  , DecCBOR (Annotator a)
+  , HasCallStack
+  ) =>
+  Gen a ->
+  Version ->
+  T.Text ->
+  SpecWith HuddleEnv
+fullAnnGenCddlSpec gen version ruleName = do
+  fullGenCddlSpec @a gen version ruleName
+  huddleRoundTripAnnCborSpec @a version ruleName
+  huddleDecoderEquivalenceSpec @a version ruleName
+
+-- | Full CDDL codec spec for types with both plain and Annotator decoders.
+fullAnnCddlSpec ::
+  forall a.
+  ( Eq a
+  , Show a
+  , Arbitrary a
+  , EncCBOR a
+  , DecCBOR a
+  , DecCBOR (Annotator a)
+  , HasCallStack
+  ) =>
+  Version ->
+  T.Text ->
+  SpecWith HuddleEnv
+fullAnnCddlSpec = fullAnnGenCddlSpec @a (arbitrary @a)
+
+-- | Like 'fullCddlSpec' but with a custom generator.
+fullGenCddlSpec ::
+  forall a.
+  ( Eq a
+  , Show a
+  , EncCBOR a
+  , DecCBOR a
+  , HasCallStack
+  ) =>
+  Gen a ->
+  Version ->
+  T.Text ->
+  SpecWith HuddleEnv
+fullGenCddlSpec gen version ruleName = do
+  huddleRoundTripCborSpec @a version ruleName
+  huddleRoundTripGenValidate @a gen version ruleName
+  huddleAntiCborSpec @a version ruleName
+
+-- | CDDL codec spec for types with only plain decoders (no Annotator).
+fullCddlSpec ::
+  forall a.
+  ( Eq a
+  , Show a
+  , Arbitrary a
+  , EncCBOR a
+  , DecCBOR a
+  , HasCallStack
+  ) =>
+  Version ->
+  T.Text ->
+  SpecWith HuddleEnv
+fullCddlSpec = fullGenCddlSpec @a (arbitrary @a)


### PR DESCRIPTION
# Description

This PR modifies the generators used in Huddle tests for `Datum` and `AccountBalanceIntervals` so that they generate good values. The problem with `Datum` was that `NoDatum` is encoded as an empty string, which breaks the decoder tests, so the generator that is used in Huddle tests for datums never generates a `NoDatum` value. For `AccountBalanceIntervals` I just made sure that we never generate an empty map, because the CDDL expects there to be at least one KV pair in the map.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
