### PR TITLE
Remove `allowLeftOver` flag from `binaryGetDecoder` and simplify IP address decoders

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 1.10.0.0
 
 * Add `FromJSON` instance for `ValidityInterval`
+
+### `cddl`
+
+* Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 * Add `ApplyTick` instance for `AllegraEra`
 * Add `EraForecast` and `ShelleyEraForecast` instances for `AllegraEra`.
 * Remove `NoThunks` instance for `AllegraUtxoPredFailure`

--- a/eras/allegra/impl/cddl/data/allegra.cddl
+++ b/eras/allegra/impl/cddl/data/allegra.cddl
@@ -178,7 +178,7 @@ vrf_keyhash = hash32
 ; 
 ; The relation between numerator and denominator can be
 ; expressed in CDDL, but we have a limitation currently
-; (see: https://github.com/input-output-hk/cuddle/issues/30). 
+; (see: https://github.com/input-output-hk/cuddle/issues/30).
 unit_interval = #6.30([uint, uint])
 
 reward_account = bytes
@@ -189,15 +189,9 @@ single_host_addr = (0, port/ nil, ipv4/ nil, ipv6/ nil)
 
 port = uint .le 65535
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv4 = bytes .size (4 .. 1024)
+ipv4 = bytes .size 4
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv6 = bytes .size (16 .. 1024)
+ipv6 = bytes .size 16
 
 ; dns_name: An A or AAAA DNS record
 single_host_name = (1, port/ nil, dns_name)

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -10,6 +10,9 @@
 * Move `toPlutusWithContext` from `Cardano.Ledger.Alonzo.Plutus.Context` to `Cardano.Ledger.Alonzo.Plutus.TxInfo`
 * Add `scriptsProvidedStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `scriptsProvidedAlonzoStAnnTx`
 * Fix `ex_unit_prices` CDDL to use `nonnegative_interval` instead of `positive_interval`
+
+### `cddl`
+
 * Remove `ToCBOR` and `FromCBOR` instances for `AlonzoExtraConfig` and `AlonzoTxOut`
 * Add `ApplyTick` instance for `AlonzoEra`
 * Add `mkPlutusTxInfoFromResult` and `toPlutusTxInfoForPurpose` helpers
@@ -33,6 +36,7 @@
 * Remove `NoThunks (ContextError era)` constraint from `EraPlutusContext` class
 * Remove `NoThunks` deriving instance for `CollectError`
 * Make `AlonzoContextError` constructors lazy
+* Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 
 ### `testlib`
 

--- a/eras/alonzo/impl/cddl/data/alonzo.cddl
+++ b/eras/alonzo/impl/cddl/data/alonzo.cddl
@@ -196,7 +196,7 @@ vrf_keyhash = hash32
 ; 
 ; The relation between numerator and denominator can be
 ; expressed in CDDL, but we have a limitation currently
-; (see: https://github.com/input-output-hk/cuddle/issues/30). 
+; (see: https://github.com/input-output-hk/cuddle/issues/30).
 unit_interval = #6.30([uint, uint])
 
 reward_account = bytes
@@ -207,15 +207,9 @@ single_host_addr = (0, port/ nil, ipv4/ nil, ipv6/ nil)
 
 port = uint .le 65535
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv4 = bytes .size (4 .. 1024)
+ipv4 = bytes .size 4
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv6 = bytes .size (16 .. 1024)
+ipv6 = bytes .size 16
 
 ; dns_name: An A or AAAA DNS record
 single_host_name = (1, port/ nil, dns_name)

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.14.0.0
 
 * Fix `ex_unit_prices` CDDL to use `nonnegative_interval` instead of `positive_interval`
+
+### `cddl`
+
 * Remove `ToCBOR` and `FromCBOR` instances for `BabbageTxOut`
 * Add `ApplyTick` instance for `BabbageEra`
 * `BabbageTxInfoResult` changed its content type to `PlutusTxInfoResult`
@@ -20,6 +23,7 @@
   - `BabbageUtxowPredFailure`
 * Remove `NoThunks` instance for `BabbageContextError`
 * Make `BabbageContextError` constructors lazy
+* Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 
 ### `testlib`
 

--- a/eras/babbage/impl/cddl/data/babbage.cddl
+++ b/eras/babbage/impl/cddl/data/babbage.cddl
@@ -308,7 +308,7 @@ vrf_keyhash = hash32
 ; 
 ; The relation between numerator and denominator can be
 ; expressed in CDDL, but we have a limitation currently
-; (see: https://github.com/input-output-hk/cuddle/issues/30). 
+; (see: https://github.com/input-output-hk/cuddle/issues/30).
 unit_interval = #6.30([uint, uint])
 
 reward_account = bytes
@@ -319,15 +319,9 @@ single_host_addr = (0, port/ nil, ipv4/ nil, ipv6/ nil)
 
 port = uint .le 65535
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv4 = bytes .size (4 .. 1024)
+ipv4 = bytes .size 4
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv6 = bytes .size (16 .. 1024)
+ipv6 = bytes .size 16
 
 ; dns_name: An A or AAAA DNS record
 single_host_name = (1, port/ nil, dns_name)

--- a/eras/conway/impl/cddl/data/conway.cddl
+++ b/eras/conway/impl/cddl/data/conway.cddl
@@ -358,7 +358,7 @@ vrf_keyhash = hash32
 ; 
 ; The relation between numerator and denominator can be
 ; expressed in CDDL, but we have a limitation currently
-; (see: https://github.com/input-output-hk/cuddle/issues/30). 
+; (see: https://github.com/input-output-hk/cuddle/issues/30).
 unit_interval = #6.30([uint, uint])
 
 reward_account = bytes

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -354,7 +354,7 @@ vrf_keyhash = hash32
 ; 
 ; The relation between numerator and denominator can be
 ; expressed in CDDL, but we have a limitation currently
-; (see: https://github.com/input-output-hk/cuddle/issues/30). 
+; (see: https://github.com/input-output-hk/cuddle/issues/30).
 unit_interval = #6.30([uint, uint])
 
 reward_account = bytes

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.10.1.0
 
+### `cddl`
+
+* Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 * Add `ApplyTick` instance for `MaryEra`
 * Add `EraForecast` and `ShelleyEraForecast` instances for `MaryEra`.
 

--- a/eras/mary/impl/cddl/data/mary.cddl
+++ b/eras/mary/impl/cddl/data/mary.cddl
@@ -186,7 +186,7 @@ vrf_keyhash = hash32
 ; 
 ; The relation between numerator and denominator can be
 ; expressed in CDDL, but we have a limitation currently
-; (see: https://github.com/input-output-hk/cuddle/issues/30). 
+; (see: https://github.com/input-output-hk/cuddle/issues/30).
 unit_interval = #6.30([uint, uint])
 
 reward_account = bytes
@@ -197,15 +197,9 @@ single_host_addr = (0, port/ nil, ipv4/ nil, ipv6/ nil)
 
 port = uint .le 65535
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv4 = bytes .size (4 .. 1024)
+ipv4 = bytes .size 4
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv6 = bytes .size (16 .. 1024)
+ipv6 = bytes .size 16
 
 ; dns_name: An A or AAAA DNS record
 single_host_name = (1, port/ nil, dns_name)

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 1.19.0.0
 
 * Add `mkStAnnTx` to `ApplyTx`
+
+### `cddl`
+
+* Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 * Add `InjectionData`, `foldInjectionData`, `InjectionError` to `Cardano.Ledger.Shelley.Genesis`
 * Add `ShelleyExtraConfig` type to `Cardano.Ledger.Shelley.Genesis`
 * Add `sgExtraConfig` field to `ShelleyGenesis`

--- a/eras/shelley/impl/cddl/data/shelley.cddl
+++ b/eras/shelley/impl/cddl/data/shelley.cddl
@@ -176,7 +176,7 @@ vrf_keyhash = hash32
 ; 
 ; The relation between numerator and denominator can be
 ; expressed in CDDL, but we have a limitation currently
-; (see: https://github.com/input-output-hk/cuddle/issues/30). 
+; (see: https://github.com/input-output-hk/cuddle/issues/30).
 unit_interval = #6.30([uint, uint])
 
 reward_account = bytes
@@ -187,15 +187,9 @@ single_host_addr = (0, port/ nil, ipv4/ nil, ipv6/ nil)
 
 port = uint .le 65535
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv4 = bytes .size (4 .. 1024)
+ipv4 = bytes .size 4
 
-;  It is not possible to express a bytestring with no upper bound
-;  in CDDL, that's why the upper bound is set to 1024. In reality
-;  there is no such upper bound on the bytestring.
-ipv6 = bytes .size (16 .. 1024)
+ipv6 = bytes .size 16
 
 ; dns_name: An A or AAAA DNS record
 single_host_name = (1, port/ nil, dns_name)

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add `decodeNonEmptySetLikeEnforceNoDuplicates`
 * Change `decodeIPv4`, `decodeIPv6`, `encodeIPv4`, `encodeIPv6`, `ipv4ToBytes`, `ipv6ToBytes` to work on `Cardano.Base.IP.IPv4/IPv6`
 * Remove default implementation for `DecCBOR` class
+* Remove `binaryGetDecoder` from exports
+* Change `decodeIPv4` and `decodeIPv6` to reject leftover bytes unconditionally, regardless of protocol version
 
 ### `testlib`
 

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Cardano.Ledger.Binary.Decoding.Decoder (
   -- * Decoders
@@ -41,7 +40,6 @@ module Cardano.Ledger.Binary.Decoding.Decoder (
   matchSize,
 
   -- ** Compatibility tools
-  binaryGetDecoder,
   allowTag,
 
   -- ** Custom decoders
@@ -1181,30 +1179,24 @@ decodeUTCTime =
 
 -- | Convert a `Get` monad from @binary@ package into a `Decoder`
 binaryGetDecoder ::
-  -- | Flag to allow left over at the end or not
-  Bool ->
   -- | Name of the function or type for error reporting
   Text.Text ->
   -- | Deserializer for the @binary@ package
   Get a ->
   Decoder s a
-binaryGetDecoder allowLeftOver name getter = do
+binaryGetDecoder name getter = do
   bs <- decodeBytes
   case runGetOrFail getter (BSL.fromStrict bs) of
     Left (_, _, err) -> cborError $ DecoderErrorCustom name (Text.pack err)
     Right (leftOver, _, ha)
-      | allowLeftOver || BSL.null leftOver -> pure ha
+      | BSL.null leftOver -> pure ha
       | otherwise ->
           cborError $ DecoderErrorLeftover name (BSL.toStrict leftOver)
 {-# INLINE binaryGetDecoder #-}
 
 decodeIPv4 :: Decoder s IPv4
 decodeIPv4 =
-  toIPv4w
-    <$> ifDecoderVersionAtLeast
-      (natVersion @9)
-      (binaryGetDecoder False "decodeIPv4" getWord32le)
-      (binaryGetDecoder True "decodeIPv4" getWord32le)
+  toIPv4w <$> binaryGetDecoder "decodeIPv4" getWord32le
 {-# INLINE decodeIPv4 #-}
 
 getHostAddress6 :: Get (Word32, Word32, Word32, Word32)
@@ -1218,11 +1210,7 @@ getHostAddress6 = do
 
 decodeIPv6 :: Decoder s IPv6
 decodeIPv6 =
-  toIPv6w
-    <$> ifDecoderVersionAtLeast
-      (natVersion @9)
-      (binaryGetDecoder False "decodeIPv6" getHostAddress6)
-      (binaryGetDecoder True "decodeIPv6" getHostAddress6)
+  toIPv6w <$> binaryGetDecoder "decodeIPv6" getHostAddress6
 {-# INLINE decodeIPv6 #-}
 
 --------------------------------------------------------------------------------

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -194,7 +194,6 @@ library cddl
 
   build-depends:
     QuickCheck,
-    antigen,
     base,
     bytestring,
     cardano-ledger-binary,

--- a/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
+++ b/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
@@ -18,15 +18,13 @@
 
 module Cardano.Ledger.Core.HuddleSpec where
 
-import Cardano.Ledger.BaseTypes (getVersion, natVersion)
+import Cardano.Ledger.BaseTypes (getVersion)
 import Cardano.Ledger.Core (ByronEra, eraProtVerHigh, eraProtVerLow)
 import Cardano.Ledger.Huddle
 import Codec.CBOR.Cuddle.CDDL (Name (..))
 import Codec.CBOR.Cuddle.CDDL.CBORGenerator (
-  CBORGen,
   CustomValidatorResult (..),
   WrappedTerm (..),
-  liftAntiGen,
  )
 import Codec.CBOR.Cuddle.Huddle as H
 import Codec.CBOR.Term (Term (..))
@@ -39,7 +37,6 @@ import Data.Proxy (Proxy (..))
 import qualified Data.Text as T
 import Data.Word (Word16, Word32, Word64)
 import GHC.TypeLits (KnownSymbol, Symbol)
-import Test.AntiGen ((|!))
 import Test.QuickCheck (Arbitrary (..), Gen, oneof, vectorOf)
 import Test.QuickCheck.GenT (MonadGen (..))
 import Text.Heredoc
@@ -81,7 +78,7 @@ instance Era era => HuddleRule "unit_interval" era where
           |
           |The relation between numerator and denominator can be
           |expressed in CDDL, but we have a limitation currently
-          |(see: https://github.com/input-output-hk/cuddle/issues/30). 
+          |(see: https://github.com/input-output-hk/cuddle/issues/30).
           |]
       . withCBORGen generator
       $ pname =.= tag 30 (arr [a VUInt, a VUInt])
@@ -311,13 +308,6 @@ instance Era era => HuddleRule "stake_credential" era where
 instance Era era => HuddleRule "port" era where
   huddleRuleNamed pname _ = pname =.= VUInt `le` 65535
 
-ipGen :: Int -> CBORGen WrappedTerm
-ipGen n = do
-  l <- liftAntiGen $ choose (n, 1024) |! choose (0, pred n)
-  bs <- liftGen $ genByteString l
-  -- TODO Also generate with TBytesI
-  pure . S $ TBytes bs
-
 ipValidator :: Int -> Term -> CustomValidatorResult
 ipValidator n = \case
   TBytes bs | BS.length bs >= n -> CustomValidatorSuccess
@@ -326,18 +316,8 @@ ipValidator n = \case
 
 ipRule ::
   forall era (r :: Symbol).
-  (Era era, KnownSymbol r) => Int -> Proxy r -> Proxy era -> Rule
-ipRule n pname _
-  | eraProtVerLow @era < natVersion @9 =
-      comment
-        [str| It is not possible to express a bytestring with no upper bound
-             | in CDDL, that's why the upper bound is set to 1024. In reality
-             | there is no such upper bound on the bytestring.
-             |]
-        . withValidator (ipValidator n)
-        . withCBORGen (ipGen n)
-        $ pname =.= VBytes `H.sized` (fromIntegral n :: Word64, 1024 :: Word64)
-  | otherwise = pname =.= VBytes `H.sized` (fromIntegral n :: Word64)
+  KnownSymbol r => Int -> Proxy r -> Proxy era -> Rule
+ipRule n pname _ = pname =.= VBytes `H.sized` (fromIntegral n :: Word64)
 
 instance Era era => HuddleRule "ipv4" era where
   huddleRuleNamed = ipRule 4


### PR DESCRIPTION
# Description

No longer allow leftover bytes when decoding IPv4/IPv6 addresses regardless of decoder version.

Used cardano-streamer to test that the replay doesn't crash after changing the ipv4/v6 decoders, but pointing the `cardano-ledger` dependency to the commit `4a21449f76e58a47526eae2995f08f384d2b60f7` (https://github.com/IntersectMBO/cardano-ledger/commits/5664-check-if-any-of-the-pre-conway-transactions-contain-padded-ip-addresses-10-7-1/).

```
> cabal run cardano-streamer:exe:cstreamer -- replay --chain-dir ~/cardano-node/mainnet/db --config ~/cardano-node/mainnet/config.json --validate none
HEAD is now at 4a21449f7 Remove `allowLeftOver` flag from `binaryGetDecoder` and simplify IP address decoders
Configuration is affected by the following files:
- cabal.project
withImmutableDb prepare
withImmutableDb start
Initializing LedgerDb
Done initializing LedgerDb
Starting to Replay
withImmutableDb end
[Conway: EpochNo 625 - SlotNo 184919890] Blocks: 13305800 - Elapsed 10 hours, 33 minutes, 32 seconds

> cabal run cardano-streamer:exe:cstreamer -- replay --chain-dir ~/cardano-node/preprod/db --config ~/cardano-node/preprod/config.json --validate none
HEAD is now at 4a21449f7 Remove `allowLeftOver` flag from `binaryGetDecoder` and simplify IP address decoders
Configuration is affected by the following files:
- cabal.project
withImmutableDb prepare
withImmutableDb start
Initializing LedgerDb
Done initializing LedgerDb
Starting to Replay
withImmutableDb end
[Conway: EpochNo 283 - SlotNo 120952676] Blocks: 4625060 - Elapsed 01 hour, 47 minutes, 40 seconds

> cabal run cardano-streamer:exe:cstreamer -- replay --chain-dir ~/cardano-node/preview/db --config ~/cardano-node/preview/config.json --validate none
HEAD is now at 4a21449f7 Remove `allowLeftOver` flag from `binaryGetDecoder` and simplify IP address decoders
Configuration is affected by the following files:
- cabal.project
withImmutableDb prepare
withImmutableDb start
Initializing LedgerDb
Done initializing LedgerDb
Starting to Replay
[withImmutableDb end
[Conway: EpochNo 1273 - SlotNo 110023974] Blocks: 4206200 - Elapsed 01 hour, 44 minutes, 56 seconds
```

After confirming that the replay works as intended, the changes were ported to work on `master` instead of `10.7.1` release branch. Hence this PR.

Fix #5664.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
