### PR TITLE
Drop `x86_64-darwin` from Hydra builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,13 +51,7 @@
   };
 
   outputs = inputs:
-    let
-      supportedSystems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        # "aarch64-linux" - disable these temporarily because the build is broken
-        "aarch64-darwin"
-      ];
+    let supportedSystems = [ "x86_64-linux" "aarch64-darwin" ];
     in inputs.flake-utils.lib.eachSystem supportedSystems (system:
       let
         # setup our nixpkgs with the haskell.nix overlays, and the iohk-nix


### PR DESCRIPTION
# Description

Our supported platforms are

* `x86_64-linux`
* `aarch64-darwin`

`x86_64-darwin` was wasting CI resources

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
