### PR TITLE
Simplify Dijkstra constraints

### DIFF
--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -57,7 +57,6 @@ import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (
   ConwayCERTS,
-  ConwayDELEG,
   ConwayEra,
   ConwayGOV,
   ConwayLEDGER,
@@ -75,10 +74,9 @@ import Cardano.Ledger.Conway.Governance (
   proposalsWithPurpose,
  )
 import Cardano.Ledger.Conway.PParams (ConwayEraPParams (..))
-import Cardano.Ledger.Conway.Rules.Cert (CertEnv, ConwayCertEvent (..), ConwayCertPredFailure (..))
+import Cardano.Ledger.Conway.Rules.Cert (CertEnv, ConwayCertPredFailure (..))
 import Cardano.Ledger.Conway.Rules.Certs (
   CertsEnv (CertsEnv),
-  ConwayCertsEvent (..),
   ConwayCertsPredFailure (..),
   updateDormantDRepExpiries,
   updateVotingDRepExpiries,
@@ -621,18 +619,3 @@ instance
   where
   wrapFailed = ConwayGovFailure
   wrapEvent = GovEvent
-
-instance
-  ( EraPParams era
-  , EraRule "DELEG" era ~ ConwayDELEG era
-  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
-  , PredicateFailure (EraRule "CERTS" era) ~ ConwayCertsPredFailure era
-  , PredicateFailure (EraRule "CERT" era) ~ ConwayCertPredFailure era
-  , Event (EraRule "CERTS" era) ~ ConwayCertsEvent era
-  , Event (EraRule "CERT" era) ~ ConwayCertEvent era
-  , ConwayEraCertState era
-  ) =>
-  Embed (ConwayDELEG era) (ConwayLEDGER era)
-  where
-  wrapFailed = ConwayCertsFailure . CertFailure . DelegFailure
-  wrapEvent = CertsEvent . CertEvent . DelegEvent

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Examples.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Examples.hs
@@ -40,7 +40,7 @@ import Cardano.Ledger.Conway.Governance (
   VotingProcedure (..),
   VotingProcedures (..),
  )
-import Cardano.Ledger.Conway.Rules (ConwayDELEG, ConwayDelegPredFailure (..), ConwayLEDGER)
+import Cardano.Ledger.Conway.Rules (ConwayDelegPredFailure (..))
 import Cardano.Ledger.Conway.Scripts (ConwayPlutusPurpose (..))
 import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Credential (Credential (..))
@@ -53,7 +53,6 @@ import Cardano.Ledger.Plutus.Data (
 import Cardano.Ledger.Plutus.Language (Language (..), plutusBinary)
 import Cardano.Ledger.State (StakePoolParams (sppId))
 import Cardano.Ledger.TxIn (TxId (..))
-import Control.State.Transition.Extended (Embed (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromJust)
@@ -91,7 +90,7 @@ ledgerExamples =
   mkAlonzoBasedLedgerExamples
     ( ConwayApplyTxError $
         pure $
-          wrapFailed @(ConwayDELEG ConwayEra) @(ConwayLEDGER ConwayEra) $
+          injectFailure $
             DelegateeStakePoolNotRegisteredDELEG @ConwayEra (mkKeyHash 1)
     )
     exampleBabbageNewEpochState

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
@@ -404,8 +404,7 @@ conwayToDijkstraBbodyPredFailure = \case
   Conway.HeaderProtVerTooHigh {} -> error "Impossible: HeaderProtVerTooHigh cannot be triggered in Dijkstra era"
 
 instance
-  ( Era era
-  , BaseM ledgers ~ ShelleyBase
+  ( BaseM ledgers ~ ShelleyBase
   , ledgers ~ EraRule "LEDGERS" era
   , STS ledgers
   ) =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Cert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Cert.hs
@@ -116,8 +116,7 @@ certTransition = do
         TRC (ConwayGovCertEnv pp currentEpoch committee committeeProposals, certState, govCert)
 
 instance
-  ( Era era
-  , STS (DijkstraGOVCERT era)
+  ( STS (DijkstraGOVCERT era)
   , PredicateFailure (EraRule "GOVCERT" era) ~ DijkstraGovCertPredFailure era
   ) =>
   Embed (DijkstraGOVCERT era) (DijkstraCERT era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Certs.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Certs.hs
@@ -7,7 +7,6 @@
 
 module Cardano.Ledger.Dijkstra.Rules.Certs () where
 
-import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Conway.Rules (
   ConwayCERTS,
   ConwayCertEvent (..),
@@ -51,7 +50,6 @@ instance InjectRuleFailure "CERTS" ConwayGovCertPredFailure DijkstraEra where
 instance
   ( Era era
   , STS (DijkstraCERT era)
-  , BaseM (EraRule "CERT" era) ~ ShelleyBase
   , Event (EraRule "CERT" era) ~ ConwayCertEvent era
   , PredicateFailure (EraRule "CERT" era) ~ ConwayCertPredFailure era
   ) =>
@@ -61,8 +59,7 @@ instance
   wrapEvent = CertEvent
 
 instance
-  ( Era era
-  , STS (ConwayDELEG era)
+  ( STS (ConwayDELEG era)
   , PredicateFailure (EraRule "DELEG" era) ~ ConwayDelegPredFailure era
   ) =>
   Embed (ConwayDELEG era) (DijkstraCERT era)
@@ -71,12 +68,9 @@ instance
   wrapEvent = absurd
 
 instance
-  ( Era era
-  , STS (ShelleyPOOL era)
-  , Event (EraRule "POOL" era) ~ PoolEvent era
+  ( STS (ShelleyPOOL era)
   , PredicateFailure (EraRule "POOL" era) ~ ShelleyPoolPredFailure era
-  , PredicateFailure (ShelleyPOOL era) ~ ShelleyPoolPredFailure era
-  , BaseM (ShelleyPOOL era) ~ ShelleyBase
+  , Event (EraRule "POOL" era) ~ PoolEvent era
   ) =>
   Embed (ShelleyPOOL era) (DijkstraCERT era)
   where
@@ -84,8 +78,7 @@ instance
   wrapEvent = PoolEvent
 
 instance
-  ( Era era
-  , STS (ConwayGOVCERT era)
+  ( STS (ConwayGOVCERT era)
   , PredicateFailure (EraRule "GOVCERT" era) ~ ConwayGovCertPredFailure era
   ) =>
   Embed (ConwayGOVCERT era) (DijkstraCERT era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -58,11 +58,8 @@ import Cardano.Ledger.Conway.Rules (
   CertEnv,
   CertsEnv (..),
   ConwayCERTS,
-  ConwayCertEvent (..),
   ConwayCertPredFailure (..),
-  ConwayCertsEvent (..),
   ConwayCertsPredFailure (..),
-  ConwayDELEG,
   ConwayDelegPredFailure,
   ConwayGovCertPredFailure,
   ConwayGovEvent,
@@ -659,21 +656,6 @@ instance
   where
   wrapFailed = DijkstraCertsFailure
   wrapEvent = CertsEvent
-
-instance
-  ( EraPParams era
-  , EraRule "DELEG" era ~ ConwayDELEG era
-  , PredicateFailure (EraRule "CERTS" era) ~ ConwayCertsPredFailure era
-  , PredicateFailure (EraRule "CERT" era) ~ ConwayCertPredFailure era
-  , Event (EraRule "CERTS" era) ~ ConwayCertsEvent era
-  , Event (EraRule "CERT" era) ~ ConwayCertEvent era
-  , ConwayEraCertState era
-  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
-  ) =>
-  Embed (ConwayDELEG era) (DijkstraLEDGER era)
-  where
-  wrapFailed = DijkstraCertsFailure . CertFailure . DelegFailure
-  wrapEvent = CertsEvent . CertEvent . DelegEvent
 
 instance
   ( AlonzoEraTx era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -24,14 +24,13 @@ module Cardano.Ledger.Dijkstra.Rules.Ledger (
 
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
 import Cardano.Ledger.Alonzo (AlonzoScript)
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxoPredFailure,
   AlonzoUtxosPredFailure,
   AlonzoUtxowEvent,
   AlonzoUtxowPredFailure,
  )
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage (BabbageTxOut)
 import Cardano.Ledger.Babbage.Rules (
   BabbageUtxoPredFailure,
@@ -55,14 +54,12 @@ import Cardano.Ledger.Conway.Governance (
   proposalsWithPurpose,
  )
 import Cardano.Ledger.Conway.Rules (
-  CertEnv,
   CertsEnv (..),
   ConwayCERTS,
   ConwayCertPredFailure (..),
   ConwayCertsPredFailure (..),
   ConwayDelegPredFailure,
   ConwayGovCertPredFailure,
-  ConwayGovEvent,
   ConwayGovPredFailure,
   ConwayLedgerPredFailure,
   ConwayUtxoPredFailure,
@@ -82,29 +79,16 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
   DijkstraGOV,
   DijkstraLEDGER,
-  DijkstraSUBCERT,
-  DijkstraSUBCERTS,
-  DijkstraSUBDELEG,
-  DijkstraSUBGOV,
-  DijkstraSUBGOVCERT,
-  DijkstraSUBUTXO,
-  DijkstraSUBUTXOW,
   DijkstraUTXOW,
  )
 import Cardano.Ledger.Dijkstra.Rules.Certs ()
 import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubGov (DijkstraSubGovEvent, DijkstraSubGovPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedger
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers
-import Cardano.Ledger.Dijkstra.Rules.SubPool
-import Cardano.Ledger.Dijkstra.Rules.SubUtxow (DijkstraSubUtxowPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxoEnv (..), DijkstraUtxowPredFailure)
 import Cardano.Ledger.Dijkstra.TxBody
-import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Rules.ValidationMode (runTest)
 import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
@@ -115,7 +99,6 @@ import Cardano.Ledger.Shelley.LedgerState (
  )
 import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
-  PoolEvent,
   ShelleyLEDGERS,
   ShelleyLedgerPredFailure (..),
   ShelleyLedgersEvent (LedgerEvent),
@@ -538,64 +521,9 @@ instance
   wrapEvent = UtxowEvent
 
 instance
-  ( Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
-  , Embed (EraRule "CERTS" era) (DijkstraLEDGER era)
-  , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
-  , ConwayEraGov era
-  , AlonzoEraTx era
-  , AlonzoEraUTxO era
-  , ConwayEraPParams era
-  , DijkstraEraTxBody era
-  , EraPlutusContext era
-  , GovState era ~ ConwayGovState era
-  , Environment (EraRule "UTXOW" era) ~ DijkstraUtxoEnv era
-  , Environment (EraRule "CERTS" era) ~ CertsEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
-  , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
-  , State (EraRule "UTXOW" era) ~ UTxOState era
-  , State (EraRule "CERTS" era) ~ CertState era
-  , EraRule "GOV" era ~ DijkstraGOV era
-  , ConwayEraCertState era
-  , EraRule "LEDGER" era ~ DijkstraLEDGER era
-  , EraRule "SUBLEDGERS" era ~ DijkstraSUBLEDGERS era
-  , EraRule "SUBLEDGER" era ~ DijkstraSUBLEDGER era
-  , EraRule "SUBGOV" era ~ DijkstraSUBGOV era
-  , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
-  , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
-  , EraRule "SUBCERTS" era ~ DijkstraSUBCERTS era
-  , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
-  , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
-  , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
-  , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
-  , InjectRuleFailure "LEDGER" ShelleyLedgerPredFailure era
-  , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
-  , InjectRuleFailure "LEDGER" DijkstraLedgerPredFailure era
-  , InjectRuleFailure "LEDGER" DijkstraSubLedgersPredFailure era
-  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
-  , InjectRuleEvent "SUBPOOL" PoolEvent era
-  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
-  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
-  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
-  , InjectRuleEvent "SUBGOV" DijkstraSubGovEvent era
-  , InjectRuleEvent "SUBGOV" ConwayGovEvent era
-  , InjectRuleFailure "SUBGOV" DijkstraSubGovPredFailure era
-  , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
-  , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
-  , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXO" ShelleyUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AllegraUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AlonzoUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" BabbageUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" DijkstraUtxoPredFailure era
-  , TxCert era ~ DijkstraTxCert era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  ( STS (DijkstraLEDGER era)
+  , PredicateFailure (EraRule "LEDGER" era) ~ DijkstraLedgerPredFailure era
+  , Event (EraRule "LEDGER" era) ~ DijkstraLedgerEvent era
   ) =>
   Embed (DijkstraLEDGER era) (ShelleyLEDGERS era)
   where
@@ -603,14 +531,9 @@ instance
   wrapEvent = LedgerEvent
 
 instance
-  ( ConwayEraCertState era
-  , ConwayEraTxCert era
-  , ConwayEraPParams era
-  , ConwayEraGov era
-  , EraRule "GOV" era ~ DijkstraGOV era
-  , InjectRuleFailure "GOV" ConwayGovPredFailure era
-  , InjectRuleFailure "GOV" DijkstraGovPredFailure era
-  , InjectRuleEvent "GOV" ConwayGovEvent era
+  ( STS (DijkstraGOV era)
+  , PredicateFailure (EraRule "GOV" era) ~ DijkstraGovPredFailure era
+  , Event (EraRule "GOV" era) ~ Conway.ConwayGovEvent era
   ) =>
   Embed (DijkstraGOV era) (DijkstraLEDGER era)
   where
@@ -639,18 +562,9 @@ shelleyToDijkstraLedgerPredFailure = \case
   ShelleyIncompleteWithdrawals x -> DijkstraIncompleteWithdrawals x
 
 instance
-  ( EraTx era
-  , ConwayEraTxBody era
-  , ConwayEraPParams era
-  , ConwayEraGov era
-  , Embed (EraRule "CERT" era) (ConwayCERTS era)
-  , State (EraRule "CERT" era) ~ CertState era
-  , Environment (EraRule "CERT" era) ~ CertEnv era
-  , Signal (EraRule "CERT" era) ~ TxCert era
-  , PredicateFailure (EraRule "CERT" era) ~ ConwayCertPredFailure era
-  , EraRuleFailure "CERT" era ~ ConwayCertPredFailure era
-  , EraRule "CERTS" era ~ ConwayCERTS era
-  , ConwayEraCertState era
+  ( STS (ConwayCERTS era)
+  , PredicateFailure (EraRule "CERTS" era) ~ ConwayCertsPredFailure era
+  , Event (EraRule "CERTS" era) ~ Conway.ConwayCertsEvent era
   ) =>
   Embed (ConwayCERTS era) (DijkstraLEDGER era)
   where
@@ -658,50 +572,9 @@ instance
   wrapEvent = CertsEvent
 
 instance
-  ( AlonzoEraTx era
-  , AlonzoEraUTxO era
-  , DijkstraEraTxBody era
-  , ConwayEraGov era
-  , ConwayEraCertState era
-  , EraPlutusContext era
-  , ConwayEraTxCert era
-  , ConwayEraPParams era
-  , EraRule "SUBLEDGERS" era ~ DijkstraSUBLEDGERS era
-  , EraRule "SUBLEDGER" era ~ DijkstraSUBLEDGER era
-  , EraRule "SUBGOV" era ~ DijkstraSUBGOV era
-  , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
-  , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
-  , EraRule "SUBCERTS" era ~ DijkstraSUBCERTS era
-  , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
-  , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
-  , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
-  , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
-  , Event (EraRule "LEDGER" era) ~ DijkstraLedgerEvent era
-  , InjectRuleEvent "SUBPOOL" PoolEvent era
-  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
-  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
-  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
-  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
-  , InjectRuleEvent "SUBGOV" DijkstraSubGovEvent era
-  , InjectRuleEvent "SUBGOV" ConwayGovEvent era
-  , InjectRuleFailure "SUBGOV" DijkstraSubGovPredFailure era
-  , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
-  , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
-  , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXO" ShelleyUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AllegraUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AlonzoUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" BabbageUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" DijkstraUtxoPredFailure era
-  , TxCert era ~ DijkstraTxCert era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  ( STS (DijkstraSUBLEDGERS era)
+  , PredicateFailure (EraRule "SUBLEDGERS" era) ~ DijkstraSubLedgersPredFailure era
+  , Event (EraRule "SUBLEDGERS" era) ~ DijkstraSubLedgersEvent era
   ) =>
   Embed (DijkstraSUBLEDGERS era) (DijkstraLEDGER era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -21,11 +21,6 @@ module Cardano.Ledger.Dijkstra.Rules.Mempool (
   DijkstraMempoolEvent (..),
 ) where
 
-import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
-import Cardano.Ledger.Alonzo.Rules (AlonzoUtxoPredFailure, AlonzoUtxowPredFailure)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (
@@ -36,60 +31,24 @@ import Cardano.Ledger.Binary.Coders (
   (!>),
   (<!),
  )
-import Cardano.Ledger.Conway.Governance (
-  ConwayEraGov,
-  ConwayGovState,
-  Proposals,
- )
-import Cardano.Ledger.Conway.Rules (
-  CertsEnv,
-  ConwayDelegPredFailure,
-  ConwayGovCertPredFailure,
-  ConwayGovEvent,
-  ConwayGovPredFailure,
-  ConwayLedgerPredFailure (ConwayMempoolFailure),
-  GovEnv,
-  GovSignal,
- )
+import Cardano.Ledger.Conway.Governance (ConwayEraGov)
+import Cardano.Ledger.Conway.Rules (ConwayLedgerPredFailure (..))
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
   DijkstraLEDGER,
   DijkstraMEMPOOL,
-  DijkstraSUBCERT,
-  DijkstraSUBCERTS,
-  DijkstraSUBDELEG,
-  DijkstraSUBGOV,
-  DijkstraSUBGOVCERT,
-  DijkstraSUBLEDGER,
-  DijkstraSUBLEDGERS,
-  DijkstraSUBPOOL,
-  DijkstraSUBUTXO,
-  DijkstraSUBUTXOW,
  )
 import Cardano.Ledger.Dijkstra.Rules.Ledger (
+  DijkstraLedgerEvent,
   DijkstraLedgerPredFailure (..),
   conwayToDijkstraLedgerPredFailure,
  )
-import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubGov (DijkstraSubGovEvent, DijkstraSubGovPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers (DijkstraSubLedgersPredFailure (..))
-import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubUtxow (DijkstraSubUtxowPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxoEnv)
 import Cardano.Ledger.Dijkstra.State
-import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Shelley.LedgerState
-import Cardano.Ledger.Shelley.Rules (
-  LedgerEnv (..),
-  PoolEvent,
-  ShelleyLedgerPredFailure,
-  ShelleyPoolPredFailure,
-  ShelleyUtxoPredFailure,
-  ShelleyUtxowPredFailure,
- )
+import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
 import Control.DeepSeq (NFData)
 import Control.State.Transition (
   BaseM,
@@ -108,7 +67,6 @@ import Control.State.Transition (
  )
 import Control.State.Transition.Extended (Embed (..), trans)
 import qualified Data.Map.Strict as Map
-import Data.Sequence (Seq)
 import Data.Text (Text)
 import GHC.Generics (Generic (..))
 import Lens.Micro ((^.))
@@ -239,64 +197,9 @@ mempoolTransition = do
     trans @(EraRule "LEDGER" era) $ TRC trc
 
 instance
-  ( AlonzoEraTx era
-  , AlonzoEraUTxO era
-  , ConwayEraCertState era
-  , DijkstraEraTxBody era
-  , ConwayEraGov era
-  , EraPlutusContext era
-  , GovState era ~ ConwayGovState era
-  , Embed (EraRule "CERTS" era) (DijkstraLEDGER era)
-  , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
-  , Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
-  , Environment (EraRule "CERTS" era) ~ CertsEnv era
-  , Environment (EraRule "GOV" era) ~ GovEnv era
-  , Environment (EraRule "UTXOW" era) ~ DijkstraUtxoEnv era
-  , State (EraRule "CERTS" era) ~ CertState era
-  , State (EraRule "GOV" era) ~ Proposals era
-  , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
-  , Signal (EraRule "GOV" era) ~ GovSignal era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
-  , EraRule "LEDGER" era ~ DijkstraLEDGER era
-  , EraRule "SUBLEDGERS" era ~ DijkstraSUBLEDGERS era
-  , EraRule "SUBLEDGER" era ~ DijkstraSUBLEDGER era
-  , EraRule "SUBGOV" era ~ DijkstraSUBGOV era
-  , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
-  , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
-  , EraRule "SUBCERTS" era ~ DijkstraSUBCERTS era
-  , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
-  , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
-  , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
-  , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
-  , InjectRuleFailure "LEDGER" ShelleyLedgerPredFailure era
-  , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
-  , InjectRuleFailure "LEDGER" DijkstraLedgerPredFailure era
-  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
-  , InjectRuleEvent "SUBPOOL" PoolEvent era
-  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
-  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
-  , InjectRuleFailure "DELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
-  , InjectRuleEvent "SUBGOV" DijkstraSubGovEvent era
-  , InjectRuleEvent "SUBGOV" ConwayGovEvent era
-  , InjectRuleFailure "SUBGOV" DijkstraSubGovPredFailure era
-  , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
-  , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
-  , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXO" ShelleyUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AllegraUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AlonzoUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" BabbageUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" DijkstraUtxoPredFailure era
-  , TxCert era ~ DijkstraTxCert era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  ( STS (DijkstraLEDGER era)
+  , PredicateFailure (EraRule "LEDGER" era) ~ DijkstraLedgerPredFailure era
+  , Event (EraRule "LEDGER" era) ~ DijkstraLedgerEvent era
   ) =>
   Embed (DijkstraLEDGER era) (DijkstraMEMPOOL era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCert.hs
@@ -37,7 +37,6 @@ import Cardano.Ledger.Conway.Rules (
   ConwayDelegEnv (..),
   ConwayDelegPredFailure,
   ConwayGovCertEnv (..),
-  ConwayGovCertPredFailure,
  )
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (
@@ -52,7 +51,7 @@ import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
 import Cardano.Ledger.Dijkstra.TxCert
-import Cardano.Ledger.Shelley.Rules (PoolEnv (..), PoolEvent, ShelleyPoolPredFailure)
+import Cardano.Ledger.Shelley.Rules (PoolEnv (..), ShelleyPoolPredFailure)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
 import Data.Void (absurd)
@@ -195,12 +194,8 @@ dijkstraSubCertTransition = do
         TRC (ConwayGovCertEnv pp currentEpoch committee committeeProposals, certState, govCert)
 
 instance
-  ( ConwayEraGov era
-  , ConwayEraCertState era
-  , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
-  , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
-  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
+  ( STS (DijkstraSUBDELEG era)
+  , PredicateFailure (EraRule "SUBDELEG" era) ~ DijkstraSubDelegPredFailure era
   ) =>
   Embed (DijkstraSUBDELEG era) (DijkstraSUBCERT era)
   where
@@ -208,13 +203,9 @@ instance
   wrapEvent = absurd
 
 instance
-  ( ConwayEraGov era
-  , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
-  , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
-  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
-  , InjectRuleEvent "SUBPOOL" PoolEvent era
-  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
-  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
+  ( STS (DijkstraSUBPOOL era)
+  , PredicateFailure (EraRule "SUBPOOL" era) ~ DijkstraSubPoolPredFailure era
+  , Event (EraRule "SUBPOOL" era) ~ DijkstraSubPoolEvent era
   ) =>
   Embed (DijkstraSUBPOOL era) (DijkstraSUBCERT era)
   where
@@ -222,13 +213,9 @@ instance
   wrapEvent = SubPoolEvent
 
 instance
-  ( ConwayEraGov era
-  , ConwayEraPParams era
-  , ConwayEraCertState era
-  , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
-  , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
-  , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
+  ( Era era
+  , STS (DijkstraSUBGOVCERT era)
+  , PredicateFailure (EraRule "SUBGOVCERT" era) ~ DijkstraSubGovCertPredFailure era
   ) =>
   Embed (DijkstraSUBGOVCERT era) (DijkstraSUBCERT era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubCerts.hs
@@ -36,25 +36,15 @@ import Cardano.Ledger.Conway.Rules (
   CertEnv (..),
   ConwayCertPredFailure,
   ConwayCertsPredFailure (..),
-  ConwayDelegPredFailure,
-  ConwayGovCertPredFailure,
  )
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
   DijkstraSUBCERT,
   DijkstraSUBCERTS,
-  DijkstraSUBDELEG,
-  DijkstraSUBGOVCERT,
-  DijkstraSUBPOOL,
  )
 import Cardano.Ledger.Dijkstra.Rules.Cert ()
-import Cardano.Ledger.Dijkstra.Rules.SubCert (DijkstraSubCertPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
-import Cardano.Ledger.Dijkstra.TxCert
-import Cardano.Ledger.Shelley.Rules (PoolEvent, ShelleyPoolPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.SubCert (DijkstraSubCertEvent, DijkstraSubCertPredFailure)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
 import qualified Data.Map.Strict as Map
@@ -150,23 +140,9 @@ dijkstraSubCertsTransition = do
         TRC (CertEnv pp currentEpoch committee committeeProposals, certStateRest, txCert)
 
 instance
-  ( ConwayEraGov era
-  , ConwayEraCertState era
-  , ConwayEraPParams era
-  , EraRule "SUBCERTS" era ~ DijkstraSUBCERTS era
-  , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
-  , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
-  , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
-  , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
-  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
-  , InjectRuleEvent "SUBPOOL" PoolEvent era
-  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
-  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
-  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
-  , TxCert era ~ DijkstraTxCert era
+  ( STS (DijkstraSUBCERT era)
+  , PredicateFailure (EraRule "SUBCERT" era) ~ DijkstraSubCertPredFailure era
+  , Event (EraRule "SUBCERT" era) ~ DijkstraSubCertEvent era
   ) =>
   Embed (DijkstraSUBCERT era) (DijkstraSUBCERTS era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -22,11 +22,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedger (
   SubLedgerEnv (..),
 ) where
 
-import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
-import Cardano.Ledger.Alonzo.Rules (AlonzoUtxoPredFailure, AlonzoUtxowPredFailure)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -40,8 +36,6 @@ import Cardano.Ledger.Conway.Rules (
   ConwayCertsPredFailure,
   ConwayDelegPredFailure,
   ConwayGovCertPredFailure,
-  ConwayGovEvent,
-  ConwayGovPredFailure,
   ConwayLedgerPredFailure (..),
   GovEnv (..),
   GovSignal (..),
@@ -65,24 +59,27 @@ import Cardano.Ledger.Dijkstra.Era (
   DijkstraSUBUTXOW,
  )
 import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure (..))
-import Cardano.Ledger.Dijkstra.Rules.SubCerts (DijkstraSubCertsPredFailure (..), SubCertsEnv (..))
+import Cardano.Ledger.Dijkstra.Rules.SubCerts (
+  DijkstraSubCertsEvent,
+  DijkstraSubCertsPredFailure (..),
+  SubCertsEnv (..),
+ )
 import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubGov (DijkstraSubGovEvent, DijkstraSubGovPredFailure (..))
 import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubUtxo (SubUtxoEnv (..))
-import Cardano.Ledger.Dijkstra.Rules.SubUtxow (DijkstraSubUtxowPredFailure (..))
-import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.SubUtxow (
+  DijkstraSubUtxowEvent (..),
+  DijkstraSubUtxowPredFailure (..),
+ )
 import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure (..))
-import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody)
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Rules.ValidationMode (runTest)
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules (
   PoolEvent,
   ShelleyPoolPredFailure,
-  ShelleyUtxoPredFailure,
-  ShelleyUtxowPredFailure,
   epochFromSlot,
  )
 import Control.DeepSeq (NFData)
@@ -251,7 +248,6 @@ dijkstraSubLedgersTransition ::
   , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
   , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
   , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
   , STS (EraRule "SUBLEDGER" era)
   , TxCert era ~ DijkstraTxCert era
   ) =>
@@ -318,15 +314,9 @@ dijkstraSubLedgersTransition = do
       & lsCertStateL .~ certStateAfterSubCerts
 
 instance
-  ( ConwayEraGov era
-  , ConwayEraCertState era
-  , ConwayEraPParams era
-  , ConwayEraTxCert era
-  , EraRule "SUBGOV" era ~ DijkstraSUBGOV era
-  , InjectRuleEvent "SUBGOV" DijkstraSubGovEvent era
-  , InjectRuleEvent "SUBGOV" ConwayGovEvent era
-  , InjectRuleFailure "SUBGOV" DijkstraSubGovPredFailure era
-  , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
+  ( STS (DijkstraSUBGOV era)
+  , PredicateFailure (EraRule "SUBGOV" era) ~ DijkstraSubGovPredFailure era
+  , Event (EraRule "SUBGOV" era) ~ DijkstraSubGovEvent era
   ) =>
   Embed (DijkstraSUBGOV era) (DijkstraSUBLEDGER era)
   where
@@ -334,24 +324,9 @@ instance
   wrapEvent = SubGovEvent
 
 instance
-  ( AlonzoEraTx era
-  , AlonzoEraUTxO era
-  , ConwayEraGov era
-  , ConwayEraCertState era
-  , DijkstraEraTxBody era
-  , EraPlutusContext era
-  , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
-  , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
-  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXO" ShelleyUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AllegraUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AlonzoUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" BabbageUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" DijkstraUtxoPredFailure era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  ( STS (DijkstraSUBUTXOW era)
+  , PredicateFailure (EraRule "SUBUTXOW" era) ~ DijkstraSubUtxowPredFailure era
+  , Event (EraRule "SUBUTXOW" era) ~ DijkstraSubUtxowEvent era
   ) =>
   Embed (DijkstraSUBUTXOW era) (DijkstraSUBLEDGER era)
   where
@@ -359,23 +334,9 @@ instance
   wrapEvent = SubUtxowEvent
 
 instance
-  ( ConwayEraGov era
-  , ConwayEraPParams era
-  , ConwayEraCertState era
-  , EraRule "SUBCERTS" era ~ DijkstraSUBCERTS era
-  , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
-  , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
-  , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
-  , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
-  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
-  , InjectRuleEvent "SUBPOOL" PoolEvent era
-  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
-  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
-  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
-  , TxCert era ~ DijkstraTxCert era
+  ( STS (DijkstraSUBCERTS era)
+  , PredicateFailure (EraRule "SUBCERTS" era) ~ DijkstraSubCertsPredFailure era
+  , Event (EraRule "SUBCERTS" era) ~ DijkstraSubCertsEvent era
   ) =>
   Embed (DijkstraSUBCERTS era) (DijkstraSUBLEDGER era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -19,11 +19,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubLedgers (
   DijkstraSubLedgersEvent (..),
 ) where
 
-import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
-import Cardano.Ledger.Alonzo.Rules (AlonzoUtxoPredFailure, AlonzoUtxowPredFailure)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
 import Cardano.Ledger.BaseTypes (
   ShelleyBase,
  )
@@ -33,45 +29,22 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
-import Cardano.Ledger.Conway.Rules (
-  ConwayDelegPredFailure,
-  ConwayGovCertPredFailure,
-  ConwayGovEvent,
-  ConwayGovPredFailure,
-  ConwayLedgerPredFailure,
- )
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
-  DijkstraSUBCERT,
-  DijkstraSUBCERTS,
-  DijkstraSUBDELEG,
-  DijkstraSUBGOV,
-  DijkstraSUBGOVCERT,
   DijkstraSUBLEDGER,
   DijkstraSUBLEDGERS,
-  DijkstraSUBPOOL,
-  DijkstraSUBUTXO,
-  DijkstraSUBUTXOW,
  )
-import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.SubGov (DijkstraSubGovEvent, DijkstraSubGovPredFailure (..))
-import Cardano.Ledger.Dijkstra.Rules.SubGovCert (DijkstraSubGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedger (
+  DijkstraSubLedgerEvent,
   DijkstraSubLedgerPredFailure (..),
   SubLedgerEnv (..),
  )
 import Cardano.Ledger.Dijkstra.Rules.SubPool (DijkstraSubPoolEvent, DijkstraSubPoolPredFailure (..))
-import Cardano.Ledger.Dijkstra.Rules.SubUtxow (DijkstraSubUtxowPredFailure)
-import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
-import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody)
-import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules (
   PoolEvent,
   ShelleyPoolPredFailure,
-  ShelleyUtxoPredFailure,
-  ShelleyUtxowPredFailure,
  )
 import Cardano.Ledger.TxIn (TxId)
 import Control.DeepSeq (NFData)
@@ -167,47 +140,9 @@ dijkstraSubLedgersTransition = do
     subTxs
 
 instance
-  ( AlonzoEraTx era
-  , AlonzoEraUTxO era
-  , DijkstraEraTxBody era
-  , ConwayEraGov era
-  , ConwayEraCertState era
-  , ConwayEraPParams era
-  , ConwayEraTxCert era
-  , EraPlutusContext era
-  , EraRule "SUBLEDGER" era ~ DijkstraSUBLEDGER era
-  , EraRule "SUBGOV" era ~ DijkstraSUBGOV era
-  , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
-  , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
-  , EraRule "SUBCERTS" era ~ DijkstraSUBCERTS era
-  , EraRule "SUBCERT" era ~ DijkstraSUBCERT era
-  , EraRule "SUBDELEG" era ~ DijkstraSUBDELEG era
-  , EraRule "SUBPOOL" era ~ DijkstraSUBPOOL era
-  , EraRule "SUBGOVCERT" era ~ DijkstraSUBGOVCERT era
-  , InjectRuleEvent "SUBPOOL" PoolEvent era
-  , InjectRuleEvent "SUBPOOL" DijkstraSubPoolEvent era
-  , InjectRuleFailure "SUBPOOL" ShelleyPoolPredFailure era
-  , InjectRuleFailure "SUBPOOL" DijkstraSubPoolPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" DijkstraSubGovCertPredFailure era
-  , InjectRuleFailure "SUBGOVCERT" ConwayGovCertPredFailure era
-  , InjectRuleFailure "SUBDELEG" ConwayDelegPredFailure era
-  , InjectRuleFailure "SUBDELEG" DijkstraSubDelegPredFailure era
-  , InjectRuleEvent "SUBGOV" DijkstraSubGovEvent era
-  , InjectRuleEvent "SUBGOV" ConwayGovEvent era
-  , InjectRuleFailure "SUBGOV" DijkstraSubGovPredFailure era
-  , InjectRuleFailure "SUBGOV" ConwayGovPredFailure era
-  , InjectRuleFailure "SUBLEDGER" ConwayLedgerPredFailure era
-  , InjectRuleFailure "SUBUTXOW" AlonzoUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" ShelleyUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" BabbageUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXOW" DijkstraSubUtxowPredFailure era
-  , InjectRuleFailure "SUBUTXO" ShelleyUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AllegraUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AlonzoUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" BabbageUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" DijkstraUtxoPredFailure era
-  , TxCert era ~ DijkstraTxCert era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  ( STS (DijkstraSUBLEDGER era)
+  , PredicateFailure (EraRule "SUBLEDGER" era) ~ DijkstraSubLedgerPredFailure era
+  , Event (EraRule "SUBLEDGER" era) ~ DijkstraSubLedgerEvent era
   ) =>
   Embed (DijkstraSUBLEDGER era) (DijkstraSUBLEDGERS era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -22,16 +22,15 @@ module Cardano.Ledger.Dijkstra.Rules.SubUtxow (
 ) where
 
 import Cardano.Crypto.Hash (ByteString)
-import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
-import Cardano.Ledger.Alonzo.Rules (AlonzoUtxoPredFailure, AlonzoUtxowPredFailure)
+import Cardano.Ledger.Alonzo.Rules (AlonzoUtxowPredFailure)
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo (
   checkScriptIntegrityHash,
   hasExactSetOfRedeemers,
   missingRequiredDatums,
  )
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..), AlonzoScriptsNeeded)
-import Cardano.Ledger.Babbage.Rules (BabbageUtxoPredFailure, BabbageUtxowPredFailure)
+import Cardano.Ledger.Babbage.Rules (BabbageUtxowPredFailure)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage (
   validateFailedBabbageScripts,
   validateScriptsWellFormedTxOuts,
@@ -66,13 +65,13 @@ import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
 import Cardano.Ledger.Keys (VKey)
 import Cardano.Ledger.Rules.ValidationMode
 import Cardano.Ledger.Shelley.LedgerState (UTxOState)
-import Cardano.Ledger.Shelley.Rules (ShelleyUtxoPredFailure, ShelleyUtxowPredFailure)
+import Cardano.Ledger.Shelley.Rules (ShelleyUtxowPredFailure)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley (
   validateMetadata,
   validateNeededWitnesses,
   validateVerifiedWits,
  )
-import Cardano.Ledger.State (EraCertState, EraStake, EraUTxO (..), ScriptsProvided (..))
+import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
@@ -309,20 +308,9 @@ dijkstraSubUtxowTransition = do
   trans @(EraRule "SUBUTXO" era) $ TRC (env, utxoState, tx)
 
 instance
-  ( EraTx era
-  , EraStake era
-  , EraCertState era
-  , AlonzoEraTxWits era
-  , ConwayEraGov era
-  , DijkstraEraTxBody era
-  , EraPlutusContext era
-  , EraRule "SUBUTXO" era ~ DijkstraSUBUTXO era
-  , EraRule "SUBUTXOW" era ~ DijkstraSUBUTXOW era
-  , InjectRuleFailure "SUBUTXO" ShelleyUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AllegraUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" AlonzoUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" BabbageUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" DijkstraUtxoPredFailure era
+  ( STS (DijkstraSUBUTXO era)
+  , PredicateFailure (EraRule "SUBUTXO" era) ~ DijkstraSubUtxoPredFailure era
+  , Event (EraRule "SUBUTXO" era) ~ DijkstraSubUtxoEvent era
   ) =>
   Embed (DijkstraSUBUTXO era) (DijkstraSUBUTXOW era)
   where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -356,8 +356,7 @@ instance
   assertions = [validSizeComputationCheck]
 
 instance
-  ( Era era
-  , STS (ConwayUTXOS era)
+  ( STS (ConwayUTXOS era)
   , PredicateFailure (EraRule "UTXOS" era) ~ ConwayUtxosPredFailure era
   , Event (EraRule "UTXOS" era) ~ Event (ConwayUTXOS era)
   ) =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -379,13 +379,9 @@ instance
   initialRules = []
 
 instance
-  ( Era era
-  , STS (DijkstraUTXO era)
+  ( STS (DijkstraUTXO era)
   , PredicateFailure (EraRule "UTXO" era) ~ DijkstraUtxoPredFailure era
   , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
-  , BaseM (DijkstraUTXOW era) ~ ShelleyBase
-  , PredicateFailure (DijkstraUTXOW era) ~ DijkstraUtxowPredFailure era
-  , Event (DijkstraUTXOW era) ~ AlonzoUtxowEvent era
   ) =>
   Embed (DijkstraUTXO era) (DijkstraUTXOW era)
   where

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
@@ -24,12 +24,12 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Rules (ConwayDELEG, ConwayDelegPredFailure (..))
+import Cardano.Ledger.Conway.Rules (ConwayDelegPredFailure (..))
 import Cardano.Ledger.Conway.TxCert (ConwayGovCert (..), Delegatee (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep (DRep (..))
 import Cardano.Ledger.Dijkstra (ApplyTxError (..), DijkstraEra)
-import Cardano.Ledger.Dijkstra.Rules (DijkstraLEDGER, DijkstraMEMPOOL)
+import qualified Cardano.Ledger.Dijkstra.Rules as Dijkstra
 import Cardano.Ledger.Dijkstra.Scripts (
   AccountBalanceInterval (..),
   AccountBalanceIntervals (..),
@@ -51,7 +51,6 @@ import Cardano.Ledger.Plutus.Data (
  )
 import Cardano.Ledger.Plutus.Language (Language (..), plutusBinary)
 import Cardano.Ledger.State (StakePoolParams (sppId))
-import Control.State.Transition.Extended (Embed (..))
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as Map
 import qualified Data.OMap.Strict as OMap
@@ -92,8 +91,8 @@ ledgerExamples =
   mkAlonzoBasedLedgerExamples
     ( DijkstraApplyTxError $
         pure $
-          wrapFailed @(DijkstraLEDGER DijkstraEra) @(DijkstraMEMPOOL DijkstraEra) $
-            wrapFailed @(ConwayDELEG DijkstraEra) @(DijkstraLEDGER DijkstraEra) $
+          Dijkstra.LedgerFailure $
+            injectFailure $
               DelegateeStakePoolNotRegisteredDELEG (mkKeyHash 1)
     )
     exampleBabbageNewEpochState


### PR DESCRIPTION
# Description

As the title says. Constraints used for `Embed` in Dijkstra were most general, which resulted in a column of constraints. It is better to stay consistent with previous eras and keep them to the minimum with some type qualities

This PR also removes to redundant Embed instances, but they aren't mentioned in the changelog since Embed instances aren't used outside of ledger

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
