### PR TITLE
More reallife implementation of PerasCertificate

### DIFF
--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -11,6 +11,7 @@ block =
   , transaction_witness_sets : [* transaction_witness_set]            
   , auxiliary_data_set       : {* transaction_index => auxiliary_data}
   , invalid_transactions     : [* transaction_index]                  
+  , peras_cert               : peras_cert                                 
   ]
 
 
@@ -784,4 +785,6 @@ auxiliary_data_map =
 
 
 transaction_index = uint .size 2
+
+peras_cert = bytes/ nil
 

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -873,6 +873,7 @@ instance HuddleRule "block" DijkstraEra where
                     ==> huddleRule @"auxiliary_data" p
                 ]
           , "invalid_transactions" ==> arr [0 <+ a (huddleRule @"transaction_index" p)]
+          , "peras_cert" ==> (huddleRule @"peras_cert" p)
           ]
 
 instance HuddleRule "auxiliary_scripts" DijkstraEra where
@@ -1019,3 +1020,6 @@ instance HuddleRule1 "multiasset" DijkstraEra where
 
 instance HuddleRule "metadatum" DijkstraEra where
   huddleRuleNamed = allegraMetadatumRule
+
+instance HuddleRule "peras_cert" DijkstraEra where
+  huddleRuleNamed pname _ = pname =.= VBytes / VNil

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -44,7 +44,6 @@ import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR,
   EncCBORGroup (..),
-  decodeListLen,
   encCBOR,
   encodeFoldableEncoder,
   encodeFoldableMapEncoder,
@@ -58,10 +57,10 @@ import Cardano.Ledger.Dijkstra.Tx ()
 import Cardano.Ledger.Shelley.BlockBody (auxDataSeqDecoder)
 import Control.DeepSeq (NFData)
 import Control.Monad (unless)
-import Data.Bifunctor (Bifunctor (..))
 import Data.ByteString (ByteString)
 import Data.ByteString.Builder (Builder, shortByteString, toLazyByteString)
 import qualified Data.ByteString.Lazy as BSL
+import Data.ByteString.Short (ShortByteString)
 import Data.Coerce (coerce)
 import Data.Maybe (fromMaybe)
 import Data.Maybe.Strict (
@@ -252,7 +251,7 @@ instance
   DecCBOR (Annotator (DijkstraBlockBody era))
   where
   decCBOR = do
-    len <- decodeListLen
+    _ <- decodeListLen
 
     (bodies, bodiesAnn) <- withSlice decCBOR
     (wits, witsAnn) <- withSlice decCBOR
@@ -284,16 +283,17 @@ instance
             StrictSeq.forceToStrict $
               Seq.zipWith4 dijkstraSegwitTx bodies wits validFlags auxData
 
-    (mbPerasCert, mbPerasCertAnn) <-
-      case len of
-        4 -> return (pure SNothing, pure Nothing)
-        5 -> bimap (pure . SJust) (fmap Just) <$> withSlice decCBOR
-        _ -> fail $ "unexpected body length: " <> show len
+    (mbPerasCert, mbPerasCertAnn) <- do
+      mbPerasCert :: (Maybe PerasCert, Annotator BSL.ByteString) <-
+        withSlice decCBOR
+      case mbPerasCert of
+        (Nothing, _) -> pure (SNothing, pure Nothing)
+        (Just cert, certAnn) -> pure (SJust cert, Just <$> certAnn)
 
-    pure $
+    pure $!
       DijkstraBlockBodyInternal
         <$> txns
-        <*> mbPerasCert
+        <*> (pure mbPerasCert)
         <*> ( hashDijkstraSegWits
                 <$> bodiesAnn
                 <*> witsAnn
@@ -362,20 +362,24 @@ dijkstraSegwitTx txBodyAnn txWitsAnn txIsValid txAuxDataAnn = Annotator $ \bytes
 
 -- | Placeholder for Peras certificates
 --
--- NOTE: The real type will be brought from 'cardano-base' once it's ready.
-data PerasCert = PerasCert
+-- NOTE: We keep a placeholder implementation for now, to allow concrete implementation
+-- and validation to be done in consensus. As it would allow to optimise development
+-- workflow, as otherwise all PRs may require an effort of 3 teams. The ultimate goal however
+-- is to keep real implementation in this module as soon as it settles down (or move that to
+-- cardano-base if it is more appropriate).
+newtype PerasCert = PerasCert ShortByteString
   deriving (Eq, Show, Generic, NoThunks)
 
 instance NFData PerasCert
 
 instance EncCBOR PerasCert where
-  encCBOR PerasCert =
-    encCBOR ()
+  encCBOR (PerasCert bs) =
+    encCBOR bs
 
 instance DecCBOR PerasCert where
   decCBOR = do
-    () <- decCBOR
-    pure PerasCert
+    bs <- decCBOR
+    pure (PerasCert bs)
 
 -- | Placeholder for Peras public keys
 --

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -291,7 +291,7 @@ instance
   arbitrary = genericArbitraryU
 
 instance Arbitrary PerasCert where
-  arbitrary = pure PerasCert
+  arbitrary = genericArbitraryU
 
 instance
   ( EraBlockBody era


### PR DESCRIPTION
# Description

This in an intermediate commit, that allow to use PerasCert with an actual data in the BlockBody. We need it to speedup development and keep everything in the consensus repo, until implementation will settle down. After that real implementation of PerasCert will be contributed to the ledger.

PR includes several changes:
  - We use `ShortByteString` as a type for PerasCert (just to keep a unpinned object)
  - Decoding of the block has changed to keep the same structure as encoder
  - Specs were updated to keep up with the changes


# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.


----

No tests were added, but other epochs do not have similar tests. I'll ready to contribute those.