### PR TITLE
Handle single failing suite case in CI test failure summaries

### DIFF
--- a/.github/workflows/check-nix-hashes.yml
+++ b/.github/workflows/check-nix-hashes.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Install cleret
       # Tag should match the one that's used in flake.nix
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.1
 
     - name: Check nix hashes
       run: cleret nix hashes -vp

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -377,7 +377,7 @@ jobs:
         path: failures
 
     - name: Generate summary
-      run: cleret failures render failures/*/failures.json -o "$GITHUB_STEP_SUMMARY"
+      run: cleret failures render $(find failures -name failures.json) -o "$GITHUB_STEP_SUMMARY"
 
   complete:
     name: Tests completed

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -147,7 +147,7 @@ jobs:
 
     - name: Install cleret
       # Tag should match the one that's used in flake.nix
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.1
 
     - name: Check workflow test matrix
       run: cabal build all --dry-run -v0 && cleret workflow check-test-matrix
@@ -337,7 +337,7 @@ jobs:
     - name: Install cleret
       if: always()
       # Tag should match the one that's used in flake.nix
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.1
 
     - name: Record test failures
       if: failure()
@@ -368,7 +368,7 @@ jobs:
 
     steps:
     - name: Install cleret
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.1
 
     - name: Download test failures artifacts
       uses: actions/download-artifact@v8
@@ -696,7 +696,7 @@ jobs:
 
     - name: Install cleret
       # Tag should match the one that's used in flake.nix
-      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.0
+      uses: input-output-hk/cardano-ledger-release-tool/actions/install-cleret@0.4.0.1
 
     - name: Run linter
       run: scripts/format-changelogs.sh || (git diff; false)

--- a/flake.lock
+++ b/flake.lock
@@ -105,16 +105,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087180,
-        "narHash": "sha256-eAwb3ZXkcRO83gP9/fiiWxC05eAhSZ4ntkLVxpv7qEY=",
+        "lastModified": 1777421013,
+        "narHash": "sha256-8Zm2a0D3A/CiGLgxVTjPKpqLLcb4spzObsyE59/XYlc=",
         "owner": "input-output-hk",
         "repo": "cardano-ledger-release-tool",
-        "rev": "e8011391f49e927f1b69878b75b69cc656e6b9cb",
+        "rev": "0734e1072f37d1b91c8018e4c8b4fe35a90f4ac3",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "0.4.0.0",
+        "ref": "0.4.0.1",
         "repo": "cardano-ledger-release-tool",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
 
     cardano-ledger-release-tool = {
       # Tag should match the ones used in .github/workflows/*.yml
-      url = "github:input-output-hk/cardano-ledger-release-tool?ref=0.4.0.0";
+      url = "github:input-output-hk/cardano-ledger-release-tool?ref=0.4.0.1";
       inputs.haskell-nix.follows = "haskellNix";
       inputs.hackage.follows = "hackageNix";
       inputs.pre-commit-hooks.follows = "pre-commit-hooks";


### PR DESCRIPTION
# Description

When `actions/download-artifact` finds only a single artifact, it uses a different directory layout, with the artifact in the top-level directory instead of a subdirectory

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.