### PR TITLE
Preparation for conformance testing in Dijkstra

### DIFF
--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -14,7 +14,6 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (
 ) where
 
 import Cardano.Ledger.Address (AccountAddress)
-import Cardano.Ledger.BaseTypes (Inject (..))
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
 import Cardano.Ledger.Coin (Coin)
@@ -44,12 +43,6 @@ data ConwayCertExecContext era
   deriving (Generic, Eq, Show)
 
 instance Era era => NFData (ConwayCertExecContext era)
-
-instance Inject (ConwayCertExecContext era) (Map AccountAddress Coin) where
-  inject = ccecWithdrawals
-
-instance Inject (ConwayCertExecContext era) (VotingProcedures era) where
-  inject = ccecVotes
 
 instance Era era => Arbitrary (ConwayCertExecContext era) where
   arbitrary =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -22,11 +22,18 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core (Era)
 import Cardano.Ledger.Conway.Governance (VotingProcedures)
 import Control.DeepSeq (NFData)
+import Control.State.Transition.Extended (TRC (..))
 import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Common (Arbitrary (..), ToExpr)
-import Test.Cardano.Ledger.Conformance (ExecSpecRule (..), runFromAgdaFunction)
+import Test.Cardano.Ledger.Conformance (
+  ExecSpecRule (..),
+  SpecTRC (..),
+  SpecTranslate (..),
+  runFromAgdaFunction,
+  runSpecTransM,
+ )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
 
 data ConwayCertExecContext era
@@ -69,5 +76,13 @@ instance Era era => ToExpr (ConwayCertExecContext era)
 
 instance ExecSpecRule "CERT" ConwayEra where
   type ExecContext "CERT" ConwayEra = ConwayCertExecContext ConwayEra
+
+  translateInputs ConwayCertExecContext {..} (TRC (env, st, sig)) = do
+    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep env
+    agdaSt <- runSpecTransM () $ toSpecRep st
+    agdaSig <- runSpecTransM () $ toSpecRep sig
+    pure $ SpecTRC agdaEnv agdaSt agdaSig
+
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
 
   runAgdaRule = runFromAgdaFunction Agda.certStep

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -14,6 +14,7 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Certs () where
 import Cardano.Ledger.Address (accountAddressCredentialL)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.State (CanSetAccounts (..), EraAccounts (..), EraCertState (..))
+import Control.State.Transition.Extended (TRC (..))
 import Data.Foldable (Foldable (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
@@ -21,6 +22,7 @@ import Lens.Micro ((%~), (.~), (^.))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
+  SpecTRC (..),
   SpecTranslate (..),
   runFromAgdaFunction,
   runSpecTransM,
@@ -30,9 +32,15 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (ConwayCertExecC
 instance ExecSpecRule "CERTS" ConwayEra where
   type ExecContext "CERTS" ConwayEra = ConwayCertExecContext ConwayEra
 
+  translateInputs ConwayCertExecContext {..} (TRC (env, st, sig)) = do
+    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep env
+    agdaSt <- runSpecTransM () $ toSpecRep st
+    agdaSig <- runSpecTransM () $ toSpecRep sig
+    pure $ SpecTRC agdaEnv agdaSt agdaSig
+
   runAgdaRule = runFromAgdaFunction Agda.certsStep
 
-  translateOutput ctx@ConwayCertExecContext {..} _ = runSpecTransM ctx . toSpecRep . fixRewards
+  translateOutput ConwayCertExecContext {..} _ = runSpecTransM () . toSpecRep . fixRewards
     where
       -- This is necessary because the implementation zeroes out the rewards
       -- in the CERTS rule, but the spec does it in a different rule

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -32,8 +32,6 @@ instance ExecSpecRule "DELEG" ConwayEra where
     agdaSig <- runSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
-
   runAgdaRule (SpecTRC env (Agda.MkCertState dState pState vState) sig) =
     second
       (\dState' -> Agda.MkCertState dState' pState vState)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -11,6 +11,7 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Deleg () where
 import Cardano.Ledger.Conway
 import Cardano.Ledger.Conway.Core (KeyRole (..))
 import Cardano.Ledger.Credential (Credential)
+import Control.State.Transition.Extended (TRC (..))
 import Data.Bifunctor (second)
 import Data.Set (Set)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
@@ -24,6 +25,14 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 instance ExecSpecRule "DELEG" ConwayEra where
   -- The context is the set of all DRep delegatees in the transaction
   type ExecContext "DELEG" ConwayEra = Set (Credential DRepRole)
+
+  translateInputs delegatees (TRC (env, st, sig)) = do
+    agdaEnv <- runSpecTransM delegatees $ toSpecRep env
+    agdaSt <- runSpecTransM () $ toSpecRep st
+    agdaSig <- runSpecTransM () $ toSpecRep sig
+    pure $ SpecTRC agdaEnv agdaSt agdaSig
+
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
 
   runAgdaRule (SpecTRC env (Agda.MkCertState dState pState vState) sig) =
     second

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
@@ -39,6 +39,4 @@ instance ExecSpecRule "ENACT" ConwayEra where
           agdaSt
           agdaSig
 
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
-
   runAgdaRule (SpecTRC env st sig) = unComputationResult $ Agda.enactStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
@@ -39,4 +39,6 @@ instance ExecSpecRule "ENACT" ConwayEra where
           agdaSt
           agdaSig
 
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
+
   runAgdaRule (SpecTRC env st sig) = unComputationResult $ Agda.enactStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
@@ -7,12 +7,24 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Epoch () where
 
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (GovActionState)
+import Control.State.Transition.Extended (TRC (..))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (ExecSpecRule (..), SpecTRC (..), unComputationResult_)
+import Test.Cardano.Ledger.Conformance (
+  ExecSpecRule (..),
+  SpecTRC (..),
+  SpecTranslate (..),
+  runSpecTransM,
+  unComputationResult_,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Conway.ImpTest ()
 
 instance ExecSpecRule "EPOCH" ConwayEra where
   type ExecContext "EPOCH" ConwayEra = [GovActionState ConwayEra]
+
+  translateInputs _ (TRC (env, st, sig)) =
+    runSpecTransM () $ SpecTRC <$> toSpecRep env <*> toSpecRep st <*> toSpecRep sig
+
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
 
   runAgdaRuleWithDebug (SpecTRC env st sig) = unComputationResult_ $ Agda.epochStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
@@ -25,6 +25,4 @@ instance ExecSpecRule "EPOCH" ConwayEra where
   translateInputs _ (TRC (env, st, sig)) =
     runSpecTransM () $ SpecTRC <$> toSpecRep env <*> toSpecRep st <*> toSpecRep sig
 
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
-
   runAgdaRuleWithDebug (SpecTRC env st sig) = unComputationResult_ $ Agda.epochStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
@@ -28,13 +28,14 @@ instance ExecSpecRule "GOV" ConwayEra where
   runAgdaRule (SpecTRC env st sig) = unComputationResult $ Agda.govStep env st sig
 
   translateInputs enactState (TRC (env@GovEnv {gePParams}, st, sig)) = do
-    runSpecTransM ctx $
-      SpecTRC
-        <$> toSpecRep env
-        <*> toSpecRep st
-        <*> toSpecRep sig
+    agdaEnv <- runSpecTransM ctx $ toSpecRep env
+    agdaSt <- runSpecTransM () $ toSpecRep st
+    agdaSig <- runSpecTransM () $ toSpecRep sig
+    pure $ SpecTRC agdaEnv agdaSt agdaSig
     where
       ctx =
         enactState
           & ensPrevGovActionIdsL .~ toPrevGovActionIds (st ^. pRootsL)
           & ensProtVerL .~ (gePParams ^. ppProtocolVersionL)
+
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep st

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
@@ -37,5 +37,3 @@ instance ExecSpecRule "GOV" ConwayEra where
         enactState
           & ensPrevGovActionIdsL .~ toPrevGovActionIds (st ^. pRootsL)
           & ensProtVerL .~ (gePParams ^. ppProtocolVersionL)
-
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep st

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -32,8 +32,6 @@ instance ExecSpecRule "GOVCERT" ConwayEra where
     agdaSig <- runSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
-
   runAgdaRule (SpecTRC env (Agda.MkCertState dState pState vState) sig) =
     second (Agda.MkCertState dState pState) . unComputationResult $
       Agda.govCertStep env vState sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -10,13 +11,28 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert () where
 
 import Cardano.Ledger.Conway (ConwayEra)
+import Control.State.Transition.Extended (TRC (..))
 import Data.Bifunctor (Bifunctor (..))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (ExecSpecRule (..), SpecTRC (..), unComputationResult)
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (ConwayCertExecContext)
+import Test.Cardano.Ledger.Conformance (
+  ExecSpecRule (..),
+  SpecTRC (..),
+  SpecTranslate (..),
+  runSpecTransM,
+  unComputationResult,
+ )
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (ConwayCertExecContext (..))
 
 instance ExecSpecRule "GOVCERT" ConwayEra where
   type ExecContext "GOVCERT" ConwayEra = ConwayCertExecContext ConwayEra
+
+  translateInputs ConwayCertExecContext {..} (TRC (env, st, sig)) = do
+    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep env
+    agdaSt <- runSpecTransM () $ toSpecRep st
+    agdaSig <- runSpecTransM () $ toSpecRep sig
+    pure $ SpecTRC agdaEnv agdaSt agdaSig
+
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
 
   runAgdaRule (SpecTRC env (Agda.MkCertState dState pState vState) sig) =
     second (Agda.MkCertState dState pState) . unComputationResult $

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -47,6 +47,10 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   SpecTRC (..),
   runFromAgdaFunction,
  )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (..),
+  runSpecTransM,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Constrained.Conway (UtxoExecContext (..))
 import Test.Cardano.Ledger.Conway.Arbitrary ()
@@ -105,6 +109,14 @@ instance
 
 instance ExecSpecRule "LEDGER" ConwayEra where
   type ExecContext "LEDGER" ConwayEra = ConwayLedgerExecContext ConwayEra
+
+  translateInputs ConwayLedgerExecContext {..} (TRC (env, st, sig)) = do
+    agdaEnv <- runSpecTransM (clecGuardrailsScriptHash, clecEnactState) $ toSpecRep env
+    agdaSt <- runSpecTransM () $ toSpecRep st
+    agdaSig <- runSpecTransM () $ toSpecRep sig
+    pure $ SpecTRC agdaEnv agdaSt agdaSig
+
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
 
   runAgdaRule trc =
     let externalFunctions' = externalFunctions {Agda.extValidPlutusScript = Agda.isValid (strcSignal trc)}

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -116,8 +116,6 @@ instance ExecSpecRule "LEDGER" ConwayEra where
     agdaSig <- runSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
-
   runAgdaRule trc =
     let externalFunctions' = externalFunctions {Agda.extValidPlutusScript = Agda.isValid (strcSignal trc)}
      in runFromAgdaFunction (Agda.ledgerStep externalFunctions') trc

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -13,7 +13,7 @@
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledger (ConwayLedgerExecContext (..)) where
 
-import Cardano.Ledger.BaseTypes (Inject (..), StrictMaybe)
+import Cardano.Ledger.BaseTypes (StrictMaybe)
 import Cardano.Ledger.Binary (EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
 import Cardano.Ledger.Conway (ConwayEra)
@@ -63,12 +63,6 @@ data ConwayLedgerExecContext era
   , clecUtxoExecContext :: UtxoExecContext era
   }
   deriving (Generic)
-
-instance Inject (ConwayLedgerExecContext era) (StrictMaybe ScriptHash) where
-  inject = clecGuardrailsScriptHash
-
-instance Inject (ConwayLedgerExecContext ConwayEra) (EnactState ConwayEra) where
-  inject = clecEnactState
 
 instance
   ( EraPParams era

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
@@ -10,7 +10,13 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledgers () where
 
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (EnactState)
+import Control.State.Transition.Extended (TRC (..))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import Test.Cardano.Ledger.Conformance (
+  SpecTRC (..),
+  SpecTranslate (..),
+  runSpecTransM,
+ )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
   externalFunctions,
  )
@@ -23,5 +29,13 @@ import Test.Cardano.Ledger.Conway.ImpTest ()
 
 instance ExecSpecRule "LEDGERS" ConwayEra where
   type ExecContext "LEDGERS" ConwayEra = EnactState ConwayEra
+
+  translateInputs enactState (TRC (env, st, sig)) = do
+    agdaEnv <- runSpecTransM enactState $ toSpecRep env
+    agdaSt <- runSpecTransM () $ toSpecRep st
+    agdaSig <- runSpecTransM () $ toSpecRep sig
+    pure $ SpecTRC agdaEnv agdaSt agdaSig
+
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
 
   runAgdaRule = runFromAgdaFunction (Agda.ledgersStep externalFunctions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
@@ -36,6 +36,4 @@ instance ExecSpecRule "LEDGERS" ConwayEra where
     agdaSig <- runSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
-
   runAgdaRule = runFromAgdaFunction (Agda.ledgersStep externalFunctions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
@@ -39,7 +39,7 @@ import Test.Cardano.Ledger.Conformance (
   SpecTranslate (..),
   runSpecTransM,
   unComputationResult_,
-  withCtx,
+  withCtxSpecTransM,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Conway.ImpTest ()
@@ -51,13 +51,13 @@ instance ExecSpecRule "RATIFY" ConwayEra where
   translateInputs _ (TRC (env, st@RatifyState {..}, sig@(RatifySignal actions))) =
     runSpecTransM () $ do
       let treasury = ensTreasury rsEnactState
-      specEnv <- withCtx treasury (toSpecRep env)
-      specSt <- withCtx (toList actions) (toSpecRep st)
+      specEnv <- withCtxSpecTransM treasury (toSpecRep env)
+      specSt <- withCtxSpecTransM (toList actions) (toSpecRep st)
       specSig <- toSpecRep sig
       pure $ SpecTRC specEnv specSt specSig
 
   translateOutput _ (TRC (_, _, RatifySignal actions)) out =
-    runSpecTransM () . withCtx (toList actions) $ toSpecRep out
+    runSpecTransM () . withCtxSpecTransM (toList actions) $ toSpecRep out
 
   extraInfo _ ctx trc@(TRC (env@RatifyEnv {..}, st@RatifyState {..}, RatifySignal actions)) _ =
     PP.vsep $ specExtraInfo : (actionAcceptedRatio <$> toList actions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
@@ -12,8 +12,17 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxo () where
 
 import Cardano.Ledger.Conway (ConwayEra)
+import Cardano.Ledger.Shelley.Rules (utxoEnvCertStateL)
+import Control.State.Transition.Extended (TRC (..))
+import Lens.Micro ((^.))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (ExecSpecRule (..), runFromAgdaFunction)
+import Test.Cardano.Ledger.Conformance (
+  ExecSpecRule (..),
+  SpecTRC (..),
+  SpecTranslate (..),
+  runFromAgdaFunction,
+  runSpecTransM,
+ )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (externalFunctions)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Utxo ()
@@ -22,5 +31,14 @@ import Test.Cardano.Ledger.Generic.Instances ()
 
 instance ExecSpecRule "UTXO" ConwayEra where
   type ExecContext "UTXO" ConwayEra = UtxoExecContext ConwayEra
+
+  translateInputs ctx (TRC (env, st, sig)) = do
+    agdaEnv <- runSpecTransM () $ toSpecRep env
+    agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
+    agdaSig <- runSpecTransM () $ toSpecRep sig
+    pure $ SpecTRC agdaEnv agdaSt agdaSig
+
+  translateOutput ctx _ st =
+    runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
 
   runAgdaRule = runFromAgdaFunction (Agda.utxoStep externalFunctions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -14,10 +14,9 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxow () where
 
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core (EraTx (..), txStAnnTxG)
-import Cardano.Ledger.Conway.TxCert (ConwayTxCert)
 import Cardano.Ledger.Conway.UTxO (getConwayWitsVKeyNeeded)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
-import Cardano.Ledger.TxIn (TxId)
+import Cardano.Ledger.Shelley.Rules (utxoEnvCertStateL)
 import Control.State.Transition.Extended (TRC (..))
 import Data.Bifunctor (Bifunctor (..))
 import Data.Coerce (coerce)
@@ -27,6 +26,7 @@ import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import qualified Prettyprinter as PP
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
+  SpecTRC (..),
   SpecTranslate (..),
   runFromAgdaFunction,
   runSpecTransM,
@@ -34,27 +34,32 @@ import Test.Cardano.Ledger.Conformance (
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (externalFunctions)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxo ()
 import Test.Cardano.Ledger.Constrained.Conway (
-  UtxoExecContext,
+  UtxoExecContext (..),
  )
 import Test.Cardano.Ledger.Conway.TreeDiff (showExpr)
 import Test.Cardano.Ledger.Shelley.Utils (runSTS)
 
-instance
-  SpecTranslate TxId (ConwayTxCert ConwayEra) =>
-  ExecSpecRule "UTXOW" ConwayEra
-  where
+instance ExecSpecRule "UTXOW" ConwayEra where
   type ExecContext "UTXOW" ConwayEra = UtxoExecContext ConwayEra
+
+  translateInputs ctx (TRC (env, st, sig)) = do
+    agdaEnv <- runSpecTransM () $ toSpecRep env
+    agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
+    agdaSig <- runSpecTransM () $ toSpecRep sig
+    pure $ SpecTRC agdaEnv agdaSt agdaSig
+
+  translateOutput ctx _ st =
+    runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
 
   runAgdaRule = runFromAgdaFunction (Agda.utxowStep externalFunctions)
 
   extraInfo globals ctx trc@(TRC (env, st, sig)) _ =
     let
-      result =
-        either show T.unpack . runSpecTransM ctx $
-          Agda.utxowDebug externalFunctions
-            <$> toSpecRep env
-            <*> toSpecRep st
-            <*> toSpecRep sig
+      result = either show T.unpack $ do
+        agdaEnv <- runSpecTransM () $ toSpecRep env
+        agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
+        agdaSig <- runSpecTransM () $ toSpecRep sig
+        pure $ Agda.utxowDebug externalFunctions agdaEnv agdaSt agdaSig
       stFinal = first (T.pack . show) $ runSTS @"UTXO" @ConwayEra globals env st sig
       utxoInfo = extraInfo @"UTXO" @ConwayEra globals ctx (coerce trc) stFinal
      in

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -172,14 +172,14 @@ class
     Either Text (SpecState rule era)
   default translateOutput ::
     ( SpecTranslate (State (EraRule rule era))
-    , SpecContext (State (EraRule rule era)) ~ ExecContext rule era
+    , SpecContext (State (EraRule rule era)) ~ ()
     , SpecRep (State (EraRule rule era)) ~ SpecState rule era
     ) =>
     ExecContext rule era ->
     TRC (EraRule rule era) ->
     State (EraRule rule era) ->
     Either Text (SpecState rule era)
-  translateOutput ctx _ st = runSpecTransM ctx $ toSpecRep st
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
 
   extraInfo ::
     HasCallStack =>

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -148,9 +148,12 @@ class
     TRC (EraRule rule era) ->
     Either Text (SpecTRC rule era)
   default translateInputs ::
-    ( SpecTranslate (ExecContext rule era) (Environment (EraRule rule era))
-    , SpecTranslate (ExecContext rule era) (State (EraRule rule era))
-    , SpecTranslate (ExecContext rule era) (Signal (EraRule rule era))
+    ( SpecTranslate (Environment (EraRule rule era))
+    , SpecTranslate (State (EraRule rule era))
+    , SpecTranslate (Signal (EraRule rule era))
+    , SpecContext (Environment (EraRule rule era)) ~ ExecContext rule era
+    , SpecContext (State (EraRule rule era)) ~ ExecContext rule era
+    , SpecContext (Signal (EraRule rule era)) ~ ExecContext rule era
     , SpecRep (Environment (EraRule rule era)) ~ SpecEnvironment rule era
     , SpecRep (State (EraRule rule era)) ~ SpecState rule era
     , SpecRep (Signal (EraRule rule era)) ~ SpecSignal rule era
@@ -168,7 +171,8 @@ class
     State (EraRule rule era) ->
     Either Text (SpecState rule era)
   default translateOutput ::
-    ( SpecTranslate (ExecContext rule era) (State (EraRule rule era))
+    ( SpecTranslate (State (EraRule rule era))
+    , SpecContext (State (EraRule rule era)) ~ ExecContext rule era
     , SpecRep (State (EraRule rule era)) ~ SpecState rule era
     ) =>
     ExecContext rule era ->
@@ -378,7 +382,7 @@ generatesWithin gen timeout =
 
 -- | Translate a Haskell type 'a' whose translation context is 'ctx' into its Agda type, in the ImpTest monad.
 translateWithContext ::
-  SpecTranslate ctx a => ctx -> a -> ImpTestM era (Either Text (SpecRep a))
+  SpecTranslate a => SpecContext a -> a -> ImpTestM era (Either Text (SpecRep a))
 translateWithContext ctx x = pure . runSpecTransM ctx $ toSpecRep x
 
 runFromAgdaFunction ::

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
@@ -22,8 +22,8 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecTransM,
   runSpecTransM,
   withSpecTransM,
+  withCtxSpecTransM,
   askSpecTransM,
-  withCtx,
   unComputationResult,
   unComputationResult_,
   toSpecRepTuple,
@@ -68,6 +68,9 @@ runSpecTransM ctx (SpecTransM m) = runReader (runExceptT m) ctx
 
 withSpecTransM :: (ctx -> ctx') -> SpecTransM ctx' a -> SpecTransM ctx a
 withSpecTransM f (SpecTransM m) = SpecTransM (mapExceptT (withReaderT f) m)
+
+withCtxSpecTransM :: ctx -> SpecTransM ctx a -> SpecTransM ctx' a
+withCtxSpecTransM ctx = withSpecTransM (const ctx)
 
 askSpecTransM :: SpecTransM ctx ctx
 askSpecTransM = ask
@@ -229,12 +232,6 @@ class SpecNormalize a where
   specNormalize :: a -> a
   default specNormalize :: (Generic a, GSpecNormalize (Rep a)) => a -> a
   specNormalize = to . genericSpecNormalize . from
-
-withCtx :: ctx -> SpecTransM ctx a -> SpecTransM ctx' a
-withCtx ctx m = do
-  case runSpecTransM ctx m of
-    Right x -> pure x
-    Left e -> throwError e
 
 -- | OpaqueErrorString behaves like unit in comparisons, but contains an
 -- error string that can be displayed.

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -20,19 +21,20 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   OpaqueErrorString (..),
   SpecTransM,
   runSpecTransM,
-  askCtx,
+  withSpecTransM,
+  askSpecTransM,
   withCtx,
   unComputationResult,
   unComputationResult_,
-  toSpecRep_,
+  dup,
 ) where
 
-import Cardano.Ledger.BaseTypes (Inject (..), NonNegativeInterval, UnitInterval, unboundRational)
+import Cardano.Ledger.BaseTypes (NonNegativeInterval, UnitInterval, unboundRational)
 import Cardano.Ledger.Binary (Sized (..))
 import Cardano.Ledger.Compactible (Compactible (..), fromCompact)
 import Control.DeepSeq (NFData)
-import Control.Monad.Except (ExceptT, MonadError (..), runExceptT)
-import Control.Monad.Reader (MonadReader (..), Reader, asks, runReader)
+import Control.Monad.Except (ExceptT, MonadError (..), mapExceptT, runExceptT)
+import Control.Monad.Reader (MonadReader (..), Reader, ask, runReader, withReaderT)
 import Data.Bitraversable (bimapM)
 import Data.Foldable (Foldable (..))
 import Data.Kind (Type)
@@ -48,12 +50,14 @@ import Data.Sequence.Strict (StrictSeq)
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Text (Text)
-import qualified Data.Text as T
 import Data.Void (Void, absurd)
 import Data.Word (Word16, Word32, Word64)
 import GHC.Generics (Generic (..), K1 (..), M1 (..), U1 (..), V1, (:*:) (..), (:+:) (..))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.TreeDiff (Expr (..), ToExpr (..))
+
+dup :: a -> (a, a)
+dup a = (a, a)
 
 newtype SpecTransM ctx a
   = SpecTransM (ExceptT Text (Reader ctx) a)
@@ -62,131 +66,142 @@ newtype SpecTransM ctx a
 runSpecTransM :: ctx -> SpecTransM ctx a -> Either Text a
 runSpecTransM ctx (SpecTransM m) = runReader (runExceptT m) ctx
 
-class SpecTranslate ctx a where
+withSpecTransM :: (ctx -> ctx') -> SpecTransM ctx' a -> SpecTransM ctx a
+withSpecTransM f (SpecTransM m) = SpecTransM (mapExceptT (withReaderT f) m)
+
+askSpecTransM :: SpecTransM ctx ctx
+askSpecTransM = ask
+
+class SpecTranslate a where
   type SpecRep a :: Type
 
-  toSpecRep :: a -> SpecTransM ctx (SpecRep a)
+  type SpecContext a :: Type
+  type SpecContext a = ()
 
-instance SpecTranslate ctx () where
+  toSpecRep :: a -> SpecTransM (SpecContext a) (SpecRep a)
+
+instance SpecTranslate () where
   type SpecRep () = ()
 
   toSpecRep = pure
 
-instance SpecTranslate ctx Bool where
+instance SpecTranslate Bool where
   type SpecRep Bool = Bool
 
   toSpecRep = pure
 
-instance SpecTranslate ctx Integer where
+instance SpecTranslate Integer where
   type SpecRep Integer = Integer
 
   toSpecRep = pure
 
-instance SpecTranslate ctx Void where
+instance SpecTranslate Void where
   type SpecRep Void = Void
 
   toSpecRep = absurd
 
-instance SpecTranslate ctx Word16 where
+instance SpecTranslate Word16 where
   type SpecRep Word16 = Integer
 
   toSpecRep = pure . toInteger
 
-instance SpecTranslate ctx Word32 where
+instance SpecTranslate Word32 where
   type SpecRep Word32 = Integer
 
   toSpecRep = pure . toInteger
 
-instance SpecTranslate ctx Word64 where
+instance SpecTranslate Word64 where
   type SpecRep Word64 = Integer
 
   toSpecRep = pure . toInteger
 
-instance
-  ( SpecTranslate ctx a
-  , SpecTranslate ctx b
-  ) =>
-  SpecTranslate ctx (a, b)
-  where
+instance (SpecTranslate a, SpecTranslate b) => SpecTranslate (a, b) where
   type SpecRep (a, b) = (SpecRep a, SpecRep b)
+  type SpecContext (a, b) = (SpecContext a, SpecContext b)
 
-  toSpecRep (x, y) = (,) <$> toSpecRep x <*> toSpecRep y
+  toSpecRep (a, b) = (,) <$> withSpecTransM fst (toSpecRep a) <*> withSpecTransM snd (toSpecRep b)
 
-instance SpecTranslate ctx a => SpecTranslate ctx [a] where
+instance SpecTranslate a => SpecTranslate [a] where
   type SpecRep [a] = [SpecRep a]
+  type SpecContext [a] = SpecContext a
 
   toSpecRep = traverse toSpecRep
 
-instance SpecTranslate ctx a => SpecTranslate ctx (StrictMaybe a) where
+instance SpecTranslate a => SpecTranslate (StrictMaybe a) where
   type SpecRep (StrictMaybe a) = Maybe (SpecRep a)
+  type SpecContext (StrictMaybe a) = SpecContext a
 
   toSpecRep = toSpecRep . strictMaybeToMaybe
 
-instance SpecTranslate ctx a => SpecTranslate ctx (Maybe a) where
+instance SpecTranslate a => SpecTranslate (Maybe a) where
   type SpecRep (Maybe a) = Maybe (SpecRep a)
+  type SpecContext (Maybe a) = SpecContext a
 
   toSpecRep = traverse toSpecRep
 
-instance SpecTranslate ctx a => SpecTranslate ctx (StrictSeq a) where
+instance SpecTranslate a => SpecTranslate (StrictSeq a) where
   type SpecRep (StrictSeq a) = [SpecRep a]
+  type SpecContext (StrictSeq a) = SpecContext a
 
   toSpecRep = traverse toSpecRep . toList
 
-instance SpecTranslate ctx a => SpecTranslate ctx (Seq a) where
+instance SpecTranslate a => SpecTranslate (Seq a) where
   type SpecRep (Seq a) = [SpecRep a]
+  type SpecContext (Seq a) = SpecContext a
 
   toSpecRep = traverse toSpecRep . toList
 
-instance SpecTranslate ctx a => SpecTranslate ctx (OSet a) where
+instance SpecTranslate a => SpecTranslate (OSet a) where
   type SpecRep (OSet a) = [SpecRep a]
-
+  type SpecContext (OSet a) = SpecContext a
   toSpecRep = traverse toSpecRep . toList
 
-instance
-  ( SpecTranslate ctx k
-  , SpecTranslate ctx v
-  , Ord k
-  ) =>
-  SpecTranslate ctx (OMap k v)
-  where
+instance (Ord k, SpecTranslate k, SpecTranslate v) => SpecTranslate (OMap k v) where
   type SpecRep (OMap k v) = [(SpecRep k, SpecRep v)]
+  type SpecContext (OMap k v) = (SpecContext k, SpecContext v)
 
-  toSpecRep = traverse (bimapM toSpecRep toSpecRep) . OMap.assocList
+  toSpecRep ::
+    OMap k v ->
+    SpecTransM (SpecContext (OMap k v)) (SpecRep (OMap k v))
+  toSpecRep =
+    traverse (bimapM (withSpecTransM fst . toSpecRep) (withSpecTransM snd . toSpecRep)) . OMap.assocList
 
-instance (SpecTranslate ctx a, Compactible a) => SpecTranslate ctx (CompactForm a) where
+instance (SpecTranslate a, Compactible a) => SpecTranslate (CompactForm a) where
   type SpecRep (CompactForm a) = SpecRep a
+  type SpecContext (CompactForm a) = SpecContext a
 
   toSpecRep = toSpecRep . fromCompact
 
-instance SpecTranslate ctx a => SpecTranslate ctx (Sized a) where
+instance SpecTranslate a => SpecTranslate (Sized a) where
   type SpecRep (Sized a) = SpecRep a
+  type SpecContext (Sized a) = SpecContext a
 
   toSpecRep (Sized x _) = toSpecRep x
 
-instance SpecTranslate ctx a => SpecTranslate ctx (Set a) where
+instance SpecTranslate a => SpecTranslate (Set a) where
   type SpecRep (Set a) = Agda.HSSet (SpecRep a)
+  type SpecContext (Set a) = SpecContext a
 
   toSpecRep = fmap Agda.MkHSSet . traverse toSpecRep . Set.toList
 
-instance SpecTranslate ctx UnitInterval where
+instance SpecTranslate UnitInterval where
   type SpecRep UnitInterval = Agda.Rational
 
   toSpecRep = pure . unboundRational
 
-instance SpecTranslate ctx NonNegativeInterval where
+instance SpecTranslate NonNegativeInterval where
   type SpecRep NonNegativeInterval = Agda.Rational
 
   toSpecRep = pure . unboundRational
 
-instance
-  ( SpecTranslate ctx k
-  , SpecTranslate ctx v
-  ) =>
-  SpecTranslate ctx (Map k v)
-  where
+instance (SpecTranslate k, SpecTranslate v) => SpecTranslate (Map k v) where
   type SpecRep (Map k v) = Agda.HSMap (SpecRep k) (SpecRep v)
+  type SpecContext (Map k v) = (SpecContext k, SpecContext v)
 
-  toSpecRep = fmap Agda.MkHSMap . traverse (bimapM toSpecRep toSpecRep) . Map.toList
+  toSpecRep =
+    fmap Agda.MkHSMap
+      . traverse (bimapM (withSpecTransM fst . toSpecRep) (withSpecTransM snd . toSpecRep))
+      . Map.toList
 
 class GSpecNormalize f where
   genericSpecNormalize :: f a -> f a
@@ -214,9 +229,6 @@ class SpecNormalize a where
   specNormalize :: a -> a
   default specNormalize :: (Generic a, GSpecNormalize (Rep a)) => a -> a
   specNormalize = to . genericSpecNormalize . from
-
-askCtx :: forall b ctx. Inject ctx b => SpecTransM ctx b
-askCtx = asks inject
 
 withCtx :: ctx -> SpecTransM ctx a -> SpecTransM ctx' a
 withCtx ctx m = do
@@ -246,11 +258,3 @@ unComputationResult (Agda.Failure e) = Left e
 unComputationResult_ :: Agda.ComputationResult Void a -> Either e a
 unComputationResult_ (Agda.Success x) = Right x
 unComputationResult_ (Agda.Failure x) = case x of {}
-
-toSpecRep_ ::
-  SpecTranslate () a =>
-  a ->
-  SpecRep a
-toSpecRep_ x = case runSpecTransM () $ toSpecRep x of
-  Right res -> res
-  Left v -> error $ "Failed to translate:\n" <> T.unpack v

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
@@ -26,7 +26,10 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   withCtx,
   unComputationResult,
   unComputationResult_,
-  dup,
+  toSpecRepTuple,
+  toSpecRepTupleGen,
+  toSpecRepOMap,
+  toSpecRepMap,
 ) where
 
 import Cardano.Ledger.BaseTypes (NonNegativeInterval, UnitInterval, unboundRational)
@@ -55,9 +58,6 @@ import Data.Word (Word16, Word32, Word64)
 import GHC.Generics (Generic (..), K1 (..), M1 (..), U1 (..), V1, (:*:) (..), (:+:) (..))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.TreeDiff (Expr (..), ToExpr (..))
-
-dup :: a -> (a, a)
-dup a = (a, a)
 
 newtype SpecTransM ctx a
   = SpecTransM (ExceptT Text (Reader ctx) a)
@@ -115,11 +115,17 @@ instance SpecTranslate Word64 where
 
   toSpecRep = pure . toInteger
 
-instance (SpecTranslate a, SpecTranslate b) => SpecTranslate (a, b) where
-  type SpecRep (a, b) = (SpecRep a, SpecRep b)
-  type SpecContext (a, b) = (SpecContext a, SpecContext b)
+toSpecRepTupleGen ::
+  (a -> SpecTransM ctx c) ->
+  (b -> SpecTransM ctx d) ->
+  (a, b) ->
+  SpecTransM ctx (c, d)
+toSpecRepTupleGen f g (a, b) = (,) <$> f a <*> g b
 
-  toSpecRep (a, b) = (,) <$> withSpecTransM fst (toSpecRep a) <*> withSpecTransM snd (toSpecRep b)
+toSpecRepTuple ::
+  (SpecTranslate a, SpecTranslate b, SpecContext a ~ ctx, SpecContext b ~ ctx) =>
+  (a, b) -> SpecTransM ctx (SpecRep a, SpecRep b)
+toSpecRepTuple = toSpecRepTupleGen toSpecRep toSpecRep
 
 instance SpecTranslate a => SpecTranslate [a] where
   type SpecRep [a] = [SpecRep a]
@@ -156,15 +162,10 @@ instance SpecTranslate a => SpecTranslate (OSet a) where
   type SpecContext (OSet a) = SpecContext a
   toSpecRep = traverse toSpecRep . toList
 
-instance (Ord k, SpecTranslate k, SpecTranslate v) => SpecTranslate (OMap k v) where
-  type SpecRep (OMap k v) = [(SpecRep k, SpecRep v)]
-  type SpecContext (OMap k v) = (SpecContext k, SpecContext v)
-
-  toSpecRep ::
-    OMap k v ->
-    SpecTransM (SpecContext (OMap k v)) (SpecRep (OMap k v))
-  toSpecRep =
-    traverse (bimapM (withSpecTransM fst . toSpecRep) (withSpecTransM snd . toSpecRep)) . OMap.assocList
+toSpecRepOMap ::
+  (Ord k, SpecTranslate k, SpecTranslate v, SpecContext k ~ ctx, SpecContext v ~ ctx) =>
+  OMap k v -> SpecTransM ctx [(SpecRep k, SpecRep v)]
+toSpecRepOMap = traverse (bimapM toSpecRep toSpecRep) . OMap.assocList
 
 instance (SpecTranslate a, Compactible a) => SpecTranslate (CompactForm a) where
   type SpecRep (CompactForm a) = SpecRep a
@@ -194,14 +195,13 @@ instance SpecTranslate NonNegativeInterval where
 
   toSpecRep = pure . unboundRational
 
-instance (SpecTranslate k, SpecTranslate v) => SpecTranslate (Map k v) where
-  type SpecRep (Map k v) = Agda.HSMap (SpecRep k) (SpecRep v)
-  type SpecContext (Map k v) = (SpecContext k, SpecContext v)
-
-  toSpecRep =
-    fmap Agda.MkHSMap
-      . traverse (bimapM (withSpecTransM fst . toSpecRep) (withSpecTransM snd . toSpecRep))
-      . Map.toList
+toSpecRepMap ::
+  (SpecTranslate k, SpecTranslate v, SpecContext k ~ ctx, SpecContext v ~ ctx) =>
+  Map k v -> SpecTransM ctx (Agda.HSMap (SpecRep k) (SpecRep v))
+toSpecRepMap =
+  fmap Agda.MkHSMap
+    . traverse (bimapM toSpecRep toSpecRep)
+    . Map.toList
 
 class GSpecNormalize f where
   genericSpecNormalize :: f a -> f a

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -44,6 +44,10 @@ import Cardano.Ledger.Conway.Scripts (AlonzoScript (..), ConwayPlutusPurpose (..
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.HKD (HKD)
+import Cardano.Ledger.Plutus.CostModels (CostModels, costModelsValid)
+import Cardano.Ledger.Plutus.Data (BinaryData, Data, Datum (..), hashBinaryData)
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Cardano.Ledger.Plutus.Language (Language (..))
 import Cardano.Ledger.Shelley.Rules (Identity)
 import Cardano.Ledger.Shelley.Scripts (
   pattern RequireAllOf,
@@ -76,6 +80,70 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (committeeCredentialToStrictMaybe)
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr (..), showExpr)
 
+instance SpecTranslate ctx TxId where
+  type SpecRep TxId = Agda.TxId
+
+  toSpecRep (TxId x) = toSpecRep @ctx x
+
+instance SpecTranslate ctx TxIn where
+  type SpecRep TxIn = Agda.TxIn
+
+  toSpecRep (TxIn txId txIx) = toSpecRep @ctx (txId, txIx)
+
+instance SpecTranslate ctx (SafeHash a) where
+  type SpecRep (SafeHash a) = Agda.DataHash
+
+  toSpecRep = toSpecRep @ctx . extractHash
+
+instance SpecTranslate ctx Language where
+  type SpecRep Language = Agda.HSLanguage
+
+  toSpecRep l = case l of
+    PlutusV1 -> return Agda.PV1
+    PlutusV2 -> return Agda.PV2
+    PlutusV3 -> return Agda.PV3
+    PlutusV4 -> error "PlutusV4 not supported"
+
+instance SpecTranslate ctx CostModels where
+  type SpecRep CostModels = Agda.LanguageCostModels
+
+  toSpecRep cm =
+    -- filter out PlutusV4 language
+    let validCostModels = filter ((/= PlutusV4) . fst) $ Map.toList (costModelsValid cm)
+     in Agda.MkLanguageCostModels <$> mapM (\(l, _) -> (,()) <$> toSpecRep @ctx l) validCostModels
+
+instance SpecTranslate ctx ExUnits where
+  type SpecRep ExUnits = Agda.ExUnits
+
+  toSpecRep (ExUnits a b) = pure (toInteger a, toInteger b)
+
+instance
+  ( SpecRep DataHash ~ Agda.DataHash
+  , Era era
+  ) =>
+  SpecTranslate ctx (BinaryData era)
+  where
+  type SpecRep (BinaryData era) = Agda.DataHash
+
+  toSpecRep = toSpecRep @ctx . hashBinaryData
+
+instance Era era => SpecTranslate ctx (Datum era) where
+  type SpecRep (Datum era) = Maybe (Either Agda.Datum Agda.DataHash)
+
+  toSpecRep NoDatum = pure Nothing
+  toSpecRep (Datum d) = Just . Left <$> toSpecRep d
+  toSpecRep (DatumHash h) = Just . Right <$> toSpecRep @ctx h
+
+instance Era era => SpecTranslate ctx (Data era) where
+  type SpecRep (Data era) = Agda.DataHash
+
+  toSpecRep = toSpecRep @ctx . hashAnnotated
+
+instance SpecTranslate ctx TxAuxDataHash where
+  type SpecRep TxAuxDataHash = Agda.DataHash
+
+  toSpecRep (TxAuxDataHash x) = toSpecRep @ctx x
+
 instance
   ( AlonzoEraScript era
   , NativeScript era ~ Timelock era
@@ -88,7 +156,7 @@ instance
   toSpecRep tl =
     Agda.HSTimelock
       <$> timelockToSpecRep tl
-      <*> toSpecRep (hashScript @era $ NativeScript tl)
+      <*> toSpecRep (hashScript $ NativeScript tl)
       <*> pure (fromIntegral $ originalBytesSize tl)
     where
       timelockToSpecRep x =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -709,7 +709,7 @@ instance
           <*> toSpecRep reStakePoolDistr
       dreps = toSpecRepMap $ Map.map drepExpiry reDRepState
     treasury <- askSpecTransM
-    withSpecTransM (const ()) $ do
+    withCtxSpecTransM () $ do
       Agda.MkRatifyEnv
         <$> stakeDistrs
         <*> toSpecRep reCurrentEpoch
@@ -754,7 +754,7 @@ instance
         lookupGAS
         (pure Set.empty)
         (rsExpired `Set.union` Set.fromList (gasId <$> toList rsEnacted))
-    withSpecTransM (const ()) $ do
+    withCtxSpecTransM () $ do
       Agda.MkRatifyState
         <$> toSpecRep rsEnactState
         <*> (Agda.MkHSSet <$> traverse toSpecRepTuple (toList removed))

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -83,7 +83,7 @@ instance SpecTranslate TxId where
 instance SpecTranslate TxIn where
   type SpecRep TxIn = Agda.TxIn
 
-  toSpecRep (TxIn txId txIx) = withSpecTransM dup $ toSpecRep (txId, txIx)
+  toSpecRep (TxIn txId txIx) = toSpecRepTuple (txId, txIx)
 
 instance SpecTranslate (SafeHash a) where
   type SpecRep (SafeHash a) = Agda.DataHash
@@ -225,7 +225,7 @@ instance
   where
   type SpecRep (UTxO era) = Agda.HSMap (SpecRep TxIn) (SpecRep (TxOut era))
 
-  toSpecRep (UTxO m) = withSpecTransM dup $ toSpecRep m
+  toSpecRep (UTxO m) = toSpecRepMap m
 
 deriving instance SpecTranslate OrdExUnits
 
@@ -326,7 +326,7 @@ instance
 instance SpecTranslate ValidityInterval where
   type SpecRep ValidityInterval = (Maybe Integer, Maybe Integer)
 
-  toSpecRep (ValidityInterval lo hi) = withSpecTransM dup $ toSpecRep (lo, hi)
+  toSpecRep (ValidityInterval lo hi) = toSpecRepTuple (lo, hi)
 
 instance Era era => SpecTranslate (TxDats era) where
   type SpecRep (TxDats era) = Agda.HSSet Agda.Datum
@@ -357,7 +357,7 @@ instance
   ( AlonzoEraScript era
   , SpecTranslate (PlutusPurpose AsIx era)
   , SpecContext (PlutusPurpose AsIx era) ~ ()
-  , SpecRep (Data era, ExUnits) ~ (Agda.Redeemer, Agda.ExUnits)
+  , SpecRep (Data era) ~ Agda.Redeemer
   ) =>
   SpecTranslate (Redeemers era)
   where
@@ -365,14 +365,18 @@ instance
     SpecRep (Redeemers era) =
       Agda.HSMap (SpecRep (PlutusPurpose AsIx era)) (Agda.Redeemer, Agda.ExUnits)
 
-  toSpecRep (Redeemers x) = withSpecTransM (const ((), ((), ()))) $ toSpecRep x
+  toSpecRep (Redeemers x) =
+    fmap Agda.MkHSMap
+      . traverse (toSpecRepTupleGen toSpecRep toSpecRepTuple)
+      . Map.toList
+      $ x
 
 instance
   ( AlonzoEraScript era
   , SpecTranslate (PlutusPurpose AsIx era)
   , SpecRep (PlutusPurpose AsIx era) ~ Agda.RdmrPtr
   , SpecContext (PlutusPurpose AsIx era) ~ ()
-  , SpecRep (Data era, ExUnits) ~ (Agda.Redeemer, Agda.ExUnits)
+  , SpecRep (Data era) ~ Agda.Redeemer
   , Script era ~ AlonzoScript era
   , NativeScript era ~ Timelock era
   ) =>
@@ -423,7 +427,7 @@ instance SpecTranslate Anchor where
 instance SpecTranslate Withdrawals where
   type SpecRep Withdrawals = Agda.Withdrawals
 
-  toSpecRep (Withdrawals w) = withSpecTransM dup $ toSpecRep w
+  toSpecRep (Withdrawals w) = toSpecRepMap w
 
 instance SpecTranslate IsValid where
   type SpecRep IsValid = Bool
@@ -438,12 +442,12 @@ instance SpecTranslate (GovPurposeId r) where
 instance SpecTranslate (Committee era) where
   type SpecRep (Committee era) = (Agda.HSMap Agda.Credential Agda.Epoch, Agda.Rational)
 
-  toSpecRep (Committee members threshold) = (,) <$> withSpecTransM dup (toSpecRep members) <*> toSpecRep threshold
+  toSpecRep (Committee members threshold) = (,) <$> toSpecRepMap members <*> toSpecRep threshold
 
 instance SpecTranslate (Constitution era) where
   type SpecRep (Constitution era) = (Agda.DataHash, Maybe Agda.ScriptHash)
 
-  toSpecRep (Constitution (Anchor _ h) policy) = withSpecTransM dup $ toSpecRep (h, policy)
+  toSpecRep (Constitution (Anchor _ h) policy) = toSpecRepTuple (h, policy)
 
 instance
   ( EraPParams era
@@ -504,7 +508,7 @@ instance SpecTranslate (VotingProcedures era) where
       go voter gaId votingProcedure m =
         (:)
           <$> ( Agda.MkGovVote
-                  <$> withSpecTransM (const ()) (toSpecRep gaId)
+                  <$> toSpecRep gaId
                   <*> toSpecRep voter
                   <*> toSpecRep (vProcVote votingProcedure)
                   <*> toSpecRep (vProcAnchor votingProcedure)
@@ -573,11 +577,11 @@ instance
   toSpecRep (HardForkInitiation _ pv) = Agda.TriggerHardFork <$> toSpecRep pv
   toSpecRep (TreasuryWithdrawals withdrawals _) =
     Agda.TreasuryWithdrawal
-      <$> withSpecTransM dup (toSpecRep withdrawals)
+      <$> toSpecRepMap withdrawals
   toSpecRep (NoConfidence _) = pure Agda.NoConfidence
   toSpecRep (UpdateCommittee _ remove add threshold) =
     Agda.UpdateCommittee
-      <$> withSpecTransM dup (toSpecRep add)
+      <$> toSpecRepMap add
       <*> toSpecRep remove
       <*> toSpecRep threshold
   toSpecRep (NewConstitution _ (Constitution (Anchor _ h) policy)) =
@@ -645,9 +649,9 @@ instance
   toSpecRep gas@GovActionState {..} = do
     Agda.MkGovActionState
       <$> ( Agda.GovVotes
-              <$> withSpecTransM dup (toSpecRep gasCommitteeVotes)
-              <*> withSpecTransM dup (toSpecRep gasDRepVotes)
-              <*> withSpecTransM dup (toSpecRep gasStakePoolVotes)
+              <$> toSpecRepMap gasCommitteeVotes
+              <*> toSpecRepMap gasDRepVotes
+              <*> toSpecRepMap gasStakePoolVotes
           )
       <*> toSpecRep (gasReturnAddr gas)
       <*> toSpecRep gasExpiresAfter
@@ -664,7 +668,7 @@ instance SpecTranslate GovActionIx where
 instance SpecTranslate GovActionId where
   type SpecRep GovActionId = Agda.GovActionID
 
-  toSpecRep (GovActionId txId gaIx) = withSpecTransM dup $ toSpecRep (txId, gaIx)
+  toSpecRep (GovActionId txId gaIx) = toSpecRepTuple (txId, gaIx)
 
 instance
   ( EraPParams era
@@ -678,7 +682,7 @@ instance
 
   -- TODO get rid of `prioritySort` once we've changed the implementation so
   -- that the proposals are always sorted
-  toSpecRep = withSpecTransM dup . toSpecRep . prioritySort . view pPropsL
+  toSpecRep = toSpecRepOMap . prioritySort . view pPropsL
     where
       prioritySort ::
         OMap GovActionId (GovActionState era) ->
@@ -701,9 +705,9 @@ instance
     let
       stakeDistrs =
         Agda.StakeDistrs
-          <$> withSpecTransM dup (toSpecRep reDRepDistr)
+          <$> toSpecRepMap reDRepDistr
           <*> toSpecRep reStakePoolDistr
-      dreps = withSpecTransM dup . toSpecRep $ Map.map drepExpiry reDRepState
+      dreps = toSpecRepMap $ Map.map drepExpiry reDRepState
     treasury <- askSpecTransM
     withSpecTransM (const ()) $ do
       Agda.MkRatifyEnv
@@ -712,12 +716,8 @@ instance
         <*> dreps
         <*> toSpecRep reCommitteeState
         <*> toSpecRep treasury
-        <*> withSpecTransM
-          dup
-          (toSpecRep (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) reStakePools))
-        <*> withSpecTransM
-          dup
-          (toSpecRep (Map.mapMaybe (^. dRepDelegationAccountStateL) (reAccounts ^. accountsMapL)))
+        <*> toSpecRepMap (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) reStakePools)
+        <*> toSpecRepMap (Map.mapMaybe (^. dRepDelegationAccountStateL) (reAccounts ^. accountsMapL))
 
 instance
   ( EraPParams era
@@ -754,10 +754,11 @@ instance
         lookupGAS
         (pure Set.empty)
         (rsExpired `Set.union` Set.fromList (gasId <$> toList rsEnacted))
-    Agda.MkRatifyState
-      <$> withSpecTransM (const ()) (toSpecRep rsEnactState)
-      <*> (Agda.MkHSSet <$> traverse (withSpecTransM (const ((), ())) . toSpecRep) (toList removed))
-      <*> withSpecTransM (const ()) (toSpecRep rsDelayed)
+    withSpecTransM (const ()) $ do
+      Agda.MkRatifyState
+        <$> toSpecRep rsEnactState
+        <*> (Agda.MkHSSet <$> traverse toSpecRepTuple (toList removed))
+        <*> toSpecRep rsDelayed
 
 instance
   ( EraPParams era
@@ -772,7 +773,7 @@ instance
       [(SpecRep GovActionId, SpecRep (GovActionState era))]
 
   toSpecRep (RatifySignal x) =
-    traverse (\gas@GovActionState {gasId} -> withSpecTransM dup $ toSpecRep (gasId, gas)) (toList x)
+    traverse (\gas@GovActionState {gasId} -> toSpecRepTuple (gasId, gas)) (toList x)
 
 instance
   ( EraPParams era

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -61,7 +61,6 @@ import Control.Monad.Except (MonadError (..))
 import Data.Default (Default (..))
 import Data.Foldable (Foldable (..))
 import Data.List (sortOn)
-import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.OMap.Strict (OMap)
 import qualified Data.Set as Set
@@ -72,30 +71,26 @@ import Lens.Micro
 import Lens.Micro.Extras (view)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.Orphans ()
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
-  SpecTransM,
-  SpecTranslate (..),
-  askCtx,
- )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (committeeCredentialToStrictMaybe)
 import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr (..), showExpr)
 
-instance SpecTranslate ctx TxId where
+instance SpecTranslate TxId where
   type SpecRep TxId = Agda.TxId
 
-  toSpecRep (TxId x) = toSpecRep @ctx x
+  toSpecRep (TxId x) = toSpecRep x
 
-instance SpecTranslate ctx TxIn where
+instance SpecTranslate TxIn where
   type SpecRep TxIn = Agda.TxIn
 
-  toSpecRep (TxIn txId txIx) = toSpecRep @ctx (txId, txIx)
+  toSpecRep (TxIn txId txIx) = withSpecTransM dup $ toSpecRep (txId, txIx)
 
-instance SpecTranslate ctx (SafeHash a) where
+instance SpecTranslate (SafeHash a) where
   type SpecRep (SafeHash a) = Agda.DataHash
 
-  toSpecRep = toSpecRep @ctx . extractHash
+  toSpecRep = toSpecRep . extractHash
 
-instance SpecTranslate ctx Language where
+instance SpecTranslate Language where
   type SpecRep Language = Agda.HSLanguage
 
   toSpecRep l = case l of
@@ -104,15 +99,15 @@ instance SpecTranslate ctx Language where
     PlutusV3 -> return Agda.PV3
     PlutusV4 -> error "PlutusV4 not supported"
 
-instance SpecTranslate ctx CostModels where
+instance SpecTranslate CostModels where
   type SpecRep CostModels = Agda.LanguageCostModels
 
   toSpecRep cm =
     -- filter out PlutusV4 language
     let validCostModels = filter ((/= PlutusV4) . fst) $ Map.toList (costModelsValid cm)
-     in Agda.MkLanguageCostModels <$> mapM (\(l, _) -> (,()) <$> toSpecRep @ctx l) validCostModels
+     in Agda.MkLanguageCostModels <$> mapM (\(l, _) -> (,()) <$> toSpecRep l) validCostModels
 
-instance SpecTranslate ctx ExUnits where
+instance SpecTranslate ExUnits where
   type SpecRep ExUnits = Agda.ExUnits
 
   toSpecRep (ExUnits a b) = pure (toInteger a, toInteger b)
@@ -121,35 +116,35 @@ instance
   ( SpecRep DataHash ~ Agda.DataHash
   , Era era
   ) =>
-  SpecTranslate ctx (BinaryData era)
+  SpecTranslate (BinaryData era)
   where
   type SpecRep (BinaryData era) = Agda.DataHash
 
-  toSpecRep = toSpecRep @ctx . hashBinaryData
+  toSpecRep = toSpecRep . hashBinaryData
 
-instance Era era => SpecTranslate ctx (Datum era) where
+instance Era era => SpecTranslate (Datum era) where
   type SpecRep (Datum era) = Maybe (Either Agda.Datum Agda.DataHash)
 
   toSpecRep NoDatum = pure Nothing
   toSpecRep (Datum d) = Just . Left <$> toSpecRep d
-  toSpecRep (DatumHash h) = Just . Right <$> toSpecRep @ctx h
+  toSpecRep (DatumHash h) = Just . Right <$> toSpecRep h
 
-instance Era era => SpecTranslate ctx (Data era) where
+instance Era era => SpecTranslate (Data era) where
   type SpecRep (Data era) = Agda.DataHash
 
-  toSpecRep = toSpecRep @ctx . hashAnnotated
+  toSpecRep = toSpecRep . hashAnnotated
 
-instance SpecTranslate ctx TxAuxDataHash where
+instance SpecTranslate TxAuxDataHash where
   type SpecRep TxAuxDataHash = Agda.DataHash
 
-  toSpecRep (TxAuxDataHash x) = toSpecRep @ctx x
+  toSpecRep (TxAuxDataHash x) = toSpecRep x
 
 instance
   ( AlonzoEraScript era
   , NativeScript era ~ Timelock era
   , Script era ~ AlonzoScript era
   ) =>
-  SpecTranslate ctx (Timelock era)
+  SpecTranslate (Timelock era)
   where
   type SpecRep (Timelock era) = Agda.HSTimelock
 
@@ -180,7 +175,7 @@ instance
   ( AlonzoEraScript era
   , Script era ~ AlonzoScript era
   ) =>
-  SpecTranslate ctx (PlutusScript era)
+  SpecTranslate (PlutusScript era)
   where
   type SpecRep (PlutusScript era) = Agda.HSPlutusScript
 
@@ -195,7 +190,7 @@ instance
   , Script era ~ AlonzoScript era
   , NativeScript era ~ Timelock era
   ) =>
-  SpecTranslate ctx (AlonzoScript era)
+  SpecTranslate (AlonzoScript era)
   where
   type SpecRep (AlonzoScript era) = Agda.Script
 
@@ -205,11 +200,12 @@ instance
 instance
   ( EraTxOut era
   , SpecRep (Value era) ~ Agda.Coin
+  , SpecContext (Value era) ~ ()
   , Script era ~ AlonzoScript era
-  , SpecTranslate ctx (Value era)
-  , SpecTranslate ctx (Script era)
+  , SpecTranslate (Value era)
+  , SpecTranslate (Script era)
   ) =>
-  SpecTranslate ctx (BabbageTxOut era)
+  SpecTranslate (BabbageTxOut era)
   where
   type SpecRep (BabbageTxOut era) = Agda.TxOut
 
@@ -221,28 +217,30 @@ instance
     pure (addr', (val', (datum', script')))
 
 instance
-  ( SpecTranslate ctx (TxOut era)
+  ( SpecTranslate (TxOut era)
   , SpecRep (TxOut era) ~ Agda.TxOut
+  , SpecContext (TxOut era) ~ ()
   ) =>
-  SpecTranslate ctx (UTxO era)
+  SpecTranslate (UTxO era)
   where
-  type SpecRep (UTxO era) = SpecRep (Map TxIn (TxOut era))
+  type SpecRep (UTxO era) = Agda.HSMap (SpecRep TxIn) (SpecRep (TxOut era))
 
-  toSpecRep (UTxO m) = toSpecRep m
+  toSpecRep (UTxO m) = withSpecTransM dup $ toSpecRep m
 
-deriving instance SpecTranslate ctx OrdExUnits
+deriving instance SpecTranslate OrdExUnits
 
-deriving instance SpecTranslate ctx CoinPerByte
+deriving instance SpecTranslate CoinPerByte
 
 instance
-  SpecTranslate ctx (HKD f a) =>
-  SpecTranslate ctx (THKD r f a)
+  SpecTranslate (HKD f a) =>
+  SpecTranslate (THKD r f a)
   where
   type SpecRep (THKD r f a) = SpecRep (HKD f a)
+  type SpecContext (THKD r f a) = SpecContext (HKD f a)
 
   toSpecRep = toSpecRep . unTHKD
 
-instance SpecTranslate ctx DRepVotingThresholds where
+instance SpecTranslate DRepVotingThresholds where
   type SpecRep DRepVotingThresholds = Agda.DrepThresholds
 
   toSpecRep DRepVotingThresholds {..} =
@@ -258,7 +256,7 @@ instance SpecTranslate ctx DRepVotingThresholds where
       <*> toSpecRep dvtPPGovGroup
       <*> toSpecRep dvtTreasuryWithdrawal
 
-instance SpecTranslate ctx PoolVotingThresholds where
+instance SpecTranslate PoolVotingThresholds where
   type SpecRep PoolVotingThresholds = Agda.PoolThresholds
 
   toSpecRep PoolVotingThresholds {..} =
@@ -273,7 +271,7 @@ instance
   ( ConwayEraPParams era
   , PParamsHKD Identity era ~ ConwayPParams Identity era
   ) =>
-  SpecTranslate ctx (ConwayPParams Identity era)
+  SpecTranslate (ConwayPParams Identity era)
   where
   type SpecRep (ConwayPParams Identity era) = Agda.PParams
 
@@ -325,17 +323,17 @@ instance
 
     pure Agda.MkPParams {..}
 
-instance SpecTranslate ctx ValidityInterval where
+instance SpecTranslate ValidityInterval where
   type SpecRep ValidityInterval = (Maybe Integer, Maybe Integer)
 
-  toSpecRep (ValidityInterval lo hi) = toSpecRep (lo, hi)
+  toSpecRep (ValidityInterval lo hi) = withSpecTransM dup $ toSpecRep (lo, hi)
 
-instance Era era => SpecTranslate ctx (TxDats era) where
+instance Era era => SpecTranslate (TxDats era) where
   type SpecRep (TxDats era) = Agda.HSSet Agda.Datum
 
   toSpecRep = fmap Agda.MkHSSet . traverse (toSpecRep . snd) . Map.toList . unTxDats
 
-instance SpecTranslate ctx (AlonzoPlutusPurpose AsIx era) where
+instance SpecTranslate (AlonzoPlutusPurpose AsIx era) where
   type SpecRep (AlonzoPlutusPurpose AsIx era) = Agda.RdmrPtr
 
   toSpecRep = \case
@@ -344,7 +342,7 @@ instance SpecTranslate ctx (AlonzoPlutusPurpose AsIx era) where
     AlonzoCertifying (AsIx i) -> pure (Agda.Cert, toInteger i)
     AlonzoRewarding (AsIx i) -> pure (Agda.Rewrd, toInteger i)
 
-instance SpecTranslate ctx (ConwayPlutusPurpose AsIx era) where
+instance SpecTranslate (ConwayPlutusPurpose AsIx era) where
   type SpecRep (ConwayPlutusPurpose AsIx era) = Agda.RdmrPtr
 
   toSpecRep = \case
@@ -357,24 +355,28 @@ instance SpecTranslate ctx (ConwayPlutusPurpose AsIx era) where
 
 instance
   ( AlonzoEraScript era
-  , SpecTranslate ctx (PlutusPurpose AsIx era)
+  , SpecTranslate (PlutusPurpose AsIx era)
+  , SpecContext (PlutusPurpose AsIx era) ~ ()
+  , SpecRep (Data era, ExUnits) ~ (Agda.Redeemer, Agda.ExUnits)
   ) =>
-  SpecTranslate ctx (Redeemers era)
+  SpecTranslate (Redeemers era)
   where
   type
     SpecRep (Redeemers era) =
       Agda.HSMap (SpecRep (PlutusPurpose AsIx era)) (Agda.Redeemer, Agda.ExUnits)
 
-  toSpecRep (Redeemers x) = toSpecRep x
+  toSpecRep (Redeemers x) = withSpecTransM (const ((), ((), ()))) $ toSpecRep x
 
 instance
   ( AlonzoEraScript era
-  , SpecTranslate ctx (PlutusPurpose AsIx era)
+  , SpecTranslate (PlutusPurpose AsIx era)
   , SpecRep (PlutusPurpose AsIx era) ~ Agda.RdmrPtr
+  , SpecContext (PlutusPurpose AsIx era) ~ ()
+  , SpecRep (Data era, ExUnits) ~ (Agda.Redeemer, Agda.ExUnits)
   , Script era ~ AlonzoScript era
   , NativeScript era ~ Timelock era
   ) =>
-  SpecTranslate ctx (AlonzoTxWits era)
+  SpecTranslate (AlonzoTxWits era)
   where
   type SpecRep (AlonzoTxWits era) = Agda.TxWitnesses
 
@@ -387,12 +389,12 @@ instance
     where
       txWitsMap = toList (txwitsVKey x)
 
-instance Era era => SpecTranslate ctx (AlonzoTxAuxData era) where
+instance Era era => SpecTranslate (AlonzoTxAuxData era) where
   type SpecRep (AlonzoTxAuxData era) = Agda.AuxiliaryData
 
   toSpecRep = toSpecRep . hashAnnotated
 
-instance SpecTranslate ctx StakePoolParams where
+instance SpecTranslate StakePoolParams where
   type SpecRep StakePoolParams = Agda.StakePoolParams
 
   toSpecRep StakePoolParams {..} =
@@ -403,52 +405,53 @@ instance SpecTranslate ctx StakePoolParams where
       <*> toSpecRep sppPledge
       <*> toSpecRep (sppAccountAddress ^. accountAddressCredentialL)
 
-instance SpecTranslate ctx DRep where
+instance SpecTranslate DRep where
   type SpecRep DRep = Agda.VDeleg
 
   toSpecRep (DRepCredential c) = Agda.VDelegCredential <$> toSpecRep c
   toSpecRep DRepAlwaysAbstain = pure Agda.VDelegAbstain
   toSpecRep DRepAlwaysNoConfidence = pure Agda.VDelegNoConfidence
 
-instance SpecTranslate ctx Url where
+instance SpecTranslate Url where
   type SpecRep Url = T.Text
   toSpecRep = pure . urlToText
 
-instance SpecTranslate ctx Anchor where
+instance SpecTranslate Anchor where
   type SpecRep Anchor = Agda.Anchor
   toSpecRep (Anchor url h) = Agda.Anchor <$> toSpecRep url <*> toSpecRep h
 
-instance SpecTranslate ctx Withdrawals where
+instance SpecTranslate Withdrawals where
   type SpecRep Withdrawals = Agda.Withdrawals
 
-  toSpecRep (Withdrawals w) = toSpecRep w
+  toSpecRep (Withdrawals w) = withSpecTransM dup $ toSpecRep w
 
-instance SpecTranslate ctx IsValid where
+instance SpecTranslate IsValid where
   type SpecRep IsValid = Bool
 
   toSpecRep (IsValid b) = pure b
 
-instance SpecTranslate ctx (GovPurposeId r) where
+instance SpecTranslate (GovPurposeId r) where
   type SpecRep (GovPurposeId r) = (Agda.TxId, Integer)
 
   toSpecRep (GovPurposeId gaId) = toSpecRep gaId
 
-instance SpecTranslate ctx (Committee era) where
+instance SpecTranslate (Committee era) where
   type SpecRep (Committee era) = (Agda.HSMap Agda.Credential Agda.Epoch, Agda.Rational)
 
-  toSpecRep (Committee members threshold) = toSpecRep (members, threshold)
+  toSpecRep (Committee members threshold) = (,) <$> withSpecTransM dup (toSpecRep members) <*> toSpecRep threshold
 
-instance SpecTranslate ctx (Constitution era) where
+instance SpecTranslate (Constitution era) where
   type SpecRep (Constitution era) = (Agda.DataHash, Maybe Agda.ScriptHash)
 
-  toSpecRep (Constitution (Anchor _ h) policy) = toSpecRep (h, policy)
+  toSpecRep (Constitution (Anchor _ h) policy) = withSpecTransM dup $ toSpecRep (h, policy)
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD Identity era)
+  , SpecTranslate (PParamsHKD Identity era)
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
+  , SpecContext (PParamsHKD Identity era) ~ ()
   ) =>
-  SpecTranslate ctx (EnactState era)
+  SpecTranslate (EnactState era)
   where
   type SpecRep (EnactState era) = Agda.EnactState
 
@@ -473,21 +476,21 @@ instance
           SNothing -> pure (0, 0)
         pure (committee, agdaLastId)
 
-instance SpecTranslate ctx Voter where
+instance SpecTranslate Voter where
   type SpecRep Voter = Agda.GovVoter
 
   toSpecRep (CommitteeVoter c) = (Agda.CC,) <$> toSpecRep c
   toSpecRep (DRepVoter c) = (Agda.DRep,) <$> toSpecRep c
   toSpecRep (StakePoolVoter kh) = (Agda.SPO,) <$> toSpecRep (KeyHashObj kh)
 
-instance SpecTranslate ctx Vote where
+instance SpecTranslate Vote where
   type SpecRep Vote = Agda.Vote
 
   toSpecRep VoteYes = pure Agda.Yes
   toSpecRep VoteNo = pure Agda.No
   toSpecRep Abstain = pure Agda.Abstain
 
-instance SpecTranslate ctx (VotingProcedures era) where
+instance SpecTranslate (VotingProcedures era) where
   type SpecRep (VotingProcedures era) = [Agda.GovVote]
 
   toSpecRep = foldrVotingProcedures go (pure [])
@@ -496,19 +499,19 @@ instance SpecTranslate ctx (VotingProcedures era) where
         Voter ->
         GovActionId ->
         VotingProcedure era ->
-        SpecTransM ctx [Agda.GovVote] ->
-        SpecTransM ctx [Agda.GovVote]
+        SpecTransM () [Agda.GovVote] ->
+        SpecTransM () [Agda.GovVote]
       go voter gaId votingProcedure m =
         (:)
           <$> ( Agda.MkGovVote
-                  <$> toSpecRep gaId
+                  <$> withSpecTransM (const ()) (toSpecRep gaId)
                   <*> toSpecRep voter
                   <*> toSpecRep (vProcVote votingProcedure)
                   <*> toSpecRep (vProcAnchor votingProcedure)
               )
           <*> m
 
-instance SpecTranslate ctx (ConwayPParams StrictMaybe era) where
+instance SpecTranslate (ConwayPParams StrictMaybe era) where
   type SpecRep (ConwayPParams StrictMaybe era) = Agda.PParamsUpdate
 
   toSpecRep (ConwayPParams {..}) = do
@@ -558,10 +561,11 @@ instance SpecTranslate ctx (ConwayPParams StrictMaybe era) where
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   ) =>
-  SpecTranslate ctx (GovAction era)
+  SpecTranslate (GovAction era)
   where
   type SpecRep (GovAction era) = Agda.GovAction
 
@@ -569,11 +573,11 @@ instance
   toSpecRep (HardForkInitiation _ pv) = Agda.TriggerHardFork <$> toSpecRep pv
   toSpecRep (TreasuryWithdrawals withdrawals _) =
     Agda.TreasuryWithdrawal
-      <$> toSpecRep withdrawals
+      <$> withSpecTransM dup (toSpecRep withdrawals)
   toSpecRep (NoConfidence _) = pure Agda.NoConfidence
   toSpecRep (UpdateCommittee _ remove add threshold) =
     Agda.UpdateCommittee
-      <$> toSpecRep add
+      <$> withSpecTransM dup (toSpecRep add)
       <*> toSpecRep remove
       <*> toSpecRep threshold
   toSpecRep (NewConstitution _ (Constitution (Anchor _ h) policy)) =
@@ -584,10 +588,11 @@ instance
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   ) =>
-  SpecTranslate ctx (ProposalProcedure era)
+  SpecTranslate (ProposalProcedure era)
   where
   type SpecRep (ProposalProcedure era) = Agda.GovProposal
 
@@ -629,19 +634,20 @@ nullifyIfNotNeeded (SJust gaId) = \case
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   ) =>
-  SpecTranslate ctx (GovActionState era)
+  SpecTranslate (GovActionState era)
   where
   type SpecRep (GovActionState era) = Agda.GovActionState
 
   toSpecRep gas@GovActionState {..} = do
     Agda.MkGovActionState
       <$> ( Agda.GovVotes
-              <$> toSpecRep gasCommitteeVotes
-              <*> toSpecRep gasDRepVotes
-              <*> toSpecRep gasStakePoolVotes
+              <$> withSpecTransM dup (toSpecRep gasCommitteeVotes)
+              <*> withSpecTransM dup (toSpecRep gasDRepVotes)
+              <*> withSpecTransM dup (toSpecRep gasStakePoolVotes)
           )
       <*> toSpecRep (gasReturnAddr gas)
       <*> toSpecRep gasExpiresAfter
@@ -650,79 +656,88 @@ instance
     where
       action = gasAction gas
 
-instance SpecTranslate ctx GovActionIx where
+instance SpecTranslate GovActionIx where
   type SpecRep GovActionIx = Integer
 
   toSpecRep = pure . fromIntegral . unGovActionIx
 
-instance SpecTranslate ctx GovActionId where
+instance SpecTranslate GovActionId where
   type SpecRep GovActionId = Agda.GovActionID
 
-  toSpecRep (GovActionId txId gaIx) = toSpecRep (txId, gaIx)
+  toSpecRep (GovActionId txId gaIx) = withSpecTransM dup $ toSpecRep (txId, gaIx)
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   ) =>
-  SpecTranslate ctx (Proposals era)
+  SpecTranslate (Proposals era)
   where
   type SpecRep (Proposals era) = Agda.GovState
 
   -- TODO get rid of `prioritySort` once we've changed the implementation so
   -- that the proposals are always sorted
-  toSpecRep = toSpecRep . prioritySort . view pPropsL
+  toSpecRep = withSpecTransM dup . toSpecRep . prioritySort . view pPropsL
     where
       prioritySort ::
         OMap GovActionId (GovActionState era) ->
         OMap GovActionId (GovActionState era)
       prioritySort = Exts.fromList . sortOn (actionPriority . gasAction) . Exts.toList
 
-instance SpecTranslate ctx MaryValue where
+instance SpecTranslate MaryValue where
   type SpecRep MaryValue = Agda.Coin
 
   toSpecRep = toSpecRep . coin
 
 instance
-  (Inject ctx Coin, ConwayEraAccounts era) =>
-  SpecTranslate ctx (RatifyEnv era)
+  ConwayEraAccounts era =>
+  SpecTranslate (RatifyEnv era)
   where
   type SpecRep (RatifyEnv era) = Agda.RatifyEnv
+  type SpecContext (RatifyEnv era) = Coin
 
   toSpecRep RatifyEnv {..} = do
     let
       stakeDistrs =
         Agda.StakeDistrs
-          <$> toSpecRep reDRepDistr
+          <$> withSpecTransM dup (toSpecRep reDRepDistr)
           <*> toSpecRep reStakePoolDistr
-      dreps = toSpecRep $ Map.map drepExpiry reDRepState
-    treasury <- askCtx @Coin
-    Agda.MkRatifyEnv
-      <$> stakeDistrs
-      <*> toSpecRep reCurrentEpoch
-      <*> dreps
-      <*> toSpecRep reCommitteeState
-      <*> toSpecRep treasury
-      <*> toSpecRep (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) reStakePools)
-      <*> toSpecRep (Map.mapMaybe (^. dRepDelegationAccountStateL) (reAccounts ^. accountsMapL))
+      dreps = withSpecTransM dup . toSpecRep $ Map.map drepExpiry reDRepState
+    treasury <- askSpecTransM
+    withSpecTransM (const ()) $ do
+      Agda.MkRatifyEnv
+        <$> stakeDistrs
+        <*> toSpecRep reCurrentEpoch
+        <*> dreps
+        <*> toSpecRep reCommitteeState
+        <*> toSpecRep treasury
+        <*> withSpecTransM
+          dup
+          (toSpecRep (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) reStakePools))
+        <*> withSpecTransM
+          dup
+          (toSpecRep (Map.mapMaybe (^. dRepDelegationAccountStateL) (reAccounts ^. accountsMapL)))
 
 instance
   ( EraPParams era
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate ctx (PParamsHKD Identity era)
-  , Inject ctx [GovActionState era]
+  , SpecContext (PParamsHKD Identity era) ~ ()
+  , SpecTranslate (PParamsHKD Identity era)
   , ToExpr (PParamsHKD StrictMaybe era)
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
+  , SpecTranslate (PParamsHKD StrictMaybe era)
   ) =>
-  SpecTranslate ctx (RatifyState era)
+  SpecTranslate (RatifyState era)
   where
   type SpecRep (RatifyState era) = Agda.RatifyState
+  type SpecContext (RatifyState era) = [GovActionState era]
 
   toSpecRep RatifyState {..} = do
     govActionMap <-
       foldl' (\acc gas -> Map.insert (gasId gas) gas acc) mempty
-        <$> askCtx @[GovActionState era]
+        <$> askSpecTransM
     let
       lookupGAS gaId m = do
         case Map.lookup gaId govActionMap of
@@ -740,31 +755,32 @@ instance
         (pure Set.empty)
         (rsExpired `Set.union` Set.fromList (gasId <$> toList rsEnacted))
     Agda.MkRatifyState
-      <$> toSpecRep rsEnactState
-      <*> toSpecRep removed
-      <*> toSpecRep rsDelayed
+      <$> withSpecTransM (const ()) (toSpecRep rsEnactState)
+      <*> (Agda.MkHSSet <$> traverse (withSpecTransM (const ((), ())) . toSpecRep) (toList removed))
+      <*> withSpecTransM (const ()) (toSpecRep rsDelayed)
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   ) =>
-  SpecTranslate ctx (RatifySignal era)
+  SpecTranslate (RatifySignal era)
   where
   type
     SpecRep (RatifySignal era) =
-      SpecRep [(GovActionId, GovActionState era)]
+      [(SpecRep GovActionId, SpecRep (GovActionState era))]
 
   toSpecRep (RatifySignal x) =
-    toSpecRep $
-      (\gas@GovActionState {gasId} -> (gasId, gas)) <$> x
+    traverse (\gas@GovActionState {gasId} -> withSpecTransM dup $ toSpecRep (gasId, gas)) (toList x)
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   ) =>
-  SpecTranslate ctx (EnactSignal era)
+  SpecTranslate (EnactSignal era)
   where
   type SpecRep (EnactSignal era) = SpecRep (GovAction era)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -41,26 +41,26 @@ import Test.Cardano.Ledger.Conway.TreeDiff
 import Test.Cardano.Ledger.Shelley.Utils (runShelleyBase)
 
 instance
-  ( SpecTranslate ctx (PParamsHKD Identity era)
+  ( SpecTranslate (PParamsHKD Identity era)
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , Inject ctx (VotingProcedures era)
-  , Inject ctx (Map AccountAddress Coin)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   ) =>
-  SpecTranslate ctx (CertEnv era)
+  SpecTranslate (CertEnv era)
   where
   type SpecRep (CertEnv era) = Agda.CertEnv
+  type SpecContext (CertEnv era) = (VotingProcedures era, Map AccountAddress Coin)
   toSpecRep CertEnv {..} = do
-    votes <- askCtx @(VotingProcedures era)
-    withdrawals <- askCtx @(Map AccountAddress Coin)
+    (votes, withdrawals) <- askSpecTransM
     let ccColdCreds = foldMap (keysSet . committeeMembers) ceCurrentCommittee
-    Agda.MkCertEnv
-      <$> toSpecRep ceCurrentEpoch
-      <*> toSpecRep cePParams
-      <*> toSpecRep votes
-      <*> toSpecRep withdrawals
-      <*> toSpecRep ccColdCreds
+    withSpecTransM (const ()) $
+      Agda.MkCertEnv
+        <$> toSpecRep ceCurrentEpoch
+        <*> toSpecRep cePParams
+        <*> toSpecRep votes
+        <*> withSpecTransM (const ((), ())) (toSpecRep withdrawals)
+        <*> toSpecRep ccColdCreds
 
-instance ConwayEraAccounts era => SpecTranslate ctx (ConwayCertState era) where
+instance ConwayEraAccounts era => SpecTranslate (ConwayCertState era) where
   type SpecRep (ConwayCertState era) = Agda.CertState
   toSpecRep ConwayCertState {..} =
     Agda.MkCertState
@@ -68,7 +68,7 @@ instance ConwayEraAccounts era => SpecTranslate ctx (ConwayCertState era) where
       <*> toSpecRep conwayCertPState
       <*> toSpecRep conwayCertVState
 
-instance Era era => SpecTranslate ctx (ConwayTxCert era) where
+instance Era era => SpecTranslate (ConwayTxCert era) where
   type SpecRep (ConwayTxCert era) = Agda.DCert
 
   toSpecRep (ConwayTxCertPool p) = toSpecRep p
@@ -79,7 +79,7 @@ depositsMap ::
   ConwayEraCertState era =>
   CertState era ->
   Proposals era ->
-  SpecTransM ctx (Agda.HSMap Agda.DepositPurpose Integer)
+  SpecTransM () (Agda.HSMap Agda.DepositPurpose Integer)
 depositsMap certState props =
   unionsHSMap
     <$> sequence
@@ -102,70 +102,75 @@ depositsMap certState props =
       ]
 
 instance
-  ( SpecTranslate ctx (TxOut era)
+  ( SpecTranslate (TxOut era)
   , SpecRep (TxOut era) ~ Agda.TxOut
+  , SpecContext (TxOut era) ~ ()
   , GovState era ~ ConwayGovState era
-  , Inject ctx (CertState era)
   , ConwayEraCertState era
   ) =>
-  SpecTranslate ctx (UTxOState era)
+  SpecTranslate (UTxOState era)
   where
   type SpecRep (UTxOState era) = Agda.UTxOState
+  type SpecContext (UTxOState era) = CertState era
 
   toSpecRep UTxOState {..} = do
-    certState <- askCtx @(CertState era)
+    certState <- askSpecTransM
     let
       props = utxosGovState ^. cgsProposalsL
       deposits = depositsMap certState props
-    Agda.MkUTxOState
-      <$> toSpecRep utxosUtxo
-      <*> toSpecRep utxosFees
-      <*> deposits
-      <*> toSpecRep utxosDonation
+    withSpecTransM (const ()) $
+      Agda.MkUTxOState
+        <$> toSpecRep utxosUtxo
+        <*> toSpecRep utxosFees
+        <*> deposits
+        <*> toSpecRep utxosDonation
 
 instance
   ( ConwayEraGov era
+  , EraPParams era
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
+  , SpecTranslate (TxOut era)
   , SpecRep (TxOut era) ~ Agda.TxOut
+  , SpecContext (TxOut era) ~ ()
   , GovState era ~ ConwayGovState era
-  , SpecTranslate (CertState era) (TxOut era)
   , SpecRep (CertState era) ~ Agda.CertState
   , ConwayEraCertState era
   , CertState era ~ ConwayCertState era
   ) =>
-  SpecTranslate ctx (LedgerState era)
+  SpecTranslate (LedgerState era)
   where
   type SpecRep (LedgerState era) = Agda.LState
 
-  toSpecRep (LedgerState {..}) = do
-    let
-      props = utxosGovState lsUTxOState ^. proposalsGovStateL
-      deposits = depositsMap lsCertState props
+  toSpecRep (LedgerState {..}) =
     Agda.MkLState
       <$> withCtx lsCertState (toSpecRep lsUTxOState)
       <*> toSpecRep props
-      <*> withCtx deposits (toSpecRep lsCertState)
+      <*> toSpecRep lsCertState
+    where
+      props = utxosGovState lsUTxOState ^. proposalsGovStateL
 
 instance
   ( EraPParams era
   , ConwayEraGov era
-  , SpecTranslate [GovActionState era] (PParamsHKD Identity era)
+  , SpecTranslate (PParamsHKD Identity era)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate [GovActionState era] (PParamsHKD StrictMaybe era)
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
-  , SpecTranslate ctx (PParamsHKD Identity era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
   , ToExpr (PParamsHKD StrictMaybe era)
+  , SpecTranslate (TxOut era)
   , SpecRep (TxOut era) ~ Agda.TxOut
+  , SpecContext (TxOut era) ~ ()
   , GovState era ~ ConwayGovState era
-  , SpecTranslate (CertState era) (TxOut era)
   , SpecRep (CertState era) ~ Agda.CertState
   , ConwayEraCertState era
   , CertState era ~ ConwayCertState era
   ) =>
-  SpecTranslate ctx (EpochState era)
+  SpecTranslate (EpochState era)
   where
   type SpecRep (EpochState era) = Agda.EpochState
 
@@ -181,7 +186,7 @@ instance
       ratifyState = getRatifyState $ utxosGovState lsUTxOState
       govActions = toList $ lsUTxOState ^. utxosGovStateL . proposalsGovStateL . pPropsL
 
-instance SpecTranslate ctx SnapShots where
+instance SpecTranslate SnapShots where
   type SpecRep SnapShots = Agda.Snapshots
 
   toSpecRep (SnapShots {..}) =
@@ -191,18 +196,18 @@ instance SpecTranslate ctx SnapShots where
       <*> toSpecRep ssStakeGo
       <*> toSpecRep ssFee
 
-instance SpecTranslate ctx SnapShot where
+instance SpecTranslate SnapShot where
   type SpecRep SnapShot = Agda.Snapshot
 
   toSpecRep (SnapShot {..}) =
     Agda.MkSnapshot
       <$> toSpecRep (Stake $ VMap.fromMap $ Map.map (unNonZero . swdStake) activeStakeMap)
-      <*> toSpecRep (Map.map swdDelegation activeStakeMap)
-      <*> toSpecRep (VMap.toMap ssStakePoolsSnapShot)
+      <*> withSpecTransM dup (toSpecRep (Map.map swdDelegation activeStakeMap))
+      <*> withSpecTransM dup (toSpecRep (VMap.toMap ssStakePoolsSnapShot))
     where
       activeStakeMap = VMap.toMap $ unActiveStake ssActiveStake
 
-instance SpecTranslate ctx StakePoolSnapShot where
+instance SpecTranslate StakePoolSnapShot where
   type SpecRep StakePoolSnapShot = Agda.StakePoolParams
 
   toSpecRep StakePoolSnapShot {..} =
@@ -213,12 +218,12 @@ instance SpecTranslate ctx StakePoolSnapShot where
       <*> toSpecRep spssPledge
       <*> toSpecRep (unAccountId spssAccountId)
 
-instance SpecTranslate ctx Stake where
+instance SpecTranslate Stake where
   type SpecRep Stake = Agda.HSMap Agda.Credential Agda.Coin
 
-  toSpecRep (Stake stake) = toSpecRep $ VMap.toMap stake
+  toSpecRep (Stake stake) = withSpecTransM dup $ toSpecRep $ VMap.toMap stake
 
-instance SpecTranslate ctx ChainAccountState where
+instance SpecTranslate ChainAccountState where
   type SpecRep ChainAccountState = Agda.Acnt
 
   toSpecRep (ChainAccountState {..}) =
@@ -226,12 +231,12 @@ instance SpecTranslate ctx ChainAccountState where
       <$> toSpecRep casTreasury
       <*> toSpecRep casReserves
 
-instance SpecTranslate ctx DeltaCoin where
+instance SpecTranslate DeltaCoin where
   type SpecRep DeltaCoin = Integer
 
   toSpecRep (DeltaCoin x) = pure x
 
-instance SpecTranslate ctx PulsingRewUpdate where
+instance SpecTranslate PulsingRewUpdate where
   type SpecRep PulsingRewUpdate = Agda.HsRewardUpdate
 
   toSpecRep x =
@@ -239,7 +244,7 @@ instance SpecTranslate ctx PulsingRewUpdate where
       <$> toSpecRep deltaT
       <*> toSpecRep deltaR
       <*> toSpecRep deltaF
-      <*> toSpecRep rwds
+      <*> withSpecTransM dup (toSpecRep rwds)
     where
       (RewardUpdate {..}, _) = runShelleyBase $ completeRupd x
       rwds = Set.foldMap rewardAmount <$> rs
@@ -247,21 +252,22 @@ instance SpecTranslate ctx PulsingRewUpdate where
 instance
   ( EraPParams era
   , ConwayEraGov era
-  , SpecTranslate ctx (PParamsHKD Identity era)
+  , SpecTranslate (PParamsHKD Identity era)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
-  , SpecTranslate [GovActionState era] (PParamsHKD Identity era)
-  , SpecTranslate [GovActionState era] (PParamsHKD StrictMaybe era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
   , ToExpr (PParamsHKD StrictMaybe era)
+  , SpecTranslate (TxOut era)
   , SpecRep (TxOut era) ~ Agda.TxOut
+  , SpecContext (TxOut era) ~ ()
   , GovState era ~ ConwayGovState era
-  , SpecTranslate (CertState era) (TxOut era)
   , SpecRep (CertState era) ~ Agda.CertState
   , ConwayEraCertState era
   , CertState era ~ ConwayCertState era
   ) =>
-  SpecTranslate ctx (NewEpochState era)
+  SpecTranslate (NewEpochState era)
   where
   type SpecRep (NewEpochState era) = Agda.NewEpochState
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -57,7 +57,7 @@ instance
         <$> toSpecRep ceCurrentEpoch
         <*> toSpecRep cePParams
         <*> toSpecRep votes
-        <*> withSpecTransM (const ((), ())) (toSpecRep withdrawals)
+        <*> toSpecRepMap withdrawals
         <*> toSpecRep ccColdCreds
 
 instance ConwayEraAccounts era => SpecTranslate (ConwayCertState era) where
@@ -202,8 +202,8 @@ instance SpecTranslate SnapShot where
   toSpecRep (SnapShot {..}) =
     Agda.MkSnapshot
       <$> toSpecRep (Stake $ VMap.fromMap $ Map.map (unNonZero . swdStake) activeStakeMap)
-      <*> withSpecTransM dup (toSpecRep (Map.map swdDelegation activeStakeMap))
-      <*> withSpecTransM dup (toSpecRep (VMap.toMap ssStakePoolsSnapShot))
+      <*> toSpecRepMap (Map.map swdDelegation activeStakeMap)
+      <*> toSpecRepMap (VMap.toMap ssStakePoolsSnapShot)
     where
       activeStakeMap = VMap.toMap $ unActiveStake ssActiveStake
 
@@ -221,7 +221,7 @@ instance SpecTranslate StakePoolSnapShot where
 instance SpecTranslate Stake where
   type SpecRep Stake = Agda.HSMap Agda.Credential Agda.Coin
 
-  toSpecRep (Stake stake) = withSpecTransM dup $ toSpecRep $ VMap.toMap stake
+  toSpecRep (Stake stake) = toSpecRepMap $ VMap.toMap stake
 
 instance SpecTranslate ChainAccountState where
   type SpecRep ChainAccountState = Agda.Acnt
@@ -244,7 +244,7 @@ instance SpecTranslate PulsingRewUpdate where
       <$> toSpecRep deltaT
       <*> toSpecRep deltaR
       <*> toSpecRep deltaF
-      <*> withSpecTransM dup (toSpecRep rwds)
+      <*> toSpecRepMap rwds
     where
       (RewardUpdate {..}, _) = runShelleyBase $ completeRupd x
       rwds = Set.foldMap rewardAmount <$> rs

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -52,7 +52,7 @@ instance
   toSpecRep CertEnv {..} = do
     (votes, withdrawals) <- askSpecTransM
     let ccColdCreds = foldMap (keysSet . committeeMembers) ceCurrentCommittee
-    withSpecTransM (const ()) $
+    withCtxSpecTransM () $
       Agda.MkCertEnv
         <$> toSpecRep ceCurrentEpoch
         <*> toSpecRep cePParams
@@ -118,7 +118,7 @@ instance
     let
       props = utxosGovState ^. cgsProposalsL
       deposits = depositsMap certState props
-    withSpecTransM (const ()) $
+    withCtxSpecTransM () $
       Agda.MkUTxOState
         <$> toSpecRep utxosUtxo
         <*> toSpecRep utxosFees
@@ -146,7 +146,7 @@ instance
 
   toSpecRep (LedgerState {..}) =
     Agda.MkLState
-      <$> withCtx lsCertState (toSpecRep lsUTxOState)
+      <$> withCtxSpecTransM lsCertState (toSpecRep lsUTxOState)
       <*> toSpecRep props
       <*> toSpecRep lsCertState
     where
@@ -180,7 +180,7 @@ instance
       <*> toSpecRep esSnapshots
       <*> toSpecRep esLState
       <*> toSpecRep enactState
-      <*> withCtx govActions (toSpecRep ratifyState)
+      <*> withCtxSpecTransM govActions (toSpecRep ratifyState)
     where
       enactState = mkEnactState $ utxosGovState lsUTxOState
       ratifyState = getRatifyState $ utxosGovState lsUTxOState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -36,7 +36,7 @@ instance
   toSpecRep CertsEnv {..} = do
     (votes, withdrawals) <- askSpecTransM
     let ccColdCreds = foldMap (keysSet . committeeMembers) certsCurrentCommittee
-    withSpecTransM (const ()) $
+    withCtxSpecTransM () $
       Agda.MkCertEnv
         <$> toSpecRep certsCurrentEpoch
         <*> toSpecRep certsPParams

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -12,7 +12,6 @@
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Certs () where
 
-import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
@@ -26,21 +25,21 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 
 instance
-  ( SpecTranslate ctx (PParamsHKD Identity era)
+  ( SpecTranslate (PParamsHKD Identity era)
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , Inject ctx (VotingProcedures era)
-  , Inject ctx (Map AccountAddress Coin)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   ) =>
-  SpecTranslate ctx (CertsEnv era)
+  SpecTranslate (CertsEnv era)
   where
   type SpecRep (CertsEnv era) = Agda.CertEnv
+  type SpecContext (CertsEnv era) = (VotingProcedures era, Map AccountAddress Coin)
   toSpecRep CertsEnv {..} = do
-    votes <- askCtx @(VotingProcedures era)
-    withdrawals <- askCtx @(Map AccountAddress Coin)
+    (votes, withdrawals) <- askSpecTransM
     let ccColdCreds = foldMap (keysSet . committeeMembers) certsCurrentCommittee
-    Agda.MkCertEnv
-      <$> toSpecRep certsCurrentEpoch
-      <*> toSpecRep certsPParams
-      <*> toSpecRep votes
-      <*> toSpecRep withdrawals
-      <*> toSpecRep ccColdCreds
+    withSpecTransM (const ()) $
+      Agda.MkCertEnv
+        <$> toSpecRep certsCurrentEpoch
+        <*> toSpecRep certsPParams
+        <*> toSpecRep votes
+        <*> withSpecTransM (const ((), ())) (toSpecRep withdrawals)
+        <*> toSpecRep ccColdCreds

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -41,5 +41,5 @@ instance
         <$> toSpecRep certsCurrentEpoch
         <*> toSpecRep certsPParams
         <*> toSpecRep votes
-        <*> withSpecTransM (const ((), ())) (toSpecRep withdrawals)
+        <*> toSpecRepMap withdrawals
         <*> toSpecRep ccColdCreds

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -38,24 +38,26 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
 instance
   ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate ctx (PParamsHKD Identity era)
-  , Inject ctx (Set (Credential DRepRole))
+  , SpecTranslate (PParamsHKD Identity era)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   ) =>
-  SpecTranslate ctx (ConwayDelegEnv era)
+  SpecTranslate (ConwayDelegEnv era)
   where
   type SpecRep (ConwayDelegEnv era) = Agda.DelegEnv
+  type SpecContext (ConwayDelegEnv era) = Set (Credential DRepRole)
 
   toSpecRep ConwayDelegEnv {..} = do
-    delegatees <- askCtx @(Set (Credential DRepRole))
-    Agda.MkDelegEnv
-      <$> toSpecRep cdePParams
-      <*> toSpecRep
-        ( Map.mapKeys (hashToInteger . unKeyHash) $
-            Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) cdePools
-        )
-      <*> toSpecRep delegatees
+    delegatees <- askSpecTransM
+    withSpecTransM (const ()) $
+      Agda.MkDelegEnv
+        <$> toSpecRep cdePParams
+        <*> withSpecTransM (const ((), ())) (toSpecRep
+          ( Map.mapKeys (hashToInteger . unKeyHash) $
+              Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) cdePools
+          ))
+        <*> toSpecRep delegatees
 
-instance SpecTranslate ctx ConwayDelegCert where
+instance SpecTranslate ConwayDelegCert where
   type SpecRep ConwayDelegCert = Agda.DCert
 
   toSpecRep (ConwayRegCert c d) =
@@ -79,14 +81,14 @@ instance SpecTranslate ctx ConwayDelegCert where
       <*> toSpecRep (hashToInteger . unKeyHash <$> getStakePoolDelegatee d)
       <*> toSpecRep c
 
-instance ConwayEraAccounts era => SpecTranslate ctx (DState era) where
+instance ConwayEraAccounts era => SpecTranslate (DState era) where
   type SpecRep (DState era) = Agda.DState
 
   toSpecRep dState =
     Agda.MkDState
-      <$> toSpecRep (Map.mapMaybe (^. dRepDelegationAccountStateL) accountsMap)
-      <*> toSpecRep (Map.mapMaybe (^. stakePoolDelegationAccountStateL) accountsMap)
-      <*> toSpecRep (Map.map (fromCompact . (^. balanceAccountStateL)) accountsMap)
+      <$> withSpecTransM dup (toSpecRep (Map.mapMaybe (^. dRepDelegationAccountStateL) accountsMap))
+      <*> withSpecTransM dup (toSpecRep (Map.mapMaybe (^. stakePoolDelegationAccountStateL) accountsMap))
+      <*> withSpecTransM dup (toSpecRep (Map.map (fromCompact . (^. balanceAccountStateL)) accountsMap))
       <*> deposits
     where
       accountsMap = dState ^. accountsL . accountsMapL

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -51,10 +51,13 @@ instance
     withSpecTransM (const ()) $
       Agda.MkDelegEnv
         <$> toSpecRep cdePParams
-        <*> withSpecTransM (const ((), ())) (toSpecRep
-          ( Map.mapKeys (hashToInteger . unKeyHash) $
-              Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) cdePools
-          ))
+        <*> withSpecTransM
+          (const ((), ()))
+          ( toSpecRep
+              ( Map.mapKeys (hashToInteger . unKeyHash) $
+                  Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) cdePools
+              )
+          )
         <*> toSpecRep delegatees
 
 instance SpecTranslate ConwayDelegCert where

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -48,7 +48,7 @@ instance
 
   toSpecRep ConwayDelegEnv {..} = do
     delegatees <- askSpecTransM
-    withSpecTransM (const ()) $
+    withCtxSpecTransM () $
       Agda.MkDelegEnv
         <$> toSpecRep cdePParams
         <*> ( toSpecRepMap

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -51,13 +51,11 @@ instance
     withSpecTransM (const ()) $
       Agda.MkDelegEnv
         <$> toSpecRep cdePParams
-        <*> withSpecTransM
-          (const ((), ()))
-          ( toSpecRep
-              ( Map.mapKeys (hashToInteger . unKeyHash) $
-                  Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) cdePools
-              )
-          )
+        <*> ( toSpecRepMap
+                ( Map.mapKeys (hashToInteger . unKeyHash) $
+                    Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) cdePools
+                )
+            )
         <*> toSpecRep delegatees
 
 instance SpecTranslate ConwayDelegCert where
@@ -89,9 +87,9 @@ instance ConwayEraAccounts era => SpecTranslate (DState era) where
 
   toSpecRep dState =
     Agda.MkDState
-      <$> withSpecTransM dup (toSpecRep (Map.mapMaybe (^. dRepDelegationAccountStateL) accountsMap))
-      <*> withSpecTransM dup (toSpecRep (Map.mapMaybe (^. stakePoolDelegationAccountStateL) accountsMap))
-      <*> withSpecTransM dup (toSpecRep (Map.map (fromCompact . (^. balanceAccountStateL)) accountsMap))
+      <$> toSpecRepMap (Map.mapMaybe (^. dRepDelegationAccountStateL) accountsMap)
+      <*> toSpecRepMap (Map.mapMaybe (^. stakePoolDelegationAccountStateL) accountsMap)
+      <*> toSpecRepMap (Map.map (fromCompact . (^. balanceAccountStateL)) accountsMap)
       <*> deposits
     where
       accountsMap = dState ^. accountsL . accountsMapL

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
@@ -26,36 +26,40 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
 instance
-  ( SpecTranslate ctx (PParamsHKD Identity era)
-  , Inject ctx (EnactState era)
+  ( SpecTranslate (PParamsHKD Identity era)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   , EraPParams era
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate ctx (CertState era)
+  , SpecTranslate (CertState era)
+  , SpecContext (CertState era) ~ ()
   , SpecRep (CertState era) ~ Agda.CertState
   , EraCertState era
   ) =>
-  SpecTranslate ctx (GovEnv era)
+  SpecTranslate (GovEnv era)
   where
   type SpecRep (GovEnv era) = Agda.GovEnv
+  type SpecContext (GovEnv era) = EnactState era
 
   toSpecRep GovEnv {..} = do
-    enactState <- askCtx @(EnactState era)
+    enactState <- askSpecTransM
     let rewardAccounts = Map.keysSet $ geCertState ^. certDStateL . accountsL . accountsMapL
-    Agda.MkGovEnv
-      <$> toSpecRep geTxId
-      <*> toSpecRep geEpoch
-      <*> toSpecRep gePParams
-      <*> toSpecRep geGuardrailsScriptHash
-      <*> toSpecRep enactState
-      <*> toSpecRep geCertState
-      <*> toSpecRep rewardAccounts
+    withSpecTransM (const ()) $
+      Agda.MkGovEnv
+        <$> toSpecRep geTxId
+        <*> toSpecRep geEpoch
+        <*> toSpecRep gePParams
+        <*> toSpecRep geGuardrailsScriptHash
+        <*> toSpecRep enactState
+        <*> toSpecRep geCertState
+        <*> toSpecRep rewardAccounts
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD StrictMaybe era)
+  , SpecTranslate (PParamsHKD StrictMaybe era)
+  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
   , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
   ) =>
-  SpecTranslate ctx (GovSignal era)
+  SpecTranslate (GovSignal era)
   where
   type SpecRep (GovSignal era) = [Either Agda.GovVote Agda.GovProposal]
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
@@ -43,7 +43,7 @@ instance
   toSpecRep GovEnv {..} = do
     enactState <- askSpecTransM
     let rewardAccounts = Map.keysSet $ geCertState ^. certDStateL . accountsL . accountsMapL
-    withSpecTransM (const ()) $
+    withCtxSpecTransM () $
       Agda.MkGovEnv
         <$> toSpecRep geTxId
         <*> toSpecRep geEpoch

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -90,8 +90,11 @@ instance SpecTranslate (VState era) where
   toSpecRep VState {..} = do
     Agda.MkGState
       <$> withSpecTransM dup (toSpecRep (updateExpiry . drepExpiry <$> vsDReps))
-      <*> withSpecTransM dup (toSpecRep
-        (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState))
+      <*> withSpecTransM
+        dup
+        ( toSpecRep
+            (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState)
+        )
       <*> deposits
     where
       transEntry (cred, val) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -76,7 +76,7 @@ instance
         ccColdCreds =
           foldMap (keysSet . committeeMembers) cgceCurrentCommittee
             <> potentialCCMembers cgceCommitteeProposals
-    withSpecTransM (const ()) $
+    withCtxSpecTransM () $
       Agda.MkCertEnv
         <$> toSpecRep cgceCurrentEpoch
         <*> toSpecRep cgcePParams

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -29,7 +29,7 @@ import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 
-instance SpecTranslate ctx ConwayGovCert where
+instance SpecTranslate ConwayGovCert where
   type SpecRep ConwayGovCert = Agda.DCert
 
   toSpecRep (ConwayRegDRep c d a) =
@@ -56,18 +56,17 @@ instance SpecTranslate ctx ConwayGovCert where
       <*> toSpecRep (SNothing @(Credential _))
 
 instance
-  ( SpecTranslate ctx (PParamsHKD Identity era)
+  ( SpecTranslate (PParamsHKD Identity era)
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , Inject ctx (VotingProcedures era)
-  , Inject ctx (Map AccountAddress Coin)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   ) =>
-  SpecTranslate ctx (ConwayGovCertEnv era)
+  SpecTranslate (ConwayGovCertEnv era)
   where
   type SpecRep (ConwayGovCertEnv era) = Agda.CertEnv
+  type SpecContext (ConwayGovCertEnv era) = (VotingProcedures era, Map AccountAddress Coin)
 
   toSpecRep ConwayGovCertEnv {..} = do
-    votes <- askCtx @(VotingProcedures era)
-    withdrawals <- askCtx @(Map AccountAddress Coin)
+    (votes, withdrawals) <- askSpecTransM
     let propGetCCMembers (UpdateCommittee _ _ x _) = Just $ keysSet x
         propGetCCMembers _ = Nothing
         potentialCCMembers =
@@ -77,21 +76,22 @@ instance
         ccColdCreds =
           foldMap (keysSet . committeeMembers) cgceCurrentCommittee
             <> potentialCCMembers cgceCommitteeProposals
-    Agda.MkCertEnv
-      <$> toSpecRep cgceCurrentEpoch
-      <*> toSpecRep cgcePParams
-      <*> toSpecRep votes
-      <*> toSpecRep withdrawals
-      <*> toSpecRep ccColdCreds
+    withSpecTransM (const ()) $
+      Agda.MkCertEnv
+        <$> toSpecRep cgceCurrentEpoch
+        <*> toSpecRep cgcePParams
+        <*> toSpecRep votes
+        <*> withSpecTransM (const ((), ())) (toSpecRep withdrawals)
+        <*> toSpecRep ccColdCreds
 
-instance SpecTranslate ctx (VState era) where
+instance SpecTranslate (VState era) where
   type SpecRep (VState era) = Agda.GState
 
   toSpecRep VState {..} = do
     Agda.MkGState
-      <$> toSpecRep (updateExpiry . drepExpiry <$> vsDReps)
-      <*> toSpecRep
-        (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState)
+      <$> withSpecTransM dup (toSpecRep (updateExpiry . drepExpiry <$> vsDReps))
+      <*> withSpecTransM dup (toSpecRep
+        (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState))
       <*> deposits
     where
       transEntry (cred, val) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -81,7 +81,7 @@ instance
         <$> toSpecRep cgceCurrentEpoch
         <*> toSpecRep cgcePParams
         <*> toSpecRep votes
-        <*> withSpecTransM (const ((), ())) (toSpecRep withdrawals)
+        <*> toSpecRepMap withdrawals
         <*> toSpecRep ccColdCreds
 
 instance SpecTranslate (VState era) where
@@ -89,12 +89,10 @@ instance SpecTranslate (VState era) where
 
   toSpecRep VState {..} = do
     Agda.MkGState
-      <$> withSpecTransM dup (toSpecRep (updateExpiry . drepExpiry <$> vsDReps))
-      <*> withSpecTransM
-        dup
-        ( toSpecRep
-            (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState)
-        )
+      <$> (toSpecRepMap (updateExpiry . drepExpiry <$> vsDReps))
+      <*> ( toSpecRepMap
+              (committeeCredentialToStrictMaybe <$> csCommitteeCreds vsCommitteeState)
+          )
       <*> deposits
     where
       transEntry (cred, val) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
@@ -37,7 +37,7 @@ import Data.Functor.Identity (Identity)
 import Data.Maybe.Strict (StrictMaybe)
 import Lens.Micro ((^.))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (askSpecTransM, withCtx, withSpecTransM)
+import Test.Cardano.Ledger.Conformance (askSpecTransM, withCtxSpecTransM)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
   SpecTranslate (..),
  )
@@ -56,7 +56,7 @@ instance
 
   toSpecRep LedgerEnv {..} = do
     (policyHash, enactState) <- askSpecTransM
-    withSpecTransM (const ()) $
+    withCtxSpecTransM () $
       Agda.MkLEnv
         <$> toSpecRep ledgerSlotNo
         <*> toSpecRep policyHash
@@ -70,7 +70,7 @@ instance SpecTranslate (TxBody TopTx ConwayEra) where
 
   toSpecRep txb = do
     txId <- askSpecTransM
-    withSpecTransM (const ()) $
+    withCtxSpecTransM () $
       Agda.MkTxBody
         <$> toSpecRep (txb ^. inputsTxBodyL)
         <*> toSpecRep (txb ^. referenceInputsTxBodyL)
@@ -103,7 +103,7 @@ instance SpecTranslate (Tx TopTx ConwayEra) where
 
   toSpecRep tx =
     Agda.MkTx
-      <$> withCtx (txIdTx tx) (toSpecRep (tx ^. bodyTxL))
+      <$> withCtxSpecTransM (txIdTx tx) (toSpecRep (tx ^. bodyTxL))
       <*> toSpecRep (tx ^. witsTxL)
       <*> toSpecRep (tx ^. sizeTxF)
       <*> toSpecRep (tx ^. isValidTxL)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
@@ -14,7 +14,6 @@
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Ledger () where
 
 import Cardano.Ledger.Alonzo.Tx (AlonzoStAnnTx)
-import Cardano.Ledger.BaseTypes (Inject)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core (
   AllegraEraTxBody (..),
@@ -38,7 +37,7 @@ import Data.Functor.Identity (Identity)
 import Data.Maybe.Strict (StrictMaybe)
 import Lens.Micro ((^.))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (askCtx, withCtx)
+import Test.Cardano.Ledger.Conformance (askSpecTransM, withCtx, withSpecTransM)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
   SpecTranslate (..),
  )
@@ -46,61 +45,60 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD Identity era)
+  , SpecTranslate (PParamsHKD Identity era)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , Inject ctx (StrictMaybe ScriptHash)
-  , Inject ctx (EnactState era)
   ) =>
-  SpecTranslate ctx (LedgerEnv era)
+  SpecTranslate (LedgerEnv era)
   where
   type SpecRep (LedgerEnv era) = Agda.LEnv
+  type SpecContext (LedgerEnv era) = (StrictMaybe ScriptHash, EnactState era)
 
   toSpecRep LedgerEnv {..} = do
-    policyHash <- askCtx @(StrictMaybe ScriptHash)
-    enactState <- askCtx @(EnactState era)
-    Agda.MkLEnv
-      <$> toSpecRep ledgerSlotNo
-      <*> toSpecRep policyHash
-      <*> toSpecRep ledgerPp
-      <*> toSpecRep enactState
-      <*> toSpecRep (casTreasury ledgerAccount)
+    (policyHash, enactState) <- askSpecTransM
+    withSpecTransM (const ()) $
+      Agda.MkLEnv
+        <$> toSpecRep ledgerSlotNo
+        <*> toSpecRep policyHash
+        <*> toSpecRep ledgerPp
+        <*> toSpecRep enactState
+        <*> toSpecRep (casTreasury ledgerAccount)
 
-instance
-  Inject ctx TxId =>
-  SpecTranslate ctx (TxBody TopTx ConwayEra)
-  where
+instance SpecTranslate (TxBody TopTx ConwayEra) where
   type SpecRep (TxBody TopTx ConwayEra) = Agda.TxBody
+  type SpecContext (TxBody TopTx ConwayEra) = TxId
 
   toSpecRep txb = do
-    txId <- askCtx @TxId
-    Agda.MkTxBody
-      <$> toSpecRep (txb ^. inputsTxBodyL)
-      <*> toSpecRep (txb ^. referenceInputsTxBodyL)
-      <*> toSpecRep (txb ^. collateralInputsTxBodyL)
-      <*> (Agda.MkHSMap . zip [0 ..] <$> toSpecRep (txb ^. outputsTxBodyL))
-      <*> toSpecRep txId
-      <*> toSpecRep (txb ^. certsTxBodyL)
-      <*> toSpecRep (txb ^. feeTxBodyL)
-      <*> toSpecRep (txb ^. withdrawalsTxBodyL)
-      <*> toSpecRep (txb ^. vldtTxBodyL)
-      <*> toSpecRep (txb ^. auxDataHashTxBodyL)
-      <*> toSpecRep (txb ^. treasuryDonationTxBodyL)
-      <*> toSpecRep (txb ^. votingProceduresTxBodyL)
-      <*> toSpecRep (txb ^. proposalProceduresTxBodyL)
-      <*> toSpecRep (txb ^. networkIdTxBodyL)
-      <*> toSpecRep (txb ^. currentTreasuryValueTxBodyL)
-      <*> pure 0
-      <*> toSpecRep (txb ^. reqSignerHashesTxBodyL)
-      -- The script integrity hash is computed using @const 0@ on the Agda
-      -- side (@Hashable-ScriptIntegrity = record { hash = λ x → 0 }@).
-      -- Until a proper hash function is used in Agda, we emulate the same
-      -- behavior here.
-      --
-      -- The following PR documents the discrepancy on the Agda side:
-      -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1086
-      <*> fmap (fmap (const 0)) (toSpecRep (txb ^. scriptIntegrityHashTxBodyL))
+    txId <- askSpecTransM
+    withSpecTransM (const ()) $
+      Agda.MkTxBody
+        <$> toSpecRep (txb ^. inputsTxBodyL)
+        <*> toSpecRep (txb ^. referenceInputsTxBodyL)
+        <*> toSpecRep (txb ^. collateralInputsTxBodyL)
+        <*> (Agda.MkHSMap . zip [0 ..] <$> toSpecRep (txb ^. outputsTxBodyL))
+        <*> toSpecRep txId
+        <*> toSpecRep (txb ^. certsTxBodyL)
+        <*> toSpecRep (txb ^. feeTxBodyL)
+        <*> toSpecRep (txb ^. withdrawalsTxBodyL)
+        <*> toSpecRep (txb ^. vldtTxBodyL)
+        <*> toSpecRep (txb ^. auxDataHashTxBodyL)
+        <*> toSpecRep (txb ^. treasuryDonationTxBodyL)
+        <*> toSpecRep (txb ^. votingProceduresTxBodyL)
+        <*> toSpecRep (txb ^. proposalProceduresTxBodyL)
+        <*> toSpecRep (txb ^. networkIdTxBodyL)
+        <*> toSpecRep (txb ^. currentTreasuryValueTxBodyL)
+        <*> pure 0
+        <*> toSpecRep (txb ^. reqSignerHashesTxBodyL)
+        -- The script integrity hash is computed using @const 0@ on the Agda
+        -- side (@Hashable-ScriptIntegrity = record { hash = λ x → 0 }@).
+        -- Until a proper hash function is used in Agda, we emulate the same
+        -- behavior here.
+        --
+        -- The following PR documents the discrepancy on the Agda side:
+        -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1086
+        <*> fmap (fmap (const 0)) (toSpecRep (txb ^. scriptIntegrityHashTxBodyL))
 
-instance SpecTranslate ctx (Tx TopTx ConwayEra) where
+instance SpecTranslate (Tx TopTx ConwayEra) where
   type SpecRep (Tx TopTx ConwayEra) = Agda.Tx
 
   toSpecRep tx =
@@ -111,7 +109,7 @@ instance SpecTranslate ctx (Tx TopTx ConwayEra) where
       <*> toSpecRep (tx ^. isValidTxL)
       <*> toSpecRep (tx ^. auxDataTxL)
 
-instance SpecTranslate ctx (AlonzoStAnnTx TopTx ConwayEra) where
+instance SpecTranslate (AlonzoStAnnTx TopTx ConwayEra) where
   type SpecRep (AlonzoStAnnTx TopTx ConwayEra) = Agda.Tx
 
   toSpecRep stAnnTx = toSpecRep (stAnnTx ^. txStAnnTxG)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
@@ -20,7 +20,7 @@ import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   SpecTranslate (..),
   askSpecTransM,
-  withSpecTransM,
+  withCtxSpecTransM,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
@@ -39,7 +39,7 @@ instance
     enactState <- askSpecTransM
     let
       guardrailsScriptHash = constitutionGuardrailsScriptHash $ ensConstitution enactState
-    withSpecTransM (const ()) $
+    withCtxSpecTransM () $
       Agda.MkLEnv
         <$> toSpecRep ledgersSlotNo
         <*> toSpecRep guardrailsScriptHash

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
@@ -12,7 +12,6 @@
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Ledgers () where
 
-import Cardano.Ledger.BaseTypes (Inject)
 import Cardano.Ledger.Conway.Core (EraPParams (..))
 import Cardano.Ledger.Conway.Governance (Constitution (..), EnactState (..))
 import Cardano.Ledger.Shelley.Rules (Identity, ShelleyLedgersEnv (..))
@@ -20,27 +19,30 @@ import Cardano.Ledger.Shelley.State (ChainAccountState (..))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   SpecTranslate (..),
-  askCtx,
+  askSpecTransM,
+  withSpecTransM,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
 instance
   ( EraPParams era
-  , SpecTranslate ctx (PParamsHKD Identity era)
-  , Inject ctx (EnactState era)
+  , SpecTranslate (PParamsHKD Identity era)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
   ) =>
-  SpecTranslate ctx (ShelleyLedgersEnv era)
+  SpecTranslate (ShelleyLedgersEnv era)
   where
   type SpecRep (ShelleyLedgersEnv era) = Agda.LEnv
+  type SpecContext (ShelleyLedgersEnv era) = EnactState era
 
   toSpecRep LedgersEnv {..} = do
-    enactState <- askCtx @(EnactState era)
+    enactState <- askSpecTransM
     let
       guardrailsScriptHash = constitutionGuardrailsScriptHash $ ensConstitution enactState
-    Agda.MkLEnv
-      <$> toSpecRep ledgersSlotNo
-      <*> toSpecRep guardrailsScriptHash
-      <*> toSpecRep ledgersPp
-      <*> toSpecRep enactState
-      <*> toSpecRep (casTreasury ledgersAccount)
+    withSpecTransM (const ()) $
+      Agda.MkLEnv
+        <$> toSpecRep ledgersSlotNo
+        <*> toSpecRep guardrailsScriptHash
+        <*> toSpecRep ledgersPp
+        <*> toSpecRep enactState
+        <*> toSpecRep (casTreasury ledgersAccount)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -34,7 +34,9 @@ instance SpecTranslate (PState era) where
 
   toSpecRep PState {..} =
     Agda.MkPState
-      <$> withSpecTransM (const ((), ())) (toSpecRep (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) psStakePools))
+      <$> withSpecTransM
+        (const ((), ()))
+        (toSpecRep (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) psStakePools))
       <*> withSpecTransM (const ((), ())) (toSpecRep psFutureStakePoolParams)
       <*> withSpecTransM (const ((), ())) (toSpecRep psRetiring)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -34,11 +34,9 @@ instance SpecTranslate (PState era) where
 
   toSpecRep PState {..} =
     Agda.MkPState
-      <$> withSpecTransM
-        (const ((), ()))
-        (toSpecRep (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) psStakePools))
-      <*> withSpecTransM (const ((), ())) (toSpecRep psFutureStakePoolParams)
-      <*> withSpecTransM (const ((), ())) (toSpecRep psRetiring)
+      <$> toSpecRepMap (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) psStakePools)
+      <*> toSpecRepMap psFutureStakePoolParams
+      <*> toSpecRepMap psRetiring
 
 instance SpecTranslate PoolCert where
   type SpecRep PoolCert = Agda.DCert

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -20,24 +20,25 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
 instance
   ( SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate ctx (PParamsHKD Identity era)
+  , SpecTranslate (PParamsHKD Identity era)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   ) =>
-  SpecTranslate ctx (PoolEnv era)
+  SpecTranslate (PoolEnv era)
   where
   type SpecRep (PoolEnv era) = Agda.PParams
 
   toSpecRep (PoolEnv _ pp) = toSpecRep pp
 
-instance SpecTranslate ctx (PState era) where
+instance SpecTranslate (PState era) where
   type SpecRep (PState era) = Agda.PState
 
   toSpecRep PState {..} =
     Agda.MkPState
-      <$> toSpecRep (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) psStakePools)
-      <*> toSpecRep psFutureStakePoolParams
-      <*> toSpecRep psRetiring
+      <$> withSpecTransM (const ((), ())) (toSpecRep (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) psStakePools))
+      <*> withSpecTransM (const ((), ())) (toSpecRep psFutureStakePoolParams)
+      <*> withSpecTransM (const ((), ())) (toSpecRep psRetiring)
 
-instance SpecTranslate ctx PoolCert where
+instance SpecTranslate PoolCert where
   type SpecRep PoolCert = Agda.DCert
 
   toSpecRep (RegPool p@StakePoolParams {sppId = KeyHash ppHash}) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxo.hs
@@ -20,9 +20,10 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 
 instance
   ( SpecRep (PParams era) ~ Agda.PParams
-  , SpecTranslate ctx (PParamsHKD Identity era)
+  , SpecTranslate (PParamsHKD Identity era)
+  , SpecContext (PParamsHKD Identity era) ~ ()
   ) =>
-  SpecTranslate ctx (UtxoEnv era)
+  SpecTranslate (UtxoEnv era)
   where
   type SpecRep (UtxoEnv era) = Agda.UTxOEnv
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -42,29 +42,19 @@ import Cardano.Ledger.BaseTypes (
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core (
   ADDRHASH,
-  DataHash,
-  Era,
   Hash,
   KeyHash (..),
   KeyRole (..),
   PParams (..),
   PParamsHKD,
   PParamsUpdate (..),
-  SafeHash,
   ScriptHash (..),
-  TxAuxDataHash (..),
-  extractHash,
-  hashAnnotated,
  )
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Keys (VKey (..))
 import Cardano.Ledger.Keys.WitVKey (WitVKey (..))
-import Cardano.Ledger.Plutus.CostModels (CostModels, costModelsValid)
-import Cardano.Ledger.Plutus.Data (BinaryData, Data, Datum (..), hashBinaryData)
-import Cardano.Ledger.Plutus.ExUnits (ExUnits (..), Prices)
-import Cardano.Ledger.Plutus.Language (Language (..))
-import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
+import Cardano.Ledger.Plutus.ExUnits (Prices)
 import Control.Monad (forM)
 import Control.Monad.Except (throwError)
 import Data.Functor.Identity (Identity (..))
@@ -78,25 +68,10 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
  )
 import Test.Cardano.Ledger.Conformance.Utils
 
-instance SpecTranslate ctx TxId where
-  type SpecRep TxId = Agda.TxId
-
-  toSpecRep (TxId x) = toSpecRep x
-
 instance SpecTranslate ctx TxIx where
   type SpecRep TxIx = Integer
 
   toSpecRep (TxIx x) = pure $ toInteger x
-
-instance SpecTranslate ctx TxIn where
-  type SpecRep TxIn = Agda.TxIn
-
-  toSpecRep (TxIn txId txIx) = toSpecRep (txId, txIx)
-
-instance SpecTranslate ctx (SafeHash a) where
-  type SpecRep (SafeHash a) = Agda.DataHash
-
-  toSpecRep = toSpecRep . extractHash
 
 instance SpecTranslate ctx StakeReference where
   type SpecRep StakeReference = Maybe Agda.Credential
@@ -157,59 +132,15 @@ instance SpecTranslate ctx ProtVer where
 
   toSpecRep (ProtVer ver minor) = pure (getVersion ver, toInteger minor)
 
-instance SpecTranslate ctx Language where
-  type SpecRep Language = Agda.HSLanguage
-
-  toSpecRep l = case l of
-    PlutusV1 -> return Agda.PV1
-    PlutusV2 -> return Agda.PV2
-    PlutusV3 -> return Agda.PV3
-    PlutusV4 -> error "PlutusV4 not supported"
-
-instance SpecTranslate ctx CostModels where
-  type SpecRep CostModels = Agda.LanguageCostModels
-
-  toSpecRep cm =
-    -- filter out PlutusV4 language
-    let validCostModels = filter ((/= PlutusV4) . fst) $ Map.toList (costModelsValid cm)
-     in Agda.MkLanguageCostModels <$> mapM (\(l, _) -> (,()) <$> toSpecRep l) validCostModels
-
 instance SpecTranslate ctx Prices where
   type SpecRep Prices = ()
 
   toSpecRep _ = pure ()
 
-instance SpecTranslate ctx ExUnits where
-  type SpecRep ExUnits = Agda.ExUnits
-
-  toSpecRep (ExUnits a b) = pure (toInteger a, toInteger b)
-
 instance SpecTranslate ctx AccountAddress where
   type SpecRep AccountAddress = Agda.RewardAddress
 
   toSpecRep (AccountAddress n (AccountId c)) = Agda.RewardAddress <$> toSpecRep n <*> toSpecRep c
-
-instance
-  ( SpecRep DataHash ~ Agda.DataHash
-  , Era era
-  ) =>
-  SpecTranslate ctx (BinaryData era)
-  where
-  type SpecRep (BinaryData era) = Agda.DataHash
-
-  toSpecRep = toSpecRep . hashBinaryData
-
-instance Era era => SpecTranslate ctx (Datum era) where
-  type SpecRep (Datum era) = Maybe (Either Agda.Datum Agda.DataHash)
-
-  toSpecRep NoDatum = pure Nothing
-  toSpecRep (Datum d) = Just . Left <$> toSpecRep d
-  toSpecRep (DatumHash h) = Just . Right <$> toSpecRep h
-
-instance Era era => SpecTranslate ctx (Data era) where
-  type SpecRep (Data era) = Agda.DataHash
-
-  toSpecRep = toSpecRep . hashAnnotated
 
 instance
   SpecTranslate ctx (PParamsHKD Identity era) =>
@@ -256,11 +187,6 @@ instance SpecTranslate ctx (WitVKey k) where
   type SpecRep (WitVKey k) = (SpecRep (VKey k), Integer)
 
   toSpecRep (WitVKey vk sk) = toSpecRep (vk, sk)
-
-instance SpecTranslate ctx TxAuxDataHash where
-  type SpecRep TxAuxDataHash = Agda.DataHash
-
-  toSpecRep (TxAuxDataHash x) = toSpecRep x
 
 instance SpecTranslate ctx CommitteeAuthorization where
   type

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -183,9 +183,9 @@ instance DSIGNAlgorithm v => SpecTranslate (SignedDSIGN v a) where
   toSpecRep (SignedDSIGN x) = pure $ signatureToInteger x
 
 instance SpecTranslate (WitVKey k) where
-  type SpecRep (WitVKey k) = SpecRep (VKey k, Integer)
+  type SpecRep (WitVKey k) = (SpecRep (VKey k), Integer)
 
-  toSpecRep (WitVKey vk sk) = withSpecTransM (const ((), ())) $ toSpecRep (vk, sk)
+  toSpecRep (WitVKey vk sk) = toSpecRepTuple (vk, sk)
 
 instance SpecTranslate CommitteeAuthorization where
   type
@@ -202,7 +202,7 @@ instance SpecTranslate (CommitteeState era) where
     SpecRep (CommitteeState era) =
       Agda.HSMap (SpecRep (Credential ColdCommitteeRole)) (SpecRep CommitteeAuthorization)
 
-  toSpecRep = withSpecTransM (const ((), ())) . toSpecRep . csCommitteeCreds
+  toSpecRep = toSpecRepMap . csCommitteeCreds
 
 committeeCredentialToStrictMaybe ::
   CommitteeAuthorization ->
@@ -218,7 +218,7 @@ instance SpecTranslate IndividualPoolStake where
 instance SpecTranslate PoolDistr where
   type SpecRep PoolDistr = Agda.HSMap (SpecRep (KeyHash StakePool)) Agda.Coin
 
-  toSpecRep (PoolDistr ps _) = withSpecTransM (const ((), ())) $ toSpecRep ps
+  toSpecRep (PoolDistr ps _) = toSpecRepMap ps
 
 instance SpecTranslate BlocksMade where
   type SpecRep BlocksMade = Agda.HSMap Integer Integer

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -58,34 +58,31 @@ import Cardano.Ledger.Plutus.ExUnits (Prices)
 import Control.Monad (forM)
 import Control.Monad.Except (throwError)
 import Data.Functor.Identity (Identity (..))
-import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import GHC.Natural (naturalToInteger)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
-  SpecTranslate (..),
- )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.Utils
 
-instance SpecTranslate ctx TxIx where
+instance SpecTranslate TxIx where
   type SpecRep TxIx = Integer
 
   toSpecRep (TxIx x) = pure $ toInteger x
 
-instance SpecTranslate ctx StakeReference where
+instance SpecTranslate StakeReference where
   type SpecRep StakeReference = Maybe Agda.Credential
 
   toSpecRep (StakeRefBase c) = Just <$> toSpecRep c
   toSpecRep (StakeRefPtr _) = pure Nothing
   toSpecRep StakeRefNull = pure Nothing
 
-instance SpecTranslate ctx BootstrapAddress where
+instance SpecTranslate BootstrapAddress where
   type SpecRep BootstrapAddress = Agda.BootstrapAddr
 
   toSpecRep _ = throwError "Cannot translate bootstrap addresses"
 
-instance SpecTranslate ctx Addr where
+instance SpecTranslate Addr where
   type SpecRep Addr = Agda.Addr
 
   toSpecRep (Addr nw pc sr) =
@@ -93,68 +90,70 @@ instance SpecTranslate ctx Addr where
       <$> (Agda.BaseAddr <$> toSpecRep nw <*> toSpecRep pc <*> toSpecRep sr)
   toSpecRep (AddrBootstrap ba) = Right <$> toSpecRep ba
 
-instance SpecTranslate ctx (Hash a b) where
+instance SpecTranslate (Hash a b) where
   type SpecRep (Hash a b) = Integer
 
   toSpecRep = pure . hashToInteger
 
-instance SpecTranslate ctx ScriptHash where
+instance SpecTranslate ScriptHash where
   type SpecRep ScriptHash = Integer
 
   toSpecRep (ScriptHash h) = toSpecRep h
 
-instance SpecTranslate ctx (KeyHash r) where
+instance SpecTranslate (KeyHash r) where
   type SpecRep (KeyHash r) = Integer
 
   toSpecRep (KeyHash h) = toSpecRep h
 
-instance SpecTranslate ctx (Credential k) where
+instance SpecTranslate (Credential k) where
   type SpecRep (Credential k) = Agda.Credential
 
   toSpecRep (KeyHashObj h) = Agda.KeyHashObj <$> toSpecRep h
   toSpecRep (ScriptHashObj h) = Agda.ScriptObj <$> toSpecRep h
 
-instance SpecTranslate ctx Network where
+instance SpecTranslate Network where
   type SpecRep Network = Integer
 
   toSpecRep = pure . fromIntegral . fromEnum
 
-deriving instance SpecTranslate ctx Coin
+deriving instance SpecTranslate Coin
 
-deriving instance SpecTranslate ctx SlotNo
+deriving instance SpecTranslate SlotNo
 
-deriving instance SpecTranslate ctx EpochNo
+deriving instance SpecTranslate EpochNo
 
-deriving instance SpecTranslate ctx EpochInterval
+deriving instance SpecTranslate EpochInterval
 
-instance SpecTranslate ctx ProtVer where
+instance SpecTranslate ProtVer where
   type SpecRep ProtVer = (Integer, Integer)
 
   toSpecRep (ProtVer ver minor) = pure (getVersion ver, toInteger minor)
 
-instance SpecTranslate ctx Prices where
+instance SpecTranslate Prices where
   type SpecRep Prices = ()
 
   toSpecRep _ = pure ()
 
-instance SpecTranslate ctx AccountAddress where
+instance SpecTranslate AccountAddress where
   type SpecRep AccountAddress = Agda.RewardAddress
 
   toSpecRep (AccountAddress n (AccountId c)) = Agda.RewardAddress <$> toSpecRep n <*> toSpecRep c
 
 instance
-  SpecTranslate ctx (PParamsHKD Identity era) =>
-  SpecTranslate ctx (PParams era)
+  SpecTranslate (PParamsHKD Identity era) =>
+  SpecTranslate (PParams era)
   where
   type SpecRep (PParams era) = SpecRep (PParamsHKD Identity era)
+  type SpecContext (PParams era) = SpecContext (PParamsHKD Identity era)
 
   toSpecRep (PParams x) = toSpecRep x
 
 instance
-  SpecTranslate ctx (PParamsHKD StrictMaybe era) =>
-  SpecTranslate ctx (PParamsUpdate era)
+  SpecTranslate (PParamsHKD StrictMaybe era) =>
+  SpecTranslate (PParamsUpdate era)
   where
   type SpecRep (PParamsUpdate era) = SpecRep (PParamsHKD StrictMaybe era)
+  type SpecContext (PParamsUpdate era) = SpecContext (PParamsHKD StrictMaybe era)
 
   toSpecRep (PParamsUpdate ppu) = toSpecRep ppu
 
@@ -170,7 +169,7 @@ signatureToInteger = toInteger . bytesToNatural . rawSerialiseSigDSIGN
 signatureFromInteger :: DSIGNAlgorithm v => Integer -> Maybe (SigDSIGN v)
 signatureFromInteger = rawDeserialiseSigDSIGN . naturalToBytes 64 . fromInteger
 
-instance SpecTranslate ctx (VKey k) where
+instance SpecTranslate (VKey k) where
   type SpecRep (VKey k) = Agda.HSVKey
 
   toSpecRep x = do
@@ -178,17 +177,17 @@ instance SpecTranslate ctx (VKey k) where
     hvkStoredHash <- toSpecRep (hashVerKeyDSIGN @_ @ADDRHASH $ unVKey x)
     pure Agda.MkHSVKey {..}
 
-instance DSIGNAlgorithm v => SpecTranslate ctx (SignedDSIGN v a) where
+instance DSIGNAlgorithm v => SpecTranslate (SignedDSIGN v a) where
   type SpecRep (SignedDSIGN v a) = Integer
 
   toSpecRep (SignedDSIGN x) = pure $ signatureToInteger x
 
-instance SpecTranslate ctx (WitVKey k) where
-  type SpecRep (WitVKey k) = (SpecRep (VKey k), Integer)
+instance SpecTranslate (WitVKey k) where
+  type SpecRep (WitVKey k) = SpecRep (VKey k, Integer)
 
-  toSpecRep (WitVKey vk sk) = toSpecRep (vk, sk)
+  toSpecRep (WitVKey vk sk) = withSpecTransM (const ((), ())) $ toSpecRep (vk, sk)
 
-instance SpecTranslate ctx CommitteeAuthorization where
+instance SpecTranslate CommitteeAuthorization where
   type
     SpecRep CommitteeAuthorization =
       SpecRep (Maybe (Credential HotCommitteeRole))
@@ -198,12 +197,12 @@ instance SpecTranslate ctx CommitteeAuthorization where
     toSpecRep $
       Nothing @(Credential HotCommitteeRole)
 
-instance SpecTranslate ctx (CommitteeState era) where
+instance SpecTranslate (CommitteeState era) where
   type
     SpecRep (CommitteeState era) =
-      SpecRep (Map (Credential ColdCommitteeRole) CommitteeAuthorization)
+      Agda.HSMap (SpecRep (Credential ColdCommitteeRole)) (SpecRep CommitteeAuthorization)
 
-  toSpecRep = toSpecRep . csCommitteeCreds
+  toSpecRep = withSpecTransM (const ((), ())) . toSpecRep . csCommitteeCreds
 
 committeeCredentialToStrictMaybe ::
   CommitteeAuthorization ->
@@ -211,17 +210,17 @@ committeeCredentialToStrictMaybe ::
 committeeCredentialToStrictMaybe (CommitteeHotCredential c) = SJust c
 committeeCredentialToStrictMaybe (CommitteeMemberResigned _) = SNothing
 
-instance SpecTranslate ctx IndividualPoolStake where
+instance SpecTranslate IndividualPoolStake where
   type SpecRep IndividualPoolStake = SpecRep Coin
 
   toSpecRep (IndividualPoolStake _ c _) = toSpecRep c
 
-instance SpecTranslate ctx PoolDistr where
+instance SpecTranslate PoolDistr where
   type SpecRep PoolDistr = Agda.HSMap (SpecRep (KeyHash StakePool)) Agda.Coin
 
-  toSpecRep (PoolDistr ps _) = toSpecRep ps
+  toSpecRep (PoolDistr ps _) = withSpecTransM (const ((), ())) $ toSpecRep ps
 
-instance SpecTranslate ctx BlocksMade where
+instance SpecTranslate BlocksMade where
   type SpecRep BlocksMade = Agda.HSMap Integer Integer
 
   toSpecRep (BlocksMade m) = do

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
@@ -17,7 +17,6 @@ import Cardano.Ledger.Conway.Rules
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules (ledgerSlotNoL)
-import Cardano.Ledger.TxIn (TxId)
 import Control.State.Transition
 import Data.Bifunctor (Bifunctor (..))
 import Data.Data (Proxy (..))
@@ -98,12 +97,12 @@ submitTxConformanceHook ::
   ( ConwayEraImp era
   , ExecSpecRule "LEDGER" era
   , ExecContext "LEDGER" era ~ ConwayLedgerExecContext era
-  , SpecTranslate (ExecContext "LEDGER" era) (TxWits era)
+  , SpecTranslate (TxWits era)
   , HasCallStack
   , SpecRep (TxWits era) ~ Agda.TxWitnesses
   , SpecRep (TxBody TopTx era) ~ Agda.TxBody
-  , SpecTranslate TxId (TxBody TopTx era)
-  , SpecTranslate (ConwayLedgerExecContext era) (Tx TopTx era)
+  , SpecTranslate (TxBody TopTx era)
+  , SpecTranslate (Tx TopTx era)
   , ToExpr (SpecRep (Tx TopTx era))
   , SpecNormalize (SpecState "LEDGER" era)
   , Eq (SpecState "LEDGER" era)

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Base.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Base.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Test.Cardano.Ledger.Conformance.Spec.Base (spec) where
 
@@ -27,7 +28,8 @@ hashDisplayProp ::
   forall a.
   ( Typeable a
   , Arbitrary a
-  , SpecTranslate () a
+  , SpecTranslate a
+  , SpecContext a ~ ()
   , SpecNormalize (SpecRep a)
   , ToExpr (SpecRep a)
   , ToExpr a

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
@@ -54,7 +54,7 @@ conformsToImplAccepted impl agda = property $ do
   let specEnv = fromSpecTransM $ runSpecTransM @Coin 0 $ toSpecRep ratifyEnv
       specSt =
         fromSpecTransM $
-          runSpecTransM govActions $
+          runSpecTransM () $
             toSpecRep (ratifySt ^. rsEnactStateL)
       specGovActions = fromSpecTransM $ runSpecTransM () $ toSpecRep govActions
   return $


### PR DESCRIPTION
# Description

This PR prepares the ground for conformance-testing Dijkstra era.

In particular, it

  - moves Conway specific `SpecTranslate` instances from `Core` to
    `Conway/Base`.
  - removes the `ctx` type parameter from `SpecTranslate`


# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
