### PR TITLE
Refactor StAnnTx memoization to avoid cyclic dependencies

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -29,12 +29,16 @@ import Cardano.Ledger.Allegra.Tx (Tx (..))
 import Cardano.Ledger.Allegra.UTxO ()
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
+import Cardano.Ledger.Core (witsTxL)
 import Cardano.Ledger.Shelley.API
+import Cardano.Ledger.Shelley.Core (scriptTxWitsL)
 import Cardano.Ledger.Shelley.Rules (ShelleyLedgerPredFailure)
 import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
+import Cardano.Ledger.State (ScriptsProvided (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 
 instance EraStAnnTx AllegraEra where
   type StAnnTx l AllegraEra = Tx l AllegraEra
@@ -42,6 +46,8 @@ instance EraStAnnTx AllegraEra where
   txStAnnTxG = id
 
   mkStAnnTx _ _ _ _ = id
+
+  scriptsProvidedStAnnTx tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
 
 instance ApplyTx AllegraEra where
   newtype ApplyTxError AllegraEra = AllegraApplyTxError (NonEmpty (ShelleyLedgerPredFailure AllegraEra))

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -37,6 +37,10 @@ import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
 
 instance EraStAnnTx AllegraEra where
+  type StAnnTx l AllegraEra = Tx l AllegraEra
+
+  txStAnnTxG = id
+
   mkStAnnTx _ _ _ _ = id
 
 instance ApplyTx AllegraEra where

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -31,16 +31,18 @@ import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Shelley.Rules (ShelleyLedgerPredFailure)
+import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+
+instance EraStAnnTx AllegraEra where
+  mkStAnnTx _ _ _ _ = id
 
 instance ApplyTx AllegraEra where
   newtype ApplyTxError AllegraEra = AllegraApplyTxError (NonEmpty (ShelleyLedgerPredFailure AllegraEra))
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
-
-  mkStAnnTx _ _ _ _ = id
 
   applyTxValidation validationPolicy globals env state tx =
     first AllegraApplyTxError $

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
@@ -57,10 +57,6 @@ instance EraTx AllegraEra where
     deriving newtype (Eq, NFData, NoThunks, Show, ToCBOR, EncCBOR)
     deriving (Generic)
 
-  type StAnnTx l AllegraEra = Tx l AllegraEra
-
-  txStAnnTxG = id
-
   mkBasicTx = MkAllegraTx . mkBasicShelleyTx
 
   bodyTxL = allegraTxL . bodyShelleyTxL

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -67,6 +68,10 @@ import GHC.Generics (Generic)
 import Lens.Micro
 
 instance EraStAnnTx AlonzoEra where
+  type StAnnTx l AlonzoEra = AlonzoStAnnTx l AlonzoEra
+
+  txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
+
   mkStAnnTx = mkAlonzoStAnnTx
 
 instance ApplyTx AlonzoEra where

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -49,6 +49,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO,
   AlonzoScriptsNeeded,
   resolveNeededPlutusScriptsWithPurpose,
+  scriptsProvidedAlonzoStAnnTx,
  )
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
@@ -73,6 +74,8 @@ instance EraStAnnTx AlonzoEra where
   txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
 
   mkStAnnTx = mkAlonzoStAnnTx
+
+  scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
 
 instance ApplyTx AlonzoEra where
   newtype ApplyTxError AlonzoEra = AlonzoApplyTxError (NonEmpty (ShelleyLedgerPredFailure AlonzoEra))

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -55,6 +55,7 @@ import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Plutus.Data ()
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Shelley.Rules (ShelleyLedgerPredFailure)
+import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Cardano.Ledger.State (EraUTxO (..))
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
@@ -65,12 +66,13 @@ import Data.Text (Text)
 import GHC.Generics (Generic)
 import Lens.Micro
 
+instance EraStAnnTx AlonzoEra where
+  mkStAnnTx = mkAlonzoStAnnTx
+
 instance ApplyTx AlonzoEra where
   newtype ApplyTxError AlonzoEra = AlonzoApplyTxError (NonEmpty (ShelleyLedgerPredFailure AlonzoEra))
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
-
-  mkStAnnTx = mkAlonzoStAnnTx
 
   applyTxValidation validationPolicy globals env state tx =
     first AlonzoApplyTxError $

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -164,10 +164,6 @@ instance EraTx AlonzoEra where
     deriving newtype (Eq, NFData, EncCBOR, ToCBOR, NoThunks, Show)
     deriving (Generic)
 
-  type StAnnTx l AlonzoEra = AlonzoStAnnTx l AlonzoEra
-
-  txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
-
   mkBasicTx = MkAlonzoTx . mkBasicAlonzoTx
 
   bodyTxL = alonzoTxL . bodyAlonzoTxL

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -129,14 +129,10 @@ class EraUTxO era => AlonzoEraUTxO era where
     PlutusPurpose AsItem era ->
     Maybe (Data era)
 
-  scriptsProvidedStAnnTx :: StAnnTx l era -> ScriptsProvided era
-
 instance AlonzoEraUTxO AlonzoEra where
   getSupplementalDataHashes _ = getAlonzoSupplementalDataHashes
 
   getSpendingDatum = getAlonzoSpendingDatum
-
-  scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
 
 scriptsProvidedAlonzoStAnnTx ::
   ( EraTxLevel era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -32,6 +32,7 @@ module Cardano.Ledger.Babbage (
 import Cardano.Ledger.Alonzo (AlonzoStAnnTx (..), mkAlonzoStAnnTx)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..))
+import Cardano.Ledger.Alonzo.UTxO (scriptsProvidedAlonzoStAnnTx)
 import Cardano.Ledger.Babbage.BlockBody ()
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.Forecast (
@@ -66,6 +67,8 @@ instance EraStAnnTx BabbageEra where
   txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
 
   mkStAnnTx = mkAlonzoStAnnTx
+
+  scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
 
 instance ApplyTx BabbageEra where
   newtype ApplyTxError BabbageEra = BabbageApplyTxError (NonEmpty (ShelleyLedgerPredFailure BabbageEra))

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -28,7 +29,7 @@ module Cardano.Ledger.Babbage (
   bfProtocolVersionL,
 ) where
 
-import Cardano.Ledger.Alonzo (mkAlonzoStAnnTx)
+import Cardano.Ledger.Alonzo (AlonzoStAnnTx (..), mkAlonzoStAnnTx)
 import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData (..))
 import Cardano.Ledger.Babbage.BlockBody ()
@@ -57,8 +58,13 @@ import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+import Lens.Micro (to)
 
 instance EraStAnnTx BabbageEra where
+  type StAnnTx l BabbageEra = AlonzoStAnnTx l BabbageEra
+
+  txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
+
   mkStAnnTx = mkAlonzoStAnnTx
 
 instance ApplyTx BabbageEra where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -53,16 +53,18 @@ import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Shelley.Rules (ShelleyLedgerPredFailure)
+import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+
+instance EraStAnnTx BabbageEra where
+  mkStAnnTx = mkAlonzoStAnnTx
 
 instance ApplyTx BabbageEra where
   newtype ApplyTxError BabbageEra = BabbageApplyTxError (NonEmpty (ShelleyLedgerPredFailure BabbageEra))
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
-
-  mkStAnnTx = mkAlonzoStAnnTx
 
   applyTxValidation validationPolicy globals env state tx =
     first BabbageApplyTxError $

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -28,7 +28,7 @@ import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Control.DeepSeq (NFData)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
-import Lens.Micro (Lens', lens, to)
+import Lens.Micro (Lens', lens)
 import NoThunks.Class (NoThunks)
 
 instance HasEraTxLevel Tx BabbageEra where
@@ -38,10 +38,6 @@ instance EraTx BabbageEra where
   newtype Tx l BabbageEra = MkBabbageTx {unBabbageTx :: AlonzoTx l BabbageEra}
     deriving newtype (Eq, NFData, Show, NoThunks, ToCBOR, EncCBOR)
     deriving (Generic)
-
-  type StAnnTx l BabbageEra = AlonzoStAnnTx l BabbageEra
-
-  txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
 
   mkBasicTx = MkBabbageTx . mkBasicAlonzoTx
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -18,7 +18,6 @@ import Cardano.Ledger.Alonzo.UTxO (
   getAlonzoScriptsHashesNeeded,
   getAlonzoScriptsNeeded,
   getAlonzoWitsVKeyNeeded,
-  scriptsProvidedAlonzoStAnnTx,
  )
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra)
@@ -62,8 +61,6 @@ instance AlonzoEraUTxO BabbageEra where
   getSupplementalDataHashes = getBabbageSupplementalDataHashes
 
   getSpendingDatum = getBabbageSpendingDatum
-
-  scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
 
 getBabbageSupplementalDataHashes ::
   BabbageEraTxBody era =>

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -20,7 +21,7 @@ module Cardano.Ledger.Conway (
   ApplyTxError (..),
 ) where
 
-import Cardano.Ledger.Alonzo (mkAlonzoStAnnTx)
+import Cardano.Ledger.Alonzo (AlonzoStAnnTx (..), mkAlonzoStAnnTx)
 import Cardano.Ledger.Babbage.TxBody ()
 import Cardano.Ledger.BaseTypes (Inject (..))
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
@@ -48,8 +49,13 @@ import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+import Lens.Micro (to)
 
 instance EraStAnnTx ConwayEra where
+  type StAnnTx l ConwayEra = AlonzoStAnnTx l ConwayEra
+
+  txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
+
   mkStAnnTx = mkAlonzoStAnnTx
 
 instance ApplyTx ConwayEra where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -22,6 +22,7 @@ module Cardano.Ledger.Conway (
 ) where
 
 import Cardano.Ledger.Alonzo (AlonzoStAnnTx (..), mkAlonzoStAnnTx)
+import Cardano.Ledger.Alonzo.UTxO (scriptsProvidedAlonzoStAnnTx)
 import Cardano.Ledger.Babbage.TxBody ()
 import Cardano.Ledger.BaseTypes (Inject (..))
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
@@ -57,6 +58,8 @@ instance EraStAnnTx ConwayEra where
   txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
 
   mkStAnnTx = mkAlonzoStAnnTx
+
+  scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
 
 instance ApplyTx ConwayEra where
   newtype ApplyTxError ConwayEra = ConwayApplyTxError (NonEmpty (ConwayLedgerPredFailure ConwayEra))

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -44,16 +44,18 @@ import Cardano.Ledger.Conway.TxInfo ()
 import Cardano.Ledger.Conway.TxOut ()
 import Cardano.Ledger.Conway.UTxO ()
 import Cardano.Ledger.Shelley.API
+import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+
+instance EraStAnnTx ConwayEra where
+  mkStAnnTx = mkAlonzoStAnnTx
 
 instance ApplyTx ConwayEra where
   newtype ApplyTxError ConwayEra = ConwayApplyTxError (NonEmpty (ConwayLedgerPredFailure ConwayEra))
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
-
-  mkStAnnTx = mkAlonzoStAnnTx
 
   applyTxValidation validationPolicy globals env state tx =
     first ConwayApplyTxError $

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -21,7 +21,6 @@ module Cardano.Ledger.Conway.Tx (
 import Cardano.Ledger.Allegra.Tx (validateTimelock)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Tx (
-  AlonzoStAnnTx (..),
   alonzoMinFeeTx,
   alonzoTxEqRaw,
   auxDataAlonzoTxL,
@@ -51,7 +50,7 @@ import Data.Typeable (Typeable)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import GHC.Stack
-import Lens.Micro (Lens', lens, to, (^.))
+import Lens.Micro (Lens', lens, (^.))
 import NoThunks.Class (NoThunks)
 
 instance HasEraTxLevel Tx ConwayEra where
@@ -61,10 +60,6 @@ instance EraTx ConwayEra where
   newtype Tx l ConwayEra = MkConwayTx {unConwayTx :: AlonzoTx l ConwayEra}
     deriving newtype (Eq, Show, NFData, NoThunks, ToCBOR, EncCBOR)
     deriving (Generic)
-
-  type StAnnTx l ConwayEra = AlonzoStAnnTx l ConwayEra
-
-  txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
 
   mkBasicTx = MkConwayTx . mkBasicAlonzoTx
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -25,7 +25,6 @@ import Cardano.Ledger.Alonzo.UTxO (
   getMintingScriptsNeeded,
   getRewardingScriptsNeeded,
   getSpendingScriptsNeeded,
-  scriptsProvidedAlonzoStAnnTx,
   zipAsIxItem,
  )
 import Cardano.Ledger.Babbage.UTxO (
@@ -151,8 +150,6 @@ instance AlonzoEraUTxO ConwayEra where
   getSupplementalDataHashes = getBabbageSupplementalDataHashes
 
   getSpendingDatum = getBabbageSpendingDatum
-
-  scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
 
 getConwayMinFeeTxUtxo ::
   ( EraTx era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -60,6 +60,7 @@ import Cardano.Ledger.Shelley.API (
   ApplyTx (..),
   ruleApplyTxValidation,
  )
+import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided, UTxO)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
@@ -72,12 +73,13 @@ import Data.Text (Text)
 import GHC.Generics (Generic)
 import Lens.Micro
 
+instance EraStAnnTx DijkstraEra where
+  mkStAnnTx = mkDijkstraStAnnTopTx
+
 instance ApplyTx DijkstraEra where
   newtype ApplyTxError DijkstraEra = DijkstraApplyTxError (NonEmpty (DijkstraMempoolPredFailure DijkstraEra))
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
-
-  mkStAnnTx = mkDijkstraStAnnTopTx
 
   applyTxValidation validationPolicy globals env state tx =
     first DijkstraApplyTxError $

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -74,6 +75,12 @@ import GHC.Generics (Generic)
 import Lens.Micro
 
 instance EraStAnnTx DijkstraEra where
+  type StAnnTx l DijkstraEra = DijkstraStAnnTx l DijkstraEra
+
+  txStAnnTxG = to $ \case
+    DijkstraStAnnTopTx {dsattTx} -> dsattTx
+    DijkstraStAnnSubTx {dsastTx} -> dsastTx
+
   mkStAnnTx = mkDijkstraStAnnTopTx
 
 instance ApplyTx DijkstraEra where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -53,7 +53,7 @@ import Cardano.Ledger.Dijkstra.Tx (DijkstraStAnnTx (..))
 import Cardano.Ledger.Dijkstra.TxBody ()
 import Cardano.Ledger.Dijkstra.TxInfo ()
 import Cardano.Ledger.Dijkstra.TxWits ()
-import Cardano.Ledger.Dijkstra.UTxO ()
+import Cardano.Ledger.Dijkstra.UTxO (scriptsProvidedDijkstraStAnnTx)
 import Cardano.Ledger.Plutus (Language (..))
 import Cardano.Ledger.Shelley.API (
   ApplyBlock (..),
@@ -82,6 +82,8 @@ instance EraStAnnTx DijkstraEra where
     DijkstraStAnnSubTx {dsastTx} -> dsastTx
 
   mkStAnnTx = mkDijkstraStAnnTopTx
+
+  scriptsProvidedStAnnTx = scriptsProvidedDijkstraStAnnTx
 
 instance ApplyTx DijkstraEra where
   newtype ApplyTxError DijkstraEra = DijkstraApplyTxError (NonEmpty (DijkstraMempoolPredFailure DijkstraEra))

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -189,12 +189,6 @@ instance EraTx DijkstraEra where
     deriving newtype (Eq, Show, NFData, NoThunks, ToCBOR, EncCBOR)
     deriving (Generic)
 
-  type StAnnTx l DijkstraEra = DijkstraStAnnTx l DijkstraEra
-
-  txStAnnTxG = to $ \case
-    DijkstraStAnnTopTx {dsattTx} -> dsattTx
-    DijkstraStAnnSubTx {dsastTx} -> dsastTx
-
   mkBasicTx = MkDijkstraTx . mkBasicDijkstraTx
 
   bodyTxL = dijkstraTxL . bodyDijkstraTxL

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -169,8 +169,6 @@ instance AlonzoEraUTxO DijkstraEra where
 
   getSpendingDatum = getBabbageSpendingDatum
 
-  scriptsProvidedStAnnTx = scriptsProvidedDijkstraStAnnTx
-
 scriptsProvidedDijkstraStAnnTx ::
   ( EraTxLevel era
   , STxLevel l era ~ STxBothLevels l era

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -44,6 +44,10 @@ import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
 
 instance EraStAnnTx MaryEra where
+  type StAnnTx l MaryEra = Tx l MaryEra
+
+  txStAnnTxG = id
+
   mkStAnnTx _ _ _ _ = id
 
 instance ApplyTx MaryEra where

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -38,16 +38,18 @@ import Cardano.Ledger.Mary.UTxO ()
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Shelley.Rules (ShelleyLedgerPredFailure)
+import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+
+instance EraStAnnTx MaryEra where
+  mkStAnnTx _ _ _ _ = id
 
 instance ApplyTx MaryEra where
   newtype ApplyTxError MaryEra = MaryApplyTxError (NonEmpty (ShelleyLedgerPredFailure MaryEra))
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
-
-  mkStAnnTx _ _ _ _ = id
 
   applyTxValidation validationPolicy globals env state tx =
     first MaryApplyTxError $

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -22,6 +22,7 @@ module Cardano.Ledger.Mary (
 
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
+import Cardano.Ledger.Core (witsTxL)
 import Cardano.Ledger.Mary.BlockBody ()
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Forecast ()
@@ -37,11 +38,14 @@ import Cardano.Ledger.Mary.TxBody (TxBody (..))
 import Cardano.Ledger.Mary.UTxO ()
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Shelley.API
+import Cardano.Ledger.Shelley.Core (scriptTxWitsL)
 import Cardano.Ledger.Shelley.Rules (ShelleyLedgerPredFailure)
 import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
+import Cardano.Ledger.State (ScriptsProvided (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 
 instance EraStAnnTx MaryEra where
   type StAnnTx l MaryEra = Tx l MaryEra
@@ -49,6 +53,8 @@ instance EraStAnnTx MaryEra where
   txStAnnTxG = id
 
   mkStAnnTx _ _ _ _ = id
+
+  scriptsProvidedStAnnTx tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
 
 instance ApplyTx MaryEra where
   newtype ApplyTxError MaryEra = MaryApplyTxError (NonEmpty (ShelleyLedgerPredFailure MaryEra))

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
@@ -48,10 +48,6 @@ instance EraTx MaryEra where
     deriving newtype (Eq, NFData, NoThunks, Show, ToCBOR, EncCBOR)
     deriving (Generic)
 
-  type StAnnTx l MaryEra = Tx l MaryEra
-
-  txStAnnTxG = id
-
   mkBasicTx = MkMaryTx . mkBasicShelleyTx
 
   bodyTxL = maryTxL . bodyShelleyTxL

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -49,9 +49,7 @@ import Cardano.Ledger.Shelley.Rules ()
 import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv, ShelleyLedgerPredFailure)
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
 import Cardano.Ledger.Slot (SlotNo)
-import Cardano.Ledger.State (UTxO)
-import Cardano.Slotting.EpochInfo (EpochInfo)
-import Cardano.Slotting.Time (SystemStart)
+import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Control.DeepSeq (NFData)
 import Control.Monad.Except (Except)
 import Control.Monad.Trans.Reader (runReader)
@@ -60,7 +58,6 @@ import Data.Bifunctor (Bifunctor (first))
 import Data.Coerce (Coercible, coerce)
 import Data.Functor ((<&>))
 import Data.List.NonEmpty (NonEmpty)
-import Data.Text (Text)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
@@ -95,7 +92,7 @@ translateValidated ::
 translateValidated ctx (Validated tx) = Validated <$> translateEra @era ctx tx
 
 class
-  ( EraTx era
+  ( EraStAnnTx era
   , Eq (ApplyTxError era)
   , Show (ApplyTxError era)
   , Typeable (ApplyTxError era)
@@ -106,14 +103,6 @@ class
   ApplyTx era
   where
   data ApplyTxError era
-
-  mkStAnnTx ::
-    EpochInfo (Either Text) ->
-    SystemStart ->
-    PParams era ->
-    UTxO era ->
-    Tx TopTx era ->
-    StAnnTx TopTx era
 
   -- | Validate a transaction against a mempool state and for given STS options,
   -- and return the new mempool state, a "validated" 'TxInBlock' and,
@@ -157,8 +146,6 @@ instance ApplyTx ShelleyEra where
   newtype ApplyTxError ShelleyEra = ShelleyApplyTxError (NonEmpty (ShelleyLedgerPredFailure ShelleyEra))
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
-
-  mkStAnnTx _ _ _ _ = id
 
   applyTxValidation validationPolicy globals env state tx =
     first ShelleyApplyTxError $

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -202,10 +202,6 @@ instance EraTx ShelleyEra where
     deriving newtype (Eq, EncCBOR, NFData, NoThunks, Show, ToCBOR)
     deriving (Generic)
 
-  type StAnnTx l ShelleyEra = Tx l ShelleyEra
-
-  txStAnnTxG = id
-
   mkBasicTx = MkShelleyTx . mkBasicShelleyTx
 
   bodyTxL = shelleyTxL . bodyShelleyTxL
@@ -226,6 +222,10 @@ instance EraTx ShelleyEra where
   getMinFeeTx pp tx _ = shelleyMinFeeTx pp tx
 
 instance EraStAnnTx ShelleyEra where
+  type StAnnTx l ShelleyEra = Tx l ShelleyEra
+
+  txStAnnTxG = id
+
   mkStAnnTx _ _ _ _ = id
 
 shelleyTxEqRaw :: EraTx era => Tx l era -> Tx l era -> Bool

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -57,6 +57,7 @@ import Cardano.Ledger.Shelley.Scripts (validateMultiSig)
 import Cardano.Ledger.Shelley.TxAuxData ()
 import Cardano.Ledger.Shelley.TxBody ()
 import Cardano.Ledger.Shelley.TxWits ()
+import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
 import Cardano.Ledger.Val ((<+>), (<×>))
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad.Trans.Fail.String (errorFail)
@@ -223,6 +224,9 @@ instance EraTx ShelleyEra where
   {-# INLINE validateNativeScript #-}
 
   getMinFeeTx pp tx _ = shelleyMinFeeTx pp tx
+
+instance EraStAnnTx ShelleyEra where
+  mkStAnnTx _ _ _ _ = id
 
 shelleyTxEqRaw :: EraTx era => Tx l era -> Tx l era -> Bool
 shelleyTxEqRaw tx1 tx2 =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -58,6 +58,7 @@ import Cardano.Ledger.Shelley.TxAuxData ()
 import Cardano.Ledger.Shelley.TxBody ()
 import Cardano.Ledger.Shelley.TxWits ()
 import Cardano.Ledger.StAnnTx (EraStAnnTx (..))
+import Cardano.Ledger.State (ScriptsProvided (..))
 import Cardano.Ledger.Val ((<+>), (<×>))
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad.Trans.Fail.String (errorFail)
@@ -227,6 +228,8 @@ instance EraStAnnTx ShelleyEra where
   txStAnnTxG = id
 
   mkStAnnTx _ _ _ _ = id
+
+  scriptsProvidedStAnnTx tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
 
 shelleyTxEqRaw :: EraTx era => Tx l era -> Tx l era -> Bool
 shelleyTxEqRaw tx1 tx2 =

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -84,6 +84,7 @@ library
     Cardano.Ledger.Rewards
     Cardano.Ledger.Rules.ValidationMode
     Cardano.Ledger.Slot
+    Cardano.Ledger.StAnnTx
     Cardano.Ledger.State
     Cardano.Ledger.Tools
     Cardano.Ledger.TxIn

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -162,21 +162,6 @@ class
   where
   data Tx (l :: TxLevel) era
 
-  -- | This is a `Tx` that is annotated with some pre-computed data derived from the ledger state,
-  -- which can be used to avoid redundant computation when a transaction is validated multiple
-  -- times.
-  --
-  -- It is critical to only store here information that satisfies the following property: if the
-  -- ledger state changes in a way that makes the annotated value stale, then some other predicate
-  -- check in the STS rules must independently cause the transaction to be rejected.  Stale
-  -- annotations must never lead to a transaction being silently accepted.
-  --
-  -- For example, if a reference input gets spent, then there must a predicate check that fails on
-  -- missing output, regardless if data from reference inputs is still present in the `StAnnTx`
-  type StAnnTx (l :: TxLevel) era = (r :: Type) | r -> l era
-
-  txStAnnTxG :: SimpleGetter (StAnnTx l era) (Tx l era)
-
   mkBasicTx :: TxBody l era -> Tx l era
 
   bodyTxL :: Lens' (Tx l era) (TxBody l era)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/StAnnTx.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/StAnnTx.hs
@@ -1,19 +1,37 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Cardano.Ledger.StAnnTx (
   EraStAnnTx (..),
 ) where
 
-import Cardano.Ledger.Core (EraTx, PParams, StAnnTx, TopTx, Tx)
+import Cardano.Ledger.Core (EraTx, PParams, TopTx, Tx, TxLevel)
 import Cardano.Ledger.State.UTxO (UTxO)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
+import Data.Kind (Type)
 import Data.Text (Text)
+import Lens.Micro (SimpleGetter)
 
 class EraTx era => EraStAnnTx era where
+  -- | This is a `Tx` that is annotated with some pre-computed data derived from the ledger state,
+  -- which can be used to avoid redundant computation when a transaction is validated multiple
+  -- times.
+  --
+  -- It is critical to only store here information that satisfies the following property: if the
+  -- ledger state changes in a way that makes the annotated value stale, then some other predicate
+  -- check in the STS rules must independently cause the transaction to be rejected.  Stale
+  -- annotations must never lead to a transaction being silently accepted.
+  --
+  -- For example, if a reference input gets spent, then there must a predicate check that fails on
+  -- missing output, regardless if data from reference inputs is still present in the `StAnnTx`
+  type StAnnTx (l :: TxLevel) era = (r :: Type) | r -> l era
+
+  txStAnnTxG :: SimpleGetter (StAnnTx l era) (Tx l era)
+
   mkStAnnTx ::
     EpochInfo (Either Text) ->
     SystemStart ->

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/StAnnTx.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/StAnnTx.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+module Cardano.Ledger.StAnnTx (
+  EraStAnnTx (..),
+) where
+
+import Cardano.Ledger.Core (EraTx, PParams, StAnnTx, TopTx, Tx)
+import Cardano.Ledger.State.UTxO (UTxO)
+import Cardano.Slotting.EpochInfo (EpochInfo)
+import Cardano.Slotting.Time (SystemStart)
+import Data.Text (Text)
+
+class EraTx era => EraStAnnTx era where
+  mkStAnnTx ::
+    EpochInfo (Either Text) ->
+    SystemStart ->
+    PParams era ->
+    UTxO era ->
+    Tx TopTx era ->
+    StAnnTx TopTx era

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/StAnnTx.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/StAnnTx.hs
@@ -9,7 +9,7 @@ module Cardano.Ledger.StAnnTx (
 ) where
 
 import Cardano.Ledger.Core (EraTx, PParams, TopTx, Tx, TxLevel)
-import Cardano.Ledger.State.UTxO (UTxO)
+import Cardano.Ledger.State.UTxO (ScriptsProvided, UTxO)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
 import Data.Kind (Type)
@@ -39,3 +39,9 @@ class EraTx era => EraStAnnTx era where
     UTxO era ->
     Tx TopTx era ->
     StAnnTx TopTx era
+
+  -- | Retrieve the `ScriptsProvided` for an annotated transaction. For eras with a real
+  -- annotation (Alonzo onward), this returns the value cached at construction time. For
+  -- pre-Alonzo eras (where `StAnnTx l era ~ Tx l era`), it computes directly from the
+  -- transaction's witness scripts.
+  scriptsProvidedStAnnTx :: StAnnTx l era -> ScriptsProvided era


### PR DESCRIPTION
# Description

While integrating `StAnnTx` (https://github.com/IntersectMBO/cardano-ledger/issues/5782), I hit a roadblock in Alonzo, in form of a cyclic dependency: 

Shelley.API.Mempool imports Shelley.Rules.Ledgers, which would have to import API.Mempool in order to access `mkStAnnTx`  so that it can prepare the `StAnnTx` and call LEDGER rule with it. 

I remember from the PR that introduced `StAnnTx` that having `mkStAnnTx` defined in `EraTx` would also create a cyclic dependency. 

In this PR I'm proposing introducing a new class `EraStAnnTx`  as a subclass of  `EraTx` with `mkStAnnTx` (moved from `ApplyTx`). 
In this way, both Mempool and Rules can call `mkStAnnTx`.  This is implemented in the first commit .

The last two commits are not intrinsic to the proposal - we could remove them and the first commit would still provide the solution to my problem. 
* moving `StAnnTx` type family to `EraStAnnTx`  - it seems natural for them to live together. Unfortunately this causes problems with `scriptsProvidedStAnnTx` defined in `AlonzoEraUTxO`, because now `StAnnTx` lives downstream of `AlonzoEraUTxO`
*  moving `scriptsProvidedStAnnTx` to `EraStAnnTx`.   This works, but it would define implementation for pre-alonzo eras, which are a bit dubious, since the StAnnTx for these types is just Tx. 


 Is there a better way to solve this problem of having to use something defined in `API.Mempool` in both `Mempool` and  `Rules`? 

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
