### PR TITLE
Integrate `StAnnTx` in rules  across all eras 

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.10.0.0
 
+* Change `Signal` to `StAnnTx TopTx era` for: `AllegraUTXOW`, `AllegraUTXO`
 * Add `FromJSON` instance for `ValidityInterval`
 * Add `ApplyTick` instance for `AllegraEra`
 * Add `EraForecast` and `ShelleyEraForecast` instances for `AllegraEra`.

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -42,9 +42,9 @@ instance ApplyTx AllegraEra where
 
   mkStAnnTx _ _ _ _ = id
 
-  applyTxValidation validationPolicy globals env state tx =
+  applyTxValidation validationPolicy globals env state stAnnTx =
     first AllegraApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx
+      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
 
 instance ApplyTick AllegraEra
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -170,8 +170,9 @@ utxoTransition ::
   ) =>
   TransitionRule (EraRule "UTXO" era)
 utxoTransition = do
-  TRC (Shelley.UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
-  let Shelley.UTxOState utxo _ _ ppup _ _ = utxos
+  TRC (Shelley.UtxoEnv slot pp certState, utxos, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
+      Shelley.UTxOState utxo _ _ ppup _ _ = utxos
       txBody = tx ^. bodyTxL
       genDelegs = certState ^. Shelley.certDStateL . Shelley.dsGenDelegsL
 
@@ -306,7 +307,7 @@ instance
   STS (AllegraUTXO era)
   where
   type State (AllegraUTXO era) = Shelley.UTxOState era
-  type Signal (AllegraUTXO era) = Tx TopTx era
+  type Signal (AllegraUTXO era) = StAnnTx TopTx era
   type Environment (AllegraUTXO era) = Shelley.UtxoEnv era
   type BaseM (AllegraUTXO era) = ShelleyBase
   type PredicateFailure (AllegraUTXO era) = AllegraUtxoPredFailure era

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxow.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxow.hs
@@ -58,7 +58,7 @@ instance
     Embed (EraRule "UTXO" era) (AllegraUTXOW era)
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , EraRule "UTXOW" era ~ AllegraUTXOW era
   , InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure era
   , EraCertState era
@@ -66,7 +66,7 @@ instance
   STS (AllegraUTXOW era)
   where
   type State (AllegraUTXOW era) = UTxOState era
-  type Signal (AllegraUTXOW era) = Tx TopTx era
+  type Signal (AllegraUTXOW era) = StAnnTx TopTx era
   type Environment (AllegraUTXOW era) = UtxoEnv era
   type BaseM (AllegraUTXOW era) = ShelleyBase
   type PredicateFailure (AllegraUTXOW era) = ShelleyUtxowPredFailure era

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Change `Signal` to `StAnnTx TopTx era` for: `AlonzoLEDGER`, `AlonzoUTXOW`, `AlonzoUTXO`, `AlonzoUTXOS`
 * Add `FromJSON` instance for `IsValid`
 * Add `ltiMemoizedSubTransactions` to `LedgerTxInfo`
 * Add `resolveNeededPlutusScriptsWithPurpose`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `NFData` instance for `AlonzoScriptsNeeded`
 * Change `Signal` to `StAnnTx TopTx era` for: `AlonzoLEDGER`, `AlonzoUTXOW`, `AlonzoUTXO`, `AlonzoUTXOS`
 * Add `FromJSON` instance for `IsValid`
 * Add `ltiMemoizedSubTransactions` to `LedgerTxInfo`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -72,9 +72,9 @@ instance ApplyTx AlonzoEra where
 
   mkStAnnTx = mkAlonzoStAnnTx
 
-  applyTxValidation validationPolicy globals env state tx =
+  applyTxValidation validationPolicy globals env state stAnnTx =
     first AlonzoApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx
+      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
 
 instance ApplyTick AlonzoEra
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledger.hs
@@ -114,7 +114,7 @@ ledgerTransition ::
   forall (someLEDGER :: Type -> Type) era.
   ( STS (someLEDGER era)
   , BaseM (someLEDGER era) ~ ShelleyBase
-  , Signal (someLEDGER era) ~ Tx TopTx era
+  , Signal (someLEDGER era) ~ StAnnTx TopTx era
   , State (someLEDGER era) ~ LedgerState era
   , Environment (someLEDGER era) ~ LedgerEnv era
   , Embed (EraRule "UTXOW" era) (someLEDGER era)
@@ -124,7 +124,7 @@ ledgerTransition ::
   , Signal (EraRule "DELEGS" era) ~ Seq (TxCert era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , AlonzoEraTx era
   , EraCertState era
   , EraRule "LEDGER" era ~ someLEDGER era
@@ -132,9 +132,10 @@ ledgerTransition ::
   ) =>
   TransitionRule (someLEDGER era)
 ledgerTransition = do
-  TRC (LedgerEnv slot mbCurEpochNo txIx pp account, LedgerState utxoSt certState, tx) <-
+  TRC (LedgerEnv slot mbCurEpochNo txIx pp account, LedgerState utxoSt certState, stAnnTx) <-
     judgmentContext
-  let txBody = tx ^. bodyTxL
+  let tx = stAnnTx ^. txStAnnTxG
+      txBody = tx ^. bodyTxL
 
   curEpochNo <- maybe (liftSTS $ epochFromSlot slot) pure mbCurEpochNo
 
@@ -156,7 +157,7 @@ ledgerTransition = do
       TRC
         ( UtxoEnv @era slot pp certState
         , utxoSt
-        , tx
+        , stAnnTx
         )
   pure $ LedgerState utxoSt' certState'
 
@@ -167,7 +168,7 @@ instance
   , Embed (EraRule "UTXOW" era) (AlonzoLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
   , State (EraRule "DELEGS" era) ~ CertState era
   , Signal (EraRule "DELEGS" era) ~ Seq (TxCert era)
@@ -180,7 +181,7 @@ instance
   STS (AlonzoLEDGER era)
   where
   type State (AlonzoLEDGER era) = LedgerState era
-  type Signal (AlonzoLEDGER era) = Tx TopTx era
+  type Signal (AlonzoLEDGER era) = StAnnTx TopTx era
   type Environment (AlonzoLEDGER era) = LedgerEnv era
   type BaseM (AlonzoLEDGER era) = ShelleyBase
   type PredicateFailure (AlonzoLEDGER era) = ShelleyLedgerPredFailure era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -502,7 +502,7 @@ utxoTransition ::
   , Embed (EraRule "UTXOS" era) (AlonzoUTXO era)
   , Environment (EraRule "UTXOS" era) ~ UtxosEnv era
   , State (EraRule "UTXOS" era) ~ ShelleyGovState era
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , EraCertState era
   , EraStake era
   , SafeToHash (TxWits era)
@@ -510,8 +510,9 @@ utxoTransition ::
   ) =>
   TransitionRule (EraRule "UTXO" era)
 utxoTransition = do
-  TRC (UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
-  let utxo = utxosUtxo utxos
+  TRC (UtxoEnv slot pp certState, utxos, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
+      utxo = utxosUtxo utxos
 
   {-   txb := txbody tx   -}
   let txBody = tx ^. bodyTxL
@@ -577,7 +578,7 @@ utxoTransition = do
 
   updatedGovState <-
     trans @(EraRule "UTXOS" era) $
-      TRC (UtxosEnv slot pp certState utxo, utxosGovState utxos, tx)
+      TRC (UtxosEnv slot pp certState utxo, utxosGovState utxos, stAnnTx)
 
   case tx ^. isValidTxL of
     IsValid True ->
@@ -611,7 +612,7 @@ instance
   , Embed (EraRule "UTXOS" era) (AlonzoUTXO era)
   , Environment (EraRule "UTXOS" era) ~ UtxosEnv era
   , State (EraRule "UTXOS" era) ~ ShelleyGovState era
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , EraRule "UTXO" era ~ AlonzoUTXO era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
   , InjectRuleFailure "UTXO" AlonzoUtxoPredFailure era
@@ -625,7 +626,7 @@ instance
   STS (AlonzoUTXO era)
   where
   type State (AlonzoUTXO era) = UTxOState era
-  type Signal (AlonzoUTXO era) = Tx TopTx era
+  type Signal (AlonzoUTXO era) = StAnnTx TopTx era
   type Environment (AlonzoUTXO era) = UtxoEnv era
   type BaseM (AlonzoUTXO era) = ShelleyBase
   type PredicateFailure (AlonzoUTXO era) = AlonzoUtxoPredFailure era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -122,7 +122,7 @@ instance
   type BaseM (AlonzoUTXOS era) = ShelleyBase
   type Environment (AlonzoUTXOS era) = UtxosEnv era
   type State (AlonzoUTXOS era) = ShelleyGovState era
-  type Signal (AlonzoUTXOS era) = Tx TopTx era
+  type Signal (AlonzoUTXOS era) = StAnnTx TopTx era
   type PredicateFailure (AlonzoUTXOS era) = AlonzoUtxosPredFailure era
   type Event (AlonzoUTXOS era) = AlonzoUtxosEvent era
   transitionRules = [utxosTransition]
@@ -179,7 +179,8 @@ utxosTransition ::
   ) =>
   TransitionRule (AlonzoUTXOS era)
 utxosTransition =
-  judgmentContext >>= \(TRC (_, _, tx)) -> do
+  judgmentContext >>= \(TRC (_, _, stAnnTx)) -> do
+    let tx = stAnnTx ^. txStAnnTxG
     case tx ^. isValidTxL of
       IsValid True -> alonzoEvalScriptsTxValid
       IsValid False -> alonzoEvalScriptsTxInvalid
@@ -237,9 +238,10 @@ alonzoEvalScriptsTxValid ::
   ) =>
   TransitionRule (AlonzoUTXOS era)
 alonzoEvalScriptsTxValid = do
-  TRC (UtxosEnv slot pp certState utxo, pup, tx) <-
+  TRC (UtxosEnv slot pp certState utxo, pup, stAnnTx) <-
     judgmentContext
-  let txBody = tx ^. bodyTxL
+  let tx = stAnnTx ^. txStAnnTxG
+      txBody = tx ^. bodyTxL
       genDelegs = certState ^. certDStateL . Shelley.dsGenDelegsL
 
   () <- pure $! Debug.traceEvent validBegin ()
@@ -267,7 +269,8 @@ alonzoEvalScriptsTxInvalid ::
   ) =>
   TransitionRule (AlonzoUTXOS era)
 alonzoEvalScriptsTxInvalid = do
-  TRC (UtxosEnv slot pp _ utxo, pup, tx) <- judgmentContext
+  TRC (UtxosEnv slot pp _ utxo, pup, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   () <- pure $! Debug.traceEvent invalidBegin ()
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -312,12 +312,13 @@ alonzoStyleWitness ::
     Embed (EraRule "UTXO" era) (AlonzoUTXOW era)
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , EraCertState era
   ) =>
   TransitionRule (EraRule "UTXOW" era)
 alonzoStyleWitness = do
-  TRC (utxoEnv@(UtxoEnv _ pp certState), u, tx) <- judgmentContext
+  TRC (utxoEnv@(UtxoEnv _ pp certState), u, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   {-  (utxo,_,_,_ ) := utxoSt  -}
   {-  txb := txbody tx  -}
@@ -378,7 +379,7 @@ alonzoStyleWitness = do
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
   runTest $ checkScriptIntegrityHash tx pp scriptIntegrity
 
-  trans @(EraRule "UTXO" era) $ TRC (utxoEnv, u, tx)
+  trans @(EraRule "UTXO" era) $ TRC (utxoEnv, u, stAnnTx)
 
 -- ================================
 
@@ -406,13 +407,13 @@ instance
     Embed (EraRule "UTXO" era) (AlonzoUTXOW era)
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , EraCertState era
   ) =>
   STS (AlonzoUTXOW era)
   where
   type State (AlonzoUTXOW era) = UTxOState era
-  type Signal (AlonzoUTXOW era) = Tx TopTx era
+  type Signal (AlonzoUTXOW era) = StAnnTx TopTx era
   type Environment (AlonzoUTXOW era) = UtxoEnv era
   type BaseM (AlonzoUTXOW era) = ShelleyBase
   type PredicateFailure (AlonzoUTXOW era) = AlonzoUtxowPredFailure era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -506,3 +506,24 @@ instance
   HasEraTxLevel AlonzoStAnnTx era
   where
   toSTxLevel (AlonzoStAnnTx {}) = STopTxOnly @era
+
+instance
+  ( AlonzoEraScript era
+  , NFData (Tx l era)
+  , NFData (ScriptsNeeded era)
+  , NFData (ScriptsProvided era)
+  , NFData (ContextError era)
+  ) =>
+  NFData (AlonzoStAnnTx l era)
+  where
+  rnf stAnnTx@(AlonzoStAnnTx _ _ _ _ _ _) =
+    let AlonzoStAnnTx {..} = stAnnTx
+     in asatTx `deepseq`
+          asatProtocolVersion `deepseq`
+            asatScriptsNeeded `deepseq`
+              asatScriptsProvided `deepseq`
+                asatPlutusLanguagesUsed `deepseq`
+                  rnf asatPlutusScriptsWithContext
+
+instance EncCBOR (Tx l era) => EncCBOR (AlonzoStAnnTx l era) where
+  encCBOR AlonzoStAnnTx {asatTx} = encCBOR asatTx

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -66,6 +66,7 @@ import Cardano.Ledger.State (
   getScriptHash,
  )
 import Cardano.Ledger.TxIn
+import Control.DeepSeq (NFData)
 import Data.Foldable as F (foldl', toList)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe, isJust)
@@ -83,6 +84,8 @@ newtype AlonzoScriptsNeeded era
 deriving instance AlonzoEraScript era => Eq (AlonzoScriptsNeeded era)
 
 deriving instance AlonzoEraScript era => Show (AlonzoScriptsNeeded era)
+
+deriving instance AlonzoEraScript era => NFData (AlonzoScriptsNeeded era)
 
 instance EraUTxO AlonzoEra where
   type ScriptsNeeded AlonzoEra = AlonzoScriptsNeeded AlonzoEra

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -31,6 +31,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Plutus.Evaluate (PlutusWithContext (..))
 import Cardano.Ledger.Shelley.Rules
+import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided)
 import qualified Data.TreeDiff.OMap as OMap
 import PlutusLedgerApi.Common (EvaluationError (..), ExBudget, ExCPU, ExMemory, SatInt)
 import Test.Cardano.Ledger.Mary.TreeDiff
@@ -140,6 +141,28 @@ instance
         , ("atIsValid", toExpr atIsValid)
         , ("atAuxData", toExpr atAuxData)
         ]
+
+instance
+  ( ToExpr (Tx TopTx era)
+  , ToExpr (ScriptsNeeded era)
+  , ToExpr (ScriptsProvided era)
+  , ToExpr (ContextError era)
+  , ToExpr (PlutusPurpose AsItem era)
+  , ToExpr (TxCert era)
+  ) =>
+  ToExpr (AlonzoStAnnTx TopTx era)
+  where
+  toExpr stAnnTx@(AlonzoStAnnTx _ _ _ _ _ _) =
+    let AlonzoStAnnTx {..} = stAnnTx
+     in Rec "AlonzoStAnnTx" $
+          OMap.fromList
+            [ ("asatTx", toExpr asatTx)
+            , ("asatProtocolVersion", toExpr asatProtocolVersion)
+            , ("asatScriptsNeeded", toExpr asatScriptsNeeded)
+            , ("asatScriptsProvided", toExpr asatScriptsProvided)
+            , ("asatPlutusLanguagesUsed", toExpr asatPlutusLanguagesUsed)
+            , ("asatPlutusScriptsWithContext", toExpr asatPlutusScriptsWithContext)
+            ]
 
 -- Plutus/TxInfo
 instance ToExpr (AlonzoContextError era)

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -16,8 +16,9 @@ module Test.Cardano.Ledger.Alonzo.Trace () where
 
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Rules (AlonzoLEDGER)
-import Cardano.Ledger.BaseTypes (Globals)
-import Cardano.Ledger.Shelley.LedgerState (UTxOState)
+import Cardano.Ledger.BaseTypes (Globals, epochInfo, systemStart)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
+import Cardano.Ledger.Shelley.LedgerState (UTxOState, lsUTxOState, utxosUtxo)
 import Cardano.Ledger.Shelley.Rules (
   DelegsEnv,
   DelplEnv,
@@ -40,12 +41,14 @@ import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
 import Test.Cardano.Ledger.Shelley.Generator.Trace.Ledger (genAccountState)
 import Test.Cardano.Ledger.Shelley.Generator.Trace.TxCert (CERTS)
 import Test.Cardano.Ledger.Shelley.Generator.Utxo (genTx)
+import Test.Cardano.Ledger.Shelley.Utils (testGlobals)
 import qualified Test.Control.State.Transition.Trace.Generator.QuickCheck as TQC
 
 -- The AlonzoLEDGER STS combines utxo and delegation rules and allows for generating transactions
 -- with meaningful delegation certificates.
 instance
-  ( EraGen era
+  ( ApplyTx era
+  , EraGen era
   , EraGov era
   , EraUTxO era
   , AlonzoEraTx era
@@ -60,7 +63,7 @@ instance
   , Embed (EraRule "UTXOW" era) (AlonzoLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
   , State (EraRule "DELEGS" era) ~ CertState era
   , Signal (EraRule "DELEGS" era) ~ Seq (TxCert era)
@@ -77,7 +80,15 @@ instance
       <$> genEraPParams @era geConstants
       <*> genAccountState geConstants
 
-  sigGen = genTx
+  sigGen ge ledgerEnv@(LedgerEnv _ _ _ pParams _) ls = do
+    tx <- genTx ge ledgerEnv ls
+    pure $
+      mkStAnnTx
+        (epochInfo testGlobals)
+        (systemStart testGlobals)
+        pParams
+        (utxosUtxo (lsUTxOState ls))
+        tx
 
   shrinkSignal _ = [] -- TODO add some kind of Shrinker?
 

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/ChainTrace.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/ChainTrace.hs
@@ -83,10 +83,11 @@ alonzoSpecificProps SourceSignalTarget {source = chainSt, signal = block} =
     alonzoSpecificPropsLEDGER
       SourceSignalTarget
         { source = LedgerState UTxOState {utxosUtxo = UTxO u, utxosDeposited = dp, utxosFees = f} ds
-        , signal = tx
+        , signal = stAnnTx
         , target = LedgerState UTxOState {utxosUtxo = UTxO u', utxosDeposited = dp', utxosFees = f'} ds'
         } =
-        let isValid' = tx ^. isValidTxL
+        let tx = stAnnTx ^. txStAnnTxG
+            isValid' = tx ^. isValidTxL
             noNewUTxO = u' `Map.isSubmapOf` u
             collateralInFees = f <> sumCollateral tx (UTxO u) == f'
             utxoConsumed = not $ u `Map.isSubmapOf` u'

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Change `Signal` to `StAnnTx TopTx era` for: `BabbageLEDGER`, `BabbageUTXOW`, `BabbageUTXO`, `BabbageUTXOS`
 * Remove `ToCBOR` and `FromCBOR` instances for `BabbageTxOut`
 * Add `ApplyTick` instance for `BabbageEra`
 * `BabbageTxInfoResult` changed its content type to `PlutusTxInfoResult`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -64,9 +64,9 @@ instance ApplyTx BabbageEra where
 
   mkStAnnTx = mkAlonzoStAnnTx
 
-  applyTxValidation validationPolicy globals env state tx =
+  applyTxValidation validationPolicy globals env state stAnnTx =
     first BabbageApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx
+      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
 
 instance ApplyTick BabbageEra
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledger.hs
@@ -113,7 +113,7 @@ instance
   , Embed (EraRule "UTXOW" era) (BabbageLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
   , State (EraRule "DELEGS" era) ~ CertState era
   , Signal (EraRule "DELEGS" era) ~ Seq (TxCert era)
@@ -126,7 +126,7 @@ instance
   STS (BabbageLEDGER era)
   where
   type State (BabbageLEDGER era) = LedgerState era
-  type Signal (BabbageLEDGER era) = Tx TopTx era
+  type Signal (BabbageLEDGER era) = StAnnTx TopTx era
   type Environment (BabbageLEDGER era) = LedgerEnv era
   type BaseM (BabbageLEDGER era) = ShelleyBase
   type PredicateFailure (BabbageLEDGER era) = ShelleyLedgerPredFailure era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -355,15 +355,16 @@ babbageUtxoValidation ::
   , InjectRuleFailure "UTXO" BabbageUtxoPredFailure era
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
   , STS (EraRule "UTXO" era)
   , EraCertState era
   ) =>
   Rule (EraRule "UTXO" era) 'Transition ()
 babbageUtxoValidation = do
-  TRC (Shelley.UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
-  let utxo = utxosUtxo utxos
+  TRC (Shelley.UtxoEnv slot pp certState, utxos, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
+      utxo = utxosUtxo utxos
 
   {-   txb := txbody tx   -}
   let txBody = tx ^. bodyTxL
@@ -447,7 +448,7 @@ utxoTransition ::
   , InjectRuleFailure "UTXO" BabbageUtxoPredFailure era
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
   , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
   , STS (EraRule "UTXO" era)
@@ -455,15 +456,16 @@ utxoTransition ::
     Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
   , Environment (EraRule "UTXOS" era) ~ UtxosEnv era
   , State (EraRule "UTXOS" era) ~ ShelleyGovState era
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   ) =>
   TransitionRule (EraRule "UTXO" era)
 utxoTransition = do
-  TRC (UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
+  TRC (UtxoEnv slot pp certState, utxos, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
   babbageUtxoValidation
   updatedGovState <-
     trans @(EraRule "UTXOS" era) $
-      TRC (UtxosEnv slot pp certState (utxosUtxo utxos), utxosGovState utxos, tx)
+      TRC (UtxosEnv slot pp certState (utxosUtxo utxos), utxosGovState utxos, stAnnTx)
   updateUTxOStateByTxValidity pp certState updatedGovState tx utxos
 
 updateUTxOStateByTxValidity ::
@@ -531,13 +533,13 @@ instance
     Embed (EraRule "UTXOS" era) (BabbageUTXO era)
   , Environment (EraRule "UTXOS" era) ~ UtxosEnv era
   , State (EraRule "UTXOS" era) ~ ShelleyGovState era
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , SafeToHash (TxWits era)
   ) =>
   STS (BabbageUTXO era)
   where
   type State (BabbageUTXO era) = UTxOState era
-  type Signal (BabbageUTXO era) = Tx TopTx era
+  type Signal (BabbageUTXO era) = StAnnTx TopTx era
   type Environment (BabbageUTXO era) = UtxoEnv era
   type BaseM (BabbageUTXO era) = ShelleyBase
   type PredicateFailure (BabbageUTXO era) = BabbageUtxoPredFailure era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -97,7 +97,7 @@ instance
   , Environment (EraRule "PPUP" era) ~ PpupEnv era
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
-  , Signal (BabbageUTXOS era) ~ Tx TopTx era
+  , Signal (BabbageUTXOS era) ~ StAnnTx TopTx era
   , EncCBOR (EraRuleFailure "PPUP" era)
   , Eq (EraRuleFailure "PPUP" era)
   , Show (EraRuleFailure "PPUP" era)
@@ -110,7 +110,7 @@ instance
   type BaseM (BabbageUTXOS era) = ShelleyBase
   type Environment (BabbageUTXOS era) = UtxosEnv era
   type State (BabbageUTXOS era) = ShelleyGovState era
-  type Signal (BabbageUTXOS era) = Tx TopTx era
+  type Signal (BabbageUTXOS era) = StAnnTx TopTx era
   type PredicateFailure (BabbageUTXOS era) = AlonzoUtxosPredFailure era
   type Event (BabbageUTXOS era) = AlonzoUtxosEvent era
   transitionRules = [utxosTransition]
@@ -151,7 +151,8 @@ utxosTransition ::
   ) =>
   TransitionRule (BabbageUTXOS era)
 utxosTransition =
-  judgmentContext >>= \(TRC (UtxosEnv _ pp _ utxo, pup, tx)) -> do
+  judgmentContext >>= \(TRC (UtxosEnv _ pp _ utxo, pup, stAnnTx)) -> do
+    let tx = stAnnTx ^. txStAnnTxG
     case tx ^. isValidTxL of
       IsValid True -> babbageEvalScriptsTxValid
       IsValid False -> do
@@ -215,9 +216,10 @@ babbageEvalScriptsTxValid ::
   ) =>
   TransitionRule (BabbageUTXOS era)
 babbageEvalScriptsTxValid = do
-  TRC (UtxosEnv slot pp certState utxo, pup, tx) <-
+  TRC (UtxosEnv slot pp certState utxo, pup, stAnnTx) <-
     judgmentContext
-  let txBody = tx ^. bodyTxL
+  let tx = stAnnTx ^. txStAnnTxG
+      txBody = tx ^. bodyTxL
       genDelegs = certState ^. certDStateL . dsGenDelegsL
 
   -- We intentionally run the PPUP rule before evaluating any Plutus scripts.

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -296,12 +296,13 @@ babbageUtxowMirTransition ::
   , InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure era
   , BaseM (EraRule "UTXOW" era) ~ ShelleyBase
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , EraCertState era
   ) =>
   Rule (EraRule "UTXOW" era) 'Transition ()
 babbageUtxowMirTransition = do
-  TRC (UtxoEnv _ _ certState, _, tx) <- judgmentContext
+  TRC (UtxoEnv _ _ certState, _, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
   -- check genesis keys signatures for instantaneous rewards certificates
   {-  genSig := { hashKey gkey | gkey ∈ dom(genDelegs)} ∩ witsKeyHashes  -}
   {-  { c ∈ txcerts txb ∩ TxCert_mir} ≠ ∅  ⇒ |genSig| ≥ Quorum  -}
@@ -319,7 +320,7 @@ babbageUtxowTransition ::
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , BabbageEraTxBody era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , State (EraRule "UTXOW" era) ~ UTxOState era
   , InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure era
   , InjectRuleFailure "UTXOW" AlonzoUtxowPredFailure era
@@ -327,12 +328,13 @@ babbageUtxowTransition ::
   , -- Allow UTXOW to call UTXO
     Embed (EraRule "UTXO" era) (EraRule "UTXOW" era)
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , State (EraRule "UTXO" era) ~ UTxOState era
   ) =>
   TransitionRule (EraRule "UTXOW" era)
 babbageUtxowTransition = do
-  TRC (utxoEnv@(UtxoEnv _ pp certState), u, tx) <- judgmentContext
+  TRC (utxoEnv@(UtxoEnv _ pp certState), u, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   {-  (utxo,_,_,_ ) := utxoSt  -}
   {-  txb := txbody tx  -}
@@ -393,7 +395,7 @@ babbageUtxowTransition = do
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
   runTest $ checkScriptIntegrityHash tx pp scriptIntegrity
 
-  trans @(EraRule "UTXO" era) $ TRC (utxoEnv, u, tx)
+  trans @(EraRule "UTXO" era) $ TRC (utxoEnv, u, stAnnTx)
 
 -- ================================
 
@@ -412,7 +414,7 @@ instance
     Embed (EraRule "UTXO" era) (BabbageUTXOW era)
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , Eq (PredicateFailure (EraRule "UTXOS" era))
   , Show (PredicateFailure (EraRule "UTXOS" era))
   , EraCertState era
@@ -420,7 +422,7 @@ instance
   STS (BabbageUTXOW era)
   where
   type State (BabbageUTXOW era) = UTxOState era
-  type Signal (BabbageUTXOW era) = Tx TopTx era
+  type Signal (BabbageUTXOW era) = StAnnTx TopTx era
   type Environment (BabbageUTXOW era) = UtxoEnv era
   type BaseM (BabbageUTXOW era) = ShelleyBase
   type PredicateFailure (BabbageUTXOW era) = BabbageUtxowPredFailure era

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.23.0.0
 
+* Change `Signal` to `StAnnTx TopTx era` for: `ConwayLEDGER`, `ConwayMEMPOOL`, `ConwayUTXOW`, `ConwayUTXO`, `ConwayUTXOS`
 * Change `conwayRegisterInitialFundsThenStaking` to require `MonadIO`, `MonadThrow`, and accept a `HasFS m h` parameter
 * Remove `ToCBOR` and `FromCBOR` instances for `PulsingSnapshot`, `EnactState`, `ConwayGovPredFailure`
 * Add `validateRefScriptSize`, `updateDormantDRepExpiries`, `updateVotingDRepExpiries`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -55,9 +55,9 @@ instance ApplyTx ConwayEra where
 
   mkStAnnTx = mkAlonzoStAnnTx
 
-  applyTxValidation validationPolicy globals env state tx =
+  applyTxValidation validationPolicy globals env state stAnnTx =
     first ConwayApplyTxError $
-      ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state tx
+      ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state stAnnTx
 
 instance ApplyTick ConwayEra
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -314,7 +314,7 @@ instance
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
   , Environment (EraRule "GOV" era) ~ GovEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ GovSignal era
   , ConwayEraCertState era
@@ -325,7 +325,7 @@ instance
   STS (ConwayLEDGER era)
   where
   type State (ConwayLEDGER era) = LedgerState era
-  type Signal (ConwayLEDGER era) = Tx TopTx era
+  type Signal (ConwayLEDGER era) = StAnnTx TopTx era
   type Environment (ConwayLEDGER era) = LedgerEnv era
   type BaseM (ConwayLEDGER era) = ShelleyBase
   type PredicateFailure (ConwayLEDGER era) = ConwayLedgerPredFailure era
@@ -344,7 +344,7 @@ conwayLedgerTransitionTRC ::
   , ConwayEraTxBody era
   , ConwayEraGov era
   , GovState era ~ ConwayGovState era
-  , Signal (someLEDGER era) ~ Tx TopTx era
+  , Signal (someLEDGER era) ~ StAnnTx TopTx era
   , State (someLEDGER era) ~ LedgerState era
   , Environment (someLEDGER era) ~ LedgerEnv era
   , Embed (EraRule "UTXOW" era) (someLEDGER era)
@@ -356,7 +356,7 @@ conwayLedgerTransitionTRC ::
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "GOV" era) ~ GovEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ GovSignal era
   , BaseM (someLEDGER era) ~ ShelleyBase
@@ -372,9 +372,10 @@ conwayLedgerTransitionTRC
   ( TRC
       ( LedgerEnv slot mbCurEpochNo _txIx pp chainAccountState
         , LedgerState utxoState certState
-        , tx
+        , stAnnTx
         )
     ) = do
+    let tx = stAnnTx ^. txStAnnTxG
     curEpochNo <- maybe (liftSTS $ epochFromSlot slot) pure mbCurEpochNo
 
     (utxoState', certStateAfterCERTS) <-
@@ -455,7 +456,7 @@ conwayLedgerTransitionTRC
           -- AccountState.
           ( UtxoEnv @era slot pp certState
           , utxoState'
-          , tx
+          , stAnnTx
           )
     pure $ LedgerState utxoState'' certStateAfterCERTS
 
@@ -513,7 +514,7 @@ conwayLedgerTransition ::
   , ConwayEraTxBody era
   , ConwayEraGov era
   , GovState era ~ ConwayGovState era
-  , Signal (someLEDGER era) ~ Tx TopTx era
+  , Signal (someLEDGER era) ~ StAnnTx TopTx era
   , State (someLEDGER era) ~ LedgerState era
   , Environment (someLEDGER era) ~ LedgerEnv era
   , Embed (EraRule "UTXOW" era) (someLEDGER era)
@@ -525,7 +526,7 @@ conwayLedgerTransition ::
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "GOV" era) ~ GovEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ GovSignal era
   , BaseM (someLEDGER era) ~ ShelleyBase
@@ -548,7 +549,7 @@ instance
   , Script era ~ AlonzoScript era
   , TxOut era ~ BabbageTxOut era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , PredicateFailure (EraRule "UTXOW" era) ~ ConwayUtxowPredFailure era
   , Event (EraRule "UTXOW" era) ~ AlonzoUtxowEvent era
   , STS (ConwayUTXOW era)
@@ -590,7 +591,7 @@ instance
   , GovState era ~ ConwayGovState era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , State (EraRule "UTXOW" era) ~ UTxOState era
   , State (EraRule "CERTS" era) ~ CertState era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Mempool.hs
@@ -75,12 +75,12 @@ instance
   , Show (PredicateFailure (EraRule "GOV" era))
   , Show (PredicateFailure (EraRule "UTXOW" era))
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Tx TopTx era ~ Signal (EraRule "LEDGER" era)
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
   STS (ConwayMEMPOOL era)
   where
   type State (ConwayMEMPOOL era) = LedgerState era
-  type Signal (ConwayMEMPOOL era) = Tx TopTx era
+  type Signal (ConwayMEMPOOL era) = StAnnTx TopTx era
   type Environment (ConwayMEMPOOL era) = LedgerEnv era
   type BaseM (ConwayMEMPOOL era) = ShelleyBase
   type PredicateFailure (ConwayMEMPOOL era) = ConwayLedgerPredFailure era
@@ -97,12 +97,13 @@ mempoolTransition ::
   , Embed (EraRule "LEDGER" era) (ConwayMEMPOOL era)
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Tx TopTx era ~ Signal (EraRule "LEDGER" era)
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
   TransitionRule (ConwayMEMPOOL era)
 mempoolTransition = do
-  TRC trc@(ledgerEnv, ledgerState, tx) <-
+  TRC trc@(ledgerEnv, ledgerState, stAnnTx) <-
     judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   -- This rule only gets invoked on transactions within the mempool.
   -- Add checks here that sanitize undesired transactions.
@@ -157,8 +158,8 @@ instance
   , GovState era ~ ConwayGovState era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ GovSignal era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , ConwayEraCertState era
   , EraRule "LEDGER" era ~ ConwayLEDGER era
   , EraRuleFailure "LEDGER" era ~ ConwayLedgerPredFailure era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -241,21 +241,22 @@ conwayUtxoTransition ::
   , InjectRuleFailure "UTXO" BabbageUtxoPredFailure era
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
   , STS (EraRule "UTXO" era)
   , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
   , -- In this function we we call the UTXOS rule, so we need some assumptions
     Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
   , State (EraRule "UTXOS" era) ~ ()
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
   ) =>
   TransitionRule (EraRule "UTXO" era)
 conwayUtxoTransition = do
-  TRC (UtxoEnv _ pp certState, utxos, tx) <- judgmentContext
+  TRC (UtxoEnv _ pp certState, utxos, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
   babbageUtxoValidation
-  () <- trans @(EraRule "UTXOS" era) $ TRC (ConwayUtxosEnv pp (utxosUtxo utxos), (), tx)
+  () <- trans @(EraRule "UTXOS" era) $ TRC (ConwayUtxosEnv pp (utxosUtxo utxos), (), stAnnTx)
   updateUTxOStateByTxValidity
     pp
     certState
@@ -283,7 +284,7 @@ instance
   , Embed (EraRule "UTXOS" era) (ConwayUTXO era)
   , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
   , State (EraRule "UTXOS" era) ~ ()
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , PredicateFailure (EraRule "UTXO" era) ~ ConwayUtxoPredFailure era
   , EraCertState era
   , SafeToHash (TxWits era)
@@ -291,7 +292,7 @@ instance
   STS (ConwayUTXO era)
   where
   type State (ConwayUTXO era) = UTxOState era
-  type Signal (ConwayUTXO era) = Tx TopTx era
+  type Signal (ConwayUTXO era) = StAnnTx TopTx era
   type Environment (ConwayUTXO era) = UtxoEnv era
   type BaseM (ConwayUTXO era) = ShelleyBase
   type PredicateFailure (ConwayUTXO era) = ConwayUtxoPredFailure era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -194,7 +194,7 @@ instance
   , EraPlutusContext era
   , GovState era ~ ConwayGovState era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , Signal (ConwayUTXOS era) ~ Tx TopTx era
+  , Signal (ConwayUTXOS era) ~ StAnnTx TopTx era
   , EraRule "UTXOS" era ~ ConwayUTXOS era
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
   , InjectRuleEvent "UTXOS" AlonzoUtxosEvent era
@@ -205,7 +205,7 @@ instance
   type BaseM (ConwayUTXOS era) = Cardano.Ledger.BaseTypes.ShelleyBase
   type Environment (ConwayUTXOS era) = ConwayUtxosEnv era
   type State (ConwayUTXOS era) = ()
-  type Signal (ConwayUTXOS era) = Tx TopTx era
+  type Signal (ConwayUTXOS era) = StAnnTx TopTx era
   type PredicateFailure (ConwayUTXOS era) = ConwayUtxosPredFailure era
   type Event (ConwayUTXOS era) = ConwayUtxosEvent era
 
@@ -223,7 +223,7 @@ instance
   , GovState era ~ ConwayGovState era
   , PredicateFailure (EraRule "UTXOS" era) ~ ConwayUtxosPredFailure era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , Signal (ConwayUTXOS era) ~ Tx TopTx era
+  , Signal (ConwayUTXOS era) ~ StAnnTx TopTx era
   , EraRule "UTXOS" era ~ ConwayUTXOS era
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
   , InjectRuleEvent "UTXOS" AlonzoUtxosEvent era
@@ -240,7 +240,7 @@ utxosTransition ::
   , AlonzoEraUTxO era
   , EraPlutusContext era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , STS (EraRule "UTXOS" era)
   , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
   , State (EraRule "UTXOS" era) ~ ()
@@ -250,7 +250,8 @@ utxosTransition ::
   ) =>
   TransitionRule (EraRule "UTXOS" era)
 utxosTransition =
-  judgmentContext >>= \(TRC (ConwayUtxosEnv pp utxo, (), tx)) -> do
+  judgmentContext >>= \(TRC (ConwayUtxosEnv pp utxo, (), stAnnTx)) -> do
+    let tx = stAnnTx ^. txStAnnTxG
     case tx ^. isValidTxL of
       IsValid True -> conwayEvalScriptsTxValid
       IsValid False -> do
@@ -262,7 +263,7 @@ conwayEvalScriptsTxValid ::
   , AlonzoEraUTxO era
   , EraPlutusContext era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , STS (EraRule "UTXOS" era)
   , State (EraRule "UTXOS" era) ~ ()
   , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
@@ -272,7 +273,8 @@ conwayEvalScriptsTxValid ::
   ) =>
   TransitionRule (EraRule "UTXOS" era)
 conwayEvalScriptsTxValid = do
-  TRC (ConwayUtxosEnv pp utxo, (), tx) <- judgmentContext
+  TRC (ConwayUtxosEnv pp utxo, (), stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   () <- pure $! Debug.traceEvent validBegin ()
   expectScriptsToPass pp tx utxo

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -200,14 +200,14 @@ instance
     Embed (EraRule "UTXO" era) (ConwayUTXOW era)
   , Environment (EraRule "UTXO" era) ~ Shelley.UtxoEnv era
   , State (EraRule "UTXO" era) ~ Shelley.UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , Eq (PredicateFailure (EraRule "UTXOS" era))
   , Show (PredicateFailure (EraRule "UTXOS" era))
   ) =>
   STS (ConwayUTXOW era)
   where
   type State (ConwayUTXOW era) = Shelley.UTxOState era
-  type Signal (ConwayUTXOW era) = Tx TopTx era
+  type Signal (ConwayUTXOW era) = StAnnTx TopTx era
   type Environment (ConwayUTXOW era) = Shelley.UtxoEnv era
   type BaseM (ConwayUTXOW era) = ShelleyBase
   type PredicateFailure (ConwayUTXOW era) = ConwayUtxowPredFailure era

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.3.0.0
 
+* Change `Signal` to `StAnnTx TopTx era` for: `DijkstraLEDGER`, `DijkstraMEMPOOL`, `DijkstraUTXOW`, `DijkstraUTXO`
+* Change `Signal` to `StAnnTx SubTx era` for: `DijkstraSUBLEDGER`, `DijkstraSUBUTXOW`, `DijkstraSUBUTXO`
+* Change `DijkstraSUBLEDGERS` `Signal` to `[StAnnTx SubTx era]`
 * Add `WithdrawalsExceedAccountBalance` to `DijkstraLedgerPredFailure`
 * Removed `DijkstraSpendingOutputFromSameTx` from `DijkstraLedgerPredFailure`
 * Added `batchNonDistinctRefScriptsSize`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -79,9 +79,9 @@ instance ApplyTx DijkstraEra where
 
   mkStAnnTx = mkDijkstraStAnnTopTx
 
-  applyTxValidation validationPolicy globals env state tx =
+  applyTxValidation validationPolicy globals env state stAnnTx =
     first DijkstraApplyTxError $
-      ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state tx
+      ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state stAnnTx
 
 instance ApplyTick DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -88,6 +88,7 @@ import Cardano.Ledger.Dijkstra.Rules.SubLedger
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoEnv (..), DijkstraUtxoPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure)
+import Cardano.Ledger.Dijkstra.Tx (DijkstraStAnnTx (..))
 import Cardano.Ledger.Dijkstra.TxBody
 import Cardano.Ledger.Dijkstra.UTxO (batchNonDistinctRefScriptsSize)
 import Cardano.Ledger.Rules.ValidationMode (Test, runTest)
@@ -324,9 +325,12 @@ instance
   , Environment (EraRule "UTXOW" era) ~ DijkstraUtxoEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
   , Environment (EraRule "GOV" era) ~ GovEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ GovSignal era
+  , Signal (EraRule "SUBLEDGERS" era) ~ [StAnnTx SubTx era]
+  , StAnnTx TopTx era ~ DijkstraStAnnTx TopTx era
+  , StAnnTx SubTx era ~ DijkstraStAnnTx SubTx era
   , ConwayEraCertState era
   , EraRule "LEDGER" era ~ DijkstraLEDGER era
   , InjectRuleFailure "LEDGER" ShelleyLedgerPredFailure era
@@ -337,7 +341,7 @@ instance
   STS (DijkstraLEDGER era)
   where
   type State (DijkstraLEDGER era) = LedgerState era
-  type Signal (DijkstraLEDGER era) = Tx TopTx era
+  type Signal (DijkstraLEDGER era) = StAnnTx TopTx era
   type Environment (DijkstraLEDGER era) = LedgerEnv era
   type BaseM (DijkstraLEDGER era) = ShelleyBase
   type PredicateFailure (DijkstraLEDGER era) = DijkstraLedgerPredFailure era
@@ -386,9 +390,11 @@ dijkstraLedgerTransition ::
   , Environment (EraRule "UTXOW" era) ~ DijkstraUtxoEnv era
   , Environment (EraRule "GOV" era) ~ GovEnv era
   , Environment (EraRule "CERTS" era) ~ CertsEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ GovSignal era
+  , StAnnTx TopTx era ~ DijkstraStAnnTx TopTx era
+  , StAnnTx SubTx era ~ DijkstraStAnnTx SubTx era
   , STS (DijkstraLEDGER era)
   , EraRule "LEDGER" era ~ DijkstraLEDGER era
   , EraRule "SUBLEDGERS" era ~ DijkstraSUBLEDGERS era
@@ -398,14 +404,15 @@ dijkstraLedgerTransition ::
   ) =>
   TransitionRule (DijkstraLEDGER era)
 dijkstraLedgerTransition = do
-  TRC (LedgerEnv slot mbCurEpochNo txIx pp chainAccountState, ledgerState, tx) <-
+  TRC (LedgerEnv slot mbCurEpochNo txIx pp chainAccountState, ledgerState, stAnnTx) <-
     judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   -- Capture the original UTxO before any subtransaction processing.
   -- This is passed through the environment to UTXOW
   -- and SUBLEDGERS, and used for all witness/validation lookups.
   let originalUtxo = utxosUtxo (ledgerState ^. lsUTxOStateL)
-      subTxs = tx ^. bodyTxL . subTransactionsTxBodyL
+      subStAnnTxs = dsattStAnnSubTxs stAnnTx
       -- getScriptsProvided is recursive for Dijkstra
       scriptsProvided = getScriptsProvided originalUtxo tx
 
@@ -423,7 +430,7 @@ dijkstraLedgerTransition = do
             originalUtxo
             (tx ^. isValidTxL)
         , ledgerState
-        , subTxs
+        , subStAnnTxs
         )
 
   curEpochNo <- maybe (liftSTS $ epochFromSlot slot) pure mbCurEpochNo
@@ -490,7 +497,7 @@ dijkstraLedgerTransition = do
       TRC
         ( DijkstraUtxoEnv slot pp certState originalUtxo scriptsProvided
         , utxoStateBeforeUtxow
-        , tx
+        , stAnnTx
         )
   pure $ LedgerState utxoStateFinal certStateAfterCERTS
 
@@ -504,7 +511,7 @@ instance
   , Script era ~ AlonzoScript era
   , TxOut era ~ BabbageTxOut era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , PredicateFailure (EraRule "UTXOW" era) ~ DijkstraUtxowPredFailure era
   , Event (EraRule "UTXOW" era) ~ AlonzoUtxowEvent era
   , STS (DijkstraUTXOW era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -154,13 +154,13 @@ instance
   , Show (PredicateFailure (EraRule "UTXOW" era))
   , Show (PredicateFailure (EraRule "SUBLEDGERS" era))
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Tx TopTx era ~ Signal (EraRule "LEDGER" era)
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , EraRuleFailure "SUBLEDGERS" era ~ DijkstraSubLedgersPredFailure era
   ) =>
   STS (DijkstraMEMPOOL era)
   where
   type State (DijkstraMEMPOOL era) = LedgerState era
-  type Signal (DijkstraMEMPOOL era) = Tx TopTx era
+  type Signal (DijkstraMEMPOOL era) = StAnnTx TopTx era
   type Environment (DijkstraMEMPOOL era) = LedgerEnv era
   type BaseM (DijkstraMEMPOOL era) = ShelleyBase
   type PredicateFailure (DijkstraMEMPOOL era) = DijkstraMempoolPredFailure era
@@ -174,12 +174,13 @@ mempoolTransition ::
   , Embed (EraRule "LEDGER" era) (DijkstraMEMPOOL era)
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Tx TopTx era ~ Signal (EraRule "LEDGER" era)
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
   TransitionRule (DijkstraMEMPOOL era)
 mempoolTransition = do
-  TRC trc@(_ledgerEnv, ledgerState, tx) <-
+  TRC trc@(_ledgerEnv, ledgerState, stAnnTx) <-
     judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   -- This rule only gets invoked on transactions within the mempool.
   -- Add checks here that sanitize undesired transactions.

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -216,7 +216,7 @@ instance
   STS (DijkstraSUBLEDGER era)
   where
   type State (DijkstraSUBLEDGER era) = LedgerState era
-  type Signal (DijkstraSUBLEDGER era) = Tx SubTx era
+  type Signal (DijkstraSUBLEDGER era) = StAnnTx SubTx era
   type Environment (DijkstraSUBLEDGER era) = SubLedgerEnv era
   type BaseM (DijkstraSUBLEDGER era) = ShelleyBase
   type PredicateFailure (DijkstraSUBLEDGER era) = DijkstraSubLedgerPredFailure era
@@ -256,10 +256,11 @@ dijkstraSubLedgersTransition = do
   TRC
     ( SubLedgerEnv slot mbCurEpochNo _ pp chainAccountState scriptsProvided originalUtxo topIsValid
       , ledgerState@(LedgerState utxoState certState)
-      , tx
+      , stAnnTx
       ) <-
     judgmentContext
 
+  let tx = stAnnTx ^. txStAnnTxG
   curEpochNo <- maybe (liftSTS $ epochFromSlot slot) pure mbCurEpochNo
   let txBody = tx ^. bodyTxL
   let govState = utxoState ^. utxosGovStateL
@@ -305,7 +306,7 @@ dijkstraSubLedgersTransition = do
       TRC
         ( SubUtxoEnv slot pp certState scriptsProvided originalUtxo topIsValid
         , utxoState
-        , tx
+        , stAnnTx
         )
   pure $
     ledgerState

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedgers.hs
@@ -46,11 +46,9 @@ import Cardano.Ledger.Shelley.Rules (
   PoolEvent,
   ShelleyPoolPredFailure,
  )
-import Cardano.Ledger.TxIn (TxId)
 import Control.DeepSeq (NFData)
 import Control.Monad (foldM)
 import Control.State.Transition.Extended
-import Data.OMap.Strict (OMap)
 import GHC.Generics (Generic)
 
 newtype DijkstraSubLedgersPredFailure era
@@ -115,7 +113,7 @@ instance
   STS (DijkstraSUBLEDGERS era)
   where
   type State (DijkstraSUBLEDGERS era) = LedgerState era
-  type Signal (DijkstraSUBLEDGERS era) = OMap TxId (Tx SubTx era)
+  type Signal (DijkstraSUBLEDGERS era) = [StAnnTx SubTx era]
   type Environment (DijkstraSUBLEDGERS era) = SubLedgerEnv era
   type BaseM (DijkstraSUBLEDGERS era) = ShelleyBase
   type PredicateFailure (DijkstraSUBLEDGERS era) = DijkstraSubLedgersPredFailure era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -231,7 +231,7 @@ instance
   STS (DijkstraSUBUTXO era)
   where
   type State (DijkstraSUBUTXO era) = UTxOState era
-  type Signal (DijkstraSUBUTXO era) = Tx SubTx era
+  type Signal (DijkstraSUBUTXO era) = StAnnTx SubTx era
   type Environment (DijkstraSUBUTXO era) = SubUtxoEnv era
   type BaseM (DijkstraSUBUTXO era) = ShelleyBase
   type PredicateFailure (DijkstraSUBUTXO era) = DijkstraSubUtxoPredFailure era
@@ -256,8 +256,9 @@ dijkstraSubUtxoTransition ::
   ) =>
   TransitionRule (EraRule "SUBUTXO" era)
 dijkstraSubUtxoTransition = do
-  TRC (SubUtxoEnv slot pp certState _ originalUtxo (IsValid isValid), utxoState, tx) <-
+  TRC (SubUtxoEnv slot pp certState _ originalUtxo (IsValid isValid), utxoState, stAnnTx) <-
     judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   let txBody = tx ^. bodyTxL
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -210,7 +210,7 @@ instance
   STS (DijkstraSUBUTXOW era)
   where
   type State (DijkstraSUBUTXOW era) = UTxOState era
-  type Signal (DijkstraSUBUTXOW era) = Tx SubTx era
+  type Signal (DijkstraSUBUTXOW era) = StAnnTx SubTx era
   type Environment (DijkstraSUBUTXOW era) = SubUtxoEnv era
   type BaseM (DijkstraSUBUTXOW era) = ShelleyBase
   type PredicateFailure (DijkstraSUBUTXOW era) = DijkstraSubUtxowPredFailure era
@@ -269,9 +269,10 @@ dijkstraSubUtxowTransition ::
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
 dijkstraSubUtxowTransition = do
-  TRC (env@(SubUtxoEnv _ pp certState scriptsProvided originalUtxo _), utxoState, tx) <-
+  TRC (env@(SubUtxoEnv _ pp certState scriptsProvided originalUtxo _), utxoState, stAnnTx) <-
     judgmentContext
-  let txBody = tx ^. bodyTxL
+  let tx = stAnnTx ^. txStAnnTxG
+      txBody = tx ^. bodyTxL
       witsKeyHashes = keyHashWitnessesTxWits (tx ^. witsTxL)
 
   {- ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes txId) σ -}
@@ -305,7 +306,7 @@ dijkstraSubUtxowTransition = do
 
   runTest $ validateGuardDatums scriptsProvided txBody
 
-  trans @(EraRule "SUBUTXO" era) $ TRC (env, utxoState, tx)
+  trans @(EraRule "SUBUTXO" era) $ TRC (env, utxoState, stAnnTx)
 
 instance
   ( STS (DijkstraSUBUTXO era)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -356,19 +356,21 @@ dijkstraUtxoTransition ::
   , InjectRuleFailure "UTXO" DijkstraUtxoPredFailure era
   , Environment (EraRule "UTXO" era) ~ DijkstraUtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
   , STS (EraRule "UTXO" era)
   , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
   , -- In this function we call the UTXOS rule, so we need some assumptions
     Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
   , State (EraRule "UTXOS" era) ~ ()
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
   ) =>
   TransitionRule (EraRule "UTXO" era)
 dijkstraUtxoTransition = do
-  TRC (DijkstraUtxoEnv slot pp certState originalUtxo _scriptsProvided, utxos, tx) <- judgmentContext
+  TRC (DijkstraUtxoEnv slot pp certState originalUtxo _scriptsProvided, utxos, stAnnTx) <-
+    judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
   -- this is the original Accounts, before any transactions were applied
   let accounts = certState ^. certDStateL . accountsL
 
@@ -442,7 +444,7 @@ dijkstraUtxoTransition = do
   {- ‖collateral tx‖ ≤ maxCollInputs pp -}
   runTest $ Alonzo.validateTooManyCollateralInputs pp txBody
 
-  () <- trans @(EraRule "UTXOS" era) $ TRC (ConwayUtxosEnv pp originalUtxo, (), tx)
+  () <- trans @(EraRule "UTXOS" era) $ TRC (ConwayUtxosEnv pp originalUtxo, (), stAnnTx)
   updateUTxOStateByTxValidity
     pp
     certState
@@ -470,14 +472,14 @@ instance
   , InjectRuleFailure "UTXO" DijkstraUtxoPredFailure era
   , Environment (EraRule "UTXO" era) ~ DijkstraUtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
   , STS (EraRule "UTXO" era)
   , -- In this function we we call the UTXOS rule, so we need some assumptions
     Embed (EraRule "UTXOS" era) (DijkstraUTXO era)
   , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
   , State (EraRule "UTXOS" era) ~ ()
-  , Signal (EraRule "UTXOS" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , EraCertState era
   , EraRule "UTXO" era ~ DijkstraUTXO era
   , SafeToHash (TxWits era)
@@ -485,7 +487,7 @@ instance
   STS (DijkstraUTXO era)
   where
   type State (DijkstraUTXO era) = UTxOState era
-  type Signal (DijkstraUTXO era) = Tx TopTx era
+  type Signal (DijkstraUTXO era) = StAnnTx TopTx era
   type Environment (DijkstraUTXO era) = DijkstraUtxoEnv era
   type BaseM (DijkstraUTXO era) = ShelleyBase
   type PredicateFailure (DijkstraUTXO era) = DijkstraUtxoPredFailure era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -246,11 +246,12 @@ dijkstraUtxowTransition ::
     Embed (EraRule "UTXO" era) (DijkstraUTXOW era)
   , Environment (EraRule "UTXO" era) ~ DijkstraUtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   ) =>
   TransitionRule (EraRule "UTXOW" era)
 dijkstraUtxowTransition = do
-  TRC (DijkstraUtxoEnv slot pp certState originalUtxo scriptsProvided, u, tx) <- judgmentContext
+  TRC (DijkstraUtxoEnv slot pp certState originalUtxo scriptsProvided, u, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   let txBody = tx ^. bodyTxL
       subTxs = OMap.elems $ txBody ^. subTransactionsTxBodyL
@@ -331,7 +332,7 @@ dijkstraUtxowTransition = do
 
   -- Pass through to UTXO sub-rule, carrying the original UTxO and scriptsProvided
   trans @(EraRule "UTXO" era) $
-    TRC (DijkstraUtxoEnv slot pp certState originalUtxo scriptsProvided, u, tx)
+    TRC (DijkstraUtxoEnv slot pp certState originalUtxo scriptsProvided, u, stAnnTx)
 
 instance
   forall era.
@@ -349,14 +350,14 @@ instance
     Embed (EraRule "UTXO" era) (DijkstraUTXOW era)
   , Environment (EraRule "UTXO" era) ~ DijkstraUtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , Eq (PredicateFailure (EraRule "UTXOS" era))
   , Show (PredicateFailure (EraRule "UTXOS" era))
   ) =>
   STS (DijkstraUTXOW era)
   where
   type State (DijkstraUTXOW era) = UTxOState era
-  type Signal (DijkstraUTXOW era) = Tx TopTx era
+  type Signal (DijkstraUTXOW era) = StAnnTx TopTx era
   type Environment (DijkstraUTXOW era) = DijkstraUtxoEnv era
   type BaseM (DijkstraUTXOW era) = ShelleyBase
   type PredicateFailure (DijkstraUTXOW era) = DijkstraUtxowPredFailure era

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -49,9 +49,9 @@ instance ApplyTx MaryEra where
 
   mkStAnnTx _ _ _ _ = id
 
-  applyTxValidation validationPolicy globals env state tx =
+  applyTxValidation validationPolicy globals env state stAnnTx =
     first MaryApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx
+      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
 
 instance ApplyTick MaryEra
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.19.0.0
 
 * Change `applyTxValidation` and `ruleApplyTxValidation` to take `StAnnTx TopTx era` instead of `Tx TopTx era`
+* Change `Signal` to `StAnnTx TopTx era` for: `ShelleyLEDGER`, `ShelleyUTXOW`, `ShelleyUTXO`
 * Add `mkStAnnTx` to `ApplyTx`
 * Add `InjectionData`, `foldInjectionData`, `InjectionError` to `Cardano.Ledger.Shelley.Genesis`
 * Add `ShelleyExtraConfig` type to `Cardano.Ledger.Shelley.Genesis`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Change `applyTxValidation` and `ruleApplyTxValidation` to take `StAnnTx TopTx era` instead of `Tx TopTx era`
 * Add `mkStAnnTx` to `ApplyTx`
 * Add `InjectionData`, `foldInjectionData`, `InjectionError` to `Cardano.Ledger.Shelley.Genesis`
 * Add `ShelleyExtraConfig` type to `Cardano.Ledger.Shelley.Genesis`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -37,18 +37,18 @@ module Cardano.Ledger.Shelley.API.Mempool (
   overNewEpochState,
 ) where
 
-import Cardano.Ledger.BaseTypes (Globals, ShelleyBase)
+import Cardano.Ledger.BaseTypes (Globals, ShelleyBase, epochInfo, systemStart)
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Rules.ValidationMode (lblStatic)
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Core (EraGov)
+import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.LedgerState (NewEpochState, curPParamsEpochStateL)
 import qualified Cardano.Ledger.Shelley.LedgerState as LedgerState
-import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv, ShelleyLedgerPredFailure)
+import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv, ShelleyLedgerPredFailure, ledgerPpL)
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
 import Cardano.Ledger.Slot (SlotNo)
-import Cardano.Ledger.State (UTxO)
+import Cardano.Ledger.State (UTxO, utxoG)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
 import Control.DeepSeq (NFData)
@@ -114,32 +114,33 @@ class
     Tx TopTx era ->
     StAnnTx TopTx era
 
-  -- | Validate a transaction against a mempool state and for given STS options,
-  -- and return the new mempool state, a "validated" 'TxInBlock' and,
+  -- | Validate a state annotated transaction against a mempool state for given STS
+  -- options, and return the new mempool state, a "validated" 'TxInBlock' and,
   -- depending on the passed options, the emitted events.
   applyTxValidation ::
     ValidationPolicy ->
     Globals ->
     MempoolEnv era ->
     MempoolState era ->
-    Tx TopTx era ->
+    StAnnTx TopTx era ->
     Either (ApplyTxError era) (MempoolState era, Validated (Tx TopTx era))
 
 ruleApplyTxValidation ::
   forall rule era.
-  ( STS (EraRule rule era)
+  ( EraTx era
+  , STS (EraRule rule era)
   , BaseM (EraRule rule era) ~ ShelleyBase
   , Environment (EraRule rule era) ~ LedgerEnv era
   , State (EraRule rule era) ~ MempoolState era
-  , Signal (EraRule rule era) ~ Tx TopTx era
+  , Signal (EraRule rule era) ~ StAnnTx TopTx era
   ) =>
   ValidationPolicy ->
   Globals ->
   MempoolEnv era ->
   MempoolState era ->
-  Tx TopTx era ->
+  StAnnTx TopTx era ->
   Either (NonEmpty (PredicateFailure (EraRule rule era))) (MempoolState era, Validated (Tx TopTx era))
-ruleApplyTxValidation validationPolicy globals env state tx =
+ruleApplyTxValidation validationPolicy globals env state stAnnTx =
   let opts =
         ApplySTSOpts
           { asoAssertions = globalAssertionPolicy
@@ -149,8 +150,8 @@ ruleApplyTxValidation validationPolicy globals env state tx =
       result =
         flip runReader globals
           . applySTSOptsEither @(EraRule rule era) opts
-          $ TRC (env, state, tx)
-   in fmap (,Validated tx) result
+          $ TRC (env, state, stAnnTx)
+   in fmap (,Validated (stAnnTx ^. txStAnnTxG)) result
 
 instance ApplyTx ShelleyEra where
   newtype ApplyTxError ShelleyEra = ShelleyApplyTxError (NonEmpty (ShelleyLedgerPredFailure ShelleyEra))
@@ -159,9 +160,9 @@ instance ApplyTx ShelleyEra where
 
   mkStAnnTx _ _ _ _ = id
 
-  applyTxValidation validationPolicy globals env state tx =
+  applyTxValidation validationPolicy globals env state stAnnTx =
     first ShelleyApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state tx
+      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
 
 type MempoolEnv era = Ledger.LedgerEnv era
 
@@ -236,7 +237,15 @@ applyTx ::
   MempoolState era ->
   Tx TopTx era ->
   Either (ApplyTxError era) (MempoolState era, Validated (Tx TopTx era))
-applyTx = applyTxValidation ValidateAll
+applyTx globals env state tx =
+  let stAnnTx =
+        mkStAnnTx
+          (epochInfo globals)
+          (systemStart globals)
+          (env ^. ledgerPpL)
+          (state ^. utxoG)
+          tx
+   in applyTxValidation ValidateAll globals env state stAnnTx
 
 -- | Reapply a previously validated 'Tx'.
 --
@@ -249,7 +258,17 @@ reapplyTx ::
   Globals ->
   MempoolEnv era ->
   MempoolState era ->
+  -- TODO: change to `Validated (StAnnTx TopTx era)` once we return this from `applyTx`
   Validated (Tx TopTx era) ->
   Either (ApplyTxError era) (MempoolState era)
 reapplyTx globals env state (Validated tx) =
-  fst <$> applyTxValidation (ValidateSuchThat (notElem lblStatic)) globals env state tx
+  -- TODO: replace `stAnnTx` creation with the argument,
+  -- once the signature is changed to take `Validated (StAnnTx TopTx era)`
+  let stAnnTx =
+        mkStAnnTx
+          (epochInfo globals)
+          (systemStart globals)
+          (env ^. ledgerPpL)
+          (state ^. utxoG)
+          tx
+   in fst <$> applyTxValidation (ValidateSuchThat (notElem lblStatic)) globals env state stAnnTx

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledger.hs
@@ -275,7 +275,7 @@ instance
   , Embed (EraRule "UTXOW" era) (ShelleyLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
   , State (EraRule "DELEGS" era) ~ CertState era
   , Signal (EraRule "DELEGS" era) ~ Seq (TxCert era)
@@ -287,7 +287,7 @@ instance
   STS (ShelleyLEDGER era)
   where
   type State (ShelleyLEDGER era) = LedgerState era
-  type Signal (ShelleyLEDGER era) = Tx TopTx era
+  type Signal (ShelleyLEDGER era) = StAnnTx TopTx era
   type Environment (ShelleyLEDGER era) = LedgerEnv era
   type BaseM (ShelleyLEDGER era) = ShelleyBase
   type PredicateFailure (ShelleyLEDGER era) = ShelleyLedgerPredFailure era
@@ -312,14 +312,15 @@ ledgerTransition ::
   , Embed (EraRule "UTXOW" era) (ShelleyLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , EraRule "LEDGER" era ~ ShelleyLEDGER era
   , InjectRuleFailure "LEDGER" ShelleyLedgerPredFailure era
   ) =>
   TransitionRule (ShelleyLEDGER era)
 ledgerTransition = do
-  TRC (LedgerEnv slot mbCurEpochNo txIx pp account, LedgerState utxoSt certState, tx) <-
+  TRC (LedgerEnv slot mbCurEpochNo txIx pp account, LedgerState utxoSt certState, stAnnTx) <-
     judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
   curEpochNo <- maybe (liftSTS $ epochFromSlot slot) pure mbCurEpochNo
   let withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
   testIncompleteAndMissingWithdrawals (certState ^. certDStateL . accountsL) withdrawals
@@ -336,7 +337,7 @@ ledgerTransition = do
       TRC
         ( UtxoEnv slot pp certState
         , utxoSt
-        , tx
+        , stAnnTx
         )
   pure (LedgerState utxoSt' certState')
 
@@ -388,47 +389,48 @@ renderDepositEqualsObligationViolation ::
   , EraGov era
   , EraCertState era
   , Environment t ~ LedgerEnv era
-  , Signal t ~ Tx TopTx era
+  , Signal t ~ StAnnTx TopTx era
   , State t ~ LedgerState era
   ) =>
   AssertionViolation t ->
   String
 renderDepositEqualsObligationViolation
-  AssertionViolation {avSTS, avMsg, avCtx = TRC (LedgerEnv slot _ _ pp _, _, tx), avState} =
-    case avState of
-      Nothing -> "\nAssertionViolation " ++ avSTS ++ " " ++ avMsg ++ " (avState is Nothing)."
-      Just lstate
-        | avMsg == "Deposit pot must equal obligation (LEDGER)" ->
-            let certstate = lsCertState lstate
-                utxoSt = lsUTxOState lstate
-                utxo = utxosUtxo utxoSt
-                txb = tx ^. bodyTxL
-                pot = utxoSt ^. utxosDepositedL
-             in "\n\nAssertionViolation ("
-                  <> avSTS
-                  <> ")\n\n  "
-                  <> avMsg
-                  <> "\n\nCERTS\n"
-                  <> showTxCerts txb
-                  <> "\n(slot,keyDeposit,poolDeposit) "
-                  <> show (slot, pp ^. ppKeyDepositL, pp ^. ppPoolDepositL)
-                  <> "\nThe Pot (utxosDeposited) = "
-                  <> show pot
-                  <> "\n"
-                  <> show (allObligations certstate (utxosGovState utxoSt))
-                  <> "\nConsumed = "
-                  <> show (consumedTxBody txb pp certstate utxo)
-                  <> "\nProduced = "
-                  <> show (producedTxBody txb pp certstate)
-        | avMsg == "Reverse stake pool delegations must match" ->
-            case calculateDelegatorsPerStakePool (lsCertState lstate) of
-              (reverseDelegatorsPerStakePool, delegatorsPerStakePool) ->
-                avMsg
-                  <> "\nReverse Delegations: \n  "
-                  <> show reverseDelegatorsPerStakePool
-                  <> "\nForward Delegations:\n  "
-                  <> show delegatorsPerStakePool
-        | otherwise -> error $ "Unexpected assertion message: " <> avMsg
+  AssertionViolation {avSTS, avMsg, avCtx = TRC (LedgerEnv slot _ _ pp _, _, stAnnTx), avState} =
+    let tx = stAnnTx ^. txStAnnTxG
+     in case avState of
+          Nothing -> "\nAssertionViolation " ++ avSTS ++ " " ++ avMsg ++ " (avState is Nothing)."
+          Just lstate
+            | avMsg == "Deposit pot must equal obligation (LEDGER)" ->
+                let certstate = lsCertState lstate
+                    utxoSt = lsUTxOState lstate
+                    utxo = utxosUtxo utxoSt
+                    txb = tx ^. bodyTxL
+                    pot = utxoSt ^. utxosDepositedL
+                 in "\n\nAssertionViolation ("
+                      <> avSTS
+                      <> ")\n\n  "
+                      <> avMsg
+                      <> "\n\nCERTS\n"
+                      <> showTxCerts txb
+                      <> "\n(slot,keyDeposit,poolDeposit) "
+                      <> show (slot, pp ^. ppKeyDepositL, pp ^. ppPoolDepositL)
+                      <> "\nThe Pot (utxosDeposited) = "
+                      <> show pot
+                      <> "\n"
+                      <> show (allObligations certstate (utxosGovState utxoSt))
+                      <> "\nConsumed = "
+                      <> show (consumedTxBody txb pp certstate utxo)
+                      <> "\nProduced = "
+                      <> show (producedTxBody txb pp certstate)
+            | avMsg == "Reverse stake pool delegations must match" ->
+                case calculateDelegatorsPerStakePool (lsCertState lstate) of
+                  (reverseDelegatorsPerStakePool, delegatorsPerStakePool) ->
+                    avMsg
+                      <> "\nReverse Delegations: \n  "
+                      <> show reverseDelegatorsPerStakePool
+                      <> "\nForward Delegations:\n  "
+                      <> show delegatorsPerStakePool
+            | otherwise -> error $ "Unexpected assertion message: " <> avMsg
 
 calculateDelegatorsPerStakePool ::
   EraCertState era =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -22,12 +22,13 @@ module Cardano.Ledger.Shelley.Rules.Ledgers (
   PredicateFailure,
 ) where
 
-import Cardano.Ledger.BaseTypes (EpochNo, ShelleyBase)
+import Cardano.Ledger.BaseTypes (EpochNo, ShelleyBase, epochInfo, systemStart)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
 import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Era (ShelleyEra, ShelleyLEDGERS)
-import Cardano.Ledger.Shelley.LedgerState (ChainAccountState, LedgerState)
+import Cardano.Ledger.Shelley.LedgerState (ChainAccountState, LedgerState (..), UTxOState (..))
 import Cardano.Ledger.Shelley.Rules.Deleg (ShelleyDelegPredFailure)
 import Cardano.Ledger.Shelley.Rules.Delegs (ShelleyDelegsPredFailure)
 import Cardano.Ledger.Shelley.Rules.Delpl (ShelleyDelplPredFailure)
@@ -44,12 +45,14 @@ import Cardano.Ledger.Shelley.Rules.Utxow (ShelleyUtxowPredFailure)
 import Cardano.Ledger.Slot (SlotNo)
 import Control.DeepSeq (NFData)
 import Control.Monad (foldM)
+import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition (
   Embed (..),
   STS (..),
   TRC (..),
   TransitionRule,
   judgmentContext,
+  liftSTS,
   trans,
  )
 import Data.Default (Default)
@@ -157,7 +160,7 @@ instance
   decCBOR = LedgerFailure <$> decCBOR
 
 instance
-  ( Era era
+  ( ApplyTx era
   , Embed (EraRule "LEDGER" era) (ShelleyLEDGERS era)
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
@@ -177,22 +180,28 @@ instance
 
 ledgersTransition ::
   forall era.
-  ( Embed (EraRule "LEDGER" era) (ShelleyLEDGERS era)
+  ( ApplyTx era
+  , Embed (EraRule "LEDGER" era) (ShelleyLEDGERS era)
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
   ) =>
   TransitionRule (ShelleyLEDGERS era)
 ledgersTransition = do
-  TRC (LedgersEnv slot epochNo pp account, ls, txwits) <- judgmentContext
+  TRC (LedgersEnv slot epochNo pp account, ls, txs) <- judgmentContext
+  ei <- liftSTS $ asks epochInfo
+  sysStart <- liftSTS $ asks systemStart
   foldM
     ( \ !ls' (ix, tx) ->
-        trans @(EraRule "LEDGER" era) $
-          TRC (LedgerEnv slot (Just epochNo) ix pp account, ls', tx)
+        -- build the annotations against the same utxo snapshot that the rule will validate against
+        let utxo = utxosUtxo (lsUTxOState ls')
+            stAnnTx = mkStAnnTx ei sysStart pp utxo tx
+         in trans @(EraRule "LEDGER" era) $
+              TRC (LedgerEnv slot (Just epochNo) ix pp account, ls', stAnnTx)
     )
     ls
     $ zip [minBound ..]
-    $ toList txwits
+    $ toList txs
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -27,6 +27,7 @@ import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
+import Cardano.Ledger.Shelley.Core (EraGov)
 import Cardano.Ledger.Shelley.Era (ShelleyEra, ShelleyLEDGERS)
 import Cardano.Ledger.Shelley.LedgerState (ChainAccountState, LedgerState (..), UTxOState (..))
 import Cardano.Ledger.Shelley.Rules.Deleg (ShelleyDelegPredFailure)
@@ -43,6 +44,7 @@ import Cardano.Ledger.Shelley.Rules.Ppup (ShelleyPpupPredFailure)
 import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoPredFailure)
 import Cardano.Ledger.Shelley.Rules.Utxow (ShelleyUtxowPredFailure)
 import Cardano.Ledger.Slot (SlotNo)
+import Cardano.Ledger.State (CertState, EraStake)
 import Control.DeepSeq (NFData)
 import Control.Monad (foldM)
 import Control.Monad.Trans.Reader (asks)
@@ -161,10 +163,13 @@ instance
 
 instance
   ( ApplyTx era
+  , EraGov era
+  , EraStake era
+  , Default (CertState era)
   , Embed (EraRule "LEDGER" era) (ShelleyLEDGERS era)
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , Default (LedgerState era)
   ) =>
   STS (ShelleyLEDGERS era)
@@ -181,10 +186,13 @@ instance
 ledgersTransition ::
   forall era.
   ( ApplyTx era
+  , EraGov era
+  , EraStake era
+  , Default (CertState era)
   , Embed (EraRule "LEDGER" era) (ShelleyLEDGERS era)
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
   TransitionRule (ShelleyLEDGERS era)
 ledgersTransition = do

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -281,7 +281,7 @@ instance
   STS (ShelleyUTXO era)
   where
   type State (ShelleyUTXO era) = UTxOState era
-  type Signal (ShelleyUTXO era) = Tx TopTx era
+  type Signal (ShelleyUTXO era) = StAnnTx TopTx era
   type Environment (ShelleyUTXO era) = UtxoEnv era
   type BaseM (ShelleyUTXO era) = ShelleyBase
   type PredicateFailure (ShelleyUTXO era) = ShelleyUtxoPredFailure era
@@ -293,22 +293,23 @@ instance
     AssertionViolation
       { avSTS
       , avMsg
-      , avCtx = TRC (UtxoEnv _slot pp certState, UTxOState {utxosDeposited, utxosUtxo}, tx)
+      , avCtx = TRC (UtxoEnv _slot pp certState, UTxOState {utxosDeposited, utxosUtxo}, stAnnTx)
       } =
-      "AssertionViolation ("
-        <> avSTS
-        <> "): "
-        <> avMsg
-        <> "\n PParams\n"
-        <> show pp
-        <> "\n Certs\n"
-        <> showTxCerts (tx ^. bodyTxL)
-        <> "\n Deposits\n"
-        <> show utxosDeposited
-        <> "\n Consumed\n"
-        <> show (consumedTxBody (tx ^. bodyTxL) pp certState utxosUtxo)
-        <> "\n Produced\n"
-        <> show (producedTxBody (tx ^. bodyTxL) pp certState)
+      let tx = stAnnTx ^. txStAnnTxG
+       in "AssertionViolation ("
+            <> avSTS
+            <> "): "
+            <> avMsg
+            <> "\n PParams\n"
+            <> show pp
+            <> "\n Certs\n"
+            <> showTxCerts (tx ^. bodyTxL)
+            <> "\n Deposits\n"
+            <> show utxosDeposited
+            <> "\n Consumed\n"
+            <> show (consumedTxBody (tx ^. bodyTxL) pp certState utxosUtxo)
+            <> "\n Produced\n"
+            <> show (producedTxBody (tx ^. bodyTxL) pp certState)
 
   assertions =
     [ PreCondition
@@ -325,8 +326,9 @@ instance
           withdrawals txb = Val.inject $ F.foldl' (<>) mempty $ unWithdrawals $ txb ^. withdrawalsTxBodyL
        in PostCondition
             "Should preserve value in the UTxO state"
-            ( \(TRC (_, us, tx)) us' ->
-                utxoBalance us <> withdrawals (tx ^. bodyTxL) == utxoBalance us'
+            ( \(TRC (_, us, stAnnTx)) us' ->
+                let tx = stAnnTx ^. txStAnnTxG
+                 in utxoBalance us <> withdrawals (tx ^. bodyTxL) == utxoBalance us'
             )
     , validSizeComputationCheck @era
     ]
@@ -343,7 +345,7 @@ utxoInductive ::
   , BaseM (EraRule "UTXO" era) ~ ShelleyBase
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , Event (EraRule "UTXO" era) ~ UtxoEvent era
   , Environment (EraRule "PPUP" era) ~ PpupEnv era
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
@@ -353,8 +355,9 @@ utxoInductive ::
   ) =>
   TransitionRule (EraRule "UTXO" era)
 utxoInductive = do
-  TRC (UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
-  let utxo = utxos ^. utxoL
+  TRC (UtxoEnv slot pp certState, utxos, stAnnTx) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
+      utxo = utxos ^. utxoL
       UTxOState _ _ _ ppup _ _ = utxos
       txBody = tx ^. bodyTxL
       outputs = txBody ^. outputsTxBodyL
@@ -652,12 +655,13 @@ instance
 validSizeComputationCheck ::
   ( EraTx era
   , SafeToHash (TxWits era)
-  , Signal (rule era) ~ Tx TopTx era
+  , Signal (rule era) ~ StAnnTx TopTx era
   ) =>
   Assertion (rule era)
 validSizeComputationCheck =
   PreCondition
     "Tx size should be the length of the serialization bytestring"
-    ( \(TRC (_, _, tx)) ->
-        tx ^. sizeTxF == sizeTxForFeeCalculation tx
+    ( \(TRC (_, _, stAnnTx)) ->
+        let tx = stAnnTx ^. txStAnnTxG
+         in tx ^. sizeTxF == sizeTxForFeeCalculation tx
     )

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -277,17 +277,18 @@ transitionRulesUTXOW ::
   , Embed (EraRule "UTXO" era) (EraRule "UTXOW" era)
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure era
   , STS (EraRule "UTXOW" era)
   , EraCertState era
   ) =>
   TransitionRule (EraRule "UTXOW" era)
 transitionRulesUTXOW = do
-  (TRC (utxoEnv@(UtxoEnv _ pp certState), u, tx)) <- judgmentContext
+  (TRC (utxoEnv@(UtxoEnv _ pp certState), u, stAnnTx)) <- judgmentContext
+  let tx = stAnnTx ^. txStAnnTxG
 
   {-  (utxo,_,_,_ ) := utxoSt  -}
   {-  witsKeyHashes := { hashKey vk | vk ∈ dom(txwitsVKey txw) }  -}
@@ -323,7 +324,7 @@ transitionRulesUTXOW = do
   runTest $
     validateMIRInsufficientGenesisSigs genDelegs coreNodeQuorum witsKeyHashes tx
 
-  trans @(EraRule "UTXO" era) $ TRC (utxoEnv, u, tx)
+  trans @(EraRule "UTXO" era) $ TRC (utxoEnv, u, stAnnTx)
 
 instance
   ( Era era
@@ -345,7 +346,7 @@ instance
     Embed (EraRule "UTXO" era) (ShelleyUTXOW era)
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
   , State (EraRule "UTXO" era) ~ UTxOState era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   , EraRule "UTXOW" era ~ ShelleyUTXOW era
   , InjectRuleFailure "UTXOW" ShelleyUtxowPredFailure era
   , EraGov era
@@ -354,7 +355,7 @@ instance
   STS (ShelleyUTXOW era)
   where
   type State (ShelleyUTXOW era) = UTxOState era
-  type Signal (ShelleyUTXOW era) = Tx TopTx era
+  type Signal (ShelleyUTXOW era) = StAnnTx TopTx era
   type Environment (ShelleyUTXOW era) = UtxoEnv era
   type BaseM (ShelleyUTXOW era) = ShelleyBase
   type PredicateFailure (ShelleyUTXOW era) = ShelleyUtxowPredFailure era

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -198,6 +198,7 @@ import Cardano.Ledger.Keys (
  )
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.API.ByronTranslation (translateToShelleyLedgerStateFromUtxo)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.API.Validation (
   ApplyBlock,
   BlockTransitionError (..),
@@ -218,12 +219,14 @@ import Cardano.Ledger.Shelley.LedgerState (
   curPParamsEpochStateL,
   esLStateL,
   lsCertStateL,
+  lsUTxOState,
   lsUTxOStateL,
   nesELL,
   nesEsL,
   prevPParamsEpochStateL,
   produced,
   utxosDonationL,
+  utxosUtxo,
  )
 import Cardano.Ledger.Shelley.Rules (
   BbodyEnv (..),
@@ -234,6 +237,7 @@ import Cardano.Ledger.Shelley.Rules (
   ShelleyUtxoPredFailure,
   ShelleyUtxowPredFailure,
   epochFromSlot,
+  ledgerPpL,
  )
 import Cardano.Ledger.Shelley.Scripts (
   ShelleyEraScript,
@@ -441,6 +445,7 @@ impRecordedTxsL = lens impRecordedTxs (\x y -> x {impRecordedTxs = y})
 
 class
   ( ShelleyEraTest era
+  , ApplyTx era
   , -- For the BBODY rule
     STS (EraRule "BBODY" era)
   , BaseM (EraRule "BBODY" era) ~ ShelleyBase
@@ -463,7 +468,7 @@ class
   , -- For the LEDGER rule
     STS (EraRule "LEDGER" era)
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , Eq (PredicateFailure (EraRule "LEDGER" era))
@@ -1256,11 +1261,19 @@ trySubmitTx tx = do
 
   st <- gets impNES
   lEnv <- impLedgerEnv st
-  res <- tryRunImpRule @"LEDGER" lEnv (st ^. nesEsL . esLStateL) txFixed
+  globals <- use impGlobalsL
+  let lState = st ^. nesEsL . esLStateL
+      stAnnTx =
+        mkStAnnTx
+          (epochInfo globals)
+          (systemStart globals)
+          (lEnv ^. ledgerPpL)
+          (utxosUtxo (lsUTxOState lState))
+          txFixed
+  res <- tryRunImpRule @"LEDGER" lEnv lState stAnnTx
 
   -- Check for conformance
-  globals <- use impGlobalsL
-  let trc = TRC (lEnv, st ^. nesEsL . esLStateL, txFixed)
+  let trc = TRC (lEnv, lState, stAnnTx)
   asks itePostSubmitTxHook >>= (\f -> f globals trc res)
 
   case res of

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/EraGen.hs
@@ -112,7 +112,7 @@ import Test.QuickCheck (Gen, choose, shuffle)
 type MinLEDGER_STS era =
   ( Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , BaseM (EraRule "LEDGERS" era) ~ ShelleyBase
@@ -136,10 +136,10 @@ type MinUTXO_STS era =
   , BaseM (EraRule "UTXOW" era) ~ ShelleyBase
   , State (EraRule "UTXOW" era) ~ UTxOState era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , State (EraRule "UTXO" era) ~ UTxOState era
   , Environment (EraRule "UTXO" era) ~ UtxoEnv era
-  , Signal (EraRule "UTXO" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXO" era) ~ StAnnTx TopTx era
   )
 
 class Show (TxOut era) => MinGenTxout era where

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
@@ -16,12 +16,15 @@
 
 module Test.Cardano.Ledger.Shelley.Generator.Trace.Ledger where
 
-import Cardano.Ledger.BaseTypes (Globals, TxIx, mkTxIxPartial)
+import Cardano.Ledger.BaseTypes (Globals, TxIx, epochInfo, mkTxIxPartial, systemStart)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   UTxOState,
   genesisState,
+  lsUTxOState,
+  utxosUtxo,
  )
 import Cardano.Ledger.Shelley.Rules (
   DelegsEnv,
@@ -57,6 +60,7 @@ import Test.Cardano.Ledger.Shelley.Generator.Utxo (genTx)
 import Test.Cardano.Ledger.Shelley.Utils (
   applySTSTest,
   runShelleyBase,
+  testGlobals,
  )
 import qualified Test.Control.State.Transition.Trace.Generator.QuickCheck as TQC
 import Test.QuickCheck (Gen)
@@ -72,7 +76,8 @@ genAccountState Constants {minTreasury, maxTreasury, minReserves, maxReserves} =
 -- The LEDGER STS combines utxo and delegation rules and allows for generating transactions
 -- with meaningful delegation certificates.
 instance
-  ( EraGen era
+  ( ApplyTx era
+  , EraGen era
   , EraGov era
   , EraUTxO era
   , EraCertState era
@@ -87,7 +92,7 @@ instance
   , Embed (EraRule "UTXOW" era) (ShelleyLEDGER era)
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Signal (EraRule "UTXOW" era) ~ Tx TopTx era
+  , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Environment (EraRule "DELEGS" era) ~ DelegsEnv era
   , State (EraRule "DELEGS" era) ~ CertState era
   , Signal (EraRule "DELEGS" era) ~ Seq (TxCert era)
@@ -102,7 +107,15 @@ instance
       <$> genEraPParams @era geConstants
       <*> genAccountState geConstants
 
-  sigGen = genTx
+  sigGen ge ledgerEnv@(LedgerEnv _ _ _ pParams _) ls = do
+    tx <- genTx ge ledgerEnv ls
+    pure $
+      mkStAnnTx
+        (epochInfo testGlobals)
+        (systemStart testGlobals)
+        pParams
+        (utxosUtxo (lsUTxOState ls))
+        tx
 
   shrinkSignal _ = [] -- TODO add some kind of Shrinker?
 
@@ -111,6 +124,7 @@ instance
 
 instance
   ( Crypto c
+  , ApplyTx era
   , EraGen era
   , EraGov era
   , EraUTxO era
@@ -156,10 +170,18 @@ instance
           let ledgerEnv = LedgerEnv slotNo (Just epochNo) txIx pParams reserves
           tx <- genTx ge ledgerEnv ls'
 
-          let res =
+          let utxo = utxosUtxo (lsUTxOState ls')
+              stAnnTx =
+                mkStAnnTx
+                  (epochInfo testGlobals)
+                  (systemStart testGlobals)
+                  pParams
+                  utxo
+                  tx
+              res =
                 runShelleyBase $
                   applySTSTest @(EraRule "LEDGER" era)
-                    (TRC (ledgerEnv, ls', tx))
+                    (TRC (ledgerEnv, ls', stAnnTx))
           case res of
             Left pf -> error ("LEDGER sigGen: " <> show pf)
             Right ls'' -> pure (ls'', tx : txs)

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -17,6 +17,7 @@ import Cardano.Ledger.Binary (EncCBORGroup)
 import Cardano.Ledger.Block (BbodySignal)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API (ApplyBlock, ShelleyEraForecast, ShelleyPOOL)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (LedgerState, NewEpochState)
 import Cardano.Ledger.Shelley.Rules (
@@ -63,10 +64,12 @@ import qualified Test.Tasty.QuickCheck as TQC
 
 commonTests ::
   forall era.
-  ( EraGen era
+  ( ApplyTx era
+  , EraGen era
   , EraStake era
   , ShelleyEraAccounts era
   , ApplyBlock TestBlockHeader era
+  , Show (StAnnTx TopTx era)
   , ShelleyEraForecast era
   , Embed (EraRule "BBODY" era) (CHAIN era)
   , Embed (EraRule "TICK" era) (CHAIN era)
@@ -88,7 +91,7 @@ commonTests ::
   , State (EraRule "BBODY" era) ~ ShelleyBbodyState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , Environment (EraRule "TICK" era) ~ ()
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , State (EraRule "LEDGERS" era) ~ LedgerState era
   , Environment (EraRule "BBODY" era) ~ BbodyEnv era
   , Signal (EraRule "TICK" era) ~ SlotNo

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Shelley.API (LedgerState)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Internal (compareAdaPots)
 import Cardano.Ledger.Shelley.LedgerState (
@@ -99,7 +100,8 @@ tests ::
   , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , GovState era ~ ShelleyGovState era
   , State (EraRule "LEDGER" era) ~ LedgerState era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , STS (EraRule "LEDGER" era)
@@ -120,7 +122,8 @@ adaPreservationProps ::
   , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , GovState era ~ ShelleyGovState era
   , State (EraRule "LEDGER" era) ~ LedgerState era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , STS (EraRule "LEDGER" era)
@@ -312,7 +315,8 @@ utxoDepositsIncreaseByFeesWithdrawals ::
   forall era.
   ( ChainProperty era
   , EraGen era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
@@ -356,7 +360,8 @@ potsSumIncreaseWithdrawalsPerTx ::
   ( ChainProperty era
   , EraGen era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , STS (EraRule "LEDGER" era)
@@ -374,13 +379,14 @@ potsSumIncreaseWithdrawalsPerTx SourceSignalTarget {source = chainSt, signal = b
     sumIncreaseWithdrawals
       SourceSignalTarget
         { source = LedgerState UTxOState {utxosUtxo = u, utxosDeposited = d, utxosFees = f} _
-        , signal = tx
+        , signal = stAnnTx
         , target = LedgerState UTxOState {utxosUtxo = u', utxosDeposited = d', utxosFees = f'} _
         } =
-        property (hasFailedScripts tx)
-          .||. (sumCoinUTxO u' <+> d' <+> f')
-            <-> (sumCoinUTxO u <+> d <+> f)
-            === fold (unWithdrawals (tx ^. bodyTxL . withdrawalsTxBodyL))
+        let tx = stAnnTx ^. txStAnnTxG
+         in property (hasFailedScripts tx)
+              .||. (sumCoinUTxO u' <+> d' <+> f')
+                <-> (sumCoinUTxO u <+> d <+> f)
+                === fold (unWithdrawals (tx ^. bodyTxL . withdrawalsTxBodyL))
 
 -- | (Utxo + Deposits + Fees) increases by the reward delta
 potsSumIncreaseByRewardsPerTx ::
@@ -388,7 +394,8 @@ potsSumIncreaseByRewardsPerTx ::
   ( ChainProperty era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , STS (EraRule "LEDGER" era)
   ) =>
@@ -423,7 +430,8 @@ potsRewardsDecreaseByWithdrawalsPerTx ::
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , STS (EraRule "LEDGER" era)
   ) =>
   SourceSignalTarget (CHAIN era) ->
@@ -438,10 +446,11 @@ potsRewardsDecreaseByWithdrawalsPerTx SourceSignalTarget {source = chainSt, sign
     rewardsDecreaseByWithdrawals
       SourceSignalTarget
         { source = LedgerState _ dpstate
-        , signal = tx
+        , signal = stAnnTx
         , target = LedgerState _ dpstate'
         } =
-        let totalRewards = sumAccountsBalances dpstate
+        let tx = stAnnTx ^. txStAnnTxG
+            totalRewards = sumAccountsBalances dpstate
             totalRewards' = sumAccountsBalances dpstate'
             txWithdrawals = fold (unWithdrawals (tx ^. bodyTxL . withdrawalsTxBodyL))
          in conjoin
@@ -462,7 +471,8 @@ preserveBalance ::
   forall era.
   ( ChainProperty era
   , EraGen era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
@@ -479,11 +489,12 @@ preserveBalance SourceSignalTarget {source = chainSt, signal = block} =
     (tickedChainSt, ledgerTr) = ledgerTraceFromBlock @era chainSt block
     pp_ = (view curPParamsEpochStateL . nesEs . chainNes) tickedChainSt
 
-    createdIsConsumed SourceSignalTarget {source = ledgerSt, signal = tx, target = ledgerSt'} =
+    createdIsConsumed SourceSignalTarget {source = ledgerSt, signal = stAnnTx, target = ledgerSt'} =
       counterexample
         "preserveBalance created /= consumed ... "
         (failedScripts .||. ediffEq created consumed_)
       where
+        tx = stAnnTx ^. txStAnnTxG
         failedScripts = property $ hasFailedScripts tx
         LedgerState (UTxOState {utxosUtxo = u}) certState = ledgerSt
         LedgerState (UTxOState {utxosUtxo = u'}) _ = ledgerSt'
@@ -503,7 +514,8 @@ preserveBalanceRestricted ::
   ( ChainProperty era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , STS (EraRule "LEDGER" era)
   ) =>
@@ -521,11 +533,11 @@ preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} 
     createdIsConsumed
       SourceSignalTarget
         { source = LedgerState (UTxOState {utxosUtxo = utxo}) certState
-        , signal = tx
+        , signal = stAnnTx
         } =
         inps === outs
         where
-          txb = tx ^. bodyTxL
+          txb = stAnnTx ^. txStAnnTxG . bodyTxL
           inps =
             sumCoinUTxO @era (txInsFilter utxo (txb ^. inputsTxBodyL))
               <> certsTotalRefundsTxBody pp_ certState txb
@@ -541,7 +553,8 @@ preserveOutputsTx ::
   , EraGen era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , STS (EraRule "LEDGER" era)
   ) =>
@@ -557,9 +570,10 @@ preserveOutputsTx SourceSignalTarget {source = chainSt, signal = block} =
     outputPreserved
       SourceSignalTarget
         { target = LedgerState (UTxOState {utxosUtxo = UTxO utxo}) _
-        , signal = tx
+        , signal = stAnnTx
         } =
-        let UTxO outs = txouts @era (tx ^. bodyTxL)
+        let tx = stAnnTx ^. txStAnnTxG
+            UTxO outs = txouts @era (tx ^. bodyTxL)
          in property $
               hasFailedScripts tx
                 .||. counterexample "TxOuts are not a subset of UTxO" (outs `Map.isSubmapOf` utxo)
@@ -567,7 +581,8 @@ preserveOutputsTx SourceSignalTarget {source = chainSt, signal = block} =
 canRestrictUTxO ::
   forall era.
   ( ChainProperty era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
@@ -612,14 +627,17 @@ withdrawals (Block _ blockBody) =
 txFees ::
   forall era.
   ( EraGen era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   ) =>
   Trace (EraRule "LEDGER" era) ->
   Coin
 txFees ledgerTr =
   foldMap
-    (\sst -> feeOrCollateral @era (signal sst :: Tx TopTx era) (source sst ^. utxoL :: UTxO era))
+    ( \sst ->
+        feeOrCollateral @era (signal sst ^. txStAnnTxG :: Tx TopTx era) (source sst ^. utxoL :: UTxO era)
+    )
     (sourceSignalTargets ledgerTr)
 
 -- | Check that deposits are always non-negative

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/ClassifyTraces.hs
@@ -345,8 +345,9 @@ propAbstractSizeBoundsBytes = property $ do
     (genEnv @era @MockCrypto p defaultConstants)
     genesisLedgerSt
     $ \tr -> do
-      let txs :: [Tx TopTx era]
-          txs = traceSignals OldestFirst tr
+      let stAnnTxs :: [StAnnTx TopTx era]
+          stAnnTxs = traceSignals OldestFirst tr
+          txs = (^. txStAnnTxG) <$> stAnnTxs
       all (\tx -> txSizeBound tx >= numBytes tx) txs
   where
     p :: Proxy era
@@ -379,8 +380,9 @@ propAbstractSizeNotTooBig = property $ do
     (genEnv @era @MockCrypto p defaultConstants)
     genesisLedgerSt
     $ \tr -> do
-      let txs :: [Tx TopTx era]
-          txs = traceSignals OldestFirst tr
+      let stAnnTxs :: [StAnnTx TopTx era]
+          stAnnTxs = traceSignals OldestFirst tr
+          txs = (^. txStAnnTxG) <$> stAnnTxs
       all notTooBig txs
   where
     p :: Proxy era

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/CollisionFreeness.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/CollisionFreeness.hs
@@ -16,6 +16,7 @@ import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Block (blockBody)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Keys (witVKeyHash)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   UTxOState (..),
@@ -68,7 +69,8 @@ tests ::
   , QC.HasTrace (CHAIN era) (GenEnv MockCrypto era)
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , STS (EraRule "LEDGER" era)
   ) =>
   TestTree
@@ -93,7 +95,8 @@ eliminateTxInputs ::
   , EraGen era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , STS (EraRule "LEDGER" era)
   ) =>
@@ -109,11 +112,12 @@ eliminateTxInputs SourceSignalTarget {source = chainSt, signal = block} =
     inputsEliminated
       SourceSignalTarget
         { target = LedgerState (UTxOState {utxosUtxo = (UTxO u')}) _
-        , signal = tx
+        , signal = stAnnTx
         } =
-        property $
-          hasFailedScripts tx
-            || Set.null (Set.intersection (txins @era (tx ^. bodyTxL)) (Map.keysSet u'))
+        let tx = stAnnTx ^. txStAnnTxG
+         in property $
+              hasFailedScripts tx
+                || Set.null (Set.intersection (txins @era (tx ^. bodyTxL)) (Map.keysSet u'))
 
 -- | Collision-Freeness of new TxIds - checks that all new outputs of a Tx are
 -- included in the new UTxO and that all TxIds are new.
@@ -123,7 +127,8 @@ newEntriesAndUniqueTxIns ::
   , EraGen era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , STS (EraRule "LEDGER" era)
   ) =>
@@ -139,10 +144,11 @@ newEntriesAndUniqueTxIns SourceSignalTarget {source = chainSt, signal = block} =
     newEntryPresent
       SourceSignalTarget
         { source = LedgerState (UTxOState {utxosUtxo = UTxO u}) _
-        , signal = tx
+        , signal = stAnnTx
         , target = LedgerState (UTxOState {utxosUtxo = UTxO u'}) _
         } =
-        let UTxO outs = txouts @era (tx ^. bodyTxL)
+        let tx = stAnnTx ^. txStAnnTxG
+            UTxO outs = txouts @era (tx ^. bodyTxL)
             outIds = Set.map (\(TxIn _id _) -> _id) (Map.keysSet outs)
             oldIds = Set.map (\(TxIn _id _) -> _id) (Map.keysSet u)
          in property $
@@ -156,7 +162,8 @@ requiredMSigSignaturesSubset ::
   forall era.
   ( ChainProperty era
   , EraGen era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , BaseM (EraRule "LEDGER" era) ~ ShelleyBase
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
@@ -172,8 +179,9 @@ requiredMSigSignaturesSubset SourceSignalTarget {source = chainSt, signal = bloc
   where
     (_, ledgerTr) = ledgerTraceFromBlock @era chainSt block
     signaturesSubset :: SourceSignalTarget (EraRule "LEDGER" era) -> Property
-    signaturesSubset SourceSignalTarget {signal = tx} =
-      let khs = keyHashSet tx
+    signaturesSubset SourceSignalTarget {signal = stAnnTx} =
+      let tx = stAnnTx ^. txStAnnTxG
+          khs = keyHashSet tx
        in property $
             all (existsReqKeyComb khs) (tx ^. witsTxL . scriptTxWitsL)
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/IncrementalStake.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), Ptr, StakeReference (StakeRefBase, StakeRefPtr))
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
@@ -78,7 +79,8 @@ incrStakeComputationTest ::
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , BaseM (EraRule "LEDGER" era) ~ ReaderT Globals Identity
   , STS (EraRule "LEDGER" era)
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   ) =>
   TestTree
@@ -94,7 +96,8 @@ incrStakeComp ::
   , BaseM (EraRule "LEDGER" era) ~ ReaderT Globals Identity
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , STS (EraRule "LEDGER" era)
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , ApplyTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , ShelleyEraAccounts era
   ) =>
@@ -110,31 +113,32 @@ incrStakeComp SourceSignalTarget {source = chainSt, signal = block} =
     checkIncrStakeComp
       SourceSignalTarget
         { source = LedgerState UTxOState {utxosUtxo = u, utxosInstantStake = is} dp
-        , signal = tx
+        , signal = stAnnTx
         , target = LedgerState UTxOState {utxosUtxo = u', utxosInstantStake = is'} dp'
         } =
-        counterexample
-          ( unlines
-              [ "\nDetails:"
-              , "\ntx"
-              , show tx
-              , "size original utxo"
-              , show (Map.size $ unUTxO u)
-              , "original utxo"
-              , show u
-              , "original instantStake"
-              , show is
-              , "final utxo"
-              , show u'
-              , "final instantStake"
-              , show is'
-              , "original ptrs"
-              , show ptrs
-              , "final ptrs"
-              , show ptrs'
-              ]
-          )
-          $ utxoBalanace === fromCompact instantStakeBalanace
+        let tx = stAnnTx ^. txStAnnTxG
+         in counterexample
+              ( unlines
+                  [ "\nDetails:"
+                  , "\ntx"
+                  , show tx
+                  , "size original utxo"
+                  , show (Map.size $ unUTxO u)
+                  , "original utxo"
+                  , show u
+                  , "original instantStake"
+                  , show is
+                  , "final utxo"
+                  , show u'
+                  , "final instantStake"
+                  , show is'
+                  , "original ptrs"
+                  , show ptrs
+                  , "final ptrs"
+                  , show ptrs'
+                  ]
+              )
+              $ utxoBalanace === fromCompact instantStakeBalanace
         where
           utxoBalanace = sumCoinUTxO u'
           instantStakeBalanace = fold (sisCredentialStake is') <> fold (sisPtrStake is')

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -23,7 +23,7 @@ module Test.Cardano.Ledger.Shelley.Rules.TestChain (
   shortChainTrace,
 ) where
 
-import Cardano.Ledger.BaseTypes (Globals, SlotNo (..))
+import Cardano.Ledger.BaseTypes (Globals, SlotNo (..), epochInfo, systemStart)
 import Cardano.Ledger.Block (
   Block (..),
   neededTxInsForBlock,
@@ -31,6 +31,7 @@ import Cardano.Ledger.Block (
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Ptr (..), SlotNo32 (..))
 import Cardano.Ledger.Shelley.API (ApplyBlock, ShelleyDELEG, ShelleyEraForecast)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
@@ -47,6 +48,7 @@ import Cardano.Ledger.Shelley.Rules (
   PoolEvent,
   ShelleyPOOL,
   ShelleyPoolPredFailure,
+  ledgerPpL,
  )
 import Cardano.Ledger.Shelley.State
 import Cardano.Protocol.TPraos.BHeader (
@@ -141,12 +143,13 @@ shortChainTrace constants f = withMaxSuccess 100 $ forAllChainTrace @era 10 cons
 -- | Reconstruct a LEDGER trace from the transactions in a Block and ChainState
 ledgerTraceFromBlock ::
   forall era.
-  ( ChainProperty era
+  ( ApplyTx era
+  , ChainProperty era
   , STS (EraRule "LEDGER" era)
   , BaseM (EraRule "LEDGER" era) ~ ReaderT Globals Identity
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
   ChainState era ->
   Block (BHeader MockCrypto) era ->
@@ -154,22 +157,29 @@ ledgerTraceFromBlock ::
 ledgerTraceFromBlock chainSt block =
   ( tickedChainSt
   , runShelleyBase $
-      Trace.closure @(EraRule "LEDGER" era) ledgerEnv ledgerSt0 txs
+      Trace.closure @(EraRule "LEDGER" era) ledgerEnv ledgerSt0 stAnnTxs
   )
   where
     (tickedChainSt, ledgerEnv, ledgerSt0, txs) = ledgerTraceBase chainSt block
+    pp_ = ledgerEnv ^. ledgerPpL
+    utxo = utxosUtxo (lsUTxOState ledgerSt0)
+    stAnnTxs =
+      map
+        (mkStAnnTx (epochInfo testGlobals) (systemStart testGlobals) pp_ utxo)
+        txs
 
 -- | This function is nearly the same as ledgerTraceFromBlock, but
 -- it restricts the UTxO state to only those needed by the block.
 -- It also returns the unused UTxO for comparison later.
 ledgerTraceFromBlockWithRestrictedUTxO ::
   forall era.
-  ( ChainProperty era
+  ( ApplyTx era
+  , ChainProperty era
   , STS (EraRule "LEDGER" era)
   , BaseM (EraRule "LEDGER" era) ~ ReaderT Globals Identity
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
   ChainState era ->
   Block (BHeader MockCrypto) era ->
@@ -177,7 +187,7 @@ ledgerTraceFromBlockWithRestrictedUTxO ::
 ledgerTraceFromBlockWithRestrictedUTxO chainSt block =
   ( UTxO irrelevantUTxO
   , runShelleyBase $
-      Trace.closure @(EraRule "LEDGER" era) ledgerEnv ledgerSt0' txs
+      Trace.closure @(EraRule "LEDGER" era) ledgerEnv ledgerSt0' stAnnTxs
   )
   where
     (_tickedChainSt, ledgerEnv, ledgerSt0, txs) = ledgerTraceBase chainSt block
@@ -186,6 +196,11 @@ ledgerTraceFromBlockWithRestrictedUTxO chainSt block =
     utxo = unUTxO . utxosUtxo $ utxoSt
     (relevantUTxO, irrelevantUTxO) = Map.partitionWithKey (const . (`Set.member` txIns)) utxo
     ledgerSt0' = LedgerState (utxoSt {utxosUtxo = UTxO relevantUTxO}) delegationSt
+    pp_ = ledgerEnv ^. ledgerPpL
+    stAnnTxs =
+      map
+        (mkStAnnTx (epochInfo testGlobals) (systemStart testGlobals) pp_ (UTxO relevantUTxO))
+        txs
 
 -- | Reconstruct a POOL trace from the transactions in a Block and ChainState
 poolTraceFromBlock ::

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -13,7 +13,7 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxow () where
 
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Core (EraTx (..))
+import Cardano.Ledger.Conway.Core (EraTx (..), txStAnnTxG)
 import Cardano.Ledger.Conway.TxCert (ConwayTxCert)
 import Cardano.Ledger.Conway.UTxO (getConwayWitsVKeyNeeded)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
@@ -63,7 +63,7 @@ instance
         , "Impl:"
         , "witsVKeyNeeded"
         , PP.pretty . showExpr $
-            getConwayWitsVKeyNeeded @ConwayEra (utxosUtxo st) (sig ^. bodyTxL)
+            getConwayWitsVKeyNeeded @ConwayEra (utxosUtxo st) (sig ^. txStAnnTxG . bodyTxL)
         , "witsVKeyHashes"
         , "Spec:"
         , PP.pretty result

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
@@ -13,6 +13,7 @@
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Ledger () where
 
+import Cardano.Ledger.Alonzo.Tx (AlonzoStAnnTx)
 import Cardano.Ledger.BaseTypes (Inject)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core (
@@ -27,6 +28,7 @@ import Cardano.Ledger.Conway.Core (
   ScriptHash,
   TxLevel (..),
   txIdTx,
+  txStAnnTxG,
  )
 import Cardano.Ledger.Conway.Rules (EnactState)
 import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
@@ -108,3 +110,8 @@ instance SpecTranslate ctx (Tx TopTx ConwayEra) where
       <*> toSpecRep (tx ^. sizeTxF)
       <*> toSpecRep (tx ^. isValidTxL)
       <*> toSpecRep (tx ^. auxDataTxL)
+
+instance SpecTranslate ctx (AlonzoStAnnTx TopTx ConwayEra) where
+  type SpecRep (AlonzoStAnnTx TopTx ConwayEra) = Agda.Tx
+
+  toSpecRep stAnnTx = toSpecRep (stAnnTx ^. txStAnnTxG)

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
@@ -124,7 +124,7 @@ submitTxConformanceHook globals trc@(TRC (env, state, signal)) =
         , clecEnactState = mkEnactState $ state ^. lsUTxOStateL . utxosGovStateL
         , clecUtxoExecContext =
             UtxoExecContext
-              { uecTx = signal
+              { uecTx = signal ^. txStAnnTxG
               , uecUTxO = state ^. utxoL
               , uecUtxoEnv =
                   UtxoEnv

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Core.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Core.hs
@@ -15,7 +15,7 @@ import Constrained.API
 import Control.Monad.Cont (ContT (..))
 import Control.Monad.Trans (MonadTrans (..))
 import Control.State.Transition.Extended (STS (..), TRC (..))
-import Test.Cardano.Ledger.Conformance (ExecSpecRule (..), ForAllExecTypes, testConformance)
+import Test.Cardano.Ledger.Conformance (ExecSpecRule (..), testConformance)
 import Test.Cardano.Ledger.Constrained.Conway.MiniTrace (
   ConstrainedGeneratorBundle (..),
  )
@@ -44,7 +44,6 @@ conformsToImpl genInputs = property @(ImpTestM era Property) . (`runContT` pure)
 genFromBundle_ ::
   ( HasSpec (Environment (EraRule rule era))
   , HasSpec (State (EraRule rule era))
-  , HasSpec (Signal (EraRule rule era))
   , Arbitrary (ExecContext rule era)
   ) =>
   ConstrainedGeneratorBundle ctx rule era ->
@@ -52,7 +51,9 @@ genFromBundle_ ::
 genFromBundle_ x = genFromBundle x $ \_ _ _ _ -> arbitrary
 
 genFromBundle ::
-  ForAllExecTypes HasSpec rule era =>
+  ( HasSpec (Environment (EraRule rule era))
+  , HasSpec (State (EraRule rule era))
+  ) =>
   ConstrainedGeneratorBundle ctx rule era ->
   ( ctx ->
     Environment (EraRule rule era) ->
@@ -65,13 +66,14 @@ genFromBundle ConstrainedGeneratorBundle {..} genExecContext = do
   ctx <- cgbContextGen
   env <- genFromSpec $ cgbEnvironmentSpec ctx
   st <- genFromSpec $ cgbStateSpec ctx env
-  sig <- genFromSpec $ cgbSignalSpec ctx env st
+  sig <- cgbSignalGen ctx env st
   (,TRC (env, st, sig)) <$> genExecContext ctx env st sig
 
 conformsToImplConstrained ::
   forall ctx rule era.
   ( ExecSpecRule rule era
-  , ForAllExecTypes HasSpec rule era
+  , HasSpec (Environment (EraRule rule era))
+  , HasSpec (State (EraRule rule era))
   ) =>
   ConstrainedGeneratorBundle ctx rule era ->
   ( ctx ->
@@ -86,7 +88,8 @@ conformsToImplConstrained bundle genExecContext =
 
 conformsToImplConstrained_ ::
   ( ExecSpecRule rule era
-  , ForAllExecTypes HasSpec rule era
+  , HasSpec (Environment (EraRule rule era))
+  , HasSpec (State (EraRule rule era))
   , Arbitrary (ExecContext rule era)
   ) =>
   ConstrainedGeneratorBundle ctx rule era ->

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -64,7 +64,7 @@ benchWithGenState ::
   , EraGen era
   , HasTrace (EraRule "LEDGER" era) (GenEnv MockCrypto era)
   , BaseEnv (EraRule "LEDGER" era) ~ Globals
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , EraStake era
@@ -83,7 +83,7 @@ benchApplyTx ::
   , ApplyTx era
   , HasTrace (EraRule "LEDGER" era) (GenEnv MockCrypto era)
   , BaseEnv (EraRule "LEDGER" era) ~ Globals
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , EraStake era
@@ -116,7 +116,7 @@ deserialiseTxEra ::
   , HasTrace (EraRule "LEDGER" era) (GenEnv MockCrypto era)
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , EraStake era
   , EraGov era
   , DecCBOR (Tx TopTx era)
@@ -136,7 +136,7 @@ deserialiseAnnTxEra ::
   , HasTrace (EraRule "LEDGER" era) (GenEnv MockCrypto era)
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , EraStake era
   , EraGov era
   ) =>

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx/Gen.hs
@@ -23,6 +23,7 @@ import Control.DeepSeq (NFData (..))
 import Control.State.Transition (Environment, Signal, State)
 import Data.Proxy (Proxy)
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 import Test.Cardano.Ledger.AllegraEraGen ()
 import Test.Cardano.Ledger.Shelley.ConcreteCryptoTypes (MockCrypto)
 import Test.Cardano.Ledger.Shelley.Constants (defaultConstants)
@@ -73,7 +74,7 @@ generateApplyTxEnvForEra ::
   ( EraGen era
   , HasTrace (EraRule "LEDGER" era) (GenEnv MockCrypto era)
   , BaseEnv (EraRule "LEDGER" era) ~ Globals
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , EraStake era
@@ -98,5 +99,5 @@ generateApplyTxEnvForEra eraProxy seed =
         { ateGlobals = testGlobals
         , ateMempoolEnv = applyTxMempoolEnv (ledgerPp (_traceEnv tr))
         , ateState = source sst
-        , ateTx = signal sst
+        , ateTx = signal sst ^. txStAnnTxG
         }

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/MiniTrace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/MiniTrace.hs
@@ -38,8 +38,10 @@ import Cardano.Ledger.BaseTypes (
   Network (..),
   ShelleyBase,
   addEpochInterval,
+  epochInfo,
   natVersion,
   nonZeroOr,
+  systemStart,
  )
 import Cardano.Ledger.Coin (Coin (..), CompactForm (..), knownNonZeroCoin)
 import Cardano.Ledger.Conway (ConwayEra)
@@ -56,6 +58,8 @@ import Cardano.Ledger.Conway.Rules (CertsEnv (..), EnactSignal)
 import Cardano.Ledger.Conway.TxCert (ConwayDelegCert (..), ConwayGovCert (..), ConwayTxCert (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
+import Cardano.Ledger.Shelley.API.Types (UtxoEnv (..))
 import Cardano.Ledger.State (
   CommitteeAuthorization (..),
   CommitteeState (..),
@@ -79,7 +83,7 @@ import Lens.Micro ((^.))
 import Test.Cardano.Ledger.Common hiding (forAll)
 import Test.Cardano.Ledger.Constrained.Conway (
   EraSpecCert (..),
-  UtxoExecContext,
+  UtxoExecContext (..),
   certEnvSpec,
   certsEnvSpec,
   committeeMinSize_,
@@ -110,6 +114,7 @@ import Test.Cardano.Ledger.Constrained.Conway.LedgerTypes.Specs (
   whoDelegatesSpec,
  )
 import Test.Cardano.Ledger.Constrained.Conway.WitnessUniverse (WitUniv, genWitUniv)
+import Test.Cardano.Ledger.Core.Utils (testGlobals)
 import Test.Cardano.Ledger.Generic.Proof (goSTS)
 
 data ConstrainedGeneratorBundle ctx rule era = ConstrainedGeneratorBundle
@@ -121,11 +126,13 @@ data ConstrainedGeneratorBundle ctx rule era = ConstrainedGeneratorBundle
       ctx ->
       Environment (EraRule rule era) ->
       Specification (State (EraRule rule era))
-  , cgbSignalSpec ::
+  , -- Accomodates signals that need post-processing after the constraint solver picks a value.
+    -- Such signals cannot have a HasSpec instance.
+    cgbSignalGen ::
       ctx ->
       Environment (EraRule rule era) ->
       State (EraRule rule era) ->
-      Specification (Signal (EraRule rule era))
+      Gen (Signal (EraRule rule era))
   }
 
 -- ====================================================================
@@ -135,7 +142,6 @@ minitraceEither ::
   forall rule era ctx.
   ( HasSpec (Environment (EraRule rule era))
   , HasSpec (State (EraRule rule era))
-  , HasSpec (Signal (EraRule rule era))
   , BaseM (EraRule rule era) ~ ShelleyBase
   , STS (EraRule rule era)
   , ToExpr (Signal (EraRule rule era))
@@ -151,7 +157,7 @@ minitraceEither n0 ConstrainedGeneratorBundle {..} = do
   let go :: State (EraRule rule era) -> Int -> Gen (Either [String] [Signal (EraRule rule era)])
       go _ 0 = pure (Right [])
       go st n = do
-        !signal <- genFromSpec $ cgbSignalSpec ctxt env st
+        !signal <- cgbSignalGen ctxt env st
         goSTS @rule @era @(Gen (Either [String] [Signal (EraRule rule era)]))
           env
           st
@@ -179,7 +185,6 @@ minitraceProp ::
   forall rule era ctx.
   ( HasSpec (Environment (EraRule rule era))
   , HasSpec (State (EraRule rule era))
-  , HasSpec (Signal (EraRule rule era))
   , BaseM (EraRule rule era) ~ ShelleyBase
   , STS (EraRule rule era)
   , ToExpr (Signal (EraRule rule era))
@@ -204,7 +209,6 @@ runMinitrace ::
   forall (rule :: Symbol) era ctx.
   ( HasSpec (Environment (EraRule rule era))
   , HasSpec (State (EraRule rule era))
-  , HasSpec (Signal (EraRule rule era))
   , BaseM (EraRule rule era) ~ ShelleyBase
   , KnownSymbol rule
   , STS (EraRule rule era)
@@ -492,7 +496,7 @@ constrainedPool =
     (genWitUniv 50)
     poolEnvSpec
     (\ctx _ -> pStateSpec ctx)
-    poolCertSpec
+    (\ctx env st -> genFromSpec (poolCertSpec ctx env st))
 
 constrainedDeleg ::
   ConstrainedGeneratorBundle
@@ -504,7 +508,7 @@ constrainedDeleg =
     genDelegCtx
     (const delegEnvSpec)
     (\ctx _ -> certStateSpec_ ctx)
-    (const conwayDelegCertSpec)
+    (\_ env st -> genFromSpec (conwayDelegCertSpec env st))
 
 constrainedGovCert ::
   ConstrainedGeneratorBundle
@@ -516,7 +520,7 @@ constrainedGovCert =
     genDelegCtx
     (\(u, _) -> govCertEnvSpec u)
     (\ctx _ -> certStateSpec_ ctx)
-    (\(u, _) -> govCertSpec u)
+    (\(u, _) env st -> genFromSpec (govCertSpec u env st))
 
 constrainedCert ::
   ConstrainedGeneratorBundle
@@ -528,7 +532,7 @@ constrainedCert =
     genDelegCtx
     (\(u, _) -> certEnvSpec u)
     (\ctx _ -> certStateSpec_ ctx)
-    (\(u, _) -> conwayTxCertSpec u)
+    (\(u, _) env st -> genFromSpec (conwayTxCertSpec u env st))
 
 constrainedCerts ::
   ConstrainedGeneratorBundle
@@ -542,7 +546,7 @@ constrainedCerts =
     ( \(u, ConwayCertGenContext {..}) CertsEnv {certsCurrentEpoch} ->
         conwayCertStateSpec u (ccccDelegatees, ccccWithdrawals) (lit certsCurrentEpoch)
     )
-    (\(u, _) -> txCertsSpec u)
+    (\(u, _) env st -> genFromSpec (txCertsSpec u env st))
 
 constrainedRatify :: ConstrainedGeneratorBundle [GovActionState ConwayEra] "RATIFY" ConwayEra
 constrainedRatify =
@@ -550,7 +554,7 @@ constrainedRatify =
     arbitrary
     ratifyEnvSpec
     (\_ env -> ratifyStateSpec env)
-    (\ctx _ _ -> ratifySignalSpec ctx)
+    (\ctx _ _ -> genFromSpec (ratifySignalSpec ctx))
 
 constrainedGov :: ConstrainedGeneratorBundle () "GOV" ConwayEra
 constrainedGov =
@@ -558,8 +562,11 @@ constrainedGov =
     (pure ())
     (const govEnvSpec)
     (const govProposalsSpec)
-    (const govProceduresSpec)
+    (\_ env st -> genFromSpec (govProceduresSpec env st))
 
+-- | Generate via the underlying 'Tx' (constraint-solved), then build the
+-- cached annotation with 'mkStAnnTx' so the cache is coherent with the Tx by
+-- construction.
 constrainedUtxo ::
   ConstrainedGeneratorBundle (UtxoExecContext ConwayEra) "UTXO" ConwayEra
 constrainedUtxo =
@@ -567,7 +574,16 @@ constrainedUtxo =
     genUtxoExecContext
     utxoEnvSpec
     utxoStateSpec
-    (\ctx _ _ -> utxoTxSpec ctx)
+    ( \ctx@UtxoExecContext {uecUTxO, uecUtxoEnv} _ _ -> do
+        tx <- genFromSpec (utxoTxSpec ctx)
+        pure $
+          mkStAnnTx
+            (epochInfo testGlobals)
+            (systemStart testGlobals)
+            (uePParams uecUtxoEnv)
+            uecUTxO
+            tx
+    )
 
 constrainedEpoch :: ConstrainedGeneratorBundle EpochNo "EPOCH" ConwayEra
 constrainedEpoch =
@@ -575,7 +591,7 @@ constrainedEpoch =
     arbitrary
     (const trueSpec)
     (\ctx _ -> epochStateSpec (lit ctx))
-    (\ctx _ _ -> epochSignalSpec ctx)
+    (\ctx _ _ -> genFromSpec (epochSignalSpec ctx))
 
 constrainedNewEpoch :: ConstrainedGeneratorBundle EpochNo "NEWEPOCH" ConwayEra
 constrainedNewEpoch =
@@ -583,7 +599,7 @@ constrainedNewEpoch =
     arbitrary
     (const trueSpec)
     (\_ _ -> newEpochStateSpec)
-    (\ctx _ _ -> epochSignalSpec ctx)
+    (\ctx _ _ -> genFromSpec (epochSignalSpec ctx))
 
 constrainedEnact :: ConstrainedGeneratorBundle EpochNo "ENACT" ConwayEra
 constrainedEnact =
@@ -591,4 +607,4 @@ constrainedEnact =
     arbitrary
     (const trueSpec)
     (\_ _ -> enactStateSpec)
-    (\epoch _ st -> enactSignalSpec epoch st)
+    (\epoch _ st -> genFromSpec (enactSignalSpec epoch st))

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -131,7 +131,7 @@ instance
   , Environment (EraRule "LEDGERS" era) ~ ShelleyLedgersEnv era
   , State (EraRule "LEDGERS" era) ~ LedgerState era
   , Embed (EraRule "LEDGERS" era) (MOCKCHAIN era)
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Eq (PredicateFailure (EraRule "LEDGER" era))
@@ -191,7 +191,7 @@ instance
   ( STS (ShelleyLEDGERS era)
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
   Embed (ShelleyLEDGERS era) (MOCKCHAIN era)
   where

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -14,14 +14,16 @@
 module Test.Cardano.Ledger.Generic.Properties where
 
 import Cardano.Ledger.Alonzo.Tx (IsValid (..))
-import Cardano.Ledger.BaseTypes (ShelleyBase)
+import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfo, systemStart)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   NewEpochState,
   PulsingRewUpdate,
   UTxOState,
+  utxosUtxo,
  )
 import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
@@ -75,6 +77,7 @@ import Test.Cardano.Ledger.Generic.TxGen (
  )
 import Test.Cardano.Ledger.Shelley.Serialisation.EraIndepGenerators ()
 import Test.Cardano.Ledger.Shelley.TreeDiff ()
+import Test.Cardano.Ledger.Shelley.Utils (testGlobals)
 import Test.Control.State.Transition.Trace (Trace (..), lastState)
 import Test.Control.State.Transition.Trace.Generator.QuickCheck (HasTrace (..))
 
@@ -82,12 +85,13 @@ import Test.Control.State.Transition.Trace.Generator.QuickCheck (HasTrace (..))
 -- Top level generators of TRC
 
 genTxAndUTXOState ::
-  ( Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  ( ApplyTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , Environment (EraRule "UTXOW" era) ~ UtxoEnv era
   , State (EraRule "UTXOW" era) ~ UTxOState era
-  , Tx TopTx era ~ Signal (EraRule "UTXOW" era)
+  , StAnnTx TopTx era ~ Signal (EraRule "UTXOW" era)
   , EraGenericGen era
   ) =>
   GenSize -> Gen (TRC (EraRule "UTXOW" era), GenState era)
@@ -97,7 +101,8 @@ genTxAndUTXOState gsize = do
 
 genTxAndLEDGERState ::
   forall era.
-  ( Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  ( ApplyTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
   , EraGenericGen era
@@ -115,7 +120,14 @@ genTxAndLEDGERState sizes = do
         pp <- gets (gePParams . gsGenEnv)
         let ledgerState = extract @(LedgerState era) model
             ledgerEnv = LedgerEnv slotNo Nothing txIx pp (ChainAccountState (Coin 0) (Coin 0))
-        pure $ TRC (ledgerEnv, ledgerState, tx)
+            stAnnTx =
+              mkStAnnTx
+                (epochInfo testGlobals)
+                (systemStart testGlobals)
+                pp
+                (utxosUtxo (lsUTxOState ledgerState))
+                tx
+        pure $ TRC (ledgerEnv, ledgerState, stAnnTx)
   (trc, genstate) <- runGenRS sizes (initStableFields >> genT)
   pure (trc, genstate)
 
@@ -125,7 +137,7 @@ genTxAndLEDGERState sizes = do
 testTxValidForLEDGER ::
   forall era.
   ( Reflect era
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , ToExpr (PredicateFailure (EraRule "LEDGER" era))
   , EraTest era
@@ -135,24 +147,25 @@ testTxValidForLEDGER ::
   ) =>
   (TRC (EraRule "LEDGER" era), GenState era) ->
   Property
-testTxValidForLEDGER (trc@(TRC (env, ledgerState, vtx)), _genstate) =
-  -- trc encodes the initial (generated) state, vtx is the transaction
-  case runSTSWithContext @era trc of
-    Right ledgerState' ->
-      -- UTxOState and CertState after applying the transaction $$$
-      classify (coerce (isValid' (reify @era) vtx)) "TxValid" $
-        totalAda ledgerState' === totalAda ledgerState
-    Left errs ->
-      counterexample
-        ( showExpr env
-            ++ "\n\n"
-            ++ showExpr ledgerState
-            ++ "\n\n"
-            ++ showExpr vtx
-            ++ "\n\n"
-            ++ showExpr errs
-        )
-        (property False)
+testTxValidForLEDGER (trc@(TRC (env, ledgerState, vstAnnTx)), _genstate) =
+  -- trc encodes the initial (generated) state, vstAnnTx is the transaction
+  let vtx = vstAnnTx ^. txStAnnTxG
+   in case runSTSWithContext @era trc of
+        Right ledgerState' ->
+          -- UTxOState and CertState after applying the transaction $$$
+          classify (coerce (isValid' (reify @era) vtx)) "TxValid" $
+            totalAda ledgerState' === totalAda ledgerState
+        Left errs ->
+          counterexample
+            ( showExpr env
+                ++ "\n\n"
+                ++ showExpr ledgerState
+                ++ "\n\n"
+                ++ showExpr vtx
+                ++ "\n\n"
+                ++ showExpr errs
+            )
+            (property False)
 
 -- =============================================
 -- Make some property tests
@@ -266,7 +279,7 @@ adaIsPreservedInEachEpoch ::
   , Signal (EraRule "RUPD" era) ~ SlotNo
   , Signal (EraRule "LEDGERS" era) ~ Seq (Tx TopTx era)
   , Signal (EraRule "TICK" era) ~ SlotNo
-  , Signal (EraRule "LEDGER" era) ~ Tx TopTx era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , BaseM (EraRule "NEWEPOCH" era) ~ ShelleyBase
   , Embed (EraRule "TICK" era) (MOCKCHAIN era)
   , Embed (EraRule "NEWEPOCH" era) (ShelleyTICK era)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -16,7 +16,10 @@ import Cardano.Ledger.Api
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Rules (ConwayUtxosEnv (..))
 import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
+import Cardano.Ledger.Shelley.LedgerState (utxosUtxo)
 import Cardano.Ledger.Shelley.Rules hiding (epochNo, slotNo)
 import Constrained.API hiding (forAll)
 import Control.Monad.Reader
@@ -137,6 +140,44 @@ stsPropertyV2' specEnv specState specSig specPostState theProp =
                             )
                             $ theProp env st sig st'
 
+-- | A variant of 'stsPropertyV2' for rules whose 'Signal' has no 'HasSpec'
+-- instance (for example 'StAnnTx').
+stsPropertyV2Gen ::
+  forall r era env st sig fail p.
+  ( era ~ ConwayEra
+  , Environment (EraRule r era) ~ env
+  , State (EraRule r era) ~ st
+  , Signal (EraRule r era) ~ sig
+  , PredicateFailure (EraRule r era) ~ fail
+  , STS (EraRule r era)
+  , BaseM (EraRule r era) ~ ReaderT Globals Identity
+  , Testable p
+  , HasSpec env
+  , HasSpec st
+  , ToExpr env
+  , ToExpr st
+  , ToExpr sig
+  , ToExpr fail
+  ) =>
+  Specification env ->
+  (env -> Specification st) ->
+  (env -> st -> Gen sig) ->
+  (env -> st -> sig -> st -> p) ->
+  Property
+stsPropertyV2Gen specEnv specState genSig theProp =
+  withMaxShrinks 200 $
+    uncurry forAllShrinkBlind (genShrinkFromSpec specEnv) $ \env ->
+      counterexample (show $ toExpr env) $
+        uncurry forAllShrinkBlind (genShrinkFromSpec $ specState env) $ \st ->
+          counterexample (show $ toExpr st) $
+            forAllBlind (genSig env st) $ \sig ->
+              counterexample (show $ toExpr sig) $
+                runShelleyBase $ do
+                  res <- applySTS @(EraRule r ConwayEra) $ TRC (env, st, sig)
+                  pure $ case res of
+                    Left pfailures -> counterexample (show $ toExpr pfailures) $ property False
+                    Right st' -> property $ theProp env st sig st'
+
 -- STS properties ---------------------------------------------------------
 
 prop_GOV :: Property
@@ -178,10 +219,19 @@ prop_ENACT =
 
 prop_UTXOS :: Property
 prop_UTXOS =
-  stsPropertyV2 @"UTXOS"
+  stsPropertyV2Gen @"UTXOS"
     trueSpec
     (\_env -> trueSpec)
-    (\_env _st -> trueSpec)
+    ( \env _st -> do
+        tx <- genFromSpec trueSpec
+        pure $
+          mkStAnnTx
+            (epochInfo testGlobals)
+            (systemStart testGlobals)
+            (cuePParams env)
+            (cueUTxO env)
+            tx
+    )
     $ \_env _st _sig _st' -> True
 
 -- prop_LEDGER :: Property
@@ -271,10 +321,19 @@ prop_GOVCERT =
 
 prop_UTXOW :: Property
 prop_UTXOW =
-  stsPropertyV2 @"UTXOW"
+  stsPropertyV2Gen @"UTXOW"
     trueSpec
     (\_env -> trueSpec)
-    (\_env _st -> trueSpec)
+    ( \env st -> do
+        tx <- genFromSpec trueSpec
+        pure $
+          mkStAnnTx
+            (epochInfo testGlobals)
+            (systemStart testGlobals)
+            (uePParams env)
+            (utxosUtxo st)
+            tx
+    )
     $ \_env _st _sig _st' -> True
 
 -- prop_UTXO :: Property


### PR DESCRIPTION
# Description

* Changes the signal of: SUB/LEDGER, SUB/UTXOW, SUB/UTXO, MEMPOOL in all eras from `Tx` to `StAnnTx`. 
* Builds an `StAnnTx` in `applyTx` and `reApplyTx` and passes it on. 

Closes https://github.com/IntersectMBO/cardano-ledger/issues/5782

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
