### PR TITLE
Change `DijkstraTx` decoder to support variable length encoding

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0.0
 
+* Add `decodeDijkstraTopTx`
 * Change `Signal` to `StAnnTx TopTx era` for: `DijkstraLEDGER`, `DijkstraMEMPOOL`, `DijkstraUTXOW`, `DijkstraUTXO`
 * Change `Signal` to `StAnnTx SubTx era` for: `DijkstraSUBLEDGER`, `DijkstraSUBUTXOW`, `DijkstraSUBUTXO`
 * Change `DijkstraSUBLEDGERS` `Signal` to `[StAnnTx SubTx era]`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -55,7 +55,7 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra.Era
-import Cardano.Ledger.Dijkstra.Tx (DijkstraTx, Tx (..), decDijkstraTopTxCBORAnn)
+import Cardano.Ledger.Dijkstra.Tx (DijkstraTx, Tx (..), decodeDijkstraTopTx)
 import Cardano.Ledger.MemoBytes (
   Mem,
   MemoBytes,
@@ -198,7 +198,7 @@ instance
           (\x -> (IntSet.size x, x))
           (decCBOR @Word16)
     invalidTxs :: IntSet <- fold <$> decodeNullMaybe decodeInvalidTxs
-    txs <- decodeSeq (decDijkstraTopTxCBORAnn @era False)
+    txs <- decodeSeq (decodeDijkstraTopTx @era False)
     perasCert <- decodeNullStrictMaybe decCBOR
     let txsLength = Seq.length txs
         inRange x = 0 <= x && x < txsLength

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -23,7 +24,7 @@ module Cardano.Ledger.Dijkstra.Tx (
   Tx (..),
   DijkstraStAnnTx (..),
   validateDijkstraNativeScript,
-  decDijkstraTopTxCBORAnn,
+  decodeDijkstraTopTx,
 ) where
 
 import Cardano.Ledger.Allegra.TxBody (AllegraEraTxBody (..), StrictMaybe)
@@ -40,10 +41,12 @@ import Cardano.Ledger.Binary (
   EncCBOR (..),
   Encoding,
   ToCBOR (..),
-  decodeListLen,
+  TokenType (..),
   decodeNullStrictMaybe,
+  decodeRecordNamed,
   encodeListLen,
   encodeNullStrictMaybe,
+  peekTokenType,
   serialize,
  )
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<*!))
@@ -126,40 +129,34 @@ instance (EraTx era, Typeable l) => ToCBOR (DijkstraTx l era) where
 instance EraTx era => EncCBOR (DijkstraTx l era) where
   encCBOR = toCBORForMempoolSubmission
 
-decDijkstraTopTxCBORAnn :: EraTx era => Bool -> Decoder s (Annotator (DijkstraTx TopTx era))
-decDijkstraTopTxCBORAnn allowIsValid = do
-  decodeListLen >>= \case
-    4 | allowIsValid -> do
+decodeDijkstraTopTx :: EraTx era => Bool -> Decoder s (Annotator (DijkstraTx TopTx era))
+decodeDijkstraTopTx allowIsValid =
+  fst <$> do
+    let isValidBackwardsCompatibleLength isValidFlagSupplied = if isValidFlagSupplied then 4 else 3
+    decodeRecordNamed "DijkstraTx" (isValidBackwardsCompatibleLength . snd) $ do
       bodyAnn <- decCBOR
       witsAnn <- decCBOR
-      isValid <-
-        decCBOR
-          >>= \case
-            True -> pure (IsValid True)
-            False -> fail "value `false` not allowed for `isValid`"
+      isValidFlagSupplied <-
+        if allowIsValid
+          then
+            peekTokenType >>= \case
+              TypeBool ->
+                decCBOR >>= \case
+                  True -> pure True
+                  False -> fail "Value `false` not allowed for `isValid`"
+              _ -> pure False
+          else pure False
       auxAnn <- decodeNullStrictMaybe decCBOR
-      pure $
-        DijkstraTx
-          <$> bodyAnn
-          <*> witsAnn
-          <*> pure isValid
-          <*> sequence auxAnn
-    3 -> do
-      bodyAnn <- decCBOR
-      witsAnn <- decCBOR
-      auxAnn <- decodeNullStrictMaybe decCBOR
-      pure $
-        DijkstraTx
-          <$> bodyAnn
-          <*> witsAnn
-          <*> pure (IsValid True)
-          <*> sequence auxAnn
-    n ->
-      fail $ "Unexpected list length: " <> show n <> ". Expected: 4 or 3."
+      let
+        -- `isValid == False` can no longer be supplied in an encoded transaction.
+        isValid = IsValid True
+        dijkstraTopTx =
+          DijkstraTx <$> bodyAnn <*> witsAnn <*> pure isValid <*> sequence auxAnn
+      pure (dijkstraTopTx, isValidFlagSupplied)
 
 instance (EraTx era, Typeable l) => DecCBOR (Annotator (DijkstraTx l era)) where
   decCBOR = withSTxBothLevels @l $ \case
-    STopTx -> decDijkstraTopTxCBORAnn True
+    STopTx -> decodeDijkstraTopTx True
     SSubTx ->
       decode $
         Ann (RecD DijkstraSubTx)

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -186,7 +186,7 @@ instance Era era => DecCBOR (DijkstraNativeScript era) where
 instance Typeable l => DecCBOR (DijkstraTx l DijkstraEra) where
   decCBOR =
     withSTxBothLevels @l $ \case
-      STopTx -> decDijkstraTopTxCBOR True
+      STopTx -> decodeDijkstraTopTx True
       SSubTx ->
         decode $
           RecD DijkstraSubTx
@@ -197,31 +197,30 @@ instance Typeable l => DecCBOR (DijkstraTx l DijkstraEra) where
 
 deriving newtype instance Typeable l => DecCBOR (Tx l DijkstraEra)
 
-decDijkstraTopTxCBOR ::
+decodeDijkstraTopTx ::
   ( DecCBOR (TxBody TopTx era)
   , DecCBOR (TxWits era)
   , DecCBOR (TxAuxData era)
   ) =>
   Bool -> Decoder s (DijkstraTx TopTx era)
-decDijkstraTopTxCBOR allowIsValid =
-  decodeListLen >>= \case
-    4 | allowIsValid -> do
+decodeDijkstraTopTx allowIsValid =
+  fst <$> do
+    let isValidBackwardsCompatibleLength isValidFlagSupplied = if isValidFlagSupplied then 4 else 3
+    decodeRecordNamed "DijkstraTx" (isValidBackwardsCompatibleLength . snd) $ do
       body <- decCBOR
       wits <- decCBOR
-      isValid <-
-        decCBOR
-          >>= \case
-            True -> pure (IsValid True)
-            False -> fail "value `false` not allowed for `isValid`"
+      isValidFlagSupplied <-
+        if allowIsValid
+          then
+            peekTokenType >>= \case
+              TypeBool ->
+                decCBOR >>= \case
+                  True -> pure True
+                  False -> fail "Value `false` not allowed for `isValid`"
+              _ -> pure False
+          else pure False
       aux <- decodeNullStrictMaybe decCBOR
-      pure $ DijkstraTx body wits isValid aux
-    3 -> do
-      DijkstraTx
-        <$> decCBOR
-        <*> decCBOR
-        <*> pure (IsValid True)
-        <*> decodeNullStrictMaybe decCBOR
-    n -> fail $ "Unexpected list length: " <> show n <> ". Expected: 4 or 3."
+      pure (DijkstraTx body wits (IsValid True) aux, isValidFlagSupplied)
 
 instance DecCBOR (DijkstraBlockBodyRaw DijkstraEra) where
   decCBOR = decodeRecordNamed "DijkstraBlockBodyRaw" (const 3) $ do
@@ -232,7 +231,7 @@ instance DecCBOR (DijkstraBlockBodyRaw DijkstraEra) where
           (\x -> (IntSet.size x, x))
           (decCBOR @Word16)
     invalidTxs :: IntSet <- fold <$> decodeNullMaybe decodeInvalidTxs
-    txs <- decodeSeq (decDijkstraTopTxCBOR @DijkstraEra False)
+    txs <- decodeSeq (decodeDijkstraTopTx @DijkstraEra False)
     perasCert <- decodeNullStrictMaybe decCBOR
 
     let txsLength = Seq.length txs

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Golden.hs
@@ -307,7 +307,7 @@ goldenIsValidFlag = do
       txWithFlagFalseEnc
       ( DecoderErrorDeserialiseFailure
           "Annotator (Tx TopTx DijkstraEra)"
-          (DeserialiseFailure 13 "value `false` not allowed for `isValid`")
+          (DeserialiseFailure 13 "Value `false` not allowed for `isValid`")
       )
   where
     version = eraProtVerLow @era

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/Decoder.hs
@@ -1537,3 +1537,4 @@ peekTokenType = fromPlainDecoder C.peekTokenType
 
 liftST :: ST s a -> Decoder s a
 liftST st = Decoder $ \_ _ -> C.liftST st
+{-# INLINE liftST #-}


### PR DESCRIPTION
# Description

Decoder for `DijkstraTopTx` implemented in #5480 did not implement support for variable length decoding, which is fixed in this PR. 
Also #5733 missed a changelog entry, which is also fixed here.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
