### PR TITLE
Make ZeroTreasuryWithdrawals a permanent check in gov state transation rule

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -38,6 +38,7 @@
   - `ConwayUtxowPredFailure`
 * Remove `NoThunks` instance for `ConwayContextError`
 * Make `ConwayContextError` constructors lazy
+* Make `ZeroTreasuryWithdrawals` a permanent check for all eras (not just post-Babbage).
 
 ### `testlib`
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs
@@ -546,9 +546,8 @@ conwayGovTransition = do
             -- Guardrails script hash check
             runTest $ checkGuardrailsScriptHash @era constitutionPolicy proposalPolicy
 
-            unless (hardforkConwayBootstrapPhase $ pp ^. ppProtocolVersionL) $
-              -- The sum of all withdrawals must be positive
-              F.fold wdrls /= mempty ?! (injectFailure . ZeroTreasuryWithdrawals) pProcGovAction
+            -- The sum of all withdrawals must be positive
+            F.fold wdrls /= mempty ?! (injectFailure . ZeroTreasuryWithdrawals) pProcGovAction
           UpdateCommittee _mPrevGovActionId membersToRemove membersToAdd _qrm -> do
             let conflicting = Set.intersection (Map.keysSet membersToAdd) membersToRemove
              in failOnNonEmptySet conflicting (injectFailure . ConflictingCommitteeUpdate)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -1105,28 +1105,31 @@ withdrawalsSpec =
               }
 
     it "Fails for empty withdrawals" $ do
-      mkTreasuryWithdrawalsGovAction [] >>= expectZeroTreasuryFailurePostBootstrap
+      mkTreasuryWithdrawalsGovAction [] >>= expectZeroTreasuryFailure
 
       accountAddress1 <- registerAccountAddress
-      mkTreasuryWithdrawalsGovAction [(accountAddress1, zero)] >>= expectZeroTreasuryFailurePostBootstrap
+      mkTreasuryWithdrawalsGovAction [(accountAddress1, zero)] >>= expectZeroTreasuryFailure
 
       accountAddress2 <- registerAccountAddress
       let withdrawals = [(accountAddress1, zero), (accountAddress2, zero)]
 
-      mkTreasuryWithdrawalsGovAction withdrawals >>= expectZeroTreasuryFailurePostBootstrap
+      mkTreasuryWithdrawalsGovAction withdrawals >>= expectZeroTreasuryFailure
 
       wdrls <- mkTreasuryWithdrawalsGovAction $ withdrawals ++ [(accountAddress2, Coin 100_000)]
       proposal <- mkProposal wdrls
       submitBootstrapAwareFailingProposal_ proposal $
         FailBootstrap [disallowedProposalFailure proposal]
   where
-    expectZeroTreasuryFailurePostBootstrap wdrls = do
+    expectZeroTreasuryFailure wdrls = do
       proposal <- mkProposal wdrls
       void $
         submitBootstrapAwareFailingProposal proposal $
           FailBootstrapAndPostBootstrap $
             FailBoth
-              { bootstrapFailures = [disallowedProposalFailure proposal]
+              { bootstrapFailures =
+                  [ disallowedProposalFailure proposal
+                  , injectFailure $ ZeroTreasuryWithdrawals wdrls
+                  ]
               , postBootstrapFailures = [injectFailure $ ZeroTreasuryWithdrawals wdrls]
               }
 


### PR DESCRIPTION
# Description

In `conwayGovTransition`, we remove the condition on `hardforkConwayBootstrapPhase` for checking `ZeroTreasuryWithdrawals`. From now on, all eras require that withdrawals (not only post-Conway era) are positive numbers.

We then replayed the preview, preprod and mainnet public chains with this change which guarantees there were no empty treasury withdrawals pre-Conway era.

Here's the proof that we replayed on public networks.

First, here's the same change, but on a ledger version that works with node 10.x: https://github.com/IntersectMBO/cardano-ledger/tree/koslambrou/make-zero-withdrawal-permanent-check. Commit hash is: `357cdd1f47cd3be82a239f4d8bed9ba117effbf8`

Then, we used `cardano-streamer` to replay the chain for each public network.

We first build `cardano-streamer` with our patch. See the cardano-ledger commit hash which matches the one above:

```
~/g/i/cardano-streamer ((10.7.1))> cabal build all
remote: Enumerating objects: 1144, done.
remote: Counting objects: 100% (553/553), done.
remote: Compressing objects: 100% (179/179), done.
remote: Total 1144 (delta 223), reused 494 (delta 202), pack-reused 591 (from 3)
Receiving objects: 100% (1144/1144), 825.01 KiB | 2.57 MiB/s, done.
Resolving deltas: 100% (359/359), completed with 23 local objects.
From https://github.com/IntersectMBO/cardano-ledger
   6bae1dbf9..666ce77a6  master                           -> origin/master
 * [new branch]          aniketd/stable-types-for-queries -> origin/aniketd/stable-types-for-queries
 + fdb572d13...fbdf39a87 benchmark-pages                  -> origin/benchmark-pages  (forced update)
 + d70bc5267...59011cd35 f-f/streaming-transitions-2      -> origin/f-f/streaming-transitions-2  (forced update)
 + 7ce2edc34...894c6100d jj/constr-fix                    -> origin/jj/constr-fix  (forced update)
 * [new branch]          lehins/variable-length-tx-fields -> origin/lehins/variable-length-tx-fields
 + b9ee057b8...90aa575ad nm/refactor-ci-testing           -> origin/nm/refactor-ci-testing  (forced update)
 * [new branch]          td/integrate-state-annotated-tx  -> origin/td/integrate-state-annotated-tx
HEAD is now at 357cdd1f4 Make ZeroTreasuryWithdrawals a permanent check in gov state transation rule
Configuration is affected by the following files:
- cabal.project
Up to date
```

For preview:

```
~/g/i/cardano-streamer ((10.7.1))> cabal run cardano-streamer:exe:cstreamer -- replay --chain-dir /media/nvme/cardano-node/preview/db --config /media/nvme/cardano-node/preview/config.json --validate full
Configuration is affected by the following files:
- cabal.project
withImmutableDb prepare
withImmutableDb start
Initializing LedgerDb
Done initializing LedgerDb
Starting to Replay
withImmutableDb end
[Conway: EpochNo 755 - SlotNo 65316218] Blocks: 2686680 - Elapsed 02 hours, 30 minutes, 53 seconds
```

For preprod:

```
~/g/i/cardano-streamer ((10.7.1))> cabal run cardano-streamer:exe:cstreamer -- replay --chain-dir /media/nvme/cardano-node/preprod/db --config /media/nvme/cardano-node/preprod/config.json --validate full
Configuration is affected by the following files:
- cabal.project
withImmutableDb prepare
withImmutableDb start
Initializing LedgerDb
Done initializing LedgerDb
Starting to Replay
withImmutableDb end
[Conway: EpochNo 286 - SlotNo 122264120] Blocks: 4674240 - Elapsed 03 hours, 50 minutes, 13 seconds
```

For mainnet:

```
~/g/i/cardano-streamer ((10.7.1))> cabal run cardano-streamer:exe:cstreamer -- replay --chain-dir /media/nvme/cardano-node/mainnet/db --config /media/nvme/cardano-node/mainnet/config.json --validate full
Configuration is affected by the following files:
- cabal.project
withImmutableDb prepare
withImmutableDb start
Initializing LedgerDb
Done initializing LedgerDb
Starting to Replay
withImmutableDb end
[Conway: EpochNo 629 - SlotNo 186391024] Blocks: 13378340 - Elapsed 001 day, 02 hours, 01 minute, 10 seconds
```

Fix #5784

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
