### PR TITLE
Refactor doctesting

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -169,6 +169,17 @@ jobs:
         path: ${{ steps.install-haskell.outputs.cabal-store }}
         key:  ${{ steps.restore-cabal-cache.outputs.cache-primary-key }}
 
+    # `doctest` needs to be present before building, to avoid `cabal repl` seeing a configuration
+    # change when `scripts/doctest.sh` runs it
+    - name: Install doctest
+      id: install-doctest
+      run: |
+        if [[ -z "$(type -t doctest)" ]]
+        then
+          cabal install doctest --ignore-project --overwrite-policy=always
+          cabal path --installdir >> $GITHUB_PATH
+        fi
+
     - name: Build
       run: cabal build all
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -173,6 +173,7 @@ jobs:
     # change when `scripts/doctest.sh` runs it
     - name: Install doctest
       id: install-doctest
+      if: matrix.ghc == '9.6.7'
       run: |
         if [[ -z "$(type -t doctest)" ]]
         then
@@ -199,6 +200,10 @@ jobs:
         path: state.tzst
         overwrite: true
         retention-days: 1
+
+    - name: Run doctests
+      if: ${{ steps.install-doctest.outcome == 'success' }}
+      run: scripts/doctest.sh
 
   test:
     needs: build

--- a/flake.lock
+++ b/flake.lock
@@ -259,11 +259,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1776040906,
-        "narHash": "sha256-nY+W05d73dy7N5KiAiASHGXMiWV+Uvmvb84ehXcs1x4=",
+        "lastModified": 1777855637,
+        "narHash": "sha256-7GxkPvU9bjww6/Ft6gPHxoaY5RWfR6VpM9teEjvNmjY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "75e4bc0024f5ed14a42c296448251f03669fc8ae",
+        "rev": "20af026f2e8265ec7531a921442dbc491f223dc0",
         "type": "github"
       },
       "original": {
@@ -348,11 +348,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1776042550,
-        "narHash": "sha256-/Hqlk1+gH79Wvr3EtPSg8+Zlbl6erjWk2q08PRGNlv8=",
+        "lastModified": 1777870306,
+        "narHash": "sha256-l30vC7T/Ma9/XnQw40xxsGZkdRINsGAeH72LMnIq3cI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "2bac360d85ea16cfa5d71ff84c2cb436ffb96481",
+        "rev": "8bd5204953012d78f1815d74896a9b08a1045e3e",
         "type": "github"
       },
       "original": {
@@ -750,11 +750,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1764572236,
-        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
         "type": "github"
       },
       "original": {
@@ -766,11 +766,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764587062,
-        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -888,11 +888,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1776039871,
-        "narHash": "sha256-EYCVZHGXLfowKHSY1pjAMwJ+6vf8+HCDz9E/cJh6goY=",
+        "lastModified": 1777854643,
+        "narHash": "sha256-UJLxngXRJMTPHfJdBZJGJjaSQXYXWgYqPEw7hTDop2A=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "5dfc02e00401aaa6125e20c37be61467ad3eed90",
+        "rev": "12436bd66325b13196b54f4d6cf16c05506786f3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -146,7 +146,7 @@
 
             # and from nixpkgs or other inputs
             nativeBuildInputs = with nixpkgs;
-              [
+              with (import nix/doctest.nix { inherit config nixpkgs; }); [
                 (python3.withPackages (ps:
                   with ps; [
                     sphinx
@@ -158,18 +158,9 @@
                 haskellPackages.implicit-hie
                 shellcheck
                 act
+                doctest
                 inputs.cardano-ledger-release-tool.packages.${system}.default
-              ] ++ (let
-                doctest = haskell-nix.hackage-package {
-                  name = "doctest";
-                  version = "0.24.3";
-                  configureArgs = "-f cabal-doctest";
-                  inherit (config) compiler-nix-name;
-                };
-              in [
-                (doctest.getComponent "exe:cabal-doctest")
-                (doctest.getComponent "exe:doctest")
-              ]);
+              ];
             # disable Hoogle until someone request it
             withHoogle = false;
             # Skip cross compilers for the shell

--- a/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Twiddle.hs
+++ b/libs/cardano-ledger-binary/testlib/Test/Cardano/Ledger/Binary/Twiddle.hs
@@ -64,7 +64,9 @@ gTwiddleTList v a = TList <$> twiddleL v (from @a @p a)
 --
 --   For any value `x :: a`, where `a` derives `Twiddle`, and for any version
 --   of the decoder, the following property must hold:
---   >>> fmap ((== x) . encodingToTerm version . encCBOR) (twiddle x)
+--   prop> \x version -> fmap (== encodingToTerm version (encCBOR x)) (twiddle version (x :: Double))
+--
+--   Note: this property doesn't hold for some types, hence the type restriction
 class Twiddle a where
   -- | Given a value of type `a`, generates a CBOR `Term` that can contain
   -- slight variations without changing the semantics. After encoding and

--- a/libs/cardano-ledger-core/internal/Cardano/Ledger/Internal/Definition/Era.hs
+++ b/libs/cardano-ledger-core/internal/Cardano/Ledger/Internal/Definition/Era.hs
@@ -67,6 +67,7 @@ class
   --
   -- Designed to be used with @TypeApplications@:
   --
+  -- >>> :set -XTypeApplications
   -- >>> eraName @ByronEra
   -- "Byron"
   eraName :: String

--- a/nix/doctest.nix
+++ b/nix/doctest.nix
@@ -1,0 +1,17 @@
+# Provide a custom-built doctest that's compatible with haskell.nix
+
+{ config, nixpkgs }:
+
+let
+  doctest = nixpkgs.haskell-nix.hackage-package {
+    name = "doctest";
+    version = "0.24.3";
+    inherit (config) compiler-nix-name;
+    modules = [{
+      packages = {
+        # This enables doctest to find ghc etc. via environment variables
+        ghc-paths.patches = nixpkgs.haskellPackages.ghc-paths.patches;
+      };
+    }];
+  };
+in { doctest = doctest.getComponent "exe:doctest"; }

--- a/scripts/doctest.sh
+++ b/scripts/doctest.sh
@@ -48,6 +48,18 @@ then
   exit 1
 fi
 
+# Find packages potentially containing doctests
+if [[ ${#PACKAGES[@]} -eq 0 ]]
+then
+  for CABAL_FILE in $(git ls-files '*.cabal')
+  do
+    if git grep -qIEe '(>>>|prop>)' "${CABAL_FILE%/*}/*.hs"
+    then
+      PACKAGES+=("$(basename "$CABAL_FILE" .cabal)")
+    fi
+  done
+fi
+
 # Specify additional arguments needed for specific modules
 EXTRA_ARGS=$(mktemp)
 trap 'rm -f "$EXTRA_ARGS"' EXIT

--- a/scripts/doctest.sh
+++ b/scripts/doctest.sh
@@ -19,14 +19,32 @@ getExecutablePath()
   "$1" -package-env - -e 'import System.Environment' -e 'putStrLn =<< getExecutablePath'
 }
 
+lookupVar()
+{
+  ghc -e 'interact $ maybe "" id . lookup "'"$1"'" . read'
+}
+
+getPackageDb()
+{
+  readlink -f "$("$1" --info | lookupVar 'Global Package DB')"
+}
+
 default_ghc=$(type -p ghc)
-doctest_ghc=$(doctest --info | ghc -e 'interact $ maybe "" id . lookup "ghc" . read')
+doctest_ghc=$(doctest --info | lookupVar 'ghc')
 
 if [[ "$(getExecutablePath "$default_ghc")" != "$(getExecutablePath "$doctest_ghc")" ]]
 then
   echo "Incompatible GHC's:" >&2
   echo "  Default ghc: $(getExecutablePath "$default_ghc")" >&2
   echo "  Doctest ghc: $(getExecutablePath "$doctest_ghc")" >&2
+  exit 1
+fi
+
+if [[ "$(getPackageDb ghc)" != "$(getPackageDb doctest)" ]]
+then
+  echo "Incompatible package DBs:" >&2
+  echo "  Default DB: $(getPackageDb ghc)" >&2
+  echo "  Doctest DB: $(getPackageDb doctest)" >&2
   exit 1
 fi
 

--- a/scripts/doctest.sh
+++ b/scripts/doctest.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 # Packages to run doctests for; defaults to all packages if none are specified
 PACKAGES=("$@")
 
-# Install doctest's Cabal integration, if it's not present already
-if [[ -z "$(type -t cabal-doctest)" ]]
+# Install doctest, if it's not present already
+if [[ -z "$(type -t doctest)" ]]
 then
-  cabal install doctest --flag cabal-doctest --ignore-project --overwrite-policy=always
+  cabal install doctest --ignore-project --overwrite-policy=always
+  PATH=$(cabal path --installdir):$PATH
 fi
 
 # Ensure doctest and PATH are using the same ghc version
@@ -29,14 +30,6 @@ then
   exit 1
 fi
 
-# Ensure the cabal-doctest executable can be found
-PATH=$(cabal path --installdir):$PATH
-
-# Ensure other scripts can be found
-case "$0" in
-  */*) PATH=$(dirname "$(which "$0")"):$PATH;;
-esac
-
 # Specify additional arguments needed for specific modules
 EXTRA_ARGS=$(mktemp)
 trap 'rm -f "$EXTRA_ARGS"' EXIT
@@ -44,11 +37,18 @@ cat <<EOF >"$EXTRA_ARGS"
 cardano-ledger-api:lib:cardano-ledger-api --build-depends=cardano-ledger-babbage:testlib
 EOF
 
+RESULT=0
+shopt -s lastpipe # Run the while loop in the current process, to enable setting RESULT=1
+
 # Run the doctests for some or all packages
 cleret cabal targets "${PACKAGES[@]}" |
 sort | join -t' ' -a1 -j1 - "$EXTRA_ARGS" |
 while read -ra ARGS
 do
   echo "***** cabal doctest ${ARGS[0]} *****"
-  cabal doctest --repl-options='-w -Wdefault' "${ARGS[@]}"
+  cabal repl --with-repl=doctest --repl-options='-w -Wdefault' \
+    --build-depends=QuickCheck --build-depends=template-haskell \
+      "${ARGS[@]}" || RESULT=1
 done
+
+exit "$RESULT"


### PR DESCRIPTION
# Description

This replaces our use of `doctest`'s cabal integration (`cabal-doctest`) with the more traditional approach of calling `cabal repl` directly (using `--with-repl=doctest`). This reduces unnecessary rebuilding, and works better with nix.

Closes #5795 #5685 #5680

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
