### PR TITLE
Start to re-organize test hierarchy: ImpSpec

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### `testlib`
 
+* Make `Test.Cardano.Ledger.Allegra.Imp.spec` accept `Proxy era`
 * In `Test.Cardano.Ledger.Allegra.Examples`:
   - Remove `mkAllegraBasedExampleTx`, `exampleAllegraBasedTxBody`, `exampleAllegraBasedShelleyTxBody`
   - Add `exampleAllegraBasedTx`

--- a/eras/allegra/impl/test/Main.hs
+++ b/eras/allegra/impl/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 
@@ -8,18 +9,18 @@ import qualified Test.Cardano.Ledger.Allegra.Binary.Golden as Golden
 import qualified Test.Cardano.Ledger.Allegra.BinarySpec as BinarySpec
 import qualified Test.Cardano.Ledger.Allegra.Imp as Imp
 import Test.Cardano.Ledger.Allegra.ImpTest ()
-import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
+import Test.Cardano.Ledger.Era
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
+
+instance EraSpec AllegraEra where
+  eraImpSpec = Imp.spec
 
 main :: IO ()
 main =
-  ledgerTestMain $
-    describe "Allegra" $ do
-      BinarySpec.spec
-      CddlSpec.spec
-      describe "Imp" $ do
-        Imp.spec @AllegraEra
-      roundTripJsonEraSpec @AllegraEra
-      roundTripJsonShelleyEraSpec @AllegraEra
-      Golden.spec @AllegraEra
+  ledgerEraTestMain @AllegraEra $ do
+    BinarySpec.spec
+    CddlSpec.spec
+    roundTripJsonEraSpec @AllegraEra
+    roundTripJsonShelleyEraSpec @AllegraEra
+    Golden.spec @AllegraEra

--- a/eras/allegra/impl/test/Main.hs
+++ b/eras/allegra/impl/test/Main.hs
@@ -11,10 +11,13 @@ import qualified Test.Cardano.Ledger.Allegra.Imp as Imp
 import Test.Cardano.Ledger.Allegra.ImpTest ()
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
 import Test.Cardano.Ledger.Era
+import qualified Test.Cardano.Ledger.Shelley.Imp as Imp (shelleyEraSpecificSpec)
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 instance EraSpec AllegraEra where
-  eraImpSpec = Imp.spec
+  eraImpSpec era = do
+    Imp.shelleyEraSpecificSpec era
+    Imp.spec era
 
 main :: IO ()
 main =

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
@@ -6,22 +6,18 @@
 
 module Test.Cardano.Ledger.Allegra.Imp (spec) where
 
-import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules
 import Test.Cardano.Ledger.Allegra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
-import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
+import qualified Test.Cardano.Ledger.Shelley.Imp as Shelley
 
 spec ::
   ( ShelleyEraImp era
-  , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
   proxy era ->
   Spec
 spec era = do
-  ShelleyImp.spec era
-
-instance EraSpecificSpec AllegraEra where
-  eraSpecificSpec = ShelleyImp.shelleyEraSpecificSpec
+  Shelley.spec era
+  describe "AllegraEra Onwards" $ pure ()

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Imp.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -17,14 +14,14 @@ import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 spec ::
-  forall era.
   ( ShelleyEraImp era
   , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
+  proxy era ->
   Spec
-spec = do
-  ShelleyImp.spec @era
+spec era = do
+  ShelleyImp.spec era
 
 instance EraSpecificSpec AllegraEra where
   eraSpecificSpec = ShelleyImp.shelleyEraSpecificSpec

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### `testlib`
 
+* Add `proxy era` argument to `alonzoEraSpecificSpec`
 * Make `Test.Cardano.Ledger.Alonzo.Imp.spec` accept `Proxy era`
 * Add `genDatumPresent`
 * Added `Proxy era` argument to `exUnitsRule`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### `testlib`
 
+* Make `Test.Cardano.Ledger.Alonzo.Imp.spec` accept `Proxy era`
 * Add `genDatumPresent`
 * Added `Proxy era` argument to `exUnitsRule`
 * `TranslationInstance` has a new field `tiPlutusPurpose`

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -98,7 +98,7 @@ library
     cardano-ledger-allegra ^>=1.10,
     cardano-ledger-binary ^>=1.9,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.21,
-    cardano-ledger-mary ^>=1.10.1,
+    cardano-ledger-mary ^>=1.11,
     cardano-ledger-shelley ^>=1.19,
     cardano-slotting,
     cardano-strict-containers,

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 
@@ -11,27 +12,28 @@ import qualified Test.Cardano.Ledger.Alonzo.BinarySpec as BinarySpec
 import qualified Test.Cardano.Ledger.Alonzo.GoldenSpec as Golden
 import qualified Test.Cardano.Ledger.Alonzo.GoldenTranslation as GoldenTranslation
 import qualified Test.Cardano.Ledger.Alonzo.Imp as Imp
-import qualified Test.Cardano.Ledger.Alonzo.Imp.TxInfoSpec as TxInfoImp
+import qualified Test.Cardano.Ledger.Alonzo.Imp.TxInfoSpec as TxInfo
 import Test.Cardano.Ledger.Alonzo.ImpTest ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
+import Test.Cardano.Ledger.Era
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
+
+instance EraSpec AlonzoEra where
+  eraImpSpec = Imp.spec
 
 main :: IO ()
 main =
-  ledgerTestMain $
-    describe "Alonzo" $ do
-      BinarySpec.spec
-      Canonical.spec
-      CddlSpec.spec
-      roundTripJsonEraSpec @AlonzoEra
-      roundTripJsonShelleyEraSpec @AlonzoEra
-      GoldenTranslation.tests
-      Golden.spec
-      describe "Imp" $ do
-        Imp.spec @AlonzoEra
-      describe "CostModels" $ do
-        CostModelsSpec.spec @AlonzoEra
-      describe "TxWits" $ do
-        TxWitsSpec.spec @AlonzoEra
-      TxInfoImp.spec
+  ledgerEraTestMain @AlonzoEra $ do
+    BinarySpec.spec
+    Canonical.spec
+    CddlSpec.spec
+    roundTripJsonEraSpec @AlonzoEra
+    roundTripJsonShelleyEraSpec @AlonzoEra
+    GoldenTranslation.tests
+    Golden.spec
+    describe "CostModels" $ do
+      CostModelsSpec.spec @AlonzoEra
+    describe "TxWits" $ do
+      TxWitsSpec.spec @AlonzoEra
+    TxInfo.spec

--- a/eras/alonzo/impl/test/Main.hs
+++ b/eras/alonzo/impl/test/Main.hs
@@ -17,10 +17,14 @@ import Test.Cardano.Ledger.Alonzo.ImpTest ()
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
 import Test.Cardano.Ledger.Era
+import qualified Test.Cardano.Ledger.Shelley.Imp as Shelley
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 instance EraSpec AlonzoEra where
-  eraImpSpec = Imp.spec
+  eraImpSpec era = do
+    Shelley.shelleyEraSpecificSpec era
+    Imp.alonzoEraSpecificSpec era
+    Imp.spec era
 
 main :: IO ()
 main =

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
@@ -1,9 +1,5 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -23,28 +19,26 @@ import qualified Test.Cardano.Ledger.Mary.Imp as MaryImp
 import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 spec ::
-  forall era.
   ( AlonzoEraImp era
   , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
+  proxy era ->
   Spec
-spec = do
-  MaryImp.spec @era
-  describe "AlonzoImpSpec" . withEachEraVersion @era $ do
+spec era = do
+  MaryImp.spec era
+  describe "AlonzoImpSpec" . withImpInitEachEraVersion era $ do
     Bbody.spec
     Utxo.spec
     Utxos.spec
     Utxow.spec
 
 alonzoEraSpecificSpec ::
-  forall era.
   (AlonzoEraImp era, ShelleyEraTxCert era) =>
   SpecWith (ImpInit (LedgerSpec era))
 alonzoEraSpecificSpec = do
-  describe "Alonzo era specific Imp spec" $
-    describe "Certificates without deposits" $ do
-      Utxow.alonzoEraSpecificSpec
+  describe "From AlonzoEra" $ do
+    Utxow.alonzoEraSpecificSpec
 
 instance EraSpecificSpec AlonzoEra where
   eraSpecificSpec =

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
@@ -5,7 +5,6 @@
 
 module Test.Cardano.Ledger.Alonzo.Imp where
 
-import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Core (ShelleyEraTxCert)
 import Cardano.Ledger.Shelley.Rules
@@ -15,19 +14,17 @@ import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec as Utxos
 import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
-import qualified Test.Cardano.Ledger.Mary.Imp as MaryImp
-import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
+import qualified Test.Cardano.Ledger.Mary.Imp as Mary
 
 spec ::
   ( AlonzoEraImp era
-  , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
   proxy era ->
   Spec
 spec era = do
-  MaryImp.spec era
-  describe "AlonzoImpSpec" . withImpInitEachEraVersion era $ do
+  Mary.spec era
+  describe "AlonzoEra Onwards" $ withImpInitEachEraVersion era $ do
     Bbody.spec
     Utxo.spec
     Utxos.spec
@@ -35,11 +32,8 @@ spec era = do
 
 alonzoEraSpecificSpec ::
   (AlonzoEraImp era, ShelleyEraTxCert era) =>
-  SpecWith (ImpInit (LedgerSpec era))
-alonzoEraSpecificSpec = do
-  describe "From AlonzoEra" $ do
+  proxy era ->
+  Spec
+alonzoEraSpecificSpec era = withImpInitEachEraVersion era $ do
+  describe "AlonzoEra Specific" $ do
     Utxow.alonzoEraSpecificSpec
-
-instance EraSpecificSpec AlonzoEra where
-  eraSpecificSpec =
-    ShelleyImp.shelleyEraSpecificSpec >> alonzoEraSpecificSpec

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp.hs
@@ -8,10 +8,10 @@ module Test.Cardano.Ledger.Alonzo.Imp where
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Core (ShelleyEraTxCert)
 import Cardano.Ledger.Shelley.Rules
-import qualified Test.Cardano.Ledger.Alonzo.Imp.BbodySpec as Bbody
-import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxoSpec as Utxo
-import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec as Utxos
-import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec as Utxow
+import qualified Test.Cardano.Ledger.Alonzo.Imp.BbodySpec as BBODY
+import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxoSpec as UTXO
+import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxosSpec as UTXOS
+import qualified Test.Cardano.Ledger.Alonzo.Imp.UtxowSpec as UTXOW
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Mary.Imp as Mary
@@ -25,10 +25,10 @@ spec ::
 spec era = do
   Mary.spec era
   describe "AlonzoEra Onwards" $ withImpInitEachEraVersion era $ do
-    Bbody.spec
-    Utxo.spec
-    Utxos.spec
-    Utxow.spec
+    BBODY.spec
+    UTXO.spec
+    UTXOS.spec
+    UTXOW.spec
 
 alonzoEraSpecificSpec ::
   (AlonzoEraImp era, ShelleyEraTxCert era) =>
@@ -36,4 +36,4 @@ alonzoEraSpecificSpec ::
   Spec
 alonzoEraSpecificSpec era = withImpInitEachEraVersion era $ do
   describe "AlonzoEra Specific" $ do
-    Utxow.alonzoEraSpecificSpec
+    UTXOW.alonzoEraSpecificSpec

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxowSpec.hs
@@ -23,5 +23,6 @@ alonzoEraSpecificSpec ::
   forall era. (AlonzoEraImp era, ShelleyEraTxCert era) => SpecWith (ImpInit (LedgerSpec era))
 alonzoEraSpecificSpec = do
   describe "UTXOW" $ do
-    Valid.alonzoEraSpecificSpec
-    Invalid.alonzoEraSpecificSpec
+    describe "Certificates without deposits" $ do
+      Valid.alonzoEraSpecificSpec
+      Invalid.alonzoEraSpecificSpec

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### `testlib`
 
+* Add `proxy era` argument to `babbageEraSpecificSpec`
 * Make `Test.Cardano.Ledger.Babbage.Imp.spec` accept `Proxy era`
 * Add `Test.Cardano.Ledger.Babbage.Imp.PoolSpec` module with `babbageEraSpecificSpec`
 * In `Test.Cardano.Ledger.Babbage.Examples`:

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### `testlib`
 
+* Make `Test.Cardano.Ledger.Babbage.Imp.spec` accept `Proxy era`
 * Add `Test.Cardano.Ledger.Babbage.Imp.PoolSpec` module with `babbageEraSpecificSpec`
 * In `Test.Cardano.Ledger.Babbage.Examples`:
   - Remove `mkBabbageBasedExampleTx`, `exampleBabbageBasedTxBody`

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -94,7 +94,7 @@ library
     cardano-ledger-alonzo ^>=1.16,
     cardano-ledger-binary >=1.6,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.20,
-    cardano-ledger-mary ^>=1.10.1,
+    cardano-ledger-mary ^>=1.11,
     cardano-ledger-shelley ^>=1.19,
     cardano-strict-containers,
     containers,

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -6,6 +6,7 @@ module Main where
 import Cardano.Ledger.Babbage (BabbageEra)
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
+import qualified Test.Cardano.Ledger.Alonzo.Imp as Alonzo
 import qualified Test.Cardano.Ledger.Babbage.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Babbage.BinarySpec as BinarySpec
 import qualified Test.Cardano.Ledger.Babbage.GoldenSpec as Golden
@@ -16,10 +17,15 @@ import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as TxInfo
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
 import Test.Cardano.Ledger.Era
+import qualified Test.Cardano.Ledger.Shelley.Imp as Shelley
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 instance EraSpec BabbageEra where
-  eraImpSpec = Imp.spec
+  eraImpSpec era = do
+    Shelley.shelleyEraSpecificSpec era
+    Alonzo.alonzoEraSpecificSpec era
+    Imp.babbageEraSpecificSpec era
+    Imp.spec era
 
 main :: IO ()
 main =

--- a/eras/babbage/impl/test/Main.hs
+++ b/eras/babbage/impl/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 
@@ -14,22 +15,23 @@ import Test.Cardano.Ledger.Babbage.ImpTest ()
 import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as TxInfo
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
+import Test.Cardano.Ledger.Era
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
+
+instance EraSpec BabbageEra where
+  eraImpSpec = Imp.spec
 
 main :: IO ()
 main =
-  ledgerTestMain $
-    describe "Babbage" $ do
-      TxInfo.spec @BabbageEra
-      GoldenTranslation.spec
-      Golden.spec
-      BinarySpec.spec
-      CddlSpec.spec
-      roundTripJsonEraSpec @BabbageEra
-      roundTripJsonShelleyEraSpec @BabbageEra
-      describe "Imp" $ do
-        Imp.spec @BabbageEra
-      describe "CostModels" $ do
-        CostModelsSpec.spec @BabbageEra
-      describe "TxWits" $ do
-        TxWitsSpec.spec @BabbageEra
+  ledgerEraTestMain @BabbageEra $ do
+    TxInfo.spec @BabbageEra
+    GoldenTranslation.spec
+    Golden.spec
+    BinarySpec.spec
+    CddlSpec.spec
+    roundTripJsonEraSpec @BabbageEra
+    roundTripJsonShelleyEraSpec @BabbageEra
+    describe "CostModels" $ do
+      CostModelsSpec.spec @BabbageEra
+    describe "TxWits" $ do
+      TxWitsSpec.spec @BabbageEra

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -8,13 +8,12 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Babbage.Imp (spec) where
+module Test.Cardano.Ledger.Babbage.Imp (spec, babbageEraSpecificSpec) where
 
-import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.State
 import Cardano.Ledger.Shelley.Rules
-import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
+import qualified Test.Cardano.Ledger.Alonzo.Imp as Alonzo
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import qualified Test.Cardano.Ledger.Babbage.Imp.PoolSpec as Pool
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxoSpec as Utxo
@@ -22,35 +21,27 @@ import qualified Test.Cardano.Ledger.Babbage.Imp.UtxosSpec as Utxos
 import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Babbage.ImpTest (BabbageEraImp)
 import Test.Cardano.Ledger.Imp.Common
-import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 spec ::
   ( BabbageEraImp era
-  , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
   proxy era ->
   Spec
 spec era = do
-  AlonzoImp.spec era
-  withImpInitEachEraVersion era $
-    describe "BabbageImpSpec - era generic tests" $ do
-      Utxo.spec
-      Utxow.spec
-      Utxos.spec
+  Alonzo.spec era
+  describe "BabbageEra Onwards" $ withImpInitEachEraVersion era $ do
+    Utxo.spec
+    Utxow.spec
+    Utxos.spec
 
 babbageEraSpecificSpec ::
   ( BabbageEraImp era
   , ShelleyEraAccounts era
   , Event (EraRule "NEWEPOCH" era) ~ ShelleyNewEpochEvent era
   ) =>
-  SpecWith (ImpInit (LedgerSpec era))
-babbageEraSpecificSpec = do
-  describe "Babbage era specific Imp spec" $
-    describe "POOL" Pool.babbageEraSpecificSpec
-
-instance EraSpecificSpec BabbageEra where
-  eraSpecificSpec =
-    ShelleyImp.shelleyEraSpecificSpec
-      >> AlonzoImp.alonzoEraSpecificSpec
-      >> babbageEraSpecificSpec
+  proxy era ->
+  Spec
+babbageEraSpecificSpec era = do
+  describe "BabbageEra Specific" $ withImpInitEachEraVersion era $ do
+    Pool.babbageEraSpecificSpec

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -15,10 +15,10 @@ import Cardano.Ledger.Babbage.State
 import Cardano.Ledger.Shelley.Rules
 import qualified Test.Cardano.Ledger.Alonzo.Imp as Alonzo
 import Test.Cardano.Ledger.Alonzo.ImpTest
-import qualified Test.Cardano.Ledger.Babbage.Imp.PoolSpec as Pool
-import qualified Test.Cardano.Ledger.Babbage.Imp.UtxoSpec as Utxo
-import qualified Test.Cardano.Ledger.Babbage.Imp.UtxosSpec as Utxos
-import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec as Utxow
+import qualified Test.Cardano.Ledger.Babbage.Imp.PoolSpec as POOL
+import qualified Test.Cardano.Ledger.Babbage.Imp.UtxoSpec as UTXO
+import qualified Test.Cardano.Ledger.Babbage.Imp.UtxosSpec as UTXOS
+import qualified Test.Cardano.Ledger.Babbage.Imp.UtxowSpec as UTXOW
 import Test.Cardano.Ledger.Babbage.ImpTest (BabbageEraImp)
 import Test.Cardano.Ledger.Imp.Common
 
@@ -31,9 +31,9 @@ spec ::
 spec era = do
   Alonzo.spec era
   describe "BabbageEra Onwards" $ withImpInitEachEraVersion era $ do
-    Utxo.spec
-    Utxow.spec
-    Utxos.spec
+    UTXO.spec
+    UTXOW.spec
+    UTXOS.spec
 
 babbageEraSpecificSpec ::
   ( BabbageEraImp era
@@ -44,4 +44,4 @@ babbageEraSpecificSpec ::
   Spec
 babbageEraSpecificSpec era = do
   describe "BabbageEra Specific" $ withImpInitEachEraVersion era $ do
-    Pool.babbageEraSpecificSpec
+    POOL.babbageEraSpecificSpec

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp.hs
@@ -25,22 +25,21 @@ import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 spec ::
-  forall era.
   ( BabbageEraImp era
   , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
+  proxy era ->
   Spec
-spec = do
-  AlonzoImp.spec @era
-  withEachEraVersion @era $
+spec era = do
+  AlonzoImp.spec era
+  withImpInitEachEraVersion era $
     describe "BabbageImpSpec - era generic tests" $ do
       Utxo.spec
       Utxow.spec
-      Utxos.spec @era
+      Utxos.spec
 
 babbageEraSpecificSpec ::
-  forall era.
   ( BabbageEraImp era
   , ShelleyEraAccounts era
   , Event (EraRule "NEWEPOCH" era) ~ ShelleyNewEpochEvent era

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/PoolSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Imp/PoolSpec.hs
@@ -33,7 +33,7 @@ babbageEraSpecificSpec ::
   , Event (EraRule "NEWEPOCH" era) ~ ShelleyNewEpochEvent era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
-babbageEraSpecificSpec = do
+babbageEraSpecificSpec = describe "POOL" $ do
   it "Pool to pool member rewards" $ do
     -- This test attempts to reproduce the issue that appeared with the release of
     -- `cardano-db-sync-10.6.1` (using `cardano-ledger-shelley-1.17.0.0`),

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### `testlib`
 
+* Make `Test.Cardano.Ledger.Conway.Imp.spec` accept `Proxy era`
 * In `Test.Cardano.Ledger.Conway.Examples`:
   - Remove `mkConwayBasedExampleTx`, `exampleConwayBasedTxBody`
   - Add `exampleConwayBasedTx`, `exampleConwayBasedTopTx`

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### `testlib`
 
+* Export `conwayEraSpecificSpec`
 * Make `Test.Cardano.Ledger.Conway.Imp.spec` accept `Proxy era`
 * In `Test.Cardano.Ledger.Conway.Examples`:
   - Remove `mkConwayBasedExampleTx`, `exampleConwayBasedTxBody`

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -112,7 +112,7 @@ library
     cardano-ledger-babbage ^>=1.14,
     cardano-ledger-binary ^>=1.9,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.21,
-    cardano-ledger-mary ^>=1.10.1,
+    cardano-ledger-mary ^>=1.11,
     cardano-ledger-shelley ^>=1.19,
     cardano-slotting,
     cardano-strict-containers,

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -6,6 +6,7 @@ module Main where
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Tx (tierRefScriptFee)
+import qualified Test.Cardano.Ledger.Alonzo.Imp as Alonzo
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Conway.GenesisSpec as Genesis
@@ -20,7 +21,10 @@ import Test.Cardano.Ledger.Era
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 instance EraSpec ConwayEra where
-  eraImpSpec = Imp.spec
+  eraImpSpec era = do
+    Alonzo.alonzoEraSpecificSpec era
+    Imp.conwayEraSpecificSpec
+    Imp.spec era
 
 main :: IO ()
 main = ledgerEraTestMain @ConwayEra $ do

--- a/eras/conway/impl/test/Main.hs
+++ b/eras/conway/impl/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 
@@ -11,13 +12,18 @@ import qualified Test.Cardano.Ledger.Conway.GenesisSpec as Genesis
 import qualified Test.Cardano.Ledger.Conway.GoldenSpec as GoldenSpec
 import qualified Test.Cardano.Ledger.Conway.GoldenTranslation as GoldenTranslation
 import qualified Test.Cardano.Ledger.Conway.GovActionReorderSpec as GovActionReorder
+import qualified Test.Cardano.Ledger.Conway.Imp as Imp
 import Test.Cardano.Ledger.Conway.Plutus.PlutusSpec as PlutusSpec
 import qualified Test.Cardano.Ledger.Conway.Spec as ConwaySpec
 import qualified Test.Cardano.Ledger.Conway.TxInfoSpec as TxInfo
+import Test.Cardano.Ledger.Era
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
+instance EraSpec ConwayEra where
+  eraImpSpec = Imp.spec
+
 main :: IO ()
-main = ledgerTestMain $ do
+main = ledgerEraTestMain @ConwayEra $ do
   describe "Conway era-generic" $ ConwaySpec.spec @ConwayEra
   describe "Conway era-specific" $ do
     GoldenTranslation.spec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Cardano.Ledger.Conway.Imp (spec) where
+module Test.Cardano.Ledger.Conway.Imp (spec, conwayEraSpecificSpec) where
 
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
@@ -18,8 +18,8 @@ import Cardano.Ledger.Conway.Rules (
  )
 import Cardano.Ledger.Shelley.Rules (RupdEvent)
 import Control.State.Transition.Extended
-import qualified Test.Cardano.Ledger.Alonzo.Imp as AlonzoImp
-import qualified Test.Cardano.Ledger.Babbage.Imp as BabbageImp
+import Data.Proxy
+import qualified Test.Cardano.Ledger.Babbage.Imp as Babbage
 import qualified Test.Cardano.Ledger.Conway.Imp.BbodySpec as Bbody
 import qualified Test.Cardano.Ledger.Conway.Imp.CertsSpec as Certs
 import qualified Test.Cardano.Ledger.Conway.Imp.DelegSpec as Deleg
@@ -38,7 +38,6 @@ import Test.Cardano.Ledger.Imp.Common
 
 spec ::
   ( ConwayEraImp era
-  , EraSpecificSpec era
   , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
@@ -47,8 +46,8 @@ spec ::
   proxy era ->
   Spec
 spec era = do
-  BabbageImp.spec era
-  withImpInitEachEraVersion era $ do
+  Babbage.spec era
+  describe "ConwayEra Onwards" $ withImpInitEachEraVersion era $ do
     Bbody.spec
     Deleg.spec
     Enact.spec
@@ -62,13 +61,8 @@ spec era = do
     Utxos.spec
     Utxow.spec
 
-conwayEraSpecificSpec :: SpecWith (ImpInit (LedgerSpec ConwayEra))
+conwayEraSpecificSpec :: Spec
 conwayEraSpecificSpec = do
-  describe "Conway era specific Imp spec" $ do
+  describe "ConwayEra Specific" $ withImpInitEachEraVersion (Proxy @ConwayEra) $ do
     Certs.spec
     Utxo.conwayEraSpecificSpec
-
-instance EraSpecificSpec ConwayEra where
-  eraSpecificSpec =
-    AlonzoImp.alonzoEraSpecificSpec
-      >> conwayEraSpecificSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -37,7 +37,6 @@ import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
 spec ::
-  forall era.
   ( ConwayEraImp era
   , EraSpecificSpec era
   , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
@@ -45,38 +44,29 @@ spec ::
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
+  proxy era ->
   Spec
-spec = do
-  BabbageImp.spec @era
-  withEachEraVersion @era $ conwayEraGenericSpec @era
-
-conwayEraGenericSpec ::
-  forall era.
-  ( ConwayEraImp era
-  , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
-  , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
-  , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
-  ) =>
-  SpecWith (ImpInit (LedgerSpec era))
-conwayEraGenericSpec = do
-  describe "BBODY" Bbody.spec
-  describe "DELEG" Deleg.spec
-  describe "ENACT" Enact.spec
-  describe "EPOCH" Epoch.spec
-  describe "GOV" Gov.spec
-  describe "GOVCERT" GovCert.spec
-  describe "LEDGER" Ledger.spec
-  describe "HARDFORK" HardFork.spec
-  describe "RATIFY" Ratify.spec
-  describe "UTXO" Utxo.spec
-  describe "UTXOS" Utxos.spec
-  describe "UTXOW" Utxow.spec
+spec era = do
+  BabbageImp.spec era
+  withImpInitEachEraVersion era $ do
+    Bbody.spec
+    Deleg.spec
+    Enact.spec
+    Epoch.spec
+    Gov.spec
+    GovCert.spec
+    Ledger.spec
+    HardFork.spec
+    Ratify.spec
+    Utxo.spec
+    Utxos.spec
+    Utxow.spec
 
 conwayEraSpecificSpec :: SpecWith (ImpInit (LedgerSpec ConwayEra))
 conwayEraSpecificSpec = do
   describe "Conway era specific Imp spec" $ do
-    describe "CERTS" Certs.spec
-    describe "UTXO" Utxo.conwayEraSpecificSpec
+    Certs.spec
+    Utxo.conwayEraSpecificSpec
 
 instance EraSpecificSpec ConwayEra where
   eraSpecificSpec =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs
@@ -20,19 +20,19 @@ import Cardano.Ledger.Shelley.Rules (RupdEvent)
 import Control.State.Transition.Extended
 import Data.Proxy
 import qualified Test.Cardano.Ledger.Babbage.Imp as Babbage
-import qualified Test.Cardano.Ledger.Conway.Imp.BbodySpec as Bbody
-import qualified Test.Cardano.Ledger.Conway.Imp.CertsSpec as Certs
-import qualified Test.Cardano.Ledger.Conway.Imp.DelegSpec as Deleg
-import qualified Test.Cardano.Ledger.Conway.Imp.EnactSpec as Enact
-import qualified Test.Cardano.Ledger.Conway.Imp.EpochSpec as Epoch
-import qualified Test.Cardano.Ledger.Conway.Imp.GovCertSpec as GovCert
-import qualified Test.Cardano.Ledger.Conway.Imp.GovSpec as Gov
-import qualified Test.Cardano.Ledger.Conway.Imp.HardForkSpec as HardFork
-import qualified Test.Cardano.Ledger.Conway.Imp.LedgerSpec as Ledger
-import qualified Test.Cardano.Ledger.Conway.Imp.RatifySpec as Ratify
-import qualified Test.Cardano.Ledger.Conway.Imp.UtxoSpec as Utxo
-import qualified Test.Cardano.Ledger.Conway.Imp.UtxosSpec as Utxos
-import qualified Test.Cardano.Ledger.Conway.Imp.UtxowSpec as Utxow
+import qualified Test.Cardano.Ledger.Conway.Imp.BbodySpec as BBODY
+import qualified Test.Cardano.Ledger.Conway.Imp.CertsSpec as CERTS
+import qualified Test.Cardano.Ledger.Conway.Imp.DelegSpec as DELEG
+import qualified Test.Cardano.Ledger.Conway.Imp.EnactSpec as ENACT
+import qualified Test.Cardano.Ledger.Conway.Imp.EpochSpec as EPOCH
+import qualified Test.Cardano.Ledger.Conway.Imp.GovCertSpec as GOVCERT
+import qualified Test.Cardano.Ledger.Conway.Imp.GovSpec as GOV
+import qualified Test.Cardano.Ledger.Conway.Imp.HardForkSpec as HARDFORK
+import qualified Test.Cardano.Ledger.Conway.Imp.LedgerSpec as LEDGER
+import qualified Test.Cardano.Ledger.Conway.Imp.RatifySpec as RATIFY
+import qualified Test.Cardano.Ledger.Conway.Imp.UtxoSpec as UTXO
+import qualified Test.Cardano.Ledger.Conway.Imp.UtxosSpec as UTXOS
+import qualified Test.Cardano.Ledger.Conway.Imp.UtxowSpec as UTXOW
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
@@ -48,21 +48,22 @@ spec ::
 spec era = do
   Babbage.spec era
   describe "ConwayEra Onwards" $ withImpInitEachEraVersion era $ do
-    Bbody.spec
-    Deleg.spec
-    Enact.spec
-    Epoch.spec
-    Gov.spec
-    GovCert.spec
-    Ledger.spec
-    HardFork.spec
-    Ratify.spec
-    Utxo.spec
-    Utxos.spec
-    Utxow.spec
+    BBODY.spec
+    DELEG.spec
+    ENACT.spec
+    EPOCH.spec
+    GOV.spec
+    GOVCERT.spec
+    LEDGER.spec
+    HARDFORK.spec
+    RATIFY.spec
+    UTXO.spec
+    UTXOS.spec
+    UTXOW.spec
 
 conwayEraSpecificSpec :: Spec
 conwayEraSpecificSpec = do
   describe "ConwayEra Specific" $ withImpInitEachEraVersion (Proxy @ConwayEra) $ do
-    Certs.spec
-    Utxo.conwayEraSpecificSpec
+    -- TODO: move to `spec` when ready: https://github.com/IntersectMBO/cardano-ledger/issues/5805
+    CERTS.spec
+    UTXO.conwayEraSpecificSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/BbodySpec.hs
@@ -39,7 +39,7 @@ import Test.Cardano.Ledger.Plutus.Examples (alwaysFailsNoDatum, purposeIsWellfor
 spec ::
   forall era.
   ConwayEraImp era => SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "BBODY" $ do
   it "BodyRefScriptsSizeTooBig" $ do
     plutusScript <- mkPlutusScript @era $ purposeIsWellformedNoDatum SPlutusV2
     let scriptSize = originalBytesSize plutusScript

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/CertsSpec.hs
@@ -28,7 +28,7 @@ spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "CERTS" $ do
   describe "Withdrawals" $ do
     it "Withdrawing from an unregistered staking address" $ do
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
@@ -55,7 +55,7 @@ spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "DELEG" $ do
   describe "Register stake credential" $ do
     it "With correct deposit" $ do
       expectedDeposit <- getsNES $ nesEsL . curPParamsEpochStateL . ppKeyDepositL

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EnactSpec.hs
@@ -48,7 +48,7 @@ spec ::
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "ENACT" $ do
   committeeSpec
   treasuryWithdrawalsSpec
   noConfidenceSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/EpochSpec.hs
@@ -46,7 +46,7 @@ spec ::
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "EPOCH" $ do
   dRepVotingSpec
   treasurySpec
   proposalsSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovCertSpec.hs
@@ -27,7 +27,7 @@ spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "GOVCERT" $ do
   it "Resigning proposed CC key" $ do
     ccColdCred <- KeyHashObj <$> freshKeyHash
     proposal <- mkUpdateCommitteeProposal Nothing mempty [(ccColdCred, EpochInterval 1234)] (1 %! 2)

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/GovSpec.hs
@@ -47,7 +47,7 @@ spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "GOV" $ do
   constitutionSpec
   proposalsSpec
   votingSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/HardForkSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/HardForkSpec.hs
@@ -24,7 +24,7 @@ spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "HARDFORK" $ do
   it "VRF Keyhashes get populated at v11 HardFork" $ do
     -- Since we're testing the HardFork to 11, the test only makes sense for protocol version 10
     whenMajorVersion @10 $ do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -52,7 +52,7 @@ spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "LEDGER" $ do
   it "TxRefScriptsSizeTooBig" $ do
     -- we use here the largest script we currently have as many times as necessary to
     -- trigger the predicate failure

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/RatifySpec.hs
@@ -39,7 +39,7 @@ spec ::
   forall era.
   (HasCallStack, ConwayEraImp era) =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "RATIFY" $ do
   votingSpec
   delayingActionsSpec
   committeeMinSizeAffectsInFlightProposalsSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
@@ -38,7 +38,7 @@ import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsNoDatum)
 
 spec :: forall era. ConwayEraImp era => SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "UTXO" $ do
   describe "Certificates" $ do
     it "Reg/UnReg collect and refund correct amounts" $ do
       utxoStart <- getUTxO
@@ -157,7 +157,7 @@ conwayEraSpecificSpec ::
   , ShelleyEraTxCert era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
-conwayEraSpecificSpec = do
+conwayEraSpecificSpec = describe "UTXO" $ do
   describe "Certificates" $ do
     it "Reg/UnReg collect and refund correct amounts" $ do
       utxoStart <- getUTxO

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxosSpec.hs
@@ -56,7 +56,7 @@ spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "UTXOS" $ do
   govPolicySpec
   costModelsSpec
   datumAndReferenceInputsSpec

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
@@ -53,7 +53,7 @@ spec ::
   forall era.
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "UTXOW" $ do
   -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1029
   -- TODO: Re-enable after issue is resolved, by removing this override
   disableInConformanceIt "Fails with PPViewHashesDontMatch before PV 11" . whenMajorVersionAtMost @10 $ do

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
@@ -18,7 +18,7 @@ import qualified Test.Cardano.Ledger.Conway.Binary.Regression as Regression
 import qualified Test.Cardano.Ledger.Conway.BinarySpec as Binary
 import qualified Test.Cardano.Ledger.Conway.CommitteeRatifySpec as CommitteeRatify
 import qualified Test.Cardano.Ledger.Conway.DRepRatifySpec as DRepRatify
-import Test.Cardano.Ledger.Conway.ImpTest (ConwayEraImp, EraSpecificSpec)
+import Test.Cardano.Ledger.Conway.ImpTest (ConwayEraImp)
 import qualified Test.Cardano.Ledger.Conway.Proposals as Proposals
 import qualified Test.Cardano.Ledger.Conway.SPORatifySpec as SPORatifySpec
 import Test.Cardano.Ledger.Core.Binary.RoundTrip (RuleListEra)
@@ -28,7 +28,6 @@ spec ::
   forall era.
   ( RuleListEra era
   , ConwayEraImp era
-  , EraSpecificSpec era
   ) =>
   Spec
 spec =

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Spec.hs
@@ -8,15 +8,7 @@
 
 module Test.Cardano.Ledger.Conway.Spec (spec) where
 
-import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Rules (
-  ConwayEpochEvent,
-  ConwayHardForkEvent,
-  ConwayNewEpochEvent,
- )
 import Cardano.Ledger.Plutus.Language (SLanguage (..))
-import Cardano.Ledger.Shelley.Rules (RupdEvent)
-import Control.State.Transition (STS (..))
 import qualified Test.Cardano.Ledger.Alonzo.Binary.CostModelsSpec as CostModelsSpec
 import qualified Test.Cardano.Ledger.Alonzo.Binary.TxWitsSpec as TxWitsSpec
 import qualified Test.Cardano.Ledger.Babbage.TxInfoSpec as BabbageTxInfo
@@ -26,7 +18,6 @@ import qualified Test.Cardano.Ledger.Conway.Binary.Regression as Regression
 import qualified Test.Cardano.Ledger.Conway.BinarySpec as Binary
 import qualified Test.Cardano.Ledger.Conway.CommitteeRatifySpec as CommitteeRatify
 import qualified Test.Cardano.Ledger.Conway.DRepRatifySpec as DRepRatify
-import qualified Test.Cardano.Ledger.Conway.Imp as Imp
 import Test.Cardano.Ledger.Conway.ImpTest (ConwayEraImp, EraSpecificSpec)
 import qualified Test.Cardano.Ledger.Conway.Proposals as Proposals
 import qualified Test.Cardano.Ledger.Conway.SPORatifySpec as SPORatifySpec
@@ -38,10 +29,6 @@ spec ::
   ( RuleListEra era
   , ConwayEraImp era
   , EraSpecificSpec era
-  , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
-  , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
-  , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
-  , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
   Spec
 spec =
@@ -54,8 +41,6 @@ spec =
     roundTripJsonEraSpec @era
     Golden.spec @era
     Golden.goldenListRedeemers @era
-    describe "Imp" $ do
-      Imp.spec @era
     describe "CostModels" $ do
       CostModelsSpec.spec @era
     describe "TxWits" $ do

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -69,6 +69,7 @@
 
 ### testlib
 
+* Make `Test.Cardano.Ledger.Dijkstra.Imp.spec` accept `Proxy era`
 * Add `ToExpr` instance for `DijkstraBlockBody`
 * Add `DecCBOR` instance for `DijkstraBlockBodyRaw`
 * Add `genNonEmptyAccountBalanceIntervals`

--- a/eras/dijkstra/impl/test/Main.hs
+++ b/eras/dijkstra/impl/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 
@@ -17,22 +18,23 @@ import qualified Test.Cardano.Ledger.Dijkstra.GoldenSpec as GoldenSpec
 import qualified Test.Cardano.Ledger.Dijkstra.Imp as Imp
 import Test.Cardano.Ledger.Dijkstra.ImpTest ()
 import qualified Test.Cardano.Ledger.Dijkstra.TxInfoSpec as DijkstraTxInfoSpec
+import Test.Cardano.Ledger.Era
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
+
+instance EraSpec DijkstraEra where
+  eraImpSpec = Imp.spec
 
 main :: IO ()
 main =
-  ledgerTestMain $
-    describe "Dijkstra" $ do
-      describe "RoundTrip" $ do
-        roundTripConwayCommonSpec @DijkstraEra
-      Cddl.spec
-      GoldenSpec.spec
-      roundTripJsonShelleyEraSpec @DijkstraEra
-      describe "Imp" $ do
-        Imp.spec @DijkstraEra
-      describe "TxInfo" $ do
-        BabbageTxInfo.spec @DijkstraEra
-        txInfoSpec @DijkstraEra SPlutusV3
-        txInfoSpec @DijkstraEra SPlutusV4
-        DijkstraTxInfoSpec.spec @DijkstraEra
-      Golden.spec @DijkstraEra
+  ledgerEraTestMain @DijkstraEra $ do
+    describe "RoundTrip" $ do
+      roundTripConwayCommonSpec @DijkstraEra
+    Cddl.spec
+    GoldenSpec.spec
+    roundTripJsonShelleyEraSpec @DijkstraEra
+    describe "TxInfo" $ do
+      BabbageTxInfo.spec @DijkstraEra
+      txInfoSpec @DijkstraEra SPlutusV3
+      txInfoSpec @DijkstraEra SPlutusV4
+      DijkstraTxInfoSpec.spec @DijkstraEra
+    Golden.spec @DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -10,11 +10,11 @@ import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Shelley.Rules
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp as ConwayImp
-import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertSpec as Cert
-import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertsSpec as Certs
-import qualified Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec as Ledger
-import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec as Utxo
-import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as Utxow
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertSpec as CERT
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertsSpec as CERTS
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec as LEDGER
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec as UTXO
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as UTXOW
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 
 spec ::
@@ -29,8 +29,8 @@ spec ::
 spec era = do
   ConwayImp.spec era
   describe "DijkstraEra Onwards" $ withImpInitEachEraVersion era $ do
-    Ledger.spec
-    Cert.spec
-    Certs.spec
-    Utxow.spec
-    Utxo.spec
+    LEDGER.spec
+    CERT.spec
+    CERTS.spec
+    UTXOW.spec
+    UTXO.spec

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -22,7 +19,6 @@ import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as Utxow
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 
 spec ::
-  forall era.
   ( DijkstraEraImp era
   , EraSpecificSpec era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
@@ -30,21 +26,15 @@ spec ::
   , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
+  proxy era ->
   Spec
-spec = do
-  ConwayImp.spec @era
-  withEachEraVersion @era $ dijkstraEraGenericSpec @era
-
-dijkstraEraGenericSpec ::
-  forall era.
-  DijkstraEraImp era =>
-  SpecWith (ImpInit (LedgerSpec era))
-dijkstraEraGenericSpec = do
-  describe "LEDGER" Ledger.spec
-  describe "CERTS" $ do
+spec era = do
+  ConwayImp.spec era
+  withImpInitEachEraVersion era $ do
+    Ledger.spec
     Cert.spec
     Certs.spec
-  describe "UTXOW" Utxow.spec
-  describe "UTXO" Utxo.spec
+    Utxow.spec
+    Utxo.spec
 
 instance EraSpecificSpec DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -6,7 +6,6 @@
 module Test.Cardano.Ledger.Dijkstra.Imp where
 
 import Cardano.Ledger.Conway.Rules
-import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Shelley.Rules
 import Test.Cardano.Ledger.Common
@@ -20,7 +19,6 @@ import Test.Cardano.Ledger.Dijkstra.ImpTest
 
 spec ::
   ( DijkstraEraImp era
-  , EraSpecificSpec era
   , Event (EraRule "EPOCH" era) ~ ConwayEpochEvent era
   , Event (EraRule "NEWEPOCH" era) ~ ConwayNewEpochEvent era
   , Event (EraRule "HARDFORK" era) ~ ConwayHardForkEvent era
@@ -30,11 +28,9 @@ spec ::
   Spec
 spec era = do
   ConwayImp.spec era
-  withImpInitEachEraVersion era $ do
+  describe "DijkstraEra Onwards" $ withImpInitEachEraVersion era $ do
     Ledger.spec
     Cert.spec
     Certs.spec
     Utxow.spec
     Utxo.spec
-
-instance EraSpecificSpec DijkstraEra

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertSpec.hs
@@ -18,7 +18,7 @@ import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "CERT" $ do
   xit "Subtransaction consumes correct refund after keyDeposit is changed" $ do
     stakingCred <- KeyHashObj <$> freshKeyHash
     _ <- registerStakeCredential stakingCred

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertsSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertsSpec.hs
@@ -21,7 +21,7 @@ import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "CERTS" $ do
   describe "Withdrawals" $ do
     it "Withdrawing from an unregistered staking address" $ do
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/LedgerSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/LedgerSpec.hs
@@ -22,7 +22,7 @@ import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "LEDGER" $ do
   -- TODO: re-enable after Imp fixup of subtransactions is implemented
   xdescribe "Spending sub-transaction outputs" $ do
     it "Fails when top-level transaction spends output from its own sub-transaction" $ do

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -33,7 +33,7 @@ spec ::
   forall era.
   DijkstraEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec =
+spec = describe "UTXO" $ do
   describe "Collaterals" $ do
     it "Fails to submit a transaction containing a Ptr in collateral return" $ do
       cred <- KeyHashObj <$> freshKeyHash

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
@@ -25,7 +25,7 @@ spec ::
   forall era.
   DijkstraEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec =
+spec = describe "UTXOW" $ do
   describe "RequireGuard native scripts" $ do
     it "Spending inputs locked by script requiring a keyhash guard" $ do
       guardKeyHash <- KeyHashObj <$> freshKeyHash

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Version history for `cardano-ledger-mary`
 
-## 1.10.1.0
+## 1.11.0.0
 
 * Add `ApplyTick` instance for `MaryEra`
 * Add `EraForecast` and `ShelleyEraForecast` instances for `MaryEra`.
@@ -11,6 +11,7 @@
 
 ### `testlib`
 
+* Make `Test.Cardano.Ledger.Mary.Imp.spec` accept `Proxy era`
 * In `Test.Cardano.Ledger.Mary.Examples`:
   - Remove `exampleMaryBasedShelleyTxBody`, `exampleMaryBasedTxBody`
   - Add `exampleMaryBasedTx`

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-mary
-version: 1.10.1.0
+version: 1.11.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/mary/impl/test/Main.hs
+++ b/eras/mary/impl/test/Main.hs
@@ -12,10 +12,13 @@ import qualified Test.Cardano.Ledger.Mary.BinarySpec as BinarySpec
 import qualified Test.Cardano.Ledger.Mary.Imp as Imp
 import Test.Cardano.Ledger.Mary.ImpTest ()
 import qualified Test.Cardano.Ledger.Mary.ValueSpec as ValueSpec
+import qualified Test.Cardano.Ledger.Shelley.Imp as Imp (shelleyEraSpecificSpec)
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 instance EraSpec MaryEra where
-  eraImpSpec = Imp.spec
+  eraImpSpec era = do
+    Imp.shelleyEraSpecificSpec era
+    Imp.spec era
 
 main :: IO ()
 main =

--- a/eras/mary/impl/test/Main.hs
+++ b/eras/mary/impl/test/Main.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 
 import Cardano.Ledger.Mary (MaryEra)
 import qualified Test.Cardano.Ledger.Allegra.Binary.Golden as Golden
-import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
+import Test.Cardano.Ledger.Era
 import qualified Test.Cardano.Ledger.Mary.Binary.CddlSpec as CddlSpec
 import qualified Test.Cardano.Ledger.Mary.BinarySpec as BinarySpec
 import qualified Test.Cardano.Ledger.Mary.Imp as Imp
@@ -13,15 +14,15 @@ import Test.Cardano.Ledger.Mary.ImpTest ()
 import qualified Test.Cardano.Ledger.Mary.ValueSpec as ValueSpec
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
+instance EraSpec MaryEra where
+  eraImpSpec = Imp.spec
+
 main :: IO ()
 main =
-  ledgerTestMain $
-    describe "Mary" $ do
-      ValueSpec.spec
-      BinarySpec.spec
-      CddlSpec.spec
-      describe "Imp" $ do
-        Imp.spec @MaryEra
-      roundTripJsonEraSpec @MaryEra
-      roundTripJsonShelleyEraSpec @MaryEra
-      Golden.spec @MaryEra
+  ledgerEraTestMain @MaryEra $ do
+    ValueSpec.spec
+    BinarySpec.spec
+    CddlSpec.spec
+    roundTripJsonEraSpec @MaryEra
+    roundTripJsonShelleyEraSpec @MaryEra
+    Golden.spec @MaryEra

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
@@ -7,26 +7,20 @@
 module Test.Cardano.Ledger.Mary.Imp (spec) where
 
 import Cardano.Ledger.Core
-import Cardano.Ledger.Mary (MaryEra)
 import Cardano.Ledger.Shelley.Rules
-import qualified Test.Cardano.Ledger.Allegra.Imp as AllegraImp
+import qualified Test.Cardano.Ledger.Allegra.Imp as Allegra
 import Test.Cardano.Ledger.Imp.Common
 import qualified Test.Cardano.Ledger.Mary.Imp.UtxoSpec as Utxo
 import Test.Cardano.Ledger.Mary.ImpTest
-import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 spec ::
   ( MaryEraImp era
-  , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
   proxy era ->
   Spec
 spec era = do
-  AllegraImp.spec era
-  describe "MaryImpSpec" $
+  Allegra.spec era
+  describe "MaryEra Onwards" $
     withImpInitEachEraVersion era $ do
       Utxo.spec
-
-instance EraSpecificSpec MaryEra where
-  eraSpecificSpec = ShelleyImp.shelleyEraSpecificSpec

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
@@ -10,7 +10,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Rules
 import qualified Test.Cardano.Ledger.Allegra.Imp as Allegra
 import Test.Cardano.Ledger.Imp.Common
-import qualified Test.Cardano.Ledger.Mary.Imp.UtxoSpec as Utxo
+import qualified Test.Cardano.Ledger.Mary.Imp.UtxoSpec as UTXO
 import Test.Cardano.Ledger.Mary.ImpTest
 
 spec ::
@@ -23,4 +23,4 @@ spec era = do
   Allegra.spec era
   describe "MaryEra Onwards" $
     withImpInitEachEraVersion era $ do
-      Utxo.spec
+      UTXO.spec

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Imp.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -19,16 +16,16 @@ import Test.Cardano.Ledger.Mary.ImpTest
 import qualified Test.Cardano.Ledger.Shelley.Imp as ShelleyImp
 
 spec ::
-  forall era.
   ( MaryEraImp era
   , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
+  proxy era ->
   Spec
-spec = do
-  AllegraImp.spec @era
+spec era = do
+  AllegraImp.spec era
   describe "MaryImpSpec" $
-    withEachEraVersion @era $
+    withImpInitEachEraVersion era $ do
       Utxo.spec
 
 instance EraSpecificSpec MaryEra where

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -60,6 +60,8 @@
 
 ### `testlib`
 
+* Make `Test.Cardano.Ledger.Shelley.Imp.spec` accept `Proxy era`
+* Add `withImpInitEachEraVersion` and deprecate `withEachEraVersion` in its favor
 * Export `exampleVrfVerKeyHash` from `Test.Cardano.Ledger.Shelley.Examples`
 * Add `HuddleRule "int32" ShelleyEra` instance
 * Add `withIssuerAndTxsInBlock_` and `withIssuerAndTxsInBlock`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -60,6 +60,8 @@
 
 ### `testlib`
 
+* Add `proxy era` argument to `shelleyEraSpecificSpec`
+* Remove `EraSpecificSpec`
 * Make `Test.Cardano.Ledger.Shelley.Imp.spec` accept `Proxy era`
 * Add `withImpInitEachEraVersion` and deprecate `withEachEraVersion` in its favor
 * Export `exampleVrfVerKeyHash` from `Test.Cardano.Ledger.Shelley.Examples`

--- a/eras/shelley/impl/test/Main.hs
+++ b/eras/shelley/impl/test/Main.hs
@@ -1,21 +1,23 @@
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Main where
 
 import Cardano.Ledger.Shelley (ShelleyEra)
-import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.JSON (roundTripJsonEraSpec)
+import Test.Cardano.Ledger.Era
 import qualified Test.Cardano.Ledger.Shelley.Binary.CddlSpec as Cddl
 import qualified Test.Cardano.Ledger.Shelley.BinarySpec as Binary
 import qualified Test.Cardano.Ledger.Shelley.Imp as Imp
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
+instance EraSpec ShelleyEra where
+  eraImpSpec = Imp.spec
+
 main :: IO ()
 main =
-  ledgerTestMain $
-    describe "Shelley" $ do
-      Binary.spec
-      Cddl.spec
-      Imp.spec @ShelleyEra
-      roundTripJsonEraSpec @ShelleyEra
-      roundTripJsonShelleyEraSpec @ShelleyEra
+  ledgerEraTestMain @ShelleyEra $ do
+    Binary.spec
+    Cddl.spec
+    roundTripJsonEraSpec @ShelleyEra
+    roundTripJsonShelleyEraSpec @ShelleyEra

--- a/eras/shelley/impl/test/Main.hs
+++ b/eras/shelley/impl/test/Main.hs
@@ -12,7 +12,9 @@ import qualified Test.Cardano.Ledger.Shelley.Imp as Imp
 import Test.Cardano.Ledger.Shelley.JSON (roundTripJsonShelleyEraSpec)
 
 instance EraSpec ShelleyEra where
-  eraImpSpec = Imp.spec
+  eraImpSpec era = do
+    Imp.shelleyEraSpecificSpec era
+    Imp.spec era
 
 main :: IO ()
 main =

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -24,22 +23,23 @@ import Test.Cardano.Ledger.Shelley.ImpTest
 import qualified Test.Cardano.Ledger.Shelley.UnitTests.InstantStakeTest as Instant
 
 spec ::
-  forall era.
+  forall proxy era.
   ( ShelleyEraImp era
   , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
+  proxy era ->
   Spec
-spec = do
-  describe "Era specific tests" . withEachEraVersion @era $ eraSpecificSpec
-  describe "ShelleyImpSpec" $ withEachEraVersion @era $ do
-    describe "DELEG" Deleg.spec
+spec era = do
+  describe "Era specific tests" $ withImpInitEachEraVersion era eraSpecificSpec
+  describe "ShelleyEraImpSpec" $ withImpInitEachEraVersion era $ do
+    Deleg.spec
     Epoch.spec
     Ledger.spec
     Pool.spec
     Utxow.spec
     Utxo.spec
-  describe "ShelleyPureTests" $ do
+  describe "ShelleyEraPureTests" $ do
     Instant.spec @era
 
 shelleyEraSpecificSpec ::
@@ -49,9 +49,8 @@ shelleyEraSpecificSpec ::
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
 shelleyEraSpecificSpec = do
-  describe "Shelley era specific Imp spec" $
-    describe "DELEG" $
-      Deleg.shelleyEraSpecificSpec
+  describe "From ShelleyEra" $
+    Deleg.shelleyEraSpecificSpec
 
 instance EraSpecificSpec ShelleyEra where
   eraSpecificSpec = shelleyEraSpecificSpec

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -12,12 +12,12 @@ import Cardano.Ledger.Shelley.Rules (RupdEvent)
 import Cardano.Ledger.Shelley.State (ShelleyEraAccounts)
 import Control.State.Transition (Event)
 import Test.Cardano.Ledger.Imp.Common
-import qualified Test.Cardano.Ledger.Shelley.Imp.DelegSpec as Deleg
-import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as Epoch
-import qualified Test.Cardano.Ledger.Shelley.Imp.LedgerSpec as Ledger
-import qualified Test.Cardano.Ledger.Shelley.Imp.PoolSpec as Pool
-import qualified Test.Cardano.Ledger.Shelley.Imp.UtxoSpec as Utxo
-import qualified Test.Cardano.Ledger.Shelley.Imp.UtxowSpec as Utxow
+import qualified Test.Cardano.Ledger.Shelley.Imp.DelegSpec as DELEG
+import qualified Test.Cardano.Ledger.Shelley.Imp.EpochSpec as EPOCH
+import qualified Test.Cardano.Ledger.Shelley.Imp.LedgerSpec as LEDGER
+import qualified Test.Cardano.Ledger.Shelley.Imp.PoolSpec as POOL
+import qualified Test.Cardano.Ledger.Shelley.Imp.UtxoSpec as UTXO
+import qualified Test.Cardano.Ledger.Shelley.Imp.UtxowSpec as UTXOW
 import Test.Cardano.Ledger.Shelley.ImpTest
 import qualified Test.Cardano.Ledger.Shelley.UnitTests.InstantStakeTest as Instant
 
@@ -30,12 +30,12 @@ spec ::
   Spec
 spec era = do
   describe "ShelleyEra Onwards" $ withImpInitEachEraVersion era $ do
-    Deleg.spec
-    Epoch.spec
-    Ledger.spec
-    Pool.spec
-    Utxow.spec
-    Utxo.spec
+    DELEG.spec
+    EPOCH.spec
+    LEDGER.spec
+    POOL.spec
+    UTXOW.spec
+    UTXO.spec
   describe "ShelleyEraPureTests" $ do
     Instant.spec @era
 
@@ -47,4 +47,4 @@ shelleyEraSpecificSpec ::
   Spec
 shelleyEraSpecificSpec era = withImpInitEachEraVersion era $ do
   describe "ShelleyEra Specific" $
-    Deleg.shelleyEraSpecificSpec
+    DELEG.shelleyEraSpecificSpec

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp.hs
@@ -8,7 +8,6 @@
 module Test.Cardano.Ledger.Shelley.Imp (spec, shelleyEraSpecificSpec) where
 
 import Cardano.Ledger.Core (EraRule)
-import Cardano.Ledger.Shelley (ShelleyEra)
 import Cardano.Ledger.Shelley.Rules (RupdEvent)
 import Cardano.Ledger.Shelley.State (ShelleyEraAccounts)
 import Control.State.Transition (Event)
@@ -25,14 +24,12 @@ import qualified Test.Cardano.Ledger.Shelley.UnitTests.InstantStakeTest as Insta
 spec ::
   forall proxy era.
   ( ShelleyEraImp era
-  , EraSpecificSpec era
   , Event (EraRule "RUPD" era) ~ RupdEvent
   ) =>
   proxy era ->
   Spec
 spec era = do
-  describe "Era specific tests" $ withImpInitEachEraVersion era eraSpecificSpec
-  describe "ShelleyEraImpSpec" $ withImpInitEachEraVersion era $ do
+  describe "ShelleyEra Onwards" $ withImpInitEachEraVersion era $ do
     Deleg.spec
     Epoch.spec
     Ledger.spec
@@ -43,14 +40,11 @@ spec era = do
     Instant.spec @era
 
 shelleyEraSpecificSpec ::
-  forall era.
   ( ShelleyEraImp era
   , ShelleyEraAccounts era
   ) =>
-  SpecWith (ImpInit (LedgerSpec era))
-shelleyEraSpecificSpec = do
-  describe "From ShelleyEra" $
+  proxy era ->
+  Spec
+shelleyEraSpecificSpec era = withImpInitEachEraVersion era $ do
+  describe "ShelleyEra Specific" $
     Deleg.shelleyEraSpecificSpec
-
-instance EraSpecificSpec ShelleyEra where
-  eraSpecificSpec = shelleyEraSpecificSpec

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/DelegSpec.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Imp/DelegSpec.hs
@@ -38,7 +38,7 @@ shelleyEraSpecificSpec ::
   , ShelleyEraAccounts era
   ) =>
   SpecWith (ImpInit (LedgerSpec era))
-shelleyEraSpecificSpec = do
+shelleyEraSpecificSpec = describe "DELEG" $ do
   it "Twice the same certificate in the same transaction" $ do
     freshKeyHash >>= \kh -> do
       regTxCert <- genRegTxCert (KeyHashObj kh)
@@ -136,7 +136,7 @@ shelleyEraSpecificSpec = do
 spec ::
   ShelleyEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
-spec = do
+spec = describe "DELEG" $ do
   describe "Register stake credential" $ do
     it "With correct deposit or without any deposit" $ do
       cred <- KeyHashObj <$> freshKeyHash

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -25,7 +25,6 @@
 module Test.Cardano.Ledger.Shelley.ImpTest (
   ImpTestM,
   LedgerSpec,
-  EraSpecificSpec (..),
   SomeSTSEvent (..),
   ImpTestState,
   ImpTestEnv (..),
@@ -343,10 +342,6 @@ instance ShelleyEraImp era => ImpSpec (LedgerSpec era) where
   -- `futurePParams` are applied and the epoch number is updated to the first epoch
   -- number of the current era
   impPrepAction = passTick
-
-class EraTest era => EraSpecificSpec era where
-  eraSpecificSpec :: SpecWith (ImpInit (LedgerSpec era))
-  eraSpecificSpec = pure ()
 
 data SomeSTSEvent era
   = forall (rule :: Symbol).

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -140,6 +140,7 @@ module Test.Cardano.Ledger.Shelley.ImpTest (
   whenMajorVersionAtMost,
   unlessMajorVersion,
   getsPParams,
+  withImpInitEachEraVersion,
   withEachEraVersion,
   impSatisfyMNativeScripts,
   impSatisfySignature,
@@ -697,10 +698,19 @@ withEachEraVersion ::
   ShelleyEraImp era =>
   SpecWith (ImpInit (LedgerSpec era)) ->
   Spec
-withEachEraVersion specWith =
+withEachEraVersion = withImpInitEachEraVersion (Proxy @era)
+{-# DEPRECATED withEachEraVersion "In favor of `withImpInitEachEraVersion`" #-}
+
+withImpInitEachEraVersion ::
+  forall proxy era.
+  ShelleyEraImp era =>
+  proxy era ->
+  SpecWith (ImpInit (LedgerSpec era)) ->
+  Spec
+withImpInitEachEraVersion _proxy specWith =
   withImpInit @(LedgerSpec era) $ do
     forM_ (eraProtVersions @era) $ \protVer ->
-      describe ("Protocol " <> show protVer) $
+      describe ("Version " <> show protVer) $
         modifyImpInitProtVer protVer specWith
 
 shelleyModifyImpInitProtVer ::

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -77,7 +77,7 @@ library
     cardano-ledger-conway >=1.22,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.20,
     cardano-ledger-dijkstra >=0.3,
-    cardano-ledger-mary ^>=1.10.1,
+    cardano-ledger-mary >=1.10.1 && <1.12,
     cardano-ledger-shelley ^>=1.19,
     cardano-strict-containers,
     containers,

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/State/Imp/QuerySpec.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.DRep
 import Cardano.Ledger.Keys (KeyRole (..))
 import Cardano.Ledger.Shelley.LedgerState
 import qualified Data.Map.Strict as Map
+import Data.Proxy
 import qualified Data.Set as Set
 import Lens.Micro
 import Lens.Micro.Mtl
@@ -44,7 +45,7 @@ spec ::
   forall era.
   ConwayEraImp era =>
   Spec
-spec = withEachEraVersion @era $ do
+spec = withImpInitEachEraVersion (Proxy @era) $ do
   describe "DRep" $ do
     describe "Expiries are reported correctly" $ do
       let drepStateFromQuery ::

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### `testlib`
 
+* Add `EraSpec` and `ledgerEraTestMain`
 * Add `toPackageGolden` and `itGolden`
 * Add `goldenForToJSON`, `itGoldenToJSON`, `aesonGoldenSpec` and `roundTripAesonProperty`
 * Add `fullAnnCddlSpec`, `fullAnnGenCddlSpec`, `fullCddlSpec` and `fullGenCddlSpec`

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Era.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Era.hs
@@ -2,10 +2,14 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Test.Cardano.Ledger.Era (
   EraTest (..),
+  EraSpec (..),
+  ledgerEraTestMain,
   registerTestAccount,
 ) where
 
@@ -103,6 +107,24 @@ class
     AccountState era
 
   accountsFromAccountsMap :: Map.Map (Credential Staking) (AccountState era) -> Accounts era
+
+class EraTest era => EraSpec era where
+  -- | All of Imp spec that is applicable to this era
+  eraImpSpec :: Proxy era -> Spec
+
+-- | This is the main entry point for every era's test suite. It contains all tests that must be
+-- supplied by each era through `EraSpec` type class and then some through the extra argument
+ledgerEraTestMain ::
+  forall era.
+  EraSpec era =>
+  -- | Tests that are specific to this era, if any.
+  Spec ->
+  IO ()
+ledgerEraTestMain extraEraSpec =
+  ledgerTestMain $
+    describe (eraName @era) $ do
+      describe "Imp" $ eraImpSpec (Proxy @era)
+      extraEraSpec
 
 -- | This is a helper function that uses `mkTestAccountState` to register an account.
 registerTestAccount ::


### PR DESCRIPTION
# Description

This PR introduces a class base approach to enforcing common types of tests to be executed for all eras.

This approach also makes `EraSpecificSpec` unnecessary, since it further expands the same concept.

For now it only applies this approach to `ImpSpec`, but other will follow in subsequent PRs
Furthermore, it changes ImpSpec tests into consistent structure. 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
