### PR TITLE
Use precomputed data from state-annotated transactions

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `scriptsNeededStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `scriptsNeededAlonzoStAnnTx`
 * Add `AlonzoEraTxAuxData` as a superclass to `AlonzoEraTx`
 * Add `NFData` instance for `AlonzoScriptsNeeded`
 * Change `Signal` to `StAnnTx TopTx era` for: `AlonzoLEDGER`, `AlonzoUTXOW`, `AlonzoUTXO`, `AlonzoUTXOS`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Replace `scriptsProvided` and `scriptsNeeded` in `mkScriptIntegrity` signature with `Set Language`
 * Add `plutusLanguagesUsedStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `plutusLanguagesUsedAlonzoStAnnTx`
 * Add `plutusScriptsWithContextStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `plutusScriptsWithContextAlonzoStAnnTx`
 * Add `ScriptsProvided` argument to `missingRequiredDatums`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `plutusScriptsWithContextStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `plutusScriptsWithContextAlonzoStAnnTx`
 * Add `ScriptsProvided` argument to `missingRequiredDatums`
 * Add `scriptsNeededStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `scriptsNeededAlonzoStAnnTx`
 * Add `AlonzoEraTxAuxData` as a superclass to `AlonzoEraTx`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `ScriptsProvided` argument to `missingRequiredDatums`
 * Add `scriptsNeededStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `scriptsNeededAlonzoStAnnTx`
 * Add `AlonzoEraTxAuxData` as a superclass to `AlonzoEraTx`
 * Add `NFData` instance for `AlonzoScriptsNeeded`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `plutusLanguagesUsedStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `plutusLanguagesUsedAlonzoStAnnTx`
 * Add `plutusScriptsWithContextStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `plutusScriptsWithContextAlonzoStAnnTx`
 * Add `ScriptsProvided` argument to `missingRequiredDatums`
 * Add `scriptsNeededStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `scriptsNeededAlonzoStAnnTx`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -212,12 +212,12 @@ missingRequiredDatums ::
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   ) =>
+  ScriptsProvided era ->
   UTxO era ->
   Tx l era ->
   Test (AlonzoUtxowPredFailure era)
-missingRequiredDatums utxo tx = do
+missingRequiredDatums scriptsProvided utxo tx = do
   let txBody = tx ^. bodyTxL
-      scriptsProvided = getScriptsProvided utxo tx
       (inputHashes, txInsNoDataHash) = getInputDataHashesTxBody utxo txBody scriptsProvided
       txHashes = Map.keysSet (tx ^. witsTxL . datsTxWitsL . unTxDatsL)
       unmatchedDatumHashes = Set.difference inputHashes txHashes
@@ -319,21 +319,21 @@ alonzoStyleWitness = do
   let utxo = utxosUtxo u
       txBody = tx ^. bodyTxL
       witsKeyHashes = keyHashWitnessesTxWits (tx ^. witsTxL)
-      scriptsProvided = getScriptsProvided utxo tx
+      scriptsProvided = scriptsProvidedStAnnTx stAnnTx
 
   -- check scripts
   {-  ∀ s ∈ range(txscripts txw) ∩ Scriptnative), runNativeScript s tx   -}
   runTestOnSignal $ Shelley.validateFailedNativeScripts scriptsProvided tx
 
   {-  { h | (_,h) ∈ scriptsNeeded utxo tx} = dom(txscripts txw)          -}
-  let scriptsNeeded = getScriptsNeeded utxo txBody
+  let scriptsNeeded = scriptsNeededStAnnTx stAnnTx
       scriptsHashesNeeded = getScriptsHashesNeeded scriptsNeeded
       shelleyScriptsNeeded = ShelleyScriptsNeeded scriptsHashesNeeded
   runTest $ Shelley.validateMissingScripts shelleyScriptsNeeded scriptsProvided
 
   {- inputHashes := { h | (_ → (a,_,h)) ∈ txins tx ◁ utxo, isTwoPhaseScriptAddress tx a} -}
   {-  inputHashes ⊆ dom(txdats txw)  -}
-  runTest $ missingRequiredDatums utxo tx
+  runTest $ missingRequiredDatums scriptsProvided utxo tx
 
   {- dom(txdats txw) ⊆ inputHashes ∪ {h | ( , , h) ∈ txouts tx -}
   -- This is incorporated into missingRequiredDatums, see the

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -367,7 +367,7 @@ alonzoStyleWitness = do
   -- This check is checked when building the TxInfo using collectTwoPhaseScriptInputs, if it fails
   -- It raises 'NoCostModel' a constructor of the predicate failure 'CollectError'.
 
-  let scriptIntegrity = mkScriptIntegrity pp tx scriptsProvided scriptsHashesNeeded
+  let scriptIntegrity = mkScriptIntegrity pp tx (plutusLanguagesUsedStAnnTx stAnnTx)
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
   runTest $ checkScriptIntegrityHash tx pp scriptIntegrity
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -80,7 +80,6 @@ import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (..),
   CostModel,
   ExUnits (..),
-  plutusScriptLanguage,
   txscriptfee,
  )
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoEraTxAuxData)
@@ -119,7 +118,7 @@ import Cardano.Ledger.Mary (Tx (..))
 import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Cardano.Ledger.Plutus (Data, Language, PlutusWithContext, hashData, nonNativeLanguages)
 import Cardano.Ledger.Shelley.Tx (shelleyTxEqRaw)
-import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided (..))
+import Cardano.Ledger.State (ScriptsNeeded, ScriptsProvided (..))
 import qualified Cardano.Ledger.State as Shelley
 import Cardano.Ledger.Val (Val ((<+>), (<×>)))
 import Control.DeepSeq (NFData (..), deepseq)
@@ -128,8 +127,6 @@ import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.Map.Strict as Map
-import Data.Maybe (mapMaybe)
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -331,24 +328,21 @@ hashScriptIntegrity :: Era era => ScriptIntegrity era -> ScriptIntegrityHash
 hashScriptIntegrity = hashAnnotated
 
 mkScriptIntegrity ::
-  ( AlonzoEraPParams era
+  ( EraTx era
+  , AlonzoEraPParams era
   , AlonzoEraTxWits era
-  , EraUTxO era
   ) =>
   PParams era ->
   Tx l era ->
-  ScriptsProvided era ->
-  Set ScriptHash ->
+  Set Language ->
   StrictMaybe (ScriptIntegrity era)
-mkScriptIntegrity pp tx (ScriptsProvided scriptsProvided) scriptsNeeded
+mkScriptIntegrity pp tx langs
   | null (txRedeemers ^. unRedeemersL)
   , null langViews
   , null (txDats ^. unTxDatsL) =
       SNothing
   | otherwise = SJust $ ScriptIntegrity txRedeemers txDats langViews
   where
-    scriptsUsed = Map.elems $ Map.restrictKeys scriptsProvided scriptsNeeded
-    langs = Set.fromList $ plutusScriptLanguage <$> mapMaybe toPlutusScript scriptsUsed
     langViews = Set.map (getLanguageView pp) langs
     txWits = tx ^. witsTxL
     txRedeemers = txWits ^. rdmrsTxWitsL

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -26,6 +26,7 @@ module Cardano.Ledger.Alonzo.UTxO (
   getRewardingScriptsNeeded,
   getMintingScriptsNeeded,
   getAlonzoScriptsHashesNeeded,
+  scriptsNeededAlonzoStAnnTx,
   zipAsIxItem,
 
   -- * Scripts provided
@@ -134,12 +135,16 @@ class EraUTxO era => AlonzoEraUTxO era where
 
   scriptsProvidedStAnnTx :: StAnnTx l era -> ScriptsProvided era
 
+  scriptsNeededStAnnTx :: StAnnTx l era -> ScriptsNeeded era
+
 instance AlonzoEraUTxO AlonzoEra where
   getSupplementalDataHashes _ = getAlonzoSupplementalDataHashes
 
   getSpendingDatum = getAlonzoSpendingDatum
 
   scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
+
+  scriptsNeededStAnnTx = scriptsNeededAlonzoStAnnTx
 
 scriptsProvidedAlonzoStAnnTx ::
   ( EraTxLevel era
@@ -149,6 +154,15 @@ scriptsProvidedAlonzoStAnnTx ::
   AlonzoStAnnTx l era -> ScriptsProvided era
 scriptsProvidedAlonzoStAnnTx stAnnTx =
   withTopTxLevelOnly stAnnTx $ \AlonzoStAnnTx {asatScriptsProvided} -> asatScriptsProvided
+
+scriptsNeededAlonzoStAnnTx ::
+  ( EraTxLevel era
+  , STxLevel l era ~ STxTopLevel l era
+  , STxLevel TopTx era ~ STxTopLevel TopTx era
+  ) =>
+  AlonzoStAnnTx l era -> ScriptsNeeded era
+scriptsNeededAlonzoStAnnTx stAnnTx =
+  withTopTxLevelOnly stAnnTx $ \AlonzoStAnnTx {asatScriptsNeeded} -> asatScriptsNeeded
 
 getAlonzoSupplementalDataHashes ::
   (EraTxBody era, AlonzoEraTxOut era) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -33,6 +33,9 @@ module Cardano.Ledger.Alonzo.UTxO (
   scriptsProvidedAlonzoStAnnTx,
   resolveNeededPlutusScriptsWithPurpose,
 
+  -- * Plutus scripts with context
+  plutusScriptsWithContextAlonzoStAnnTx,
+
   -- * Datums needed
   getInputDataHashesTxBody,
 
@@ -43,6 +46,7 @@ module Cardano.Ledger.Alonzo.UTxO (
 import Cardano.Ledger.Address (accountAddressCredentialL)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
+import Cardano.Ledger.Alonzo.Plutus.Context (CollectError)
 import Cardano.Ledger.Alonzo.Scripts (lookupPlutusScript, plutusScriptLanguage)
 import Cardano.Ledger.Alonzo.State ()
 import Cardano.Ledger.Alonzo.Tx (AlonzoStAnnTx (..))
@@ -52,7 +56,7 @@ import Cardano.Ledger.Credential (credScriptHash)
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue, getProducedMaryValue)
 import Cardano.Ledger.Mary.Value (PolicyID (..))
-import Cardano.Ledger.Plutus (Language (..))
+import Cardano.Ledger.Plutus (Language (..), PlutusWithContext)
 import Cardano.Ledger.Plutus.Data (Data, Datum (..))
 import Cardano.Ledger.Shelley.UTxO (
   getShelleyMinFeeTxUtxo,
@@ -69,6 +73,7 @@ import Cardano.Ledger.State (
 import Cardano.Ledger.TxIn
 import Control.DeepSeq (NFData)
 import Data.Foldable as F (foldl', toList)
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe, isJust)
 import qualified Data.Set as Set
@@ -137,6 +142,10 @@ class EraUTxO era => AlonzoEraUTxO era where
 
   scriptsNeededStAnnTx :: StAnnTx l era -> ScriptsNeeded era
 
+  plutusScriptsWithContextStAnnTx ::
+    StAnnTx l era ->
+    Either (NonEmpty (CollectError era)) [PlutusWithContext]
+
 instance AlonzoEraUTxO AlonzoEra where
   getSupplementalDataHashes _ = getAlonzoSupplementalDataHashes
 
@@ -145,6 +154,8 @@ instance AlonzoEraUTxO AlonzoEra where
   scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
 
   scriptsNeededStAnnTx = scriptsNeededAlonzoStAnnTx
+
+  plutusScriptsWithContextStAnnTx = plutusScriptsWithContextAlonzoStAnnTx
 
 scriptsProvidedAlonzoStAnnTx ::
   ( EraTxLevel era
@@ -163,6 +174,17 @@ scriptsNeededAlonzoStAnnTx ::
   AlonzoStAnnTx l era -> ScriptsNeeded era
 scriptsNeededAlonzoStAnnTx stAnnTx =
   withTopTxLevelOnly stAnnTx $ \AlonzoStAnnTx {asatScriptsNeeded} -> asatScriptsNeeded
+
+plutusScriptsWithContextAlonzoStAnnTx ::
+  ( EraTxLevel era
+  , STxLevel l era ~ STxTopLevel l era
+  , STxLevel TopTx era ~ STxTopLevel TopTx era
+  ) =>
+  AlonzoStAnnTx l era ->
+  Either (NonEmpty (CollectError era)) [PlutusWithContext]
+plutusScriptsWithContextAlonzoStAnnTx stAnnTx =
+  withTopTxLevelOnly stAnnTx $
+    \AlonzoStAnnTx {asatPlutusScriptsWithContext} -> asatPlutusScriptsWithContext
 
 getAlonzoSupplementalDataHashes ::
   (EraTxBody era, AlonzoEraTxOut era) =>

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -36,6 +36,9 @@ module Cardano.Ledger.Alonzo.UTxO (
   -- * Plutus scripts with context
   plutusScriptsWithContextAlonzoStAnnTx,
 
+  -- * Plutus languages used
+  plutusLanguagesUsedAlonzoStAnnTx,
+
   -- * Datums needed
   getInputDataHashesTxBody,
 
@@ -146,6 +149,8 @@ class EraUTxO era => AlonzoEraUTxO era where
     StAnnTx l era ->
     Either (NonEmpty (CollectError era)) [PlutusWithContext]
 
+  plutusLanguagesUsedStAnnTx :: StAnnTx l era -> Set.Set Language
+
 instance AlonzoEraUTxO AlonzoEra where
   getSupplementalDataHashes _ = getAlonzoSupplementalDataHashes
 
@@ -156,6 +161,8 @@ instance AlonzoEraUTxO AlonzoEra where
   scriptsNeededStAnnTx = scriptsNeededAlonzoStAnnTx
 
   plutusScriptsWithContextStAnnTx = plutusScriptsWithContextAlonzoStAnnTx
+
+  plutusLanguagesUsedStAnnTx = plutusLanguagesUsedAlonzoStAnnTx
 
 scriptsProvidedAlonzoStAnnTx ::
   ( EraTxLevel era
@@ -185,6 +192,16 @@ plutusScriptsWithContextAlonzoStAnnTx ::
 plutusScriptsWithContextAlonzoStAnnTx stAnnTx =
   withTopTxLevelOnly stAnnTx $
     \AlonzoStAnnTx {asatPlutusScriptsWithContext} -> asatPlutusScriptsWithContext
+
+plutusLanguagesUsedAlonzoStAnnTx ::
+  ( EraTxLevel era
+  , STxLevel l era ~ STxTopLevel l era
+  , STxLevel TopTx era ~ STxTopLevel TopTx era
+  ) =>
+  AlonzoStAnnTx l era -> Set.Set Language
+plutusLanguagesUsedAlonzoStAnnTx stAnnTx =
+  withTopTxLevelOnly stAnnTx $
+    \AlonzoStAnnTx {asatPlutusLanguagesUsed} -> asatPlutusLanguagesUsed
 
 getAlonzoSupplementalDataHashes ::
   (EraTxBody era, AlonzoEraTxOut era) =>

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -63,7 +63,11 @@ import Cardano.Ledger.Alonzo.Rules (
   TagMismatchDescription (..),
   scriptFailureToFailureDescription,
  )
-import Cardano.Ledger.Alonzo.Scripts (toAsItem, toAsIx)
+import Cardano.Ledger.Alonzo.Scripts (
+  plutusScriptLanguage,
+  toAsItem,
+  toAsIx,
+ )
 import Cardano.Ledger.Alonzo.Tx (ScriptIntegrity, hashScriptIntegrity, mkScriptIntegrity)
 import Cardano.Ledger.Alonzo.TxAuxData (AlonzoTxAuxData)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL, unTxDatsL)
@@ -99,7 +103,7 @@ import qualified Data.List.NonEmpty as NonEmpty
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.MapExtras (fromElems)
-import Data.Maybe (catMaybes, isJust, isNothing)
+import Data.Maybe (catMaybes, isJust, isNothing, mapMaybe)
 import Data.Set ((\\))
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -559,10 +563,12 @@ computeScriptIntegrity ::
   UTxO era ->
   Tx l era ->
   StrictMaybe (ScriptIntegrity era)
-computeScriptIntegrity pp utxo tx = mkScriptIntegrity pp tx scriptsProvided scriptsNeeded
+computeScriptIntegrity pp utxo tx = mkScriptIntegrity pp tx langs
   where
-    scriptsProvided = getScriptsProvided utxo tx
+    ScriptsProvided scriptsProvided = getScriptsProvided utxo tx
     scriptsNeeded = getScriptsHashesNeeded . getScriptsNeeded utxo $ tx ^. bodyTxL
+    scriptsUsed = Map.elems $ Map.restrictKeys scriptsProvided scriptsNeeded
+    langs = Set.fromList $ plutusScriptLanguage <$> mapMaybe toPlutusScript scriptsUsed
 
 impComputeScriptIntegrity ::
   AlonzoEraImp era =>

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.14.0.0
 
+* Replace arguments of `babbageEvalScriptsTxInvalid` with `StAnnTx`
+* Replace arguments of `expectScriptsToPass` with `StAnnTx`
 * Change `Signal` to `StAnnTx TopTx era` for: `BabbageLEDGER`, `BabbageUTXOW`, `BabbageUTXO`, `BabbageUTXOS`
 * Remove `ToCBOR` and `FromCBOR` instances for `BabbageTxOut`
 * Add `ApplyTick` instance for `BabbageEra`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -19,10 +19,7 @@ module Cardano.Ledger.Babbage.Rules.Utxos (
 ) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
-import Cardano.Ledger.Alonzo.Plutus.Evaluate (
-  collectPlutusScriptsWithContext,
-  evalPlutusScripts,
- )
+import Cardano.Ledger.Alonzo.Plutus.Evaluate (evalPlutusScripts)
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
@@ -32,12 +29,7 @@ import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra, BabbageUTXOS)
 import Cardano.Ledger.Babbage.Rules.Ppup ()
 import Cardano.Ledger.Babbage.State
-import Cardano.Ledger.BaseTypes (
-  ShelleyBase,
-  StrictMaybe,
-  epochInfo,
-  systemStart,
- )
+import Cardano.Ledger.BaseTypes (ShelleyBase, StrictMaybe)
 import Cardano.Ledger.Binary (EncCBOR (..))
 import Cardano.Ledger.Plutus.Evaluate (
   ScriptFailure (..),
@@ -46,7 +38,6 @@ import Cardano.Ledger.Plutus.Evaluate (
 import Cardano.Ledger.Shelley.PParams (Update)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.Monad (forM_)
-import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
 import Data.List.NonEmpty (nonEmpty)
 import qualified Debug.Trace as Debug
@@ -114,33 +105,24 @@ utxosTransition ::
   forall era.
   ( AlonzoEraTx era
   , ShelleyEraTxBody era
-  , BabbageEraTxBody era
   , AlonzoEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , EraCertState era
-  , EraStake era
-  , EraGov era
-  , GovState era ~ ShelleyGovState era
   , Environment (EraRule "PPUP" era) ~ Shelley.PpupEnv era
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , Embed (EraRule "PPUP" era) (BabbageUTXOS era)
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
-  , EncCBOR (EraRuleFailure "PPUP" era)
-  , Eq (EraRuleFailure "PPUP" era)
-  , Show (EraRuleFailure "PPUP" era)
-  , EraPlutusContext era
   , EraRule "UTXOS" era ~ BabbageUTXOS era
   , InjectRuleFailure "UTXOS" Alonzo.AlonzoUtxosPredFailure era
   , InjectRuleEvent "UTXOS" Alonzo.AlonzoUtxosEvent era
   ) =>
   TransitionRule (BabbageUTXOS era)
 utxosTransition =
-  judgmentContext >>= \(TRC (Alonzo.UtxosEnv _ pp _ utxo, pup, stAnnTx)) -> do
+  judgmentContext >>= \(TRC (_, pup, stAnnTx)) -> do
     let tx = stAnnTx ^. txStAnnTxG
     case tx ^. isValidTxL of
       IsValid True -> babbageEvalScriptsTxValid
       IsValid False -> do
-        babbageEvalScriptsTxInvalid @era pp tx utxo
+        babbageEvalScriptsTxInvalid @era stAnnTx
         pure pup
 
 -- ===================================================================
@@ -148,25 +130,16 @@ utxosTransition =
 expectScriptsToPass ::
   forall era.
   ( AlonzoEraTx era
-  , EraPlutusContext era
   , AlonzoEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , STS (EraRule "UTXOS" era)
   , InjectRuleFailure "UTXOS" Alonzo.AlonzoUtxosPredFailure era
-  , BaseM (EraRule "UTXOS" era) ~ ShelleyBase
   , InjectRuleEvent "UTXOS" Alonzo.AlonzoUtxosEvent era
   ) =>
-  PParams era ->
-  Tx TopTx era ->
-  UTxO era ->
+  StAnnTx TopTx era ->
   Rule (EraRule "UTXOS" era) 'Transition ()
-expectScriptsToPass pp tx utxo = do
-  sysSt <- liftSTS $ asks systemStart
-  ei <- liftSTS $ asks epochInfo
+expectScriptsToPass stAnnTx = do
+  let tx = stAnnTx ^. txStAnnTxG
   {- sLst := collectTwoPhaseScriptInputs pp tx utxo -}
-  let
-    scriptsWithContextEither =
-      collectPlutusScriptsWithContext ei sysSt pp tx utxo
+  let scriptsWithContextEither = plutusScriptsWithContextStAnnTx stAnnTx
   (() <$ scriptsWithContextEither) ?!: (injectFailure . Alonzo.CollectErrors)
   {- isValid tx = evalScripts tx sLst = True -}
   Alonzo.when2Phase $
@@ -187,20 +160,17 @@ babbageEvalScriptsTxValid ::
   , AlonzoEraUTxO era
   , ShelleyEraTxBody era
   , EraCertState era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , STS (BabbageUTXOS era)
   , Environment (EraRule "PPUP" era) ~ Shelley.PpupEnv era
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , Embed (EraRule "PPUP" era) (BabbageUTXOS era)
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
-  , EraPlutusContext era
   , InjectRuleFailure "UTXOS" Alonzo.AlonzoUtxosPredFailure era
   , EraRule "UTXOS" era ~ BabbageUTXOS era
   , InjectRuleEvent "UTXOS" Alonzo.AlonzoUtxosEvent era
   ) =>
   TransitionRule (BabbageUTXOS era)
 babbageEvalScriptsTxValid = do
-  TRC (Alonzo.UtxosEnv slot pp certState utxo, pup, stAnnTx) <-
+  TRC (Alonzo.UtxosEnv slot pp certState _utxo, pup, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
       txBody = tx ^. bodyTxL
@@ -214,7 +184,7 @@ babbageEvalScriptsTxValid = do
       TRC (Shelley.PPUPEnv slot pp genDelegs, pup, txBody ^. updateTxBodyL)
 
   () <- pure $! Debug.traceEvent Alonzo.validBegin ()
-  expectScriptsToPass pp tx utxo
+  expectScriptsToPass stAnnTx
   () <- pure $! Debug.traceEvent Alonzo.validEnd ()
 
   pure updatedGovState
@@ -222,26 +192,17 @@ babbageEvalScriptsTxValid = do
 babbageEvalScriptsTxInvalid ::
   forall era.
   ( AlonzoEraTx era
-  , EraPlutusContext era
   , AlonzoEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , InjectRuleFailure "UTXOS" Alonzo.AlonzoUtxosPredFailure era
   , InjectRuleEvent "UTXOS" Alonzo.AlonzoUtxosEvent era
-  , BaseM (EraRule "UTXOS" era) ~ ShelleyBase
-  , STS (EraRule "UTXOS" era)
   ) =>
-  PParams era ->
-  Tx TopTx era ->
-  UTxO era ->
+  StAnnTx TopTx era ->
   Rule (EraRule "UTXOS" era) 'Transition ()
-babbageEvalScriptsTxInvalid pp tx utxo = do
-  sysSt <- liftSTS $ asks systemStart
-  ei <- liftSTS $ asks epochInfo
+babbageEvalScriptsTxInvalid stAnnTx = do
+  let tx = stAnnTx ^. txStAnnTxG
   () <- pure $! Debug.traceEvent Alonzo.invalidBegin ()
   {- sLst := collectTwoPhaseScriptInputs pp tx utxo -}
-  let
-    scriptsWithContextEither =
-      collectPlutusScriptsWithContext ei sysSt pp tx utxo
+  let scriptsWithContextEither = plutusScriptsWithContextStAnnTx stAnnTx
   (() <$ scriptsWithContextEither) ?!: (injectFailure . Alonzo.CollectErrors)
   {- isValid tx = evalScripts tx sLst = False -}
   Alonzo.when2Phase $

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -27,7 +27,7 @@ module Cardano.Ledger.Babbage.Rules.Utxow (
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (validScript)
-import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..), AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra, BabbageUTXOW)
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUTXO, BabbageUtxoPredFailure (..))
@@ -331,8 +331,8 @@ babbageUtxowTransition = do
   -- check scripts
   {- neededHashes := {h | ( , h) ∈ scriptsNeeded utxo txb} -}
   {- neededHashes − dom(refScripts tx utxo) = dom(txwitscripts txw) -}
-  let scriptsNeeded = getScriptsNeeded utxo txBody
-      scriptsProvided = getScriptsProvided utxo tx
+  let scriptsNeeded = scriptsNeededStAnnTx stAnnTx
+      scriptsProvided = scriptsProvidedStAnnTx stAnnTx
       scriptHashesNeeded = getScriptsHashesNeeded scriptsNeeded
   {- ∀s ∈ (txscripts txw utxo neededHashes ) ∩ Scriptph1 , validateScript s tx -}
   -- CHANGED In BABBAGE txscripts depends on UTxO
@@ -344,7 +344,7 @@ babbageUtxowTransition = do
   runTest $ babbageMissingScripts pp scriptHashesNeeded sRefs sReceived
 
   {-  inputHashes ⊆  dom(txdats txw) ⊆  allowed -}
-  runTest $ Alonzo.missingRequiredDatums utxo tx
+  runTest $ Alonzo.missingRequiredDatums scriptsProvided utxo tx
 
   {-  dom (txrdmrs tx) = { rdptr txb sp | (sp, h) ∈ scriptsNeeded utxo tx,
                            h ↦ s ∈ txscripts txw, s ∈ Scriptph2}     -}

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -374,7 +374,7 @@ babbageUtxowTransition = do
   -- This check is checked when building the TxInfo using collectTwoPhaseScriptInputs, if it fails
   -- It raises 'NoCostModel' a constructor of the predicate failure 'CollectError'.
 
-  let scriptIntegrity = mkScriptIntegrity pp tx scriptsProvided scriptHashesNeeded
+  let scriptIntegrity = mkScriptIntegrity pp tx (plutusLanguagesUsedStAnnTx stAnnTx)
   {-  scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw)  -}
   runTest $ Alonzo.checkScriptIntegrityHash tx pp scriptIntegrity
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   getAlonzoScriptsHashesNeeded,
   getAlonzoScriptsNeeded,
   getAlonzoWitsVKeyNeeded,
+  scriptsNeededAlonzoStAnnTx,
   scriptsProvidedAlonzoStAnnTx,
  )
 import Cardano.Ledger.Babbage.Core
@@ -64,6 +65,8 @@ instance AlonzoEraUTxO BabbageEra where
   getSpendingDatum = getBabbageSpendingDatum
 
   scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
+
+  scriptsNeededStAnnTx = scriptsNeededAlonzoStAnnTx
 
 getBabbageSupplementalDataHashes ::
   BabbageEraTxBody era =>

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   getAlonzoScriptsHashesNeeded,
   getAlonzoScriptsNeeded,
   getAlonzoWitsVKeyNeeded,
+  plutusLanguagesUsedAlonzoStAnnTx,
   plutusScriptsWithContextAlonzoStAnnTx,
   scriptsNeededAlonzoStAnnTx,
   scriptsProvidedAlonzoStAnnTx,
@@ -70,6 +71,8 @@ instance AlonzoEraUTxO BabbageEra where
   scriptsNeededStAnnTx = scriptsNeededAlonzoStAnnTx
 
   plutusScriptsWithContextStAnnTx = plutusScriptsWithContextAlonzoStAnnTx
+
+  plutusLanguagesUsedStAnnTx = plutusLanguagesUsedAlonzoStAnnTx
 
 getBabbageSupplementalDataHashes ::
   BabbageEraTxBody era =>

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   getAlonzoScriptsHashesNeeded,
   getAlonzoScriptsNeeded,
   getAlonzoWitsVKeyNeeded,
+  plutusScriptsWithContextAlonzoStAnnTx,
   scriptsNeededAlonzoStAnnTx,
   scriptsProvidedAlonzoStAnnTx,
  )
@@ -67,6 +68,8 @@ instance AlonzoEraUTxO BabbageEra where
   scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
 
   scriptsNeededStAnnTx = scriptsNeededAlonzoStAnnTx
+
+  plutusScriptsWithContextStAnnTx = plutusScriptsWithContextAlonzoStAnnTx
 
 getBabbageSupplementalDataHashes ::
   BabbageEraTxBody era =>

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Add `validateRefScriptSize`, `updateDormantDRepExpiries`, `updateVotingDRepExpiries`
 * Add `ApplyTick` instance for `ConwayEra`
 * Add `ConwayUtxosEnv`
-* Change `STS` instance of `ConwayUTXOS`: use `ConwayUtxosEnv` as `Environment` and `()` as `State`
+* Change `STS` instance of `ConwayUTXOS`: use `()` as `Environment` and `State`
 * Add `updateTreasuryDonation`
 * Add `checkReferenceInputsNotDisjointFromInputs`
 * Add `ConwayEraScript` superclass to `ConwayEraPlutusTxInfo`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -50,7 +50,6 @@ import Cardano.Ledger.Coin (Coin, DeltaCoin)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Era (ConwayEra, ConwayUTXO, ConwayUTXOS)
 import Cardano.Ledger.Conway.Rules.Utxos (
-  ConwayUtxosEnv (..),
   ConwayUtxosPredFailure (..),
  )
 import Cardano.Ledger.Plutus (ExUnits)
@@ -227,7 +226,7 @@ conwayUtxoTransition ::
   , STS (EraRule "UTXO" era)
   , Event (EraRule "UTXO" era) ~ Alonzo.AlonzoUtxoEvent era
   , -- In this function we we call the UTXOS rule, so we need some assumptions
-    Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
+    Environment (EraRule "UTXOS" era) ~ ()
   , State (EraRule "UTXOS" era) ~ ()
   , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
@@ -237,7 +236,7 @@ conwayUtxoTransition = do
   TRC (Shelley.UtxoEnv _ pp certState, utxos, stAnnTx) <- judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
   Babbage.babbageUtxoValidation
-  () <- trans @(EraRule "UTXOS" era) $ TRC (ConwayUtxosEnv pp (utxosUtxo utxos), (), stAnnTx)
+  () <- trans @(EraRule "UTXOS" era) $ TRC ((), (), stAnnTx)
   Babbage.updateUTxOStateByTxValidity
     pp
     certState
@@ -263,7 +262,7 @@ instance
   , InjectRuleFailure "UTXO" Babbage.BabbageUtxoPredFailure era
   , InjectRuleFailure "UTXO" ConwayUtxoPredFailure era
   , Embed (EraRule "UTXOS" era) (ConwayUTXO era)
-  , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
+  , Environment (EraRule "UTXOS" era) ~ ()
   , State (EraRule "UTXOS" era) ~ ()
   , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , PredicateFailure (EraRule "UTXO" era) ~ ConwayUtxoPredFailure era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -17,7 +17,6 @@
 
 module Cardano.Ledger.Conway.Rules.Utxos (
   ConwayUTXOS,
-  ConwayUtxosEnv (..),
   ConwayUtxosPredFailure (..),
   ConwayUtxosEvent (..),
   alonzoToConwayUtxosPredFailure,
@@ -67,18 +66,6 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Debug.Trace as Debug
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
-
-data ConwayUtxosEnv era = ConwayUtxosEnv
-  { cuePParams :: !(PParams era)
-  , cueUTxO :: !(UTxO era)
-  }
-  deriving (Generic)
-
-deriving instance (Show (PParams era), Show (UTxO era)) => Show (ConwayUtxosEnv era)
-
-deriving instance (Eq (PParams era), Eq (UTxO era)) => Eq (ConwayUtxosEnv era)
-
-instance (Era era, NFData (PParams era), NFData (UTxO era)) => NFData (ConwayUtxosEnv era)
 
 data ConwayUtxosPredFailure era
   = -- | The 'isValid' tag on the transaction is incorrect. The tag given
@@ -203,7 +190,7 @@ instance
   STS (ConwayUTXOS era)
   where
   type BaseM (ConwayUTXOS era) = Cardano.Ledger.BaseTypes.ShelleyBase
-  type Environment (ConwayUTXOS era) = ConwayUtxosEnv era
+  type Environment (ConwayUTXOS era) = ()
   type State (ConwayUTXOS era) = ()
   type Signal (ConwayUTXOS era) = StAnnTx TopTx era
   type PredicateFailure (ConwayUTXOS era) = ConwayUtxosPredFailure era
@@ -239,13 +226,14 @@ utxosTransition ::
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
+  , Environment (EraRule "UTXOS" era) ~ ()
   , State (EraRule "UTXOS" era) ~ ()
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
   , InjectRuleEvent "UTXOS" AlonzoUtxosEvent era
   ) =>
   TransitionRule (EraRule "UTXOS" era)
 utxosTransition =
-  judgmentContext >>= \(TRC (_, (), stAnnTx)) -> do
+  judgmentContext >>= \(TRC ((), (), stAnnTx)) -> do
     let tx = stAnnTx ^. txStAnnTxG
     case tx ^. isValidTxL of
       IsValid True -> conwayEvalScriptsTxValid
@@ -257,13 +245,14 @@ conwayEvalScriptsTxValid ::
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
+  , Environment (EraRule "UTXOS" era) ~ ()
   , State (EraRule "UTXOS" era) ~ ()
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
   , InjectRuleEvent "UTXOS" AlonzoUtxosEvent era
   ) =>
   TransitionRule (EraRule "UTXOS" era)
 conwayEvalScriptsTxValid = do
-  TRC (_, (), stAnnTx) <- judgmentContext
+  TRC ((), (), stAnnTx) <- judgmentContext
 
   () <- pure $! Debug.traceEvent validBegin ()
   expectScriptsToPass stAnnTx

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxos.hs
@@ -238,44 +238,33 @@ utxosTransition ::
   forall era.
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
-  , EraPlutusContext era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
-  , STS (EraRule "UTXOS" era)
-  , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
   , State (EraRule "UTXOS" era) ~ ()
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
-  , BaseM (EraRule "UTXOS" era) ~ ShelleyBase
   , InjectRuleEvent "UTXOS" AlonzoUtxosEvent era
   ) =>
   TransitionRule (EraRule "UTXOS" era)
 utxosTransition =
-  judgmentContext >>= \(TRC (ConwayUtxosEnv pp utxo, (), stAnnTx)) -> do
+  judgmentContext >>= \(TRC (_, (), stAnnTx)) -> do
     let tx = stAnnTx ^. txStAnnTxG
     case tx ^. isValidTxL of
       IsValid True -> conwayEvalScriptsTxValid
       IsValid False -> do
-        babbageEvalScriptsTxInvalid @era pp tx utxo
+        babbageEvalScriptsTxInvalid @era stAnnTx
 
 conwayEvalScriptsTxValid ::
   forall era.
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
-  , EraPlutusContext era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
-  , STS (EraRule "UTXOS" era)
   , State (EraRule "UTXOS" era) ~ ()
-  , Environment (EraRule "UTXOS" era) ~ ConwayUtxosEnv era
   , InjectRuleFailure "UTXOS" AlonzoUtxosPredFailure era
-  , BaseM (EraRule "UTXOS" era) ~ ShelleyBase
   , InjectRuleEvent "UTXOS" AlonzoUtxosEvent era
   ) =>
   TransitionRule (EraRule "UTXOS" era)
 conwayEvalScriptsTxValid = do
-  TRC (ConwayUtxosEnv pp utxo, (), stAnnTx) <- judgmentContext
-  let tx = stAnnTx ^. txStAnnTxG
+  TRC (_, (), stAnnTx) <- judgmentContext
 
   () <- pure $! Debug.traceEvent validBegin ()
-  expectScriptsToPass pp tx utxo
+  expectScriptsToPass stAnnTx
   pure $! Debug.traceEvent validEnd ()

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   getMintingScriptsNeeded,
   getRewardingScriptsNeeded,
   getSpendingScriptsNeeded,
+  scriptsNeededAlonzoStAnnTx,
   scriptsProvidedAlonzoStAnnTx,
   zipAsIxItem,
  )
@@ -153,6 +154,8 @@ instance AlonzoEraUTxO ConwayEra where
   getSpendingDatum = getBabbageSpendingDatum
 
   scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
+
+  scriptsNeededStAnnTx = scriptsNeededAlonzoStAnnTx
 
 getConwayMinFeeTxUtxo ::
   ( EraTx era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   getMintingScriptsNeeded,
   getRewardingScriptsNeeded,
   getSpendingScriptsNeeded,
+  plutusLanguagesUsedAlonzoStAnnTx,
   plutusScriptsWithContextAlonzoStAnnTx,
   scriptsNeededAlonzoStAnnTx,
   scriptsProvidedAlonzoStAnnTx,
@@ -159,6 +160,8 @@ instance AlonzoEraUTxO ConwayEra where
   scriptsNeededStAnnTx = scriptsNeededAlonzoStAnnTx
 
   plutusScriptsWithContextStAnnTx = plutusScriptsWithContextAlonzoStAnnTx
+
+  plutusLanguagesUsedStAnnTx = plutusLanguagesUsedAlonzoStAnnTx
 
 getConwayMinFeeTxUtxo ::
   ( EraTx era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   getMintingScriptsNeeded,
   getRewardingScriptsNeeded,
   getSpendingScriptsNeeded,
+  plutusScriptsWithContextAlonzoStAnnTx,
   scriptsNeededAlonzoStAnnTx,
   scriptsProvidedAlonzoStAnnTx,
   zipAsIxItem,
@@ -156,6 +157,8 @@ instance AlonzoEraUTxO ConwayEra where
   scriptsProvidedStAnnTx = scriptsProvidedAlonzoStAnnTx
 
   scriptsNeededStAnnTx = scriptsNeededAlonzoStAnnTx
+
+  plutusScriptsWithContextStAnnTx = plutusScriptsWithContextAlonzoStAnnTx
 
 getConwayMinFeeTxUtxo ::
   ( EraTx era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/TreeDiff.hs
@@ -195,8 +195,6 @@ instance
   ) =>
   ToExpr (ConwayUtxosPredFailure era)
 
-instance (ToExpr (PParamsHKD Identity era), ToExpr (TxOut era)) => ToExpr (ConwayUtxosEnv era)
-
 -- TxBody
 instance ToExpr (ConwayTxBodyRaw TopTx ConwayEra) where
   toExpr ConwayTxBodyRaw {..} =

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0.0
 
+* Add `DijkstraEraUTxO` type class with `subTransactionsStAnnTx` method
 * Add `TranslateEra` instance for `DijkstraEra VState`
 * Fix `TranslateEra` instance for `DijkstraEra CertState`
 * Add `GuardScriptHashesNotSupported` constructor to `DijkstraContextError`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -145,7 +145,7 @@ mkDijkstraStAnnTopTx ei sysStart pp utxo tx =
       , dsattPlutusLanguagesUsed = languagesUsed
       , dsattPlutusScriptsWithContext =
           scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL) plutusScriptsUsed
-      , dsattStAnnSubTxs = stAnnSubTxs
+      , dsattSubTransactions = stAnnSubTxs
       }
 
 mkDijkstraStAnnSubTx ::

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -25,7 +25,7 @@ module Cardano.Ledger.Dijkstra.Rules.Ledger (
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
 import Cardano.Ledger.Alonzo (AlonzoScript)
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
-import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded, scriptsProvidedStAnnTx)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage (BabbageTxOut)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage
 import Cardano.Ledger.BaseTypes (
@@ -369,7 +369,6 @@ dijkstraLedgerTransition = do
   -- and SUBLEDGERS, and used for all witness/validation lookups.
   let originalUtxo = utxosUtxo (ledgerState ^. lsUTxOStateL)
       subStAnnTxs = subTransactionsStAnnTx stAnnTx
-      scriptsProvided = scriptsProvidedStAnnTx stAnnTx
 
   -- Process all subtransactions first
   LedgerState utxoStateAfterSubLedgers certStateAfterSubLedgers <-
@@ -381,7 +380,6 @@ dijkstraLedgerTransition = do
             txIx
             pp
             chainAccountState
-            scriptsProvided
             originalUtxo
             (tx ^. isValidTxL)
         , ledgerState
@@ -446,11 +444,11 @@ dijkstraLedgerTransition = do
           )
       else pure (utxoStateAfterSubLedgers, certStateAfterSubLedgers)
 
-  -- Call UTXOW with DijkstraUtxoEnv, passing the original UTxO and aggregated scriptsProvided
+  -- Call UTXOW with DijkstraUtxoEnv, passing the original UTxO
   utxoStateFinal <-
     trans @(EraRule "UTXOW" era) $
       TRC
-        ( DijkstraUtxoEnv slot pp certState originalUtxo scriptsProvided
+        ( DijkstraUtxoEnv slot pp certState originalUtxo
         , utxoStateBeforeUtxow
         , stAnnTx
         )

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -61,9 +61,8 @@ import Cardano.Ledger.Dijkstra.Rules.SubLedger
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoEnv (..), DijkstraUtxoPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure)
-import Cardano.Ledger.Dijkstra.Tx (DijkstraStAnnTx (..))
 import Cardano.Ledger.Dijkstra.TxBody
-import Cardano.Ledger.Dijkstra.UTxO (batchNonDistinctRefScriptsSize)
+import Cardano.Ledger.Dijkstra.UTxO (DijkstraEraUTxO (..), batchNonDistinctRefScriptsSize)
 import Cardano.Ledger.Rules.ValidationMode (Test, runTest)
 import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
@@ -274,7 +273,7 @@ instance
   , ConwayEraTxBody era
   , ConwayEraGov era
   , DijkstraEraTxBody era
-  , EraUTxO era
+  , DijkstraEraUTxO era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
@@ -290,8 +289,6 @@ instance
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ Conway.GovSignal era
   , Signal (EraRule "SUBLEDGERS" era) ~ [StAnnTx SubTx era]
-  , StAnnTx TopTx era ~ DijkstraStAnnTx TopTx era
-  , StAnnTx SubTx era ~ DijkstraStAnnTx SubTx era
   , ConwayEraCertState era
   , EraRule "LEDGER" era ~ DijkstraLEDGER era
   , InjectRuleFailure "LEDGER" Shelley.ShelleyLedgerPredFailure era
@@ -339,7 +336,7 @@ dijkstraLedgerTransition ::
   , ConwayEraCertState era
   , ConwayEraGov era
   , DijkstraEraTxBody era
-  , EraUTxO era
+  , DijkstraEraUTxO era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
@@ -354,8 +351,6 @@ dijkstraLedgerTransition ::
   , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , Signal (EraRule "CERTS" era) ~ Seq (TxCert era)
   , Signal (EraRule "GOV" era) ~ Conway.GovSignal era
-  , StAnnTx TopTx era ~ DijkstraStAnnTx TopTx era
-  , StAnnTx SubTx era ~ DijkstraStAnnTx SubTx era
   , STS (DijkstraLEDGER era)
   , EraRule "LEDGER" era ~ DijkstraLEDGER era
   , EraRule "SUBLEDGERS" era ~ DijkstraSUBLEDGERS era
@@ -373,7 +368,7 @@ dijkstraLedgerTransition = do
   -- This is passed through the environment to UTXOW
   -- and SUBLEDGERS, and used for all witness/validation lookups.
   let originalUtxo = utxosUtxo (ledgerState ^. lsUTxOStateL)
-      subStAnnTxs = dsattStAnnSubTxs stAnnTx
+      subStAnnTxs = subTransactionsStAnnTx stAnnTx
       -- getScriptsProvided is recursive for Dijkstra
       scriptsProvided = getScriptsProvided originalUtxo tx
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -25,7 +25,7 @@ module Cardano.Ledger.Dijkstra.Rules.Ledger (
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
 import Cardano.Ledger.Alonzo (AlonzoScript)
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
-import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded, scriptsProvidedStAnnTx)
 import Cardano.Ledger.Babbage (BabbageTxOut)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage
 import Cardano.Ledger.BaseTypes (
@@ -369,8 +369,7 @@ dijkstraLedgerTransition = do
   -- and SUBLEDGERS, and used for all witness/validation lookups.
   let originalUtxo = utxosUtxo (ledgerState ^. lsUTxOStateL)
       subStAnnTxs = subTransactionsStAnnTx stAnnTx
-      -- getScriptsProvided is recursive for Dijkstra
-      scriptsProvided = getScriptsProvided originalUtxo tx
+      scriptsProvided = scriptsProvidedStAnnTx stAnnTx
 
   -- Process all subtransactions first
   LedgerState utxoStateAfterSubLedgers certStateAfterSubLedgers <-

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -94,7 +94,6 @@ data SubLedgerEnv era = SubLedgerEnv
   , sleTxIx :: TxIx
   , slePParams :: PParams era
   , sleAccount :: ChainAccountState
-  , sleScriptsProvided :: ScriptsProvided era
   , sleOriginalUtxo :: UTxO era
   , sleTopTxIsValid :: IsValid
   }
@@ -238,7 +237,7 @@ dijkstraSubLedgersTransition ::
   TransitionRule (EraRule "SUBLEDGER" era)
 dijkstraSubLedgersTransition = do
   TRC
-    ( SubLedgerEnv slot mbCurEpochNo _ pp chainAccountState scriptsProvided originalUtxo topIsValid
+    ( SubLedgerEnv slot mbCurEpochNo _ pp chainAccountState originalUtxo topIsValid
       , ledgerState@(LedgerState utxoState certState)
       , stAnnTx
       ) <-
@@ -288,7 +287,7 @@ dijkstraSubLedgersTransition = do
   utxoStateAfterSubUtxow <-
     trans @(EraRule "SUBUTXOW" era) $
       TRC
-        ( SubUtxoEnv slot pp certState scriptsProvided originalUtxo topIsValid
+        ( SubUtxoEnv slot pp certState originalUtxo topIsValid
         , utxoState
         , stAnnTx
         )

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -65,7 +65,6 @@ data SubUtxoEnv era = SubUtxoEnv
   { sueSlot :: SlotNo
   , suePParams :: PParams era
   , sueCertState :: CertState era
-  , sueScriptsProvided :: ScriptsProvided era
   , sueOriginalUtxo :: UTxO era
   , sueTopTxIsValid :: IsValid
   }
@@ -230,7 +229,7 @@ dijkstraSubUtxoTransition ::
   ) =>
   TransitionRule (EraRule "SUBUTXO" era)
 dijkstraSubUtxoTransition = do
-  TRC (SubUtxoEnv slot pp certState _ originalUtxo (IsValid isValid), utxoState, stAnnTx) <-
+  TRC (SubUtxoEnv slot pp certState originalUtxo (IsValid isValid), utxoState, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -250,11 +250,12 @@ dijkstraSubUtxowTransition ::
   ) =>
   TransitionRule (EraRule "SUBUTXOW" era)
 dijkstraSubUtxowTransition = do
-  TRC (env@(SubUtxoEnv _ pp certState scriptsProvided originalUtxo _), utxoState, stAnnTx) <-
+  TRC (env@(SubUtxoEnv _ pp certState originalUtxo _), utxoState, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
       txBody = tx ^. bodyTxL
       witsKeyHashes = keyHashWitnessesTxWits (tx ^. witsTxL)
+      scriptsProvided = scriptsProvidedStAnnTx stAnnTx
 
   {- ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes txId) σ -}
   runTestOnSignal $ Shelley.validateVerifiedWits tx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -259,7 +259,7 @@ dijkstraSubUtxowTransition = do
   {- ∀[ (vk , σ) ∈ vKeySigs ] isSigned vk (txidBytes txId) σ -}
   runTestOnSignal $ Shelley.validateVerifiedWits tx
 
-  let scriptsNeeded = getScriptsNeeded originalUtxo txBody
+  let scriptsNeeded = scriptsNeededStAnnTx stAnnTx
       scriptHashesNeeded = getScriptsHashesNeeded scriptsNeeded
 
   {- ∀[ s ∈ p1ScriptsNeeded ] validP1Script vKeyHashesProvided txVldt s -}
@@ -269,7 +269,7 @@ dijkstraSubUtxowTransition = do
   runTest $ Shelley.validateNeededWitnesses witsKeyHashes certState originalUtxo txBody
 
   {- dataHashesNeeded ⊆ mapˢ hash dataProvided -}
-  runTest $ Alonzo.missingRequiredDatums originalUtxo tx
+  runTest $ Alonzo.missingRequiredDatums scriptsProvided originalUtxo tx
 
   {- txADhash ≡ map hash txAuxData -}
   runTestOnSignal $ Shelley.validateMetadata pp tx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -275,7 +275,7 @@ dijkstraSubUtxowTransition = do
   {- txADhash ≡ map hash txAuxData -}
   runTestOnSignal $ Shelley.validateMetadata pp tx
 
-  let scriptIntegrity = mkScriptIntegrity pp tx scriptsProvided scriptHashesNeeded
+  let scriptIntegrity = mkScriptIntegrity pp tx (plutusLanguagesUsedStAnnTx stAnnTx)
   runTest $ Alonzo.checkScriptIntegrityHash tx pp scriptIntegrity
 
   runTest $ Alonzo.hasExactSetOfRedeemers tx scriptsProvided scriptsNeeded

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -334,7 +334,7 @@ dijkstraUtxoTransition ::
   , STS (EraRule "UTXO" era)
   , Event (EraRule "UTXO" era) ~ Alonzo.AlonzoUtxoEvent era
   , -- In this function we call the UTXOS rule, so we need some assumptions
-    Environment (EraRule "UTXOS" era) ~ Conway.ConwayUtxosEnv era
+    Environment (EraRule "UTXOS" era) ~ ()
   , State (EraRule "UTXOS" era) ~ ()
   , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , Embed (EraRule "UTXOS" era) (EraRule "UTXO" era)
@@ -417,7 +417,7 @@ dijkstraUtxoTransition = do
   {- ‖collateral tx‖ ≤ maxCollInputs pp -}
   runTest $ Alonzo.validateTooManyCollateralInputs pp txBody
 
-  () <- trans @(EraRule "UTXOS" era) $ TRC (Conway.ConwayUtxosEnv pp originalUtxo, (), stAnnTx)
+  () <- trans @(EraRule "UTXOS" era) $ TRC ((), (), stAnnTx)
   Babbage.updateUTxOStateByTxValidity
     pp
     certState
@@ -450,7 +450,7 @@ instance
   , STS (EraRule "UTXO" era)
   , -- In this function we we call the UTXOS rule, so we need some assumptions
     Embed (EraRule "UTXOS" era) (DijkstraUTXO era)
-  , Environment (EraRule "UTXOS" era) ~ Conway.ConwayUtxosEnv era
+  , Environment (EraRule "UTXOS" era) ~ ()
   , State (EraRule "UTXOS" era) ~ ()
   , Signal (EraRule "UTXOS" era) ~ StAnnTx TopTx era
   , EraCertState era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -96,8 +96,6 @@ data DijkstraUtxoEnv era = DijkstraUtxoEnv
   , duePParams :: PParams era
   , dueCertState :: CertState era
   , dueOriginalUtxo :: UTxO era
-  , dueScriptsProvided :: ScriptsProvided era
-  -- ^ aggregated scripts provided across all transaction levels
   }
 
 -- | Predicate failure for the Dijkstra Era
@@ -343,7 +341,7 @@ dijkstraUtxoTransition ::
   ) =>
   TransitionRule (EraRule "UTXO" era)
 dijkstraUtxoTransition = do
-  TRC (DijkstraUtxoEnv slot pp certState originalUtxo _scriptsProvided, utxos, stAnnTx) <-
+  TRC (DijkstraUtxoEnv slot pp certState originalUtxo, utxos, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
   -- this is the original Accounts, before any transactions were applied

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -217,8 +217,9 @@ dijkstraUtxowTransition ::
   ) =>
   TransitionRule (EraRule "UTXOW" era)
 dijkstraUtxowTransition = do
-  TRC (DijkstraUtxoEnv slot pp certState originalUtxo scriptsProvided, u, stAnnTx) <- judgmentContext
+  TRC (DijkstraUtxoEnv slot pp certState originalUtxo, u, stAnnTx) <- judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
+      scriptsProvided = scriptsProvidedStAnnTx stAnnTx
 
   let txBody = tx ^. bodyTxL
       subTxs = OMap.elems $ txBody ^. subTransactionsTxBodyL
@@ -295,9 +296,9 @@ dijkstraUtxowTransition = do
       missingGuards = requiredGuardsBySubTxs `Set.difference` topLevelGuards
   runTestOnSignal $ failureOnNonEmptySet missingGuards MissingRequiredGuards
 
-  -- Pass through to UTXO sub-rule, carrying the original UTxO and scriptsProvided
+  -- Pass through to UTXO sub-rule, carrying the original UTxO
   trans @(EraRule "UTXO" era) $
-    TRC (DijkstraUtxoEnv slot pp certState originalUtxo scriptsProvided, u, stAnnTx)
+    TRC (DijkstraUtxoEnv slot pp certState originalUtxo, u, stAnnTx)
 
 instance
   forall era.

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -53,6 +53,7 @@ import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra, DijkstraUTXO, DijkstraUTXOW)
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoEnv (..), DijkstraUtxoPredFailure)
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
+import Cardano.Ledger.Dijkstra.UTxO (DijkstraEraUTxO (..))
 import Cardano.Ledger.Keys (VKey)
 import Cardano.Ledger.Rules.ValidationMode (runTest, runTestOnSignal)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState)
@@ -200,7 +201,7 @@ instance
 dijkstraUtxowTransition ::
   forall era.
   ( AlonzoEraTx era
-  , AlonzoEraUTxO era
+  , DijkstraEraUTxO era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , DijkstraEraTxBody era
   , EraRule "UTXOW" era ~ DijkstraUTXOW era
@@ -227,17 +228,15 @@ dijkstraUtxowTransition = do
   -- A subtx may consume a txout that the top-level tx references, so the UTXO threaded in the state may not contain it.
 
   -- scriptsNeeded for the top-level tx
-  let topScriptsNeeded = getScriptsNeeded originalUtxo txBody
+  let topScriptsNeeded = scriptsNeededStAnnTx stAnnTx
       topScriptHashesNeeded = getScriptsHashesNeeded topScriptsNeeded
+      subStAnnTxs = subTransactionsStAnnTx stAnnTx
 
   -- scriptsNeeded aggregated across all levels
   let allScriptHashesNeeded =
         Set.unions $
           topScriptHashesNeeded
-            : [ getScriptsHashesNeeded
-                  (getScriptsNeeded originalUtxo (subTx ^. bodyTxL))
-              | subTx <- subTxs
-              ]
+            : (getScriptsHashesNeeded . scriptsNeededStAnnTx <$> subStAnnTxs)
 
   {- ∀s ∈ (txscripts txw utxo neededHashes ) ∩ Scriptph1 , validateScript s tx -}
   -- Per-level: phase-1 script validation is per-tx (script execution)
@@ -262,7 +261,7 @@ dijkstraUtxowTransition = do
 
   {-  inputHashes ⊆  dom(txdats txw) ⊆  allowed -}
   -- Per-level: datum check for top-level tx's own spend inputs
-  runTest $ Alonzo.missingRequiredDatums originalUtxo tx
+  runTest $ Alonzo.missingRequiredDatums scriptsProvided originalUtxo tx
 
   {- dom (txrdmrs tx) = { rdptr txb sp | (sp, h) ∈ scriptsNeeded utxo tx,
                           h ↦ s ∈ txscripts txw, s ∈ Scriptph2} -}
@@ -303,7 +302,7 @@ dijkstraUtxowTransition = do
 instance
   forall era.
   ( AlonzoEraTx era
-  , AlonzoEraUTxO era
+  , DijkstraEraUTxO era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , DijkstraEraTxBody era
   , EraRule "UTXOW" era ~ DijkstraUTXOW era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -286,7 +286,7 @@ dijkstraUtxowTransition = do
 
   {- scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw) -}
   -- Per-level: script integrity is per-tx (depends on that tx's redeemers and language views)
-  let scriptIntegrity = mkScriptIntegrity pp tx scriptsProvided topScriptHashesNeeded
+  let scriptIntegrity = mkScriptIntegrity pp tx (plutusLanguagesUsedStAnnTx stAnnTx)
   runTest $ Alonzo.checkScriptIntegrityHash tx pp scriptIntegrity
 
   {- concatMapˡ (λ txSub → mapˢ proj₁ (TopLevelGuardsOf txSub)) (SubTransactionsOf txTop) ⊆ GuardsOf txTop -}

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -378,7 +378,7 @@ data DijkstraStAnnTx l era where
     , dsattPlutusLegacyMode :: Bool
     , dsattPlutusLanguagesUsed :: Set Language
     , dsattPlutusScriptsWithContext :: Either (NonEmpty (CollectError era)) [PlutusWithContext]
-    , dsattStAnnSubTxs :: [DijkstraStAnnTx SubTx era]
+    , dsattSubTransactions :: [DijkstraStAnnTx SubTx era]
     } ->
     DijkstraStAnnTx TopTx era
   DijkstraStAnnSubTx ::

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -47,13 +47,14 @@ import Cardano.Ledger.Dijkstra.State
 import Cardano.Ledger.Dijkstra.Tx (DijkstraStAnnTx (..))
 import Cardano.Ledger.Mary.UTxO (burnedMultiAssets, getConsumedMaryValue)
 import Cardano.Ledger.Mary.Value (MaryValue (..))
-import Cardano.Ledger.Plutus (PlutusWithContext)
+import Cardano.Ledger.Plutus (Language, PlutusWithContext)
 import Data.Foldable (Foldable (..))
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
 import Data.Monoid (Sum (..))
 import qualified Data.OMap.Strict as OMap
+import Data.Set (Set)
 import Lens.Micro ((^.))
 import Lens.Micro.Extras (view)
 
@@ -184,6 +185,8 @@ instance AlonzoEraUTxO DijkstraEra where
 
   plutusScriptsWithContextStAnnTx = plutusScriptsWithContextDijkstraStAnnTx
 
+  plutusLanguagesUsedStAnnTx = plutusLanguagesUsedDijkstraStAnnTx
+
 scriptsProvidedDijkstraStAnnTx ::
   ( EraTxLevel era
   , STxLevel l era ~ STxBothLevels l era
@@ -223,6 +226,19 @@ plutusScriptsWithContextDijkstraStAnnTx stAnnTx =
     stAnnTx
     (\DijkstraStAnnTopTx {dsattPlutusScriptsWithContext} -> dsattPlutusScriptsWithContext)
     (\DijkstraStAnnSubTx {dsastPlutusScriptsWithContext} -> dsastPlutusScriptsWithContext)
+
+plutusLanguagesUsedDijkstraStAnnTx ::
+  ( EraTxLevel era
+  , STxLevel l era ~ STxBothLevels l era
+  , STxLevel SubTx era ~ STxBothLevels SubTx era
+  , STxLevel TopTx era ~ STxBothLevels TopTx era
+  ) =>
+  DijkstraStAnnTx l era -> Set Language
+plutusLanguagesUsedDijkstraStAnnTx stAnnTx =
+  withBothTxLevels
+    stAnnTx
+    (\DijkstraStAnnTopTx {dsattPlutusLanguagesUsed} -> dsattPlutusLanguagesUsed)
+    (\DijkstraStAnnSubTx {dsastPlutusLanguagesUsed} -> dsastPlutusLanguagesUsed)
 
 instance DijkstraEraUTxO DijkstraEra where
   subTransactionsStAnnTx = subTransactionsDijkstraStAnnTx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -17,6 +17,7 @@ module Cardano.Ledger.Dijkstra.UTxO (
   batchNonDistinctRefScriptsSize,
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (CollectError)
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
   AlonzoScriptsNeeded (..),
@@ -46,7 +47,9 @@ import Cardano.Ledger.Dijkstra.State
 import Cardano.Ledger.Dijkstra.Tx (DijkstraStAnnTx (..))
 import Cardano.Ledger.Mary.UTxO (burnedMultiAssets, getConsumedMaryValue)
 import Cardano.Ledger.Mary.Value (MaryValue (..))
+import Cardano.Ledger.Plutus (PlutusWithContext)
 import Data.Foldable (Foldable (..))
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
 import Data.Monoid (Sum (..))
@@ -179,6 +182,8 @@ instance AlonzoEraUTxO DijkstraEra where
 
   scriptsNeededStAnnTx = scriptsNeededDijkstraStAnnTx
 
+  plutusScriptsWithContextStAnnTx = plutusScriptsWithContextDijkstraStAnnTx
+
 scriptsProvidedDijkstraStAnnTx ::
   ( EraTxLevel era
   , STxLevel l era ~ STxBothLevels l era
@@ -204,6 +209,20 @@ scriptsNeededDijkstraStAnnTx stAnnTx =
     stAnnTx
     (\DijkstraStAnnTopTx {dsattScriptsNeeded} -> dsattScriptsNeeded)
     (\DijkstraStAnnSubTx {dsastScriptsNeeded} -> dsastScriptsNeeded)
+
+plutusScriptsWithContextDijkstraStAnnTx ::
+  ( EraTxLevel era
+  , STxLevel l era ~ STxBothLevels l era
+  , STxLevel SubTx era ~ STxBothLevels SubTx era
+  , STxLevel TopTx era ~ STxBothLevels TopTx era
+  ) =>
+  DijkstraStAnnTx l era ->
+  Either (NonEmpty (CollectError era)) [PlutusWithContext]
+plutusScriptsWithContextDijkstraStAnnTx stAnnTx =
+  withBothTxLevels
+    stAnnTx
+    (\DijkstraStAnnTopTx {dsattPlutusScriptsWithContext} -> dsattPlutusScriptsWithContext)
+    (\DijkstraStAnnSubTx {dsastPlutusScriptsWithContext} -> dsastPlutusScriptsWithContext)
 
 instance DijkstraEraUTxO DijkstraEra where
   subTransactionsStAnnTx = subTransactionsDijkstraStAnnTx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Dijkstra.UTxO (
+  DijkstraEraUTxO (..),
   getDijkstraScriptsNeeded,
   getDijkstraScriptsProvided,
   scriptsProvidedDijkstraStAnnTx,
@@ -50,6 +53,9 @@ import Data.Monoid (Sum (..))
 import qualified Data.OMap.Strict as OMap
 import Lens.Micro ((^.))
 import Lens.Micro.Extras (view)
+
+class AlonzoEraUTxO era => DijkstraEraUTxO era where
+  subTransactionsStAnnTx :: StAnnTx TopTx era -> [StAnnTx SubTx era]
 
 getConsumedDijkstraValue ::
   forall era l.
@@ -183,6 +189,13 @@ scriptsProvidedDijkstraStAnnTx stAnnTx =
     stAnnTx
     (\DijkstraStAnnTopTx {dsattScriptsProvided} -> dsattScriptsProvided)
     (\DijkstraStAnnSubTx {dsastScriptsProvided} -> dsastScriptsProvided)
+
+instance DijkstraEraUTxO DijkstraEra where
+  subTransactionsStAnnTx = subTransactionsDijkstraStAnnTx
+
+subTransactionsDijkstraStAnnTx ::
+  DijkstraStAnnTx TopTx era -> [DijkstraStAnnTx SubTx era]
+subTransactionsDijkstraStAnnTx DijkstraStAnnTopTx {dsattSubTransactions} = dsattSubTransactions
 
 dijkstraSubTxProducedValue ::
   (ConwayEraTxBody era, Value era ~ MaryValue) =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -177,6 +177,8 @@ instance AlonzoEraUTxO DijkstraEra where
 
   scriptsProvidedStAnnTx = scriptsProvidedDijkstraStAnnTx
 
+  scriptsNeededStAnnTx = scriptsNeededDijkstraStAnnTx
+
 scriptsProvidedDijkstraStAnnTx ::
   ( EraTxLevel era
   , STxLevel l era ~ STxBothLevels l era
@@ -189,6 +191,19 @@ scriptsProvidedDijkstraStAnnTx stAnnTx =
     stAnnTx
     (\DijkstraStAnnTopTx {dsattScriptsProvided} -> dsattScriptsProvided)
     (\DijkstraStAnnSubTx {dsastScriptsProvided} -> dsastScriptsProvided)
+
+scriptsNeededDijkstraStAnnTx ::
+  ( EraTxLevel era
+  , STxLevel l era ~ STxBothLevels l era
+  , STxLevel SubTx era ~ STxBothLevels SubTx era
+  , STxLevel TopTx era ~ STxBothLevels TopTx era
+  ) =>
+  DijkstraStAnnTx l era -> ScriptsNeeded era
+scriptsNeededDijkstraStAnnTx stAnnTx =
+  withBothTxLevels
+    stAnnTx
+    (\DijkstraStAnnTopTx {dsattScriptsNeeded} -> dsattScriptsNeeded)
+    (\DijkstraStAnnSubTx {dsastScriptsNeeded} -> dsastScriptsNeeded)
 
 instance DijkstraEraUTxO DijkstraEra where
   subTransactionsStAnnTx = subTransactionsDijkstraStAnnTx

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/Instances/Ledger.hs
@@ -1572,12 +1572,6 @@ instance
   (EraGov era, EraTxOut era, EraSpecPParams era, EraCertState era, HasSpec (CertState era)) =>
   HasSpec (Shelley.UtxoEnv era)
 
-instance Era era => HasSimpleRep (Conway.ConwayUtxosEnv era)
-
-instance
-  (Era era, EraSpecPParams era, HasSpec (TxOut era), IsNormalType (TxOut era)) =>
-  HasSpec (Conway.ConwayUtxosEnv era)
-
 -- ================================================================
 -- All the Tx instances
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -16,7 +16,6 @@ import Cardano.Ledger.Api
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Core
-import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.LedgerState (utxosUtxo)
@@ -222,14 +221,16 @@ prop_UTXOS =
   stsPropertyV2Gen @"UTXOS"
     trueSpec
     (\_env -> trueSpec)
-    ( \env _st -> do
+    ( \_env _st -> do
+        pp <- genFromSpec trueSpec
+        utxo <- genFromSpec trueSpec
         tx <- genFromSpec trueSpec
         pure $
           mkStAnnTx
             (epochInfo testGlobals)
             (systemStart testGlobals)
-            (Conway.cuePParams env)
-            (Conway.cueUTxO env)
+            pp
+            utxo
             tx
     )
     $ \_env _st _sig _st' -> True


### PR DESCRIPTION
# Description

Now that we have `StAnnTx` threaded from `applyTx` through the rules (PR:  https://github.com/IntersectMBO/cardano-ledger/pull/5789) , it's time to make use of the precomputed information stored in `StAnnTx`, which is what this PR does: 

* scriptsNeeded and scriptsProvided 
* plutus contexts  - in these entry points: `Babbage.expectScriptsToPass`, `Babbage.babbageEvalScriptsTxInvalid` ~and `Alonzo.scriptsTransition`~
* plutus languages: in `mkScriptIntegrity` arguments

~This PR also deals with the obscure `unsafeLinearExtendEpochInfo` which - only in Alonzo - has to be applied to EpochInfo before setting it in LedgerTxInfo  (commit [Pass extended EpochInfo to mkAlonzoStAnnTx in mkStAnnTx for Alonzo](https://github.com/IntersectMBO/cardano-ledger/pull/5804/changes/c56cf3f5c05586e202e6c60794897721c20f16ae)
Reusing the cache in `StAnnTx` while accounting for this difference introduces some boilerplate (eg: extra Slot argument in mkStTxAnn). 
I'm ambivalent about the value of this change -  we can easily remove this commit and the following ([Use precomputed plutus contexts in alonzo scriptsTransition](https://github.com/IntersectMBO/cardano-ledger/pull/5804/changes/be51e5d7ad25ba0ab1dccf4b8249ba30cdb8030d)), and adapt the last  two which are just cleaning up fields made redundant by previous commits.~

EDIT: Agreed with Alexey to remove the commits mentioned in the strikethrough text above and handle it better in a different PR. 
So as it is now, the pre-computed values from StAnnTx are used in rules starting with Babbage. 
Handling of Alonzo will come separately in a future PR. 

This PR depends on another PR https://github.com/IntersectMBO/cardano-ledger/pull/5826 which fixes a bug, which only this PR makes visible. 
Without it, this test failure occurs: 

```
Alonzo tests
  total amount of Ada is preserved (Chain) [✘] (2582ms)

Failures:

  src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs:112:3:
  1) Alonzo tests total amount of Ada is preserved (Chain)
       Falsified (after 1 test):
         utxoDepositsIncreaseByFeesWithdrawals
         Coin (-54683687) /= Coin (-53652287)

  To rerun use: --match "/Alonzo tests/total amount of Ada is preserved (Chain)/" --seed 1397446474
```
The test is fixed with the change  in https://github.com/IntersectMBO/cardano-ledger/pull/5826 , which has to be merged before this one. 

Closes https://github.com/IntersectMBO/cardano-ledger/issues/5791

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
