### PR TITLE
Relax `NoThunks` instance for `BlockTransitionError`

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.19.0.0
 
+* Change `NoThunks` instance for `BlockTransitionError` to not check for thunks in its contents
+* Add `NFData` constriant to `BlockTransitionError` constructor.
 * Add `injectStakeCredentials`, `injectStakePools`, `resolveInjectionSource`, `injectInitialFundsAndStaking` to `Cardano.Ledger.Shelley.Transition`
   - `injectStakeCredentials` and `injectStakePools` take a leading `Network` argument and throw `InjectionNotAllowedOnMainnet` when called with `Mainnet`
 * Deprecate `registerInitialStakePools`, `shelleyRegisterInitialAccounts`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.19.0.0
 
 * Change `NoThunks` instance for `BlockTransitionError` to not check for thunks in its contents
-* Add `NFData` constriant to `BlockTransitionError` constructor.
+* Add `NFData` constraint to `BlockTransitionError` constructor.
 * Add `injectStakeCredentials`, `injectStakePools`, `resolveInjectionSource`, `injectInitialFundsAndStaking` to `Cardano.Ledger.Shelley.Transition`
   - `injectStakeCredentials` and `injectStakePools` take a leading `Network` argument and throw `InjectionNotAllowedOnMainnet` when called with `Mainnet`
 * Deprecate `registerInitialStakePools`, `shelleyRegisterInitialAccounts`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Validation.hs
@@ -4,10 +4,12 @@
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -25,7 +27,7 @@ module Cardano.Ledger.Shelley.API.Validation (
   applyBlockEitherNoEvents,
   applyBlockNoValidaton,
   applyTickNoEvents,
-  BlockTransitionError (..),
+  BlockTransitionError (BlockTransitionError),
   chainChecks,
 ) where
 
@@ -42,13 +44,14 @@ import Cardano.Ledger.Shelley.Rules (BbodySignal (..))
 import qualified Cardano.Ledger.Shelley.Rules as STS
 import Cardano.Ledger.Shelley.State ()
 import Cardano.Ledger.Slot (SlotNo)
+import Control.DeepSeq (NFData, deepseq)
 import Control.Monad.Except
 import Control.Monad.Trans.Reader (runReader)
 import Control.State.Transition.Extended
 import Data.List.NonEmpty (NonEmpty (..))
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
-import NoThunks.Class (NoThunks (..))
+import NoThunks.Class (AllowThunk (..), NoThunks (..))
 
 class EraGov era => ApplyTick era where
   -- | Run the `TICK` rule with `globalAssertionPolicy` and without any
@@ -83,7 +86,14 @@ class EraGov era => ApplyTick era where
         flip runReader globals . applySTSOptsResult @(EraRule "TICK" era) opts $
           TRC ((), newEpochState, slotNo)
 
-class (ApplyTick era, EraBlockBody era, EraBlockHeader h era) => ApplyBlock h era where
+class
+  ( ApplyTick era
+  , EraBlockBody era
+  , EraBlockHeader h era
+  , NFData (PredicateFailure (EraRule "BBODY" era))
+  ) =>
+  ApplyBlock h era
+  where
   wrapBlockSignal :: Block h era -> Signal (EraRule "BBODY" era)
   default wrapBlockSignal ::
     Signal (EraRule "BBODY" era) ~ BbodySignal era =>
@@ -222,8 +232,19 @@ updateNewEpochState ss (STS.BbodyState ls bcur) =
   LedgerState.updateNES ss bcur ls
 
 newtype BlockTransitionError era
-  = BlockTransitionError (NonEmpty (STS.PredicateFailure (EraRule "BBODY" era)))
+  = BlockTransitionErrorInternal (NonEmpty (STS.PredicateFailure (EraRule "BBODY" era)))
   deriving (Generic)
+
+pattern BlockTransitionError ::
+  NFData (PredicateFailure (EraRule "BBODY" era)) =>
+  NonEmpty (PredicateFailure (EraRule "BBODY" era)) ->
+  BlockTransitionError era
+pattern BlockTransitionError failures <-
+  BlockTransitionErrorInternal failures
+  where
+    BlockTransitionError failures = failures `deepseq` BlockTransitionErrorInternal failures
+
+{-# COMPLETE BlockTransitionError #-}
 
 deriving stock instance
   Eq (STS.PredicateFailure (EraRule "BBODY" era)) =>
@@ -233,6 +254,6 @@ deriving stock instance
   Show (STS.PredicateFailure (EraRule "BBODY" era)) =>
   Show (BlockTransitionError era)
 
-instance
-  NoThunks (STS.PredicateFailure (EraRule "BBODY" era)) =>
-  NoThunks (BlockTransitionError era)
+-- | We do not check for thunks in this instance, because `BlockTransitionError` uses `NFData` to
+-- force its contents to Normal Form upon construction.
+deriving via AllowThunk (BlockTransitionError era) instance NoThunks (BlockTransitionError era)


### PR DESCRIPTION
# Description

We no longer need to check for thunks in the contents of `BlockTransitionError`, becasue this PR introduces a pattern synonym that uses `deepseq` to force everything to normal form.

We could of course bring back strictness annotation and `NoThunks` instances for all of the predicate failures, however this whole overhead is an overkill, because:
* we do not need to optimize for the failing case and it is ok to introduce a little overhead upon failure. FTR: the only time we persist predicate failures is when we write to disk temporarely for chains with bad blocks.
* Maintaining `NoThunks` instances for *all* predicate failures for a single edge is a burden
* There is a plan to utilize laziness in predicate failures in order to add timing measurement for failure checks in ledger rules


# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
