### PR TITLE
Fix `TranslateEra`instance for `DijkstraEra` `CertState` 

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `AlonzoEraTxAuxData` as a superclass to `AlonzoEraTx`
 * Add `NFData` instance for `AlonzoScriptsNeeded`
 * Change `Signal` to `StAnnTx TopTx era` for: `AlonzoLEDGER`, `AlonzoUTXOW`, `AlonzoUTXO`, `AlonzoUTXOS`
 * Add `FromJSON` instance for `IsValid`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -83,6 +83,7 @@ import Cardano.Ledger.Alonzo.Scripts (
   plutusScriptLanguage,
   txscriptfee,
  )
+import Cardano.Ledger.Alonzo.TxAuxData (AlonzoEraTxAuxData)
 import Cardano.Ledger.Alonzo.TxBody (
   AlonzoEraTxBody (..),
   ScriptIntegrityHash,
@@ -205,7 +206,12 @@ alonzoTxL :: Lens' (Tx l AlonzoEra) (AlonzoTx l AlonzoEra)
 alonzoTxL = lens unAlonzoTx $ const MkAlonzoTx
 
 class
-  (EraTx era, AlonzoEraTxBody era, AlonzoEraTxWits era, AlonzoEraScript era) =>
+  ( EraTx era
+  , AlonzoEraTxBody era
+  , AlonzoEraTxWits era
+  , AlonzoEraScript era
+  , AlonzoEraTxAuxData era
+  ) =>
   AlonzoEraTx era
   where
   isValidTxL :: Lens' (Tx TopTx era) IsValid

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
@@ -158,7 +158,6 @@ exampleAlonzoNewEpochState =
 exampleAlonzoBasedTopTx ::
   forall era.
   ( AlonzoEraTx era
-  , AlonzoEraTxAuxData era
   , EraPlutusTxInfo 'PlutusV1 era
   , Value era ~ MaryValue
   ) =>
@@ -170,7 +169,6 @@ exampleAlonzoBasedTopTx =
 exampleAlonzoBasedTx ::
   forall era l.
   ( AlonzoEraTx era
-  , AlonzoEraTxAuxData era
   , EraPlutusTxInfo 'PlutusV1 era
   , Value era ~ MaryValue
   , Typeable l
@@ -193,7 +191,6 @@ addAlonzoBasedTopTxFeatureExamples tx =
 addAlonzoBasedTxFeatureExamples ::
   forall era l.
   ( AlonzoEraTx era
-  , AlonzoEraTxAuxData era
   , EraPlutusTxInfo 'PlutusV1 era
   , Value era ~ MaryValue
   ) =>

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Examples.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Examples.hs
@@ -103,7 +103,6 @@ exampleBabbageBasedTopTx ::
   forall era.
   ( AlonzoEraTx era
   , BabbageEraTxBody era
-  , AlonzoEraTxAuxData era
   , Value era ~ MaryValue
   , EraPlutusTxInfo PlutusV1 era
   , EraPlutusTxInfo PlutusV2 era
@@ -118,7 +117,6 @@ exampleBabbageBasedTx ::
   forall era l.
   ( AlonzoEraTx era
   , BabbageEraTxBody era
-  , AlonzoEraTxAuxData era
   , Value era ~ MaryValue
   , EraPlutusTxInfo PlutusV1 era
   , EraPlutusTxInfo PlutusV2 era
@@ -146,7 +144,6 @@ addBabbageBasedTxFeatures ::
   forall era l.
   ( AlonzoEraTx era
   , BabbageEraTxBody era
-  , AlonzoEraTxAuxData era
   , Value era ~ MaryValue
   , EraPlutusTxInfo PlutusV1 era
   , EraPlutusTxInfo PlutusV2 era

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Examples.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Examples.hs
@@ -117,7 +117,6 @@ exampleConwayBasedTopTx ::
   forall era.
   ( AlonzoEraTx era
   , ConwayEraTxBody era
-  , AlonzoEraTxAuxData era
   , EraPlutusTxInfo 'PlutusV1 era
   , EraPlutusTxInfo 'PlutusV2 era
   , EraPlutusTxInfo 'PlutusV3 era
@@ -132,7 +131,6 @@ exampleConwayBasedTx ::
   forall era l.
   ( AlonzoEraTx era
   , ConwayEraTxBody era
-  , AlonzoEraTxAuxData era
   , EraPlutusTxInfo 'PlutusV1 era
   , EraPlutusTxInfo 'PlutusV2 era
   , EraPlutusTxInfo 'PlutusV3 era

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.0.0
 
+* Add `TranslateEra` instance for `DijkstraEra VState`
+* Fix `TranslateEra` instance for `DijkstraEra CertState`
 * Add `GuardScriptHashesNotSupported` constructor to `DijkstraContextError`
 * Add `SubTxsAreNotSupported` constructor to `DijkstraContextError`
 * Add `decodeDijkstraTopTx`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Translation.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Translation.hs
@@ -39,9 +39,9 @@ import Cardano.Ledger.Dijkstra.Tx ()
 import Cardano.Ledger.Dijkstra.TxAuxData ()
 import Cardano.Ledger.Dijkstra.TxBody (upgradeGovAction, upgradeProposals)
 import Cardano.Ledger.Dijkstra.TxWits ()
-import qualified Cardano.Ledger.Shelley.API as API
 import Cardano.Ledger.Shelley.LedgerState (
   EpochState (..),
+  LedgerState (..),
   NewEpochState (..),
   UTxOState (..),
   epochStateGovStateL,
@@ -123,18 +123,18 @@ instance TranslateEra DijkstraEra DState where
 instance TranslateEra DijkstraEra PState where
   translateEra _ PState {..} = pure PState {..}
 
-instance TranslateEra DijkstraEra API.LedgerState where
+instance TranslateEra DijkstraEra LedgerState where
   translateEra ctx ls =
     pure
-      API.LedgerState
-        { API.lsUTxOState = translateEra' ctx $ ls ^. lsUTxOStateL
-        , API.lsCertState = translateCertState ctx $ ls ^. lsCertStateL
+      LedgerState
+        { lsUTxOState = translateEra' ctx $ ls ^. lsUTxOStateL
+        , lsCertState = translateCertState ctx $ ls ^. lsCertStateL
         }
 
 translateCertState ::
   TranslationContext DijkstraEra ->
-  API.CertState ConwayEra ->
-  API.CertState DijkstraEra
+  CertState ConwayEra ->
+  CertState DijkstraEra
 translateCertState ctx scert =
   def
     & certDStateL .~ translateEra' ctx (scert ^. certDStateL)
@@ -217,14 +217,14 @@ instance TranslateEra DijkstraEra UTxOState where
   translateEra ctxt us =
     pure
       UTxOState
-        { API.utxosUtxo = translateEra' ctxt $ API.utxosUtxo us
-        , API.utxosDeposited = API.utxosDeposited us
-        , API.utxosFees = API.utxosFees us
-        , API.utxosGovState = translateEra' ctxt $ API.utxosGovState us
-        , API.utxosInstantStake = coerce $ API.utxosInstantStake us
-        , API.utxosDonation = API.utxosDonation us
+        { utxosUtxo = translateEra' ctxt $ utxosUtxo us
+        , utxosDeposited = utxosDeposited us
+        , utxosFees = utxosFees us
+        , utxosGovState = translateEra' ctxt $ utxosGovState us
+        , utxosInstantStake = coerce $ utxosInstantStake us
+        , utxosDonation = utxosDonation us
         }
 
-instance TranslateEra DijkstraEra API.UTxO where
+instance TranslateEra DijkstraEra UTxO where
   translateEra _ctxt utxo =
-    pure $ API.UTxO $ upgradeTxOut `Map.map` API.unUTxO utxo
+    pure $ UTxO $ upgradeTxOut `Map.map` unUTxO utxo

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Translation.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Translation.hs
@@ -123,6 +123,9 @@ instance TranslateEra DijkstraEra DState where
 instance TranslateEra DijkstraEra PState where
   translateEra _ PState {..} = pure PState {..}
 
+instance TranslateEra DijkstraEra VState where
+  translateEra _ vState = pure $ coerce vState
+
 instance TranslateEra DijkstraEra LedgerState where
   translateEra ctx ls =
     pure
@@ -135,10 +138,12 @@ translateCertState ::
   TranslationContext DijkstraEra ->
   CertState ConwayEra ->
   CertState DijkstraEra
-translateCertState ctx scert =
-  def
-    & certDStateL .~ translateEra' ctx (scert ^. certDStateL)
-    & certPStateL .~ translateEra' ctx (scert ^. certPStateL)
+translateCertState ctx ConwayCertState {..} =
+  ConwayCertState
+    { conwayCertVState = translateEra' ctx conwayCertVState
+    , conwayCertPState = translateEra' ctx conwayCertPState
+    , conwayCertDState = translateEra' ctx conwayCertDState
+    }
 
 instance TranslateEra DijkstraEra GovAction where
   translateEra _ = pure . upgradeGovAction

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
@@ -109,7 +109,6 @@ exampleDijkstraBasedTopTx ::
   , EraPlutusTxInfo PlutusV2 era
   , EraPlutusTxInfo PlutusV3 era
   , EraPlutusTxInfo PlutusV4 era
-  , AlonzoEraTxAuxData era
   ) =>
   Tx TopTx era
 exampleDijkstraBasedTopTx =
@@ -127,7 +126,6 @@ exampleDijkstraBasedSubTx ::
   , EraPlutusTxInfo PlutusV2 era
   , EraPlutusTxInfo PlutusV3 era
   , EraPlutusTxInfo PlutusV4 era
-  , AlonzoEraTxAuxData era
   ) =>
   Tx SubTx era
 exampleDijkstraBasedSubTx =
@@ -139,7 +137,6 @@ addDijkstraBasedTopTxFeatures ::
   forall era.
   ( AlonzoEraTx era
   , DijkstraEraTxBody era
-  , AlonzoEraTxAuxData era
   , DijkstraEraScript era
   , EraPlutusTxInfo 'PlutusV1 era
   , EraPlutusTxInfo 'PlutusV2 era
@@ -172,7 +169,6 @@ addDijkstraBasedTxFeatures ::
   forall era l.
   ( AlonzoEraTx era
   , DijkstraEraTxBody era
-  , AlonzoEraTxAuxData era
   , DijkstraEraScript era
   , EraPlutusTxInfo 'PlutusV1 era
   , EraPlutusTxInfo 'PlutusV4 era


### PR DESCRIPTION
# Description

Previous implementation incorrectly copied over Conway era's implementation, thus failing translate `VState`

This PR also makes a slight improvement to class hierarchy for `AlonzoEraTx` by adding `AlonzoEraTxAuxData` superclass

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
