### PR TITLE
Switch `ChainData` and `Attributes` to use `ByteArray`

### DIFF
--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.21.0.0
 
+* Change `ChainCode` type to use `ByteArray` instead of `ByteString`
+* Change `bwAttributes` field to use `ByteArray` instead of `ByteString`
 * Add `StAnnTx` type family and `txStAnnTxG` to `Tx` type class
 * Add `decodeProtVer` to `Cardano.Ledger.BaseTypes`
 * Add `EraDecoder` type and `ppEraDecoder` field to `PParam`

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -328,7 +328,7 @@ test-suite tests
     base16-bytestring,
     binary,
     bytestring,
-    cardano-base:testlib >=0.1.3,
+    cardano-base:{cardano-base, testlib} >=0.1.3,
     cardano-crypto-class,
     cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-byron,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Keys.Bootstrap (
   verifyBootstrapWit,
 ) where
 
+import Cardano.Base.Bytes (byteStringToByteArray)
 import qualified Cardano.Chain.Common as Byron
 import Cardano.Crypto.DSIGN (SignedDSIGN (..))
 import qualified Cardano.Crypto.DSIGN as DSIGN
@@ -32,6 +33,8 @@ import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
   encodeListLen,
+  natVersion,
+  whenDecoderVersionAtLeast,
  )
 import Cardano.Ledger.Binary.Crypto (decodeSignedDSIGN)
 import Cardano.Ledger.Binary.Decoding (decodeRecordNamed)
@@ -46,25 +49,39 @@ import Cardano.Ledger.Keys.Internal (
   verifySignedDSIGN,
  )
 import Control.DeepSeq (NFData (..), rwhnf)
+import Control.Monad (unless)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Builder as B
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Short as SBS
 import Data.Coerce (coerce)
 import Data.Maybe (fromMaybe)
+import Data.MemPack.Buffer (byteArrayToShortByteString)
 import Data.Ord (comparing)
+import qualified Data.Primitive.ByteArray as BA
 import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Quiet
 
-newtype ChainCode = ChainCode {unChainCode :: ByteString}
+newtype ChainCode = ChainCode {unChainCode :: BA.ByteArray}
   deriving (Eq, Generic)
   deriving (Show) via Quiet ChainCode
-  deriving newtype (NoThunks, EncCBOR, DecCBOR, NFData)
+  deriving newtype (NoThunks, EncCBOR, NFData)
+
+instance DecCBOR ChainCode where
+  decCBOR = do
+    chainCode <- decCBOR
+    whenDecoderVersionAtLeast (natVersion @12) $ do
+      unless (BA.sizeofByteArray chainCode == 32) $
+        fail "ChainCode is expected to be 32 bytes in size"
+    pure $ ChainCode chainCode
 
 data BootstrapWitness = BootstrapWitness
   { bwKey :: !(VKey Witness)
   , bwSignature :: !(SignedDSIGN DSIGN (Hash HASH EraIndependentTxBody))
   , bwChainCode :: !ChainCode
-  , bwAttributes :: !ByteString
+  , bwAttributes :: !BA.ByteArray
   }
   deriving (Generic, Show, Eq)
 
@@ -109,14 +126,20 @@ bootstrapWitKeyHash (BootstrapWitness (VKey key) _ (ChainCode cc) attributes) =
     -- 3e: chain code bytes (32)
     -- 4: the addrAttributes
     -- the prefix is constant, and hard coded here:
-    prefix :: ByteString
+    prefix :: SBS.ShortByteString
     prefix = "\131\00\130\00\88\64"
     -- Here we are reserializing a key which we have previously deserialized.
     -- This is normally naughty. However, this is a blob of bytes -- serializing
     -- it amounts to wrapping the underlying byte array in a ByteString
     -- constructor.
     keyBytes = DSIGN.rawSerialiseVerKeyDSIGN key
-    bytes = prefix <> keyBytes <> cc <> attributes
+    bytes =
+      BSL.toStrict $
+        B.toLazyByteString $
+          B.shortByteString prefix
+            <> B.byteString keyBytes
+            <> B.shortByteString (byteArrayToShortByteString cc)
+            <> B.shortByteString (byteArrayToShortByteString attributes)
     hash_SHA3_256 :: ByteString -> ByteString
     hash_SHA3_256 = Hash.digest (Proxy :: Proxy Hash.SHA3_256)
     hash_crypto :: ByteString -> Hash.Hash ADDRHASH a
@@ -133,7 +156,7 @@ unpackByronVKey
     -- is the correct one. (32 bytes). If the XPub was constructed correctly,
     -- we already know that it has this length.
     Nothing -> error "unpackByronVKey: impossible!"
-    Just vk -> (VKey vk, ChainCode chainCodeBytes)
+    Just vk -> (VKey vk, ChainCode $ byteStringToByteArray chainCodeBytes)
 
 verifyBootstrapWit ::
   Hash HASH EraIndependentTxBody ->
@@ -156,7 +179,7 @@ makeBootstrapWitness ::
   Byron.Attributes Byron.AddrAttributes ->
   BootstrapWitness
 makeBootstrapWitness txBodyHash byronSigningKey addrAttributes =
-  BootstrapWitness vk signature cc (serialize' addrAttributes)
+  BootstrapWitness vk signature cc $ byteStringToByteArray (serialize' addrAttributes)
   where
     (vk, cc) = unpackByronVKey $ Byron.toVerification byronSigningKey
     signature =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Tools.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Tools.hs
@@ -24,6 +24,7 @@ module Cardano.Ledger.Tools (
   byteStringToNum,
 ) where
 
+import Cardano.Base.Bytes (byteStringToByteArray)
 import qualified Cardano.Chain.Common as Byron
 import Cardano.Crypto.DSIGN.Class (sigSizeDSIGN, verKeySizeDSIGN)
 import Cardano.Ledger.Address (BootstrapAddress (..), bootstrapKeyHash)
@@ -44,9 +45,11 @@ import Cardano.Ledger.State.UTxO (EraUTxO (..), UTxO (..))
 import Data.Bits (Bits (..), shiftR)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
 import Data.Default (def)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
+import Data.MemPack.Buffer (byteArrayFromShortByteString)
 import Data.Proxy
 import qualified Data.Set as Set
 import GHC.Stack (HasCallStack)
@@ -268,14 +271,14 @@ addDummyWitsTx pp tx numKeyWits byronAttrs =
       Set.fromList [WitVKey key dummySig | key <- take numKeyWits dummyKeys]
 
     -- ChainCode is always 32 bytes long.
-    chainCode = ChainCode $ BS.replicate 32 0
+    chainCode = ChainCode $ byteArrayFromShortByteString $ SBS.replicate 32 0
 
     mkDummyByronKeyWit ::
       VKey Witness ->
       Byron.Attributes Byron.AddrAttributes ->
       BootstrapWitness
     mkDummyByronKeyWit key =
-      BootstrapWitness key dummySig chainCode . serialize' byronProtVer
+      BootstrapWitness key dummySig chainCode . byteStringToByteArray . serialize' byronProtVer
     dummyByronKeyWits =
       Set.fromList $ zipWith mkDummyByronKeyWit dummyKeys byronAttrs
 

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/AddressSpec.hs
@@ -10,6 +10,7 @@
 
 module Test.Cardano.Ledger.AddressSpec (spec) where
 
+import Cardano.Base.Bytes (byteStringToByteArray)
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Crypto.Hash.Class as Hash
 import Cardano.Ledger.Address
@@ -66,7 +67,8 @@ spec =
               { bwKey = shelleyVKey
               , bwChainCode = chainCode
               , bwSignature = sig
-              , bwAttributes = serialize' byronProtVer $ Byron.addrAttributes byronAddr
+              , bwAttributes =
+                  byteStringToByteArray $ serialize' byronProtVer $ Byron.addrAttributes byronAddr
               }
       pure $
         coerceKeyRole (bootstrapKeyHash addr)

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -113,7 +113,7 @@ import Generic.Random (genericArbitraryU)
 import Numeric.Natural (Natural)
 import qualified PlutusLedgerApi.V1 as PV1
 import System.Random.Stateful (StatefulGen, uniformRM)
-import Test.Cardano.Base.Bytes (genByteString, genShortByteString)
+import Test.Cardano.Base.Bytes (genByteArray, genShortByteString)
 import qualified Test.Cardano.Chain.Common.Gen as Byron
 import Test.Cardano.Ledger.Binary.Arbitrary
 import Test.Cardano.Ledger.Core.Utils (unsafeBoundRational)
@@ -342,7 +342,7 @@ instance Typeable kr => Arbitrary (WitVKey kr) where
   arbitrary = WitVKey <$> arbitrary <*> arbitrary
 
 instance Arbitrary ChainCode where
-  arbitrary = ChainCode <$> genByteString 32
+  arbitrary = ChainCode <$> genByteArray 32
 
 instance Arbitrary BootstrapWitness where
   arbitrary = do


### PR DESCRIPTION


# Description

In order to avoid pinned memory fragmentation it is beneficial to use `ByteArray` instead of `ByteString`

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
