### PR TITLE
Add TICK and NEWEPOCH benchmarks

### DIFF
--- a/libs/ledger-state/README.md
+++ b/libs/ledger-state/README.md
@@ -113,3 +113,5 @@ $ cabal bench ledger-state:performance --benchmark-option=--csv=ledger-state:per
 The csv file will be saved in the `libs/ledger-state` directory.
 
 Since the `performance` benchmark uses only `new-epoch-state.bin` you don't need to run the `sqlite.db` steps above if you want to run only the `performance` benchmark.
+
+Not all benchmarks require `UTxO` to be loaded, therefore `BENCH_UTXO_PATH` does not need to be set for such benchmarks.

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -125,58 +125,63 @@ main = do
           , env (pure $ tickToEpochEnd newEpochStateStart) $
               bench "tickOverTheEpochBoundary" . nf tickOverTheEpochBoundary
           ]
-    , env (pure (mkMempoolEnv newEpochState slotNo, toMempoolState newEpochState)) $
-        \ ~(mempoolEnv, mempoolState) ->
-          bgroup
-            "reapplyTx"
-            [ env (pure validatedTx1) $
-                bench "Tx1" . whnf (reapplyTx' mempoolEnv mempoolState)
-            , env (pure validatedTx2) $
-                bench "Tx2" . whnf (reapplyTx' mempoolEnv mempoolState)
-            , env (pure validatedTx3) $
-                bench "Tx3" . whnf (reapplyTx' mempoolEnv mempoolState)
-            , env
-                (pure [validatedTx1, validatedTx2, validatedTx3])
-                $ bench "Tx1+Tx2+Tx3" . whnf (F.foldl' (reapplyTx' mempoolEnv) mempoolState)
-            ]
-    , env (pure (mkMempoolEnv newEpochState slotNo, toMempoolState newEpochState)) $
-        \ ~(mempoolEnv, mempoolState) ->
-          bgroup
-            "applyTx"
-            [ env (pure (extractTx validatedTx1)) $
-                bench "Tx1" . whnf (applyTx' mempoolEnv mempoolState)
-            , env (pure (extractTx validatedTx2)) $
-                bench "Tx2" . whnf (applyTx' mempoolEnv mempoolState)
-            , env (pure (extractTx validatedTx3)) $
-                bench "Tx3" . whnf (applyTx' mempoolEnv mempoolState)
-            , env
-                (pure [validatedTx1, validatedTx2, validatedTx3])
-                $ bench "Tx1+Tx2+Tx3"
-                  -- TODO: revert this to `foldl'` without `fmap` after tx's are fixed
-                  . whnf (F.foldlM (\ms -> fmap fst . applyTx' mempoolEnv ms . extractTx) mempoolState)
-            ]
-    , env (pure utxo) $ \utxo' ->
-        bgroup
-          "UTxO"
-          [ bench "sumUTxO" $ nf sumUTxO utxo'
-          , bench "sumCoinUTxO" $ nf sumCoinUTxO utxo'
-          , -- We need to filter out all multi-assets to prevent `areAllAdaOnly`
-            -- from short circuiting and producing results that are way better
-            -- than the worst case
-            env (pure $ Map.filter (\txOut -> isAdaOnly (txOut ^. valueTxOutL)) $ unUTxO utxo') $
-              bench "areAllAdaOnly" . nf areAllAdaOnly
-          ]
-    , env (pure newEpochState) $ \nes ->
-        let (_, minTxOut) = Map.findMin utxoMap
-            (_, maxTxOut) = Map.findMax utxoMap
-            setAddr =
-              Set.fromList [minTxOut ^. addrTxOutL, maxTxOut ^. addrTxOutL]
-         in bgroup
-              "MinMaxTxId"
-              [ env (pure setAddr) $ bench "getFilteredNewUTxO" . nf (getFilteredUTxO nes)
-              , env (pure setAddr) $ bench "getFilteredOldUTxO" . nf (getFilteredOldUTxO nes)
-              ]
     ]
+      ++ [ utxoBenchmark
+         | utxoBenchmark <-
+             [ env (pure (mkMempoolEnv newEpochState slotNo, toMempoolState newEpochState)) $
+                 \ ~(mempoolEnv, mempoolState) ->
+                   bgroup
+                     "reapplyTx"
+                     [ env (pure validatedTx1) $
+                         bench "Tx1" . whnf (reapplyTx' mempoolEnv mempoolState)
+                     , env (pure validatedTx2) $
+                         bench "Tx2" . whnf (reapplyTx' mempoolEnv mempoolState)
+                     , env (pure validatedTx3) $
+                         bench "Tx3" . whnf (reapplyTx' mempoolEnv mempoolState)
+                     , env
+                         (pure [validatedTx1, validatedTx2, validatedTx3])
+                         $ bench "Tx1+Tx2+Tx3" . whnf (F.foldl' (reapplyTx' mempoolEnv) mempoolState)
+                     ]
+             , env (pure (mkMempoolEnv newEpochState slotNo, toMempoolState newEpochState)) $
+                 \ ~(mempoolEnv, mempoolState) ->
+                   bgroup
+                     "applyTx"
+                     [ env (pure (extractTx validatedTx1)) $
+                         bench "Tx1" . whnf (applyTx' mempoolEnv mempoolState)
+                     , env (pure (extractTx validatedTx2)) $
+                         bench "Tx2" . whnf (applyTx' mempoolEnv mempoolState)
+                     , env (pure (extractTx validatedTx3)) $
+                         bench "Tx3" . whnf (applyTx' mempoolEnv mempoolState)
+                     , env
+                         (pure [validatedTx1, validatedTx2, validatedTx3])
+                         $ bench "Tx1+Tx2+Tx3"
+                           -- TODO: revert this to `foldl'` without `fmap` after tx's are fixed
+                           . whnf (F.foldlM (\ms -> fmap fst . applyTx' mempoolEnv ms . extractTx) mempoolState)
+                     ]
+             , env (pure utxo) $ \utxo' ->
+                 bgroup
+                   "UTxO"
+                   [ bench "sumUTxO" $ nf sumUTxO utxo'
+                   , bench "sumCoinUTxO" $ nf sumCoinUTxO utxo'
+                   , -- We need to filter out all multi-assets to prevent `areAllAdaOnly`
+                     -- from short circuiting and producing results that are way better
+                     -- than the worst case
+                     env (pure $ Map.filter (\txOut -> isAdaOnly (txOut ^. valueTxOutL)) $ unUTxO utxo') $
+                       bench "areAllAdaOnly" . nf areAllAdaOnly
+                   ]
+             , env (pure newEpochState) $ \nes ->
+                 let (_, minTxOut) = Map.findMin utxoMap
+                     (_, maxTxOut) = Map.findMax utxoMap
+                     setAddr =
+                       Set.fromList [minTxOut ^. addrTxOutL, maxTxOut ^. addrTxOutL]
+                  in bgroup
+                       "MinMaxTxId"
+                       [ env (pure setAddr) $ bench "getFilteredNewUTxO" . nf (getFilteredUTxO nes)
+                       , env (pure setAddr) $ bench "getFilteredOldUTxO" . nf (getFilteredOldUTxO nes)
+                       ]
+             ]
+         , utxoSize > 0
+         ]
       ++ [ env (selectRandomMapKeys largeKeysNum stdGen utxoMap) $ \largeKeys ->
              bgroup
                "DeleteTxOuts"

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -69,10 +69,10 @@ main = do
 
   genesis <- either error id <$> eitherDecodeFileStrict' genesisFilePath
 
-  let es = case mUtxo of
+  let newEpochState = case mUtxo of
         Nothing -> nesFromFile
         Just utxoFromFile -> nesFromFile & utxoL .~ utxoFromFile
-      utxo = es ^. utxoL
+      utxo = newEpochState ^. utxoL
       utxoMap = unUTxO utxo
       utxoSize = Map.size utxoMap
       largeKeysNum = 100000
@@ -118,41 +118,43 @@ main = do
          in applyTickNoEvents @CurrentEra globals nes firstSlotNoOfTheNextEpoch
 
   defaultMain $
-    [ env (pure $ tickOverTheEpochBoundary $ tickToEpochEnd es) $ \newEpochStateStart ->
+    [ env (pure $ tickOverTheEpochBoundary $ tickToEpochEnd newEpochState) $ \newEpochStateStart ->
         bgroup
           "applyTick"
           [ bench "tickToEpochEnd" $ nf tickToEpochEnd newEpochStateStart
           , env (pure $ tickToEpochEnd newEpochStateStart) $
               bench "tickOverTheEpochBoundary" . nf tickOverTheEpochBoundary
           ]
-    , env (pure (mkMempoolEnv es slotNo, toMempoolState es)) $ \ ~(mempoolEnv, mempoolState) ->
-        bgroup
-          "reapplyTx"
-          [ env (pure validatedTx1) $
-              bench "Tx1" . whnf (reapplyTx' mempoolEnv mempoolState)
-          , env (pure validatedTx2) $
-              bench "Tx2" . whnf (reapplyTx' mempoolEnv mempoolState)
-          , env (pure validatedTx3) $
-              bench "Tx3" . whnf (reapplyTx' mempoolEnv mempoolState)
-          , env
-              (pure [validatedTx1, validatedTx2, validatedTx3])
-              $ bench "Tx1+Tx2+Tx3" . whnf (F.foldl' (reapplyTx' mempoolEnv) mempoolState)
-          ]
-    , env (pure (mkMempoolEnv es slotNo, toMempoolState es)) $ \ ~(mempoolEnv, mempoolState) ->
-        bgroup
-          "applyTx"
-          [ env (pure (extractTx validatedTx1)) $
-              bench "Tx1" . whnf (applyTx' mempoolEnv mempoolState)
-          , env (pure (extractTx validatedTx2)) $
-              bench "Tx2" . whnf (applyTx' mempoolEnv mempoolState)
-          , env (pure (extractTx validatedTx3)) $
-              bench "Tx3" . whnf (applyTx' mempoolEnv mempoolState)
-          , env
-              (pure [validatedTx1, validatedTx2, validatedTx3])
-              $ bench "Tx1+Tx2+Tx3"
-                -- TODO: revert this to `foldl'` without `fmap` after tx's are fixed
-                . whnf (F.foldlM (\ms -> fmap fst . applyTx' mempoolEnv ms . extractTx) mempoolState)
-          ]
+    , env (pure (mkMempoolEnv newEpochState slotNo, toMempoolState newEpochState)) $
+        \ ~(mempoolEnv, mempoolState) ->
+          bgroup
+            "reapplyTx"
+            [ env (pure validatedTx1) $
+                bench "Tx1" . whnf (reapplyTx' mempoolEnv mempoolState)
+            , env (pure validatedTx2) $
+                bench "Tx2" . whnf (reapplyTx' mempoolEnv mempoolState)
+            , env (pure validatedTx3) $
+                bench "Tx3" . whnf (reapplyTx' mempoolEnv mempoolState)
+            , env
+                (pure [validatedTx1, validatedTx2, validatedTx3])
+                $ bench "Tx1+Tx2+Tx3" . whnf (F.foldl' (reapplyTx' mempoolEnv) mempoolState)
+            ]
+    , env (pure (mkMempoolEnv newEpochState slotNo, toMempoolState newEpochState)) $
+        \ ~(mempoolEnv, mempoolState) ->
+          bgroup
+            "applyTx"
+            [ env (pure (extractTx validatedTx1)) $
+                bench "Tx1" . whnf (applyTx' mempoolEnv mempoolState)
+            , env (pure (extractTx validatedTx2)) $
+                bench "Tx2" . whnf (applyTx' mempoolEnv mempoolState)
+            , env (pure (extractTx validatedTx3)) $
+                bench "Tx3" . whnf (applyTx' mempoolEnv mempoolState)
+            , env
+                (pure [validatedTx1, validatedTx2, validatedTx3])
+                $ bench "Tx1+Tx2+Tx3"
+                  -- TODO: revert this to `foldl'` without `fmap` after tx's are fixed
+                  . whnf (F.foldlM (\ms -> fmap fst . applyTx' mempoolEnv ms . extractTx) mempoolState)
+            ]
     , env (pure utxo) $ \utxo' ->
         bgroup
           "UTxO"
@@ -164,17 +166,15 @@ main = do
             env (pure $ Map.filter (\txOut -> isAdaOnly (txOut ^. valueTxOutL)) $ unUTxO utxo') $
               bench "areAllAdaOnly" . nf areAllAdaOnly
           ]
-    , env (pure es) $ \newEpochState ->
+    , env (pure newEpochState) $ \nes ->
         let (_, minTxOut) = Map.findMin utxoMap
             (_, maxTxOut) = Map.findMax utxoMap
             setAddr =
               Set.fromList [minTxOut ^. addrTxOutL, maxTxOut ^. addrTxOutL]
          in bgroup
               "MinMaxTxId"
-              [ env (pure setAddr) $
-                  bench "getFilteredNewUTxO" . nf (getFilteredUTxO newEpochState)
-              , env (pure setAddr) $
-                  bench "getFilteredOldUTxO" . nf (getFilteredOldUTxO newEpochState)
+              [ env (pure setAddr) $ bench "getFilteredNewUTxO" . nf (getFilteredUTxO nes)
+              , env (pure setAddr) $ bench "getFilteredOldUTxO" . nf (getFilteredOldUTxO nes)
               ]
     ]
       ++ [ env (selectRandomMapKeys largeKeysNum stdGen utxoMap) $ \largeKeys ->

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -15,6 +15,7 @@ import Cardano.Ledger.Conway
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API.Mempool
+import Cardano.Ledger.Shelley.API.Validation
 import Cardano.Ledger.Shelley.API.Wallet (getFilteredUTxO, getUTxO)
 import Cardano.Ledger.Shelley.Genesis (
   ShelleyGenesis (..),
@@ -22,6 +23,7 @@ import Cardano.Ledger.Shelley.Genesis (
   mkShelleyGlobals,
  )
 import Cardano.Ledger.Shelley.LedgerState
+import Cardano.Ledger.Slot
 import Cardano.Ledger.State
 import Cardano.Ledger.State.UTxO (CurrentEra, readHexUTxO, readNewEpochState)
 import Cardano.Ledger.Val
@@ -86,6 +88,30 @@ main = do
       reapplyTx' mempoolEnv mempoolState =
         either (error . show) id
           . reapplyTx globals mempoolEnv mempoolState
+      slotsPerTick =
+        let f = positiveUnitIntervalNonZeroRational (activeSlotVal (activeSlotCoeff globals))
+         in round (1 /. f)
+
+      epochInfo = epochInfoPure globals
+      -- Assume we are at the very first slot number in the epoch and tick all the way to the very
+      -- last slot number. Note, that if the assumption was wrong, the whole reward computation and
+      -- other pulsers might restart, which shouldn't impact the final result at the end of the
+      -- epoch.
+      tickToEpochEnd nes =
+        let !lastSlotNo = epochInfoFirst epochInfo (succ (nesEL nes)) *- Duration slotsPerTick
+            go !curSlotNo !curNes
+              | nextSlotNo < lastSlotNo =
+                  go nextSlotNo (applyTickNoEvents @CurrentEra globals curNes nextSlotNo)
+              | otherwise = curNes
+              where
+                !nextSlotNo = curSlotNo +* Duration slotsPerTick
+         in go (epochInfoFirst epochInfo (nesEL nes)) nes
+      -- Assume we are at most `slotsPerTick` number of slots away from the first slot number of the
+      -- next epoch and perform one TICK over that many slot numbers, which has the net result of
+      -- crossing over the next epoch boundary.
+      tickOverTheEpochBoundary nes =
+        let !firstSlotNoOfTheNextEpoch = epochInfoFirst epochInfo (succ (nesEL nes))
+         in applyTickNoEvents @CurrentEra globals nes firstSlotNoOfTheNextEpoch
 
   when (utxoSize < largeKeysNum) $
     die $
@@ -93,7 +119,14 @@ main = do
   largeKeys <- selectRandomMapKeys 100000 stdGen utxoMap
 
   defaultMain
-    [ env (pure (mkMempoolEnv es slotNo, toMempoolState es)) $ \ ~(mempoolEnv, mempoolState) ->
+    [ env (pure $ tickOverTheEpochBoundary $ tickToEpochEnd es) $ \newEpochStateStart ->
+        bgroup
+          "applyTick"
+          [ bench "tickToEpochEnd" $ nf tickToEpochEnd newEpochStateStart
+          , env (pure $ tickToEpochEnd newEpochStateStart) $
+              bench "tickOverTheEpochBoundary" . nf tickOverTheEpochBoundary
+          ]
+    , env (pure (mkMempoolEnv es slotNo, toMempoolState es)) $ \ ~(mempoolEnv, mempoolState) ->
         bgroup
           "reapplyTx"
           [ env (pure validatedTx1) $

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.Val
 import Cardano.Slotting.EpochInfo (fixedEpochInfo)
 import Cardano.Slotting.Time (mkSlotLength)
 import Control.DeepSeq
-import Control.Monad (when)
+import Control.Monad (forM)
 import Criterion.Main
 import Data.Aeson
 import Data.Bifunctor (bimap, first)
@@ -46,8 +46,7 @@ import qualified Data.Set as Set
 import Data.Typeable (Typeable)
 import GHC.Stack (HasCallStack)
 import Lens.Micro ((&), (.~), (^.))
-import System.Environment (getEnv)
-import System.Exit (die)
+import System.Environment (getEnv, lookupEnv)
 import System.Random.Stateful
 
 main :: IO ()
@@ -56,19 +55,24 @@ main = do
       utxoVarName = "BENCH_UTXO_PATH"
       ledgerStateVarName = "BENCH_LEDGER_STATE_PATH"
   genesisFilePath <- getEnv genesisVarName
-  utxoFilePath <- getEnv utxoVarName
+  mUtxoFilePath <- lookupEnv utxoVarName
   ledgerStateFilePath <- getEnv ledgerStateVarName
 
-  genesis <- either error id <$> eitherDecodeFileStrict' genesisFilePath
-  putStrLn $ "Importing UTxO from: " ++ show utxoFilePath
-  utxo <- readHexUTxO utxoFilePath
-  putStrLn "Done importing UTxO"
   putStrLn $ "Importing NewEpochState from: " ++ show ledgerStateFilePath
-  es' <- readNewEpochState ledgerStateFilePath
+  nesFromFile <- readNewEpochState ledgerStateFilePath
   putStrLn "Done importing NewEpochState"
 
-  let nesUTxOL = nesEsL . esLStateL . lsUTxOStateL . utxoL
-      es = es' & nesUTxOL .~ utxo
+  mUtxo <- forM mUtxoFilePath $ \utxoFilePath -> do
+    putStrLn $ "Importing UTxO from: " ++ show utxoFilePath
+    utxo <- readHexUTxO utxoFilePath
+    utxo <$ putStrLn "Done importing UTxO"
+
+  genesis <- either error id <$> eitherDecodeFileStrict' genesisFilePath
+
+  let es = case mUtxo of
+        Nothing -> nesFromFile
+        Just utxoFromFile -> nesFromFile & utxoL .~ utxoFromFile
+      utxo = es ^. utxoL
       utxoMap = unUTxO utxo
       utxoSize = Map.size utxoMap
       largeKeysNum = 100000
@@ -113,12 +117,7 @@ main = do
         let !firstSlotNoOfTheNextEpoch = epochInfoFirst epochInfo (succ (nesEL nes))
          in applyTickNoEvents @CurrentEra globals nes firstSlotNoOfTheNextEpoch
 
-  when (utxoSize < largeKeysNum) $
-    die $
-      "UTxO size is too small (" <> show utxoSize <> " < " <> show largeKeysNum <> ")"
-  largeKeys <- selectRandomMapKeys 100000 stdGen utxoMap
-
-  defaultMain
+  defaultMain $
     [ env (pure $ tickOverTheEpochBoundary $ tickToEpochEnd es) $ \newEpochStateStart ->
         bgroup
           "applyTick"
@@ -177,14 +176,17 @@ main = do
               , env (pure setAddr) $
                   bench "getFilteredOldUTxO" . nf (getFilteredOldUTxO newEpochState)
               ]
-    , bgroup
-        "DeleteTxOuts"
-        [ extractKeysBench utxoMap largeKeysNum largeKeys
-        , extractKeysBench utxoMap 9 (Set.take 9 largeKeys)
-        , extractKeysBench utxoMap 5 (Set.take 5 largeKeys)
-        , extractKeysBench utxoMap 2 (Set.take 2 largeKeys)
-        ]
     ]
+      ++ [ env (selectRandomMapKeys largeKeysNum stdGen utxoMap) $ \largeKeys ->
+             bgroup
+               "DeleteTxOuts"
+               [ extractKeysBench utxoMap largeKeysNum largeKeys
+               , extractKeysBench utxoMap 9 (Set.take 9 largeKeys)
+               , extractKeysBench utxoMap 5 (Set.take 5 largeKeys)
+               , extractKeysBench utxoMap 2 (Set.take 2 largeKeys)
+               ]
+         | utxoSize >= largeKeysNum
+         ]
 
 extractKeysBench ::
   (NFData k, NFData a, Ord k) =>


### PR DESCRIPTION
# Description

This PR adds two criterion microbenchmarks:
* for ticking all the way through the whole epoch
* as well as ticking over the epoch boundary

This is a tremendously useful benchmark for analyzing performance of TICK and EPOCH rules

Naturally it works with any NewEpochState encoded in CBOR format that can be acquired with `cardano-streamer` or `db-analyzer`.

Note that neither TICK nor NEWEPOCH rules need UTxO data, therefore this PR also makes loading UTxO data optional.

Here is an example run from `master`:
```
$ cabal bench ledger-state:performance --benchmark-options="--match pattern Tick"
Running 1 benchmarks...
Benchmark performance: RUNNING...
Importing NewEpochState from: "/home/lehins/github/cardano-streamer/10.7-dump-state/146621246_newEpochState.cbor"
Done importing NewEpochState
benchmarking applyTick/tickToEpochEnd
time                 422.0 ms   (416.5 ms .. 430.3 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 421.7 ms   (419.1 ms .. 423.6 ms)
std dev              2.568 ms   (838.0 μs .. 3.459 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking applyTick/tickOverTheEpochBoundary
time                 1.192 s    (1.046 s .. 1.300 s)
                     0.998 R²   (0.994 R² .. 1.000 R²)
mean                 1.100 s    (1.058 s .. 1.143 s)
std dev              49.71 ms   (40.03 ms .. 55.73 ms)
variance introduced by outliers: 19% (moderately inflated)

Benchmark performance: FINISH
```

And comparison to benchmark with ledger version from `cardano-node-10.6.2`:

```
$ cabal bench ledger-state:performance --benchmark-options="--match pattern Tick"
Running 1 benchmarks...
Benchmark performance: RUNNING...
Importing NewEpochState from: "/home/lehins/github/cardano-streamer/10.6-dump-state/146621246_newEpochState.cbor"
Done importing NewEpochState
benchmarking applyTick/tickToEpochEnd
time                 989.4 ms   (865.2 ms .. 1.246 s)
                     0.992 R²   (0.986 R² .. 1.000 R²)
mean                 897.6 ms   (872.4 ms .. 945.9 ms)
std dev              47.68 ms   (2.397 ms .. 57.19 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking applyTick/tickOverTheEpochBoundary
time                 1.205 s    (1.070 s .. 1.303 s)
                     0.999 R²   (0.995 R² .. 1.000 R²)
mean                 1.080 s    (941.8 ms .. 1.132 s)
std dev              93.97 ms   (9.982 ms .. 120.5 ms)
variance introduced by outliers: 22% (moderately inflated)

Benchmark performance: FINISH
```

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
