### PR TITLE
Switch to unsafe vector indexing

### DIFF
--- a/libs/vector-map/CHANGELOG.md
+++ b/libs/vector-map/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `vector-map`
 
-## 1.2.0.1
+## 1.2.1.0
 
-*
+* Add `lookupIndex`
 
 ## 1.2.0.0
 

--- a/libs/vector-map/bench/Bench.hs
+++ b/libs/vector-map/bench/Bench.hs
@@ -5,6 +5,7 @@ module Main where
 import Control.Monad
 import Criterion.Main
 import Data.Map.Strict as Map
+import Data.Maybe (fromJust)
 import Data.VMap as VMap
 import System.Random.Stateful as Random
 
@@ -16,13 +17,9 @@ main = do
       n = 200000
       randList :: StdGen -> [(Key, Int)]
       randList gen = runStateGen_ gen (uniformListM n)
-      prefixList :: StdGen -> [(Key, Int)]
-      prefixList gen =
-        runStateGen_ gen $ \g ->
-          replicateM n $ do
-            key <- uniformM g
-            val <- uniformM g
-            pure (key, val)
+      duplicatedList :: StdGen -> [(Key, Int)]
+      duplicatedList gen =
+        replicate n $ runStateGen_ gen uniformM
       sequentialList :: StdGen -> [(Key, Int)]
       sequentialList gen =
         runStateGen_ gen $ \g -> do
@@ -33,56 +30,30 @@ main = do
     [ bgroup
         "fromList"
         [ fromListBench "uniform" (randList std1)
-        , fromListBench "prefixed" (prefixList std1)
         , fromListBench "sequential" (sequentialList std1)
+        , fromListBench "duplicated" (duplicatedList std1)
         ]
-    , bgroup
-        "toList"
-        [ toListBench "uniform" (randList std1)
-        , toListBench "prefixed" (prefixList std1)
-        , toListBench "sequential" (sequentialList std1)
-        ]
-    , bgroup
-        "toMapThroughList"
-        [ toMapThroughListBench "uniform" (randList std1)
-        , toMapThroughListBench "prefixed" (prefixList std1)
-        , toMapThroughListBench "sequential" (sequentialList std1)
-        ]
-    , bgroup
-        "fromMap"
-        [ fromMapBench "uniform" (randList std1)
-        , fromMapBench "prefixed" (prefixList std1)
-        , fromMapBench "sequential" (sequentialList std1)
-        ]
-    , bgroup
-        "foldlWithKey"
-        [ foldlWithKeyBench "uniform" (randList std1)
-        , foldlWithKeyBench "prefixed" (prefixList std1)
-        , foldlWithKeyBench "sequential" (sequentialList std1)
-        ]
-    , bgroup
-        "mapMaybeWithKey"
-        [ mapMaybeWithKeyBench "uniform" (randList std1)
-        , mapMaybeWithKeyBench "prefixed" (prefixList std1)
-        , mapMaybeWithKeyBench "sequential" (sequentialList std1)
-        ]
+    , lookupBench (randList std1)
+    , toListBench (randList std1)
+    , toMapThroughListBench (randList std1)
+    , fromMapBench (randList std1)
+    , foldlWithKeyBench (randList std1)
+    , mapMaybeWithKeyBench (randList std1)
     ]
 
-fromMapBench :: String -> [(Key, Int)] -> Benchmark
-fromMapBench name xs =
+fromMapBench :: [(Key, Int)] -> Benchmark
+fromMapBench xs =
   env (pure $ Map.fromList xs) $ \xsMap ->
     bgroup
-      name
-      [ bgroup
-          "fromMap"
-          [ bench "VMap" $ nf (VMap.fromMap :: Map Key Int -> VMap VB VP Key Int) xsMap
-          ]
+      "fromMap"
+      [ bench "VMap" $ nf (VMap.fromMap :: Map Key Int -> VMap VB VP Key Int) xsMap
       ]
 
-toMapThroughListBench :: String -> [(Key, Int)] -> Benchmark
-toMapThroughListBench name xs =
+-- This benchmark compares `toMap` implementation to a similar one if it was written for `Map`
+toMapThroughListBench :: [(Key, Int)] -> Benchmark
+toMapThroughListBench xs =
   bgroup
-    name
+    "toMapThroughList"
     [ bgroup
         "toMap"
         [ env (pure (Map.fromList xs)) $
@@ -92,10 +63,10 @@ toMapThroughListBench name xs =
         ]
     ]
 
-toListBench :: String -> [(Key, Int)] -> Benchmark
-toListBench name xs =
+toListBench :: [(Key, Int)] -> Benchmark
+toListBench xs =
   bgroup
-    name
+    "toList"
     [ bgroup
         "toList"
         [ env (pure (Map.fromList xs)) $ bench "Map" . nf Map.toList
@@ -118,28 +89,31 @@ toListBench name xs =
 
 fromListBench :: String -> [(Key, Int)] -> Benchmark
 fromListBench name xs =
-  env (pure xs) $ \xsnf ->
-    bgroup
-      name
-      [ bench "Map" $ nf Map.fromList xsnf
-      , bench "VMap" $
-          nf (VMap.fromList :: [(Key, Int)] -> VMap VB VP Key Int) xsnf
-      ]
-
-foldlWithKeyBench :: String -> [(Key, Int)] -> Benchmark
-foldlWithKeyBench name xs =
   bgroup
     name
+    [ env (pure xs) $ bench "Map.fromList" . nf Map.fromList
+    , env (pure xs) $
+        bench "VMap.fromList"
+          . nf (VMap.fromList :: [(Key, Int)] -> VMap VB VP Key Int)
+    , env (pure (length xs, xs)) $ \ ~(n, xsnf) ->
+        bench "VMap.fromListN" $
+          nf (VMap.fromListN n :: [(Key, Int)] -> VMap VB VP Key Int) xsnf
+    ]
+
+foldlWithKeyBench :: [(Key, Int)] -> Benchmark
+foldlWithKeyBench xs =
+  bgroup
+    "foldlWithKey"
     [ env (pure (Map.fromList xs)) $
-        bench "Map" . nf (Map.foldlWithKey (\a !_ -> (a +)) 0)
+        bench "Map" . nf (Map.foldlWithKey' (\a !_ -> (a +)) 0)
     , env (pure (VMap.fromList xs :: VMap VB VP Key Int)) $
         bench "VMap" . nf (VMap.foldlWithKey (\a !_ -> (a +)) 0)
     ]
 
-mapMaybeWithKeyBench :: String -> [(Key, Int)] -> Benchmark
-mapMaybeWithKeyBench name xs =
+mapMaybeWithKeyBench :: [(Key, Int)] -> Benchmark
+mapMaybeWithKeyBench xs =
   bgroup
-    name
+    "mapMaybeWithKey"
     [ env (pure (Map.fromList xs)) $
         bench "Map" . nf (Map.mapMaybeWithKey f)
     , env (pure (VMap.fromList xs :: VMap VB VP Key Int)) $
@@ -147,3 +121,13 @@ mapMaybeWithKeyBench name xs =
     ]
   where
     f key val = if even key then Just (key + val) else Nothing
+
+lookupBench :: [(Key, Int)] -> Benchmark
+lookupBench xs =
+  bgroup
+    "lookup"
+    [ env (pure (Prelude.map fst xs, Map.fromList xs)) $ \ ~(ks, m) ->
+        bench "Map" $ whnfIO $ mapM_ (\k -> fromJust (Map.lookup k m) `seq` pure ()) ks
+    , env (pure (Prelude.map fst xs, VMap.fromList xs :: VMap VB VP Key Int)) $ \ ~(ks, m) ->
+        bench "VMap" $ whnfIO $ mapM_ (\k -> fromJust (VMap.lookup k m) `seq` pure ()) ks
+    ]

--- a/libs/vector-map/src/Data/VMap.hs
+++ b/libs/vector-map/src/Data/VMap.hs
@@ -13,6 +13,7 @@ module Data.VMap (
   size,
   lookup,
   findWithDefault,
+  lookupIndex,
   elemAt,
   member,
   notMember,
@@ -125,6 +126,11 @@ elemAt ::
   (VG.Vector kv k, VG.Vector vv v) => Int -> VMap kv vv k v -> (k, v)
 elemAt ix = KV.elemAtKVVector ix . unVMap
 {-# INLINE elemAt #-}
+
+lookupIndex ::
+  (Ord k, VG.Vector kv k) => k -> VMap kv vv k v -> Maybe Int
+lookupIndex key = KV.lookupIndexKVVector key . unVMap
+{-# INLINE lookupIndex #-}
 
 member ::
   (Ord k, VG.Vector kv k) => k -> VMap kv vv k v -> Bool

--- a/libs/vector-map/src/Data/VMap/KVVector.hs
+++ b/libs/vector-map/src/Data/VMap/KVVector.hs
@@ -31,6 +31,7 @@ module Data.VMap.KVVector (
   memberKVVector,
   lookupKVVector,
   lookupDefaultKVVector,
+  lookupIndexKVVector,
   elemAtKVVector,
   sortAscKVMVector,
   internKVVectorMaybe,
@@ -216,6 +217,11 @@ lookupKVVector ::
 lookupKVVector key (KVVector keys values) =
   VG.unsafeIndex values <$> lookupIxSortedVector key keys
 {-# INLINE lookupKVVector #-}
+
+lookupIndexKVVector ::
+  (Ord k, VG.Vector kv k) => k -> KVVector kv vv (k, v) -> Maybe Int
+lookupIndexKVVector key (KVVector keys _values) = lookupIxSortedVector key keys
+{-# INLINE lookupIndexKVVector #-}
 
 -- | Look up a value by the key in a __sorted__ key/value vector. Ensure it is
 -- sorted otherwise terrible things happen.

--- a/libs/vector-map/src/Data/VMap/KVVector.hs
+++ b/libs/vector-map/src/Data/VMap/KVVector.hs
@@ -107,7 +107,7 @@ fromListN n xs = VG.create $ do
   removeDuplicates keepSecondDuplicate mv
 {-# INLINE fromListN #-}
 
--- | Convert a sorted assoc list with distionct keys into a KVVector
+-- | Convert a sorted assoc list with distinct keys into a KVVector
 fromDistinctAscList ::
   (VG.Vector kv k, VG.Vector vv v) =>
   [(k, v)] ->

--- a/libs/vector-map/src/Data/VMap/KVVector.hs
+++ b/libs/vector-map/src/Data/VMap/KVVector.hs
@@ -154,11 +154,11 @@ fillWithList ::
   m (v (PrimState m) a)
 fillWithList zs mv = go 0 zs
   where
-    n = VGM.length mv
-    go i ys
+    !n = VGM.length mv
+    go !i ys
       | i == n = pure mv
-      | x : xs <- ys = VGM.write mv i x >> go (i + 1) xs
-      | otherwise = pure $ VGM.slice 0 i mv
+      | x : xs <- ys = VGM.unsafeWrite mv i x >> go (i + 1) xs
+      | otherwise = pure $! VGM.unsafeSlice 0 i mv
 {-# INLINE fillWithList #-}
 
 fromAscListWithKey ::
@@ -206,7 +206,7 @@ fromAscListWithKeyN n f xs
 
 internKVVectorMaybe :: (VG.Vector kv k, Ord k) => k -> KVVector kv vv (k, v) -> Maybe k
 internKVVectorMaybe key (KVVector keys _values) =
-  VG.indexM keys =<< lookupIxSortedVector key keys
+  VG.unsafeIndex keys <$> lookupIxSortedVector key keys
 {-# INLINE internKVVectorMaybe #-}
 
 -- | Look up a value by the key in a __sorted__ key/value vector. Ensure it is
@@ -214,7 +214,7 @@ internKVVectorMaybe key (KVVector keys _values) =
 lookupKVVector ::
   (Ord k, VG.Vector kv k, VG.Vector vv v) => k -> KVVector kv vv (k, v) -> Maybe v
 lookupKVVector key (KVVector keys values) =
-  VG.indexM values =<< lookupIxSortedVector key keys
+  VG.unsafeIndex values <$> lookupIxSortedVector key keys
 {-# INLINE lookupKVVector #-}
 
 -- | Look up a value by the key in a __sorted__ key/value vector. Ensure it is
@@ -230,7 +230,12 @@ memberKVVector k = isJust . lookupIxSortedVector k . keysVector
 
 elemAtKVVector ::
   (VG.Vector kv k, VG.Vector vv v) => Int -> KVVector kv vv (k, v) -> (k, v)
-elemAtKVVector ix (KVVector keys values) = (keys VG.! ix, values VG.! ix)
+elemAtKVVector ix (KVVector keys values)
+  | 0 <= ix && ix < n = (keys `VG.unsafeIndex` ix, values `VG.unsafeIndex` ix)
+  | otherwise =
+      error $ "Index " ++ show ix ++ " is out of bounds for 'VMap' with size: " ++ show n
+  where
+    !n = VG.length keys
 {-# INLINE elemAtKVVector #-}
 
 -- | Perform a binary search on a sorted vector
@@ -241,7 +246,7 @@ lookupIxSortedVector key keys = go 0 (VG.length keys)
     go !l !u = do
       guard (l < u)
       let !i = ((u - l) `div` 2) + l
-      case compare key (keys VG.! i) of
+      case compare key (keys `VG.unsafeIndex` i) of
         LT -> go l i
         GT -> go (i + 1) u
         EQ -> Just i
@@ -271,23 +276,27 @@ removeDuplicates f mv
   | VGM.null mv = pure mv
   | otherwise = do
       let n = VGM.length mv
-          goMoved lastIx prev@(pk, pv) curIx = do
-            VGM.write mv lastIx prev
+          goMoved !lastIx prev@(pk, pv) !curIx = do
+            VGM.unsafeWrite mv lastIx prev
             if curIx < n
               then do
-                cur@(ck, cv) <- VGM.read mv curIx
+                cur@(ck, cv) <- VGM.unsafeRead mv curIx
                 if ck == pk
-                  then goMoved lastIx (ck, f ck pv cv) (curIx + 1)
+                  then
+                    let !npv = f ck pv cv
+                     in goMoved lastIx (ck, npv) (curIx + 1)
                   else goMoved (lastIx + 1) cur (curIx + 1)
-              else pure $ VGM.slice 0 (lastIx + 1) mv
-          goUnmoved (pk, pv) curIx
+              else pure $! VGM.unsafeSlice 0 (lastIx + 1) mv
+          goUnmoved (pk, pv) !curIx
             | curIx < n = do
-                cur@(ck, cv) <- VGM.read mv curIx
+                cur@(ck, cv) <- VGM.unsafeRead mv curIx
                 if ck == pk
-                  then goMoved (curIx - 1) (ck, f ck pv cv) (curIx + 1)
+                  then
+                    let !npv = f ck pv cv
+                     in goMoved (curIx - 1) (ck, npv) (curIx + 1)
                   else goUnmoved cur (curIx + 1)
             | otherwise = pure mv
-      x0 <- VGM.read mv 0
+      x0 <- VGM.unsafeRead mv 0
       goUnmoved x0 1
 {-# INLINE removeDuplicates #-}
 

--- a/libs/vector-map/test/Test/VMap.hs
+++ b/libs/vector-map/test/Test/VMap.hs
@@ -112,6 +112,10 @@ vMapTests =
         let f' k v = applyFun2 f k v :: String
          in prop_AsMapTo (VMap.foldMapWithKey f') (Map.foldMapWithKey f')
       prop "lookup" $ \k -> prop_AsMapTo (VMap.lookup k) (Map.lookup k)
+      prop "elemAt/lookupIndex" $ \k m ->
+        case VMap.lookupIndex k m of
+          Nothing -> label "Nothing" $ Map.lookupIndex k (VMap.toMap m) === Nothing
+          Just ix -> label "Just" $ prop_AsMapTo (VMap.elemAt ix) (Map.elemAt ix) m
       prop "lookup (existing)" $ \k v xs ->
         let xs' = xs <> [(k, v)]
          in (VMap.lookup k (VMap.fromList xs' :: VMapT) === Just v)

--- a/libs/vector-map/vector-map.cabal
+++ b/libs/vector-map/vector-map.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: vector-map
-version: 1.2.0.0
+version: 1.2.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK


### PR DESCRIPTION
# Description

This PR fixes `vector-map` benchmarks. It also removes redundant computation through switching to unsafe vector functions that do no bounds checking. These changes are not semantic, they only convert usage of impossible to fail partial functions into usage of unsafe functions.
Unfortunately, it is hard to quantify performance improvements without having both versions of implementations (pre-PR and post-PR) benchmarkable at the same time. These optimizations are marginal and benchmark results are mostly masked by noise that is present in benchmarks between different runs, but they are absolutely safe to make, so there is no downside to these changes.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
