### PR TITLE
Remove weird hyperlinked space between badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 <h1 align="center">Cardano Ledger</h1>
 
 <p align="center">
-  <a href="https://input-output-hk.github.io/cardano-engineering-handbook">
-    <img alt="CEH" src="https://img.shields.io/badge/policy-Cardano%20Engineering%20Handbook-informational?style=for-the-badge" />
-  </a>
-  <a href="https://github.com/intersectmbo/cardano-ledger/actions/workflows/haskell.yml">
-    <img alt="GitHub Workflow Status (master)" src="https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-ledger/haskell.yml?branch=master&style=for-the-badge" />
-  </a>
-  <a href="https://cardano-ledger.cardano.intersectmbo.org/">
-    <img alt="Haddock (master)" src="https://img.shields.io/badge/documentation-Haddock-yellow?style=for-the-badge" />
-  </a>
+  <a href="https://input-output-hk.github.io/cardano-engineering-handbook"><img alt="CEH" src="https://img.shields.io/badge/policy-Cardano%20Engineering%20Handbook-informational?style=for-the-badge"/></a>
+  <a href="https://github.com/intersectmbo/cardano-ledger/actions/workflows/haskell.yml"><img alt="GitHub Workflow Status (master)" src="https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-ledger/haskell.yml?branch=master&style=for-the-badge"/></a>
+  <a href="https://cardano-ledger.cardano.intersectmbo.org/"><img alt="Haddock (master)" src="https://img.shields.io/badge/documentation-Haddock-yellow?style=for-the-badge"/></a>
 </p>
 
 This repository contains the formal specifications, executable models,


### PR DESCRIPTION
# Description

A minor visual improvement to the README.

Before:
<img width="1298" height="168" alt="weird_space" src="https://github.com/user-attachments/assets/f6838336-1666-44c9-a3a2-a00e0f8bf4ef" />

After:
<img width="1300" height="185" alt="normal_space" src="https://github.com/user-attachments/assets/e03e661e-9cd3-4648-b99e-44e3e4d3dae8" />


# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
