### PR TITLE
Add `NoThunks` instances for `ChainTransitionError` and `ChainPredicateFailure`

### DIFF
--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -49,7 +49,6 @@
   - `ShelleyLedgersPredFailure`
   - `ShelleyPoolPredFailure`
   - `ShelleyPpupPredFailure`
-  - `ChainPredicateFailure`
 * Add protocol version validation to `createInitialState`:
   - Validate that current protocol version is within the era's bounds
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Chain.hs
@@ -60,6 +60,8 @@ data ChainPredicateFailure
       Version -- max protocol version
   deriving (Generic, Show, Eq, Ord)
 
+instance NoThunks ChainPredicateFailure
+
 chainChecks ::
   (MonadError ChainPredicateFailure m, EraBlockHeader h era) =>
   Version ->

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -8,10 +8,6 @@
   - Update `tickChainDepState`, `updateChainDepState`, and `reupdateChainDepState` to use the new `TPraosLedgerView`.
   - Deprecate `mkInitialShelleyLedgerView`.
 * Remove `TicknPredicateFailure` and make `PredicateFailure TICKN` be `Void`.
-* Remove `NoThunks` instance for
-  - `UpdnPredicateFailure`
-  - `OverlayPredicateFailure`
-  - `ChainTransitionError`
 
 ### `testlib`
 

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/API.hs
@@ -499,6 +499,8 @@ deriving instance Crypto c => Eq (ChainTransitionError c)
 
 deriving instance Crypto c => Show (ChainTransitionError c)
 
+instance Crypto c => NoThunks (ChainTransitionError c)
+
 -- | Tick the chain state to a new epoch.
 tickChainDepState ::
   Globals ->

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/OCert.hs
@@ -24,6 +24,7 @@ import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
 
 data OCERT c
 
@@ -49,6 +50,8 @@ data OcertPredicateFailure
   | NoCounterForKeyHashOCERT
       (KeyHash BlockIssuer) -- stake pool key hash
   deriving (Show, Eq, Generic)
+
+instance NoThunks OcertPredicateFailure
 
 instance
   ( Crypto c

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Overlay.hs
@@ -153,6 +153,10 @@ deriving instance
   VRF.VRFAlgorithm (VRF c) =>
   Eq (OverlayPredicateFailure c)
 
+instance
+  VRF.VRFAlgorithm (VRF c) =>
+  NoThunks (OverlayPredicateFailure c)
+
 vrfChecks ::
   forall c.
   ( Crypto c

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Prtcl.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Prtcl.hs
@@ -117,6 +117,8 @@ deriving instance
   VRF.VRFAlgorithm (VRF c) =>
   Eq (PrtclPredicateFailure c)
 
+instance Crypto c => NoThunks (PrtclPredicateFailure c)
+
 instance
   ( Crypto c
   , KES.Signable (KES c) (BHBody c)

--- a/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
+++ b/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/Rules/Updn.hs
@@ -17,6 +17,7 @@ import Cardano.Protocol.Crypto
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition
 import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
 
 data UPDN c
 
@@ -30,6 +31,8 @@ data UpdnState = UpdnState Nonce Nonce
 
 data UpdnPredicateFailure c -- No predicate failures
   deriving (Generic, Show, Eq)
+
+instance NoThunks (UpdnPredicateFailure c)
 
 newtype UpdnEvent c = NewEpoch EpochNo
 


### PR DESCRIPTION
# Description

We add back these `NoThunks` instances that were removed in https://github.com/IntersectMBO/cardano-ledger/pull/5671, as they are needed for `consensus`, which needs to write these to disk through [`ChainDB`](https://github.com/IntersectMBO/ouroboros-consensus/blob/90649008c219b484567d4ee2732079c3e1c88f9a/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Storage/ChainDB/Impl.hs#L147)

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
