### PR TITLE
Fix trace  construction in `TestChain`

### DIFF
--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -40,6 +40,7 @@ import Cardano.Ledger.Shelley.LedgerState (
   UTxOState (..),
   curPParamsEpochStateL,
   lsCertStateL,
+  lsUTxOStateL,
  )
 import Cardano.Ledger.Shelley.Rules (
   DelegEnv (..),
@@ -157,16 +158,21 @@ ledgerTraceFromBlock ::
 ledgerTraceFromBlock chainSt block =
   ( tickedChainSt
   , runShelleyBase $
-      Trace.closure @(EraRule "LEDGER" era) ledgerEnv ledgerSt0 stAnnTxs
+      Trace.closureWith @(EraRule "LEDGER" era)
+        ledgerEnv
+        ledgerSt0
+        ( \ls tx ->
+            mkStAnnTx
+              (epochInfo testGlobals)
+              (systemStart testGlobals)
+              (ledgerEnv ^. ledgerPpL)
+              (ls ^. lsUTxOStateL . utxoG)
+              tx
+        )
+        txs
   )
   where
     (tickedChainSt, ledgerEnv, ledgerSt0, txs) = ledgerTraceBase chainSt block
-    pp_ = ledgerEnv ^. ledgerPpL
-    utxo = utxosUtxo (lsUTxOState ledgerSt0)
-    stAnnTxs =
-      map
-        (mkStAnnTx (epochInfo testGlobals) (systemStart testGlobals) pp_ utxo)
-        txs
 
 -- | This function is nearly the same as ledgerTraceFromBlock, but
 -- it restricts the UTxO state to only those needed by the block.
@@ -187,7 +193,18 @@ ledgerTraceFromBlockWithRestrictedUTxO ::
 ledgerTraceFromBlockWithRestrictedUTxO chainSt block =
   ( UTxO irrelevantUTxO
   , runShelleyBase $
-      Trace.closure @(EraRule "LEDGER" era) ledgerEnv ledgerSt0' stAnnTxs
+      Trace.closureWith @(EraRule "LEDGER" era)
+        ledgerEnv
+        restrictedSt0
+        ( \ls tx ->
+            mkStAnnTx
+              (epochInfo testGlobals)
+              (systemStart testGlobals)
+              (ledgerEnv ^. ledgerPpL)
+              (ls ^. lsUTxOStateL . utxoG)
+              tx
+        )
+        txs
   )
   where
     (_tickedChainSt, ledgerEnv, ledgerSt0, txs) = ledgerTraceBase chainSt block
@@ -195,12 +212,7 @@ ledgerTraceFromBlockWithRestrictedUTxO chainSt block =
     LedgerState utxoSt delegationSt = ledgerSt0
     utxo = unUTxO . utxosUtxo $ utxoSt
     (relevantUTxO, irrelevantUTxO) = Map.partitionWithKey (const . (`Set.member` txIns)) utxo
-    ledgerSt0' = LedgerState (utxoSt {utxosUtxo = UTxO relevantUTxO}) delegationSt
-    pp_ = ledgerEnv ^. ledgerPpL
-    stAnnTxs =
-      map
-        (mkStAnnTx (epochInfo testGlobals) (systemStart testGlobals) pp_ (UTxO relevantUTxO))
-        txs
+    restrictedSt0 = LedgerState (utxoSt {utxosUtxo = UTxO relevantUTxO}) delegationSt
 
 -- | Reconstruct a POOL trace from the transactions in a Block and ChainState
 poolTraceFromBlock ::

--- a/libs/small-steps/CHANGELOG.md
+++ b/libs/small-steps/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Version history for `small-steps`
 
-## 1.1.3.1
+## 1.1.4.0
 
-*
+### `testlib`
+
+* Add `closureWith`
 
 ## 1.1.3.0
 

--- a/libs/small-steps/small-steps.cabal
+++ b/libs/small-steps/small-steps.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: small-steps
-version: 1.1.3.0
+version: 1.1.4.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/libs/small-steps/testlib/Test/Control/State/Transition/Trace.hs
+++ b/libs/small-steps/testlib/Test/Control/State/Transition/Trace.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -45,6 +46,7 @@ module Test.Control.State.Transition.Trace (
   lastSignal,
   firstAndLastState,
   closure,
+  closureWith,
 
   -- * Miscellaneous utilities
   extractValues,
@@ -54,7 +56,7 @@ module Test.Control.State.Transition.Trace (
 ) where
 
 import Control.DeepSeq (NFData)
-import Control.Monad (void)
+import Control.Monad (foldM, void)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (MonadReader, ReaderT, ask, runReaderT)
 import Control.State.Transition.Extended hiding (Assertion, trans)
@@ -382,13 +384,28 @@ closure ::
   -- | List of signals to apply, where the newest signal comes first.
   [Signal s] ->
   m (Trace s)
-closure env st0 sigs = mkTrace env st0 <$> loop st0 (reverse sigs) []
+closure env st0 = closureWith env st0 (const id)
+
+-- | Like `closure`, but the signal for each step is built from the running
+-- state (the post-state of the previous successful step, or the initial
+-- state for the first step) via the supplied builder.
+closureWith ::
+  forall s m a.
+  (STS s, m ~ BaseM s) =>
+  Environment s ->
+  State s ->
+  -- | Build a 'Signal' from the running 'State'
+  (State s -> a -> Signal s) ->
+  [a] ->
+  m (Trace s)
+closureWith env st0 mkSig xs =
+  mkTrace env st0 . snd <$> foldM accum (st0, []) (reverse xs)
   where
-    loop _ [] acc = pure acc
-    loop sti (sig : sigs') acc =
-      applySTSTest @s (TRC (env, sti, sig)) >>= \case
-        Left _ -> loop sti sigs' acc
-        Right sti' -> loop sti' sigs' ((sti', sig) : acc)
+    accum (!accState, !accTrace) x =
+      let sig = mkSig accState x
+       in applySTSTest @s (TRC (env, accState, sig)) >>= \case
+            Left _ -> pure (accState, accTrace)
+            Right newState -> pure (newState, (newState, sig) : accTrace)
 
 --------------------------------------------------------------------------------
 -- Minimal DSL to specify expectations on traces


### PR DESCRIPTION
# Description


When I made the change of threading `StAnnTx` through the rules in https://github.com/IntersectMBO/cardano-ledger/pull/5789,   I created the list of Signals needed in `TestChain` by mapping `mkStTxAnn` over the list of transactions. 

This is incorrect, because  StTxAnn signals should be built by folding over the `LedgerState`: whenever we build a `StAnnTx` based on a transaction from the list , we should be using the `LedgerState` produced by the previous STS application. 
(this is how it's done also in LEDGERS rule).

This PR fixes this by providing an alternative to Trace.chain that is able to construct signals based on state, and using it in CHAIN Trace projections.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
