### PR TITLE
Prepare conformance for Dijkstra 2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: f478f2206df3c12c062bd6674d206456f3206ceb
+  tag: cd29f5155f4188320ca67f5e5e34b96112ad7cae
 
 source-repository-package
   type: git

--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1775115298,
-        "narHash": "sha256-uJwq9v5QFHlN9yWmgV2fo6JCK716RUpQBu1ltmKadxI=",
+        "lastModified": 1778811846,
+        "narHash": "sha256-hTgOvAPZzJKqTxfJMPEcQF+S+b28d5Rw1XCY3wLntmM=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "f478f2206df3c12c062bd6674d206456f3206ceb",
+        "rev": "cd29f5155f4188320ca67f5e5e34b96112ad7cae",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Base.hs
@@ -22,7 +22,7 @@ import Cardano.Ledger.Keys (DSIGN, VKey (..))
 import Data.ByteString (ByteString)
 import Data.Either (isRight)
 import Data.Maybe (fromMaybe)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (integerToHash)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (signatureFromInteger, vkeyFromInteger)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -27,14 +27,18 @@ import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Common (Arbitrary (..), ToExpr)
-import Test.Cardano.Ledger.Conformance (
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),
   SpecTRC (..),
-  SpecTranslate (..),
   runFromAgdaFunction,
-  runSpecTransM,
  )
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (..),
+  askSpecTransM,
+  runSpecTransM,
+  withCtxSpecTransM,
+ )
 
 data ConwayCertExecContext era
   = ConwayCertExecContext
@@ -71,10 +75,11 @@ instance Era era => ToExpr (ConwayCertExecContext era)
 instance ExecSpecRule "CERT" ConwayEra where
   type ExecContext "CERT" ConwayEra = ConwayCertExecContext ConwayEra
 
-  translateInputs ConwayCertExecContext {..} (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep @ConwayEra env
-    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
-    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
+  translateInputs (TRC (env, st, sig)) = do
+    ConwayCertExecContext {..} <- askSpecTransM
+    agdaEnv <- withCtxSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep env
+    agdaSt <- withCtxSpecTransM () $ toSpecRep st
+    agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   translateOutput _ _ st = runSpecTransM () $ toSpecRep @ConwayEra st

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -71,11 +72,11 @@ instance ExecSpecRule "CERT" ConwayEra where
   type ExecContext "CERT" ConwayEra = ConwayCertExecContext ConwayEra
 
   translateInputs ConwayCertExecContext {..} (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep env
-    agdaSt <- runSpecTransM () $ toSpecRep st
-    agdaSig <- runSpecTransM () $ toSpecRep sig
+    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep @ConwayEra env
+    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
+    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep @ConwayEra st
 
   runAgdaRule = runFromAgdaFunction Agda.certStep

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -36,7 +35,6 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecTranslate (..),
   askSpecTransM,
-  runSpecTransM,
   withCtxSpecTransM,
  )
 
@@ -81,7 +79,5 @@ instance ExecSpecRule "CERT" ConwayEra where
     agdaSt <- withCtxSpecTransM () $ toSpecRep st
     agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
-
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep @ConwayEra st
 
   runAgdaRule = runFromAgdaFunction Agda.certStep

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Cert.hs
@@ -25,7 +25,7 @@ import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended (TRC (..))
 import Data.Map.Strict (Map)
 import GHC.Generics (Generic)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Common (Arbitrary (..), ToExpr)
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -29,7 +29,6 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecTranslate (..),
   askSpecTransM,
-  runSpecTransM,
   withCtxSpecTransM,
  )
 
@@ -45,13 +44,15 @@ instance ExecSpecRule "CERTS" ConwayEra where
 
   runAgdaRule = runFromAgdaFunction Agda.certsStep
 
-  translateOutput ConwayCertExecContext {..} _ = runSpecTransM () . toSpecRep @ConwayEra . fixRewards
-    where
+  translateOutput _ st = do
+    ConwayCertExecContext {..} <- askSpecTransM
+    let
       -- This is necessary because the implementation zeroes out the rewards
       -- in the CERTS rule, but the spec does it in a different rule
+      zeroRewards = Map.adjust (balanceAccountStateL .~ mempty)
       fixRewards =
         certDStateL . accountsL . accountsMapL
           %~ \m ->
             foldr' zeroRewards m . Set.map (^. accountAddressCredentialL) $
               Map.keysSet ccecWithdrawals
-      zeroRewards = Map.adjust (balanceAccountStateL .~ mempty)
+    withCtxSpecTransM () $ toSpecRep $ fixRewards st

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -19,7 +19,7 @@ import Data.Foldable (Foldable (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Lens.Micro ((%~), (.~), (^.))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
   SpecTRC (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -18,7 +18,8 @@ import Control.State.Transition.Extended (TRC (..))
 import Data.Foldable (Foldable (..))
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
-import Lens.Micro ((%~), (.~), (^.))
+import Lens.Micro ((%~), (.~))
+import Lens.Micro.Extras (view)
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (ConwayCertExecContext (..))
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
@@ -53,6 +54,6 @@ instance ExecSpecRule "CERTS" ConwayEra where
       fixRewards =
         certDStateL . accountsL . accountsMapL
           %~ \m ->
-            foldr' zeroRewards m . Set.map (^. accountAddressCredentialL) $
+            foldr' zeroRewards m . Set.map (view accountAddressCredentialL) $
               Map.keysSet ccecWithdrawals
     withCtxSpecTransM () $ toSpecRep $ fixRewards st

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -20,22 +20,27 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Lens.Micro ((%~), (.~), (^.))
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (ConwayCertExecContext (..))
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),
   SpecTRC (..),
-  SpecTranslate (..),
   runFromAgdaFunction,
-  runSpecTransM,
  )
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (ConwayCertExecContext (..))
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (..),
+  askSpecTransM,
+  runSpecTransM,
+  withCtxSpecTransM,
+ )
 
 instance ExecSpecRule "CERTS" ConwayEra where
   type ExecContext "CERTS" ConwayEra = ConwayCertExecContext ConwayEra
 
-  translateInputs ConwayCertExecContext {..} (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep @ConwayEra env
-    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
-    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
+  translateInputs (TRC (env, st, sig)) = do
+    ConwayCertExecContext {..} <- askSpecTransM
+    agdaEnv <- withCtxSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep env
+    agdaSt <- withCtxSpecTransM () $ toSpecRep st
+    agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule = runFromAgdaFunction Agda.certsStep

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Certs.hs
@@ -33,14 +33,14 @@ instance ExecSpecRule "CERTS" ConwayEra where
   type ExecContext "CERTS" ConwayEra = ConwayCertExecContext ConwayEra
 
   translateInputs ConwayCertExecContext {..} (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep env
-    agdaSt <- runSpecTransM () $ toSpecRep st
-    agdaSig <- runSpecTransM () $ toSpecRep sig
+    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep @ConwayEra env
+    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
+    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule = runFromAgdaFunction Agda.certsStep
 
-  translateOutput ConwayCertExecContext {..} _ = runSpecTransM () . toSpecRep . fixRewards
+  translateOutput ConwayCertExecContext {..} _ = runSpecTransM () . toSpecRep @ConwayEra . fixRewards
     where
       -- This is necessary because the implementation zeroes out the rewards
       -- in the CERTS rule, but the spec does it in a different rule

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Credential (Credential)
 import Control.State.Transition.Extended (TRC (..))
 import Data.Bifunctor (second)
 import Data.Set (Set)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -27,9 +28,9 @@ instance ExecSpecRule "DELEG" ConwayEra where
   type ExecContext "DELEG" ConwayEra = Set (Credential DRepRole)
 
   translateInputs delegatees (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM delegatees $ toSpecRep env
-    agdaSt <- runSpecTransM () $ toSpecRep st
-    agdaSig <- runSpecTransM () $ toSpecRep sig
+    agdaEnv <- runSpecTransM delegatees $ toSpecRep @ConwayEra env
+    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
+    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule (SpecTRC env (Agda.MkCertState dState pState vState) sig) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -27,10 +27,10 @@ instance ExecSpecRule "DELEG" ConwayEra where
   -- The context is the set of all DRep delegatees in the transaction
   type ExecContext "DELEG" ConwayEra = Set (Credential DRepRole)
 
-  translateInputs delegatees (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM delegatees $ toSpecRep @ConwayEra env
-    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
-    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
+  translateInputs (TRC (env, st, sig)) = do
+    agdaEnv <- toSpecRep env
+    agdaSt <- withCtxSpecTransM () $ toSpecRep st
+    agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule (SpecTRC env (Agda.MkCertState dState pState vState) sig) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Deleg.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -16,9 +15,16 @@ import Control.State.Transition.Extended (TRC (..))
 import Data.Bifunctor (second)
 import Data.Set (Set)
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
+  ExecSpecRule (ExecContext, runAgdaRule, translateInputs),
+  SpecTRC (SpecTRC),
+ )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (toSpecRep),
+  unComputationResult,
+  withCtxSpecTransM,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -28,11 +29,11 @@ instance ExecSpecRule "ENACT" ConwayEra where
 
   translateInputs ctx (TRC (_, st@EnactState {..}, sig@Conway.EnactSignal {..})) =
     runSpecTransM () $ do
-      agdaSt <- toSpecRep st
-      agdaSig <- toSpecRep sig
-      treasury <- toSpecRep ensTreasury
-      gaId <- toSpecRep esGovActionId
-      curEpoch <- toSpecRep ctx
+      agdaSt <- toSpecRep @ConwayEra st
+      agdaSig <- toSpecRep @ConwayEra sig
+      treasury <- toSpecRep @ConwayEra ensTreasury
+      gaId <- toSpecRep @ConwayEra esGovActionId
+      curEpoch <- toSpecRep @ConwayEra ctx
       pure $
         SpecTRC
           (Agda.MkEnactEnv gaId treasury curEpoch)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
@@ -12,7 +12,7 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (EnactState (..))
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Control.State.Transition.Extended (TRC (..))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
   SpecTRC (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Enact.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -13,12 +12,15 @@ import Cardano.Ledger.Conway.Governance (EnactState (..))
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Control.State.Transition.Extended (TRC (..))
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),
   SpecTRC (..),
+ )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecTranslate (..),
-  runSpecTransM,
+  askSpecTransM,
   unComputationResult,
+  withCtxSpecTransM,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Conway.ImpTest ()
@@ -27,13 +29,14 @@ instance ExecSpecRule "ENACT" ConwayEra where
   type ExecContext "ENACT" ConwayEra = EpochNo
   type SpecEnvironment "ENACT" ConwayEra = Agda.EnactEnv
 
-  translateInputs ctx (TRC (_, st@EnactState {..}, sig@Conway.EnactSignal {..})) =
-    runSpecTransM () $ do
-      agdaSt <- toSpecRep @ConwayEra st
-      agdaSig <- toSpecRep @ConwayEra sig
-      treasury <- toSpecRep @ConwayEra ensTreasury
-      gaId <- toSpecRep @ConwayEra esGovActionId
-      curEpoch <- toSpecRep @ConwayEra ctx
+  translateInputs (TRC (_, st@EnactState {..}, sig@Conway.EnactSignal {..})) = do
+    epochNo <- askSpecTransM
+    withCtxSpecTransM () $ do
+      agdaSt <- toSpecRep st
+      agdaSig <- toSpecRep sig
+      treasury <- toSpecRep ensTreasury
+      gaId <- toSpecRep esGovActionId
+      curEpoch <- toSpecRep epochNo
       pure $
         SpecTRC
           (Agda.MkEnactEnv gaId treasury curEpoch)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
@@ -1,29 +1,26 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Epoch () where
 
 import Cardano.Ledger.Conway (ConwayEra)
-import Cardano.Ledger.Conway.Governance (GovActionState)
 import Control.State.Transition.Extended (TRC (..))
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),
   SpecTRC (..),
+ )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecTranslate (..),
-  runSpecTransM,
   unComputationResult_,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Conway.ImpTest ()
 
 instance ExecSpecRule "EPOCH" ConwayEra where
-  type ExecContext "EPOCH" ConwayEra = [GovActionState ConwayEra]
-
-  translateInputs _ (TRC (env, st, sig)) =
-    runSpecTransM () $ SpecTRC <$> toSpecRep env <*> toSpecRep @ConwayEra st <*> toSpecRep sig
+  translateInputs (TRC (env, st, sig)) =
+    SpecTRC <$> toSpecRep env <*> toSpecRep st <*> toSpecRep sig
 
   runAgdaRuleWithDebug (SpecTRC env st sig) = unComputationResult_ $ Agda.epochStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -23,6 +24,6 @@ instance ExecSpecRule "EPOCH" ConwayEra where
   type ExecContext "EPOCH" ConwayEra = [GovActionState ConwayEra]
 
   translateInputs _ (TRC (env, st, sig)) =
-    runSpecTransM () $ SpecTRC <$> toSpecRep env <*> toSpecRep st <*> toSpecRep sig
+    runSpecTransM () $ SpecTRC <$> toSpecRep env <*> toSpecRep @ConwayEra st <*> toSpecRep sig
 
   runAgdaRuleWithDebug (SpecTRC env st sig) = unComputationResult_ $ Agda.epochStep env st sig

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Epoch.hs
@@ -9,7 +9,7 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Epoch () where
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (GovActionState)
 import Control.State.Transition.Extended (TRC (..))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
   SpecTRC (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
@@ -28,13 +28,13 @@ instance ExecSpecRule "GOV" ConwayEra where
 
   runAgdaRule (SpecTRC env st sig) = unComputationResult $ Agda.govStep env st sig
 
-  translateInputs enactState (TRC (env@Conway.GovEnv {Conway.gePParams}, st, sig)) = do
-    agdaEnv <- runSpecTransM ctx $ toSpecRep @ConwayEra env
-    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
-    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
+  translateInputs (TRC (env@Conway.GovEnv {Conway.gePParams}, st, sig)) = do
+    enactState <- askSpecTransM
+    let ctx =
+          enactState
+            & ensPrevGovActionIdsL .~ toPrevGovActionIds (st ^. pRootsL)
+            & ensProtVerL .~ (gePParams ^. ppProtocolVersionL)
+    agdaEnv <- withCtxSpecTransM ctx $ toSpecRep env
+    agdaSt <- withCtxSpecTransM () $ toSpecRep st
+    agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
-    where
-      ctx =
-        enactState
-          & ensPrevGovActionIdsL .~ toPrevGovActionIds (st ^. pRootsL)
-          & ensProtVerL .~ (gePParams ^. ppProtocolVersionL)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -28,9 +29,9 @@ instance ExecSpecRule "GOV" ConwayEra where
   runAgdaRule (SpecTRC env st sig) = unComputationResult $ Agda.govStep env st sig
 
   translateInputs enactState (TRC (env@Conway.GovEnv {Conway.gePParams}, st, sig)) = do
-    agdaEnv <- runSpecTransM ctx $ toSpecRep env
-    agdaSt <- runSpecTransM () $ toSpecRep st
-    agdaSig <- runSpecTransM () $ toSpecRep sig
+    agdaEnv <- runSpecTransM ctx $ toSpecRep @ConwayEra env
+    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
+    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
     where
       ctx =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
@@ -18,7 +18,7 @@ import Cardano.Ledger.Conway.Governance
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Control.State.Transition.Extended (TRC (..))
 import Lens.Micro ((&), (.~), (^.))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
 import Test.Cardano.Ledger.Conway.Arbitrary ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Gov.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -19,8 +18,17 @@ import qualified Cardano.Ledger.Conway.Rules as Conway
 import Control.State.Transition.Extended (TRC (..))
 import Lens.Micro ((&), (.~), (^.))
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
+  ExecSpecRule (ExecContext, runAgdaRule, translateInputs),
+  SpecTRC (SpecTRC),
+ )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (toSpecRep),
+  askSpecTransM,
+  unComputationResult,
+  withCtxSpecTransM,
+ )
 import Test.Cardano.Ledger.Conway.Arbitrary ()
 
 instance ExecSpecRule "GOV" ConwayEra where

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -14,7 +14,7 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.GovCert () where
 import Cardano.Ledger.Conway (ConwayEra)
 import Control.State.Transition.Extended (TRC (..))
 import Data.Bifunctor (Bifunctor (..))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
   SpecTRC (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -27,9 +28,9 @@ instance ExecSpecRule "GOVCERT" ConwayEra where
   type ExecContext "GOVCERT" ConwayEra = ConwayCertExecContext ConwayEra
 
   translateInputs ConwayCertExecContext {..} (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep env
-    agdaSt <- runSpecTransM () $ toSpecRep st
-    agdaSig <- runSpecTransM () $ toSpecRep sig
+    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep @ConwayEra env
+    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
+    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule (SpecTRC env (Agda.MkCertState dState pState vState) sig) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/GovCert.hs
@@ -15,22 +15,26 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Control.State.Transition.Extended (TRC (..))
 import Data.Bifunctor (Bifunctor (..))
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (ConwayCertExecContext (..))
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),
   SpecTRC (..),
-  SpecTranslate (..),
-  runSpecTransM,
-  unComputationResult,
  )
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Cert (ConwayCertExecContext (..))
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (..),
+  askSpecTransM,
+  unComputationResult,
+  withCtxSpecTransM,
+ )
 
 instance ExecSpecRule "GOVCERT" ConwayEra where
   type ExecContext "GOVCERT" ConwayEra = ConwayCertExecContext ConwayEra
 
-  translateInputs ConwayCertExecContext {..} (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep @ConwayEra env
-    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
-    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
+  translateInputs (TRC (env, st, sig)) = do
+    ConwayCertExecContext {..} <- askSpecTransM
+    agdaEnv <- withCtxSpecTransM (ccecVotes, ccecWithdrawals) $ toSpecRep env
+    agdaSt <- withCtxSpecTransM () $ toSpecRep st
+    agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule (SpecTRC env (Agda.MkCertState dState pState vState) sig) =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -49,7 +49,8 @@ import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecTranslate (..),
-  runSpecTransM,
+  askSpecTransM,
+  withCtxSpecTransM,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Constrained.Conway (UtxoExecContext (..))
@@ -104,10 +105,11 @@ instance
 instance ExecSpecRule "LEDGER" ConwayEra where
   type ExecContext "LEDGER" ConwayEra = ConwayLedgerExecContext ConwayEra
 
-  translateInputs ConwayLedgerExecContext {..} (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM (clecGuardrailsScriptHash, clecEnactState) $ toSpecRep @ConwayEra env
-    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
-    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
+  translateInputs (TRC (env, st, sig)) = do
+    ConwayLedgerExecContext {..} <- askSpecTransM
+    agdaEnv <- withCtxSpecTransM (clecGuardrailsScriptHash, clecEnactState) $ toSpecRep env
+    agdaSt <- withCtxSpecTransM () $ toSpecRep st
+    agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule trc =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -105,9 +105,9 @@ instance ExecSpecRule "LEDGER" ConwayEra where
   type ExecContext "LEDGER" ConwayEra = ConwayLedgerExecContext ConwayEra
 
   translateInputs ConwayLedgerExecContext {..} (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM (clecGuardrailsScriptHash, clecEnactState) $ toSpecRep env
-    agdaSt <- runSpecTransM () $ toSpecRep st
-    agdaSig <- runSpecTransM () $ toSpecRep sig
+    agdaEnv <- runSpecTransM (clecGuardrailsScriptHash, clecEnactState) $ toSpecRep @ConwayEra env
+    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
+    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule trc =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledger.hs
@@ -36,7 +36,7 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.Functor.Identity (Identity)
 import qualified Data.Text as T
 import GHC.Generics (Generic)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Common (NFData, ToExpr)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
   externalFunctions,

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
@@ -12,7 +12,7 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Ledgers () where
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (EnactState)
 import Control.State.Transition.Extended (TRC (..))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   SpecTRC (..),
   SpecTranslate (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
@@ -13,17 +13,17 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (EnactState)
 import Control.State.Transition.Extended (TRC (..))
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance (
-  SpecTRC (..),
-  SpecTranslate (..),
-  runSpecTransM,
- )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (
   externalFunctions,
  )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),
+  SpecTRC (..),
   runFromAgdaFunction,
+ )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (..),
+  withCtxSpecTransM,
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Conway.ImpTest ()
@@ -31,10 +31,10 @@ import Test.Cardano.Ledger.Conway.ImpTest ()
 instance ExecSpecRule "LEDGERS" ConwayEra where
   type ExecContext "LEDGERS" ConwayEra = EnactState ConwayEra
 
-  translateInputs enactState (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM enactState $ toSpecRep @ConwayEra env
-    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
-    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
+  translateInputs (TRC (env, st, sig)) = do
+    agdaEnv <- toSpecRep env
+    agdaSt <- withCtxSpecTransM () $ toSpecRep st
+    agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule = runFromAgdaFunction (Agda.ledgersStep externalFunctions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ledgers.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -31,9 +32,9 @@ instance ExecSpecRule "LEDGERS" ConwayEra where
   type ExecContext "LEDGERS" ConwayEra = EnactState ConwayEra
 
   translateInputs enactState (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM enactState $ toSpecRep env
-    agdaSt <- runSpecTransM () $ toSpecRep st
-    agdaSig <- runSpecTransM () $ toSpecRep sig
+    agdaEnv <- runSpecTransM enactState $ toSpecRep @ConwayEra env
+    agdaSt <- runSpecTransM () $ toSpecRep @ConwayEra st
+    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   runAgdaRule = runFromAgdaFunction (Agda.ledgersStep externalFunctions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/NewEpoch.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/NewEpoch.hs
@@ -6,7 +6,7 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.NewEpoch () where
 
 import Cardano.Ledger.Conway (ConwayEra)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (ExecSpecRule (..), SpecTRC (..), unComputationResult_)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway ()
 import Test.Cardano.Ledger.Conway.ImpTest ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
@@ -10,7 +10,7 @@
 module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool where
 
 import Cardano.Ledger.Conway
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Pool.hs
@@ -11,8 +11,10 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Pool where
 
 import Cardano.Ledger.Conway
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance
-import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
+  ExecSpecRule (runAgdaRule),
+  runFromAgdaFunction,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 import Test.Cardano.Ledger.Conway.ImpTest ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
@@ -24,7 +24,7 @@ import Control.State.Transition.Extended (TRC (..))
 import Data.Foldable (Foldable (..))
 import Data.Ratio (denominator, numerator)
 import Lens.Micro ((^.))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import qualified Prettyprinter as PP
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
@@ -44,13 +44,13 @@ instance ExecSpecRule "RATIFY" ConwayEra where
   translateInputs _ (TRC (env, st@RatifyState {..}, sig@(RatifySignal actions))) =
     runSpecTransM () $ do
       let treasury = ensTreasury rsEnactState
-      specEnv <- withCtxSpecTransM treasury (toSpecRep env)
-      specSt <- withCtxSpecTransM (toList actions) (toSpecRep st)
-      specSig <- toSpecRep sig
+      specEnv <- withCtxSpecTransM treasury (toSpecRep @ConwayEra env)
+      specSt <- withCtxSpecTransM (toList actions) (toSpecRep @ConwayEra st)
+      specSig <- withCtxSpecTransM () (toSpecRep @ConwayEra sig)
       pure $ SpecTRC specEnv specSt specSig
 
   translateOutput _ (TRC (_, _, RatifySignal actions)) out =
-    runSpecTransM () . withCtxSpecTransM (toList actions) $ toSpecRep out
+    runSpecTransM () . withCtxSpecTransM (toList actions) $ toSpecRep @ConwayEra out
 
   extraInfo _ ctx trc@(TRC (env@RatifyEnv {..}, st@RatifyState {..}, RatifySignal actions)) _ =
     PP.vsep $ specExtraInfo : (actionAcceptedRatio <$> toList actions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
@@ -50,8 +50,8 @@ instance ExecSpecRule "RATIFY" ConwayEra where
       specSig <- withCtxSpecTransM () (toSpecRep sig)
       pure $ SpecTRC specEnv specSt specSig
 
-  translateOutput _ (TRC (_, _, RatifySignal actions)) out =
-    runSpecTransM () . withCtxSpecTransM (toList actions) $ toSpecRep @ConwayEra out
+  translateOutput (TRC (_, _, RatifySignal actions)) =
+    withCtxSpecTransM (toList actions) . toSpecRep
 
   extraInfo _ _ trc@(TRC (env@RatifyEnv {..}, st@RatifyState {..}, RatifySignal actions)) _ =
     PP.vsep $ specExtraInfo : (actionAcceptedRatio <$> toList actions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Ratify.hs
@@ -26,9 +26,11 @@ import Data.Ratio (denominator, numerator)
 import Lens.Micro ((^.))
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import qualified Prettyprinter as PP
-import Test.Cardano.Ledger.Conformance (
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
   ExecSpecRule (..),
   SpecTRC (..),
+ )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecTranslate (..),
   runSpecTransM,
   unComputationResult_,
@@ -41,18 +43,17 @@ import Test.Cardano.Ledger.Conway.TreeDiff (ansiExpr, tableDoc)
 instance ExecSpecRule "RATIFY" ConwayEra where
   runAgdaRule (SpecTRC env st sig) = unComputationResult_ $ Agda.ratifyStep env st sig
 
-  translateInputs _ (TRC (env, st@RatifyState {..}, sig@(RatifySignal actions))) =
-    runSpecTransM () $ do
-      let treasury = ensTreasury rsEnactState
-      specEnv <- withCtxSpecTransM treasury (toSpecRep @ConwayEra env)
-      specSt <- withCtxSpecTransM (toList actions) (toSpecRep @ConwayEra st)
-      specSig <- withCtxSpecTransM () (toSpecRep @ConwayEra sig)
+  translateInputs (TRC (env, st@RatifyState {..}, sig@(RatifySignal actions))) =
+    do
+      specEnv <- withCtxSpecTransM (ensTreasury rsEnactState) (toSpecRep env)
+      specSt <- withCtxSpecTransM (toList actions) (toSpecRep st)
+      specSig <- withCtxSpecTransM () (toSpecRep sig)
       pure $ SpecTRC specEnv specSt specSig
 
   translateOutput _ (TRC (_, _, RatifySignal actions)) out =
     runSpecTransM () . withCtxSpecTransM (toList actions) $ toSpecRep @ConwayEra out
 
-  extraInfo _ ctx trc@(TRC (env@RatifyEnv {..}, st@RatifyState {..}, RatifySignal actions)) _ =
+  extraInfo _ _ trc@(TRC (env@RatifyEnv {..}, st@RatifyState {..}, RatifySignal actions)) _ =
     PP.vsep $ specExtraInfo : (actionAcceptedRatio <$> toList actions)
     where
       members = foldMap' (committeeMembers @ConwayEra) $ ensCommittee rsEnactState
@@ -62,7 +63,7 @@ instance ExecSpecRule "RATIFY" ConwayEra where
       specExtraInfo =
         PP.vsep
           [ "Spec extra info:"
-          , either PP.viaShow ansiExpr $ translateInputs @_ @ConwayEra ctx trc
+          , either PP.viaShow ansiExpr $ runSpecTransM () $ translateInputs @_ @ConwayEra trc
           ]
       pv = st ^. rsEnactStateL . ensProtVerL
       actionAcceptedRatio gas@GovActionState {..} =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
@@ -20,7 +20,6 @@ import Test.Cardano.Ledger.Conformance (
   SpecTRC (..),
   SpecTranslate (..),
   runFromAgdaFunction,
-  runSpecTransM,
   withCtxSpecTransM,
   withSpecTransM,
  )
@@ -39,7 +38,7 @@ instance ExecSpecRule "UTXO" ConwayEra where
     agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
-  translateOutput ctx _ st =
-    runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep @ConwayEra st
+  translateOutput _ =
+    withSpecTransM ((^. utxoEnvCertStateL) . uecUtxoEnv) . toSpecRep
 
   runAgdaRule = runFromAgdaFunction (Agda.utxoStep externalFunctions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -22,6 +21,8 @@ import Test.Cardano.Ledger.Conformance (
   SpecTranslate (..),
   runFromAgdaFunction,
   runSpecTransM,
+  withCtxSpecTransM,
+  withSpecTransM,
  )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (externalFunctions)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
@@ -32,10 +33,10 @@ import Test.Cardano.Ledger.Generic.Instances ()
 instance ExecSpecRule "UTXO" ConwayEra where
   type ExecContext "UTXO" ConwayEra = UtxoExecContext ConwayEra
 
-  translateInputs ctx (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM () $ toSpecRep @ConwayEra env
-    agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep @ConwayEra st
-    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
+  translateInputs (TRC (env, st, sig)) = do
+    agdaEnv <- withCtxSpecTransM () $ toSpecRep env
+    agdaSt <- withSpecTransM ((^. utxoEnvCertStateL) . uecUtxoEnv) $ toSpecRep st
+    agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   translateOutput ctx _ st =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
@@ -33,12 +33,12 @@ instance ExecSpecRule "UTXO" ConwayEra where
   type ExecContext "UTXO" ConwayEra = UtxoExecContext ConwayEra
 
   translateInputs ctx (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM () $ toSpecRep env
-    agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
-    agdaSig <- runSpecTransM () $ toSpecRep sig
+    agdaEnv <- runSpecTransM () $ toSpecRep @ConwayEra env
+    agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep @ConwayEra st
+    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   translateOutput ctx _ st =
-    runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
+    runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep @ConwayEra st
 
   runAgdaRule = runFromAgdaFunction (Agda.utxoStep externalFunctions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
@@ -15,7 +15,7 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Shelley.Rules (utxoEnvCertStateL)
 import Control.State.Transition.Extended (TRC (..))
 import Lens.Micro ((^.))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
   SpecTRC (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxo.hs
@@ -13,7 +13,7 @@ module Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxo () where
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Shelley.Rules (utxoEnvCertStateL)
 import Control.State.Transition.Extended (TRC (..))
-import Lens.Micro ((^.))
+import Lens.Micro.Extras (view)
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),
@@ -34,11 +34,11 @@ instance ExecSpecRule "UTXO" ConwayEra where
 
   translateInputs (TRC (env, st, sig)) = do
     agdaEnv <- withCtxSpecTransM () $ toSpecRep env
-    agdaSt <- withSpecTransM ((^. utxoEnvCertStateL) . uecUtxoEnv) $ toSpecRep st
+    agdaSt <- withSpecTransM (view utxoEnvCertStateL . uecUtxoEnv) $ toSpecRep st
     agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   translateOutput _ =
-    withSpecTransM ((^. utxoEnvCertStateL) . uecUtxoEnv) . toSpecRep
+    withSpecTransM (view utxoEnvCertStateL . uecUtxoEnv) . toSpecRep
 
   runAgdaRule = runFromAgdaFunction (Agda.utxoStep externalFunctions)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -24,15 +24,19 @@ import qualified Data.Text as T
 import Lens.Micro ((^.))
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import qualified Prettyprinter as PP
-import Test.Cardano.Ledger.Conformance (
-  ExecSpecRule (..),
-  SpecTRC (..),
-  SpecTranslate (..),
-  runFromAgdaFunction,
-  runSpecTransM,
- )
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (externalFunctions)
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Utxo ()
+import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core (
+  ExecSpecRule (..),
+  SpecTRC (..),
+  runFromAgdaFunction,
+ )
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (..),
+  runSpecTransM,
+  withCtxSpecTransM,
+  withSpecTransM,
+ )
 import Test.Cardano.Ledger.Constrained.Conway (
   UtxoExecContext (..),
  )
@@ -42,10 +46,10 @@ import Test.Cardano.Ledger.Shelley.Utils (runSTS)
 instance ExecSpecRule "UTXOW" ConwayEra where
   type ExecContext "UTXOW" ConwayEra = UtxoExecContext ConwayEra
 
-  translateInputs ctx (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM () $ toSpecRep @ConwayEra env
-    agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep @ConwayEra st
-    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
+  translateInputs (TRC (env, st, sig)) = do
+    agdaEnv <- withCtxSpecTransM () $ toSpecRep env
+    agdaSt <- withSpecTransM ((^. utxoEnvCertStateL) . uecUtxoEnv) $ toSpecRep st
+    agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   translateOutput ctx _ st =

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -22,7 +22,7 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.Coerce (coerce)
 import qualified Data.Text as T
 import Lens.Micro ((^.))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import qualified Prettyprinter as PP
 import Test.Cardano.Ledger.Conformance (
   ExecSpecRule (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -22,6 +22,7 @@ import Data.Bifunctor (Bifunctor (..))
 import Data.Coerce (coerce)
 import qualified Data.Text as T
 import Lens.Micro ((^.))
+import Lens.Micro.Extras (view)
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import qualified Prettyprinter as PP
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway.Base (externalFunctions)
@@ -48,12 +49,12 @@ instance ExecSpecRule "UTXOW" ConwayEra where
 
   translateInputs (TRC (env, st, sig)) = do
     agdaEnv <- withCtxSpecTransM () $ toSpecRep env
-    agdaSt <- withSpecTransM ((^. utxoEnvCertStateL) . uecUtxoEnv) $ toSpecRep st
+    agdaSt <- withSpecTransM (view utxoEnvCertStateL . uecUtxoEnv) $ toSpecRep st
     agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   translateOutput _ =
-    withSpecTransM ((^. utxoEnvCertStateL) . uecUtxoEnv) . toSpecRep
+    withSpecTransM (view utxoEnvCertStateL . uecUtxoEnv) . toSpecRep
 
   runAgdaRule = runFromAgdaFunction (Agda.utxowStep externalFunctions)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -43,22 +43,22 @@ instance ExecSpecRule "UTXOW" ConwayEra where
   type ExecContext "UTXOW" ConwayEra = UtxoExecContext ConwayEra
 
   translateInputs ctx (TRC (env, st, sig)) = do
-    agdaEnv <- runSpecTransM () $ toSpecRep env
-    agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
-    agdaSig <- runSpecTransM () $ toSpecRep sig
+    agdaEnv <- runSpecTransM () $ toSpecRep @ConwayEra env
+    agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep @ConwayEra st
+    agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
   translateOutput ctx _ st =
-    runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
+    runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep @ConwayEra st
 
   runAgdaRule = runFromAgdaFunction (Agda.utxowStep externalFunctions)
 
   extraInfo globals ctx trc@(TRC (env, st, sig)) _ =
     let
       result = either show T.unpack $ do
-        agdaEnv <- runSpecTransM () $ toSpecRep env
-        agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep st
-        agdaSig <- runSpecTransM () $ toSpecRep sig
+        agdaEnv <- runSpecTransM () $ toSpecRep @ConwayEra env
+        agdaSt <- runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep @ConwayEra st
+        agdaSig <- runSpecTransM () $ toSpecRep @ConwayEra sig
         pure $ Agda.utxowDebug externalFunctions agdaEnv agdaSt agdaSig
       stFinal = first (T.pack . show) $ runSTS @"UTXO" @ConwayEra globals env st sig
       utxoInfo = extraInfo @"UTXO" @ConwayEra globals ctx (coerce trc) stFinal

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Conway/Utxow.hs
@@ -52,8 +52,8 @@ instance ExecSpecRule "UTXOW" ConwayEra where
     agdaSig <- withCtxSpecTransM () $ toSpecRep sig
     pure $ SpecTRC agdaEnv agdaSt agdaSig
 
-  translateOutput ctx _ st =
-    runSpecTransM (uecUtxoEnv ctx ^. utxoEnvCertStateL) $ toSpecRep @ConwayEra st
+  translateOutput _ =
+    withSpecTransM ((^. utxoEnvCertStateL) . uecUtxoEnv) . toSpecRep
 
   runAgdaRule = runFromAgdaFunction (Agda.utxowStep externalFunctions)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -55,6 +55,7 @@ import Test.Cardano.Ledger.Api.DebugTools (writeCBOR)
 import Test.Cardano.Ledger.Binary.TreeDiff (Pretty (..), ansiWlPretty, ediff, ppEditExpr)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecNormalize (..),
+  SpecTransM,
   SpecTranslate (..),
   runSpecTransM,
   unComputationResult,
@@ -144,9 +145,8 @@ class
 
   translateInputs ::
     HasCallStack =>
-    ExecContext rule era ->
     TRC (EraRule rule era) ->
-    Either Text (SpecTRC rule era)
+    SpecTransM era (ExecContext rule era) (SpecTRC rule era)
   default translateInputs ::
     ( SpecTranslate era (Environment (EraRule rule era))
     , SpecTranslate era (State (EraRule rule era))
@@ -158,12 +158,10 @@ class
     , SpecRep era (State (EraRule rule era)) ~ SpecState rule era
     , SpecRep era (Signal (EraRule rule era)) ~ SpecSignal rule era
     ) =>
-    ExecContext rule era ->
     TRC (EraRule rule era) ->
-    Either Text (SpecTRC rule era)
-  translateInputs ctx (TRC (env, st, sig)) = do
-    runSpecTransM ctx $
-      SpecTRC <$> toSpecRep @era env <*> toSpecRep @era st <*> toSpecRep @era sig
+    SpecTransM era (ExecContext rule era) (SpecTRC rule era)
+  translateInputs (TRC (env, st, sig)) = do
+    SpecTRC <$> toSpecRep env <*> toSpecRep st <*> toSpecRep sig
 
   translateOutput ::
     ExecContext rule era ->
@@ -340,7 +338,8 @@ runConformance execContext trc@(TRC (env, st, sig)) = do
   SpecTRC specEnv specSt specSig <-
     impAnn "Translating the inputs" $
       expectRightDeepExpr $
-        translateInputs @rule @era execContext trc
+        runSpecTransM @era execContext $
+          translateInputs trc
   logDoc $ "ctx:\n" <> ansiExpr execContext
   logDoc $ "implEnv:\n" <> ansiExpr env
   logDoc $ "implSt:\n" <> ansiExpr st

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -122,13 +122,13 @@ class
   type ExecContext rule era = ()
 
   type SpecEnvironment rule era
-  type SpecEnvironment rule era = SpecRep (Environment (EraRule rule era))
+  type SpecEnvironment rule era = SpecRep era (Environment (EraRule rule era))
 
   type SpecState rule era
-  type SpecState rule era = SpecRep (State (EraRule rule era))
+  type SpecState rule era = SpecRep era (State (EraRule rule era))
 
   type SpecSignal rule era
-  type SpecSignal rule era = SpecRep (Signal (EraRule rule era))
+  type SpecSignal rule era = SpecRep era (Signal (EraRule rule era))
 
   runAgdaRule ::
     HasCallStack =>
@@ -148,22 +148,22 @@ class
     TRC (EraRule rule era) ->
     Either Text (SpecTRC rule era)
   default translateInputs ::
-    ( SpecTranslate (Environment (EraRule rule era))
-    , SpecTranslate (State (EraRule rule era))
-    , SpecTranslate (Signal (EraRule rule era))
-    , SpecContext (Environment (EraRule rule era)) ~ ExecContext rule era
-    , SpecContext (State (EraRule rule era)) ~ ExecContext rule era
-    , SpecContext (Signal (EraRule rule era)) ~ ExecContext rule era
-    , SpecRep (Environment (EraRule rule era)) ~ SpecEnvironment rule era
-    , SpecRep (State (EraRule rule era)) ~ SpecState rule era
-    , SpecRep (Signal (EraRule rule era)) ~ SpecSignal rule era
+    ( SpecTranslate era (Environment (EraRule rule era))
+    , SpecTranslate era (State (EraRule rule era))
+    , SpecTranslate era (Signal (EraRule rule era))
+    , SpecContext era (Environment (EraRule rule era)) ~ ExecContext rule era
+    , SpecContext era (State (EraRule rule era)) ~ ExecContext rule era
+    , SpecContext era (Signal (EraRule rule era)) ~ ExecContext rule era
+    , SpecRep era (Environment (EraRule rule era)) ~ SpecEnvironment rule era
+    , SpecRep era (State (EraRule rule era)) ~ SpecState rule era
+    , SpecRep era (Signal (EraRule rule era)) ~ SpecSignal rule era
     ) =>
     ExecContext rule era ->
     TRC (EraRule rule era) ->
     Either Text (SpecTRC rule era)
   translateInputs ctx (TRC (env, st, sig)) = do
     runSpecTransM ctx $
-      SpecTRC <$> toSpecRep env <*> toSpecRep st <*> toSpecRep sig
+      SpecTRC <$> toSpecRep @era env <*> toSpecRep @era st <*> toSpecRep @era sig
 
   translateOutput ::
     ExecContext rule era ->
@@ -171,15 +171,15 @@ class
     State (EraRule rule era) ->
     Either Text (SpecState rule era)
   default translateOutput ::
-    ( SpecTranslate (State (EraRule rule era))
-    , SpecContext (State (EraRule rule era)) ~ ()
-    , SpecRep (State (EraRule rule era)) ~ SpecState rule era
+    ( SpecTranslate era (State (EraRule rule era))
+    , SpecContext era (State (EraRule rule era)) ~ ()
+    , SpecRep era (State (EraRule rule era)) ~ SpecState rule era
     ) =>
     ExecContext rule era ->
     TRC (EraRule rule era) ->
     State (EraRule rule era) ->
     Either Text (SpecState rule era)
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep st
+  translateOutput _ _ st = runSpecTransM () $ toSpecRep @era st
 
   extraInfo ::
     HasCallStack =>
@@ -382,8 +382,9 @@ generatesWithin gen timeout =
 
 -- | Translate a Haskell type 'a' whose translation context is 'ctx' into its Agda type, in the ImpTest monad.
 translateWithContext ::
-  SpecTranslate a => SpecContext a -> a -> ImpTestM era (Either Text (SpecRep a))
-translateWithContext ctx x = pure . runSpecTransM ctx $ toSpecRep x
+  forall era a.
+  SpecTranslate era a => SpecContext era a -> a -> ImpTestM era (Either Text (SpecRep era a))
+translateWithContext ctx x = pure . runSpecTransM ctx $ toSpecRep @era x
 
 runFromAgdaFunction ::
   ( SpecEnvironment rule era ->

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -47,7 +47,7 @@ import GHC.Base (Constraint, Symbol, Type)
 import GHC.Generics (Generic)
 import GHC.TypeLits (KnownSymbol)
 import Lens.Micro.Mtl (use)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Core.Foreign.API as Agda
 import Prettyprinter
 import Prettyprinter.Render.Terminal
 import System.FilePath ((<.>))

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Core.hs
@@ -59,6 +59,7 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
   SpecTranslate (..),
   runSpecTransM,
   unComputationResult,
+  withCtxSpecTransM,
  )
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Shelley.ImpTest (
@@ -164,20 +165,18 @@ class
     SpecTRC <$> toSpecRep env <*> toSpecRep st <*> toSpecRep sig
 
   translateOutput ::
-    ExecContext rule era ->
     TRC (EraRule rule era) ->
     State (EraRule rule era) ->
-    Either Text (SpecState rule era)
+    SpecTransM era (ExecContext rule era) (SpecState rule era)
   default translateOutput ::
     ( SpecTranslate era (State (EraRule rule era))
     , SpecContext era (State (EraRule rule era)) ~ ()
     , SpecRep era (State (EraRule rule era)) ~ SpecState rule era
     ) =>
-    ExecContext rule era ->
     TRC (EraRule rule era) ->
     State (EraRule rule era) ->
-    Either Text (SpecState rule era)
-  translateOutput _ _ st = runSpecTransM () $ toSpecRep @era st
+    SpecTransM era (ExecContext rule era) (SpecState rule era)
+  translateOutput _ = withCtxSpecTransM () . toSpecRep
 
   extraInfo ::
     HasCallStack =>
@@ -358,7 +357,8 @@ runConformance execContext trc@(TRC (env, st, sig)) = do
       case implRes of
         Right (st', _) ->
           fmap (Right . specNormalize) . expectRightExpr $
-            translateOutput @rule @era execContext trc st'
+            runSpecTransM @era execContext $
+              translateOutput trc st'
         Left err -> pure $ Left err
   pure $ ConformanceResult implResTest agdaResTest implRes
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -8,17 +8,10 @@
 module Test.Cardano.Ledger.Conformance.Orphans where
 
 import Cardano.Ledger.Hashes (standardAddrHashSize)
-import Data.Bifunctor (Bifunctor (..))
 import Data.Default (Default)
-import Data.List (nub, sortOn)
-import Data.List.NonEmpty (NonEmpty)
-import qualified Data.Set as Set
-import Data.Text (Text)
-import Data.Void (Void)
 import GHC.Generics (Generic)
 import MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Common (NFData, ToExpr)
-import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (OpaqueErrorString, SpecNormalize (..))
 import Test.Cardano.Ledger.Conformance.Utils
 import Test.Cardano.Ledger.Conway.TreeDiff (Expr (..), ToExpr (..))
 
@@ -283,135 +276,6 @@ instance ToExpr NewEpochState
 instance ToExpr LEnv
 
 instance Default (HSMap k v)
-
-instance SpecNormalize Void
-
-instance SpecNormalize a => SpecNormalize (NonEmpty a)
-
-instance SpecNormalize Text where
-  specNormalize = id
-
-instance SpecNormalize OpaqueErrorString
-
-instance SpecNormalize a => SpecNormalize [a]
-
-instance SpecNormalize Char where
-  specNormalize = id
-
-instance
-  ( Eq v
-  , Ord k
-  , SpecNormalize k
-  , SpecNormalize v
-  ) =>
-  SpecNormalize (HSMap k v)
-  where
-  specNormalize (MkHSMap l) = MkHSMap . sortOn fst $ bimap specNormalize specNormalize <$> nub l
-
-instance (Ord a, SpecNormalize a) => SpecNormalize (HSSet a) where
-  specNormalize (MkHSSet l) = MkHSSet . Set.toList . Set.fromList $ specNormalize <$> l
-
-instance (SpecNormalize a, SpecNormalize b) => SpecNormalize (a, b)
-
-instance SpecNormalize a => SpecNormalize (Maybe a)
-
-instance (SpecNormalize a, SpecNormalize b) => SpecNormalize (Either a b)
-
-instance SpecNormalize Bool
-
-instance SpecNormalize TxId where
-  specNormalize = id
-
-instance SpecNormalize ()
-
-instance SpecNormalize BaseAddr
-
-instance SpecNormalize BootstrapAddr
-
-instance SpecNormalize Timelock
-
-instance SpecNormalize HSTimelock
-
-instance SpecNormalize Agda.LanguageCostModels where
-  specNormalize = MkLanguageCostModels . sortOn fst . lcmLanguageCostModels
-
-instance SpecNormalize HSLanguage
-
-instance SpecNormalize HSPlutusScript
-
-instance SpecNormalize UTxOState
-
-instance SpecNormalize Credential
-
-instance SpecNormalize GovRole
-
-instance SpecNormalize GovVotes
-
-instance SpecNormalize VDeleg
-
-instance SpecNormalize DepositPurpose
-
-instance SpecNormalize DState
-
-instance SpecNormalize StakePoolParams
-
-instance SpecNormalize PState
-
-instance SpecNormalize GState
-
-instance SpecNormalize CertState
-
-instance SpecNormalize Vote
-
-instance SpecNormalize Agda.Rational where
-  specNormalize = id
-
-instance SpecNormalize PParamsUpdate
-
-instance SpecNormalize RewardAddress
-
-instance SpecNormalize GovAction
-
-instance SpecNormalize GovActionState
-
-instance SpecNormalize StakeDistrs
-
-instance SpecNormalize PoolThresholds
-
-instance SpecNormalize DrepThresholds
-
-instance SpecNormalize PParams
-
-instance SpecNormalize EnactState
-
-instance SpecNormalize RatifyEnv
-
-instance SpecNormalize RatifyState
-
-instance SpecNormalize EpochState
-
-instance SpecNormalize Snapshots
-
-instance SpecNormalize Snapshot where
-  specNormalize (MkSnapshot s d p) =
-    MkSnapshot (specNormalize s') (specNormalize d') p
-    where
-      s' = removeZero s
-      -- Only keep delegations for credentials that have non-zero stake,
-      -- since ActiveStake drops zero-stake credentials
-      d' = keepOnlyStaked s' (removeZero d)
-      removeZero (MkHSMap l) = MkHSMap $ filter ((/= 0) . snd) l
-      keepOnlyStaked (MkHSMap sl) (MkHSMap dl) =
-        let stakeKeys = Set.fromList (map fst sl)
-         in MkHSMap $ filter ((`Set.member` stakeKeys) . fst) dl
-
-instance SpecNormalize Acnt
-
-instance SpecNormalize LState
-
-instance SpecNormalize HsRewardUpdate
-
-instance SpecNormalize NewEpochState
 
 deriving instance Semigroup (HSMap k v)
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Orphans.hs
@@ -16,7 +16,7 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import Data.Void (Void)
 import GHC.Generics (Generic)
-import MAlonzo.Code.Ledger.Foreign.API as Agda
+import MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Common (NFData, ToExpr)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (OpaqueErrorString, SpecNormalize (..))
 import Test.Cardano.Ledger.Conformance.Utils

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
@@ -57,7 +57,7 @@ import Data.Text (Text)
 import Data.Void (Void, absurd)
 import Data.Word (Word16, Word32, Word64)
 import GHC.Generics (Generic (..), K1 (..), M1 (..), U1 (..), V1, (:*:) (..), (:+:) (..))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Core.Foreign.API as Agda
 import Test.Cardano.Ledger.TreeDiff (Expr (..), ToExpr (..))
 
 newtype SpecTransM era ctx a

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -59,148 +60,153 @@ import GHC.Generics (Generic (..), K1 (..), M1 (..), U1 (..), V1, (:*:) (..), (:
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.TreeDiff (Expr (..), ToExpr (..))
 
-newtype SpecTransM ctx a
+newtype SpecTransM era ctx a
   = SpecTransM (ExceptT Text (Reader ctx) a)
   deriving (Functor, Applicative, Monad, MonadError Text, MonadReader ctx)
 
-runSpecTransM :: ctx -> SpecTransM ctx a -> Either Text a
+runSpecTransM :: ctx -> SpecTransM era ctx a -> Either Text a
 runSpecTransM ctx (SpecTransM m) = runReader (runExceptT m) ctx
 
-withSpecTransM :: (ctx -> ctx') -> SpecTransM ctx' a -> SpecTransM ctx a
+withSpecTransM :: (ctx -> ctx') -> SpecTransM era ctx' a -> SpecTransM era ctx a
 withSpecTransM f (SpecTransM m) = SpecTransM (mapExceptT (withReaderT f) m)
 
-withCtxSpecTransM :: ctx -> SpecTransM ctx a -> SpecTransM ctx' a
+withCtxSpecTransM :: ctx -> SpecTransM era ctx a -> SpecTransM era ctx' a
 withCtxSpecTransM ctx = withSpecTransM (const ctx)
 
-askSpecTransM :: SpecTransM ctx ctx
+askSpecTransM :: SpecTransM era ctx ctx
 askSpecTransM = ask
 
-class SpecTranslate a where
-  type SpecRep a :: Type
+class SpecTranslate era a where
+  type SpecRep era a :: Type
 
-  type SpecContext a :: Type
-  type SpecContext a = ()
+  type SpecContext era a :: Type
+  type SpecContext era a = ()
 
-  toSpecRep :: a -> SpecTransM (SpecContext a) (SpecRep a)
+  toSpecRep :: a -> SpecTransM era (SpecContext era a) (SpecRep era a)
 
-instance SpecTranslate () where
-  type SpecRep () = ()
-
-  toSpecRep = pure
-
-instance SpecTranslate Bool where
-  type SpecRep Bool = Bool
+instance SpecTranslate era () where
+  type SpecRep era () = ()
 
   toSpecRep = pure
 
-instance SpecTranslate Integer where
-  type SpecRep Integer = Integer
+instance SpecTranslate era Bool where
+  type SpecRep era Bool = Bool
 
   toSpecRep = pure
 
-instance SpecTranslate Void where
-  type SpecRep Void = Void
+instance SpecTranslate era Integer where
+  type SpecRep era Integer = Integer
+
+  toSpecRep = pure
+
+instance SpecTranslate era Void where
+  type SpecRep era Void = Void
 
   toSpecRep = absurd
 
-instance SpecTranslate Word16 where
-  type SpecRep Word16 = Integer
+instance SpecTranslate era Word16 where
+  type SpecRep era Word16 = Integer
 
   toSpecRep = pure . toInteger
 
-instance SpecTranslate Word32 where
-  type SpecRep Word32 = Integer
+instance SpecTranslate era Word32 where
+  type SpecRep era Word32 = Integer
 
   toSpecRep = pure . toInteger
 
-instance SpecTranslate Word64 where
-  type SpecRep Word64 = Integer
+instance SpecTranslate era Word64 where
+  type SpecRep era Word64 = Integer
 
   toSpecRep = pure . toInteger
 
 toSpecRepTupleGen ::
-  (a -> SpecTransM ctx c) ->
-  (b -> SpecTransM ctx d) ->
+  forall era a b c d ctx.
+  (a -> SpecTransM era ctx c) ->
+  (b -> SpecTransM era ctx d) ->
   (a, b) ->
-  SpecTransM ctx (c, d)
+  SpecTransM era ctx (c, d)
 toSpecRepTupleGen f g (a, b) = (,) <$> f a <*> g b
 
 toSpecRepTuple ::
-  (SpecTranslate a, SpecTranslate b, SpecContext a ~ ctx, SpecContext b ~ ctx) =>
-  (a, b) -> SpecTransM ctx (SpecRep a, SpecRep b)
+  forall era a b ctx.
+  (SpecTranslate era a, SpecTranslate era b, SpecContext era a ~ ctx, SpecContext era b ~ ctx) =>
+  (a, b) -> SpecTransM era ctx (SpecRep era a, SpecRep era b)
 toSpecRepTuple = toSpecRepTupleGen toSpecRep toSpecRep
 
-instance SpecTranslate a => SpecTranslate [a] where
-  type SpecRep [a] = [SpecRep a]
-  type SpecContext [a] = SpecContext a
+instance SpecTranslate era a => SpecTranslate era [a] where
+  type SpecRep era [a] = [SpecRep era a]
+  type SpecContext era [a] = SpecContext era a
 
   toSpecRep = traverse toSpecRep
 
-instance SpecTranslate a => SpecTranslate (StrictMaybe a) where
-  type SpecRep (StrictMaybe a) = Maybe (SpecRep a)
-  type SpecContext (StrictMaybe a) = SpecContext a
+instance SpecTranslate era a => SpecTranslate era (StrictMaybe a) where
+  type SpecRep era (StrictMaybe a) = Maybe (SpecRep era a)
+  type SpecContext era (StrictMaybe a) = SpecContext era a
 
   toSpecRep = toSpecRep . strictMaybeToMaybe
 
-instance SpecTranslate a => SpecTranslate (Maybe a) where
-  type SpecRep (Maybe a) = Maybe (SpecRep a)
-  type SpecContext (Maybe a) = SpecContext a
+instance SpecTranslate era a => SpecTranslate era (Maybe a) where
+  type SpecRep era (Maybe a) = Maybe (SpecRep era a)
+  type SpecContext era (Maybe a) = SpecContext era a
 
   toSpecRep = traverse toSpecRep
 
-instance SpecTranslate a => SpecTranslate (StrictSeq a) where
-  type SpecRep (StrictSeq a) = [SpecRep a]
-  type SpecContext (StrictSeq a) = SpecContext a
+instance SpecTranslate era a => SpecTranslate era (StrictSeq a) where
+  type SpecRep era (StrictSeq a) = [SpecRep era a]
+  type SpecContext era (StrictSeq a) = SpecContext era a
 
   toSpecRep = traverse toSpecRep . toList
 
-instance SpecTranslate a => SpecTranslate (Seq a) where
-  type SpecRep (Seq a) = [SpecRep a]
-  type SpecContext (Seq a) = SpecContext a
+instance SpecTranslate era a => SpecTranslate era (Seq a) where
+  type SpecRep era (Seq a) = [SpecRep era a]
+  type SpecContext era (Seq a) = SpecContext era a
 
   toSpecRep = traverse toSpecRep . toList
 
-instance SpecTranslate a => SpecTranslate (OSet a) where
-  type SpecRep (OSet a) = [SpecRep a]
-  type SpecContext (OSet a) = SpecContext a
+instance SpecTranslate era a => SpecTranslate era (OSet a) where
+  type SpecRep era (OSet a) = [SpecRep era a]
+  type SpecContext era (OSet a) = SpecContext era a
+
   toSpecRep = traverse toSpecRep . toList
 
 toSpecRepOMap ::
-  (Ord k, SpecTranslate k, SpecTranslate v, SpecContext k ~ ctx, SpecContext v ~ ctx) =>
-  OMap k v -> SpecTransM ctx [(SpecRep k, SpecRep v)]
+  forall era k v ctx.
+  (Ord k, SpecTranslate era k, SpecTranslate era v, SpecContext era k ~ ctx, SpecContext era v ~ ctx) =>
+  OMap k v -> SpecTransM era ctx [(SpecRep era k, SpecRep era v)]
 toSpecRepOMap = traverse (bimapM toSpecRep toSpecRep) . OMap.assocList
 
-instance (SpecTranslate a, Compactible a) => SpecTranslate (CompactForm a) where
-  type SpecRep (CompactForm a) = SpecRep a
-  type SpecContext (CompactForm a) = SpecContext a
+instance (SpecTranslate era a, Compactible a) => SpecTranslate era (CompactForm a) where
+  type SpecRep era (CompactForm a) = SpecRep era a
+  type SpecContext era (CompactForm a) = SpecContext era a
 
   toSpecRep = toSpecRep . fromCompact
 
-instance SpecTranslate a => SpecTranslate (Sized a) where
-  type SpecRep (Sized a) = SpecRep a
-  type SpecContext (Sized a) = SpecContext a
+instance SpecTranslate era a => SpecTranslate era (Sized a) where
+  type SpecRep era (Sized a) = SpecRep era a
+  type SpecContext era (Sized a) = SpecContext era a
 
   toSpecRep (Sized x _) = toSpecRep x
 
-instance SpecTranslate a => SpecTranslate (Set a) where
-  type SpecRep (Set a) = Agda.HSSet (SpecRep a)
-  type SpecContext (Set a) = SpecContext a
+instance SpecTranslate era a => SpecTranslate era (Set a) where
+  type SpecRep era (Set a) = Agda.HSSet (SpecRep era a)
+  type SpecContext era (Set a) = SpecContext era a
 
   toSpecRep = fmap Agda.MkHSSet . traverse toSpecRep . Set.toList
 
-instance SpecTranslate UnitInterval where
-  type SpecRep UnitInterval = Agda.Rational
+instance SpecTranslate era UnitInterval where
+  type SpecRep era UnitInterval = Agda.Rational
 
   toSpecRep = pure . unboundRational
 
-instance SpecTranslate NonNegativeInterval where
-  type SpecRep NonNegativeInterval = Agda.Rational
+instance SpecTranslate era NonNegativeInterval where
+  type SpecRep era NonNegativeInterval = Agda.Rational
 
   toSpecRep = pure . unboundRational
 
 toSpecRepMap ::
-  (SpecTranslate k, SpecTranslate v, SpecContext k ~ ctx, SpecContext v ~ ctx) =>
-  Map k v -> SpecTransM ctx (Agda.HSMap (SpecRep k) (SpecRep v))
+  forall era k v ctx.
+  (SpecTranslate era k, SpecTranslate era v, SpecContext era k ~ ctx, SpecContext era v ~ ctx) =>
+  Map k v -> SpecTransM era ctx (Agda.HSMap (SpecRep era k) (SpecRep era v))
 toSpecRepMap =
   fmap Agda.MkHSMap
     . traverse (bimapM toSpecRep toSpecRep)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
@@ -64,7 +64,7 @@ newtype SpecTransM era ctx a
   = SpecTransM (ExceptT Text (Reader ctx) a)
   deriving (Functor, Applicative, Monad, MonadError Text, MonadReader ctx)
 
-runSpecTransM :: ctx -> SpecTransM era ctx a -> Either Text a
+runSpecTransM :: forall era ctx a. ctx -> SpecTransM era ctx a -> Either Text a
 runSpecTransM ctx (SpecTransM m) = runReader (runExceptT m) ctx
 
 withSpecTransM :: (ctx -> ctx') -> SpecTransM era ctx' a -> SpecTransM era ctx a

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Base.hs
@@ -6,12 +6,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -39,9 +37,11 @@ import Cardano.Ledger.Compactible (Compactible (..), fromCompact)
 import Control.DeepSeq (NFData)
 import Control.Monad.Except (ExceptT, MonadError (..), mapExceptT, runExceptT)
 import Control.Monad.Reader (MonadReader (..), Reader, ask, runReader, withReaderT)
+import Data.Bifunctor (bimap)
 import Data.Bitraversable (bimapM)
 import Data.Foldable (Foldable (..))
 import Data.Kind (Type)
+import Data.List (nub, sortOn)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -238,6 +238,49 @@ class SpecNormalize a where
   specNormalize :: a -> a
   default specNormalize :: (Generic a, GSpecNormalize (Rep a)) => a -> a
   specNormalize = to . genericSpecNormalize . from
+
+instance SpecNormalize Void
+
+instance SpecNormalize Text where
+  specNormalize = id
+
+instance SpecNormalize OpaqueErrorString
+
+instance SpecNormalize Char where
+  specNormalize = id
+
+instance SpecNormalize Integer where
+  specNormalize = id
+
+instance SpecNormalize Bool
+
+instance SpecNormalize ()
+
+instance SpecNormalize a => SpecNormalize [a]
+
+instance SpecNormalize a => SpecNormalize (NonEmpty a)
+
+instance
+  ( Eq v
+  , Ord k
+  , SpecNormalize k
+  , SpecNormalize v
+  ) =>
+  SpecNormalize (Agda.HSMap k v)
+  where
+  specNormalize (Agda.MkHSMap l) = Agda.MkHSMap . sortOn fst $ bimap specNormalize specNormalize <$> nub l
+
+instance (Ord a, SpecNormalize a) => SpecNormalize (Agda.HSSet a) where
+  specNormalize (Agda.MkHSSet l) = Agda.MkHSSet . Set.toList . Set.fromList $ specNormalize <$> l
+
+instance (SpecNormalize a, SpecNormalize b) => SpecNormalize (a, b)
+
+instance SpecNormalize a => SpecNormalize (Maybe a)
+
+instance (SpecNormalize a, SpecNormalize b) => SpecNormalize (Either a b)
+
+instance SpecNormalize Agda.Rational where
+  specNormalize = id
 
 -- | OpaqueErrorString behaves like unit in comparisons, but contains an
 -- error string that can be displayed.

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -36,6 +36,7 @@ import Cardano.Ledger.Alonzo.TxWits (AlonzoTxWits (..), Redeemers (..), TxDats (
 import Cardano.Ledger.Babbage.TxOut (BabbageTxOut (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import Cardano.Ledger.Conway.PParams (ConwayEraPParams (..), ConwayPParams (..), THKD (..))
@@ -60,6 +61,7 @@ import Cardano.Ledger.Val (Val (..))
 import Control.Monad.Except (MonadError (..))
 import Data.Default (Default (..))
 import Data.Foldable (Foldable (..))
+import Data.Functor.Identity (Identity)
 import Data.List (sortOn)
 import qualified Data.Map.Strict as Map
 import Data.OMap.Strict (OMap)
@@ -73,25 +75,25 @@ import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.Orphans ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (committeeCredentialToStrictMaybe)
-import Test.Cardano.Ledger.Conway.TreeDiff (ToExpr (..), showExpr)
+import Test.Cardano.Ledger.Conway.TreeDiff (showExpr)
 
-instance SpecTranslate TxId where
-  type SpecRep TxId = Agda.TxId
+instance SpecTranslate ConwayEra TxId where
+  type SpecRep ConwayEra TxId = Agda.TxId
 
   toSpecRep (TxId x) = toSpecRep x
 
-instance SpecTranslate TxIn where
-  type SpecRep TxIn = Agda.TxIn
+instance SpecTranslate ConwayEra TxIn where
+  type SpecRep ConwayEra TxIn = Agda.TxIn
 
   toSpecRep (TxIn txId txIx) = toSpecRepTuple (txId, txIx)
 
-instance SpecTranslate (SafeHash a) where
-  type SpecRep (SafeHash a) = Agda.DataHash
+instance SpecTranslate ConwayEra (SafeHash a) where
+  type SpecRep ConwayEra (SafeHash a) = Agda.DataHash
 
   toSpecRep = toSpecRep . extractHash
 
-instance SpecTranslate Language where
-  type SpecRep Language = Agda.HSLanguage
+instance SpecTranslate ConwayEra Language where
+  type SpecRep ConwayEra Language = Agda.HSLanguage
 
   toSpecRep l = case l of
     PlutusV1 -> return Agda.PV1
@@ -99,54 +101,43 @@ instance SpecTranslate Language where
     PlutusV3 -> return Agda.PV3
     PlutusV4 -> error "PlutusV4 not supported"
 
-instance SpecTranslate CostModels where
-  type SpecRep CostModels = Agda.LanguageCostModels
+instance SpecTranslate ConwayEra CostModels where
+  type SpecRep ConwayEra CostModels = Agda.LanguageCostModels
 
   toSpecRep cm =
     -- filter out PlutusV4 language
     let validCostModels = filter ((/= PlutusV4) . fst) $ Map.toList (costModelsValid cm)
      in Agda.MkLanguageCostModels <$> mapM (\(l, _) -> (,()) <$> toSpecRep l) validCostModels
 
-instance SpecTranslate ExUnits where
-  type SpecRep ExUnits = Agda.ExUnits
+instance SpecTranslate ConwayEra ExUnits where
+  type SpecRep ConwayEra ExUnits = Agda.ExUnits
 
   toSpecRep (ExUnits a b) = pure (toInteger a, toInteger b)
 
-instance
-  ( SpecRep DataHash ~ Agda.DataHash
-  , Era era
-  ) =>
-  SpecTranslate (BinaryData era)
-  where
-  type SpecRep (BinaryData era) = Agda.DataHash
+instance SpecTranslate ConwayEra (BinaryData ConwayEra) where
+  type SpecRep ConwayEra (BinaryData ConwayEra) = Agda.DataHash
 
   toSpecRep = toSpecRep . hashBinaryData
 
-instance Era era => SpecTranslate (Datum era) where
-  type SpecRep (Datum era) = Maybe (Either Agda.Datum Agda.DataHash)
+instance SpecTranslate ConwayEra (Datum ConwayEra) where
+  type SpecRep ConwayEra (Datum ConwayEra) = Maybe (Either Agda.Datum Agda.DataHash)
 
   toSpecRep NoDatum = pure Nothing
   toSpecRep (Datum d) = Just . Left <$> toSpecRep d
   toSpecRep (DatumHash h) = Just . Right <$> toSpecRep h
 
-instance Era era => SpecTranslate (Data era) where
-  type SpecRep (Data era) = Agda.DataHash
+instance SpecTranslate ConwayEra (Data ConwayEra) where
+  type SpecRep ConwayEra (Data ConwayEra) = Agda.DataHash
 
   toSpecRep = toSpecRep . hashAnnotated
 
-instance SpecTranslate TxAuxDataHash where
-  type SpecRep TxAuxDataHash = Agda.DataHash
+instance SpecTranslate ConwayEra TxAuxDataHash where
+  type SpecRep ConwayEra TxAuxDataHash = Agda.DataHash
 
   toSpecRep (TxAuxDataHash x) = toSpecRep x
 
-instance
-  ( AlonzoEraScript era
-  , NativeScript era ~ Timelock era
-  , Script era ~ AlonzoScript era
-  ) =>
-  SpecTranslate (Timelock era)
-  where
-  type SpecRep (Timelock era) = Agda.HSTimelock
+instance SpecTranslate ConwayEra (Timelock ConwayEra) where
+  type SpecRep ConwayEra (Timelock ConwayEra) = Agda.HSTimelock
 
   toSpecRep tl =
     Agda.HSTimelock
@@ -171,13 +162,8 @@ instance
           RequireTimeStart slot -> Agda.RequireTimeStart <$> toSpecRep slot
           _ -> error "Impossible: All NativeScripts should have been accounted for"
 
-instance
-  ( AlonzoEraScript era
-  , Script era ~ AlonzoScript era
-  ) =>
-  SpecTranslate (PlutusScript era)
-  where
-  type SpecRep (PlutusScript era) = Agda.HSPlutusScript
+instance SpecTranslate ConwayEra (PlutusScript ConwayEra) where
+  type SpecRep ConwayEra (PlutusScript ConwayEra) = Agda.HSPlutusScript
 
   toSpecRep ps =
     Agda.MkHSPlutusScript
@@ -185,29 +171,14 @@ instance
       <*> pure (fromIntegral $ originalBytesSize ps)
       <*> toSpecRep (plutusScriptLanguage ps)
 
-instance
-  ( AlonzoEraScript era
-  , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
-  ) =>
-  SpecTranslate (AlonzoScript era)
-  where
-  type SpecRep (AlonzoScript era) = Agda.Script
+instance SpecTranslate ConwayEra (AlonzoScript ConwayEra) where
+  type SpecRep ConwayEra (AlonzoScript ConwayEra) = Agda.Script
 
   toSpecRep (NativeScript s) = Left <$> toSpecRep s
   toSpecRep (PlutusScript s) = Right <$> toSpecRep s
 
-instance
-  ( EraTxOut era
-  , SpecRep (Value era) ~ Agda.Coin
-  , SpecContext (Value era) ~ ()
-  , Script era ~ AlonzoScript era
-  , SpecTranslate (Value era)
-  , SpecTranslate (Script era)
-  ) =>
-  SpecTranslate (BabbageTxOut era)
-  where
-  type SpecRep (BabbageTxOut era) = Agda.TxOut
+instance SpecTranslate ConwayEra (BabbageTxOut ConwayEra) where
+  type SpecRep ConwayEra (BabbageTxOut ConwayEra) = Agda.TxOut
 
   toSpecRep (BabbageTxOut addr val datum script) = do
     addr' <- toSpecRep addr
@@ -216,32 +187,28 @@ instance
     script' <- toSpecRep script
     pure (addr', (val', (datum', script')))
 
-instance
-  ( SpecTranslate (TxOut era)
-  , SpecRep (TxOut era) ~ Agda.TxOut
-  , SpecContext (TxOut era) ~ ()
-  ) =>
-  SpecTranslate (UTxO era)
-  where
-  type SpecRep (UTxO era) = Agda.HSMap (SpecRep TxIn) (SpecRep (TxOut era))
+instance SpecTranslate ConwayEra (UTxO ConwayEra) where
+  type
+    SpecRep ConwayEra (UTxO ConwayEra) =
+      Agda.HSMap (SpecRep ConwayEra TxIn) (SpecRep ConwayEra (TxOut ConwayEra))
 
   toSpecRep (UTxO m) = toSpecRepMap m
 
-deriving instance SpecTranslate OrdExUnits
+deriving instance SpecTranslate ConwayEra OrdExUnits
 
-deriving instance SpecTranslate CoinPerByte
+deriving instance SpecTranslate ConwayEra CoinPerByte
 
 instance
-  SpecTranslate (HKD f a) =>
-  SpecTranslate (THKD r f a)
+  SpecTranslate ConwayEra (HKD f a) =>
+  SpecTranslate ConwayEra (THKD r f a)
   where
-  type SpecRep (THKD r f a) = SpecRep (HKD f a)
-  type SpecContext (THKD r f a) = SpecContext (HKD f a)
+  type SpecRep ConwayEra (THKD r f a) = SpecRep ConwayEra (HKD f a)
+  type SpecContext ConwayEra (THKD r f a) = SpecContext ConwayEra (HKD f a)
 
   toSpecRep = toSpecRep . unTHKD
 
-instance SpecTranslate DRepVotingThresholds where
-  type SpecRep DRepVotingThresholds = Agda.DrepThresholds
+instance SpecTranslate ConwayEra DRepVotingThresholds where
+  type SpecRep ConwayEra DRepVotingThresholds = Agda.DrepThresholds
 
   toSpecRep DRepVotingThresholds {..} =
     Agda.MkDrepThresholds
@@ -256,8 +223,8 @@ instance SpecTranslate DRepVotingThresholds where
       <*> toSpecRep dvtPPGovGroup
       <*> toSpecRep dvtTreasuryWithdrawal
 
-instance SpecTranslate PoolVotingThresholds where
-  type SpecRep PoolVotingThresholds = Agda.PoolThresholds
+instance SpecTranslate ConwayEra PoolVotingThresholds where
+  type SpecRep ConwayEra PoolVotingThresholds = Agda.PoolThresholds
 
   toSpecRep PoolVotingThresholds {..} =
     Agda.MkPoolThresholds
@@ -267,13 +234,8 @@ instance SpecTranslate PoolVotingThresholds where
       <*> toSpecRep pvtHardForkInitiation
       <*> toSpecRep pvtPPSecurityGroup
 
-instance
-  ( ConwayEraPParams era
-  , PParamsHKD Shelley.Identity era ~ ConwayPParams Shelley.Identity era
-  ) =>
-  SpecTranslate (ConwayPParams Shelley.Identity era)
-  where
-  type SpecRep (ConwayPParams Shelley.Identity era) = Agda.PParams
+instance SpecTranslate ConwayEra (ConwayPParams Identity ConwayEra) where
+  type SpecRep ConwayEra (ConwayPParams Shelley.Identity ConwayEra) = Agda.PParams
 
   toSpecRep cpp@ConwayPParams {..} = do
     ppA <- toSpecRep cppTxFeePerByte
@@ -323,18 +285,18 @@ instance
 
     pure Agda.MkPParams {..}
 
-instance SpecTranslate ValidityInterval where
-  type SpecRep ValidityInterval = (Maybe Integer, Maybe Integer)
+instance SpecTranslate ConwayEra ValidityInterval where
+  type SpecRep ConwayEra ValidityInterval = (Maybe Integer, Maybe Integer)
 
   toSpecRep (ValidityInterval lo hi) = toSpecRepTuple (lo, hi)
 
-instance Era era => SpecTranslate (TxDats era) where
-  type SpecRep (TxDats era) = Agda.HSSet Agda.Datum
+instance SpecTranslate ConwayEra (TxDats ConwayEra) where
+  type SpecRep ConwayEra (TxDats ConwayEra) = Agda.HSSet Agda.Datum
 
   toSpecRep = fmap Agda.MkHSSet . traverse (toSpecRep . snd) . Map.toList . unTxDats
 
-instance SpecTranslate (AlonzoPlutusPurpose AsIx era) where
-  type SpecRep (AlonzoPlutusPurpose AsIx era) = Agda.RdmrPtr
+instance SpecTranslate ConwayEra (AlonzoPlutusPurpose AsIx ConwayEra) where
+  type SpecRep ConwayEra (AlonzoPlutusPurpose AsIx ConwayEra) = Agda.RdmrPtr
 
   toSpecRep = \case
     AlonzoSpending (AsIx i) -> pure (Agda.Spend, toInteger i)
@@ -342,8 +304,8 @@ instance SpecTranslate (AlonzoPlutusPurpose AsIx era) where
     AlonzoCertifying (AsIx i) -> pure (Agda.Cert, toInteger i)
     AlonzoRewarding (AsIx i) -> pure (Agda.Rewrd, toInteger i)
 
-instance SpecTranslate (ConwayPlutusPurpose AsIx era) where
-  type SpecRep (ConwayPlutusPurpose AsIx era) = Agda.RdmrPtr
+instance SpecTranslate ConwayEra (ConwayPlutusPurpose AsIx ConwayEra) where
+  type SpecRep ConwayEra (ConwayPlutusPurpose AsIx ConwayEra) = Agda.RdmrPtr
 
   toSpecRep = \case
     ConwaySpending (AsIx i) -> pure (Agda.Spend, toInteger i)
@@ -353,17 +315,10 @@ instance SpecTranslate (ConwayPlutusPurpose AsIx era) where
     ConwayVoting (AsIx i) -> pure (Agda.Vote, toInteger i)
     ConwayProposing (AsIx i) -> pure (Agda.Propose, toInteger i)
 
-instance
-  ( AlonzoEraScript era
-  , SpecTranslate (PlutusPurpose AsIx era)
-  , SpecContext (PlutusPurpose AsIx era) ~ ()
-  , SpecRep (Data era) ~ Agda.Redeemer
-  ) =>
-  SpecTranslate (Redeemers era)
-  where
+instance SpecTranslate ConwayEra (Redeemers ConwayEra) where
   type
-    SpecRep (Redeemers era) =
-      Agda.HSMap (SpecRep (PlutusPurpose AsIx era)) (Agda.Redeemer, Agda.ExUnits)
+    SpecRep ConwayEra (Redeemers ConwayEra) =
+      Agda.HSMap (SpecRep ConwayEra (PlutusPurpose AsIx ConwayEra)) (Agda.Redeemer, Agda.ExUnits)
 
   toSpecRep (Redeemers x) =
     fmap Agda.MkHSMap
@@ -371,18 +326,8 @@ instance
       . Map.toList
       $ x
 
-instance
-  ( AlonzoEraScript era
-  , SpecTranslate (PlutusPurpose AsIx era)
-  , SpecRep (PlutusPurpose AsIx era) ~ Agda.RdmrPtr
-  , SpecContext (PlutusPurpose AsIx era) ~ ()
-  , SpecRep (Data era) ~ Agda.Redeemer
-  , Script era ~ AlonzoScript era
-  , NativeScript era ~ Timelock era
-  ) =>
-  SpecTranslate (AlonzoTxWits era)
-  where
-  type SpecRep (AlonzoTxWits era) = Agda.TxWitnesses
+instance SpecTranslate ConwayEra (AlonzoTxWits ConwayEra) where
+  type SpecRep ConwayEra (AlonzoTxWits ConwayEra) = Agda.TxWitnesses
 
   toSpecRep x =
     Agda.MkTxWitnesses
@@ -393,13 +338,13 @@ instance
     where
       txWitsMap = toList (txwitsVKey x)
 
-instance Era era => SpecTranslate (AlonzoTxAuxData era) where
-  type SpecRep (AlonzoTxAuxData era) = Agda.AuxiliaryData
+instance SpecTranslate ConwayEra (AlonzoTxAuxData ConwayEra) where
+  type SpecRep ConwayEra (AlonzoTxAuxData ConwayEra) = Agda.AuxiliaryData
 
   toSpecRep = toSpecRep . hashAnnotated
 
-instance SpecTranslate StakePoolParams where
-  type SpecRep StakePoolParams = Agda.StakePoolParams
+instance SpecTranslate ConwayEra StakePoolParams where
+  type SpecRep ConwayEra StakePoolParams = Agda.StakePoolParams
 
   toSpecRep StakePoolParams {..} =
     Agda.StakePoolParams
@@ -409,55 +354,50 @@ instance SpecTranslate StakePoolParams where
       <*> toSpecRep sppPledge
       <*> toSpecRep (sppAccountAddress ^. accountAddressCredentialL)
 
-instance SpecTranslate DRep where
-  type SpecRep DRep = Agda.VDeleg
+instance SpecTranslate ConwayEra DRep where
+  type SpecRep ConwayEra DRep = Agda.VDeleg
 
   toSpecRep (DRepCredential c) = Agda.VDelegCredential <$> toSpecRep c
   toSpecRep DRepAlwaysAbstain = pure Agda.VDelegAbstain
   toSpecRep DRepAlwaysNoConfidence = pure Agda.VDelegNoConfidence
 
-instance SpecTranslate Url where
-  type SpecRep Url = T.Text
+instance SpecTranslate ConwayEra Url where
+  type SpecRep ConwayEra Url = T.Text
   toSpecRep = pure . urlToText
 
-instance SpecTranslate Anchor where
-  type SpecRep Anchor = Agda.Anchor
+instance SpecTranslate ConwayEra Anchor where
+  type SpecRep ConwayEra Anchor = Agda.Anchor
   toSpecRep (Anchor url h) = Agda.Anchor <$> toSpecRep url <*> toSpecRep h
 
-instance SpecTranslate Withdrawals where
-  type SpecRep Withdrawals = Agda.Withdrawals
+instance SpecTranslate ConwayEra Withdrawals where
+  type SpecRep ConwayEra Withdrawals = Agda.Withdrawals
 
   toSpecRep (Withdrawals w) = toSpecRepMap w
 
-instance SpecTranslate IsValid where
-  type SpecRep IsValid = Bool
+instance SpecTranslate ConwayEra IsValid where
+  type SpecRep ConwayEra IsValid = Bool
 
   toSpecRep (IsValid b) = pure b
 
-instance SpecTranslate (GovPurposeId r) where
-  type SpecRep (GovPurposeId r) = (Agda.TxId, Integer)
+instance SpecTranslate ConwayEra (GovPurposeId r) where
+  type SpecRep ConwayEra (GovPurposeId r) = (Agda.TxId, Integer)
 
   toSpecRep (GovPurposeId gaId) = toSpecRep gaId
 
-instance SpecTranslate (Committee era) where
-  type SpecRep (Committee era) = (Agda.HSMap Agda.Credential Agda.Epoch, Agda.Rational)
+instance SpecTranslate ConwayEra (Committee ConwayEra) where
+  type
+    SpecRep ConwayEra (Committee ConwayEra) =
+      (Agda.HSMap Agda.Credential Agda.Epoch, Agda.Rational)
 
   toSpecRep (Committee members threshold) = (,) <$> toSpecRepMap members <*> toSpecRep threshold
 
-instance SpecTranslate (Constitution era) where
-  type SpecRep (Constitution era) = (Agda.DataHash, Maybe Agda.ScriptHash)
+instance SpecTranslate ConwayEra (Constitution ConwayEra) where
+  type SpecRep ConwayEra (Constitution ConwayEra) = (Agda.DataHash, Maybe Agda.ScriptHash)
 
   toSpecRep (Constitution (Anchor _ h) policy) = toSpecRepTuple (h, policy)
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD Shelley.Identity era)
-  , SpecRep (PParamsHKD Shelley.Identity era) ~ Agda.PParams
-  , SpecContext (PParamsHKD Shelley.Identity era) ~ ()
-  ) =>
-  SpecTranslate (EnactState era)
-  where
-  type SpecRep (EnactState era) = Agda.EnactState
+instance SpecTranslate ConwayEra (EnactState ConwayEra) where
+  type SpecRep ConwayEra (EnactState ConwayEra) = Agda.EnactState
 
   toSpecRep EnactState {..} =
     Agda.MkEnactState
@@ -473,6 +413,11 @@ instance
           agdaCred <- toSpecRep cred
           network <- toSpecRep Testnet -- TODO where should this really come from?
           pure (Agda.RewardAddress network agdaCred, amount)
+      transHashProtected ::
+        (SpecTranslate ConwayEra a, SpecContext ConwayEra a ~ ()) =>
+        a ->
+        StrictMaybe (GovPurposeId p) ->
+        SpecTransM ConwayEra () (SpecRep ConwayEra a, (Integer, Integer))
       transHashProtected x h = do
         committee <- toSpecRep x
         agdaLastId <- case h of
@@ -480,31 +425,31 @@ instance
           SNothing -> pure (0, 0)
         pure (committee, agdaLastId)
 
-instance SpecTranslate Voter where
-  type SpecRep Voter = Agda.GovVoter
+instance SpecTranslate ConwayEra Voter where
+  type SpecRep ConwayEra Voter = Agda.GovVoter
 
   toSpecRep (CommitteeVoter c) = (Agda.CC,) <$> toSpecRep c
   toSpecRep (DRepVoter c) = (Agda.DRep,) <$> toSpecRep c
   toSpecRep (StakePoolVoter kh) = (Agda.SPO,) <$> toSpecRep (KeyHashObj kh)
 
-instance SpecTranslate Vote where
-  type SpecRep Vote = Agda.Vote
+instance SpecTranslate ConwayEra Vote where
+  type SpecRep ConwayEra Vote = Agda.Vote
 
   toSpecRep VoteYes = pure Agda.Yes
   toSpecRep VoteNo = pure Agda.No
   toSpecRep Abstain = pure Agda.Abstain
 
-instance SpecTranslate (VotingProcedures era) where
-  type SpecRep (VotingProcedures era) = [Agda.GovVote]
+instance SpecTranslate ConwayEra (VotingProcedures ConwayEra) where
+  type SpecRep ConwayEra (VotingProcedures ConwayEra) = [Agda.GovVote]
 
   toSpecRep = foldrVotingProcedures go (pure [])
     where
       go ::
         Voter ->
         GovActionId ->
-        VotingProcedure era ->
-        SpecTransM () [Agda.GovVote] ->
-        SpecTransM () [Agda.GovVote]
+        VotingProcedure ConwayEra ->
+        SpecTransM ConwayEra () [Agda.GovVote] ->
+        SpecTransM ConwayEra () [Agda.GovVote]
       go voter gaId votingProcedure m =
         (:)
           <$> ( Agda.MkGovVote
@@ -515,8 +460,8 @@ instance SpecTranslate (VotingProcedures era) where
               )
           <*> m
 
-instance SpecTranslate (ConwayPParams StrictMaybe era) where
-  type SpecRep (ConwayPParams StrictMaybe era) = Agda.PParamsUpdate
+instance SpecTranslate ConwayEra (ConwayPParams StrictMaybe ConwayEra) where
+  type SpecRep ConwayEra (ConwayPParams StrictMaybe ConwayEra) = Agda.PParamsUpdate
 
   toSpecRep (ConwayPParams {..}) = do
     ppuA <- toSpecRep cppTxFeePerByte
@@ -563,15 +508,8 @@ instance SpecTranslate (ConwayPParams StrictMaybe era) where
 
     pure Agda.MkPParamsUpdate {..}
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  ) =>
-  SpecTranslate (GovAction era)
-  where
-  type SpecRep (GovAction era) = Agda.GovAction
+instance SpecTranslate ConwayEra (GovAction ConwayEra) where
+  type SpecRep ConwayEra (GovAction ConwayEra) = Agda.GovAction
 
   toSpecRep (ParameterChange _ ppu _) = Agda.ChangePParams <$> toSpecRep ppu
   toSpecRep (HardForkInitiation _ pv) = Agda.TriggerHardFork <$> toSpecRep pv
@@ -590,15 +528,8 @@ instance
       <*> toSpecRep policy
   toSpecRep InfoAction = pure Agda.Info
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  ) =>
-  SpecTranslate (ProposalProcedure era)
-  where
-  type SpecRep (ProposalProcedure era) = Agda.GovProposal
+instance SpecTranslate ConwayEra (ProposalProcedure ConwayEra) where
+  type SpecRep ConwayEra (ProposalProcedure ConwayEra) = Agda.GovProposal
 
   toSpecRep ProposalProcedure {..} =
     Agda.MkGovProposal
@@ -636,15 +567,8 @@ nullifyIfNotNeeded (SJust gaId) = \case
   InfoAction -> nullGovActionId
   _ -> gaId
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  ) =>
-  SpecTranslate (GovActionState era)
-  where
-  type SpecRep (GovActionState era) = Agda.GovActionState
+instance SpecTranslate ConwayEra (GovActionState ConwayEra) where
+  type SpecRep ConwayEra (GovActionState ConwayEra) = Agda.GovActionState
 
   toSpecRep gas@GovActionState {..} = do
     Agda.MkGovActionState
@@ -660,46 +584,36 @@ instance
     where
       action = gasAction gas
 
-instance SpecTranslate GovActionIx where
-  type SpecRep GovActionIx = Integer
+instance SpecTranslate ConwayEra GovActionIx where
+  type SpecRep ConwayEra GovActionIx = Integer
 
   toSpecRep = pure . fromIntegral . unGovActionIx
 
-instance SpecTranslate GovActionId where
-  type SpecRep GovActionId = Agda.GovActionID
+instance SpecTranslate ConwayEra GovActionId where
+  type SpecRep ConwayEra GovActionId = Agda.GovActionID
 
   toSpecRep (GovActionId txId gaIx) = toSpecRepTuple (txId, gaIx)
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  ) =>
-  SpecTranslate (Proposals era)
-  where
-  type SpecRep (Proposals era) = Agda.GovState
+instance SpecTranslate ConwayEra (Proposals ConwayEra) where
+  type SpecRep ConwayEra (Proposals ConwayEra) = Agda.GovState
 
   -- TODO get rid of `prioritySort` once we've changed the implementation so
   -- that the proposals are always sorted
   toSpecRep = toSpecRepOMap . prioritySort . view pPropsL
     where
       prioritySort ::
-        OMap GovActionId (GovActionState era) ->
-        OMap GovActionId (GovActionState era)
+        OMap GovActionId (GovActionState ConwayEra) ->
+        OMap GovActionId (GovActionState ConwayEra)
       prioritySort = Exts.fromList . sortOn (actionPriority . gasAction) . Exts.toList
 
-instance SpecTranslate MaryValue where
-  type SpecRep MaryValue = Agda.Coin
+instance SpecTranslate ConwayEra MaryValue where
+  type SpecRep ConwayEra MaryValue = Agda.Coin
 
   toSpecRep = toSpecRep . coin
 
-instance
-  ConwayEraAccounts era =>
-  SpecTranslate (RatifyEnv era)
-  where
-  type SpecRep (RatifyEnv era) = Agda.RatifyEnv
-  type SpecContext (RatifyEnv era) = Coin
+instance SpecTranslate ConwayEra (RatifyEnv ConwayEra) where
+  type SpecRep ConwayEra (RatifyEnv ConwayEra) = Agda.RatifyEnv
+  type SpecContext ConwayEra (RatifyEnv ConwayEra) = Coin
 
   toSpecRep RatifyEnv {..} = do
     let
@@ -719,20 +633,9 @@ instance
         <*> toSpecRepMap (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) reStakePools)
         <*> toSpecRepMap (Map.mapMaybe (^. dRepDelegationAccountStateL) (reAccounts ^. accountsMapL))
 
-instance
-  ( EraPParams era
-  , SpecRep (PParamsHKD Shelley.Identity era) ~ Agda.PParams
-  , SpecContext (PParamsHKD Shelley.Identity era) ~ ()
-  , SpecTranslate (PParamsHKD Shelley.Identity era)
-  , ToExpr (PParamsHKD StrictMaybe era)
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  ) =>
-  SpecTranslate (RatifyState era)
-  where
-  type SpecRep (RatifyState era) = Agda.RatifyState
-  type SpecContext (RatifyState era) = [GovActionState era]
+instance SpecTranslate ConwayEra (RatifyState ConwayEra) where
+  type SpecRep ConwayEra (RatifyState ConwayEra) = Agda.RatifyState
+  type SpecContext ConwayEra (RatifyState ConwayEra) = [GovActionState ConwayEra]
 
   toSpecRep RatifyState {..} = do
     govActionMap <-
@@ -760,29 +663,15 @@ instance
         <*> (Agda.MkHSSet <$> traverse toSpecRepTuple (toList removed))
         <*> toSpecRep rsDelayed
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  ) =>
-  SpecTranslate (RatifySignal era)
-  where
+instance SpecTranslate ConwayEra (RatifySignal ConwayEra) where
   type
-    SpecRep (RatifySignal era) =
-      [(SpecRep GovActionId, SpecRep (GovActionState era))]
+    SpecRep ConwayEra (RatifySignal ConwayEra) =
+      [(SpecRep ConwayEra GovActionId, SpecRep ConwayEra (GovActionState ConwayEra))]
 
   toSpecRep (RatifySignal x) =
     traverse (\gas@GovActionState {gasId} -> toSpecRepTuple (gasId, gas)) (toList x)
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  ) =>
-  SpecTranslate (Conway.EnactSignal era)
-  where
-  type SpecRep (Conway.EnactSignal era) = SpecRep (GovAction era)
+instance SpecTranslate ConwayEra (Conway.EnactSignal ConwayEra) where
+  type SpecRep ConwayEra (Conway.EnactSignal ConwayEra) = SpecRep ConwayEra (GovAction ConwayEra)
 
   toSpecRep (Conway.EnactSignal _ ga) = toSpecRep ga

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -631,7 +631,7 @@ instance SpecTranslate ConwayEra (RatifyEnv ConwayEra) where
         <*> toSpecRep reCommitteeState
         <*> toSpecRep treasury
         <*> toSpecRepMap (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) reStakePools)
-        <*> toSpecRepMap (Map.mapMaybe (^. dRepDelegationAccountStateL) (reAccounts ^. accountsMapL))
+        <*> toSpecRepMap (Map.mapMaybe (view dRepDelegationAccountStateL) (reAccounts ^. accountsMapL))
 
 instance SpecTranslate ConwayEra (RatifyState ConwayEra) where
   type SpecRep ConwayEra (RatifyState ConwayEra) = Agda.RatifyState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -675,3 +675,86 @@ instance SpecTranslate ConwayEra (Conway.EnactSignal ConwayEra) where
   type SpecRep ConwayEra (Conway.EnactSignal ConwayEra) = SpecRep ConwayEra (GovAction ConwayEra)
 
   toSpecRep (Conway.EnactSignal _ ga) = toSpecRep ga
+
+instance SpecNormalize TxId where
+  specNormalize = id
+
+instance SpecNormalize Agda.Timelock
+
+instance SpecNormalize Agda.HSTimelock
+
+instance SpecNormalize Agda.LanguageCostModels where
+  specNormalize = Agda.MkLanguageCostModels . sortOn fst . Agda.lcmLanguageCostModels
+
+instance SpecNormalize Agda.HSLanguage
+
+instance SpecNormalize Agda.HSPlutusScript
+
+instance SpecNormalize Agda.UTxOState
+
+instance SpecNormalize Agda.GovRole
+
+instance SpecNormalize Agda.GovVotes
+
+instance SpecNormalize Agda.VDeleg
+
+instance SpecNormalize Agda.DepositPurpose
+
+instance SpecNormalize Agda.DState
+
+instance SpecNormalize Agda.StakePoolParams
+
+instance SpecNormalize Agda.PState
+
+instance SpecNormalize Agda.GState
+
+instance SpecNormalize Agda.CertState
+
+instance SpecNormalize Agda.Vote
+
+instance SpecNormalize Agda.PParamsUpdate
+
+instance SpecNormalize Agda.RewardAddress
+
+instance SpecNormalize Agda.GovAction
+
+instance SpecNormalize Agda.GovActionState
+
+instance SpecNormalize Agda.StakeDistrs
+
+instance SpecNormalize Agda.PoolThresholds
+
+instance SpecNormalize Agda.DrepThresholds
+
+instance SpecNormalize Agda.PParams
+
+instance SpecNormalize Agda.EnactState
+
+instance SpecNormalize Agda.RatifyEnv
+
+instance SpecNormalize Agda.RatifyState
+
+instance SpecNormalize Agda.EpochState
+
+instance SpecNormalize Agda.Snapshots
+
+instance SpecNormalize Agda.Snapshot where
+  specNormalize (Agda.MkSnapshot s d p) =
+    Agda.MkSnapshot (specNormalize s') (specNormalize d') p
+    where
+      s' = removeZero s
+      -- Only keep delegations for credentials that have non-zero stake,
+      -- since ActiveStake drops zero-stake credentials
+      d' = keepOnlyStaked s' (removeZero d)
+      removeZero (Agda.MkHSMap l) = Agda.MkHSMap $ filter ((/= 0) . snd) l
+      keepOnlyStaked (Agda.MkHSMap sl) (Agda.MkHSMap dl) =
+        let stakeKeys = Set.fromList (map fst sl)
+         in Agda.MkHSMap $ filter ((`Set.member` stakeKeys) . fst) dl
+
+instance SpecNormalize Agda.Acnt
+
+instance SpecNormalize Agda.LState
+
+instance SpecNormalize Agda.HsRewardUpdate
+
+instance SpecNormalize Agda.NewEpochState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Base.hs
@@ -71,7 +71,7 @@ import Data.Traversable (forM)
 import qualified GHC.Exts as Exts
 import Lens.Micro
 import Lens.Micro.Extras (view)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.Orphans ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Core (committeeCredentialToStrictMaybe)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -32,7 +32,7 @@ import qualified Data.OMap.Strict as OMap
 import qualified Data.VMap as VMap
 import Lens.Micro
 import Lens.Micro.Extras (view)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -16,6 +16,7 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert () where
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible (Compactible (..))
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import qualified Cardano.Ledger.Conway.Rules as Conway
@@ -25,7 +26,6 @@ import Cardano.Ledger.Rewards (rewardAmount)
 import Cardano.Ledger.Shelley.LedgerState
 import Data.Foldable (Foldable (..))
 import qualified Data.Foldable as Set
-import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map, keysSet)
 import qualified Data.Map.Strict as Map
 import qualified Data.OMap.Strict as OMap
@@ -37,18 +37,13 @@ import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
-import Test.Cardano.Ledger.Conway.TreeDiff
 import Test.Cardano.Ledger.Shelley.Utils (runShelleyBase)
 
-instance
-  ( SpecTranslate (PParamsHKD Identity era)
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecContext (PParamsHKD Identity era) ~ ()
-  ) =>
-  SpecTranslate (Conway.CertEnv era)
-  where
-  type SpecRep (Conway.CertEnv era) = Agda.CertEnv
-  type SpecContext (Conway.CertEnv era) = (VotingProcedures era, Map AccountAddress Coin)
+instance SpecTranslate ConwayEra (Conway.CertEnv ConwayEra) where
+  type SpecRep ConwayEra (Conway.CertEnv ConwayEra) = Agda.CertEnv
+  type
+    SpecContext ConwayEra (Conway.CertEnv ConwayEra) =
+      (VotingProcedures ConwayEra, Map AccountAddress Coin)
   toSpecRep Conway.CertEnv {..} = do
     (votes, withdrawals) <- askSpecTransM
     let ccColdCreds = foldMap (keysSet . committeeMembers) ceCurrentCommittee
@@ -60,26 +55,25 @@ instance
         <*> toSpecRepMap withdrawals
         <*> toSpecRep ccColdCreds
 
-instance ConwayEraAccounts era => SpecTranslate (ConwayCertState era) where
-  type SpecRep (ConwayCertState era) = Agda.CertState
+instance SpecTranslate ConwayEra (ConwayCertState ConwayEra) where
+  type SpecRep ConwayEra (ConwayCertState ConwayEra) = Agda.CertState
   toSpecRep ConwayCertState {..} =
     Agda.MkCertState
       <$> toSpecRep conwayCertDState
       <*> toSpecRep conwayCertPState
       <*> toSpecRep conwayCertVState
 
-instance Era era => SpecTranslate (ConwayTxCert era) where
-  type SpecRep (ConwayTxCert era) = Agda.DCert
+instance SpecTranslate ConwayEra (ConwayTxCert ConwayEra) where
+  type SpecRep ConwayEra (ConwayTxCert ConwayEra) = Agda.DCert
 
   toSpecRep (ConwayTxCertPool p) = toSpecRep p
   toSpecRep (ConwayTxCertGov c) = toSpecRep c
   toSpecRep (ConwayTxCertDeleg x) = toSpecRep x
 
 depositsMap ::
-  ConwayEraCertState era =>
-  CertState era ->
-  Proposals era ->
-  SpecTransM () (Agda.HSMap Agda.DepositPurpose Integer)
+  CertState ConwayEra ->
+  Proposals ConwayEra ->
+  SpecTransM ConwayEra () (Agda.HSMap Agda.DepositPurpose Integer)
 depositsMap certState props =
   unionsHSMap
     <$> sequence
@@ -89,7 +83,7 @@ depositsMap certState props =
           (Agda.MkHSMap . Map.toList $ certState ^. certDStateL . accountsL . accountsMapL)
       , bimapMHSMap
           (fmap Agda.PoolDeposit . toSpecRep)
-          toSpecRep
+          (toSpecRep)
           (Agda.MkHSMap . Map.toList $ fromCompact . spsDeposit <$> certState ^. certPStateL . psStakePoolsL)
       , bimapMHSMap
           (fmap Agda.DRepDeposit . toSpecRep)
@@ -101,17 +95,9 @@ depositsMap certState props =
           (Agda.MkHSMap . OMap.assocList $ props ^. pPropsL)
       ]
 
-instance
-  ( SpecTranslate (TxOut era)
-  , SpecRep (TxOut era) ~ Agda.TxOut
-  , SpecContext (TxOut era) ~ ()
-  , GovState era ~ ConwayGovState era
-  , ConwayEraCertState era
-  ) =>
-  SpecTranslate (UTxOState era)
-  where
-  type SpecRep (UTxOState era) = Agda.UTxOState
-  type SpecContext (UTxOState era) = CertState era
+instance SpecTranslate ConwayEra (UTxOState ConwayEra) where
+  type SpecRep ConwayEra (UTxOState ConwayEra) = Agda.UTxOState
+  type SpecContext ConwayEra (UTxOState ConwayEra) = CertState ConwayEra
 
   toSpecRep UTxOState {..} = do
     certState <- askSpecTransM
@@ -125,24 +111,8 @@ instance
         <*> deposits
         <*> toSpecRep utxosDonation
 
-instance
-  ( ConwayEraGov era
-  , EraPParams era
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , SpecTranslate (TxOut era)
-  , SpecRep (TxOut era) ~ Agda.TxOut
-  , SpecContext (TxOut era) ~ ()
-  , GovState era ~ ConwayGovState era
-  , SpecRep (CertState era) ~ Agda.CertState
-  , ConwayEraCertState era
-  , CertState era ~ ConwayCertState era
-  ) =>
-  SpecTranslate (LedgerState era)
-  where
-  type SpecRep (LedgerState era) = Agda.LState
+instance SpecTranslate ConwayEra (LedgerState ConwayEra) where
+  type SpecRep ConwayEra (LedgerState ConwayEra) = Agda.LState
 
   toSpecRep (LedgerState {..}) =
     Agda.MkLState
@@ -152,27 +122,8 @@ instance
     where
       props = utxosGovState lsUTxOState ^. proposalsGovStateL
 
-instance
-  ( EraPParams era
-  , ConwayEraGov era
-  , SpecTranslate (PParamsHKD Identity era)
-  , SpecContext (PParamsHKD Identity era) ~ ()
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , ToExpr (PParamsHKD StrictMaybe era)
-  , SpecTranslate (TxOut era)
-  , SpecRep (TxOut era) ~ Agda.TxOut
-  , SpecContext (TxOut era) ~ ()
-  , GovState era ~ ConwayGovState era
-  , SpecRep (CertState era) ~ Agda.CertState
-  , ConwayEraCertState era
-  , CertState era ~ ConwayCertState era
-  ) =>
-  SpecTranslate (EpochState era)
-  where
-  type SpecRep (EpochState era) = Agda.EpochState
+instance SpecTranslate ConwayEra (EpochState ConwayEra) where
+  type SpecRep ConwayEra (EpochState ConwayEra) = Agda.EpochState
 
   toSpecRep (EpochState {esLState = esLState@LedgerState {lsUTxOState}, ..}) =
     Agda.MkEpochState
@@ -186,8 +137,8 @@ instance
       ratifyState = getRatifyState $ utxosGovState lsUTxOState
       govActions = toList $ lsUTxOState ^. utxosGovStateL . proposalsGovStateL . pPropsL
 
-instance SpecTranslate SnapShots where
-  type SpecRep SnapShots = Agda.Snapshots
+instance SpecTranslate ConwayEra SnapShots where
+  type SpecRep ConwayEra SnapShots = Agda.Snapshots
 
   toSpecRep (SnapShots {..}) =
     Agda.MkSnapshots
@@ -196,8 +147,8 @@ instance SpecTranslate SnapShots where
       <*> toSpecRep ssStakeGo
       <*> toSpecRep ssFee
 
-instance SpecTranslate SnapShot where
-  type SpecRep SnapShot = Agda.Snapshot
+instance SpecTranslate ConwayEra SnapShot where
+  type SpecRep ConwayEra SnapShot = Agda.Snapshot
 
   toSpecRep (SnapShot {..}) =
     Agda.MkSnapshot
@@ -207,8 +158,8 @@ instance SpecTranslate SnapShot where
     where
       activeStakeMap = VMap.toMap $ unActiveStake ssActiveStake
 
-instance SpecTranslate StakePoolSnapShot where
-  type SpecRep StakePoolSnapShot = Agda.StakePoolParams
+instance SpecTranslate ConwayEra StakePoolSnapShot where
+  type SpecRep ConwayEra StakePoolSnapShot = Agda.StakePoolParams
 
   toSpecRep StakePoolSnapShot {..} =
     Agda.StakePoolParams
@@ -218,26 +169,26 @@ instance SpecTranslate StakePoolSnapShot where
       <*> toSpecRep spssPledge
       <*> toSpecRep (unAccountId spssAccountId)
 
-instance SpecTranslate Stake where
-  type SpecRep Stake = Agda.HSMap Agda.Credential Agda.Coin
+instance SpecTranslate ConwayEra Stake where
+  type SpecRep ConwayEra Stake = Agda.HSMap Agda.Credential Agda.Coin
 
   toSpecRep (Stake stake) = toSpecRepMap $ VMap.toMap stake
 
-instance SpecTranslate ChainAccountState where
-  type SpecRep ChainAccountState = Agda.Acnt
+instance SpecTranslate ConwayEra ChainAccountState where
+  type SpecRep ConwayEra ChainAccountState = Agda.Acnt
 
   toSpecRep (ChainAccountState {..}) =
     Agda.MkAcnt
       <$> toSpecRep casTreasury
       <*> toSpecRep casReserves
 
-instance SpecTranslate DeltaCoin where
-  type SpecRep DeltaCoin = Integer
+instance SpecTranslate ConwayEra DeltaCoin where
+  type SpecRep ConwayEra DeltaCoin = Integer
 
   toSpecRep (DeltaCoin x) = pure x
 
-instance SpecTranslate PulsingRewUpdate where
-  type SpecRep PulsingRewUpdate = Agda.HsRewardUpdate
+instance SpecTranslate ConwayEra PulsingRewUpdate where
+  type SpecRep ConwayEra PulsingRewUpdate = Agda.HsRewardUpdate
 
   toSpecRep x =
     Agda.MkRewardUpdate
@@ -249,27 +200,8 @@ instance SpecTranslate PulsingRewUpdate where
       (RewardUpdate {..}, _) = runShelleyBase $ completeRupd x
       rwds = Set.foldMap rewardAmount <$> rs
 
-instance
-  ( EraPParams era
-  , ConwayEraGov era
-  , SpecTranslate (PParamsHKD Identity era)
-  , SpecContext (PParamsHKD Identity era) ~ ()
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  , ToExpr (PParamsHKD StrictMaybe era)
-  , SpecTranslate (TxOut era)
-  , SpecRep (TxOut era) ~ Agda.TxOut
-  , SpecContext (TxOut era) ~ ()
-  , GovState era ~ ConwayGovState era
-  , SpecRep (CertState era) ~ Agda.CertState
-  , ConwayEraCertState era
-  , CertState era ~ ConwayCertState era
-  ) =>
-  SpecTranslate (NewEpochState era)
-  where
-  type SpecRep (NewEpochState era) = Agda.NewEpochState
+instance SpecTranslate ConwayEra (NewEpochState ConwayEra) where
+  type SpecRep ConwayEra (NewEpochState ConwayEra) = Agda.NewEpochState
 
   toSpecRep (NewEpochState {..}) =
     Agda.MkNewEpochState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Cert.hs
@@ -5,9 +5,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -33,10 +31,20 @@ import qualified Data.VMap as VMap
 import Lens.Micro
 import Lens.Micro.Extras (view)
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTransM,
+  SpecTranslate (..),
+  askSpecTransM,
+  toSpecRepMap,
+  withCtxSpecTransM,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
+import Test.Cardano.Ledger.Conformance.Utils (
+  bimapMHSMap,
+  unionsHSMap,
+ )
 import Test.Cardano.Ledger.Shelley.Utils (runShelleyBase)
 
 instance SpecTranslate ConwayEra (Conway.CertEnv ConwayEra) where
@@ -83,7 +91,7 @@ depositsMap certState props =
           (Agda.MkHSMap . Map.toList $ certState ^. certDStateL . accountsL . accountsMapL)
       , bimapMHSMap
           (fmap Agda.PoolDeposit . toSpecRep)
-          (toSpecRep)
+          toSpecRep
           (Agda.MkHSMap . Map.toList $ fromCompact . spsDeposit <$> certState ^. certPStateL . psStakePoolsL)
       , bimapMHSMap
           (fmap Agda.DRepDeposit . toSpecRep)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -13,10 +13,10 @@
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Certs () where
 
 import Cardano.Ledger.Coin
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import qualified Cardano.Ledger.Conway.Rules as Conway
-import Data.Functor.Identity (Identity)
 import Data.Map (keysSet)
 import Data.Map.Strict (Map)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
@@ -24,15 +24,11 @@ import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 
-instance
-  ( SpecTranslate (PParamsHKD Identity era)
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecContext (PParamsHKD Identity era) ~ ()
-  ) =>
-  SpecTranslate (Conway.CertsEnv era)
-  where
-  type SpecRep (Conway.CertsEnv era) = Agda.CertEnv
-  type SpecContext (Conway.CertsEnv era) = (VotingProcedures era, Map AccountAddress Coin)
+instance SpecTranslate ConwayEra (Conway.CertsEnv ConwayEra) where
+  type SpecRep ConwayEra (Conway.CertsEnv ConwayEra) = Agda.CertEnv
+  type
+    SpecContext ConwayEra (Conway.CertsEnv ConwayEra) =
+      (VotingProcedures ConwayEra, Map AccountAddress Coin)
   toSpecRep Conway.CertsEnv {..} = do
     (votes, withdrawals) <- askSpecTransM
     let ccColdCreds = foldMap (keysSet . committeeMembers) certsCurrentCommittee

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -4,9 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -20,7 +18,12 @@ import qualified Cardano.Ledger.Conway.Rules as Conway
 import Data.Map (keysSet)
 import Data.Map.Strict (Map)
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (..),
+  askSpecTransM,
+  toSpecRepMap,
+  withCtxSpecTransM,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Certs.hs
@@ -19,7 +19,7 @@ import Cardano.Ledger.Conway.Governance
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Data.Map (keysSet)
 import Data.Map.Strict (Map)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -14,6 +14,7 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Deleg () where
 
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Compactible (fromCompact)
+import Cardano.Ledger.Conway (ConwayEra)
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Conway.TxCert (
@@ -23,7 +24,6 @@ import Cardano.Ledger.Conway.TxCert (
  )
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
-import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Lens.Micro
@@ -34,15 +34,9 @@ import Test.Cardano.Ledger.Conformance (
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
-instance
-  ( SpecRep (PParamsHKD Shelley.Identity era) ~ Agda.PParams
-  , SpecTranslate (PParamsHKD Shelley.Identity era)
-  , SpecContext (PParamsHKD Shelley.Identity era) ~ ()
-  ) =>
-  SpecTranslate (Conway.ConwayDelegEnv era)
-  where
-  type SpecRep (Conway.ConwayDelegEnv era) = Agda.DelegEnv
-  type SpecContext (Conway.ConwayDelegEnv era) = Set (Credential DRepRole)
+instance SpecTranslate ConwayEra (Conway.ConwayDelegEnv ConwayEra) where
+  type SpecRep ConwayEra (Conway.ConwayDelegEnv ConwayEra) = Agda.DelegEnv
+  type SpecContext ConwayEra (Conway.ConwayDelegEnv ConwayEra) = Set (Credential DRepRole)
 
   toSpecRep Conway.ConwayDelegEnv {..} = do
     delegatees <- askSpecTransM
@@ -56,8 +50,8 @@ instance
             )
         <*> toSpecRep delegatees
 
-instance SpecTranslate ConwayDelegCert where
-  type SpecRep ConwayDelegCert = Agda.DCert
+instance SpecTranslate ConwayEra ConwayDelegCert where
+  type SpecRep ConwayEra ConwayDelegCert = Agda.DCert
 
   toSpecRep (ConwayRegCert c d) =
     Agda.Reg
@@ -80,8 +74,8 @@ instance SpecTranslate ConwayDelegCert where
       <*> toSpecRep (hashToInteger . unKeyHash <$> getStakePoolDelegatee d)
       <*> toSpecRep c
 
-instance ConwayEraAccounts era => SpecTranslate (DState era) where
-  type SpecRep (DState era) = Agda.DState
+instance SpecTranslate ConwayEra (DState ConwayEra) where
+  type SpecRep ConwayEra (DState ConwayEra) = Agda.DState
 
   toSpecRep dState =
     Agda.MkDState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Credential (Credential)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Lens.Micro
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   hashToInteger,
  )

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Deleg.hs
@@ -27,6 +27,7 @@ import Cardano.Ledger.Credential (Credential)
 import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Lens.Micro
+import Lens.Micro.Extras (view)
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   hashToInteger,
@@ -79,15 +80,15 @@ instance SpecTranslate ConwayEra (DState ConwayEra) where
 
   toSpecRep dState =
     Agda.MkDState
-      <$> toSpecRepMap (Map.mapMaybe (^. dRepDelegationAccountStateL) accountsMap)
-      <*> toSpecRepMap (Map.mapMaybe (^. stakePoolDelegationAccountStateL) accountsMap)
-      <*> toSpecRepMap (Map.map (fromCompact . (^. balanceAccountStateL)) accountsMap)
+      <$> toSpecRepMap (Map.mapMaybe (view dRepDelegationAccountStateL) accountsMap)
+      <*> toSpecRepMap (Map.mapMaybe (view stakePoolDelegationAccountStateL) accountsMap)
+      <*> toSpecRepMap (Map.map (fromCompact . (view balanceAccountStateL)) accountsMap)
       <*> deposits
     where
       accountsMap = dState ^. accountsL . accountsMapL
       deposits = do
         let
-          m = Map.map (fromCompact . (^. depositAccountStateL)) accountsMap
+          m = Map.map (fromCompact . (view depositAccountStateL)) accountsMap
           transEntry (cred, val) =
             (,)
               <$> (Agda.CredentialDeposit <$> toSpecRep cred)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
@@ -5,40 +5,25 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Gov () where
 
-import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Conway.Core
-import Cardano.Ledger.Conway.Governance
+import Cardano.Ledger.Conway (ConwayEra)
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.State
-import Data.Functor.Identity (Identity)
 import qualified Data.Map.Strict as Map
 import Lens.Micro ((^.))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 
-instance
-  ( SpecTranslate (PParamsHKD Identity era)
-  , SpecContext (PParamsHKD Identity era) ~ ()
-  , EraPParams era
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecTranslate (CertState era)
-  , SpecContext (CertState era) ~ ()
-  , SpecRep (CertState era) ~ Agda.CertState
-  , EraCertState era
-  ) =>
-  SpecTranslate (Conway.GovEnv era)
-  where
-  type SpecRep (Conway.GovEnv era) = Agda.GovEnv
-  type SpecContext (Conway.GovEnv era) = EnactState era
+instance SpecTranslate ConwayEra (Conway.GovEnv ConwayEra) where
+  type SpecRep ConwayEra (Conway.GovEnv ConwayEra) = Agda.GovEnv
+  type SpecContext ConwayEra (Conway.GovEnv ConwayEra) = Conway.EnactState ConwayEra
 
   toSpecRep Conway.GovEnv {..} = do
     enactState <- askSpecTransM
@@ -53,15 +38,8 @@ instance
         <*> toSpecRep geCertState
         <*> toSpecRep rewardAccounts
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD StrictMaybe era)
-  , SpecContext (PParamsHKD StrictMaybe era) ~ ()
-  , SpecRep (PParamsHKD StrictMaybe era) ~ Agda.PParamsUpdate
-  ) =>
-  SpecTranslate (Conway.GovSignal era)
-  where
-  type SpecRep (Conway.GovSignal era) = [Either Agda.GovVote Agda.GovProposal]
+instance SpecTranslate ConwayEra (Conway.GovSignal ConwayEra) where
+  type SpecRep ConwayEra (Conway.GovSignal ConwayEra) = [Either Agda.GovVote Agda.GovProposal]
 
   toSpecRep Conway.GovSignal {gsVotingProcedures, gsProposalProcedures} = do
     votingProcedures <- toSpecRep gsVotingProcedures

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Gov.hs
@@ -16,7 +16,7 @@ import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.State
 import qualified Data.Map.Strict as Map
 import Lens.Micro ((^.))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -14,6 +14,7 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.GovCert () where
 
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import qualified Cardano.Ledger.Conway.Rules as Conway
@@ -21,7 +22,6 @@ import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Conway.TxCert (ConwayGovCert (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Data.Default (Default (..))
-import Data.Functor.Identity (Identity)
 import Data.Map.Strict (Map, keysSet)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
@@ -29,8 +29,8 @@ import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 
-instance SpecTranslate ConwayGovCert where
-  type SpecRep ConwayGovCert = Agda.DCert
+instance SpecTranslate ConwayEra ConwayGovCert where
+  type SpecRep ConwayEra ConwayGovCert = Agda.DCert
 
   toSpecRep (ConwayRegDRep c d a) =
     Agda.Regdrep
@@ -55,15 +55,11 @@ instance SpecTranslate ConwayGovCert where
       <$> toSpecRep c
       <*> toSpecRep (SNothing @(Credential _))
 
-instance
-  ( SpecTranslate (PParamsHKD Identity era)
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  , SpecContext (PParamsHKD Identity era) ~ ()
-  ) =>
-  SpecTranslate (Conway.ConwayGovCertEnv era)
-  where
-  type SpecRep (Conway.ConwayGovCertEnv era) = Agda.CertEnv
-  type SpecContext (Conway.ConwayGovCertEnv era) = (VotingProcedures era, Map AccountAddress Coin)
+instance SpecTranslate ConwayEra (Conway.ConwayGovCertEnv ConwayEra) where
+  type SpecRep ConwayEra (Conway.ConwayGovCertEnv ConwayEra) = Agda.CertEnv
+  type
+    SpecContext ConwayEra (Conway.ConwayGovCertEnv ConwayEra) =
+      (VotingProcedures ConwayEra, Map AccountAddress Coin)
 
   toSpecRep Conway.ConwayGovCertEnv {..} = do
     (votes, withdrawals) <- askSpecTransM
@@ -84,8 +80,8 @@ instance
         <*> toSpecRepMap withdrawals
         <*> toSpecRep ccColdCreds
 
-instance SpecTranslate (VState era) where
-  type SpecRep (VState era) = Agda.GState
+instance SpecTranslate ConwayEra (VState ConwayEra) where
+  type SpecRep ConwayEra (VState ConwayEra) = Agda.GState
 
   toSpecRep VState {..} = do
     Agda.MkGState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/GovCert.hs
@@ -25,7 +25,7 @@ import Data.Default (Default (..))
 import Data.Map.Strict (Map, keysSet)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
@@ -21,7 +21,6 @@ import Cardano.Ledger.Conway.Core (
   AlonzoEraTxBody (..),
   BabbageEraTxBody (..),
   ConwayEraTxBody (..),
-  EraPParams (..),
   EraTx (..),
   EraTxBody (..),
   ScriptHash,
@@ -33,7 +32,6 @@ import qualified Cardano.Ledger.Conway.Rules as Conway
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.State (ChainAccountState (..))
 import Cardano.Ledger.TxIn (TxId)
-import Data.Functor.Identity (Identity)
 import Data.Maybe.Strict (StrictMaybe)
 import Lens.Micro ((^.))
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
@@ -43,16 +41,11 @@ import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD Identity era)
-  , SpecContext (PParamsHKD Identity era) ~ ()
-  , SpecRep (PParamsHKD Identity era) ~ Agda.PParams
-  ) =>
-  SpecTranslate (Shelley.LedgerEnv era)
-  where
-  type SpecRep (Shelley.LedgerEnv era) = Agda.LEnv
-  type SpecContext (Shelley.LedgerEnv era) = (StrictMaybe ScriptHash, Conway.EnactState era)
+instance SpecTranslate ConwayEra (Shelley.LedgerEnv ConwayEra) where
+  type SpecRep ConwayEra (Shelley.LedgerEnv ConwayEra) = Agda.LEnv
+  type
+    SpecContext ConwayEra (Shelley.LedgerEnv ConwayEra) =
+      (StrictMaybe ScriptHash, Conway.EnactState ConwayEra)
 
   toSpecRep Shelley.LedgerEnv {..} = do
     (policyHash, enactState) <- askSpecTransM
@@ -64,9 +57,9 @@ instance
         <*> toSpecRep enactState
         <*> toSpecRep (casTreasury ledgerAccount)
 
-instance SpecTranslate (TxBody TopTx ConwayEra) where
-  type SpecRep (TxBody TopTx ConwayEra) = Agda.TxBody
-  type SpecContext (TxBody TopTx ConwayEra) = TxId
+instance SpecTranslate ConwayEra (TxBody TopTx ConwayEra) where
+  type SpecRep ConwayEra (TxBody TopTx ConwayEra) = Agda.TxBody
+  type SpecContext ConwayEra (TxBody TopTx ConwayEra) = TxId
 
   toSpecRep txb = do
     txId <- askSpecTransM
@@ -98,8 +91,8 @@ instance SpecTranslate (TxBody TopTx ConwayEra) where
         -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1086
         <*> fmap (fmap (const 0)) (toSpecRep (txb ^. scriptIntegrityHashTxBodyL))
 
-instance SpecTranslate (Tx TopTx ConwayEra) where
-  type SpecRep (Tx TopTx ConwayEra) = Agda.Tx
+instance SpecTranslate ConwayEra (Tx TopTx ConwayEra) where
+  type SpecRep ConwayEra (Tx TopTx ConwayEra) = Agda.Tx
 
   toSpecRep tx =
     Agda.MkTx
@@ -109,7 +102,7 @@ instance SpecTranslate (Tx TopTx ConwayEra) where
       <*> toSpecRep (tx ^. isValidTxL)
       <*> toSpecRep (tx ^. auxDataTxL)
 
-instance SpecTranslate (AlonzoStAnnTx TopTx ConwayEra) where
-  type SpecRep (AlonzoStAnnTx TopTx ConwayEra) = Agda.Tx
+instance SpecTranslate ConwayEra (AlonzoStAnnTx TopTx ConwayEra) where
+  type SpecRep ConwayEra (AlonzoStAnnTx TopTx ConwayEra) = Agda.Tx
 
   toSpecRep stAnnTx = toSpecRep (stAnnTx ^. txStAnnTxG)

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledger.hs
@@ -34,7 +34,7 @@ import Cardano.Ledger.Shelley.State (ChainAccountState (..))
 import Cardano.Ledger.TxIn (TxId)
 import Data.Maybe.Strict (StrictMaybe)
 import Lens.Micro ((^.))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (askSpecTransM, withCtxSpecTransM)
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (
   SpecTranslate (..),

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
@@ -12,7 +12,7 @@
 
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Ledgers () where
 
-import Cardano.Ledger.Conway.Core (EraPParams (..))
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (Constitution (..), EnactState (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.State (ChainAccountState (..))
@@ -24,16 +24,9 @@ import Test.Cardano.Ledger.Conformance (
  )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
-instance
-  ( EraPParams era
-  , SpecTranslate (PParamsHKD Shelley.Identity era)
-  , SpecContext (PParamsHKD Shelley.Identity era) ~ ()
-  , SpecRep (PParamsHKD Shelley.Identity era) ~ Agda.PParams
-  ) =>
-  SpecTranslate (Shelley.ShelleyLedgersEnv era)
-  where
-  type SpecRep (Shelley.ShelleyLedgersEnv era) = Agda.LEnv
-  type SpecContext (Shelley.ShelleyLedgersEnv era) = EnactState era
+instance SpecTranslate ConwayEra (Shelley.ShelleyLedgersEnv ConwayEra) where
+  type SpecRep ConwayEra (Shelley.ShelleyLedgersEnv ConwayEra) = Agda.LEnv
+  type SpecContext ConwayEra (Shelley.ShelleyLedgersEnv ConwayEra) = EnactState ConwayEra
 
   toSpecRep Shelley.LedgersEnv {..} = do
     enactState <- askSpecTransM

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Ledgers.hs
@@ -16,7 +16,7 @@ import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (Constitution (..), EnactState (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.State (ChainAccountState (..))
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance (
   SpecTranslate (..),
   askSpecTransM,

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -17,7 +17,7 @@ import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.State
 import qualified Data.Map.Strict as Map
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -10,6 +12,7 @@
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool where
 
 import Cardano.Ledger.BaseTypes (Network (Testnet))
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.State
@@ -18,19 +21,13 @@ import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
-instance
-  ( SpecRep (PParamsHKD Shelley.Identity era) ~ Agda.PParams
-  , SpecTranslate (PParamsHKD Shelley.Identity era)
-  , SpecContext (PParamsHKD Shelley.Identity era) ~ ()
-  ) =>
-  SpecTranslate (Shelley.PoolEnv era)
-  where
-  type SpecRep (Shelley.PoolEnv era) = Agda.PParams
+instance SpecTranslate ConwayEra (Shelley.PoolEnv ConwayEra) where
+  type SpecRep ConwayEra (Shelley.PoolEnv ConwayEra) = Agda.PParams
 
   toSpecRep (Shelley.PoolEnv _ pp) = toSpecRep pp
 
-instance SpecTranslate (PState era) where
-  type SpecRep (PState era) = Agda.PState
+instance SpecTranslate ConwayEra (PState ConwayEra) where
+  type SpecRep ConwayEra (PState ConwayEra) = Agda.PState
 
   toSpecRep PState {..} =
     Agda.MkPState
@@ -38,8 +35,8 @@ instance SpecTranslate (PState era) where
       <*> toSpecRepMap psFutureStakePoolParams
       <*> toSpecRepMap psRetiring
 
-instance SpecTranslate PoolCert where
-  type SpecRep PoolCert = Agda.DCert
+instance SpecTranslate ConwayEra PoolCert where
+  type SpecRep ConwayEra PoolCert = Agda.DCert
 
   toSpecRep (RegPool p@StakePoolParams {sppId = KeyHash ppHash}) =
     Agda.Regpool

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -3,9 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -18,7 +16,10 @@ import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.State
 import qualified Data.Map.Strict as Map
 import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
-import Test.Cardano.Ledger.Conformance
+import Test.Cardano.Ledger.Conformance.SpecTranslate.Base (
+  SpecTranslate (SpecRep, toSpecRep),
+  toSpecRepMap,
+ )
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base ()
 
 instance SpecTranslate ConwayEra (Shelley.PoolEnv ConwayEra) where

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxo.hs
@@ -15,7 +15,7 @@ module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Utxo () where
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Conway.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (SpecTranslate (..))
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxo.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Utxo.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -11,21 +13,14 @@
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Utxo () where
 
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway.Core (EraPParams (..), PParams)
+import Cardano.Ledger.Conway (ConwayEra)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import Data.Functor.Identity (Identity)
 import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Base (SpecTranslate (..))
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Cert ()
 
-instance
-  ( SpecRep (PParams era) ~ Agda.PParams
-  , SpecTranslate (PParamsHKD Identity era)
-  , SpecContext (PParamsHKD Identity era) ~ ()
-  ) =>
-  SpecTranslate (Shelley.UtxoEnv era)
-  where
-  type SpecRep (Shelley.UtxoEnv era) = Agda.UTxOEnv
+instance SpecTranslate ConwayEra (Shelley.UtxoEnv ConwayEra) where
+  type SpecRep ConwayEra (Shelley.UtxoEnv ConwayEra) = Agda.UTxOEnv
 
   toSpecRep x =
     Agda.MkUTxOEnv

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -62,7 +62,7 @@ import Data.Functor.Identity (Identity (..))
 import qualified Data.Map as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import GHC.Natural (naturalToInteger)
-import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
+import qualified MAlonzo.Code.Ledger.Core.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.Utils
 

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -7,10 +7,8 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -229,3 +227,9 @@ instance SpecTranslate era BlocksMade where
       k' <- toSpecRep k
       pure (k', naturalToInteger v)
     pure $ Agda.MkHSMap xs
+
+instance SpecNormalize Agda.BaseAddr
+
+instance SpecNormalize Agda.BootstrapAddr
+
+instance SpecNormalize Agda.Credential

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Core.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -65,95 +66,95 @@ import qualified MAlonzo.Code.Ledger.Foreign.API as Agda
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
 import Test.Cardano.Ledger.Conformance.Utils
 
-instance SpecTranslate TxIx where
-  type SpecRep TxIx = Integer
+instance SpecTranslate era TxIx where
+  type SpecRep era TxIx = Integer
 
   toSpecRep (TxIx x) = pure $ toInteger x
 
-instance SpecTranslate StakeReference where
-  type SpecRep StakeReference = Maybe Agda.Credential
+instance SpecTranslate era StakeReference where
+  type SpecRep era StakeReference = Maybe Agda.Credential
 
   toSpecRep (StakeRefBase c) = Just <$> toSpecRep c
   toSpecRep (StakeRefPtr _) = pure Nothing
   toSpecRep StakeRefNull = pure Nothing
 
-instance SpecTranslate BootstrapAddress where
-  type SpecRep BootstrapAddress = Agda.BootstrapAddr
+instance SpecTranslate era BootstrapAddress where
+  type SpecRep era BootstrapAddress = Agda.BootstrapAddr
 
   toSpecRep _ = throwError "Cannot translate bootstrap addresses"
 
-instance SpecTranslate Addr where
-  type SpecRep Addr = Agda.Addr
+instance SpecTranslate era Addr where
+  type SpecRep era Addr = Agda.Addr
 
   toSpecRep (Addr nw pc sr) =
     Left
       <$> (Agda.BaseAddr <$> toSpecRep nw <*> toSpecRep pc <*> toSpecRep sr)
   toSpecRep (AddrBootstrap ba) = Right <$> toSpecRep ba
 
-instance SpecTranslate (Hash a b) where
-  type SpecRep (Hash a b) = Integer
+instance SpecTranslate era (Hash a b) where
+  type SpecRep era (Hash a b) = Integer
 
   toSpecRep = pure . hashToInteger
 
-instance SpecTranslate ScriptHash where
-  type SpecRep ScriptHash = Integer
+instance SpecTranslate era ScriptHash where
+  type SpecRep era ScriptHash = Integer
 
   toSpecRep (ScriptHash h) = toSpecRep h
 
-instance SpecTranslate (KeyHash r) where
-  type SpecRep (KeyHash r) = Integer
+instance SpecTranslate era (KeyHash r) where
+  type SpecRep era (KeyHash r) = Integer
 
   toSpecRep (KeyHash h) = toSpecRep h
 
-instance SpecTranslate (Credential k) where
-  type SpecRep (Credential k) = Agda.Credential
+instance SpecTranslate era (Credential k) where
+  type SpecRep era (Credential k) = Agda.Credential
 
   toSpecRep (KeyHashObj h) = Agda.KeyHashObj <$> toSpecRep h
   toSpecRep (ScriptHashObj h) = Agda.ScriptObj <$> toSpecRep h
 
-instance SpecTranslate Network where
-  type SpecRep Network = Integer
+instance SpecTranslate era Network where
+  type SpecRep era Network = Integer
 
   toSpecRep = pure . fromIntegral . fromEnum
 
-deriving instance SpecTranslate Coin
+deriving instance SpecTranslate era Coin
 
-deriving instance SpecTranslate SlotNo
+deriving instance SpecTranslate era SlotNo
 
-deriving instance SpecTranslate EpochNo
+deriving instance SpecTranslate era EpochNo
 
-deriving instance SpecTranslate EpochInterval
+deriving instance SpecTranslate era EpochInterval
 
-instance SpecTranslate ProtVer where
-  type SpecRep ProtVer = (Integer, Integer)
+instance SpecTranslate era ProtVer where
+  type SpecRep era ProtVer = (Integer, Integer)
 
   toSpecRep (ProtVer ver minor) = pure (getVersion ver, toInteger minor)
 
-instance SpecTranslate Prices where
-  type SpecRep Prices = ()
+instance SpecTranslate era Prices where
+  type SpecRep era Prices = ()
 
   toSpecRep _ = pure ()
 
-instance SpecTranslate AccountAddress where
-  type SpecRep AccountAddress = Agda.RewardAddress
+instance SpecTranslate era AccountAddress where
+  type SpecRep era AccountAddress = Agda.RewardAddress
 
   toSpecRep (AccountAddress n (AccountId c)) = Agda.RewardAddress <$> toSpecRep n <*> toSpecRep c
 
 instance
-  SpecTranslate (PParamsHKD Identity era) =>
-  SpecTranslate (PParams era)
+  SpecTranslate era (PParamsHKD Identity era) =>
+  SpecTranslate era (PParams era)
   where
-  type SpecRep (PParams era) = SpecRep (PParamsHKD Identity era)
-  type SpecContext (PParams era) = SpecContext (PParamsHKD Identity era)
+  type SpecRep era (PParams era) = SpecRep era (PParamsHKD Identity era)
+  type SpecContext era (PParams era) = SpecContext era (PParamsHKD Identity era)
 
   toSpecRep (PParams x) = toSpecRep x
 
 instance
-  SpecTranslate (PParamsHKD StrictMaybe era) =>
-  SpecTranslate (PParamsUpdate era)
+  SpecTranslate era (PParamsHKD StrictMaybe era) =>
+  SpecTranslate era (PParamsUpdate era)
   where
-  type SpecRep (PParamsUpdate era) = SpecRep (PParamsHKD StrictMaybe era)
-  type SpecContext (PParamsUpdate era) = SpecContext (PParamsHKD StrictMaybe era)
+  type SpecRep era (PParamsUpdate era) = SpecRep era (PParamsHKD StrictMaybe era)
+  type SpecContext era (PParamsUpdate era) = SpecContext era (PParamsHKD StrictMaybe era)
 
   toSpecRep (PParamsUpdate ppu) = toSpecRep ppu
 
@@ -169,38 +170,38 @@ signatureToInteger = toInteger . bytesToNatural . rawSerialiseSigDSIGN
 signatureFromInteger :: DSIGNAlgorithm v => Integer -> Maybe (SigDSIGN v)
 signatureFromInteger = rawDeserialiseSigDSIGN . naturalToBytes 64 . fromInteger
 
-instance SpecTranslate (VKey k) where
-  type SpecRep (VKey k) = Agda.HSVKey
+instance SpecTranslate era (VKey k) where
+  type SpecRep era (VKey k) = Agda.HSVKey
 
   toSpecRep x = do
     let hvkVKey = vkeyToInteger x
     hvkStoredHash <- toSpecRep (hashVerKeyDSIGN @_ @ADDRHASH $ unVKey x)
     pure Agda.MkHSVKey {..}
 
-instance DSIGNAlgorithm v => SpecTranslate (SignedDSIGN v a) where
-  type SpecRep (SignedDSIGN v a) = Integer
+instance DSIGNAlgorithm v => SpecTranslate era (SignedDSIGN v a) where
+  type SpecRep era (SignedDSIGN v a) = Integer
 
   toSpecRep (SignedDSIGN x) = pure $ signatureToInteger x
 
-instance SpecTranslate (WitVKey k) where
-  type SpecRep (WitVKey k) = (SpecRep (VKey k), Integer)
+instance SpecTranslate era (WitVKey k) where
+  type SpecRep era (WitVKey k) = (SpecRep era (VKey k), Integer)
 
   toSpecRep (WitVKey vk sk) = toSpecRepTuple (vk, sk)
 
-instance SpecTranslate CommitteeAuthorization where
+instance SpecTranslate era CommitteeAuthorization where
   type
-    SpecRep CommitteeAuthorization =
-      SpecRep (Maybe (Credential HotCommitteeRole))
+    SpecRep era CommitteeAuthorization =
+      SpecRep era (Maybe (Credential HotCommitteeRole))
 
   toSpecRep (CommitteeHotCredential c) = toSpecRep $ Just c
   toSpecRep (CommitteeMemberResigned _) =
     toSpecRep $
       Nothing @(Credential HotCommitteeRole)
 
-instance SpecTranslate (CommitteeState era) where
+instance SpecTranslate era (CommitteeState era) where
   type
-    SpecRep (CommitteeState era) =
-      Agda.HSMap (SpecRep (Credential ColdCommitteeRole)) (SpecRep CommitteeAuthorization)
+    SpecRep era (CommitteeState era) =
+      Agda.HSMap (SpecRep era (Credential ColdCommitteeRole)) (SpecRep era CommitteeAuthorization)
 
   toSpecRep = toSpecRepMap . csCommitteeCreds
 
@@ -210,18 +211,18 @@ committeeCredentialToStrictMaybe ::
 committeeCredentialToStrictMaybe (CommitteeHotCredential c) = SJust c
 committeeCredentialToStrictMaybe (CommitteeMemberResigned _) = SNothing
 
-instance SpecTranslate IndividualPoolStake where
-  type SpecRep IndividualPoolStake = SpecRep Coin
+instance SpecTranslate era IndividualPoolStake where
+  type SpecRep era IndividualPoolStake = SpecRep era Coin
 
   toSpecRep (IndividualPoolStake _ c _) = toSpecRep c
 
-instance SpecTranslate PoolDistr where
-  type SpecRep PoolDistr = Agda.HSMap (SpecRep (KeyHash StakePool)) Agda.Coin
+instance SpecTranslate era PoolDistr where
+  type SpecRep era PoolDistr = Agda.HSMap (SpecRep era (KeyHash StakePool)) Agda.Coin
 
   toSpecRep (PoolDistr ps _) = toSpecRepMap ps
 
-instance SpecTranslate BlocksMade where
-  type SpecRep BlocksMade = Agda.HSMap Integer Integer
+instance SpecTranslate era BlocksMade where
+  type SpecRep era BlocksMade = Agda.HSMap Integer Integer
 
   toSpecRep (BlocksMade m) = do
     xs <- forM (Map.toList m) $ \(k, v) -> do

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/Utils.hs
@@ -13,7 +13,7 @@ import Data.Containers.ListUtils (nubOrdOn)
 import Data.Data (Proxy (..))
 import Data.Foldable (Foldable (..))
 import Data.List (sortOn)
-import MAlonzo.Code.Ledger.Foreign.API as Agda
+import MAlonzo.Code.Ledger.Core.Foreign.API as Agda
 import Test.Cardano.Ledger.TreeDiff (Expr, ToExpr (..))
 
 agdaHashToBytes :: Int -> Integer -> ByteString

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
@@ -97,13 +97,13 @@ submitTxConformanceHook ::
   ( ConwayEraImp era
   , ExecSpecRule "LEDGER" era
   , ExecContext "LEDGER" era ~ ConwayLedgerExecContext era
-  , SpecTranslate (TxWits era)
+  , SpecTranslate era (TxWits era)
   , HasCallStack
-  , SpecRep (TxWits era) ~ Agda.TxWitnesses
-  , SpecRep (TxBody TopTx era) ~ Agda.TxBody
-  , SpecTranslate (TxBody TopTx era)
-  , SpecTranslate (Tx TopTx era)
-  , ToExpr (SpecRep (Tx TopTx era))
+  , SpecRep era (TxWits era) ~ Agda.TxWitnesses
+  , SpecRep era (TxBody TopTx era) ~ Agda.TxBody
+  , SpecTranslate era (TxBody TopTx era)
+  , SpecTranslate era (Tx TopTx era)
+  , ToExpr (SpecRep era (Tx TopTx era))
   , SpecNormalize (SpecState "LEDGER" era)
   , Eq (SpecState "LEDGER" era)
   ) =>

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
@@ -24,7 +24,6 @@ import Data.List.NonEmpty
 import Data.Text qualified as T
 import GHC.TypeLits (symbolVal)
 import Lens.Micro
-import MAlonzo.Code.Ledger.Foreign.API qualified as Agda
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway (ConwayLedgerExecContext (..))
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Core
 import Test.Cardano.Ledger.Conformance.SpecTranslate.Base
@@ -99,8 +98,6 @@ submitTxConformanceHook ::
   , ExecContext "LEDGER" era ~ ConwayLedgerExecContext era
   , SpecTranslate era (TxWits era)
   , HasCallStack
-  , SpecRep era (TxWits era) ~ Agda.TxWitnesses
-  , SpecRep era (TxBody TopTx era) ~ Agda.TxBody
   , SpecTranslate era (TxBody TopTx era)
   , SpecTranslate era (Tx TopTx era)
   , ToExpr (SpecRep era (Tx TopTx era))

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
@@ -49,7 +49,7 @@ conformanceHook globals ctx trc@(TRC (env, state, signal)) impRuleResult =
   impAnn ("Conformance hook (" <> symbolVal (Proxy @rule) <> ")") $ do
     -- translate inputs
     specTRC@(SpecTRC specEnv specState specSignal) <-
-      impAnn "Translating inputs" . expectRightDeepExpr $ translateInputs ctx trc
+      impAnn "Translating inputs" . expectRightDeepExpr $ runSpecTransM ctx $ translateInputs trc
     -- get agda response
     agdaResponse' <-
       fmap (second $ first specNormalize) . evaluateDeep $ runAgdaRuleWithDebug @rule @era specTRC

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Core.hs
@@ -58,7 +58,7 @@ conformanceHook globals ctx trc@(TRC (env, state, signal)) impRuleResult =
       agdaResponse = fmap fst agdaResponse'
       agdaDebug = either (const "") snd agdaResponse'
       impRuleResult' = bimap (T.pack . show) fst impRuleResult
-      impResponse = first (T.pack . show) . translateOutput @rule @era ctx trc =<< impRuleResult'
+      impResponse = first (T.pack . show) . runSpecTransM @era ctx . translateOutput trc =<< impRuleResult'
 
     logString "implEnv"
     logToExpr env

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Base.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Base.hs
@@ -8,6 +8,7 @@
 
 module Test.Cardano.Ledger.Conformance.Spec.Base (spec) where
 
+import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Hashes (ADDRHASH)
 import Cardano.Ledger.TxIn (TxId)
 import Data.List (isInfixOf)
@@ -25,13 +26,13 @@ import Test.Cardano.Ledger.Conformance (
 import Test.Cardano.Ledger.Conformance.Spec.Conway ()
 
 hashDisplayProp ::
-  forall a.
+  forall era a.
   ( Typeable a
   , Arbitrary a
-  , SpecTranslate a
-  , SpecContext a ~ ()
-  , SpecNormalize (SpecRep a)
-  , ToExpr (SpecRep a)
+  , SpecTranslate era a
+  , SpecContext era a ~ ()
+  , SpecNormalize (SpecRep era a)
+  , ToExpr (SpecRep era a)
   , ToExpr a
   ) =>
   Spec
@@ -39,7 +40,7 @@ hashDisplayProp = prop (show $ typeRep (Proxy @a)) $ do
   someHash <- arbitrary @a
   let
     specRes =
-      case runSpecTransM () (specNormalize <$> toSpecRep someHash) of
+      case runSpecTransM () (specNormalize <$> toSpecRep @era someHash) of
         Left e -> error $ "Failed to translate hash: " <> show e
         Right x -> x
   pure
@@ -53,7 +54,7 @@ spec :: Spec
 spec =
   describe "Translation" $ do
     describe "Hashes are displayed in the same way in the implementation and in the spec" $ do
-      hashDisplayProp @TxId
+      hashDisplayProp @ConwayEra @TxId
     describe "Utility properties" $ do
       prop "vkeyToInteger and vkeyFromInteger are inverses" $
         \vk -> vkeyFromInteger (vkeyToInteger vk) === Just vk

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
@@ -36,11 +36,10 @@ import Test.Cardano.Ledger.Conway.TreeDiff (tableDoc)
 import Test.Cardano.Ledger.Imp.Common
 
 conformsToImplAccepted ::
-  era ~ ConwayEra =>
-  (RatifyEnv era -> RatifyState era -> GovActionState era -> Bool) ->
-  ( SpecRep era (RatifyEnv era) ->
-    SpecRep era (EnactState era) ->
-    SpecRep era (GovActionState era) ->
+  (RatifyEnv ConwayEra -> RatifyState ConwayEra -> GovActionState ConwayEra -> Bool) ->
+  ( SpecRep ConwayEra (RatifyEnv ConwayEra) ->
+    SpecRep ConwayEra (EnactState ConwayEra) ->
+    SpecRep ConwayEra (GovActionState ConwayEra) ->
     Bool
   ) ->
   Property

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
@@ -24,7 +24,7 @@ import Cardano.Ledger.Conway.Rules qualified as Conway
 import Constrained.Generation
 import Data.Either (fromRight)
 import Lens.Micro
-import MAlonzo.Code.Ledger.Foreign.API qualified as Agda
+import MAlonzo.Code.Ledger.Conway.Foreign.API qualified as Agda
 import Prettyprinter as Pretty
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Conway ()
 import Test.Cardano.Ledger.Conformance.Spec.Core

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
@@ -11,7 +11,6 @@
 
 module Test.Cardano.Ledger.Conformance.Spec.Conway.Ratify (spec) where
 
-import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Governance (
   EnactState,
@@ -51,7 +50,7 @@ conformsToImplAccepted impl agda = property $ do
   govActions <- cgbContextGen
   ratifyEnv <- genFromSpec $ cgbEnvironmentSpec govActions
   ratifySt <- genFromSpec $ cgbStateSpec govActions ratifyEnv
-  let specEnv = fromSpecTransM $ runSpecTransM @Coin 0 $ toSpecRep @ConwayEra ratifyEnv
+  let specEnv = fromSpecTransM $ runSpecTransM 0 $ toSpecRep @ConwayEra ratifyEnv
       specSt =
         fromSpecTransM $
           runSpecTransM () $

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Spec/Conway/Ratify.hs
@@ -39,7 +39,11 @@ import Test.Cardano.Ledger.Imp.Common
 conformsToImplAccepted ::
   era ~ ConwayEra =>
   (RatifyEnv era -> RatifyState era -> GovActionState era -> Bool) ->
-  (SpecRep (RatifyEnv era) -> SpecRep (EnactState era) -> SpecRep (GovActionState era) -> Bool) ->
+  ( SpecRep era (RatifyEnv era) ->
+    SpecRep era (EnactState era) ->
+    SpecRep era (GovActionState era) ->
+    Bool
+  ) ->
   Property
 conformsToImplAccepted impl agda = property $ do
   let ConstrainedGeneratorBundle {..} = constrainedRatify
@@ -47,12 +51,12 @@ conformsToImplAccepted impl agda = property $ do
   govActions <- cgbContextGen
   ratifyEnv <- genFromSpec $ cgbEnvironmentSpec govActions
   ratifySt <- genFromSpec $ cgbStateSpec govActions ratifyEnv
-  let specEnv = fromSpecTransM $ runSpecTransM @Coin 0 $ toSpecRep ratifyEnv
+  let specEnv = fromSpecTransM $ runSpecTransM @Coin 0 $ toSpecRep @ConwayEra ratifyEnv
       specSt =
         fromSpecTransM $
           runSpecTransM () $
-            toSpecRep (ratifySt ^. rsEnactStateL)
-      specGovActions = fromSpecTransM $ runSpecTransM () $ toSpecRep govActions
+            toSpecRep @ConwayEra (ratifySt ^. rsEnactStateL)
+      specGovActions = fromSpecTransM $ runSpecTransM () $ toSpecRep @ConwayEra govActions
   return $
     conjoin $
       zipWith


### PR DESCRIPTION
# Description

- Add `era` type parameter to `SpecTranslate` and `SpecTransM`
- Instantiate `era` parameter for Conway modules
- Update formal-ledger-specifications and update imports
- Redistribute `SpecNormalize` instances from Orphans to Base, Core and Conway.Base
- Change the type of `translateInputs` and `translateOutput` to `SpecTransM`

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
