### PR TITLE
Add `transaction_mempool`

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -65,6 +65,7 @@
 
 ### cddl
 
+* Add `transaction_mempool` rule
 * Add `peras_certificate`, `block_body`
 * Extend `constr` CDDL rule to include tags 1280–1400 for Plutus `Data` constructor indexes
 

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -2,10 +2,20 @@
 
 block = [header, block_body]
 
-transaction =
-  [  transaction_body, transaction_witness_set, true, auxiliary_data/ nil
-  // transaction_body, transaction_witness_set, auxiliary_data/ nil
-  ]
+transaction = [transaction_body, transaction_witness_set, auxiliary_data/ nil]
+
+; In Dijkstra we're deprecating the `is_valid` flag, but for backwards
+; compatibility we still allow this flag to be present in incoming
+; transactions. Once the transaction is added to a block, the flag will
+; be stripped, so the `is_valid` flag cannot appear in transactions that
+; are in a block.
+;
+; In the next era `is_valid` flags will not be allowed even in mempool
+; transactions, so it's strongly recommended to encode transactions
+; according to the `transaction` rule.
+transaction_mempool =
+  transaction
+  / [transaction_body, transaction_witness_set, true, auxiliary_data/ nil]
 
 kes_signature = bytes .size 448
 

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -54,6 +54,7 @@ dijkstraCDDL =
   collectFromInit
     [ HIRule $ huddleRule @"block" (Proxy @DijkstraEra)
     , HIRule $ huddleRule @"transaction" (Proxy @DijkstraEra)
+    , HIRule $ huddleRule @"transaction_mempool" (Proxy @DijkstraEra)
     , HIRule $ huddleRule @"kes_signature" (Proxy @DijkstraEra)
     , HIRule $ huddleRule @"language" (Proxy @DijkstraEra)
     , HIRule $ huddleRule @"potential_languages" (Proxy @DijkstraEra)
@@ -780,16 +781,32 @@ instance HuddleRule "script_data_hash" DijkstraEra where
           |]
       $ scriptDataHashRule pname p
 
+instance HuddleRule "transaction_mempool" DijkstraEra where
+  huddleRuleNamed pname p =
+    comment
+      [str| In Dijkstra we're deprecating the `is_valid` flag, but for backwards
+          | compatibility we still allow this flag to be present in incoming 
+          | transactions. Once the transaction is added to a block, the flag will
+          | be stripped, so the `is_valid` flag cannot appear in transactions that
+          | are in a block.
+          |
+          | In the next era `is_valid` flags will not be allowed even in mempool 
+          | transactions, so it's strongly recommended to encode transactions
+          | according to the `transaction` rule.
+          |]
+      $ pname
+        =.= huddleRule @"transaction" p
+        / sarr
+          [ a $ huddleRule @"transaction_body" p
+          , a $ huddleRule @"transaction_witness_set" p
+          , a $ bool True
+          , a (huddleRule @"auxiliary_data" p / VNil)
+          ]
+
 instance HuddleRule "transaction" DijkstraEra where
   huddleRuleNamed pname p =
     pname
       =.= arr
-        [ a $ huddleRule @"transaction_body" p
-        , a $ huddleRule @"transaction_witness_set" p
-        , a $ (bool True)
-        , a (huddleRule @"auxiliary_data" p / VNil)
-        ]
-      / arr
         [ a $ huddleRule @"transaction_body" p
         , a $ huddleRule @"transaction_witness_set" p
         , a (huddleRule @"auxiliary_data" p / VNil)


### PR DESCRIPTION
# Description

This PR adds a `transaction_mempool` rule to the CDDL. This is needed because the transaction deserializer is used in two places: to decode incoming transactions and in the `block_body` deserializer. In Dijkstra we are getting rid of the `is_valid` flag in block transactions, but for backwards compatibility, we still allow the `is_valid` flags in incoming transactions as long as the flag is set to `true`. Once the transaction is added to a block, that flag is stripped.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
