### PR TITLE
Update Dijkstra `chain_code`

### DIFF
--- a/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
+++ b/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
@@ -232,7 +232,7 @@ instance HuddleRule "vkeywitness" AllegraEra where
   huddleRuleNamed = vkeywitnessRule
 
 instance HuddleRule "bootstrap_witness" AllegraEra where
-  huddleRuleNamed = bootstrapWitnessRule
+  huddleRuleNamed = shelleyBootstrapWitnessRule
 
 instance HuddleRule "transaction_witness_set" AllegraEra where
   huddleRuleNamed = transactionWitnessSetRule

--- a/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
+++ b/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
@@ -219,7 +219,7 @@ instance HuddleRule "vkeywitness" AlonzoEra where
   huddleRuleNamed = vkeywitnessRule
 
 instance HuddleRule "bootstrap_witness" AlonzoEra where
-  huddleRuleNamed = bootstrapWitnessRule
+  huddleRuleNamed = shelleyBootstrapWitnessRule
 
 instance HuddleRule "auxiliary_scripts" AlonzoEra where
   huddleRuleNamed = auxiliaryScriptsRule

--- a/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
+++ b/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
@@ -244,7 +244,7 @@ instance HuddleRule "vkeywitness" BabbageEra where
   huddleRuleNamed = vkeywitnessRule
 
 instance HuddleRule "bootstrap_witness" BabbageEra where
-  huddleRuleNamed = bootstrapWitnessRule
+  huddleRuleNamed = shelleyBootstrapWitnessRule
 
 instance HuddleRule "policy_id" BabbageEra where
   huddleRuleNamed pname p = pname =.= huddleRule @"script_hash" p

--- a/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
+++ b/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
@@ -756,7 +756,7 @@ instance HuddleRule "vkeywitness" ConwayEra where
   huddleRuleNamed = vkeywitnessRule
 
 instance HuddleRule "bootstrap_witness" ConwayEra where
-  huddleRuleNamed = bootstrapWitnessRule
+  huddleRuleNamed = shelleyBootstrapWitnessRule
 
 instance HuddleRule "ex_units" ConwayEra where
   huddleRuleNamed = exUnitsRule

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -833,7 +833,7 @@ vkeywitness = [vkey, signature]
 bootstrap_witness =
   [ public_key : vkey
   , signature  : signature
-  , chain_code : bytes
+  , chain_code : bytes .size 32
   , attributes : bytes
   ]
 

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -434,8 +434,18 @@ instance HuddleRule "transaction_id" DijkstraEra where
 instance HuddleRule "vkeywitness" DijkstraEra where
   huddleRuleNamed = vkeywitnessRule
 
+dijkstraBootstrapWitnessRule :: Proxy "bootstrap_witness" -> Proxy DijkstraEra -> Rule
+dijkstraBootstrapWitnessRule pname p =
+  pname
+    =.= arr
+      [ "public_key" ==> huddleRule @"vkey" p
+      , "signature" ==> huddleRule @"signature" p
+      , "chain_code" ==> VBytes `sized` (32 :: Word64)
+      , "attributes" ==> VBytes
+      ]
+
 instance HuddleRule "bootstrap_witness" DijkstraEra where
-  huddleRuleNamed = bootstrapWitnessRule
+  huddleRuleNamed = dijkstraBootstrapWitnessRule
 
 instance HuddleRule "ex_units" DijkstraEra where
   huddleRuleNamed = exUnitsRule

--- a/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
+++ b/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
@@ -104,7 +104,7 @@ instance HuddleRule "vkeywitness" MaryEra where
   huddleRuleNamed = vkeywitnessRule
 
 instance HuddleRule "bootstrap_witness" MaryEra where
-  huddleRuleNamed = bootstrapWitnessRule
+  huddleRuleNamed = shelleyBootstrapWitnessRule
 
 instance HuddleRule "transaction_witness_set" MaryEra where
   huddleRuleNamed = transactionWitnessSetRule

--- a/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
+++ b/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
@@ -23,7 +23,7 @@ module Cardano.Ledger.Shelley.HuddleSpec (
   shelleyHeaderBodyRule,
   transactionWitnessSetRule,
   vkeywitnessRule,
-  bootstrapWitnessRule,
+  shelleyBootstrapWitnessRule,
   shelleyOperationalCertGroup,
   genesisHashRule,
   scriptPubkeyGroup,
@@ -170,9 +170,9 @@ vkeywitnessRule pname p =
   pname
     =.= arr [a $ huddleRule @"vkey" p, a $ huddleRule @"signature" p]
 
-bootstrapWitnessRule ::
+shelleyBootstrapWitnessRule ::
   forall era. Era era => Proxy "bootstrap_witness" -> Proxy era -> Rule
-bootstrapWitnessRule pname p =
+shelleyBootstrapWitnessRule pname p =
   pname
     =.= arr
       [ "public_key" ==> huddleRule @"vkey" p
@@ -568,7 +568,7 @@ instance HuddleRule "vkeywitness" ShelleyEra where
   huddleRuleNamed = vkeywitnessRule
 
 instance HuddleRule "bootstrap_witness" ShelleyEra where
-  huddleRuleNamed = bootstrapWitnessRule
+  huddleRuleNamed = shelleyBootstrapWitnessRule
 
 instance HuddleRule "transaction_witness_set" ShelleyEra where
   huddleRuleNamed = transactionWitnessSetRule


### PR DESCRIPTION
# Description

This PR updates the Huddle spec in Dijkstra to limit `chain_code` to 32 bytes.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
