### PR TITLE
Reduce test sizes for large round-tripping tests if NIGHTLY flag is not set

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/RoundTrip.hs
@@ -52,8 +52,10 @@ roundTripConwayEraTypesSpec = do
     roundTripEraTypeSpec @era @VotingProcedures
     roundTripEraTypeSpec @era @ProposalProcedure
     roundTripEraTypeSpec @era @Constitution
-    prop "CostModels" $ roundTripEraExpectation @era @CostModels
-  describe (eraName @era <> " State Types") $ do
+    reducedTestsUnlessNightly $
+      prop "CostModels" $
+        roundTripEraExpectation @era @CostModels
+  reducedTestsUnlessNightly $ describe (eraName @era <> " State Types") $ do
     roundTripShareEraTypeSpec @era @EnactState
     roundTripShareEraTypeSpec @era @GovActionState
     roundTripShareEraTypeSpec @era @Proposals

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
@@ -64,7 +64,7 @@ roundTripStateEraTypesSpec ::
   , Arbitrary (InstantStake era)
   ) =>
   Spec
-roundTripStateEraTypesSpec = do
+roundTripStateEraTypesSpec = reducedTestsUnlessNightly $ do
   describe "State Types Families" $ do
     roundTripShareEraSpec @era @(GovState era)
   describe "State Types" $ do

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Common.hs
@@ -65,6 +65,8 @@ module Test.Cardano.Ledger.Common (
   -- * Miscellanous helpers
   tracedDiscard,
   forEachEraVersion,
+  nightlyEnabled,
+  reducedTestsUnlessNightly,
 ) where
 
 import Cardano.Ledger.Binary (Version)
@@ -75,8 +77,11 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Types as Aeson (parseEither)
 import qualified Data.ByteString.Lazy as BSL
+import Data.Maybe (isJust)
 import Data.Typeable
 import qualified Debug.Trace as Debug
+import System.Environment (lookupEnv)
+import System.IO.Unsafe (unsafePerformIO)
 import Test.Cardano.Ledger.Binary.Golden (toPackageGolden)
 import Test.Cardano.Ledger.Binary.TreeDiff (
   ToExpr (..),
@@ -112,6 +117,19 @@ ledgerTestMainWith = impSpecMainWithConfig
 
 ledgerTestMain :: Spec -> IO ()
 ledgerTestMain = ledgerTestMainWith ledgerHspecConfig
+
+-- | True when the @NIGHTLY@ environment variable is set.
+nightlyEnabled :: Bool
+nightlyEnabled = unsafePerformIO $ isJust <$> lookupEnv "NIGHTLY"
+{-# NOINLINE nightlyEnabled #-}
+
+-- | Cap QuickCheck @maxSuccess@ at 25 unless @NIGHTLY@ is set. Use this to wrap
+-- expensive round-trip property blocks so CI stays fast while nightly runs the
+-- full 100 samples.
+reducedTestsUnlessNightly :: SpecWith a -> SpecWith a
+reducedTestsUnlessNightly
+  | nightlyEnabled = id
+  | otherwise = modifyMaxSuccess (`min` 25)
 
 shouldBeExpr :: (HasCallStack, ToExpr a, Eq a) => a -> a -> IO ()
 shouldBeExpr = expectExprEqualWithMessage ""

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/Annotator.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/Annotator.hs
@@ -63,5 +63,6 @@ decoderEquivalenceCoreEraTypesSpec =
     decoderEquivalenceEraSpec @era @(Script era)
     decoderEquivalenceEraSpec @era @(TxAuxData era)
     decoderEquivalenceEraSpec @era @(TxWits era)
-    decoderEquivalenceEraSpec @era @(TxBody TopTx era)
-    decoderEquivalenceEraSpec @era @(Tx TopTx era)
+    reducedTestsUnlessNightly $ do
+      decoderEquivalenceEraSpec @era @(TxBody TopTx era)
+      decoderEquivalenceEraSpec @era @(Tx TopTx era)

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/RoundTrip.hs
@@ -217,18 +217,20 @@ roundTripCoreEraTypesSpec = do
     roundTripEraSpec @era @(CompactForm (Value era))
     roundTripEraSpec @era @(TxOut era)
     roundTripEraSpec @era @(TxCert era)
-    roundTripEraSpec @era @(PParams era)
-    roundTripEraSpec @era @(PParamsUpdate era)
+    reducedTestsUnlessNightly $ do
+      roundTripEraSpec @era @(PParams era)
+      roundTripEraSpec @era @(PParamsUpdate era)
     roundTripAnnEraSpec @era @(Script era)
     roundTripEraSpec @era @(Script era)
     roundTripAnnEraSpec @era @(TxAuxData era)
     roundTripEraSpec @era @(TxAuxData era)
     roundTripAnnEraSpec @era @(TxWits era)
     roundTripEraSpec @era @(TxWits era)
-    roundTripAnnEraSpec @era @(TxBody TopTx era)
-    roundTripEraSpec @era @(TxBody TopTx era)
-    roundTripAnnEraSpec @era @(Tx TopTx era)
-    roundTripEraSpec @era @(Tx TopTx era)
+    reducedTestsUnlessNightly $ do
+      roundTripAnnEraSpec @era @(TxBody TopTx era)
+      roundTripEraSpec @era @(TxBody TopTx era)
+      roundTripAnnEraSpec @era @(Tx TopTx era)
+      roundTripEraSpec @era @(Tx TopTx era)
     prop ("MemPack/CBOR Roundtrip " <> show (typeRep $ Proxy @(TxOut era))) $
       roundTripRangeExpectation @(TxOut era)
         (mkTrip encodeMemPack decNoShareCBOR)
@@ -289,7 +291,8 @@ roundTripAllPredicateFailures ::
   ) =>
   Spec
 roundTripAllPredicateFailures =
-  describe "Predicate Failures" . go $ unliftEraRuleProofs @era @(EraRules era)
+  reducedTestsUnlessNightly . describe "Predicate Failures" . go $
+    unliftEraRuleProofs @era @(EraRules era)
   where
     go :: EraRuleProof era rs' -> Spec
     go EraRuleProofEmpty = pure ()


### PR DESCRIPTION
# Description

This PR scales down some of the larger roundtripping tests when running without the NIGHTLY flag. This speeds up the Conway test suite significantly, saving ~48 min.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
