### PR TITLE
Add ToJSON/FromJSON instances for EraTxWits

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -15,8 +15,9 @@
 * Add `ApplyTick` instance for `AllegraEra`
 * Add `EraForecast` and `ShelleyEraForecast` instances for `AllegraEra`.
 * Remove `NoThunks` instance for `AllegraUtxoPredFailure`
-* Add `ToJSON` and `FromJSON` instances for `AllegraTxAuxData era`
-* Add `ToJSON` and `FromJSON` instances for `Timelock era`
+* Add `ToJSON` and `FromJSON` instances for
+  - `AllegraTxAuxData era`
+  - `Timelock era`
 * Export `allegraBasedEraNativeScriptToJSON` and `allegraBasedEraNativeScriptJSONParser` from `Cardano.Ledger.Allegra.Scripts`
 
 ### `cddl`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -76,6 +76,13 @@
 * Add `FromJSON (AlonzoScript era)` instance
 * Add `EncCBOR` and `ToCBOR` instances for `PlutusScript era`
 * Add `ToJSON` and `FromJSON` instances for `AlonzoTxAuxData era`
+* Add `ToJSON` and `FromJSON` instances for
+  - `TxDats era`
+  - `Redeemers era`
+  - `AlonzoTxWits era`
+* Add `FromJSON` instance for
+  - `AsIx ix it`
+  - `AlonzoPlutusPurpose AsIx era`
 
 ### `cddl`
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -114,7 +114,7 @@ import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..), nativeMultiSigTag)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData (..), deepseq, rwhnf)
 import Control.Monad (guard, (>=>))
-import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), object, (.=))
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), object, withObject, (.:), (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.ByteString as BS
 import Data.Kind (Type)
@@ -310,8 +310,14 @@ instance (NFData ix, NFData it) => NFData (AsIxItem ix it) where
 instance ToJSON ix => ToJSON (AsIx ix it) where
   toJSON (AsIx i) = object ["index" .= toJSON i]
 
+instance FromJSON ix => FromJSON (AsIx ix it) where
+  parseJSON = withObject "AsIx" $ \o -> AsIx <$> o .: "index"
+
 instance ToJSON it => ToJSON (AsItem ix it) where
   toJSON (AsItem i) = object ["item" .= toJSON i]
+
+instance FromJSON it => FromJSON (AsItem ix it) where
+  parseJSON = withObject "AsItem" $ \o -> AsItem <$> o .: "item"
 
 instance (ToJSON ix, ToJSON it) => ToJSON (AsIxItem ix it) where
   toJSON (AsIxItem ix it) =
@@ -319,6 +325,10 @@ instance (ToJSON ix, ToJSON it) => ToJSON (AsIxItem ix it) where
       [ "index" .= toJSON ix
       , "item" .= toJSON it
       ]
+
+instance (FromJSON ix, FromJSON it) => FromJSON (AsIxItem ix it) where
+  parseJSON = withObject "AsIxItem" $ \o ->
+    AsIxItem <$> o .: "index" <*> o .: "item"
 
 toAsPurpose :: f ix it -> AsPurpose ix it
 toAsPurpose = const AsPurpose
@@ -431,6 +441,25 @@ instance
     AlonzoWithdrawing n -> kindObjectWithValue "AlonzoWithdrawing" n
     where
       kindObjectWithValue name n = kindObjectValue name ["value" .= n]
+
+instance
+  ( FromJSON (f Word32 TxIn)
+  , FromJSON (f Word32 PolicyID)
+  , FromJSON (f Word32 (TxCert era))
+  , FromJSON (f Word32 AccountAddress)
+  , Era era
+  ) =>
+  FromJSON (AlonzoPlutusPurpose f era)
+  where
+  parseJSON = withObject "AlonzoPlutusPurpose" $ \o -> do
+    kind <- o .: "kind"
+    value <- o .: "value"
+    case (kind :: String) of
+      "AlonzoSpending" -> AlonzoSpending <$> parseJSON value
+      "AlonzoMinting" -> AlonzoMinting <$> parseJSON value
+      "AlonzoCertifying" -> AlonzoCertifying <$> parseJSON value
+      "AlonzoWithdrawing" -> AlonzoWithdrawing <$> parseJSON value
+      _ -> fail $ "Unknown AlonzoPlutusPurpose kind: " <> kind
 
 pattern AlonzoRewarding :: f Word32 AccountAddress -> AlonzoPlutusPurpose f era
 pattern AlonzoRewarding x = AlonzoWithdrawing x

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxWits.hs
@@ -126,7 +126,10 @@ import Cardano.Ledger.Shelley.TxWits (
 import Control.DeepSeq (NFData)
 import Control.Monad (when, (>=>))
 import Control.Monad.Trans.Fail (runFail)
+import Data.Aeson (FromJSON (..), ToJSON (..), object, withArray, withObject, (.:), (.=))
+import qualified Data.Aeson as Aeson
 import Data.Coerce (coerce)
+import qualified Data.Foldable as Foldable
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -778,3 +781,83 @@ encodeWithSetTag xs =
     (natVersion @9)
     (encodeTag setTag <> encCBOR xs)
     (encCBOR xs)
+
+instance (Era era, ToJSON (Data era)) => ToJSON (TxDats era) where
+  toJSON (TxDats m) =
+    Aeson.toJSON
+      [ object ["dataHash" .= k, "data" .= v]
+      | (k, v) <- Map.toList m
+      ]
+
+instance (Era era, FromJSON (Data era)) => FromJSON (TxDats era) where
+  parseJSON = withArray "TxDats" $ \arr -> do
+    pairs <- mapM parsePair (Foldable.toList arr)
+    pure $ TxDats (Map.fromList pairs)
+    where
+      parsePair = withObject "TxDat" $ \o -> do
+        !datHash <- o .: "dataHash"
+        !dat <- o .: "data"
+        pure (datHash, dat)
+
+instance
+  ( AlonzoEraScript era
+  , ToJSON (Data era)
+  , ToJSON (PlutusPurpose AsIx era)
+  ) =>
+  ToJSON (Redeemers era)
+  where
+  toJSON (Redeemers rdmrs) =
+    Aeson.toJSON
+      [ object ["purpose" .= k, "data" .= d, "exUnits" .= ex]
+      | (k, (d, ex)) <- Map.toList rdmrs
+      ]
+
+instance
+  ( AlonzoEraScript era
+  , FromJSON (Data era)
+  , FromJSON (PlutusPurpose AsIx era)
+  ) =>
+  FromJSON (Redeemers era)
+  where
+  parseJSON = withArray "Redeemers" $ \arr -> do
+    pairs <- mapM parseRedeemer (Foldable.toList arr)
+    pure $ Redeemers (Map.fromList pairs)
+    where
+      parseRedeemer = withObject "Redeemer" $ \o -> do
+        !purpose <- o .: "purpose"
+        !dat <- o .: "data"
+        !exUnits <- o .: "exUnits"
+        pure (purpose, (dat, exUnits))
+
+instance
+  ( AlonzoEraScript era
+  , ToJSON (Script era)
+  , ToJSON (Data era)
+  , ToJSON (PlutusPurpose AsIx era)
+  ) =>
+  ToJSON (AlonzoTxWits era)
+  where
+  toJSON (AlonzoTxWits vkeys boots scripts dats rdmrs) =
+    object
+      [ "addrWits" .= Set.toList vkeys
+      , "bootWits" .= Set.toList boots
+      , "scriptWits" .= scripts
+      , "datums" .= dats
+      , "redeemers" .= rdmrs
+      ]
+
+instance
+  ( AlonzoEraScript era
+  , FromJSON (Script era)
+  , FromJSON (Data era)
+  , FromJSON (PlutusPurpose AsIx era)
+  ) =>
+  FromJSON (AlonzoTxWits era)
+  where
+  parseJSON = withObject "AlonzoTxWits" $ \o ->
+    AlonzoTxWits
+      <$> (Set.fromList <$> o .: "addrWits")
+      <*> (Set.fromList <$> o .: "bootWits")
+      <*> o .: "scriptWits"
+      <*> o .: "datums"
+      <*> o .: "redeemers"

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -69,6 +69,18 @@
 * Remove `NoThunks` instance for `ConwayContextError`
 * Make `ConwayContextError` constructors lazy
 * Make `ZeroTreasuryWithdrawals` a permanent check for all eras (not just post-Babbage).
+* Add `FromJSON` instances for
+  - `GovActionId`
+  - `Voter`
+  - `Vote`
+  - `VotingProcedure`
+  - `ProposalProcedure`
+  - `GovAction`
+  - `GovPurposeId`
+  - `ConwayDelegCert`
+  - `ConwayGovCert`
+  - `ConwayTxCert era`
+  - `ConwayPlutusPurpose f era`
 * Add `ToJSON` instance for `DefaultVote`.
 
 ### cddl

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Procedures.hs
@@ -2,12 +2,10 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -21,7 +19,6 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -125,9 +122,9 @@ import Cardano.Ledger.Binary.Coders (
   (<!),
  )
 import Cardano.Ledger.Coin (Coin)
-import Cardano.Ledger.Credential (Credential (..), credToText)
+import Cardano.Ledger.Credential (Credential (..), credToText, parseCredential)
 import Cardano.Ledger.Shelley.RewardProvenance ()
-import Cardano.Ledger.TxIn (TxId (..))
+import Cardano.Ledger.TxIn (TxId (..), parseTxId)
 import Cardano.Slotting.Slot (EpochNo)
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad (when)
@@ -135,6 +132,7 @@ import Control.Monad.Trans (lift)
 import Control.Monad.Trans.State.Strict (get, put)
 import Data.Aeson (
   FromJSON (..),
+  FromJSONKey (..),
   KeyValue (..),
   ToJSON (..),
   ToJSONKey (..),
@@ -142,7 +140,7 @@ import Data.Aeson (
   (.:),
   (.:?),
  )
-import Data.Aeson.Types (toJSONKeyText)
+import Data.Aeson.Types (FromJSONKeyFunction (..), toJSONKeyText)
 import Data.Data (Typeable)
 import Data.Default
 import Data.Kind
@@ -170,6 +168,7 @@ newtype GovActionIx = GovActionIx {unGovActionIx :: Word16}
     , EncCBOR
     , DecCBOR
     , ToJSON
+    , FromJSON
     )
 
 data GovActionId = GovActionId
@@ -215,6 +214,20 @@ govActionIdToText (GovActionId (TxId txidHash) (GovActionIx ix)) =
   hashToTextAsHex (extractHash txidHash)
     <> Text.pack "#"
     <> Text.pack (show ix)
+
+instance FromJSON GovActionId where
+  parseJSON = withObject "GovActionId" $ \o ->
+    GovActionId
+      <$> o .: "txId"
+      <*> o .: "govActionIx"
+
+instance FromJSONKey GovActionId where
+  fromJSONKey = FromJSONKeyTextParser parseGovActionId
+
+parseGovActionId :: MonadFail m => Text.Text -> m GovActionId
+parseGovActionId t = do
+  (txId, ix) <- parseTxId t
+  pure $ GovActionId txId (GovActionIx ix)
 
 data GovActionState era = GovActionState
   { gasId :: !GovActionId
@@ -273,7 +286,7 @@ deriving via
     EraPParams era => ToJSON (GovActionState era)
 
 instance EraPParams era => ToKeyValuePairs (GovActionState era) where
-  toKeyValuePairs gas@(GovActionState _ _ _ _ _ _ _) =
+  toKeyValuePairs gas =
     let GovActionState {..} = gas
      in [ "actionId" .= gasId
         , "committeeVotes" .= gasCommitteeVotes
@@ -352,6 +365,22 @@ instance ToJSONKey Voter where
     StakePoolVoter kh ->
       "stakepool-" <> credToText (KeyHashObj kh)
 
+instance FromJSON Voter
+
+instance FromJSONKey Voter where
+  fromJSONKey = FromJSONKeyTextParser parseVoter
+
+parseVoter :: MonadFail m => Text.Text -> m Voter
+parseVoter t = case Text.splitOn "-" t of
+  ("committee" : rest) -> CommitteeVoter <$> parseCredential (Text.intercalate "-" rest)
+  ("drep" : rest) -> DRepVoter <$> parseCredential (Text.intercalate "-" rest)
+  ("stakepool" : rest) -> do
+    cred <- parseCredential (Text.intercalate "-" rest)
+    case cred of
+      KeyHashObj kh -> pure $ StakePoolVoter kh
+      ScriptHashObj _ -> fail "StakePool voter cannot be a script hash"
+  _ -> fail $ "Invalid Voter: " <> show t
+
 instance DecCBOR Voter where
   decCBOR = decodeRecordSum "Voter" $ \case
     0 -> (2,) . CommitteeVoter . KeyHashObj <$> decCBOR
@@ -387,6 +416,8 @@ data Vote
 
 instance ToJSON Vote
 
+instance FromJSON Vote
+
 instance NoThunks Vote
 
 instance NFData Vote
@@ -401,7 +432,7 @@ newtype VotingProcedures era = VotingProcedures
   { unVotingProcedures :: Map Voter (Map GovActionId (VotingProcedure era))
   }
   deriving stock (Generic, Eq, Show)
-  deriving newtype (NoThunks, EncCBOR, ToJSON)
+  deriving newtype (NoThunks, EncCBOR, ToJSON, FromJSON)
 
 deriving newtype instance Era era => NFData (VotingProcedures era)
 
@@ -485,6 +516,12 @@ instance EraPParams era => ToKeyValuePairs (VotingProcedure era) where
         , "decision" .= vProcVote
         ]
 
+instance EraPParams era => FromJSON (VotingProcedure era) where
+  parseJSON = withObject "VotingProcedure" $ \o ->
+    VotingProcedure
+      <$> o .: "decision"
+      <*> o .: "anchor"
+
 -- | Attaches indices to a sequence of proposal procedures. The indices grow
 -- from left to right.
 indexedGovProps ::
@@ -549,13 +586,21 @@ deriving via
     EraPParams era => ToJSON (ProposalProcedure era)
 
 instance EraPParams era => ToKeyValuePairs (ProposalProcedure era) where
-  toKeyValuePairs proposalProcedure@(ProposalProcedure _ _ _ _) =
+  toKeyValuePairs proposalProcedure =
     let ProposalProcedure {..} = proposalProcedure
      in [ "deposit" .= pProcDeposit
         , "returnAddr" .= pProcReturnAddr
         , "govAction" .= pProcGovAction
         , "anchor" .= pProcAnchor
         ]
+
+instance EraPParams era => FromJSON (ProposalProcedure era) where
+  parseJSON = withObject "ProposalProcedure" $ \o ->
+    ProposalProcedure
+      <$> o .: "deposit"
+      <*> o .: "returnAddr"
+      <*> o .: "govAction"
+      <*> o .: "anchor"
 
 data Committee era = Committee
   { committeeMembers :: !(Map (Credential ColdCommitteeRole) EpochNo)
@@ -668,6 +713,10 @@ deriving newtype instance ToJSONKey (GovPurposeId (p :: GovActionPurpose))
 
 deriving newtype instance ToJSON (GovPurposeId (p :: GovActionPurpose))
 
+deriving newtype instance FromJSON (GovPurposeId (p :: GovActionPurpose))
+
+deriving newtype instance FromJSONKey (GovPurposeId (p :: GovActionPurpose))
+
 deriving newtype instance Show (GovPurposeId (p :: GovActionPurpose))
 
 -- | Abstract data type for representing relationship of governance action with the same purpose
@@ -741,7 +790,7 @@ instance
   (forall p. Typeable p => EncCBOR (f (GovPurposeId (p :: GovActionPurpose)))) =>
   EncCBOR (GovRelation f)
   where
-  encCBOR govPurpose@(GovRelation _ _ _ _) =
+  encCBOR govPurpose =
     let GovRelation {..} = govPurpose
      in encodeListLen 4
           <> encCBOR grPParamUpdate
@@ -753,7 +802,7 @@ instance
   (forall p. ToJSON (f (GovPurposeId (p :: GovActionPurpose)))) =>
   ToKeyValuePairs (GovRelation f)
   where
-  toKeyValuePairs govPurpose@(GovRelation _ _ _ _) =
+  toKeyValuePairs govPurpose =
     let GovRelation {..} = govPurpose
      in [ "PParamUpdate" .= grPParamUpdate
         , "HardFork" .= grHardFork
@@ -872,6 +921,8 @@ instance EraPParams era => NoThunks (GovAction era)
 instance EraPParams era => NFData (GovAction era)
 
 instance EraPParams era => ToJSON (GovAction era)
+
+instance EraPParams era => FromJSON (GovAction era)
 
 instance EraPParams era => DecCBOR (GovAction era) where
   decCBOR =

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Scripts.hs
@@ -53,7 +53,7 @@ import Cardano.Ledger.Plutus.Language
 import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData (..), rwhnf)
-import Data.Aeson (ToJSON (..), (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), withObject, (.:), (.=))
 import Data.MemPack
 import Data.Typeable
 import Data.Word (Word32)
@@ -315,6 +315,26 @@ instance
 pattern ConwayRewarding :: f Word32 AccountAddress -> ConwayPlutusPurpose f era
 pattern ConwayRewarding x = ConwayWithdrawing x
 {-# DEPRECATED ConwayRewarding "In favor of `ConwayWithdrawing`" #-}
+
+instance
+  ( forall a b. (FromJSON a, FromJSON b) => FromJSON (f a b)
+  , FromJSON (TxCert era)
+  , EraPParams era
+  ) =>
+  FromJSON (ConwayPlutusPurpose f era)
+  where
+  parseJSON = withObject "ConwayPlutusPurpose" $ \o -> do
+    kind <- o .: "kind"
+    value <- o .: "value"
+    case (kind :: String) of
+      "ConwaySpending" -> ConwaySpending <$> parseJSON value
+      "ConwayMinting" -> ConwayMinting <$> parseJSON value
+      "ConwayCertifying" -> ConwayCertifying <$> parseJSON value
+      "ConwayWithdrawing" -> ConwayWithdrawing <$> parseJSON value
+      "ConwayRewarding" -> ConwayRewarding <$> parseJSON value
+      "ConwayVoting" -> ConwayVoting <$> parseJSON value
+      "ConwayProposing" -> ConwayProposing <$> parseJSON value
+      _ -> fail $ "Unknown ConwayPlutusPurpose kind: " <> kind
 
 pattern VotingPurpose ::
   ConwayEraScript era => f Word32 Voter -> PlutusPurpose f era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -90,7 +90,9 @@ import Cardano.Ledger.Shelley.TxCert (
  )
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
-import Data.Aeson (FromJSON (..), ToJSON (..), withObject, (.:?), (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), withObject, (.:), (.:?), (.=))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (Parser)
 import Data.Foldable as F (foldMap')
 import Data.Monoid (Sum (getSum))
 import GHC.Generics (Generic)
@@ -565,6 +567,20 @@ instance ToJSON ConwayDelegCert where
         , "deposit" .= toJSON deposit
         ]
 
+instance FromJSON ConwayDelegCert where
+  parseJSON = withObject "ConwayDelegCert" $ \o -> do
+    kind <- o .: "kind" :: Parser Aeson.Value
+    case kind of
+      Aeson.String "RegCert" ->
+        ConwayRegCert <$> o .: "credential" <*> o .: "deposit"
+      Aeson.String "UnRegCert" ->
+        ConwayUnRegCert <$> o .: "credential" <*> o .: "refund"
+      Aeson.String "DelegCert" ->
+        ConwayDelegCert <$> o .: "credential" <*> o .: "delegatee"
+      Aeson.String "RegDelegCert" ->
+        ConwayRegDelegCert <$> o .: "credential" <*> o .: "delegatee" <*> o .: "deposit"
+      _ -> fail $ "Unknown ConwayDelegCert kind: " <> show kind
+
 data ConwayGovCert
   = ConwayRegDRep !(Credential DRepRole) !Coin !(StrictMaybe Anchor)
   | ConwayUnRegDRep !(Credential DRepRole) !Coin
@@ -611,6 +627,22 @@ instance ToJSON ConwayGovCert where
         , "anchor" .= toJSON anchor
         ]
 
+instance FromJSON ConwayGovCert where
+  parseJSON = withObject "ConwayGovCert" $ \o -> do
+    kind <- o .: "kind" :: Parser Aeson.Value
+    case kind of
+      Aeson.String "RegDRep" ->
+        ConwayRegDRep <$> o .: "dRep" <*> o .: "deposit" <*> o .: "anchor"
+      Aeson.String "UnRegDRep" ->
+        ConwayUnRegDRep <$> o .: "dRep" <*> o .: "refund"
+      Aeson.String "UpdateDRep" ->
+        ConwayUpdateDRep <$> o .: "dRep" <*> o .: "anchor"
+      Aeson.String "AuthCommitteeHotKey" ->
+        ConwayAuthCommitteeHotKey <$> o .: "coldCredential" <*> o .: "hotCredential"
+      Aeson.String "ResignCommitteeColdKey" ->
+        ConwayResignCommitteeColdKey <$> o .: "coldCredential" <*> o .: "anchor"
+      _ -> fail $ "Unknown ConwayGovCert kind: " <> show kind
+
 instance EncCBOR ConwayGovCert where
   encCBOR = \case
     ConwayAuthCommitteeHotKey cred key ->
@@ -655,6 +687,19 @@ instance Era era => ToJSON (ConwayTxCert era) where
     ConwayTxCertDeleg delegCert -> toJSON delegCert
     ConwayTxCertPool poolCert -> toJSON poolCert
     ConwayTxCertGov govCert -> toJSON govCert
+
+instance Era era => FromJSON (ConwayTxCert era) where
+  parseJSON = withObject "ConwayTxCert" $ \o -> do
+    kind <- o .: "kind" :: Parser Aeson.Value
+    case kind of
+      Aeson.String k
+        | k `elem` ["RegCert", "UnRegCert", "DelegCert", "RegDelegCert"] ->
+            ConwayTxCertDeleg <$> parseJSON (Aeson.Object o)
+        | k `elem` ["RegPool", "RetirePool"] ->
+            ConwayTxCertPool <$> parseJSON (Aeson.Object o)
+        | k `elem` ["RegDRep", "UnRegDRep", "UpdateDRep", "AuthCommitteeHotKey", "ResignCommitteeColdKey"] ->
+            ConwayTxCertGov <$> parseJSON (Aeson.Object o)
+      _ -> fail $ "Unknown ConwayTxCert kind: " <> show kind
 
 instance
   ( ShelleyEraTxCert era

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -165,7 +165,13 @@
   - `DijkstraUtxowPredFailure`
 * Remove `NoThunks` instance for `DijkstraContextError`
 * Make `DijkstraContextError` constructors lazy
-* Add `ToJSON` and `FromJSON` instances for `DijkstraNativeScript era`
+* Add `ToJSON` and `FromJSON` instances for
+  - `DijkstraNativeScript era`
+  - `AccountBalanceInterval era`
+* Add `FromJSON` instance for
+  - `DijkstraScript era`
+  - `DijkstraDelegCert`
+  - `DijkstraTxCert era`
 * Export `dijkstraBasedEraNativeScriptToJSON` and `dijkstraBasedEraNativeScriptJSONParser` from `Cardano.Ledger.Dijkstra.Scripts`
 * Remove DRep requirement for reward withdrawals
   - Remove `WdrlNotDelegatedToDRep` constructor from `EntitiesPredFailure`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Scripts.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Scripts.hs
@@ -89,7 +89,7 @@ import Cardano.Ledger.Shelley.Scripts
 import Cardano.Ledger.TxIn (TxIn)
 import Control.Applicative ((<|>))
 import Control.DeepSeq (NFData (..), rwhnf)
-import Data.Aeson (FromJSON (parseJSON), KeyValue (..), ToJSON (toJSON), (.:))
+import Data.Aeson (FromJSON (..), KeyValue (..), ToJSON (..), withObject, (.:))
 import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (Parser)
 import qualified Data.Map.Strict as Map
@@ -211,6 +211,27 @@ instance
     DijkstraGuarding n -> kindObjectWithValue "DijkstraGuarding" n
     where
       kindObjectWithValue name n = kindObjectValue name ["value" .= n]
+
+instance
+  ( forall a b. (FromJSON a, FromJSON b) => FromJSON (f a b)
+  , FromJSON (TxCert era)
+  , EraPParams era
+  ) =>
+  FromJSON (DijkstraPlutusPurpose f era)
+  where
+  parseJSON = withObject "DijkstraPlutusPurpose" $ \o -> do
+    kind <- o .: "kind"
+    value <- o .: "value"
+    case (kind :: String) of
+      "DijkstraSpending" -> DijkstraSpending <$> parseJSON value
+      "DijkstraMinting" -> DijkstraMinting <$> parseJSON value
+      "DijkstraCertifying" -> DijkstraCertifying <$> parseJSON value
+      "DijkstraWithdrawing" -> DijkstraWithdrawing <$> parseJSON value
+      "DijkstraRewarding" -> DijkstraRewarding <$> parseJSON value
+      "DijkstraVoting" -> DijkstraVoting <$> parseJSON value
+      "DijkstraProposing" -> DijkstraProposing <$> parseJSON value
+      "DijkstraGuarding" -> DijkstraGuarding <$> parseJSON value
+      _ -> fail $ "Unknown DijkstraPlutusPurpose kind: " <> kind
 
 deriving instance (EraTxCert era, EraPParams era) => Eq (DijkstraPlutusPurpose AsItem era)
 
@@ -658,8 +679,25 @@ instance Typeable era => DecCBOR (AccountBalanceInterval era) where
           (Nothing, Just u) -> pure $! AccountBalanceUpperBound u
           _ -> cborError $ DecoderErrorCustom "AccountBalanceInterval" "Both interval bounds cannot be nil."
 
+instance ToJSON (AccountBalanceInterval era) where
+  toJSON = \case
+    AccountBalanceLowerBound l -> kindObjectValue "lowerBound" ["lower" .= l]
+    AccountBalanceUpperBound u -> kindObjectValue "upperBound" ["upper" .= u]
+    AccountBalanceBothBounds l u -> kindObjectValue "bothBounds" ["lower" .= l, "upper" .= u]
+    AccountBalanceExact c -> kindObjectValue "exact" ["coin" .= c]
+
+instance FromJSON (AccountBalanceInterval era) where
+  parseJSON = withObject "AccountBalanceInterval" $ \o -> do
+    kind <- o .: "kind"
+    case (kind :: String) of
+      "lowerBound" -> AccountBalanceLowerBound <$> o .: "lower"
+      "upperBound" -> AccountBalanceUpperBound <$> o .: "upper"
+      "bothBounds" -> AccountBalanceBothBounds <$> o .: "lower" <*> o .: "upper"
+      "exact" -> AccountBalanceExact <$> o .: "coin"
+      _ -> fail $ "Unknown AccountBalanceInterval kind: " <> kind
+
 newtype AccountBalanceIntervals era
   = AccountBalanceIntervals
   {unAccountBalanceIntervals :: Map.Map AccountId (AccountBalanceInterval era)}
   deriving (Generic)
-  deriving newtype (Show, Ord, Eq, NoThunks, NFData, EncCBOR, DecCBOR)
+  deriving newtype (Show, Ord, Eq, NoThunks, NFData, EncCBOR, DecCBOR, ToJSON, FromJSON)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
@@ -80,7 +80,9 @@ import Cardano.Ledger.Shelley.TxCert (
  )
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
-import Data.Aeson (KeyValue ((.=)), ToJSON (..))
+import Data.Aeson (FromJSON (..), KeyValue ((.=)), ToJSON (..), (.:))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (Parser)
 import Data.Foldable (Foldable (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
@@ -168,6 +170,17 @@ instance ToJSON DijkstraDelegCert where
         , "deposit" .= toJSON deposit
         ]
 
+instance FromJSON DijkstraDelegCert where
+  parseJSON = Aeson.withObject "DijkstraDelegCert" $ \o -> do
+    kind <- o .: "kind" :: Parser Aeson.Value
+    case kind of
+      Aeson.String "RegCert" -> DijkstraRegCert <$> o .: "credential" <*> o .: "deposit"
+      Aeson.String "UnRegCert" -> DijkstraUnRegCert <$> o .: "credential" <*> o .: "refund"
+      Aeson.String "DelegCert" -> DijkstraDelegCert <$> o .: "credential" <*> o .: "delegatee"
+      Aeson.String "RegDelegCert" ->
+        DijkstraRegDelegCert <$> o .: "credential" <*> o .: "delegatee" <*> o .: "deposit"
+      _ -> fail $ "Unknown DijkstraDelegCert kind: " <> show kind
+
 data DijkstraTxCert era
   = DijkstraTxCertDeleg !DijkstraDelegCert
   | DijkstraTxCertPool !PoolCert
@@ -188,6 +201,25 @@ instance Era era => ToJSON (DijkstraTxCert era) where
     DijkstraTxCertDeleg delegCert -> toJSON delegCert
     DijkstraTxCertPool poolCert -> toJSON poolCert
     DijkstraTxCertGov govCert -> toJSON govCert
+
+instance Era era => FromJSON (DijkstraTxCert era) where
+  parseJSON = Aeson.withObject "DijkstraTxCert" $ \o -> do
+    kind <- o .: "kind" :: Parser Aeson.Value
+    case kind of
+      Aeson.String k
+        | k `elem` ["RegCert", "UnRegCert", "DelegCert", "RegDelegCert"] ->
+            DijkstraTxCertDeleg <$> parseJSON (Aeson.Object o)
+        | k `elem` ["RegPool", "RetirePool"] ->
+            DijkstraTxCertPool <$> parseJSON (Aeson.Object o)
+        | k
+            `elem` [ "RegDRep"
+                   , "UnRegDRep"
+                   , "UpdateDRep"
+                   , "AuthCommitteeHotKey"
+                   , "ResignCommitteeColdKey"
+                   ] ->
+            DijkstraTxCertGov <$> parseJSON (Aeson.Object o)
+      _ -> fail $ "Unknown DijkstraTxCert kind: " <> show kind
 
 instance
   ( EraTxCert era

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -125,8 +125,10 @@
   - `ShelleyPpupPredFailure`
 * Add protocol version validation to `createInitialState`:
   - Validate that current protocol version is within the era's bounds
-* Add `ToJSON` and `FromJSON` instances for `ShelleyTxAuxData era`
-* Add `ToJSON` and `FromJSON` instances for `MultiSig era`
+* Add `ToJSON` and `FromJSON` instances for
+  - `ShelleyTxAuxData era`
+  - `ShelleyTxWits era`
+  - `MultiSig era`
 * Export `shelleyBasedEraNativeScriptToJSON` and `shelleyBasedEraNativeScriptJSONParser` from `Cardano.Ledger.Shelley.Scripts`
 * Change `shelleyBasedEraNativeScriptToJSON` to accept a `(NativeScript era -> Aeson.Object)` continuation as its first argument for recursive child serialisation
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxWits.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -34,6 +36,7 @@ module Cardano.Ledger.Shelley.TxWits (
   mapTraverseableDecoderA,
 ) where
 
+import Cardano.Ledger.BaseTypes (KeyValuePairs (..), ToKeyValuePairs (..))
 import Cardano.Ledger.Binary (
   Annotator (..),
   DecCBOR (decCBOR),
@@ -65,6 +68,8 @@ import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.Scripts ()
 import Cardano.Ledger.Shelley.TxAuxData ()
 import Control.DeepSeq (NFData)
+import Data.Aeson (FromJSON (parseJSON), KeyValue ((.=)), ToJSON, (.:))
+import qualified Data.Aeson as Aeson
 import Data.Functor.Classes (Eq1 (liftEq))
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -193,6 +198,25 @@ instance EraScript era => Semigroup (ShelleyTxWits era) where
 
 instance EraScript era => Monoid (ShelleyTxWits era) where
   mempty = ShelleyTxWits mempty mempty mempty
+
+instance (EraScript era, ToJSON (Script era)) => ToKeyValuePairs (ShelleyTxWits era) where
+  toKeyValuePairs ShelleyTxWits {addrWits, scriptWits, bootWits} =
+    [ "addrWits" .= Set.toList addrWits
+    , "scriptWits" .= scriptWits
+    , "bootWits" .= Set.toList bootWits
+    ]
+
+deriving via
+  KeyValuePairs (ShelleyTxWits era)
+  instance
+    (EraScript era, ToJSON (Script era)) => ToJSON (ShelleyTxWits era)
+
+instance (EraScript era, FromJSON (Script era)) => FromJSON (ShelleyTxWits era) where
+  parseJSON = Aeson.withObject "ShelleyTxWits" $ \o ->
+    ShelleyTxWits
+      <$> (Set.fromList <$> o .: "addrWits")
+      <*> o .: "scriptWits"
+      <*> (Set.fromList <$> o .: "bootWits")
 
 pattern ShelleyTxWits ::
   forall era.

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -7,6 +7,17 @@
 * Add `ppMaxPledgeLeverageG` method to `EraPParams`, which defaults to `MaxPledgeLeverage SNothing` for eras up to Conway
 * Add a `MaxPledgeLeverage` argument to `maxPool'` and thread it through `maxPool`
 * Add `withdrawalsMissingAccounts` to `Account`
+* Add `sppBlsKey` field to `StakePoolParams`
+* Add `spsBlsKey` field and `spsBlsKeyL` lens to `StakePoolState`
+* Add `BlsKey` type with `EncCBOR`/`DecCBOR`, `ToJSON`/`FromJSON` instances
+* Make `FromJSON StakePoolParams` backward-compatible: `blsKey` field is optional (defaults to `SNothing`)
+* Add `ToJSON`, `FromJSON` and `NFData` as `EraTxWits` superclass constraints
+* Add `ToJSONKey` and `FromJSONKey` instances to `AccountId`
+* Add `ToJSON` and `FromJSON` instances for `Inclusive a` and `Exclusive a`
+* Add `ToJSON` and `FromJSON` instances for `WitVKey kr`
+* Add `ToJSON` and `FromJSON` instances for `BootstrapWitness`
+* Add `FromJSON` instance for `TxIn`; fix `txInToText` to use `unTxIx` instead of `show`
+* Add `FromJSON` instance for `PoolCert`
 
 ### `testlib`
 
@@ -81,10 +92,6 @@
 * Move `EncCBOR PoolCert` instance to `cardano-ledger-conformance`
 * Remove `[Enc|Dec]CBORGRoup` instances for `StakePoolParams`
 * Add `withStakePoolParamsFlatEncoding` and `decodeStakePoolParamsFlat` for flat (non-nested) CBOR encoding/decoding
-* Add `sppBlsKey` field to `StakePoolParams`
-* Add `spsBlsKey` field and `spsBlsKeyL` lens to `StakePoolState`
-* Add `BlsKey` type with `EncCBOR`/`DecCBOR`, `ToJSON`/`FromJSON` instances
-* Make `FromJSON StakePoolParams` backward-compatible: `blsKey` field is optional (defaults to `SNothing`)
 
 ### `cddl`
 
@@ -126,6 +133,7 @@
 * Add `Arbitrary (NativeScript era)` and `ToExpr (NativeScript era)` constraints to `EraConstraints`
 * Add round-trip JSON property test for `NativeScript era` and `Script era` to the shared era spec
 * Add round-trip JSON property test for `TxAuxData era` to the shared era spec
+* Add round-trip JSON property test for `TxWits era` to the shared era spec
 
 ## 1.20.0.0
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Address.hs
@@ -188,7 +188,7 @@ data AccountAddress = AccountAddress
 
 newtype AccountId = AccountId {unAccountId :: Credential Staking}
   deriving (Show, Eq, Generic, Ord)
-  deriving newtype (NFData, NoThunks, ToJSON, FromJSON, EncCBOR, DecCBOR)
+  deriving newtype (NFData, NoThunks, ToJSON, ToJSONKey, FromJSON, FromJSONKey, EncCBOR, DecCBOR)
 
 -- | Deprecated pattern synonym for backward compatibility
 pattern RewardAccount :: Network -> Credential Staking -> AccountAddress

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -808,10 +808,10 @@ deriving instance Show EpochErr
 instance Exception EpochErr
 
 newtype Inclusive a = Inclusive {unInclusive :: a}
-  deriving newtype (Generic, Show, Eq, Ord, NoThunks, NFData, EncCBOR, DecCBOR)
+  deriving newtype (Generic, Show, Eq, Ord, NoThunks, NFData, EncCBOR, DecCBOR, ToJSON, FromJSON)
 
 newtype Exclusive a = Exclusive {unExclusive :: a}
-  deriving newtype (Generic, Show, Eq, Ord, NoThunks, NFData, EncCBOR, DecCBOR)
+  deriving newtype (Generic, Show, Eq, Ord, NoThunks, NFData, EncCBOR, DecCBOR, ToJSON, FromJSON)
 
 -- | Relationship descriptor for the expectation in the 'Mismatch' type.
 type data Relation

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -510,6 +510,9 @@ class
   , ToCBOR (TxWits era)
   , EncCBOR (TxWits era)
   , DecCBOR (Annotator (TxWits era))
+  , NFData (TxWits era)
+  , ToJSON (TxWits era)
+  , FromJSON (TxWits era)
   ) =>
   EraTxWits era
   where

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -33,9 +33,12 @@ import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..), asWitness)
 import Cardano.Ledger.Slot (EpochNo (..))
 import Cardano.Ledger.State.StakePool (StakePoolParams (sppId))
 import Control.DeepSeq (NFData (..), rwhnf)
-import Data.Aeson (ToJSON (..), (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (Parser)
 import Data.Kind (Type)
 import Data.Maybe (isJust)
+import Data.Text (Text)
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
@@ -147,6 +150,14 @@ instance ToJSON PoolCert where
         [ "poolId" .= toJSON poolId
         , "epochNo" .= toJSON epochNo
         ]
+
+instance FromJSON PoolCert where
+  parseJSON = Aeson.withObject "PoolCert" $ \o -> do
+    kind <- o .: "kind" :: Parser Text
+    case kind of
+      "RegPool" -> RegPool <$> o .: "poolParams"
+      "RetirePool" -> RetirePool <$> o .: "poolId" <*> o .: "epochNo"
+      _ -> fail $ "Unknown PoolCert kind: " <> show kind
 
 poolCertKeyHashWitness :: PoolCert -> KeyHash Witness
 poolCertKeyHashWitness = \case

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/Bootstrap.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -50,7 +51,11 @@ import Cardano.Ledger.Keys.Internal (
  )
 import Control.DeepSeq (NFData (..), rwhnf)
 import Control.Monad (unless)
+import Data.Aeson (FromJSON (parseJSON), KeyValue ((.=)), ToJSON (toJSON), (.:))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (Parser)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Builder as B
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Short as SBS
@@ -60,6 +65,8 @@ import Data.MemPack.Buffer (byteArrayToShortByteString)
 import Data.Ord (comparing)
 import qualified Data.Primitive.ByteArray as BA
 import Data.Proxy (Proxy (..))
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks (..))
 import Quiet
@@ -91,7 +98,7 @@ instance NFData BootstrapWitness where
 instance NoThunks BootstrapWitness
 
 instance EncCBOR BootstrapWitness where
-  encCBOR bw@(BootstrapWitness _ _ _ _) =
+  encCBOR bw@(BootstrapWitness {}) =
     let BootstrapWitness {..} = bw
      in encodeListLen 4
           <> encCBOR bwKey
@@ -107,6 +114,45 @@ instance DecCBOR BootstrapWitness where
 
 instance Ord BootstrapWitness where
   compare = comparing bootstrapWitKeyHash
+
+instance ToJSON BootstrapWitness where
+  toJSON (BootstrapWitness (VKey vk) (SignedDSIGN sig) (ChainCode cc) attrs) =
+    let
+      encodeHex :: ByteString -> Text
+      encodeHex = Text.decodeUtf8 . Base16.encode
+      toBS :: BA.ByteArray -> ByteString
+      toBS = SBS.fromShort . byteArrayToShortByteString
+     in
+      Aeson.object
+        [ "key" .= encodeHex (rawEncodeFixedSized vk)
+        , "signature" .= encodeHex (rawEncodeFixedSized sig)
+        , "chainCode" .= encodeHex (toBS cc)
+        , "attributes" .= encodeHex (toBS attrs)
+        ]
+
+instance FromJSON BootstrapWitness where
+  parseJSON =
+    let
+      decodeHex :: Text -> Parser ByteString
+      decodeHex t = either fail pure $ Base16.decode (Text.encodeUtf8 t)
+     in
+      Aeson.withObject "BootstrapWitness" $ \o -> do
+        !keyHex <- o .: "key"
+        !sigHex <- o .: "signature"
+        !ccHex <- o .: "chainCode"
+        !attrsHex <- o .: "attributes"
+        !keyBytes <- decodeHex keyHex
+        !sigBytes <- decodeHex sigHex
+        !ccBytes <- decodeHex ccHex
+        !attrsBytes <- decodeHex attrsHex
+        !vk <- rawDecodeFixedSized keyBytes
+        !sig <- rawDecodeFixedSized sigBytes
+        pure $
+          BootstrapWitness
+            (VKey vk)
+            (SignedDSIGN sig)
+            (ChainCode (byteArrayFromByteString ccBytes))
+            (byteArrayFromByteString attrsBytes)
 
 -- | Rebuild the addrRoot of the corresponding address.
 bootstrapWitKeyHash ::

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Keys/WitVKey.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
@@ -14,11 +15,12 @@ module Cardano.Ledger.Keys.WitVKey (
 ) where
 
 import Cardano.Crypto.DSIGN.Class (
-  SignedDSIGN,
+  SignedDSIGN (..),
  )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
+  FixedSizeCodec (..),
   decodeRecordNamed,
   encodeListLen,
  )
@@ -30,9 +32,20 @@ import Cardano.Ledger.Hashes (
   hashKey,
   hashTxBodySignature,
  )
-import Cardano.Ledger.Keys.Internal (DSIGN, KeyRole (..), VKey, asWitness)
+import Cardano.Ledger.Keys.Internal (
+  DSIGN,
+  KeyRole (..),
+  VKey (..),
+  asWitness,
+ )
 import Control.DeepSeq
+import Data.Aeson (FromJSON (..), ToJSON (..), (.:), (.=))
+import qualified Data.Aeson as Aeson
+import Data.Aeson.Types (Parser)
+import qualified Data.ByteString.Base16 as B16
 import Data.Ord (comparing)
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
@@ -66,6 +79,23 @@ instance Typeable kr => Ord (WitVKey kr) where
     -- comparison on signatures is unlikely to happen and is only needed for
     -- compliance with Ord laws.
     comparing wvkKeyHash x y <> comparing (hashTxBodySignature . wvkSignature) x y
+
+instance ToJSON (WitVKey kr) where
+  toJSON (WitVKey (VKey vk) (SignedDSIGN sig)) =
+    Aeson.object
+      [ "key" .= Text.decodeUtf8 (B16.encode (rawEncodeFixedSized vk))
+      , "signature" .= Text.decodeUtf8 (B16.encode (rawEncodeFixedSized sig))
+      ]
+
+instance Typeable kr => FromJSON (WitVKey kr) where
+  parseJSON = Aeson.withObject "WitVKey" $ \o -> do
+    !keyHex <- o .: "key" :: Parser Text
+    !sigHex <- o .: "signature" :: Parser Text
+    !keyBytes <- either fail pure $ B16.decode (Text.encodeUtf8 keyHex)
+    !sigBytes <- either fail pure $ B16.decode (Text.encodeUtf8 sigHex)
+    !vk <- rawDecodeFixedSized keyBytes
+    !sig <- rawDecodeFixedSized sigBytes
+    pure $ WitVKey (VKey vk) (SignedDSIGN sig)
 
 instance EncCBOR (WitVKey kr) where
   encCBOR (WitVKey k sig) =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/TxIn.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -19,6 +20,7 @@ module Cardano.Ledger.TxIn (
   TxIn (TxIn),
   mkTxInPartial,
   txInToText,
+  parseTxId,
   TxIx,
 ) where
 
@@ -36,11 +38,14 @@ import Cardano.Ledger.Binary (
  )
 import Cardano.Ledger.Hashes (EraIndependentTxBody, SafeHash, extractHash)
 import Control.DeepSeq (NFData)
-import Data.Aeson (FromJSON, ToJSON (..))
+import Data.Aeson (FromJSON (..), ToJSON (..), eitherDecodeStrict')
+import qualified Data.Aeson as Aeson
 import Data.Aeson.Types (ToJSONKey (..), toJSONKeyText)
 import Data.MemPack
 import Data.Text (Text)
 import qualified Data.Text as Text
+import Data.Text.Encoding (encodeUtf8)
+import Data.Word (Word16)
 import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
 import NoThunks.Class (NoThunks (..))
@@ -59,19 +64,6 @@ import NoThunks.Class (NoThunks (..))
 newtype TxId = TxId {unTxId :: SafeHash EraIndependentTxBody}
   deriving (Show, Eq, Ord, Generic)
   deriving newtype (NoThunks, ToJSON, FromJSON, EncCBOR, DecCBOR, NFData, MemPack)
-
-instance ToJSON TxIn where
-  toJSON = toJSON . txInToText
-  toEncoding = toEncoding . txInToText
-
-instance ToJSONKey TxIn where
-  toJSONKey = toJSONKeyText txInToText
-
-txInToText :: TxIn -> Text
-txInToText (TxIn (TxId txidHash) ix) =
-  hashToTextAsHex (extractHash txidHash)
-    <> Text.pack "#"
-    <> Text.pack (show ix)
 
 -- | The input of a UTxO.
 data TxIn = TxIn !TxId {-# UNPACK #-} !TxIx
@@ -93,6 +85,37 @@ mkTxInPartial txId = TxIn txId . mkTxIxPartial
 instance NFData TxIn
 
 instance NoThunks TxIn
+
+instance ToJSON TxIn where
+  toJSON = toJSON . txInToText
+  toEncoding = toEncoding . txInToText
+
+instance ToJSONKey TxIn where
+  toJSONKey = toJSONKeyText txInToText
+
+instance FromJSON TxIn where
+  parseJSON v = do
+    t <- parseJSON @Text v
+    (txId, txIx) <- parseTxId t
+    pure $ TxIn txId (TxIx txIx)
+
+parseTxId :: MonadFail m => Text -> m (TxId, Word16)
+parseTxId t = case Text.splitOn "#" t of
+  [txIdText, txIxText] -> do
+    txId <- case Aeson.fromJSON (Aeson.String txIdText) of
+      Aeson.Success v -> pure v
+      Aeson.Error e -> fail $ "invalid txId: " <> e
+    txIx <- case eitherDecodeStrict' (encodeUtf8 txIxText) of
+      Left err -> fail $ "invalid transaction index: " <> err
+      Right ix -> pure ix
+    pure (txId, txIx)
+  _ -> fail "expected 'txhash#ix'"
+
+txInToText :: TxIn -> Text
+txInToText (TxIn (TxId txidHash) ix) =
+  hashToTextAsHex (extractHash txidHash)
+    <> Text.pack "#"
+    <> Text.pack (show (unTxIx ix))
 
 instance EncCBOR TxIn where
   encCBOR (TxIn txId index) =

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Era.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Era.hs
@@ -174,6 +174,8 @@ ledgerEraTestMain extraEraSpec =
           roundTripAesonProperty @(Script era)
         prop (show $ typeRep $ Proxy @(TxAuxData era)) $
           roundTripAesonProperty @(TxAuxData era)
+        prop (show $ typeRep $ Proxy @(TxWits era)) $
+          roundTripAesonProperty @(TxWits era)
       describe "Era-specific spec" extraEraSpec
 
 -- | This is a helper function that uses `mkTestAccountState` to register an account.


### PR DESCRIPTION
# Description

* Add ToJSON, FromJSON and NFData as EraTxWits superclass constraints
* Add ToJSON/FromJSON for WitVKey, BootstrapWitness
* Add ToJSONKey/FromJSONKey for AccountId
* Add ToJSON/FromJSON for Inclusive and Exclusive
* Add FromJSON for TxIn; fix txInToText to use unTxIx
* Add FromJSON for PoolCert
* Add ToJSON/FromJSON for ShelleyTxWits era
* Add FromJSON for AsIx, AlonzoPlutusPurpose AsIx, TxDats, Redeemers, AlonzoTxWits
* Add FromJSON for ConwayDelegCert, ConwayGovCert, ConwayTxCert era, ConwayPlutusPurpose
* Add FromJSON for GovActionId, Voter, Vote, VotingProcedure, ProposalProcedure, GovAction, GovPurposeId
* Add ToJSON/FromJSON for AccountBalanceInterval, DijkstraScript
* Add FromJSON for DijkstraDelegCert, DijkstraTxCert era
* Add round-trip JSON property test for TxWits era

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
