### PR TITLE
Further `StAnnTx` integration

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -29,16 +29,10 @@ import Cardano.Ledger.Allegra.Tx (Tx (..))
 import Cardano.Ledger.Allegra.UTxO ()
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
-import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
-import Cardano.Ledger.Shelley.Rules (ledgerPpL)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import Cardano.Ledger.State (utxoG)
-import Control.State.Transition.Extended (ValidationPolicy (..))
-import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
-import Lens.Micro ((^.))
 
 instance ApplyTx AllegraEra where
   newtype ApplyTxError AllegraEra
@@ -48,28 +42,9 @@ instance ApplyTx AllegraEra where
 
   mkStAnnTx _ _ _ _ = id
 
-  internalApplyTxWithValidation validationPolicy globals env state tx =
-    let stAnnTx =
-          mkStAnnTx
-            (epochInfo globals)
-            (systemStart globals)
-            (env ^. ledgerPpL)
-            (state ^. utxoG)
-            tx
-     in first AllegraApplyTxError $
-          ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation = defaultApplyTxWithValidation @"LEDGER" AllegraApplyTxError
 
-  internalReapplyValidatedTx globals env state vtx =
-    fst
-      <$> first
-        AllegraApplyTxError
-        ( ruleApplyTxValidation @"LEDGER"
-            (ValidateSuchThat (notElem lblStatic))
-            globals
-            env
-            state
-            (vtStAnnTx vtx)
-        )
+  internalReapplyValidatedTx = defaultReapplyValidatedTx @"LEDGER" AllegraApplyTxError
 
 instance ApplyTick AllegraEra
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -29,11 +29,16 @@ import Cardano.Ledger.Allegra.Tx (Tx (..))
 import Cardano.Ledger.Allegra.UTxO ()
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
+import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
+import Cardano.Ledger.Shelley.Rules (ledgerPpL)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Cardano.Ledger.State (utxoG)
+import Control.State.Transition.Extended (ValidationPolicy (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 
 instance ApplyTx AllegraEra where
   newtype ApplyTxError AllegraEra
@@ -43,9 +48,28 @@ instance ApplyTx AllegraEra where
 
   mkStAnnTx _ _ _ _ = id
 
-  applyTxValidation validationPolicy globals env state stAnnTx =
-    first AllegraApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation validationPolicy globals env state tx =
+    let stAnnTx =
+          mkStAnnTx
+            (epochInfo globals)
+            (systemStart globals)
+            (env ^. ledgerPpL)
+            (state ^. utxoG)
+            tx
+     in first AllegraApplyTxError $
+          ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+
+  internalReapplyValidatedTx globals env state vtx =
+    fst
+      <$> first
+        AllegraApplyTxError
+        ( ruleApplyTxValidation @"LEDGER"
+            (ValidateSuchThat (notElem lblStatic))
+            globals
+            env
+            state
+            (vtStAnnTx vtx)
+        )
 
 instance ApplyTick AllegraEra
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.16.0.0
 
+* Introduce `LEDGERS` and `STS` instance and wire it to `EraRule LEDGERS`
 * Export `alonzoPlutusScriptDecoder` from `Cardano.Ledger.Alonzo.TxWits`
-* Add `generate-cbor` executable
 * Rename the `Rewarding` verb to `Withdrawing` and deprecate the old names:
   - `AlonzoRewarding` -> `AlonzoWithdrawing`
   - `RewardingPurpose` -> `WithdrawingPurpose`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Remove `ueUtxo` field from `UtxoEnv`
 * Introduce `LEDGERS` and `STS` instance and wire it to `EraRule LEDGERS`
 * Export `alonzoPlutusScriptDecoder` from `Cardano.Ledger.Alonzo.TxWits`
 * Rename the `Rewarding` verb to `Withdrawing` and deprecate the old names:

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -141,7 +141,6 @@ mkAlonzoStAnnTx ei sysStart pp utxo tx =
    in
     AlonzoStAnnTx
       { asatTx = tx
-      , asatProtocolVersion = pp ^. ppProtocolVersionL
       , asatScriptsNeeded = scriptsNeeded
       , asatScriptsProvided = scriptsProvided
       , asatPlutusLanguagesUsed =

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -53,11 +53,15 @@ import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Plutus.Data ()
+import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
+import Cardano.Ledger.Shelley.Rules (ledgerPpL, ledgerSlotNoL)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import Cardano.Ledger.State (EraUTxO (..))
+import Cardano.Ledger.State (EraUTxO (..), utxoG)
 import Cardano.Slotting.EpochInfo (EpochInfo)
+import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
 import Cardano.Slotting.Time (SystemStart)
+import Control.State.Transition.Extended (ValidationPolicy (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Set as Set
@@ -72,9 +76,37 @@ instance ApplyTx AlonzoEra where
 
   mkStAnnTx = mkAlonzoStAnnTx
 
-  applyTxValidation validationPolicy globals env state stAnnTx =
-    first AlonzoApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation validationPolicy globals env state tx =
+    let stAnnTx =
+          mkStAnnTx
+            (unsafeLinearExtendEpochInfo (env ^. ledgerSlotNoL) (epochInfo globals))
+            (systemStart globals)
+            (env ^. ledgerPpL)
+            (state ^. utxoG)
+            tx
+     in first AlonzoApplyTxError $
+          ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+
+  internalReapplyValidatedTx globals env state vtx
+    | getValidatedTxSlotNo vtx == env ^. ledgerSlotNoL =
+        fst
+          <$> first
+            AlonzoApplyTxError
+            ( ruleApplyTxValidation @"LEDGER"
+                (ValidateSuchThat (notElem lblStatic))
+                globals
+                env
+                state
+                (getValidatedTxStAnnTx vtx)
+            )
+    | otherwise =
+        fst
+          <$> internalApplyTxWithValidation
+            ValidateAll
+            globals
+            env
+            state
+            (getValidatedTxStAnnTx vtx ^. txStAnnTxG)
 
 instance ApplyTick AlonzoEra
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Era.hs
@@ -14,6 +14,7 @@ module Cardano.Ledger.Alonzo.Era (
   UTXOW,
   BBODY,
   LEDGER,
+  LEDGERS,
 
   -- * Deprecated
   AlonzoUTXO,
@@ -40,6 +41,10 @@ type instance Value AlonzoEra = MaryValue
 -------------------------------------------------------------------------------
 
 -- These rules are new or changed in Alonzo
+
+data LEDGERS era
+
+type instance EraRule "LEDGERS" AlonzoEra = LEDGERS AlonzoEra
 
 data UTXOS era
 
@@ -90,8 +95,6 @@ type instance EraRule "DELEGS" AlonzoEra = Shelley.DELEGS AlonzoEra
 type instance EraRule "DELPL" AlonzoEra = Shelley.DELPL AlonzoEra
 
 type instance EraRule "EPOCH" AlonzoEra = Shelley.EPOCH AlonzoEra
-
-type instance EraRule "LEDGERS" AlonzoEra = Shelley.LEDGERS AlonzoEra
 
 type instance EraRule "MIR" AlonzoEra = Shelley.MIR AlonzoEra
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules.hs
@@ -5,6 +5,7 @@
 module Cardano.Ledger.Alonzo.Rules (
   module Cardano.Ledger.Alonzo.Rules.Bbody,
   module Cardano.Ledger.Alonzo.Rules.Ledger,
+  module Cardano.Ledger.Alonzo.Rules.Ledgers,
   module Cardano.Ledger.Alonzo.Rules.Utxo,
   module Cardano.Ledger.Alonzo.Rules.Utxos,
   module Cardano.Ledger.Alonzo.Rules.Utxow,
@@ -17,7 +18,7 @@ import Cardano.Ledger.Alonzo.Rules.Deleg ()
 import Cardano.Ledger.Alonzo.Rules.Delegs ()
 import Cardano.Ledger.Alonzo.Rules.Delpl ()
 import Cardano.Ledger.Alonzo.Rules.Ledger
-import Cardano.Ledger.Alonzo.Rules.Ledgers ()
+import Cardano.Ledger.Alonzo.Rules.Ledgers
 import Cardano.Ledger.Alonzo.Rules.Pool ()
 import Cardano.Ledger.Alonzo.Rules.Ppup ()
 import Cardano.Ledger.Alonzo.Rules.Utxo

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledgers.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledgers.hs
@@ -1,18 +1,48 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Alonzo.Rules.Ledgers () where
+module Cardano.Ledger.Alonzo.Rules.Ledgers (
+  LEDGERS,
+) where
 
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
-import Cardano.Ledger.Alonzo.Era (AlonzoEra)
+import Cardano.Ledger.Alonzo.Era (AlonzoEra, LEDGER, LEDGERS)
 import Cardano.Ledger.Alonzo.Rules.Ledger ()
 import Cardano.Ledger.Alonzo.Rules.Utxo (AlonzoUtxoPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxos (AlonzoUtxosPredFailure)
 import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoUtxowPredFailure)
+import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfo, systemStart)
 import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
+import Cardano.Ledger.Shelley.Core (EraGov)
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), UTxOState (..))
+import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Cardano.Ledger.State (CertState, EraStake)
+import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
+import Control.Monad (foldM)
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition (
+  Embed (..),
+  STS (..),
+  TRC (..),
+  TransitionRule,
+  judgmentContext,
+  liftSTS,
+  trans,
+ )
+import Data.Default (Default)
+import Data.Foldable (toList)
+import Data.Sequence (Seq)
 
 type instance EraRuleFailure "LEDGERS" AlonzoEra = Shelley.ShelleyLedgersPredFailure AlonzoEra
 
@@ -53,3 +83,63 @@ instance InjectRuleFailure "LEDGERS" Shelley.ShelleyPoolPredFailure AlonzoEra wh
 
 instance InjectRuleFailure "LEDGERS" Shelley.ShelleyDelegPredFailure AlonzoEra where
   injectFailure = Shelley.LedgerFailure . injectFailure
+
+instance
+  ( ApplyTx era
+  , EraGov era
+  , EraStake era
+  , Default (CertState era)
+  , Embed (EraRule "LEDGER" era) (LEDGERS era)
+  , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
+  , State (EraRule "LEDGER" era) ~ LedgerState era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , Default (LedgerState era)
+  ) =>
+  STS (LEDGERS era)
+  where
+  type State (LEDGERS era) = LedgerState era
+  type Signal (LEDGERS era) = Seq (Tx TopTx era)
+  type Environment (LEDGERS era) = Shelley.ShelleyLedgersEnv era
+  type BaseM (LEDGERS era) = ShelleyBase
+  type PredicateFailure (LEDGERS era) = Shelley.ShelleyLedgersPredFailure era
+  type Event (LEDGERS era) = Shelley.ShelleyLedgersEvent era
+
+  transitionRules = [alonzoLedgersTransition]
+
+alonzoLedgersTransition ::
+  forall era.
+  ( ApplyTx era
+  , EraGov era
+  , EraStake era
+  , Default (CertState era)
+  , Embed (EraRule "LEDGER" era) (LEDGERS era)
+  , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
+  , State (EraRule "LEDGER" era) ~ LedgerState era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  ) =>
+  TransitionRule (LEDGERS era)
+alonzoLedgersTransition = do
+  TRC (Shelley.LedgersEnv slot epochNo pp account, ls, txs) <- judgmentContext
+  ei <- liftSTS $ asks epochInfo
+  sysStart <- liftSTS $ asks systemStart
+  foldM
+    ( \ !ls' (ix, tx) ->
+        let utxo = utxosUtxo (lsUTxOState ls')
+            stAnnTx = mkStAnnTx (unsafeLinearExtendEpochInfo slot ei) sysStart pp utxo tx
+         in trans @(EraRule "LEDGER" era) $
+              TRC (LedgerEnv slot (Just epochNo) ix pp account, ls', stAnnTx)
+    )
+    ls
+    $ zip [minBound ..]
+    $ toList txs
+
+instance
+  ( Era era
+  , STS (LEDGER era)
+  , PredicateFailure (EraRule "LEDGER" era) ~ Shelley.ShelleyLedgerPredFailure era
+  , Event (EraRule "LEDGER" era) ~ Shelley.ShelleyLedgerEvent era
+  ) =>
+  Embed (LEDGER era) (LEDGERS era)
+  where
+  wrapFailed = Shelley.LedgerFailure
+  wrapEvent = Shelley.LedgerEvent

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -571,7 +571,7 @@ utxoTransition = do
 
   updatedGovState <-
     trans @(EraRule "UTXOS" era) $
-      TRC (UtxosEnv slot pp certState utxo, utxosGovState utxos, stAnnTx)
+      TRC (UtxosEnv slot pp certState, utxosGovState utxos, stAnnTx)
 
   case tx ^. isValidTxL of
     IsValid True ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -38,19 +38,15 @@ import Cardano.Ledger.Alonzo.Era (AlonzoEra, UTXOS)
 import Cardano.Ledger.Alonzo.Plutus.Context (ContextError, EraPlutusContext)
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
   CollectError (..),
-  collectPlutusScriptsWithContext,
   evalPlutusScripts,
  )
 import Cardano.Ledger.Alonzo.Rules.Ppup ()
 import Cardano.Ledger.Alonzo.State
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..), AlonzoScriptsNeeded)
 import Cardano.Ledger.BaseTypes (
-  Globals,
   ShelleyBase,
   StrictMaybe,
-  epochInfo,
   kindObjectValue,
-  systemStart,
  )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
@@ -68,10 +64,8 @@ import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Ledger.Shelley.PParams (Update)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.TxCert (ShelleyTxCert)
-import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
 import Cardano.Slotting.Slot (SlotNo)
 import Control.DeepSeq (NFData)
-import Control.Monad.Trans.Reader (ReaderT, asks)
 import Control.State.Transition.Extended
 import Data.Aeson (ToJSON (..), (.=))
 import qualified Data.Aeson as Aeson
@@ -100,7 +94,6 @@ instance
   , AlonzoEraScript era
   , TxCert era ~ ShelleyTxCert era
   , EraGov era
-  , GovState era ~ ShelleyGovState era
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
   , Embed (EraRule "PPUP" era) (UTXOS era)
   , Environment (EraRule "PPUP" era) ~ Shelley.PpupEnv era
@@ -157,20 +150,11 @@ utxosTransition ::
   ( AlonzoEraTx era
   , ShelleyEraTxBody era
   , AlonzoEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , TxCert era ~ ShelleyTxCert era
-  , EraGov era
-  , GovState era ~ ShelleyGovState era
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
   , Environment (EraRule "PPUP" era) ~ Shelley.PpupEnv era
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , Embed (EraRule "PPUP" era) (UTXOS era)
-  , EncCBOR (PredicateFailure (EraRule "PPUP" era)) -- Serializing the PredicateFailure
-  , Eq (EraRuleFailure "PPUP" era)
-  , Show (EraRuleFailure "PPUP" era)
-  , EraPlutusContext era
   , EraCertState era
-  , EraStake era
   ) =>
   TransitionRule (UTXOS era)
 utxosTransition =
@@ -183,28 +167,14 @@ utxosTransition =
 -- ===================================================================
 
 scriptsTransition ::
-  ( STS sts
-  , Monad m
-  , AlonzoEraTxBody era
-  , AlonzoEraTxWits era
-  , AlonzoEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , BaseM sts ~ ReaderT Globals m
+  ( AlonzoEraUTxO era
   , PredicateFailure sts ~ AlonzoUtxosPredFailure era
-  , EraPlutusContext era
   ) =>
-  SlotNo ->
-  PParams era ->
-  Tx TopTx era ->
-  UTxO era ->
+  StAnnTx TopTx era ->
   (ScriptResult -> Rule sts ctx ()) ->
   Rule sts ctx ()
-scriptsTransition slot pp tx utxo action = do
-  sysSt <- liftSTS $ asks systemStart
-  ei <- liftSTS $ asks epochInfo
-  let
-    scriptsWithContext =
-      collectPlutusScriptsWithContext (unsafeLinearExtendEpochInfo slot ei) sysSt pp tx utxo
+scriptsTransition stAnnTx action = do
+  let scriptsWithContext = plutusScriptsWithContextStAnnTx stAnnTx
   failOnNonEmpty
     (either (NonEmpty.filter isNotBadTranslation) (const []) scriptsWithContext)
     CollectErrors
@@ -222,18 +192,15 @@ alonzoEvalScriptsTxValid ::
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   , ShelleyEraTxBody era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , STS (UTXOS era)
   , Environment (EraRule "PPUP" era) ~ Shelley.PpupEnv era
   , Signal (EraRule "PPUP" era) ~ StrictMaybe (Update era)
   , Embed (EraRule "PPUP" era) (UTXOS era)
   , State (EraRule "PPUP" era) ~ ShelleyGovState era
-  , EraPlutusContext era
   , EraCertState era
   ) =>
   TransitionRule (UTXOS era)
 alonzoEvalScriptsTxValid = do
-  TRC (UtxosEnv slot pp certState utxo, pup, stAnnTx) <-
+  TRC (UtxosEnv slot pp certState _utxo, pup, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
       txBody = tx ^. bodyTxL
@@ -241,7 +208,7 @@ alonzoEvalScriptsTxValid = do
 
   () <- pure $! Debug.traceEvent validBegin ()
 
-  scriptsTransition slot pp tx utxo $ \case
+  scriptsTransition stAnnTx $ \case
     Fails _ps fs ->
       failBecause $
         ValidationTagMismatch
@@ -258,18 +225,15 @@ alonzoEvalScriptsTxInvalid ::
   forall era.
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
-  , STS (UTXOS era)
-  , EraPlutusContext era
   ) =>
   TransitionRule (UTXOS era)
 alonzoEvalScriptsTxInvalid = do
-  TRC (UtxosEnv slot pp _ utxo, pup, stAnnTx) <- judgmentContext
+  TRC (UtxosEnv _slot _pp _ _utxo, pup, stAnnTx) <- judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
 
   () <- pure $! Debug.traceEvent invalidBegin ()
 
-  scriptsTransition slot pp tx utxo $ \case
+  scriptsTransition stAnnTx $ \case
     Passes _ps ->
       failBecause $
         ValidationTagMismatch (tx ^. isValidTxL) PassedUnexpectedly

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxos.hs
@@ -119,7 +119,6 @@ data UtxosEnv era = UtxosEnv
   { ueSlot :: SlotNo
   , uePParams :: PParams era
   , ueCertState :: CertState era
-  , ueUtxo :: UTxO era
   }
   deriving (Generic)
 
@@ -200,7 +199,7 @@ alonzoEvalScriptsTxValid ::
   ) =>
   TransitionRule (UTXOS era)
 alonzoEvalScriptsTxValid = do
-  TRC (UtxosEnv slot pp certState _utxo, pup, stAnnTx) <-
+  TRC (UtxosEnv slot pp certState, pup, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
       txBody = tx ^. bodyTxL
@@ -228,7 +227,7 @@ alonzoEvalScriptsTxInvalid ::
   ) =>
   TransitionRule (UTXOS era)
 alonzoEvalScriptsTxInvalid = do
-  TRC (UtxosEnv _slot _pp _ _utxo, pup, stAnnTx) <- judgmentContext
+  TRC (UtxosEnv _slot _pp _, pup, stAnnTx) <- judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
 
   () <- pure $! Debug.traceEvent invalidBegin ()

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -98,7 +98,7 @@ import Cardano.Ledger.Alonzo.TxWits (
   unRedeemersL,
   unTxDatsL,
  )
-import Cardano.Ledger.BaseTypes (ProtVer, integralToBounded)
+import Cardano.Ledger.BaseTypes (integralToBounded)
 import Cardano.Ledger.Binary (
   Annotator,
   DecCBOR (..),
@@ -495,7 +495,6 @@ instance
 data AlonzoStAnnTx l era where
   AlonzoStAnnTx ::
     { asatTx :: !(Tx TopTx era)
-    , asatProtocolVersion :: !ProtVer
     , asatScriptsNeeded :: ScriptsNeeded era
     , asatScriptsProvided :: ScriptsProvided era
     , asatPlutusLanguagesUsed :: Set Language
@@ -536,14 +535,13 @@ instance
   ) =>
   NFData (AlonzoStAnnTx l era)
   where
-  rnf stAnnTx@(AlonzoStAnnTx _ _ _ _ _ _) =
+  rnf stAnnTx@(AlonzoStAnnTx _ _ _ _ _) =
     let AlonzoStAnnTx {..} = stAnnTx
      in asatTx `deepseq`
-          asatProtocolVersion `deepseq`
-            asatScriptsNeeded `deepseq`
-              asatScriptsProvided `deepseq`
-                asatPlutusLanguagesUsed `deepseq`
-                  rnf asatPlutusScriptsWithContext
+          asatScriptsNeeded `deepseq`
+            asatScriptsProvided `deepseq`
+              asatPlutusLanguagesUsed `deepseq`
+                rnf asatPlutusScriptsWithContext
 
 instance EncCBOR (Tx l era) => EncCBOR (AlonzoStAnnTx l era) where
   encCBOR AlonzoStAnnTx {asatTx} = encCBOR asatTx

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -153,12 +153,11 @@ instance
   ) =>
   ToExpr (AlonzoStAnnTx TopTx era)
   where
-  toExpr stAnnTx@(AlonzoStAnnTx _ _ _ _ _ _) =
+  toExpr stAnnTx@(AlonzoStAnnTx _ _ _ _ _) =
     let AlonzoStAnnTx {..} = stAnnTx
      in Rec "AlonzoStAnnTx" $
           OMap.fromList
             [ ("asatTx", toExpr asatTx)
-            , ("asatProtocolVersion", toExpr asatProtocolVersion)
             , ("asatScriptsNeeded", toExpr asatScriptsNeeded)
             , ("asatScriptsProvided", toExpr asatScriptsProvided)
             , ("asatPlutusLanguagesUsed", toExpr asatPlutusLanguagesUsed)

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -15,14 +15,14 @@
 module Test.Cardano.Ledger.Alonzo.Trace () where
 
 import Cardano.Ledger.Alonzo.Core
-import Cardano.Ledger.Alonzo.Rules (LEDGER)
+import Cardano.Ledger.Alonzo.Rules (LEDGER, LEDGERS)
 import Cardano.Ledger.BaseTypes (Globals, epochInfo, systemStart)
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.LedgerState (UTxOState, lsUTxOState, utxosUtxo)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.Shelley.State
 import Cardano.Protocol.Crypto (Crypto)
-import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Slotting.Slot (EpochNo (..), SlotNo (..))
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.State.Transition
 import Data.Functor.Identity (runIdentity)
@@ -31,7 +31,10 @@ import Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
 import Test.Cardano.Ledger.Shelley.Generator.Core (GenEnv (..))
 import Test.Cardano.Ledger.Shelley.Generator.EraGen (EraGen (..), MinLEDGER_STS)
 import Test.Cardano.Ledger.Shelley.Generator.ShelleyEraGen ()
-import Test.Cardano.Ledger.Shelley.Generator.Trace.Ledger (genAccountState)
+import Test.Cardano.Ledger.Shelley.Generator.Trace.Ledger (
+  genAccountState,
+  ledgersSigGen,
+ )
 import Test.Cardano.Ledger.Shelley.Generator.Trace.TxCert (CERTS)
 import Test.Cardano.Ledger.Shelley.Generator.Utxo (genTx)
 import Test.Cardano.Ledger.Shelley.Utils (testGlobals)
@@ -86,4 +89,36 @@ instance
   shrinkSignal _ = [] -- TODO add some kind of Shrinker?
 
   type BaseEnv (LEDGER era) = Globals
+  interpretSTS globals act = runIdentity $ runReaderT act globals
+
+instance
+  ( Crypto c
+  , ApplyTx era
+  , EraGen era
+  , EraGov era
+  , EraUTxO era
+  , EraStake era
+  , EraCertState era
+  , ShelleyEraAccounts era
+  , MinLEDGER_STS era
+  , Embed (EraRule "DELPL" era) (CERTS era)
+  , Environment (EraRule "DELPL" era) ~ Shelley.DelplEnv era
+  , State (EraRule "DELPL" era) ~ CertState era
+  , Signal (EraRule "DELPL" era) ~ TxCert era
+  , PredicateFailure (EraRule "DELPL" era) ~ Shelley.ShelleyDelplPredFailure era
+  , Embed (EraRule "DELEG" era) (Shelley.DELPL era)
+  , Embed (EraRule "LEDGER" era) (LEDGERS era)
+  , AtMostEra "Babbage" era
+  ) =>
+  TQC.HasTrace (LEDGERS era) (GenEnv c era)
+  where
+  envGen GenEnv {geConstants} =
+    Shelley.LedgersEnv (SlotNo 0) (EpochNo 0)
+      <$> genEraPParams @era geConstants
+      <*> genAccountState geConstants
+
+  sigGen = ledgersSigGen
+  shrinkSignal = const []
+
+  type BaseEnv (LEDGERS era) = Globals
   interpretSTS globals act = runIdentity $ runReaderT act globals

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -51,11 +51,16 @@ import Cardano.Ledger.Babbage.TxInfo ()
 import Cardano.Ledger.Babbage.UTxO ()
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
+import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
+import Cardano.Ledger.Shelley.Rules (ledgerPpL)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Cardano.Ledger.State (utxoG)
+import Control.State.Transition.Extended (ValidationPolicy (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 
 instance ApplyTx BabbageEra where
   newtype ApplyTxError BabbageEra
@@ -65,9 +70,28 @@ instance ApplyTx BabbageEra where
 
   mkStAnnTx = mkAlonzoStAnnTx
 
-  applyTxValidation validationPolicy globals env state stAnnTx =
-    first BabbageApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation validationPolicy globals env state tx =
+    let stAnnTx =
+          mkStAnnTx
+            (epochInfo globals)
+            (systemStart globals)
+            (env ^. ledgerPpL)
+            (state ^. utxoG)
+            tx
+     in first BabbageApplyTxError $
+          ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+
+  internalReapplyValidatedTx globals env state vtx =
+    fst
+      <$> first
+        BabbageApplyTxError
+        ( ruleApplyTxValidation @"LEDGER"
+            (ValidateSuchThat (notElem lblStatic))
+            globals
+            env
+            state
+            (vtStAnnTx vtx)
+        )
 
 instance ApplyTick BabbageEra
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage.hs
@@ -51,16 +51,10 @@ import Cardano.Ledger.Babbage.TxInfo ()
 import Cardano.Ledger.Babbage.UTxO ()
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
-import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
-import Cardano.Ledger.Shelley.Rules (ledgerPpL)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import Cardano.Ledger.State (utxoG)
-import Control.State.Transition.Extended (ValidationPolicy (..))
-import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
-import Lens.Micro ((^.))
 
 instance ApplyTx BabbageEra where
   newtype ApplyTxError BabbageEra
@@ -70,28 +64,9 @@ instance ApplyTx BabbageEra where
 
   mkStAnnTx = mkAlonzoStAnnTx
 
-  internalApplyTxWithValidation validationPolicy globals env state tx =
-    let stAnnTx =
-          mkStAnnTx
-            (epochInfo globals)
-            (systemStart globals)
-            (env ^. ledgerPpL)
-            (state ^. utxoG)
-            tx
-     in first BabbageApplyTxError $
-          ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation = defaultApplyTxWithValidation @"LEDGER" BabbageApplyTxError
 
-  internalReapplyValidatedTx globals env state vtx =
-    fst
-      <$> first
-        BabbageApplyTxError
-        ( ruleApplyTxValidation @"LEDGER"
-            (ValidateSuchThat (notElem lblStatic))
-            globals
-            env
-            state
-            (vtStAnnTx vtx)
-        )
+  internalReapplyValidatedTx = defaultReapplyValidatedTx @"LEDGER" BabbageApplyTxError
 
 instance ApplyTick BabbageEra
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -443,7 +443,7 @@ utxoTransition = do
   babbageUtxoValidation
   updatedGovState <-
     trans @(EraRule "UTXOS" era) $
-      TRC (Alonzo.UtxosEnv slot pp certState (utxosUtxo utxos), utxosGovState utxos, stAnnTx)
+      TRC (Alonzo.UtxosEnv slot pp certState, utxosGovState utxos, stAnnTx)
   updateUTxOStateByTxValidity pp certState updatedGovState tx utxos
 
 updateUTxOStateByTxValidity ::

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxos.hs
@@ -170,7 +170,7 @@ babbageEvalScriptsTxValid ::
   ) =>
   TransitionRule (UTXOS era)
 babbageEvalScriptsTxValid = do
-  TRC (Alonzo.UtxosEnv slot pp certState _utxo, pup, stAnnTx) <-
+  TRC (Alonzo.UtxosEnv slot pp certState, pup, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
       txBody = tx ^. bodyTxL

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -43,10 +43,15 @@ import Cardano.Ledger.Conway.Tx (Tx (..))
 import Cardano.Ledger.Conway.TxInfo ()
 import Cardano.Ledger.Conway.TxOut ()
 import Cardano.Ledger.Conway.UTxO ()
+import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
+import Cardano.Ledger.Shelley.Rules (ledgerPpL)
+import Cardano.Ledger.State (utxoG)
+import Control.State.Transition.Extended (ValidationPolicy (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 
 instance ApplyTx ConwayEra where
   newtype ApplyTxError ConwayEra = ConwayApplyTxError (NonEmpty (ConwayLedgerPredFailure ConwayEra))
@@ -55,9 +60,28 @@ instance ApplyTx ConwayEra where
 
   mkStAnnTx = mkAlonzoStAnnTx
 
-  applyTxValidation validationPolicy globals env state stAnnTx =
-    first ConwayApplyTxError $
-      ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation validationPolicy globals env state tx =
+    let stAnnTx =
+          mkStAnnTx
+            (epochInfo globals)
+            (systemStart globals)
+            (env ^. ledgerPpL)
+            (state ^. utxoG)
+            tx
+     in first ConwayApplyTxError $
+          ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state stAnnTx
+
+  internalReapplyValidatedTx globals env state vtx =
+    fst
+      <$> first
+        ConwayApplyTxError
+        ( ruleApplyTxValidation @"MEMPOOL"
+            (ValidateSuchThat (notElem lblStatic))
+            globals
+            env
+            state
+            (vtStAnnTx vtx)
+        )
 
 instance ApplyTick ConwayEra
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway.hs
@@ -43,15 +43,9 @@ import Cardano.Ledger.Conway.Tx (Tx (..))
 import Cardano.Ledger.Conway.TxInfo ()
 import Cardano.Ledger.Conway.TxOut ()
 import Cardano.Ledger.Conway.UTxO ()
-import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
-import Cardano.Ledger.Shelley.Rules (ledgerPpL)
-import Cardano.Ledger.State (utxoG)
-import Control.State.Transition.Extended (ValidationPolicy (..))
-import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
-import Lens.Micro ((^.))
 
 instance ApplyTx ConwayEra where
   newtype ApplyTxError ConwayEra = ConwayApplyTxError (NonEmpty (ConwayLedgerPredFailure ConwayEra))
@@ -60,28 +54,9 @@ instance ApplyTx ConwayEra where
 
   mkStAnnTx = mkAlonzoStAnnTx
 
-  internalApplyTxWithValidation validationPolicy globals env state tx =
-    let stAnnTx =
-          mkStAnnTx
-            (epochInfo globals)
-            (systemStart globals)
-            (env ^. ledgerPpL)
-            (state ^. utxoG)
-            tx
-     in first ConwayApplyTxError $
-          ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation = defaultApplyTxWithValidation @"MEMPOOL" ConwayApplyTxError
 
-  internalReapplyValidatedTx globals env state vtx =
-    fst
-      <$> first
-        ConwayApplyTxError
-        ( ruleApplyTxValidation @"MEMPOOL"
-            (ValidateSuchThat (notElem lblStatic))
-            globals
-            env
-            state
-            (vtStAnnTx vtx)
-        )
+  internalReapplyValidatedTx = defaultReapplyValidatedTx @"MEMPOOL" ConwayApplyTxError
 
 instance ApplyTick ConwayEra
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Conway.Rules (
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep
 import Cardano.Ledger.Plutus (SLanguage (..), hashPlutusScript)
-import Cardano.Ledger.Shelley.API.Mempool (applyTx, mkMempoolEnv)
+import Cardano.Ledger.Shelley.API.Mempool (applyTxWithFullValidation, mkMempoolEnv)
 import Cardano.Ledger.Shelley.LedgerState
 import Control.Monad.Reader (asks)
 import Data.List.NonEmpty (NonEmpty)
@@ -230,7 +230,7 @@ spec = describe "LEDGER" $ do
           ls = nes ^. nesEsL . esLStateL
         txFixed <- (tx &) =<< asks iteFixup
         logToExpr txFixed
-        case applyTx globals mempoolEnv ls txFixed of
+        case applyTxWithFullValidation globals mempoolEnv ls txFixed of
           Left err -> do
             err `shouldBe` inject expectedFailures
           Right _ ->

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -163,7 +163,6 @@ mkDijkstraStAnnTopTx ei sysStart pp utxo tx =
    in
     DijkstraStAnnTopTx
       { dsattTx = tx
-      , dsattProtocolVersion = pp ^. ppProtocolVersionL
       , dsattScriptsNeeded = scriptsNeeded
       , dsattScriptsProvided = scriptsProvided
       , dsattPlutusLegacyMode = not $ Set.null $ Set.filter (<= PlutusV3) languagesUsed

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -54,15 +54,21 @@ import Cardano.Ledger.Dijkstra.TxInfo ()
 import Cardano.Ledger.Dijkstra.TxWits ()
 import Cardano.Ledger.Dijkstra.UTxO ()
 import Cardano.Ledger.Plutus (Language (..))
+import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API (
   ApplyBlock (..),
   ApplyTick (..),
   ApplyTx (..),
+  ValidatedTx (..),
+  epochInfo,
   ruleApplyTxValidation,
+  systemStart,
  )
-import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided, UTxO)
+import Cardano.Ledger.Shelley.Rules (ledgerPpL)
+import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided, UTxO, utxoG)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
+import Control.State.Transition.Extended (ValidationPolicy (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty)
@@ -79,9 +85,28 @@ instance ApplyTx DijkstraEra where
 
   mkStAnnTx = mkDijkstraStAnnTopTx
 
-  applyTxValidation validationPolicy globals env state stAnnTx =
-    first DijkstraApplyTxError $
-      ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation validationPolicy globals env state tx =
+    let stAnnTx =
+          mkStAnnTx
+            (epochInfo globals)
+            (systemStart globals)
+            (env ^. ledgerPpL)
+            (state ^. utxoG)
+            tx
+     in first DijkstraApplyTxError $
+          ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state stAnnTx
+
+  internalReapplyValidatedTx globals env state vtx =
+    fst
+      <$> first
+        DijkstraApplyTxError
+        ( ruleApplyTxValidation @"MEMPOOL"
+            (ValidateSuchThat (notElem lblStatic))
+            globals
+            env
+            state
+            (vtStAnnTx vtx)
+        )
 
 instance ApplyTick DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -54,22 +54,16 @@ import Cardano.Ledger.Dijkstra.TxInfo ()
 import Cardano.Ledger.Dijkstra.TxWits ()
 import Cardano.Ledger.Dijkstra.UTxO ()
 import Cardano.Ledger.Plutus (Language (..))
-import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API (
   ApplyBlock (..),
   ApplyTick (..),
   ApplyTx (..),
-  ValidatedTx (..),
-  epochInfo,
-  ruleApplyTxValidation,
-  systemStart,
+  defaultApplyTxWithValidation,
+  defaultReapplyValidatedTx,
  )
-import Cardano.Ledger.Shelley.Rules (ledgerPpL)
-import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided, UTxO, utxoG)
+import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided, UTxO)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
-import Control.State.Transition.Extended (ValidationPolicy (..))
-import Data.Bifunctor (Bifunctor (first))
 import Data.Foldable (toList)
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
@@ -85,28 +79,9 @@ instance ApplyTx DijkstraEra where
 
   mkStAnnTx = mkDijkstraStAnnTopTx
 
-  internalApplyTxWithValidation validationPolicy globals env state tx =
-    let stAnnTx =
-          mkStAnnTx
-            (epochInfo globals)
-            (systemStart globals)
-            (env ^. ledgerPpL)
-            (state ^. utxoG)
-            tx
-     in first DijkstraApplyTxError $
-          ruleApplyTxValidation @"MEMPOOL" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation = defaultApplyTxWithValidation @"MEMPOOL" DijkstraApplyTxError
 
-  internalReapplyValidatedTx globals env state vtx =
-    fst
-      <$> first
-        DijkstraApplyTxError
-        ( ruleApplyTxValidation @"MEMPOOL"
-            (ValidateSuchThat (notElem lblStatic))
-            globals
-            env
-            state
-            (vtStAnnTx vtx)
-        )
+  internalReapplyValidatedTx = defaultReapplyValidatedTx @"MEMPOOL" DijkstraApplyTxError
 
 instance ApplyTick DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -33,7 +33,7 @@ import Cardano.Ledger.Alonzo.Tx (
   AlonzoEraTx,
   IsValid (..),
  )
-import Cardano.Ledger.BaseTypes (ProtVer, StrictMaybe (..), integralToBounded)
+import Cardano.Ledger.BaseTypes (StrictMaybe (..), integralToBounded)
 import Cardano.Ledger.Binary (
   Annotator,
   DecCBOR (..),
@@ -372,7 +372,6 @@ toCBORForMempoolSubmission = \case
 data DijkstraStAnnTx l era where
   DijkstraStAnnTopTx ::
     { dsattTx :: !(Tx TopTx era)
-    , dsattProtocolVersion :: !ProtVer
     , dsattScriptsNeeded :: ScriptsNeeded era
     , dsattScriptsProvided :: ScriptsProvided era
     , dsattPlutusLegacyMode :: Bool

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -98,6 +98,7 @@ library
     microlens,
     nothunks,
     primitive,
+    small-steps,
     text,
 
   if flag(asserts)

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -98,7 +98,6 @@ library
     microlens,
     nothunks,
     primitive,
-    small-steps,
     text,
 
   if flag(asserts)

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -36,16 +36,10 @@ import Cardano.Ledger.Mary.TxAuxData ()
 import Cardano.Ledger.Mary.TxBody (TxBody (..))
 import Cardano.Ledger.Mary.UTxO ()
 import Cardano.Ledger.Mary.Value (MaryValue)
-import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
-import Cardano.Ledger.Shelley.Rules (ledgerPpL)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import Cardano.Ledger.State (utxoG)
-import Control.State.Transition.Extended (ValidationPolicy (..))
-import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
-import Lens.Micro ((^.))
 
 instance ApplyTx MaryEra where
   newtype ApplyTxError MaryEra = MaryApplyTxError (NonEmpty (Shelley.ShelleyLedgerPredFailure MaryEra))
@@ -54,28 +48,9 @@ instance ApplyTx MaryEra where
 
   mkStAnnTx _ _ _ _ = id
 
-  internalApplyTxWithValidation validationPolicy globals env state tx =
-    let stAnnTx =
-          mkStAnnTx
-            (epochInfo globals)
-            (systemStart globals)
-            (env ^. ledgerPpL)
-            (state ^. utxoG)
-            tx
-     in first MaryApplyTxError $
-          ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation = defaultApplyTxWithValidation @"LEDGER" MaryApplyTxError
 
-  internalReapplyValidatedTx globals env state vtx =
-    fst
-      <$> first
-        MaryApplyTxError
-        ( ruleApplyTxValidation @"LEDGER"
-            (ValidateSuchThat (notElem lblStatic))
-            globals
-            env
-            state
-            (vtStAnnTx vtx)
-        )
+  internalReapplyValidatedTx = defaultReapplyValidatedTx @"LEDGER" MaryApplyTxError
 
 instance ApplyTick MaryEra
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -36,11 +36,16 @@ import Cardano.Ledger.Mary.TxAuxData ()
 import Cardano.Ledger.Mary.TxBody (TxBody (..))
 import Cardano.Ledger.Mary.UTxO ()
 import Cardano.Ledger.Mary.Value (MaryValue)
+import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
+import Cardano.Ledger.Shelley.Rules (ledgerPpL)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Cardano.Ledger.State (utxoG)
+import Control.State.Transition.Extended (ValidationPolicy (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 
 instance ApplyTx MaryEra where
   newtype ApplyTxError MaryEra = MaryApplyTxError (NonEmpty (Shelley.ShelleyLedgerPredFailure MaryEra))
@@ -49,9 +54,28 @@ instance ApplyTx MaryEra where
 
   mkStAnnTx _ _ _ _ = id
 
-  applyTxValidation validationPolicy globals env state stAnnTx =
-    first MaryApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation validationPolicy globals env state tx =
+    let stAnnTx =
+          mkStAnnTx
+            (epochInfo globals)
+            (systemStart globals)
+            (env ^. ledgerPpL)
+            (state ^. utxoG)
+            tx
+     in first MaryApplyTxError $
+          ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+
+  internalReapplyValidatedTx globals env state vtx =
+    fst
+      <$> first
+        MaryApplyTxError
+        ( ruleApplyTxValidation @"LEDGER"
+            (ValidateSuchThat (notElem lblStatic))
+            globals
+            env
+            state
+            (vtStAnnTx vtx)
+        )
 
 instance ApplyTick MaryEra
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `defaultApplyTxWithValidation` and `defaultReapplyValidatedTx` helpers to `Mempool` module
 * Deprecate:
   - `Validated`
   - `extractTx`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.19.0.0
 
-* Add `internalApplyTxWithValidation` to `ApplyTx`
+* Add `internalApplyTxWithValidation` and `internalReapplyValidatedTx` to `ApplyTx`
 * Change return type of `ruleApplyTxValidation` to `ValidatedTx`
 * Add:
   - `ValidatedTx`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 1.19.0.0
 
+* Add:
+  - `ValidatedTx`
+  - `getValidatedTxStAnnTx`
+  - `getValidatedTxProtocolVersion`
+  - `getValidatedTxSlotNo`
+  - `extractValidatedTx`
 * Rename rule types and deprecate the old names:
   - `ShelleyBBODY` -> `BBODY`
   - `ShelleyDELEG` -> `DELEG`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.19.0.0
 
+* Add `internalApplyTxWithValidation` to `ApplyTx`
+* Change return type of `ruleApplyTxValidation` to `ValidatedTx`
 * Add:
   - `ValidatedTx`
   - `getValidatedTxStAnnTx`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `applyTxWithFullValidation` and `reapplyValidatedTx` to `Mempool` module
 * Add `internalApplyTxWithValidation` and `internalReapplyValidatedTx` to `ApplyTx`
 * Change return type of `ruleApplyTxValidation` to `ValidatedTx`
 * Add:

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## 1.19.0.0
 
+* Deprecate:
+  - `Validated`
+  - `extractTx`
+  - `coerceValidated`
+  - `unsafeMakeValidated`
+  - `translateValidated`
+  - `applyTxValidation`
+  - `applyTx`
+  - `reapplyTx`
 * Add functions to `Mempool` module:
   - `applyTxWithFullValidation`
   - `reapplyValidatedTx`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.19.0.0
 
+* Add functions to `Mempool` module:
+  - `applyTxWithFullValidation`
+  - `reapplyValidatedTx`
+  - `unsafeMakeValidatedTx`
 * Add `applyTxWithFullValidation` and `reapplyValidatedTx` to `Mempool` module
 * Add `internalApplyTxWithValidation` and `internalReapplyValidatedTx` to `ApplyTx`
 * Change return type of `ruleApplyTxValidation` to `ValidatedTx`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -33,6 +33,8 @@ module Cardano.Ledger.Shelley.API.Mempool (
   coerceValidated,
   translateValidated,
   ruleApplyTxValidation,
+  defaultApplyTxWithValidation,
+  defaultReapplyValidatedTx,
 
   -- * Exports for testing
   MempoolEnv,
@@ -158,7 +160,10 @@ translateValidated ::
   Validated (f (PreviousEra era)) ->
   Except (TranslationError era f) (Validated (f era))
 translateValidated ctx (Validated tx) = Validated <$> translateEra @era ctx tx
-{-# DEPRECATED translateValidated "Translation of `Validated` does not make sense. It must be fully re-validated in a new era" #-}
+{-# DEPRECATED
+  translateValidated
+  "Translation of `Validated` does not make sense. It must be fully re-validated in a new era"
+  #-}
 
 class
   ( EraTx era
@@ -253,6 +258,66 @@ ruleApplyTxValidation validationPolicy globals env state stAnnTx =
           }
    in fmap (,validatedTx) result
 
+-- | A default implementation for 'internalApplyTxWithValidation', parameterised by the
+-- STS rule to run and a wrapper that lifts predicate failures into the era's
+-- 'ApplyTxError'.
+defaultApplyTxWithValidation ::
+  forall rule era.
+  ( ApplyTx era
+  , STS (EraRule rule era)
+  , BaseM (EraRule rule era) ~ ShelleyBase
+  , Environment (EraRule rule era) ~ LedgerEnv era
+  , State (EraRule rule era) ~ MempoolState era
+  , Signal (EraRule rule era) ~ StAnnTx TopTx era
+  ) =>
+  (NonEmpty (PredicateFailure (EraRule rule era)) -> ApplyTxError era) ->
+  ValidationPolicy ->
+  Globals ->
+  MempoolEnv era ->
+  MempoolState era ->
+  Tx TopTx era ->
+  Either (ApplyTxError era) (MempoolState era, ValidatedTx era)
+defaultApplyTxWithValidation wrap validationPolicy globals env state tx =
+  let stAnnTx =
+        mkStAnnTx
+          (epochInfo globals)
+          (systemStart globals)
+          (env ^. ledgerPpL)
+          (state ^. utxoG)
+          tx
+   in first wrap $
+        ruleApplyTxValidation @rule validationPolicy globals env state stAnnTx
+
+-- | A default implementation for 'internalReapplyValidatedTx', parameterised by the
+-- STS rule to run and a wrapper that lifts predicate failures into the era's
+-- 'ApplyTxError'.
+defaultReapplyValidatedTx ::
+  forall rule era.
+  ( ApplyTx era
+  , STS (EraRule rule era)
+  , BaseM (EraRule rule era) ~ ShelleyBase
+  , Environment (EraRule rule era) ~ LedgerEnv era
+  , State (EraRule rule era) ~ MempoolState era
+  , Signal (EraRule rule era) ~ StAnnTx TopTx era
+  ) =>
+  (NonEmpty (PredicateFailure (EraRule rule era)) -> ApplyTxError era) ->
+  Globals ->
+  MempoolEnv era ->
+  MempoolState era ->
+  ValidatedTx era ->
+  Either (ApplyTxError era) (MempoolState era)
+defaultReapplyValidatedTx wrap globals env state vtx =
+  fst
+    <$> first
+      wrap
+      ( ruleApplyTxValidation @rule
+          (ValidateSuchThat (notElem lblStatic))
+          globals
+          env
+          state
+          (vtStAnnTx vtx)
+      )
+
 instance ApplyTx ShelleyEra where
   newtype ApplyTxError ShelleyEra = ShelleyApplyTxError (NonEmpty (ShelleyLedgerPredFailure ShelleyEra))
     deriving (Eq, Show)
@@ -271,17 +336,7 @@ instance ApplyTx ShelleyEra where
      in first ShelleyApplyTxError $
           ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
 
-  internalReapplyValidatedTx globals env state vtx =
-    fst
-      <$> first
-        ShelleyApplyTxError
-        ( ruleApplyTxValidation @"LEDGER"
-            (ValidateSuchThat (notElem lblStatic))
-            globals
-            env
-            state
-            (vtStAnnTx vtx)
-        )
+  internalReapplyValidatedTx = defaultReapplyValidatedTx @"LEDGER" ShelleyApplyTxError
 
 type MempoolEnv era = LedgerEnv era
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -49,23 +49,15 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Rules.ValidationMode (lblStatic)
-import Cardano.Ledger.Shelley.Core (EraGov)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
-import Cardano.Ledger.Shelley.LedgerState (
-  NewEpochState,
-  curPParamsEpochStateL,
-  lsUTxOStateL,
-  utxosGovStateL,
- )
-import qualified Cardano.Ledger.Shelley.LedgerState as LedgerState
+import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.Rules.Ledger (
-  LedgerEnv,
+  LedgerEnv (..),
   ShelleyLedgerPredFailure,
   ledgerPpL,
   ledgerSlotNoL,
  )
-import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
-import Cardano.Ledger.State (UTxO, curPParamsGovStateL, utxoG)
+import Cardano.Ledger.State
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
 import Control.DeepSeq (NFData)
@@ -262,9 +254,9 @@ instance ApplyTx ShelleyEra where
             (vtStAnnTx vtx)
         )
 
-type MempoolEnv era = Ledger.LedgerEnv era
+type MempoolEnv era = LedgerEnv era
 
-type MempoolState era = LedgerState.LedgerState era
+type MempoolState era = LedgerState era
 
 -- | Construct the environment used to validate transactions from the full
 -- ledger state.
@@ -285,16 +277,14 @@ mkMempoolEnv ::
   SlotNo ->
   MempoolEnv era
 mkMempoolEnv
-  LedgerState.NewEpochState
-    { LedgerState.nesEs
-    }
+  NewEpochState {nesEs}
   slot =
-    Ledger.LedgerEnv
-      { Ledger.ledgerSlotNo = slot
-      , Ledger.ledgerEpochNo = Nothing
-      , Ledger.ledgerIx = minBound
-      , Ledger.ledgerPp = nesEs ^. curPParamsEpochStateL
-      , Ledger.ledgerAccount = LedgerState.esChainAccountState nesEs
+    LedgerEnv
+      { ledgerSlotNo = slot
+      , ledgerEpochNo = Nothing
+      , ledgerIx = minBound
+      , ledgerPp = nesEs ^. curPParamsEpochStateL
+      , ledgerAccount = esChainAccountState nesEs
       }
 
 -- | Construct a mempool state from the wider ledger state.
@@ -303,7 +293,7 @@ mkMempoolEnv
 --   regenerated when the ledger state gets updated (e.g. through application of
 --   a new block).
 mkMempoolState :: NewEpochState era -> MempoolState era
-mkMempoolState LedgerState.NewEpochState {LedgerState.nesEs} = LedgerState.esLState nesEs
+mkMempoolState NewEpochState {nesEs} = esLState nesEs
 
 -- | Transform a function over mempool states to one over the full
 -- 'NewEpochState'.
@@ -316,9 +306,9 @@ overNewEpochState f st = do
   f (mkMempoolState st)
     <&> \ls ->
       st
-        { LedgerState.nesEs =
-            (LedgerState.nesEs st)
-              { LedgerState.esLState = ls
+        { nesEs =
+            (nesEs st)
+              { esLState = ls
               }
         }
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -21,7 +22,12 @@ module Cardano.Ledger.Shelley.API.Mempool (
   ApplyTx (..),
   ApplyTxError (..),
   Validated,
+  ValidatedTx,
+  getValidatedTxStAnnTx,
+  getValidatedTxProtocolVersion,
+  getValidatedTxSlotNo,
   extractTx,
+  extractValidatedTx,
   coerceValidated,
   translateValidated,
   ruleApplyTxValidation,
@@ -37,7 +43,7 @@ module Cardano.Ledger.Shelley.API.Mempool (
   overNewEpochState,
 ) where
 
-import Cardano.Ledger.BaseTypes (Globals, ShelleyBase, epochInfo, systemStart)
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Rules.ValidationMode (lblStatic)
@@ -47,7 +53,6 @@ import Cardano.Ledger.Shelley.LedgerState (NewEpochState, curPParamsEpochStateL)
 import qualified Cardano.Ledger.Shelley.LedgerState as LedgerState
 import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv, ShelleyLedgerPredFailure, ledgerPpL)
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
-import Cardano.Ledger.Slot (SlotNo)
 import Cardano.Ledger.State (UTxO, utxoG)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
@@ -64,6 +69,37 @@ import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
 import NoThunks.Class (NoThunks)
+
+-- | A transaction that has been validated against some chain state.
+data ValidatedTx era = ValidatedTx
+  { vtStAnnTx :: !(StAnnTx TopTx era)
+  -- ^ The transaction paired with the state-derived annotation produced during validation
+  , vtProtocolVersion :: !ProtVer
+  -- ^ Protocol version under which the validation took place
+  , vtSlotNo :: !SlotNo
+  -- ^ Slot number under which the validation took place
+  }
+  deriving (Generic)
+
+deriving instance Eq (StAnnTx TopTx era) => Eq (ValidatedTx era)
+
+deriving instance Show (StAnnTx TopTx era) => Show (ValidatedTx era)
+
+instance NFData (StAnnTx TopTx era) => NFData (ValidatedTx era)
+
+instance NoThunks (StAnnTx TopTx era) => NoThunks (ValidatedTx era)
+
+getValidatedTxStAnnTx :: ValidatedTx era -> StAnnTx TopTx era
+getValidatedTxStAnnTx = vtStAnnTx
+
+getValidatedTxProtocolVersion :: ValidatedTx era -> ProtVer
+getValidatedTxProtocolVersion = vtProtocolVersion
+
+getValidatedTxSlotNo :: ValidatedTx era -> SlotNo
+getValidatedTxSlotNo = vtSlotNo
+
+extractValidatedTx :: EraTx era => ValidatedTx era -> Tx TopTx era
+extractValidatedTx validatedTx = getValidatedTxStAnnTx validatedTx ^. txStAnnTxG
 
 -- | A newtype which indicates that a transaction has been validated against
 -- some chain state.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -38,6 +38,7 @@ module Cardano.Ledger.Shelley.API.Mempool (
   MempoolEnv,
   MempoolState,
   unsafeMakeValidated,
+  unsafeMakeValidatedTx,
 
   -- * Exports for compatibility
   mkMempoolEnv,
@@ -120,6 +121,27 @@ coerceValidated (Validated a) = Validated $ coerce a
 -- Don't use this except in Testing to make Arbitrary instances, etc.
 unsafeMakeValidated :: tx -> Validated tx
 unsafeMakeValidated = Validated
+
+-- | Build a 'ValidatedTx' without running the LEDGER rule - should only be used for testing.
+unsafeMakeValidatedTx ::
+  ApplyTx era =>
+  Globals ->
+  MempoolEnv era ->
+  MempoolState era ->
+  Tx TopTx era ->
+  ValidatedTx era
+unsafeMakeValidatedTx globals env state tx =
+  ValidatedTx
+    { vtStAnnTx =
+        mkStAnnTx
+          (epochInfo globals)
+          (systemStart globals)
+          (env ^. ledgerPpL)
+          (state ^. utxoG)
+          tx
+    , vtProtocolVersion = env ^. ledgerPpL . ppProtocolVersionL
+    , vtSlotNo = env ^. ledgerSlotNoL
+    }
 
 -- | Translate a validated transaction across eras.
 --

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -51,7 +51,12 @@ import Cardano.Ledger.Shelley.Core (EraGov)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.LedgerState (NewEpochState, curPParamsEpochStateL)
 import qualified Cardano.Ledger.Shelley.LedgerState as LedgerState
-import Cardano.Ledger.Shelley.Rules.Ledger (LedgerEnv, ShelleyLedgerPredFailure, ledgerPpL)
+import Cardano.Ledger.Shelley.Rules.Ledger (
+  LedgerEnv,
+  ShelleyLedgerPredFailure,
+  ledgerPpL,
+  ledgerSlotNoL,
+ )
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
 import Cardano.Ledger.State (UTxO, utxoG)
 import Cardano.Slotting.EpochInfo (EpochInfo)
@@ -150,9 +155,21 @@ class
     Tx TopTx era ->
     StAnnTx TopTx era
 
-  -- | Validate a state annotated transaction against a mempool state for given STS
-  -- options, and return the new mempool state, a "validated" 'TxInBlock' and,
-  -- depending on the passed options, the emitted events.
+  -- | Validate a transaction against a mempool state for given STS options.
+  --
+  -- /Warning/ - This function is only safe when `ValidateAll` policy is supplied,
+  -- otherwise invariant for `ValidatedTx` could be violated.
+  -- It will always be safer to use `applyTxWithFullValidation` instead.
+  internalApplyTxWithValidation ::
+    ValidationPolicy ->
+    Globals ->
+    MempoolEnv era ->
+    MempoolState era ->
+    Tx TopTx era ->
+    Either (ApplyTxError era) (MempoolState era, ValidatedTx era)
+
+  -- | Validate a transaction against a mempool state for given STS
+  -- options, and return the new mempool state, a "validated" 'TxInBlock
   applyTxValidation ::
     ValidationPolicy ->
     Globals ->
@@ -160,6 +177,9 @@ class
     MempoolState era ->
     StAnnTx TopTx era ->
     Either (ApplyTxError era) (MempoolState era, Validated (Tx TopTx era))
+  applyTxValidation policy globals env state stAnnTx =
+    fmap (\vtx -> Validated (vtStAnnTx vtx ^. txStAnnTxG))
+      <$> internalApplyTxWithValidation policy globals env state (stAnnTx ^. txStAnnTxG)
 
 ruleApplyTxValidation ::
   forall rule era.
@@ -175,7 +195,7 @@ ruleApplyTxValidation ::
   MempoolEnv era ->
   MempoolState era ->
   StAnnTx TopTx era ->
-  Either (NonEmpty (PredicateFailure (EraRule rule era))) (MempoolState era, Validated (Tx TopTx era))
+  Either (NonEmpty (PredicateFailure (EraRule rule era))) (MempoolState era, ValidatedTx era)
 ruleApplyTxValidation validationPolicy globals env state stAnnTx =
   let opts =
         ApplySTSOpts
@@ -187,7 +207,13 @@ ruleApplyTxValidation validationPolicy globals env state stAnnTx =
         flip runReader globals
           . applySTSOptsEither @(EraRule rule era) opts
           $ TRC (env, state, stAnnTx)
-   in fmap (,Validated (stAnnTx ^. txStAnnTxG)) result
+      validatedTx =
+        ValidatedTx
+          { vtStAnnTx = stAnnTx
+          , vtProtocolVersion = env ^. ledgerPpL . ppProtocolVersionL
+          , vtSlotNo = env ^. ledgerSlotNoL
+          }
+   in fmap (,validatedTx) result
 
 instance ApplyTx ShelleyEra where
   newtype ApplyTxError ShelleyEra = ShelleyApplyTxError (NonEmpty (ShelleyLedgerPredFailure ShelleyEra))
@@ -196,9 +222,16 @@ instance ApplyTx ShelleyEra where
 
   mkStAnnTx _ _ _ _ = id
 
-  applyTxValidation validationPolicy globals env state stAnnTx =
-    first ShelleyApplyTxError $
-      ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+  internalApplyTxWithValidation validationPolicy globals env state tx =
+    let stAnnTx =
+          mkStAnnTx
+            (epochInfo globals)
+            (systemStart globals)
+            (env ^. ledgerPpL)
+            (state ^. utxoG)
+            tx
+     in first ShelleyApplyTxError $
+          ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
 
 type MempoolEnv era = Ledger.LedgerEnv era
 
@@ -273,15 +306,9 @@ applyTx ::
   MempoolState era ->
   Tx TopTx era ->
   Either (ApplyTxError era) (MempoolState era, Validated (Tx TopTx era))
-applyTx globals env state tx =
-  let stAnnTx =
-        mkStAnnTx
-          (epochInfo globals)
-          (systemStart globals)
-          (env ^. ledgerPpL)
-          (state ^. utxoG)
-          tx
-   in applyTxValidation ValidateAll globals env state stAnnTx
+applyTx globals env state tx = do
+  (mempoolState, vtx) <- internalApplyTxWithValidation ValidateAll globals env state tx
+  pure (mempoolState, Validated (vtStAnnTx vtx ^. txStAnnTxG))
 
 -- | Reapply a previously validated 'Tx'.
 --
@@ -294,17 +321,7 @@ reapplyTx ::
   Globals ->
   MempoolEnv era ->
   MempoolState era ->
-  -- TODO: change to `Validated (StAnnTx TopTx era)` once we return this from `applyTx`
   Validated (Tx TopTx era) ->
   Either (ApplyTxError era) (MempoolState era)
 reapplyTx globals env state (Validated tx) =
-  -- TODO: replace `stAnnTx` creation with the argument,
-  -- once the signature is changed to take `Validated (StAnnTx TopTx era)`
-  let stAnnTx =
-        mkStAnnTx
-          (epochInfo globals)
-          (systemStart globals)
-          (env ^. ledgerPpL)
-          (state ^. utxoG)
-          tx
-   in fst <$> applyTxValidation (ValidateSuchThat (notElem lblStatic)) globals env state stAnnTx
+  fst <$> internalApplyTxWithValidation (ValidateSuchThat (notElem lblStatic)) globals env state tx

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -168,6 +168,16 @@ class
     Tx TopTx era ->
     Either (ApplyTxError era) (MempoolState era, ValidatedTx era)
 
+  -- | Reapply a previously validated transaction.
+  --
+  -- /Warning/ - Should not be used directly. `reapplyValidatedTx` should be used instead.
+  internalReapplyValidatedTx ::
+    Globals ->
+    MempoolEnv era ->
+    MempoolState era ->
+    ValidatedTx era ->
+    Either (ApplyTxError era) (MempoolState era)
+
   -- | Validate a transaction against a mempool state for given STS
   -- options, and return the new mempool state, a "validated" 'TxInBlock
   applyTxValidation ::
@@ -232,6 +242,18 @@ instance ApplyTx ShelleyEra where
             tx
      in first ShelleyApplyTxError $
           ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
+
+  internalReapplyValidatedTx globals env state vtx =
+    fst
+      <$> first
+        ShelleyApplyTxError
+        ( ruleApplyTxValidation @"LEDGER"
+            (ValidateSuchThat (notElem lblStatic))
+            globals
+            env
+            state
+            (vtStAnnTx vtx)
+        )
 
 type MempoolEnv era = Ledger.LedgerEnv era
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -18,6 +18,8 @@
 -- mempool.
 module Cardano.Ledger.Shelley.API.Mempool (
   applyTx,
+  applyTxWithFullValidation,
+  reapplyValidatedTx,
   reapplyTx,
   ApplyTx (..),
   ApplyTxError (..),
@@ -49,7 +51,12 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.Core (EraGov)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
-import Cardano.Ledger.Shelley.LedgerState (NewEpochState, curPParamsEpochStateL)
+import Cardano.Ledger.Shelley.LedgerState (
+  NewEpochState,
+  curPParamsEpochStateL,
+  lsUTxOStateL,
+  utxosGovStateL,
+ )
 import qualified Cardano.Ledger.Shelley.LedgerState as LedgerState
 import Cardano.Ledger.Shelley.Rules.Ledger (
   LedgerEnv,
@@ -58,7 +65,7 @@ import Cardano.Ledger.Shelley.Rules.Ledger (
   ledgerSlotNoL,
  )
 import qualified Cardano.Ledger.Shelley.Rules.Ledger as Ledger
-import Cardano.Ledger.State (UTxO, utxoG)
+import Cardano.Ledger.State (UTxO, curPParamsGovStateL, utxoG)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
 import Control.DeepSeq (NFData)
@@ -314,6 +321,43 @@ overNewEpochState f st = do
               { LedgerState.esLState = ls
               }
         }
+
+-- | Validate a transaction against a mempool state and return the new
+-- mempool state together with a 'ValidatedTx'
+applyTxWithFullValidation ::
+  ApplyTx era =>
+  Globals ->
+  MempoolEnv era ->
+  MempoolState era ->
+  Tx TopTx era ->
+  Either (ApplyTxError era) (MempoolState era, ValidatedTx era)
+applyTxWithFullValidation = internalApplyTxWithValidation ValidateAll
+
+-- | Reapply a previously validated transaction, skipping static checks.
+-- Use the state-derived annotations in `StAnnTx` if the current protocol version
+-- matches the one in `ValidatedTx`, otherwise reconstruct `StAnnTx.
+-- If major protocol version has changed from when `ValidatedTx`
+-- was constructed, then full validation is triggered again.
+reapplyValidatedTx ::
+  (ApplyTx era, EraGov era) =>
+  Globals ->
+  MempoolEnv era ->
+  MempoolState era ->
+  ValidatedTx era ->
+  Either (ApplyTxError era) (MempoolState era)
+reapplyValidatedTx globals env ledgerState vtx
+  | pvMajor (vtProtocolVersion vtx) == pvMajor currentPv =
+      internalReapplyValidatedTx globals env ledgerState vtx
+  | otherwise =
+      fst
+        <$> internalApplyTxWithValidation
+          ValidateAll
+          globals
+          env
+          ledgerState
+          (vtStAnnTx vtx ^. txStAnnTxG)
+  where
+    currentPv = ledgerState ^. lsUTxOStateL . utxosGovStateL . curPParamsGovStateL . ppProtocolVersionL
 
 -- | Validate a transaction against a mempool state using default STS options
 -- and return both the new mempool state and a "validated" 'TxInBlock'.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -110,17 +110,21 @@ extractValidatedTx validatedTx = getValidatedTxStAnnTx validatedTx ^. txStAnnTxG
 -- some chain state.
 newtype Validated tx = Validated tx
   deriving (Eq, NoThunks, Show, NFData)
+{-# DEPRECATED Validated "Use 'ValidatedTx' instead." #-}
 
 -- | Extract the underlying unvalidated Tx.
 extractTx :: Validated tx -> tx
 extractTx (Validated tx) = tx
+{-# DEPRECATED extractTx "Use 'extractValidatedTx'" #-}
 
 coerceValidated :: Coercible a b => Validated a -> Validated b
 coerceValidated (Validated a) = Validated $ coerce a
+{-# DEPRECATED coerceValidated "'Validated' is deprecated; switch to 'ValidatedTx'." #-}
 
 -- Don't use this except in Testing to make Arbitrary instances, etc.
 unsafeMakeValidated :: tx -> Validated tx
 unsafeMakeValidated = Validated
+{-# DEPRECATED unsafeMakeValidated "Use 'unsafeMakeValidatedTx' instead." #-}
 
 -- | Build a 'ValidatedTx' without running the LEDGER rule - should only be used for testing.
 unsafeMakeValidatedTx ::
@@ -154,6 +158,7 @@ translateValidated ::
   Validated (f (PreviousEra era)) ->
   Except (TranslationError era f) (Validated (f era))
 translateValidated ctx (Validated tx) = Validated <$> translateEra @era ctx tx
+{-# DEPRECATED translateValidated "Translation of `Validated` does not make sense. It must be fully re-validated in a new era" #-}
 
 class
   ( EraTx era
@@ -211,6 +216,8 @@ class
   applyTxValidation policy globals env state stAnnTx =
     fmap (\vtx -> Validated (vtStAnnTx vtx ^. txStAnnTxG))
       <$> internalApplyTxWithValidation policy globals env state (stAnnTx ^. txStAnnTxG)
+
+{-# DEPRECATED applyTxValidation "Use 'internalApplyTxWithValidation' instead." #-}
 
 ruleApplyTxValidation ::
   forall rule era.
@@ -387,6 +394,7 @@ applyTx ::
 applyTx globals env state tx = do
   (mempoolState, vtx) <- internalApplyTxWithValidation ValidateAll globals env state tx
   pure (mempoolState, Validated (vtStAnnTx vtx ^. txStAnnTxG))
+{-# DEPRECATED applyTx "Use 'applyTxWithFullValidation' instead." #-}
 
 -- | Reapply a previously validated 'Tx'.
 --
@@ -403,3 +411,4 @@ reapplyTx ::
   Either (ApplyTxError era) (MempoolState era)
 reapplyTx globals env state (Validated tx) =
   fst <$> internalApplyTxWithValidation (ValidateSuchThat (notElem lblStatic)) globals env state tx
+{-# DEPRECATED reapplyTx "Use 'reapplyValidatedTx' instead." #-}

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.9.0.0
 
+* Add `ledgersSigGen`
 * Remove `Test.Cardano.Ledger.Shelley.Examples.TwoPools` module
 * Remove `NoThunks` instance for `TestChainPredicateFailure`
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
@@ -122,6 +122,60 @@ instance
   type BaseEnv (LEDGER era) = Globals
   interpretSTS globals act = runIdentity $ runReaderT act globals
 
+ledgersSigGen ::
+  forall c era.
+  ( Crypto c
+  , ApplyTx era
+  , EraGen era
+  , EraUTxO era
+  , ShelleyEraAccounts era
+  , MinLEDGER_STS era
+  , Embed (EraRule "DELPL" era) (CERTS era)
+  , Environment (EraRule "DELPL" era) ~ DelplEnv era
+  , State (EraRule "DELPL" era) ~ CertState era
+  , Signal (EraRule "DELPL" era) ~ TxCert era
+  ) =>
+  GenEnv c era ->
+  ShelleyLedgersEnv era ->
+  LedgerState era ->
+  Gen (Seq (Tx TopTx era))
+ledgersSigGen
+  ge@(GenEnv _ _ Constants {maxTxsPerBlock})
+  (LedgersEnv slotNo epochNo pParams reserves)
+  ls = do
+    (_, txs') <-
+      foldM
+        genAndApplyTx
+        (ls, [])
+        [minBound .. mkTxIxPartial (toInteger maxTxsPerBlock - 1)]
+
+    pure $ Seq.fromList (reverse txs') -- reverse Newest first to Oldest first
+    where
+      genAndApplyTx ::
+        HasCallStack =>
+        (LedgerState era, [Tx TopTx era]) ->
+        TxIx ->
+        Gen (LedgerState era, [Tx TopTx era])
+      genAndApplyTx (ls', txs) txIx = do
+        let ledgerEnv = LedgerEnv slotNo (Just epochNo) txIx pParams reserves
+        tx <- genTx ge ledgerEnv ls'
+
+        let utxo = utxosUtxo (lsUTxOState ls')
+            stAnnTx =
+              mkStAnnTx
+                (epochInfo testGlobals)
+                (systemStart testGlobals)
+                pParams
+                utxo
+                tx
+            res =
+              runShelleyBase $
+                applySTSTest @(EraRule "LEDGER" era)
+                  (TRC (ledgerEnv, ls', stAnnTx))
+        case res of
+          Left pf -> error ("LEDGER sigGen: " <> show pf)
+          Right ls'' -> pure (ls'', tx : txs)
+
 instance
   ( Crypto c
   , ApplyTx era
@@ -149,43 +203,7 @@ instance
       <*> genAccountState geConstants
 
   -- a LEDGERS signal is a sequence of LEDGER signals
-  sigGen
-    ge@(GenEnv _ _ Constants {maxTxsPerBlock})
-    (LedgersEnv slotNo epochNo pParams reserves)
-    ls = do
-      (_, txs') <-
-        foldM
-          genAndApplyTx
-          (ls, [])
-          [minBound .. mkTxIxPartial (toInteger maxTxsPerBlock - 1)]
-
-      pure $ Seq.fromList (reverse txs') -- reverse Newest first to Oldest first
-      where
-        genAndApplyTx ::
-          HasCallStack =>
-          (LedgerState era, [Tx TopTx era]) ->
-          TxIx ->
-          Gen (LedgerState era, [Tx TopTx era])
-        genAndApplyTx (ls', txs) txIx = do
-          let ledgerEnv = LedgerEnv slotNo (Just epochNo) txIx pParams reserves
-          tx <- genTx ge ledgerEnv ls'
-
-          let utxo = utxosUtxo (lsUTxOState ls')
-              stAnnTx =
-                mkStAnnTx
-                  (epochInfo testGlobals)
-                  (systemStart testGlobals)
-                  pParams
-                  utxo
-                  tx
-              res =
-                runShelleyBase $
-                  applySTSTest @(EraRule "LEDGER" era)
-                    (TRC (ledgerEnv, ls', stAnnTx))
-          case res of
-            Left pf -> error ("LEDGER sigGen: " <> show pf)
-            Right ls'' -> pure (ls'', tx : txs)
-
+  sigGen = ledgersSigGen
   shrinkSignal = const []
 
   type BaseEnv (LEDGERS era) = Globals

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Dijkstra/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Dijkstra/Ledger.hs
@@ -125,16 +125,15 @@ instance
   ) =>
   NFData (DijkstraStAnnTx TopTx era)
   where
-  rnf stAnnTx@(DijkstraStAnnTopTx _ _ _ _ _ _ _ _) =
+  rnf stAnnTx@(DijkstraStAnnTopTx _ _ _ _ _ _ _) =
     let DijkstraStAnnTopTx {..} = stAnnTx
      in dsattTx `deepseq`
-          dsattProtocolVersion `deepseq`
-            dsattScriptsNeeded `deepseq`
-              dsattScriptsProvided `deepseq`
-                dsattPlutusLegacyMode `deepseq`
-                  dsattPlutusLanguagesUsed `deepseq`
-                    dsattPlutusScriptsWithContext `deepseq`
-                      rnf dsattSubTransactions
+          dsattScriptsNeeded `deepseq`
+            dsattScriptsProvided `deepseq`
+              dsattPlutusLegacyMode `deepseq`
+                dsattPlutusLanguagesUsed `deepseq`
+                  dsattPlutusScriptsWithContext `deepseq`
+                    rnf dsattSubTransactions
 
 instance
   ( AlonzoEraTx era
@@ -168,12 +167,11 @@ instance
   ) =>
   ToExpr (DijkstraStAnnTx TopTx era)
   where
-  toExpr stAnnTx@(DijkstraStAnnTopTx _ _ _ _ _ _ _ _) =
+  toExpr stAnnTx@(DijkstraStAnnTopTx _ _ _ _ _ _ _) =
     let DijkstraStAnnTopTx {..} = stAnnTx
      in TD.Rec "DijkstraStAnnTopTx" $
           OMap.fromList
             [ ("dsattTx", toExpr dsattTx)
-            , ("dsattProtocolVersion", toExpr dsattProtocolVersion)
             , ("dsattScriptsNeeded", toExpr dsattScriptsNeeded)
             , ("dsattScriptsProvided", toExpr dsattScriptsProvided)
             , ("dsattPlutusLegacyMode", toExpr dsattPlutusLegacyMode)

--- a/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
+++ b/libs/cardano-ledger-test/bench/Bench/Cardano/Ledger/ApplyTx.hs
@@ -27,7 +27,7 @@ import Cardano.Ledger.Shelley.API (
   Globals,
   LedgerEnv,
   LedgerState,
-  applyTx,
+  applyTxWithFullValidation,
  )
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.State
@@ -99,7 +99,7 @@ benchApplyTx px =
               either
                 (error . show)
                 fst
-                (applyTx ateGlobals ateMempoolEnv st ateTx)
+                (applyTxWithFullValidation ateGlobals ateMempoolEnv st ateTx)
           )
           ateState
 

--- a/libs/cardano-ledger-test/benchProperty/Main.hs
+++ b/libs/cardano-ledger-test/benchProperty/Main.hs
@@ -41,6 +41,7 @@ import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.State.Transition.Extended (Embed (..))
 import Test.Cardano.Ledger.Alonzo.AlonzoEraGen ()
 import Test.Cardano.Ledger.Alonzo.EraMapping ()
+import Test.Cardano.Ledger.Alonzo.Trace ()
 import Test.Cardano.Ledger.Common (ledgerTestMain)
 import Test.Cardano.Ledger.Shelley.Rules.Chain (
   CHAIN,

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -17,6 +17,7 @@
 
 module Test.Cardano.Ledger.Generic.MockChain where
 
+import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.BaseTypes (BlocksMade (..), ShelleyBase)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
@@ -185,6 +186,17 @@ instance
   , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
   Embed (Shelley.LEDGERS era) (MOCKCHAIN era)
+  where
+  wrapFailed = MockChainFromLedgersFailure
+  wrapEvent = MockChainFromLedgersEvent
+
+instance
+  ( STS (Alonzo.LEDGERS era)
+  , State (EraRule "LEDGER" era) ~ LedgerState era
+  , Environment (EraRule "LEDGER" era) ~ Shelley.LedgerEnv era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  ) =>
+  Embed (Alonzo.LEDGERS era) (MOCKCHAIN era)
   where
   wrapFailed = MockChainFromLedgersFailure
   wrapEvent = MockChainFromLedgersEvent

--- a/libs/ledger-state/bench/Performance.hs
+++ b/libs/ledger-state/bench/Performance.hs
@@ -88,10 +88,10 @@ main = do
       applyTx' mempoolEnv mempoolState =
         -- TODO: revert this to `either (error . show) seqTuple` after tx's are fixed
         bimap restrictError seqTuple
-          . applyTx globals mempoolEnv mempoolState
+          . applyTxWithFullValidation globals mempoolEnv mempoolState
       reapplyTx' mempoolEnv mempoolState =
         either (error . show) id
-          . reapplyTx globals mempoolEnv mempoolState
+          . internalReapplyValidatedTx globals mempoolEnv mempoolState
       slotsPerTick =
         let f = positiveUnitIntervalNonZeroRational (activeSlotVal (activeSlotCoeff globals))
          in round (1 /. f)
@@ -132,31 +132,36 @@ main = do
                  \ ~(mempoolEnv, mempoolState) ->
                    bgroup
                      "reapplyTx"
-                     [ env (pure validatedTx1) $
+                     [ env (pure (unsafeMakeValidatedTx globals mempoolEnv mempoolState validatedTx1)) $
                          bench "Tx1" . whnf (reapplyTx' mempoolEnv mempoolState)
-                     , env (pure validatedTx2) $
+                     , env (pure (unsafeMakeValidatedTx globals mempoolEnv mempoolState validatedTx2)) $
                          bench "Tx2" . whnf (reapplyTx' mempoolEnv mempoolState)
-                     , env (pure validatedTx3) $
+                     , env (pure (unsafeMakeValidatedTx globals mempoolEnv mempoolState validatedTx3)) $
                          bench "Tx3" . whnf (reapplyTx' mempoolEnv mempoolState)
                      , env
-                         (pure [validatedTx1, validatedTx2, validatedTx3])
+                         ( pure
+                             ( map
+                                 (unsafeMakeValidatedTx globals mempoolEnv mempoolState)
+                                 [validatedTx1, validatedTx2, validatedTx3]
+                             )
+                         )
                          $ bench "Tx1+Tx2+Tx3" . whnf (F.foldl' (reapplyTx' mempoolEnv) mempoolState)
                      ]
              , env (pure (mkMempoolEnv newEpochState slotNo, toMempoolState newEpochState)) $
                  \ ~(mempoolEnv, mempoolState) ->
                    bgroup
                      "applyTx"
-                     [ env (pure (extractTx validatedTx1)) $
+                     [ env (pure validatedTx1) $
                          bench "Tx1" . whnf (applyTx' mempoolEnv mempoolState)
-                     , env (pure (extractTx validatedTx2)) $
+                     , env (pure validatedTx2) $
                          bench "Tx2" . whnf (applyTx' mempoolEnv mempoolState)
-                     , env (pure (extractTx validatedTx3)) $
+                     , env (pure validatedTx3) $
                          bench "Tx3" . whnf (applyTx' mempoolEnv mempoolState)
                      , env
                          (pure [validatedTx1, validatedTx2, validatedTx3])
                          $ bench "Tx1+Tx2+Tx3"
                            -- TODO: revert this to `foldl'` without `fmap` after tx's are fixed
-                           . whnf (F.foldlM (\ms -> fmap fst . applyTx' mempoolEnv ms . extractTx) mempoolState)
+                           . whnf (F.foldlM (\ms -> fmap fst . applyTx' mempoolEnv ms) mempoolState)
                      ]
              , env (pure utxo) $ \utxo' ->
                  bgroup
@@ -236,58 +241,55 @@ decodeTx hex = either error id $ do
 --
 -- * One input with Shelley address without staking
 -- * One destination and change back to the address from original input.
-validatedTx1 :: Validated (Tx TopTx CurrentEra)
+validatedTx1 :: Tx TopTx CurrentEra
 validatedTx1 =
-  unsafeMakeValidated $
-    decodeTx
-      "84a500818258201a42ba3e89f7ac4e526a61836b29847cb143c504e1429caa75c9ee06\
-      \312f7ef7000d80018282581d61780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54\
-      \142dd9f1b1361a001440b3825839011e9c9362752648dda1dfa9382c70aad2bedbb683\
-      \c213c6cdf4c4ef14800525c22102c1a6e05589b0209ccc06f57cb332960920d45080ba\
-      \c31a000f4240021a0002a2ad0e81581c780648b89ea2f11fa9bbdd67552db5dd020eda\
-      \1c9a54142dd9f1b136a10081825820cf2477066091b565f87f0445817c4df726900b29\
-      \af3f05d229309afdbf94296d5840028182010e2204fae981f24df1be5e890122d2d854\
-      \dde86c57635fa88de1df834b4321e2aaade0353947b682f265cc546abc4db86853f435\
-      \842a808e500e4201f5f6"
+  decodeTx
+    "84a500818258201a42ba3e89f7ac4e526a61836b29847cb143c504e1429caa75c9ee06\
+    \312f7ef7000d80018282581d61780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54\
+    \142dd9f1b1361a001440b3825839011e9c9362752648dda1dfa9382c70aad2bedbb683\
+    \c213c6cdf4c4ef14800525c22102c1a6e05589b0209ccc06f57cb332960920d45080ba\
+    \c31a000f4240021a0002a2ad0e81581c780648b89ea2f11fa9bbdd67552db5dd020eda\
+    \1c9a54142dd9f1b136a10081825820cf2477066091b565f87f0445817c4df726900b29\
+    \af3f05d229309afdbf94296d5840028182010e2204fae981f24df1be5e890122d2d854\
+    \dde86c57635fa88de1df834b4321e2aaade0353947b682f265cc546abc4db86853f435\
+    \842a808e500e4201f5f6"
 
 -- | Slightly less basic ada-only transaction:
 --
 -- * One input with Shelley address /with/ staking address
 -- * One destination and change back to the address from original input.
-validatedTx2 :: Validated (Tx TopTx CurrentEra)
+validatedTx2 :: Tx TopTx CurrentEra
 validatedTx2 =
-  unsafeMakeValidated $
-    decodeTx
-      "84a500818258204c94b067b71c219d178e81d5aa87d2bc8c567855056f646fd244979d\
-      \7b989f83000d80018282583901780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54\
-      \142dd9f1b13693d02e102e7e1917f14280d263c6878f9a7f238c2a24e702e9ea6ccf1a\
-      \0011cae3825839011e9c9362752648dda1dfa9382c70aad2bedbb683c213c6cdf4c4ef\
-      \14800525c22102c1a6e05589b0209ccc06f57cb332960920d45080bac31a000f424002\
-      \1a0002a77d0e81581c780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54142dd9f1\
-      \b136a10081825820cf2477066091b565f87f0445817c4df726900b29af3f05d229309a\
-      \fdbf94296d5840634a53d6826e3c63a0fd451e142c565beea8e08ff47bb302b7365a97\
-      \5a723618c48ffafe2048ae9181a388bdea5f61ca7f085d1073e91d64722a2e76509c7b\
-      \0ef5f6"
+  decodeTx
+    "84a500818258204c94b067b71c219d178e81d5aa87d2bc8c567855056f646fd244979d\
+    \7b989f83000d80018282583901780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54\
+    \142dd9f1b13693d02e102e7e1917f14280d263c6878f9a7f238c2a24e702e9ea6ccf1a\
+    \0011cae3825839011e9c9362752648dda1dfa9382c70aad2bedbb683c213c6cdf4c4ef\
+    \14800525c22102c1a6e05589b0209ccc06f57cb332960920d45080bac31a000f424002\
+    \1a0002a77d0e81581c780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54142dd9f1\
+    \b136a10081825820cf2477066091b565f87f0445817c4df726900b29af3f05d229309a\
+    \fdbf94296d5840634a53d6826e3c63a0fd451e142c565beea8e08ff47bb302b7365a97\
+    \5a723618c48ffafe2048ae9181a388bdea5f61ca7f085d1073e91d64722a2e76509c7b\
+    \0ef5f6"
 
 -- | Transaction with non-ADA value
 --
 -- * One input with Shelley address /with/ staking address and some tokens
 -- * One destination and change back to the address from original input.
-validatedTx3 :: Validated (Tx TopTx CurrentEra)
+validatedTx3 :: Tx TopTx CurrentEra
 validatedTx3 =
-  unsafeMakeValidated $
-    decodeTx
-      "84a500818258200e5d59af740d8682656ade4af6c069f926b9ec51689ee962260b4127\
-      \8d21538e000d80018282583901780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54\
-      \142dd9f1b13693d02e102e7e1917f14280d263c6878f9a7f238c2a24e702e9ea6ccf1a\
-      \002a26f282583901780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54142dd9f1b1\
-      \3693d02e102e7e1917f14280d263c6878f9a7f238c2a24e702e9ea6ccf821a00150bd0\
-      \a1581ca89568bb399d0cdc38367e47831c95186f5c79e58174e08a18232396a14a4554\
-      \424643546f6b656e1a006cc9f2021a0002afe90e81581c780648b89ea2f11fa9bbdd67\
-      \552db5dd020eda1c9a54142dd9f1b136a10081825820cf2477066091b565f87f044581\
-      \7c4df726900b29af3f05d229309afdbf94296d584088444a5845b198a2d255175770be\
-      \7120c2d3482751b14f06dd41d7ff023eeae6e63933b097c023c1ed19df6a061173c45a\
-      \a54cceb568ff1886e2716e84e6260df5f6"
+  decodeTx
+    "84a500818258200e5d59af740d8682656ade4af6c069f926b9ec51689ee962260b4127\
+    \8d21538e000d80018282583901780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54\
+    \142dd9f1b13693d02e102e7e1917f14280d263c6878f9a7f238c2a24e702e9ea6ccf1a\
+    \002a26f282583901780648b89ea2f11fa9bbdd67552db5dd020eda1c9a54142dd9f1b1\
+    \3693d02e102e7e1917f14280d263c6878f9a7f238c2a24e702e9ea6ccf821a00150bd0\
+    \a1581ca89568bb399d0cdc38367e47831c95186f5c79e58174e08a18232396a14a4554\
+    \424643546f6b656e1a006cc9f2021a0002afe90e81581c780648b89ea2f11fa9bbdd67\
+    \552db5dd020eda1c9a54142dd9f1b136a10081825820cf2477066091b565f87f044581\
+    \7c4df726900b29af3f05d229309afdbf94296d584088444a5845b198a2d255175770be\
+    \7120c2d3482751b14f06dd41d7ff023eeae6e63933b097c023c1ed19df6a061173c45a\
+    \a54cceb568ff1886e2716e84e6260df5f6"
 
 mkGlobals :: ShelleyGenesis -> Globals
 mkGlobals genesis =


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

So far, integration of `StAnnTx` - which means using the memoized values that it holds  - has been done for eras starting with Babbage (https://github.com/IntersectMBO/cardano-ledger/pull/5804).
Alonzo is problematic because  the EpochInfo used when creating plutus contexts in Alonzo is modified with `unsafeLinearExtendEpochInfo`, which depends on the slot number. 
Passing the slot number when creating the `StAnnTx` turned out to be an incorrect solution, because that would make the memoized version dependent on the environment. 
Instead, in this PR, the problem is handled by pushing  the discrepancy more at the "edges" - namely modifying the EpochInfo via `unsafeLinearExtendEpochInfo` at the entry points:  in `ApplyTx` and `LEDGERS`  rule for alonzo. 

`ApplyTx` has been restructured (old methods deprecated), in order to facilitate the change we needed ,and also to provide better names, as follows:

`applyTxValidation`  deprecated in favor of  `applyTxWithValidation` 
`applyTx`   deprecated in favour of  `applyTxWithFullValidation`
`reapplyTx` deprecated in favor of `reapplyValidatedTx`
`unsafeMakeValidated` deprecated in favor of `unsafeMakeValidatedTx`

A new method was added to `ApplyTx`: `reapplyTxFromValidated` - for full per-era flexibility and safety.

A new `AlonzoLEDGERS` had to be introduced instead of reusing ShelleyLEDGERS, that passes the  `unsafeLinearExtendEpochInfo` modification.

Finally, the memoized plutus contexts have been reused in Alonzo UTXOS. 

Closes https://github.com/IntersectMBO/cardano-ledger/issues/5836

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
