### PR TITLE
Prevent `TxInfo` translation failure for `LegacyMode`

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -25,7 +25,6 @@
 * Add `TranslateEra` instance for `DijkstraEra VState`
 * Fix `TranslateEra` instance for `DijkstraEra CertState`
 * Add `GuardScriptHashesNotSupported` constructor to `DijkstraContextError`
-* Add `SubTxsAreNotSupported` constructor to `DijkstraContextError`
 * Add `decodeDijkstraTopTx`
 * Change `Signal` to `StAnnTx TopTx era` for: `DijkstraLEDGER`, `DijkstraMEMPOOL`, `DijkstraUTXOW`, `DijkstraUTXO`
 * Change `Signal` to `StAnnTx SubTx era` for: `DijkstraSUBLEDGER`, `DijkstraSUBUTXOW`, `DijkstraSUBUTXO`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -104,8 +104,6 @@ data DijkstraContextError era
     DirectDepositsNotSupported DirectDeposits
   | -- | Attempt to use PlutusV1-V3 with non-empty account balance intervals will result in this failure
     AccountBalanceIntervalsNotSupported (AccountBalanceIntervals era)
-  | -- | Attempt to use sub-transactions with PlutusV1-V3 scripts at the top level will result in this failure
-    SubTxsAreNotSupported (NonEmpty TxId)
   | -- | Attempt to use PlutusV1-V3 with script hashes in guards will result in this failure
     GuardScriptHashesNotSupported (NonEmpty ScriptHash)
   deriving (Generic)
@@ -163,8 +161,6 @@ instance
       kindObject "DirectDepositsNotSupported" ["direct_deposits" .= show dd]
     AccountBalanceIntervalsNotSupported abi ->
       kindObject "AccountBalanceIntervalsNotSupported" ["account_balance_intervals" .= show abi]
-    SubTxsAreNotSupported txIds ->
-      kindObject "SubTxsAreNotSupported" ["txIds" .= toJSON txIds]
     GuardScriptHashesNotSupported scriptHashes ->
       kindObject "GuardScriptHashesNotSupported" ["script_hashes" .= toJSON scriptHashes]
 
@@ -185,8 +181,7 @@ instance
     19 -> SumD UnsupportedScriptInSubTx <! From <! From
     20 -> SumD DirectDepositsNotSupported <! From
     21 -> SumD AccountBalanceIntervalsNotSupported <! From
-    22 -> SumD SubTxsAreNotSupported <! From
-    23 -> SumD GuardScriptHashesNotSupported <! From
+    22 -> SumD GuardScriptHashesNotSupported <! From
     k -> Invalid k
 
 instance
@@ -208,9 +203,8 @@ instance
         Sum UnsupportedScriptInSubTx 19 !> To lang !> To txId
       DirectDepositsNotSupported dd -> Sum DirectDepositsNotSupported 20 !> To dd
       AccountBalanceIntervalsNotSupported abi -> Sum AccountBalanceIntervalsNotSupported 21 !> To abi
-      SubTxsAreNotSupported txIds -> Sum SubTxsAreNotSupported 22 !> To txIds
       GuardScriptHashesNotSupported scriptHashes ->
-        Sum GuardScriptHashesNotSupported 23 !> To scriptHashes
+        Sum GuardScriptHashesNotSupported 22 !> To scriptHashes
 
 instance Inject (ConwayContextError era) (DijkstraContextError era) where
   inject = ConwayContextError
@@ -429,7 +423,6 @@ guardDijkstraFeaturesForPlutusV1toV3 tx = do
   let txBody = tx ^. bodyTxL
       directDeposits = txBody ^. directDepositsTxBodyL
       accountBalanceIntervals = txBody ^. accountBalanceIntervalsTxBodyL
-      subTransactions = txBody ^. subTransactionsTxBodyL
       scriptHashes = [sh | ScriptHashObj sh <- toList (txBody ^. guardsTxBodyL)]
   unless (null $ unDirectDeposits directDeposits) $
     Left $
@@ -439,12 +432,6 @@ guardDijkstraFeaturesForPlutusV1toV3 tx = do
     Left $
       inject $
         AccountBalanceIntervalsNotSupported @era accountBalanceIntervals
-  case NE.nonEmpty . toList $ OMap.toStrictSeqOKeys subTransactions of
-    Nothing -> Right ()
-    Just subTxIds ->
-      Left $
-        inject $
-          SubTxsAreNotSupported @era subTxIds
   case NE.nonEmpty scriptHashes of
     Nothing -> Right ()
     Just neScriptHashes ->

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
@@ -28,7 +28,6 @@ import Cardano.Ledger.Plutus (Language (..), SLanguage (..), plutusLanguage)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
-import qualified Data.OMap.Strict as OMap
 import qualified Data.OSet.Strict as OSet
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Common
@@ -147,27 +146,6 @@ spec = describe "TxInfo" $ do
               <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
          in
           txInfoResult `shouldBeLeft` inject (AccountBalanceIntervalsNotSupported @era abi)
-      it "SubTxsAreNotSupported" $ do
-        let
-          subTx = mkBasicTx @era @SubTx mkBasicTxBody
-          tx =
-            mkBasicTx @era @TopTx $
-              mkBasicTxBody
-                & subTransactionsTxBodyL .~ OMap.singleton subTx
-          ledgerTxInfo =
-            LedgerTxInfo
-              { ltiProtVer = ProtVer (eraProtVerLow @era) 0
-              , ltiEpochInfo = epochInfo testGlobals
-              , ltiSystemStart = systemStart testGlobals
-              , ltiUTxO = mempty
-              , ltiTx = tx
-              , ltiMemoizedSubTransactions = mempty
-              }
-          txInfoResult =
-            ($ SpendingPurpose AsPurpose)
-              <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
-        txInfoResult
-          `shouldBeLeft` inject (SubTxsAreNotSupported @era (pure (txIdTx subTx)))
       prop "GuardScriptHashesNotSupported" $ \(scriptHash :: ScriptHash) ->
         let
           neScriptHashes = scriptHash :| []


### PR DESCRIPTION
# Description
Resolves #5819 
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
