### PR TITLE
ARC - Stream - Dynamic Pricing Prototype

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/PParams.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/PParams.hs
@@ -3,6 +3,7 @@
 
 module Cardano.Ledger.Allegra.PParams () where
 
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..), NoPricing)
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.Governance
@@ -41,6 +42,10 @@ instance EraPParams AllegraEra where
   hkdMinPoolCostCompactL = lens sppMinPoolCost $ \pp x -> pp {sppMinPoolCost = x}
 
   eraPParams = shelleyPParams
+
+
+instance EraPricing AllegraEra where
+  type PricingState AllegraEra = NoPricing AllegraEra
 
 instance EraGov AllegraEra where
   type GovState AllegraEra = ShelleyGovState AllegraEra

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -179,7 +179,7 @@ utxoTransition ::
   TransitionRule (EraRule "UTXO" era)
 utxoTransition = do
   TRC (Shelley.UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
-  let Shelley.UTxOState utxo _ _ ppup _ _ = utxos
+  let Shelley.UTxOState utxo _ _ ppup _ _ _ = utxos
       txBody = tx ^. bodyTxL
       genDelegs = certState ^. Shelley.certDStateL . Shelley.dsGenDelegsL
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Translation.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Translation.hs
@@ -12,6 +12,7 @@
 
 module Cardano.Ledger.Allegra.Translation (shelleyToAllegraAVVMsToDelete) where
 
+import Cardano.Ledger.DynamicPricing.State (NoPricing (..))
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.State
 import Cardano.Ledger.Allegra.Tx ()
@@ -121,6 +122,7 @@ instance TranslateEra AllegraEra UTxOState where
         , utxosGovState = translateEra' ctxt $ utxosGovState us
         , utxosInstantStake = translateEra' ctxt $ utxosInstantStake us
         , utxosDonation = utxosDonation us
+        , utxosPricing = NoPricing
         }
 
 instance TranslateEra AllegraEra ShelleyInstantStake where

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/PParams.hs
@@ -70,6 +70,7 @@ module Cardano.Ledger.Alonzo.PParams (
   appMinFeeB,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..), NoPricing)
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.BaseTypes (
   EpochInterval (..),
@@ -385,6 +386,10 @@ instance AlonzoEraPParams AlonzoEra where
     lens appCollateralPercentage $ \pp x -> pp {appCollateralPercentage = x}
   hkdMaxCollateralInputsL =
     lens appMaxCollateralInputs $ \pp x -> pp {appMaxCollateralInputs = x}
+
+
+instance EraPricing AlonzoEra where
+  type PricingState AlonzoEra = NoPricing AlonzoEra
 
 instance EraGov AlonzoEra where
   type GovState AlonzoEra = ShelleyGovState AlonzoEra

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Translation.hs
@@ -13,6 +13,7 @@
 
 module Cardano.Ledger.Alonzo.Translation () where
 
+import Cardano.Ledger.DynamicPricing.State (NoPricing (..))
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.Genesis (AlonzoGenesis (..))
@@ -141,6 +142,7 @@ instance TranslateEra AlonzoEra UTxOState where
         , utxosGovState = translateEra' ctxt $ utxosGovState us
         , utxosInstantStake = translateEra' ctxt $ utxosInstantStake us
         , utxosDonation = utxosDonation us
+        , utxosPricing = NoPricing
         }
 
 instance TranslateEra AlonzoEra ShelleyInstantStake where

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/PParams.hs
@@ -41,6 +41,7 @@ module Cardano.Ledger.Babbage.PParams (
   bppMinFeeB,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..), NoPricing)
 import Cardano.Ledger.Alonzo (AlonzoEra)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.PParams
@@ -245,6 +246,10 @@ instance AlonzoEraPParams BabbageEra where
 
 instance BabbageEraPParams BabbageEra where
   hkdCoinsPerUTxOByteL = lens bppCoinsPerUTxOByte (\pp x -> pp {bppCoinsPerUTxOByte = x})
+
+
+instance EraPricing BabbageEra where
+  type PricingState BabbageEra = NoPricing BabbageEra
 
 instance EraGov BabbageEra where
   type GovState BabbageEra = ShelleyGovState BabbageEra

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Translation.hs
@@ -13,6 +13,7 @@
 
 module Cardano.Ledger.Babbage.Translation () where
 
+import Cardano.Ledger.DynamicPricing.State (NoPricing (..))
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.PParams ()
@@ -140,6 +141,7 @@ instance TranslateEra BabbageEra UTxOState where
         , utxosGovState = translateEra' ctxt $ utxosGovState us
         , utxosInstantStake = translateEra' ctxt $ utxosInstantStake us
         , utxosDonation = utxosDonation us
+        , utxosPricing = NoPricing
         }
 
 instance TranslateEra BabbageEra ShelleyInstantStake where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -175,6 +175,7 @@ module Cardano.Ledger.Conway.Governance (
   showGovActionType,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..), NoPricing)
 import Cardano.Ledger.BaseTypes (
   EpochNo (..),
   Globals (..),
@@ -403,6 +404,10 @@ instance (ConwayEraAccounts era, EraPParams era, EraStake era) => ToKeyValuePair
         , "previousPParams" .= cgsPrevPParams
         , "futurePParams" .= cgsFuturePParams
         ]
+
+
+instance EraPricing ConwayEra where
+  type PricingState ConwayEra = NoPricing ConwayEra
 
 instance EraGov ConwayEra where
   type GovState ConwayEra = ConwayGovState ConwayEra

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Translation.hs
@@ -14,6 +14,7 @@
 
 module Cardano.Ledger.Conway.Translation () where
 
+import Cardano.Ledger.DynamicPricing.State (NoPricing (..))
 import Cardano.Ledger.Babbage (BabbageEra)
 import Cardano.Ledger.BaseTypes (strictMaybeToMaybe)
 import Cardano.Ledger.Binary (DecoderError)
@@ -184,6 +185,7 @@ instance TranslateEra ConwayEra UTxOState where
         , API.utxosGovState = translateGovState ctxt $ API.utxosGovState us
         , API.utxosInstantStake = ConwayInstantStake . sisCredentialStake $ API.utxosInstantStake us
         , API.utxosDonation = API.utxosDonation us
+        , API.utxosPricing = NoPricing
         }
 
 instance TranslateEra ConwayEra API.UTxO where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Governance.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Governance.hs
@@ -3,6 +3,7 @@
 
 module Cardano.Ledger.Dijkstra.Governance () where
 
+import Cardano.Ledger.DynamicPricing.State (DynamicPricing, EraPricing (..), initialPricingState)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Governance (
   ConwayEraGov (..),
@@ -24,6 +25,11 @@ import Cardano.Ledger.Dijkstra.PParams ()
 import Cardano.Ledger.Dijkstra.State.Stake ()
 import Data.Foldable (Foldable (..))
 import Lens.Micro ((^.))
+
+
+instance EraPricing DijkstraEra where
+  type PricingState DijkstraEra = DynamicPricing DijkstraEra
+  emptyPricing = initialPricingState
 
 instance EraGov DijkstraEra where
   type GovState DijkstraEra = ConwayGovState DijkstraEra

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Bbody.hs
@@ -24,7 +24,7 @@ module Cardano.Ledger.Dijkstra.Rules.Bbody (
 ) where
 
 import Cardano.Ledger.Allegra.Rules (AllegraUtxoPredFailure)
-import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams)
+import Cardano.Ledger.Alonzo.PParams (AlonzoEraPParams, ppMaxBlockExUnitsL)
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoBbodyEvent (ShelleyInAlonzoEvent),
   AlonzoBbodyPredFailure,
@@ -73,7 +73,16 @@ import Cardano.Ledger.Dijkstra.Rules.Ledger (DijkstraLedgerPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Ledgers ()
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.Utxow (DijkstraUtxowPredFailure)
-import Cardano.Ledger.Shelley.LedgerState (LedgerState (..))
+import Cardano.Ledger.DynamicPricing (
+  DynamicPricing (..),
+  Inclusion (..),
+  InclusionUsage (..),
+  TxSizeInBytes (..),
+  endOfBlock,
+ )
+import Cardano.Ledger.DynamicPricing.State (PricingState)
+import Cardano.Ledger.Plutus.ExUnits (pointWiseExUnits)
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), lsUTxOStateL, utxosPricingL)
 import Cardano.Ledger.Shelley.Rules (
   BbodyEnv (..),
   ShelleyBbodyPredFailure,
@@ -95,7 +104,9 @@ import Control.State.Transition (
 import Control.State.Transition.Extended (TRC (..), failBecause, (?!))
 import Data.Sequence (Seq)
 import GHC.Generics (Generic)
-import Lens.Micro ((^.))
+import qualified Data.Map.Strict as Map
+import Data.Word (Word32)
+import Lens.Micro ((%~), (&), (^.))
 import NoThunks.Class (NoThunks (..))
 
 data DijkstraBbodyPredFailure era
@@ -107,6 +118,12 @@ data DijkstraBbodyPredFailure era
   | BodyRefScriptsSizeTooBig (Mismatch RelLTEQ Int)
   | PrevEpochNonceNotPresent
   | PerasCertValidationFailed PerasCert Nonce
+  | -- | Dynamic pricing (B1, spec: @sdChecks@): the optimistic usage of the
+    -- block exceeds the on-chain block byte budget.
+    OptimisticOverflowsBlock (Mismatch RelLTEQ Word32)
+  | -- | Dynamic pricing (B1, spec: @sdChecks@): the optimistic usage of the
+    -- block exceeds the on-chain block ExUnits budget.
+    OptimisticOverflowsBlockExUnits (Mismatch RelLTEQ ExUnits)
   deriving (Generic)
 
 instance NFData (PredicateFailure (EraRule "LEDGERS" era)) => NFData (DijkstraBbodyPredFailure era)
@@ -139,6 +156,8 @@ instance
       PrevEpochNonceNotPresent -> Sum PrevEpochNonceNotPresent 5
       PerasCertValidationFailed cert nonce ->
         Sum PerasCertValidationFailed 6 !> To cert !> To nonce
+      OptimisticOverflowsBlock mm -> Sum OptimisticOverflowsBlock 7 !> To mm
+      OptimisticOverflowsBlockExUnits mm -> Sum OptimisticOverflowsBlockExUnits 8 !> To mm
 
 instance
   ( Era era
@@ -154,6 +173,8 @@ instance
     4 -> SumD BodyRefScriptsSizeTooBig <! From
     5 -> SumD PrevEpochNonceNotPresent
     6 -> SumD PerasCertValidationFailed <! From <! From
+    7 -> SumD OptimisticOverflowsBlock <! From
+    8 -> SumD OptimisticOverflowsBlockExUnits <! From
     n -> Invalid n
 
 type instance EraRuleFailure "BBODY" DijkstraEra = DijkstraBbodyPredFailure DijkstraEra
@@ -323,6 +344,7 @@ instance
   , BabbageEraTxBody era
   , ConwayEraPParams era
   , DijkstraEraBlockBody era
+  , PricingState era ~ DynamicPricing era
   ) =>
   STS (DijkstraBBODY era)
   where
@@ -343,7 +365,45 @@ instance
     [ dijkstraBbodyTransition @era
         >> Conway.conwayBbodyTransition @era
         >> alonzoBbodyTransition @era
+        >>= divupTransition @era
     ]
+
+-- | Close the block for dynamic pricing (spec: the @DIVUP@ rule), running
+-- AFTER the block's transactions so it sees the accumulated usage:
+--
+-- * B1 (@sdChecks@): the optimistic usage fits the on-chain block budgets.
+--   Praos-only: every block is an RB, so the premise always applies; the
+--   EB exemption arrives with the consensus phase.
+-- * B2 (@endOfBlock@): republish the prices ('reprice', still the identity)
+--   and reset the usage counters. The prices published here are what the
+--   UTXO rule judges the NEXT block's transactions against.
+divupTransition ::
+  forall era.
+  ( State (EraRule "BBODY" era) ~ ShelleyBbodyState era
+  , State (EraRule "LEDGERS" era) ~ LedgerState era
+  , Environment (EraRule "BBODY" era) ~ BbodyEnv era
+  , AlonzoEraPParams era
+  , PricingState era ~ DynamicPricing era
+  , InjectRuleFailure "BBODY" DijkstraBbodyPredFailure era
+  ) =>
+  ShelleyBbodyState era ->
+  TransitionRule (EraRule "BBODY" era)
+divupTransition (BbodyState ls blocksMade) = do
+  TRC (BbodyEnv pp _, _, _) <- judgmentContext
+  let pricing = ls ^. lsUTxOStateL . utxosPricingL
+      usage = Map.findWithDefault mempty Optimistic (blockUsage pricing)
+      TxSizeInBytes optimisticBytes = bytesUsed usage
+      maxBytes = pp ^. ppMaxBBSizeL
+      maxExUnits = pp ^. ppMaxBlockExUnitsL
+  optimisticBytes <= maxBytes
+    ?! injectFailure
+      (OptimisticOverflowsBlock Mismatch {mismatchSupplied = optimisticBytes, mismatchExpected = maxBytes})
+  pointWiseExUnits (<=) (exUnitsUsed usage) maxExUnits
+    ?! injectFailure
+      ( OptimisticOverflowsBlockExUnits
+          Mismatch {mismatchSupplied = exUnitsUsed usage, mismatchExpected = maxExUnits}
+      )
+  pure $! BbodyState (ls & lsUTxOStateL . utxosPricingL %~ endOfBlock) blocksMade
 
 dijkstraBbodyTransition ::
   forall era.

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -44,7 +44,7 @@ import Cardano.Ledger.BaseTypes (
  )
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
-import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Coin (Coin, compactCoinOrError)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (
   ConwayEraGov (..),
@@ -74,6 +74,12 @@ import Cardano.Ledger.Conway.Rules (
  )
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Conway.State
+import Cardano.Ledger.DynamicPricing.State (
+  DynamicPricing,
+  PricingState,
+  drainPendingRefunds,
+  pendingRefunds,
+ )
 import Cardano.Ledger.Dijkstra.Era (
   DijkstraEra,
   DijkstraGOV,
@@ -103,6 +109,9 @@ import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   UTxOState (..),
+  lsCertStateL,
+  lsUTxOStateL,
+  utxosPricingL,
  )
 import Cardano.Ledger.Shelley.Rules (
   LedgerEnv (..),
@@ -334,6 +343,7 @@ instance
   , ConwayEraTxBody era
   , ConwayEraGov era
   , DijkstraEraTxBody era
+  , PricingState era ~ DynamicPricing era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
@@ -392,6 +402,7 @@ dijkstraLedgerTransition ::
   , ConwayEraCertState era
   , ConwayEraGov era
   , DijkstraEraTxBody era
+  , PricingState era ~ DynamicPricing era
   , GovState era ~ ConwayGovState era
   , Embed (EraRule "UTXOW" era) (DijkstraLEDGER era)
   , Embed (EraRule "GOV" era) (DijkstraLEDGER era)
@@ -421,7 +432,31 @@ dijkstraLedgerTransition = do
   ledgerStateAfterSubledgers <-
     trans @(EraRule "SUBLEDGERS" era) $
       TRC (env, ledgerState, tx ^. bodyTxL . subTransactionsTxBodyL)
-  conwayLedgerTransitionTRC (TRC (env, ledgerStateAfterSubledgers, tx))
+  finalLedgerState <- conwayLedgerTransitionTRC (TRC (env, ledgerStateAfterSubledgers, tx))
+  -- Rule 4: deliver the refunds owed by this transaction's fee split into
+  -- account balances (spec: the feeRewards flush, once per transaction).
+  -- NOTE(prototype): refunds to unregistered accounts stay pending.
+  pure $! flushPendingRefunds finalLedgerState
+
+flushPendingRefunds ::
+  forall era.
+  ( EraCertState era
+  , PricingState era ~ DynamicPricing era
+  ) =>
+  LedgerState era ->
+  LedgerState era
+flushPendingRefunds ls
+  | Map.null refunds = ls
+  | otherwise =
+      ls
+        & lsCertStateL . certDStateL . accountsL
+          %~ addToBalanceAccounts (Map.map compactCoinOrError registered)
+        & lsUTxOStateL . utxosPricingL
+          .~ drained {pendingRefunds = unregistered}
+  where
+    (refunds, drained) = drainPendingRefunds (ls ^. lsUTxOStateL . utxosPricingL)
+    accounts = ls ^. lsCertStateL . certDStateL . accountsL . accountsMapL
+    (registered, unregistered) = Map.partitionWithKey (\cred _ -> Map.member cred accounts) refunds
 
 instance
   ( AlonzoEraTx era
@@ -451,6 +486,8 @@ instance
   , Embed (EraRule "SUBLEDGERS" era) (DijkstraSUBLEDGERS era)
   , ConwayEraGov era
   , AlonzoEraTx era
+  , EraAccounts era
+  , PricingState era ~ DynamicPricing era
   , ConwayEraPParams era
   , DijkstraEraTxBody era
   , EraPlutusContext era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Mempool.hs
@@ -21,6 +21,7 @@ module Cardano.Ledger.Dijkstra.Rules.Mempool (
   DijkstraMempoolEvent (..),
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (DynamicPricing, PricingState)
 import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
 import Cardano.Ledger.BaseTypes (ShelleyBase)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
@@ -236,6 +237,7 @@ instance
   ( AlonzoEraTx era
   , ConwayEraCertState era
   , DijkstraEraTxBody era
+  , PricingState era ~ DynamicPricing era
   , ConwayEraGov era
   , EraPlutusContext era
   , GovState era ~ ConwayGovState era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -240,3 +240,5 @@ dijkstraUtxoToDijkstraSubUtxoPredFailure = \case
   BabbageOutputTooSmallUTxO txouts -> SubBabbageOutputTooSmallUTxO txouts
   BabbageNonDisjointRefInputs _ -> error "Impossible: `BabbageNonDisjointRefInputs` for SUBUTXO"
   PtrPresentInCollateralReturn _ -> error "Impossible: `PtrPresentInCollateralReturn` for SUBUTXO"
+  -- Sub-transactions carry no fee and purchase no inclusion strategy.
+  BidBelowQuote _ -> error "Impossible: `BidBelowQuote` for SUBUTXO"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -70,6 +70,21 @@ import Cardano.Ledger.Dijkstra.Era (DijkstraEra, DijkstraUTXO)
 import Cardano.Ledger.Dijkstra.Rules.Utxos ()
 import Cardano.Ledger.Plutus (ExUnits)
 import Cardano.Ledger.Rules.ValidationMode (failOnJustStatic)
+import Cardano.Ledger.Alonzo.Tx (totExUnits)
+import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
+import Cardano.Ledger.Val ((<->))
+import Cardano.Ledger.DynamicPricing (
+  DynamicPricing,
+  MinimumTxFee (..),
+  Quote (..),
+  addPendingRefund,
+  currentPrice,
+  minimumTxFee,
+  quoteFor,
+  recordTx,
+  txSizeInBytes,
+ )
+import Cardano.Ledger.DynamicPricing.State (PricingState)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
 import Cardano.Ledger.Shelley.Rules (
   ShelleyUtxoPredFailure,
@@ -91,6 +106,7 @@ import Control.State.Transition.Extended (
   TransitionRule,
   judgmentContext,
   trans,
+  (?!),
  )
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map.NonEmpty (NonEmptyMap)
@@ -116,6 +132,10 @@ data DijkstraUtxoPredFailure era
   | MaxTxSizeUTxO (Mismatch RelLTEQ Word32)
   | InputSetEmptyUTxO
   | FeeTooSmallUTxO
+      (Mismatch RelGTEQ Coin)
+  | -- | Dynamic pricing (U1): the bid (fee field, read as a price cap) does
+    -- not cover the current quote for the declared inclusion strategy.
+    BidBelowQuote
       (Mismatch RelGTEQ Coin)
   | ValueNotConservedUTxO
       (Mismatch RelEQ (Value era)) -- Serialise consumed first, then produced
@@ -256,7 +276,8 @@ dijkstraUtxoTransition ::
   forall era.
   ( EraUTxO era
   , EraCertState era
-  , BabbageEraTxBody era
+  , DijkstraEraTxBody era
+  , PricingState era ~ DynamicPricing era
   , AlonzoEraTx era
   , EraStake era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
@@ -279,10 +300,41 @@ dijkstraUtxoTransition ::
   TransitionRule (EraRule "UTXO" era)
 dijkstraUtxoTransition = do
   TRC (UtxoEnv _ pp certState, utxos, tx) <- judgmentContext
+  let txBody = tx ^. bodyTxL
+      declared = txBody ^. inclusionTxBodyL
+      bid = txBody ^. feeTxBodyL
+      Quote quote = quoteFor pp tx (currentPrice declared (utxosPricing utxos))
   babbageUtxoValidation
-  validateNoPtrInCollateralReturn $ tx ^. bodyTxL
+  -- U1: the bid covers the current quote for the declared inclusion strategy.
+  -- Subsumes the plain min-fee premise (the quote never undercuts the
+  -- protocol minimum fee), which babbageUtxoValidation still checks anyway.
+  quote <= bid
+    ?! injectFailure
+      (BidBelowQuote Mismatch {mismatchSupplied = bid, mismatchExpected = quote})
+  validateNoPtrInCollateralReturn txBody
   updatedUtxos <- trans @(EraRule "UTXOS" era) $ TRC (pp, utxos, tx)
-  updateUTxOStateByTxValidity pp certState (utxosGovState utxos) tx updatedUtxos
+  finalUtxos <- updateUTxOStateByTxValidity pp certState (utxosGovState utxos) tx updatedUtxos
+  -- U2: usage accounting by declared strategy (spec: processTxTiers).
+  -- Recorded for valid and invalid (collateral-consuming) transactions alike:
+  -- both occupy block space.
+  let recorded =
+        recordTx declared (txSizeInBytes tx) bid (totExUnits tx) (utxosPricing finalUtxos)
+  -- Fee split (rule 3), only when the bidder asked for a refund:
+  --   base    (the protocol minimum)   stays in the fee pot   [prototype answer to Q3]
+  --   premium (quote − base)           goes to the treasury via the donation pot
+  --   refund  (bid − quote)            owed back to the bidder, flushed by LEDGER
+  -- Without a refund account: today's semantics, the full bid stays in the fee pot.
+  pure $! case txBody ^. feeRefundAccountTxBodyL of
+    SNothing -> finalUtxos {utxosPricing = recorded}
+    SJust (AccountAddress _ (AccountId cred)) ->
+      let MinimumTxFee base = minimumTxFee pp tx
+          premium = quote <-> base
+          refund = bid <-> quote
+       in finalUtxos
+            { utxosPricing = addPendingRefund cred refund recorded
+            , utxosFees = utxosFees finalUtxos <-> premium <-> refund
+            , utxosDonation = utxosDonation finalUtxos <> premium
+            }
 
 instance
   forall era.
@@ -290,6 +342,8 @@ instance
   , EraUTxO era
   , EraStake era
   , ConwayEraTxBody era
+  , DijkstraEraTxBody era
+  , PricingState era ~ DynamicPricing era
   , AlonzoEraTx era
   , EraRule "UTXO" era ~ DijkstraUTXO era
   , InjectRuleFailure "UTXO" ShelleyUtxoPredFailure era
@@ -376,6 +430,7 @@ instance
       BabbageOutputTooSmallUTxO x -> Sum BabbageOutputTooSmallUTxO 21 !> To x
       BabbageNonDisjointRefInputs x -> Sum BabbageNonDisjointRefInputs 22 !> To x
       PtrPresentInCollateralReturn x -> Sum PtrPresentInCollateralReturn 23 !> To x
+      BidBelowQuote mm -> Sum BidBelowQuote 24 !> To mm
 
 instance
   ( Era era
@@ -411,6 +466,7 @@ instance
     21 -> SumD BabbageOutputTooSmallUTxO <! From
     22 -> SumD BabbageNonDisjointRefInputs <! From
     23 -> SumD PtrPresentInCollateralReturn <! From
+    24 -> SumD BidBelowQuote <! From
     n -> Invalid n
 
 -- =====================================================

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Translation.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Translation.hs
@@ -11,6 +11,7 @@
 
 module Cardano.Ledger.Dijkstra.Translation () where
 
+import Cardano.Ledger.DynamicPricing.State (initialPricingState)
 import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Conway.Core
@@ -223,6 +224,7 @@ instance TranslateEra DijkstraEra UTxOState where
         , API.utxosGovState = translateEra' ctxt $ API.utxosGovState us
         , API.utxosInstantStake = coerce $ API.utxosInstantStake us
         , API.utxosDonation = API.utxosDonation us
+        , API.utxosPricing = initialPricingState
         }
 
 instance TranslateEra DijkstraEra API.UTxO where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
@@ -35,7 +35,7 @@ module Cardano.Ledger.Dijkstra.TxBody (
     dtbTotalCollateral,
     dtbCerts,
     dtbWithdrawals,
-    dtbTxfee,
+    dtbBidFee,
     dtbVldt,
     dtbMint,
     dtbScriptIntegrityHash,
@@ -49,6 +49,8 @@ module Cardano.Ledger.Dijkstra.TxBody (
     dtbSubTransactions,
     dtbDirectDeposits,
     dtbAccountBalanceIntervals,
+    dtbInclusion,
+    dtbFeeRefundAccount,
     dstbSpendInputs,
     dstbReferenceInputs,
     dstbOutputs,
@@ -75,7 +77,7 @@ module Cardano.Ledger.Dijkstra.TxBody (
   basicDijkstraTxBodyRaw,
   inputsDijkstraTxBodyRawL,
   outputsDijkstraTxBodyRawL,
-  feeDijkstraTxBodyRawL,
+  bidFeeDijkstraTxBodyRawL,
   vldtDijkstraTxBodyRawL,
   certsDijkstraTxBodyRawL,
   withdrawalsDijkstraTxBodyRawL,
@@ -96,6 +98,8 @@ module Cardano.Ledger.Dijkstra.TxBody (
   requiredTopLevelGuardsDijkstraTxBodyRawL,
   directDepositsDijkstraTxBodyRawL,
   accountBalanceIntervalsDijkstraTxBodyRawL,
+  inclusionDijkstraTxBodyRawL,
+  feeRefundAccountDijkstraTxBodyRawL,
 ) where
 
 import Cardano.Ledger.Address (DirectDeposits (..))
@@ -122,6 +126,7 @@ import Cardano.Ledger.Conway.TxBody (
  )
 import Cardano.Ledger.Core (EraPParams (..))
 import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.DynamicPricing (Inclusion (..))
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceIntervals (..), DijkstraPlutusPurpose (..))
 import Cardano.Ledger.Dijkstra.TxOut ()
@@ -169,7 +174,7 @@ data DijkstraTxBodyRaw l era where
     , dtbrTotalCollateral :: !(StrictMaybe Coin)
     , dtbrCerts :: !(OSet.OSet (TxCert era))
     , dtbrWithdrawals :: !Withdrawals
-    , dtbrFee :: !Coin
+    , dtbrBidFee :: !Coin
     , dtbrVldt :: !ValidityInterval
     , dtbrGuards :: !(OSet (Credential Guard))
     , dtbrMint :: !MultiAsset
@@ -183,6 +188,8 @@ data DijkstraTxBodyRaw l era where
     , dtbrSubTransactions :: !(OMap TxId (Tx SubTx era))
     , dtbrDirectDeposits :: !DirectDeposits
     , dtbrAccountBalanceIntervals :: !(AccountBalanceIntervals era)
+    , dtbrInclusion :: !Inclusion
+    , dtbrFeeRefundAccount :: !(StrictMaybe AccountAddress)
     } ->
     DijkstraTxBodyRaw TopTx era
   DijkstraSubTxBodyRaw ::
@@ -225,7 +232,7 @@ deriving via
     (Typeable l, EraTxBody era) => NoThunks (DijkstraTxBodyRaw l era)
 
 instance (EraTxBody era, NFData (Tx SubTx era)) => NFData (DijkstraTxBodyRaw l era) where
-  rnf txBodyRaw@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) =
+  rnf txBodyRaw@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) =
     let DijkstraTxBodyRaw {..} = txBodyRaw
      in dtbrSpendInputs `deepseq`
           dtbrCollateralInputs `deepseq`
@@ -235,7 +242,7 @@ instance (EraTxBody era, NFData (Tx SubTx era)) => NFData (DijkstraTxBodyRaw l e
                   dtbrTotalCollateral `deepseq`
                     dtbrCerts `deepseq`
                       dtbrWithdrawals `deepseq`
-                        dtbrFee `deepseq`
+                        dtbrBidFee `deepseq`
                           dtbrVldt `deepseq`
                             dtbrGuards `deepseq`
                               dtbrMint `deepseq`
@@ -248,7 +255,9 @@ instance (EraTxBody era, NFData (Tx SubTx era)) => NFData (DijkstraTxBodyRaw l e
                                             dtbrTreasuryDonation `deepseq`
                                               dtbrSubTransactions `deepseq`
                                                 dtbrDirectDeposits `deepseq`
-                                                  rnf dtbrAccountBalanceIntervals
+                                                  dtbrAccountBalanceIntervals `deepseq`
+                                                    dtbrInclusion `deepseq`
+                                                      rnf dtbrFeeRefundAccount
   rnf txBodyRaw@(DijkstraSubTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) =
     let DijkstraSubTxBodyRaw {..} = txBodyRaw
      in dstbrSpendInputs `deepseq`
@@ -297,6 +306,8 @@ basicDijkstraTxBodyRaw STopTx =
     OMap.Empty
     (DirectDeposits mempty)
     (AccountBalanceIntervals mempty)
+    Optimistic
+    SNothing
 basicDijkstraTxBodyRaw SSubTx =
   DijkstraSubTxBodyRaw
     mempty
@@ -338,7 +349,7 @@ instance
       bodyFields sTxLevel = \case
         0 -> fieldA (inputsDijkstraTxBodyRawL .~) From
         1 -> fieldA (outputsDijkstraTxBodyRawL .~) From
-        2 | STopTx <- sTxLevel -> fieldA (feeDijkstraTxBodyRawL .~) From
+        2 | STopTx <- sTxLevel -> fieldA (bidFeeDijkstraTxBodyRawL .~) From
         3 -> ofieldA (vldtDijkstraTxBodyRawL . invalidHereAfterL .~) From
         4 ->
           fieldAGuarded
@@ -424,6 +435,12 @@ instance
             (null . unAccountBalanceIntervals)
             (accountBalanceIntervalsDijkstraTxBodyRawL .~)
             From
+        27
+          | STopTx <- sTxLevel ->
+              fieldA (inclusionDijkstraTxBodyRawL .~) From
+        28
+          | STopTx <- sTxLevel ->
+              ofieldA (feeRefundAccountDijkstraTxBodyRawL .~) From
         n -> invalidField n
       decodeSubTransactions :: Decoder s (Annotator (OMap TxId (Tx SubTx era)))
       decodeSubTransactions =
@@ -453,7 +470,7 @@ encodeTxBodyRaw DijkstraTxBodyRaw {..} =
         !> Key 1 (To dtbrOutputs)
         !> encodeKeyedStrictMaybe 16 dtbrCollateralReturn
         !> encodeKeyedStrictMaybe 17 dtbrTotalCollateral
-        !> Key 2 (To dtbrFee)
+        !> Key 2 (To dtbrBidFee)
         !> encodeKeyedStrictMaybe 3 top
         !> Omit OSet.null (Key 4 (To dtbrCerts))
         !> Omit (null . unWithdrawals) (Key 5 (To dtbrWithdrawals))
@@ -470,6 +487,8 @@ encodeTxBodyRaw DijkstraTxBodyRaw {..} =
         !> Omit null (Key 23 $ To dtbrSubTransactions)
         !> Omit (null . unDirectDeposits) (Key 25 (To dtbrDirectDeposits))
         !> Omit (null . unAccountBalanceIntervals) (Key 26 (To dtbrAccountBalanceIntervals))
+        !> Omit (== Optimistic) (Key 27 (To dtbrInclusion))
+        !> encodeKeyedStrictMaybe 28 dtbrFeeRefundAccount
 encodeTxBodyRaw DijkstraSubTxBodyRaw {..} =
   let ValidityInterval bot top = dstbrVldt
    in Keyed
@@ -577,6 +596,8 @@ pattern DijkstraTxBody ::
   OMap TxId (Tx SubTx DijkstraEra) ->
   DirectDeposits ->
   AccountBalanceIntervals DijkstraEra ->
+  Inclusion ->
+  StrictMaybe AccountAddress ->
   TxBody TopTx DijkstraEra
 pattern DijkstraTxBody
   { dtbSpendInputs
@@ -587,7 +608,7 @@ pattern DijkstraTxBody
   , dtbTotalCollateral
   , dtbCerts
   , dtbWithdrawals
-  , dtbTxfee
+  , dtbBidFee
   , dtbVldt
   , dtbGuards
   , dtbMint
@@ -601,6 +622,8 @@ pattern DijkstraTxBody
   , dtbSubTransactions
   , dtbDirectDeposits
   , dtbAccountBalanceIntervals
+  , dtbInclusion
+  , dtbFeeRefundAccount
   } <-
   ( getMemoRawType ->
       DijkstraTxBodyRaw
@@ -612,7 +635,7 @@ pattern DijkstraTxBody
         , dtbrTotalCollateral = dtbTotalCollateral
         , dtbrCerts = dtbCerts
         , dtbrWithdrawals = dtbWithdrawals
-        , dtbrFee = dtbTxfee
+        , dtbrBidFee = dtbBidFee
         , dtbrVldt = dtbVldt
         , dtbrGuards = dtbGuards
         , dtbrMint = dtbMint
@@ -626,6 +649,8 @@ pattern DijkstraTxBody
         , dtbrSubTransactions = dtbSubTransactions
         , dtbrDirectDeposits = dtbDirectDeposits
         , dtbrAccountBalanceIntervals = dtbAccountBalanceIntervals
+        , dtbrInclusion = dtbInclusion
+        , dtbrFeeRefundAccount = dtbFeeRefundAccount
         }
     )
   where
@@ -651,7 +676,9 @@ pattern DijkstraTxBody
       treasuryDonation
       subTransactions
       directDeposits
-      accountBalanceIntervals =
+      accountBalanceIntervals
+      serviceLevel
+      feeRefundAccount =
         mkMemoizedEra @DijkstraEra $
           DijkstraTxBodyRaw
             inputsX
@@ -676,6 +703,8 @@ pattern DijkstraTxBody
             subTransactions
             directDeposits
             accountBalanceIntervals
+            serviceLevel
+            feeRefundAccount
 
 pattern DijkstraSubTxBody ::
   ( EncCBOR (Tx SubTx DijkstraEra)
@@ -846,8 +875,8 @@ outputsDijkstraTxBodyRawL =
         x@DijkstraSubTxBodyRaw {} -> \y -> x {dstbrOutputs = mkSized (eraProtVerLow @era) <$> y}
     )
 
-feeDijkstraTxBodyRawL :: Lens' (DijkstraTxBodyRaw TopTx era) Coin
-feeDijkstraTxBodyRawL = lens dtbrFee (\txb x -> txb {dtbrFee = x})
+bidFeeDijkstraTxBodyRawL :: Lens' (DijkstraTxBodyRaw TopTx era) Coin
+bidFeeDijkstraTxBodyRawL = lens dtbrBidFee (\txb x -> txb {dtbrBidFee = x})
 
 auxDataHashDijkstraTxBodyRawL :: Lens' (DijkstraTxBodyRaw l era) (StrictMaybe TxAuxDataHash)
 auxDataHashDijkstraTxBodyRawL =
@@ -931,7 +960,7 @@ instance
   outputsTxBodyL = memoRawTypeL @DijkstraEra . outputsDijkstraTxBodyRawL
   {-# INLINE outputsTxBodyL #-}
 
-  feeTxBodyL = memoRawTypeL @DijkstraEra . feeDijkstraTxBodyRawL
+  feeTxBodyL = memoRawTypeL @DijkstraEra . bidFeeDijkstraTxBodyRawL
   {-# INLINE feeTxBodyL #-}
 
   auxDataHashTxBodyL = memoRawTypeL @DijkstraEra . auxDataHashDijkstraTxBodyRawL
@@ -1094,6 +1123,15 @@ instance
   where
   mintTxBodyL = memoRawTypeL @DijkstraEra . mintDijkstraTxBodyRawL
   {-# INLINE mintTxBodyL #-}
+
+inclusionDijkstraTxBodyRawL :: Lens' (DijkstraTxBodyRaw TopTx era) Inclusion
+inclusionDijkstraTxBodyRawL =
+  lens dtbrInclusion $ \txb x -> txb {dtbrInclusion = x}
+
+feeRefundAccountDijkstraTxBodyRawL ::
+  Lens' (DijkstraTxBodyRaw TopTx era) (StrictMaybe AccountAddress)
+feeRefundAccountDijkstraTxBodyRawL =
+  lens dtbrFeeRefundAccount $ \txb x -> txb {dtbrFeeRefundAccount = x}
 
 collateralInputsDijkstraTxBodyRawL :: Lens' (DijkstraTxBodyRaw TopTx era) (Set TxIn)
 collateralInputsDijkstraTxBodyRawL =
@@ -1301,6 +1339,12 @@ class ConwayEraTxBody era => DijkstraEraTxBody era where
 
   accountBalanceIntervalsTxBodyL :: Lens' (TxBody l era) (AccountBalanceIntervals era)
 
+  -- | The inclusion strategy the transaction purchases (dynamic pricing).
+  inclusionTxBodyL :: Lens' (TxBody TopTx era) Inclusion
+
+  -- | Where the unused headroom of the bid is refunded (dynamic pricing).
+  feeRefundAccountTxBodyL :: Lens' (TxBody TopTx era) (StrictMaybe AccountAddress)
+
 guardsDijkstraTxBodyRawL :: Lens' (DijkstraTxBodyRaw l era) (OSet (Credential Guard))
 guardsDijkstraTxBodyRawL =
   lens
@@ -1344,6 +1388,12 @@ instance
 
   accountBalanceIntervalsTxBodyL = memoRawTypeL @DijkstraEra . accountBalanceIntervalsDijkstraTxBodyRawL
   {-# INLINE accountBalanceIntervalsTxBodyL #-}
+
+  inclusionTxBodyL = memoRawTypeL @DijkstraEra . inclusionDijkstraTxBodyRawL
+  {-# INLINE inclusionTxBodyL #-}
+
+  feeRefundAccountTxBodyL = memoRawTypeL @DijkstraEra . feeRefundAccountDijkstraTxBodyRawL
+  {-# INLINE feeRefundAccountTxBodyL #-}
 
 -- | Decoder for decoding guards in a backwards-compatible manner. It peeks at
 -- the first element and if it's a credential, it decodes the rest of the

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -24,6 +24,7 @@ import Cardano.Ledger.BaseTypes (LeiosCert (..), PerasCert (..), StrictMaybe)
 import Cardano.Ledger.Conway.Rules (ConwayDelegPredFailure)
 import Cardano.Ledger.Dijkstra (ApplyTxError (DijkstraApplyTxError), DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
+import Cardano.Ledger.DynamicPricing (Inclusion (..))
 import Cardano.Ledger.Dijkstra.Genesis (DijkstraGenesis (..))
 import Cardano.Ledger.Dijkstra.PParams (DijkstraPParams, UpgradeDijkstraPParams)
 import Cardano.Ledger.Dijkstra.Rules
@@ -97,6 +98,11 @@ instance Arbitrary (TxBody TopTx DijkstraEra) where
       <*> (choose (0, 4) >>= \n -> OMap.fromFoldable <$> vectorOf n arbitrary)
       <*> arbitrary
       <*> arbitrary
+      <*> arbitrary
+      <*> arbitrary
+
+instance Arbitrary Inclusion where
+  arbitrary = elements [Urgent, Optimistic]
 
 instance Arbitrary (UpgradeDijkstraPParams Identity DijkstraEra) where
   arbitrary = genericArbitraryU

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -50,7 +50,7 @@ instance Typeable l => DecCBOR (DijkstraTxBodyRaw l DijkstraEra) where
       bodyFields sTxLevel = \case
         0 -> field (inputsDijkstraTxBodyRawL .~) From
         1 -> field (outputsDijkstraTxBodyRawL .~) From
-        2 | STopTx <- sTxLevel -> field (feeDijkstraTxBodyRawL .~) From
+        2 | STopTx <- sTxLevel -> field (bidFeeDijkstraTxBodyRawL .~) From
         3 -> ofield (vldtDijkstraTxBodyRawL . invalidHereAfterL .~) From
         4 ->
           fieldGuarded
@@ -140,6 +140,9 @@ instance Typeable l => DecCBOR (DijkstraTxBodyRaw l DijkstraEra) where
             (null . unAccountBalanceIntervals)
             (accountBalanceIntervalsDijkstraTxBodyRawL .~)
             From
+        27
+          | STopTx <- sTxLevel ->
+              field (inclusionDijkstraTxBodyRawL .~) From
         n -> invalidField n
       requiredFields :: STxBothLevels l DijkstraEra -> [(Word, String)]
       requiredFields sTxLevel

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Examples.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
 import Cardano.Ledger.Conway.Rules (ConwayDELEG, ConwayDelegPredFailure (..))
 import Cardano.Ledger.Credential (Credential (..))
+import Cardano.Ledger.DynamicPricing (Inclusion (..))
 import Cardano.Ledger.Dijkstra (ApplyTxError (..), DijkstraEra)
 import Cardano.Ledger.Dijkstra.Rules (DijkstraLEDGER, DijkstraMEMPOOL)
 import Cardano.Ledger.Dijkstra.Scripts (AccountBalanceIntervals (..), DijkstraPlutusPurpose (..))
@@ -115,6 +116,8 @@ exampleTxBodyDijkstra =
     mempty -- sub-transactions
     (DirectDeposits mempty)
     (AccountBalanceIntervals mempty)
+    Optimistic -- inclusion strategy
+    SNothing -- fee refund account
   where
     MaryValue _ exampleMultiAsset = exampleMultiAssetValue 3
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TreeDiff.hs
@@ -45,6 +45,7 @@ import Cardano.Ledger.Dijkstra.Scripts (
   DijkstraPlutusPurpose,
  )
 import Cardano.Ledger.Dijkstra.Tx (DijkstraTx (..), Tx (..))
+import Cardano.Ledger.DynamicPricing (Inclusion)
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraTxBodyRaw (..))
 import Cardano.Ledger.Dijkstra.TxCert
 import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError)
@@ -68,9 +69,11 @@ instance ToExpr (DijkstraPParams Identity DijkstraEra)
 
 instance ToExpr (DijkstraPParams StrictMaybe DijkstraEra)
 
+instance ToExpr Inclusion
+
 instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
   toExpr = \case
-    txBody@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
+    txBody@(DijkstraTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
       let DijkstraTxBodyRaw {..} = txBody
        in Rec "DijkstraTxBodyRaw" $
             OMap.fromList
@@ -82,7 +85,7 @@ instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
               , ("dtbrTotalCollateral", toExpr dtbrTotalCollateral)
               , ("dtbrCerts", toExpr dtbrCerts)
               , ("dtbrWithdrawals", toExpr dtbrWithdrawals)
-              , ("dtbrFee", toExpr dtbrFee)
+              , ("dtbrBidFee", toExpr dtbrBidFee)
               , ("dtbrVldt", toExpr dtbrVldt)
               , ("dtbrGuards", toExpr dtbrGuards)
               , ("dtbrMint", toExpr dtbrMint)
@@ -96,6 +99,8 @@ instance ToExpr (DijkstraTxBodyRaw l DijkstraEra) where
               , ("dtbrSubTransactions", toExpr dtbrSubTransactions)
               , ("dtbrDirectDeposits", toExpr dtbrDirectDeposits)
               , ("dtbrAccountBalanceIntervals", toExpr dtbrAccountBalanceIntervals)
+              , ("dtbrInclusion", toExpr dtbrInclusion)
+              , ("dtbrFeeRefundAccount", toExpr dtbrFeeRefundAccount)
               ]
     txBody@(DijkstraSubTxBodyRaw _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _) ->
       let DijkstraSubTxBodyRaw {..} = txBody

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/PParams.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/PParams.hs
@@ -3,6 +3,7 @@
 
 module Cardano.Ledger.Mary.PParams () where
 
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..), NoPricing)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Shelley.Governance (
@@ -48,6 +49,10 @@ instance EraPParams MaryEra where
   hkdMinPoolCostCompactL = lens sppMinPoolCost $ \pp x -> pp {sppMinPoolCost = x}
 
   eraPParams = shelleyPParams
+
+
+instance EraPricing MaryEra where
+  type PricingState MaryEra = NoPricing MaryEra
 
 instance EraGov MaryEra where
   type GovState MaryEra = ShelleyGovState MaryEra

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Translation.hs
@@ -13,6 +13,7 @@
 
 module Cardano.Ledger.Mary.Translation () where
 
+import Cardano.Ledger.DynamicPricing.State (NoPricing (..))
 import Cardano.Ledger.Binary (DecoderError)
 import Cardano.Ledger.Genesis (NoGenesis (..))
 import Cardano.Ledger.Mary.Core
@@ -143,6 +144,7 @@ instance TranslateEra MaryEra UTxOState where
         , utxosGovState = translateEra' ctxt $ utxosGovState us
         , utxosInstantStake = translateEra' ctxt $ utxosInstantStake us
         , utxosDonation = utxosDonation us
+        , utxosPricing = NoPricing
         }
 
 instance TranslateEra MaryEra ShelleyInstantStake where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/ByronTranslation.hs
@@ -13,6 +13,7 @@ module Cardano.Ledger.Shelley.API.ByronTranslation (
   translateTxIdByronToShelley,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..))
 import qualified Cardano.Chain.Block as Byron
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.Chain.UTxO as Byron
@@ -167,6 +168,7 @@ translateToShelleyLedgerStateFromUtxo transCtxt epochNo utxoByron =
               , utxosGovState = emptyGovState
               , utxosInstantStake = mempty
               , utxosDonation = mempty
+              , utxosPricing = emptyPricing
               }
         , lsCertState = mkShelleyCertState def dState
         }

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -65,7 +65,7 @@ totalAdaPotsES (EpochState (ChainAccountState {casTreasury, casReserves}) ls _ _
     , obligationsPot = obligationCertState certState <> govStateObligations
     }
   where
-    UTxOState u _ fees_ _ _ _ = lsUTxOState ls
+    UTxOState u _ fees_ _ _ _ _ = lsUTxOState ls
     certState = ls ^. lsCertStateL
     rewards_ = sumBalancesAccounts (certState ^. certDStateL . accountsL)
     coins = sumCoinUTxO u

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Governance.hs
@@ -26,6 +26,7 @@ module Cardano.Ledger.Shelley.Governance (
   futurePParamsShelleyGovStateL,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..), NoPricing)
 import Cardano.Ledger.BaseTypes (KeyValuePairs (..), ToKeyValuePairs (..))
 import Cardano.Ledger.Binary (
   DecCBOR (decCBOR),
@@ -48,6 +49,10 @@ import Data.Default (Default (..))
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens)
 import NoThunks.Class (NoThunks (..))
+
+
+instance EraPricing ShelleyEra where
+  type PricingState ShelleyEra = NoPricing ShelleyEra
 
 instance EraGov ShelleyEra where
   type GovState ShelleyEra = ShelleyGovState ShelleyEra

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -93,6 +93,7 @@ module Cardano.Ledger.Shelley.LedgerState (
   utxosFeesL,
   utxosGovStateL,
   utxosDonationL,
+  utxosPricingL,
   epochStateGovStateL,
   epochStateStakeDistrL,
   epochStateStakePoolsL,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/IncrementalStake.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Shelley.LedgerState.IncrementalStake (
 ) where
 
 import Cardano.Ledger.BaseTypes (ProtVer)
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..))
 import Cardano.Ledger.Coin (Coin (..), addDeltaCoin)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
@@ -57,7 +58,7 @@ import Lens.Micro
 --
 --   TO IncrementalStake
 smartUTxOState ::
-  EraStake era =>
+  (EraStake era, EraPricing era) =>
   PParams era ->
   UTxO era ->
   Coin ->
@@ -65,13 +66,15 @@ smartUTxOState ::
   GovState era ->
   Coin ->
   UTxOState era
-smartUTxOState _pp utxo c1 c2 st =
+smartUTxOState _pp utxo c1 c2 st donation =
   UTxOState
     utxo
     c1
     c2
     st
     (addInstantStake utxo mempty)
+    donation
+    emptyPricing
 
 -- =====================================================
 -- Part 3 Apply a reward update, in NewEpoch rule

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/NewEpochState.hs
@@ -18,6 +18,7 @@ import Cardano.Ledger.BaseTypes (
   BlocksMade (..),
  )
 import Cardano.Ledger.Coin (Coin (..), addDeltaCoin)
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..))
 import Cardano.Ledger.Keys (GenDelegPair (..), GenDelegs (..))
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState.Types
@@ -69,6 +70,7 @@ genesisState genDelegs0 utxo0 =
         emptyGovState
         mempty
         mempty
+        emptyPricing
     )
     ( def
         & certDStateL .~ dState

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState/Types.hs
@@ -43,6 +43,7 @@ import Cardano.Ledger.Binary (
   encodeMemPack,
  )
 import Cardano.Ledger.Binary.Coders (Decode (From, RecD), Encode (..), decode, encode, (!>), (<!))
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..), PricingState)
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Shelley.Core
@@ -98,6 +99,7 @@ deriving stock instance
   , Show (GovState era)
   , Show (CertState era)
   , Show (InstantStake era)
+  , Show (PricingState era)
   ) =>
   Show (EpochState era)
 
@@ -106,6 +108,7 @@ deriving stock instance
   , Eq (GovState era)
   , Eq (CertState era)
   , Eq (InstantStake era)
+  , Eq (PricingState era)
   ) =>
   Eq (EpochState era)
 
@@ -114,6 +117,7 @@ instance
   , NoThunks (GovState era)
   , NoThunks (CertState era)
   , NoThunks (InstantStake era)
+  , NoThunks (PricingState era)
   ) =>
   NoThunks (EpochState era)
 
@@ -122,12 +126,14 @@ instance
   , NFData (GovState era)
   , NFData (CertState era)
   , NFData (InstantStake era)
+  , NFData (PricingState era)
   ) =>
   NFData (EpochState era)
 
 instance
   ( EraTxOut era
   , EraStake era
+  , EraPricing era
   , EncCBOR (GovState era)
   , EncCBOR (CertState era)
   ) =>
@@ -202,6 +208,7 @@ data UTxOState era = UTxOState
   , utxosGovState :: !(GovState era)
   , utxosInstantStake :: !(InstantStake era)
   , utxosDonation :: !Coin
+  , utxosPricing :: !(PricingState era)
   }
   deriving (Generic)
 
@@ -221,6 +228,7 @@ instance
   ( EraTxOut era
   , NFData (GovState era)
   , NFData (InstantStake era)
+  , NFData (PricingState era)
   ) =>
   NFData (UTxOState era)
 
@@ -228,6 +236,7 @@ deriving stock instance
   ( EraTxOut era
   , Show (GovState era)
   , Show (InstantStake era)
+  , Show (PricingState era)
   ) =>
   Show (UTxOState era)
 
@@ -235,6 +244,7 @@ deriving stock instance
   ( EraTxOut era
   , Eq (GovState era)
   , Eq (InstantStake era)
+  , Eq (PricingState era)
   ) =>
   Eq (UTxOState era)
 
@@ -242,17 +252,19 @@ instance
   ( NoThunks (UTxO era)
   , NoThunks (GovState era)
   , NoThunks (InstantStake era)
+  , NoThunks (PricingState era)
   ) =>
   NoThunks (UTxOState era)
 
 instance
   ( EraTxOut era
   , EraStake era
+  , EraPricing era
   , EncCBOR (GovState era)
   ) =>
   EncCBOR (UTxOState era)
   where
-  encCBOR utxos@(UTxOState _ _ _ _ _ _) =
+  encCBOR utxos@(UTxOState _ _ _ _ _ _ _) =
     let UTxOState {..} = utxos
      in encode $
           Rec UTxOState
@@ -264,6 +276,7 @@ instance
             !> To utxosGovState
             !> To utxosInstantStake
             !> To utxosDonation
+            !> To utxosPricing
 
 instance (EraTxOut era, EraGov era, EraStake era) => DecShareCBOR (UTxOState era) where
   type
@@ -274,13 +287,14 @@ instance (EraTxOut era, EraGov era, EraStake era) => DecShareCBOR (UTxOState era
       , Interns (Credential HotCommitteeRole)
       )
   decShareCBOR is@(cs, _, _, _) =
-    decodeRecordNamed "UTxOState" (const 6) $ do
+    decodeRecordNamed "UTxOState" (const 7) $ do
       utxosUtxo <- decShareCBOR cs
       utxosDeposited <- decCBOR
       utxosFees <- decCBOR
       utxosGovState <- decShareCBOR is
       utxosInstantStake <- decShareCBOR cs
       utxosDonation <- decCBOR
+      utxosPricing <- decCBOR
       pure UTxOState {..}
 
 instance (EraTxOut era, EraGov era, EraStake era) => ToCBOR (UTxOState era) where
@@ -295,9 +309,10 @@ deriving via
     (EraTxOut era, EraGov era, EraStake era) => ToJSON (UTxOState era)
 
 instance (EraTxOut era, EraGov era, EraStake era) => ToKeyValuePairs (UTxOState era) where
-  toKeyValuePairs utxoState@(UTxOState _ _ _ _ _ _) =
+  toKeyValuePairs utxoState@(UTxOState _ _ _ _ _ _ _) =
     let UTxOState {..} = utxoState
-     in [ "utxo" .= utxosUtxo
+     in [ "pricing" .= utxosPricing
+        , "utxo" .= utxosUtxo
         , "deposited" .= utxosDeposited
         , "fees" .= utxosFees
         , "ppups" .= utxosGovState
@@ -370,6 +385,7 @@ deriving stock instance
   , Show (GovState era)
   , Show (CertState era)
   , Show (InstantStake era)
+  , Show (PricingState era)
   ) =>
   Show (NewEpochState era)
 
@@ -379,6 +395,7 @@ deriving stock instance
   , Eq (GovState era)
   , Eq (CertState era)
   , Eq (InstantStake era)
+  , Eq (PricingState era)
   ) =>
   Eq (NewEpochState era)
 
@@ -388,12 +405,14 @@ instance
   , NFData (GovState era)
   , NFData (CertState era)
   , NFData (InstantStake era)
+  , NFData (PricingState era)
   ) =>
   NFData (NewEpochState era)
 
 instance
   ( EraTxOut era
   , EraStake era
+  , EraPricing era
   , EncCBOR (StashedAVVMAddresses era)
   , EncCBOR (GovState era)
   , EncCBOR (CertState era)
@@ -474,6 +493,7 @@ deriving stock instance
   , Show (GovState era)
   , Show (CertState era)
   , Show (InstantStake era)
+  , Show (PricingState era)
   ) =>
   Show (LedgerState era)
 
@@ -482,6 +502,7 @@ deriving stock instance
   , Eq (GovState era)
   , Eq (CertState era)
   , Eq (InstantStake era)
+  , Eq (PricingState era)
   ) =>
   Eq (LedgerState era)
 
@@ -490,6 +511,7 @@ instance
   , NoThunks (GovState era)
   , NoThunks (CertState era)
   , NoThunks (InstantStake era)
+  , NoThunks (PricingState era)
   ) =>
   NoThunks (LedgerState era)
 
@@ -498,12 +520,14 @@ instance
   , NFData (GovState era)
   , NFData (CertState era)
   , NFData (InstantStake era)
+  , NFData (PricingState era)
   ) =>
   NFData (LedgerState era)
 
 instance
   ( EraTxOut era
   , EraStake era
+  , EraPricing era
   , EncCBOR (GovState era)
   , EncCBOR (CertState era)
   ) =>
@@ -567,7 +591,7 @@ instance
 --------------------------------------------------------------------------------
 
 instance (EraGov era, EraStake era) => Default (UTxOState era) where
-  def = UTxOState mempty mempty mempty def mempty mempty
+  def = UTxOState mempty mempty mempty def mempty mempty emptyPricing
 
 instance
   Default (LedgerState era) =>
@@ -653,6 +677,9 @@ utxosGovStateL = lens utxosGovState (\x y -> x {utxosGovState = y})
 
 utxosDonationL :: Lens' (UTxOState era) Coin
 utxosDonationL = lens utxosDonation (\x y -> x {utxosDonation = y})
+
+utxosPricingL :: Lens' (UTxOState era) (PricingState era)
+utxosPricingL = lens utxosPricing (\x y -> x {utxosPricing = y})
 
 -- ====================  Compound Lenses =======================
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Snap.hs
@@ -78,7 +78,7 @@ snapTransition ::
 snapTransition = do
   TRC (snapEnv, s, _) <- judgmentContext
 
-  let SnapEnv ls@(LedgerState (UTxOState _utxo _ fees _ _ _) certState) _pp = snapEnv
+  let SnapEnv ls@(LedgerState (UTxOState _utxo _ fees _ _ _ _) certState) _pp = snapEnv
       instantStake = ls ^. instantStakeG
       -- per the spec: stakeSnap = stakeDistr @era utxo dstate pstate
       istakeSnap =

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -362,7 +362,7 @@ utxoInductive ::
 utxoInductive = do
   TRC (UtxoEnv slot pp certState, utxos, tx) <- judgmentContext
   let utxo = utxos ^. utxoL
-      UTxOState _ _ _ ppup _ _ = utxos
+      UTxOState _ _ _ ppup _ _ _ = utxos
       txBody = tx ^. bodyTxL
       outputs = txBody ^. outputsTxBodyL
       genDelegs = dsGenDelegs (certState ^. certDStateL)
@@ -596,7 +596,7 @@ updateUTxOState ::
   (UTxO era -> UTxO era -> m ()) ->
   m (UTxOState era)
 updateUTxOState pp utxos txBody certState govState depositChangeEvent txUtxODiffEvent = do
-  let UTxOState {utxosUtxo, utxosDeposited, utxosFees, utxosDonation} = utxos
+  let UTxOState {utxosUtxo, utxosDeposited, utxosFees, utxosDonation, utxosPricing} = utxos
       UTxO utxo = utxosUtxo
       !utxoAdd = txouts txBody -- These will be inserted into the UTxO
       {- utxoDel  = txins txb ◁ utxo -}
@@ -618,6 +618,7 @@ updateUTxOState pp utxos txBody certState govState depositChangeEvent txUtxODiff
       , utxosInstantStake =
           deleteInstantStake deletedUTxO (addInstantStake utxoAdd (utxos ^. instantStakeL))
       , utxosDonation = utxosDonation
+      , utxosPricing = utxosPricing
       }
 
 instance

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -27,6 +27,7 @@ module Test.Cardano.Ledger.Shelley.Arbitrary (
   sizedNativeScriptGens,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (DynamicPricing, EraPricing (..), NoPricing (..), PricingState, initialPricingState)
 import qualified Cardano.Chain.UTxO as Byron
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (EncCBOR (..))
@@ -134,6 +135,8 @@ instance
   , Arbitrary (GovState era)
   , Arbitrary (CertState era)
   , Arbitrary (InstantStake era)
+  , EraPricing era
+  , Arbitrary (PricingState era)
   ) =>
   Arbitrary (NewEpochState era)
   where
@@ -153,6 +156,8 @@ instance
   , Arbitrary (GovState era)
   , Arbitrary (CertState era)
   , Arbitrary (InstantStake era)
+  , EraPricing era
+  , Arbitrary (PricingState era)
   ) =>
   Arbitrary (EpochState era)
   where
@@ -170,6 +175,8 @@ instance
   , Arbitrary (GovState era)
   , Arbitrary (CertState era)
   , Arbitrary (InstantStake era)
+  , EraPricing era
+  , Arbitrary (PricingState era)
   ) =>
   Arbitrary (LedgerState era)
   where
@@ -185,11 +192,20 @@ instance
         <$> (lsUTxOState : shrink lsUTxOState)
         <*> (lsCertState : shrink lsCertState)
 
+instance Arbitrary (NoPricing era) where
+  arbitrary = pure NoPricing
+
+-- Deterministic for now: prices move only when the controllers land.
+instance Arbitrary (DynamicPricing era) where
+  arbitrary = pure initialPricingState
+
 instance
   ( EraTxOut era
   , Arbitrary (TxOut era)
   , Arbitrary (GovState era)
   , Arbitrary (InstantStake era)
+  , EraPricing era
+  , Arbitrary (PricingState era)
   ) =>
   Arbitrary (UTxOState era)
   where
@@ -201,6 +217,7 @@ instance
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
+      <*> pure emptyPricing
 
   -- The 'genericShrink' function returns first the immediate subterms of a
   -- value (in case it is a recursive data-type), and then shrinks the value

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/RoundTrip.hs
@@ -11,6 +11,7 @@ module Test.Cardano.Ledger.Shelley.Binary.RoundTrip (
   roundTripStateEraTypesSpec,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (PricingState)
 import Cardano.Ledger.Binary
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -50,6 +51,7 @@ roundTripStateEraTypesSpec ::
   , Arbitrary (GovState era)
   , Arbitrary (CertState era)
   , Arbitrary (InstantStake era)
+  , Arbitrary (PricingState era)
   ) =>
   Spec
 roundTripStateEraTypesSpec = do

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Era.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Era.hs
@@ -15,6 +15,7 @@ module Test.Cardano.Ledger.Shelley.Era (
   shelleyAccountsFromAccountsMap,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (PricingState)
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR, ToCBOR)
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Core
@@ -55,6 +56,8 @@ class
   , ToExpr (ScriptsNeeded era)
   , SafeToHash (TxWits era)
   , Typeable (CertState era)
+  , Arbitrary (PricingState era)
+  , ToExpr (PricingState era)
   ) =>
   ShelleyEraTest era
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Examples.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Examples.hs
@@ -38,6 +38,7 @@ module Test.Cardano.Ledger.Shelley.Examples (
   seedFromWords,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (EraPricing (..))
 import qualified Cardano.Chain.Common as Byron
 import Cardano.Crypto.DSIGN as DSIGN
 import Cardano.Crypto.Hash as Hash
@@ -248,6 +249,7 @@ exampleNewEpochState value ppp pp =
                     , utxosGovState = emptyGovState
                     , utxosInstantStake = mempty
                     , utxosDonation = mempty
+                    , utxosPricing = emptyPricing
                     }
               , lsCertState = def
               }

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/TreeDiff.hs
@@ -10,6 +10,7 @@ module Test.Cardano.Ledger.Shelley.TreeDiff (
   module Test.Cardano.Ledger.TreeDiff,
 ) where
 
+import Cardano.Ledger.DynamicPricing.State (DynamicPricing, NoPricing, PricingState)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Core
 import Cardano.Ledger.Rewards
@@ -151,6 +152,7 @@ instance
   , ToExpr (GovState era)
   , ToExpr (CertState era)
   , ToExpr (InstantStake era)
+  , ToExpr (PricingState era)
   ) =>
   ToExpr (NewEpochState era)
 
@@ -160,6 +162,7 @@ instance
   , ToExpr (GovState era)
   , ToExpr (CertState era)
   , ToExpr (InstantStake era)
+  , ToExpr (PricingState era)
   ) =>
   ToExpr (EpochState era)
 
@@ -168,13 +171,20 @@ instance
   , ToExpr (GovState era)
   , ToExpr (CertState era)
   , ToExpr (InstantStake era)
+  , ToExpr (PricingState era)
   ) =>
   ToExpr (LedgerState era)
+
+instance ToExpr (NoPricing era)
+
+instance ToExpr (DynamicPricing era) where
+  toExpr = defaultExprViaShow
 
 instance
   ( ToExpr (TxOut era)
   , ToExpr (GovState era)
   , ToExpr (InstantStake era)
+  , ToExpr (PricingState era)
   ) =>
   ToExpr (UTxOState era)
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -63,6 +63,10 @@ library
     Cardano.Ledger.Core
     Cardano.Ledger.Credential
     Cardano.Ledger.DRep
+    Cardano.Ledger.DynamicPricing
+    Cardano.Ledger.DynamicPricing.InclusionStrategy
+    Cardano.Ledger.DynamicPricing.Pricing
+    Cardano.Ledger.DynamicPricing.State
     Cardano.Ledger.Genesis
     Cardano.Ledger.HKD
     Cardano.Ledger.Hashes

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DynamicPricing.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DynamicPricing.hs
@@ -1,0 +1,28 @@
+-- | Domain model for dynamic pricing: transactions purchase one of two
+-- inclusion strategies, each with its own protocol-driven price.
+--
+-- Umbrella module re-exporting the whole vocabulary. The /lanes/ (RB vs EB
+-- transport) are infrastructure and deliberately absent from it.
+--
+-- Spec correspondence (@formal-ledger-specifications\@polina\/dynamic@):
+--
+-- @
+--   Inclusion          \<-\> TierNo (fastTier = 0, slowTier = 1)
+--   InclusionPrice     \<-\> TierCoeff \/ PolicyClause.coeffRange
+--   InclusionPrices    \<-\> DiversityPolicy
+--   Quote (lovelace)   \<-\> the @tierCoeff × minfee@ premise, made first-class
+--   declared strategy  \<-\> TxTier (without the declared tierCoeff)
+--   feeRefundAccount   \<-\> feeChangeAddr
+--   delivered strategy \<-\> actualTier
+--   DynamicPricing     \<-\> SDPolicy
+--   reprice            \<-\> updateTiers
+-- @
+module Cardano.Ledger.DynamicPricing (
+  module Cardano.Ledger.DynamicPricing.InclusionStrategy,
+  module Cardano.Ledger.DynamicPricing.Pricing,
+  module Cardano.Ledger.DynamicPricing.State,
+) where
+
+import Cardano.Ledger.DynamicPricing.InclusionStrategy
+import Cardano.Ledger.DynamicPricing.Pricing
+import Cardano.Ledger.DynamicPricing.State

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DynamicPricing/InclusionStrategy.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DynamicPricing/InclusionStrategy.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeApplications #-}
+
+-- | The inclusion strategy a transaction purchases.
+--
+-- The /lanes/ (RB vs EB transport) are infrastructure: the consensus-layer
+-- mechanism that delivers each strategy. They are deliberately absent from
+-- this vocabulary.
+--
+-- Spec correspondence (@formal-ledger-specifications\@polina\/dynamic@):
+-- 'Inclusion' \<-\> @TierNo@ (@fastTier@ = 0, @slowTier@ = 1).
+--
+-- Implementation choice (flagged to Polina): the spec keeps @TierNo = ℕ@
+-- open (N tiers); we close the domain to exactly two strategies per the
+-- phase-2 down-select.
+module Cardano.Ledger.DynamicPricing.InclusionStrategy (
+  Inclusion (..),
+) where
+
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Control.DeepSeq (NFData)
+import Data.Word (Word8)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+
+-- | The kind of inclusion a transaction purchases:
+-- guaranteed-and-serialized, or cheaper-but-conditional.
+--
+-- Wire format note: serializes as the spec's @TierNo@ — 'Urgent' = 0
+-- (@fastTier@), 'Optimistic' = 1 (@slowTier@).
+data Inclusion
+  = -- | Urgent, serialized inclusion — included whatever happens to EB
+    -- certification. Infra: direct RB inclusion (in the certified EB
+    -- otherwise).
+    Urgent
+  | -- | Optimistic inclusion — cheaper, carries the certification risk.
+    -- Infra: via EBs.
+    Optimistic
+  deriving (Eq, Ord, Show, Enum, Bounded, Generic)
+
+instance NoThunks Inclusion
+
+instance NFData Inclusion
+
+instance EncCBOR Inclusion where
+  encCBOR =
+    encCBOR @Word8 . \case
+      Urgent -> 0
+      Optimistic -> 1
+
+instance DecCBOR Inclusion where
+  decCBOR =
+    decCBOR @Word8 >>= \case
+      0 -> pure Urgent
+      1 -> pure Optimistic
+      n -> fail $ "Invalid Inclusion (expected 0 or 1): " <> show n

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DynamicPricing/Pricing.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DynamicPricing/Pricing.hs
@@ -1,0 +1,183 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- | Prices and quotes for the dynamic pricing mechanism.
+--
+-- Deck notation (Giorgos): DP1 = the 'urgent' price, DP2 = the 'optimistic'
+-- price.
+--
+-- Spec correspondence (@formal-ledger-specifications\@polina\/dynamic@):
+--
+-- @
+--   InclusionPrice    \<-\> TierCoeff \/ PolicyClause.coeffRange
+--   InclusionPrices   \<-\> DiversityPolicy
+--   Quote (lovelace)  \<-\> the @tierCoeff × minfee@ premise, made first-class
+-- @
+--
+-- Implementation choice (to be validated at the weekly): an 'InclusionPrice'
+-- is a per-byte rate in lovelace (mechanism-design doc: \"the per-byte rate
+-- is the dynamic part\"), matching the sim's fee formula. The spec instead
+-- applies a dimensionless multiplier to the full min fee (incl. script
+-- costs) — known divergence, ABSTRACT_SIM findings §2; only 'quoteFor'
+-- changes if the spec side wins.
+module Cardano.Ledger.DynamicPricing.Pricing (
+  -- * Prices
+  InclusionPrice (..),
+  InclusionPrices (urgent, optimistic),
+  mkInclusionPrices,
+  priceDiscriminationFloor,
+  priceOf,
+
+  -- * Measuring a transaction
+  MinimumTxFee (..),
+  minimumTxFee,
+  TxSizeInBytes (..),
+  txSizeInBytes,
+
+  -- * Quotes
+  Quote (..),
+  quoteFor,
+) where
+
+import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core (EraTx, PParams, Tx, getMinFeeTx, ppTxFeeFixedL, sizeTxF)
+import Control.DeepSeq (NFData)
+import Cardano.Ledger.DynamicPricing.InclusionStrategy (Inclusion (..))
+import Data.Word (Word32)
+import GHC.Generics (Generic)
+import Lens.Micro ((^.))
+import NoThunks.Class (NoThunks)
+
+-- | An inclusion strategy's public price: the rate, in lovelace per byte of
+-- transaction, currently demanded by the protocol. This is the value the
+-- end-of-block controllers move (deck: DP1\/DP2).
+--
+-- Today's protocol equivalent is @minFeeA@ (44 lovelace\/byte on mainnet):
+-- 'Optimistic' starts there, 'Urgent' starts at a multiple of it.
+newtype InclusionPrice = InclusionPrice {unInclusionPrice :: Coin}
+  deriving (Eq, Ord, Show, Generic)
+  deriving newtype (EncCBOR, DecCBOR, NFData, NoThunks)
+
+-- | The protocol-mandated minimum fee of a transaction — what the chain
+-- charges today regardless of inclusion strategy (size, scripts, the lot).
+newtype MinimumTxFee = MinimumTxFee {unMinimumTxFee :: Coin}
+  deriving (Eq, Ord, Show, Generic)
+
+-- | A transaction's size, in bytes — the resource an 'InclusionPrice' is
+-- charged on.
+newtype TxSizeInBytes = TxSizeInBytes {unTxSizeInBytes :: Word32}
+  deriving stock (Eq, Ord, Show, Generic)
+  deriving newtype (Num, EncCBOR, DecCBOR, NFData, NoThunks)
+
+-- | Measure a transaction (via @sizeTxF@).
+txSizeInBytes :: EraTx era => Tx l era -> TxSizeInBytes
+txSizeInBytes tx = TxSizeInBytes (tx ^. sizeTxF)
+
+-- | Compute a transaction's 'MinimumTxFee' (via @getMinFeeTx@).
+--
+-- NOTE(prototype): reference-script size is taken as 0 for now.
+minimumTxFee :: EraTx era => PParams era -> Tx l era -> MinimumTxFee
+minimumTxFee pp tx = MinimumTxFee (getMinFeeTx pp tx 0)
+
+-- | A quote: the fee, in lovelace, the protocol currently demands for one
+-- specific transaction under one specific inclusion strategy. This is what
+-- wallets display and what the transaction's @fee@ field (acting as max
+-- fee) is checked against: a bid is valid while @quote ≤ maxFee@.
+newtype Quote = Quote {unQuote :: Coin}
+  deriving (Eq, Ord, Show, Generic)
+
+-- | Price a transaction under an inclusion strategy:
+-- @quote = max minimumTxFee (txFeeFixed + rate × txSizeInBytes)@.
+--
+-- The quote never undercuts the transaction's 'MinimumTxFee': script-heavy
+-- transactions keep paying their execution costs in full.
+--
+-- = An open design question lives here: WHICH resources does urgency reprice?
+--
+-- A transaction consumes two scarce resources: block bytes (size) and
+-- computation (ExUnits). The sim and the spec disagree on which of the two
+-- the dynamic premium applies to:
+--
+-- [Sim (implemented here)] @quote = txFeeFixed + rate × size@, floored at
+-- the protocol minimum. Only /block bytes/ are repriced by congestion;
+-- computation stays at today's flat ExUnits prices, merely covered by the
+-- floor. Consequence: two same-size urgent transactions pay the same
+-- premium even if one burns 1000× more CPU — under compute-bound congestion
+-- the premium misprices the actual scarcity, and a compute-heavy spammer
+-- buys 'Urgent' relatively cheap.
+--
+-- [Spec (@tierCoeff × minfee ≤ txFee@)] the multiplier scales the /full/
+-- minimum fee — constant part, bytes AND script costs. Consequence: the
+-- premium tracks total resource consumption, but the fixed part scales too
+-- (at 16×, every urgent transaction pays ~2.5₳ of constant fee before its
+-- first byte), and \"price per byte\" stops being the published unit, which
+-- breaks the mechanism-design doc's framing (\"the per-byte rate is the
+-- dynamic part\", @minFeeB@ \"never multiplied\").
+--
+-- Note the tension with the rest of the mechanism: usage accounting and the
+-- spec's @sdChecks@ both track bytes AND ExUnits as congestion signals — if
+-- ExUnits feed the controller but are not repriced, demand can push prices
+-- that the compute-heavy users causing it do not proportionally pay.
+--
+-- To settle with Polina\/Will (ABSTRACT_SIM findings §2). Only this function
+-- changes either way.
+quoteFor ::
+  EraTx era =>
+  PParams era ->
+  Tx l era ->
+  InclusionPrice ->
+  Quote
+quoteFor pp tx (InclusionPrice (Coin rate)) =
+  Quote $ max txMinimum sizePriced
+  where
+    MinimumTxFee txMinimum = minimumTxFee pp tx
+    Coin minFeeB = pp ^. ppTxFeeFixedL
+    TxSizeInBytes size = txSizeInBytes tx
+    sizePriced = Coin $ minFeeB + rate * fromIntegral size
+
+-- | The two dynamic prices: the protocol always publishes exactly one price
+-- per inclusion strategy — no more, no less. Total by construction (no
+-- lookup can fail, no inconsistent key\/value pairing is representable).
+--
+-- The raw constructor is not exported: build with 'mkInclusionPrices',
+-- which guarantees the price-discrimination invariant.
+data InclusionPrices = InclusionPrices
+  { urgent :: !InclusionPrice
+  -- ^ Deck: DP1.
+  , optimistic :: !InclusionPrice
+  -- ^ Deck: DP2.
+  }
+  deriving (Eq, Show, Generic)
+
+instance NoThunks InclusionPrices
+
+instance NFData InclusionPrices
+
+-- | The price-discrimination guarantee (mechanism-design doc): 'Urgent'
+-- always costs at least this many times 'Optimistic', whatever the load
+-- regime — so the premium service keeps meaning something even when both
+-- prices drift.
+--
+-- Sim default (@multiplierFloor@); eventually a protocol parameter.
+priceDiscriminationFloor :: Integer
+priceDiscriminationFloor = 16
+
+-- | Publish the prices, enforcing
+-- @urgent ≥ priceDiscriminationFloor × optimistic@.
+mkInclusionPrices ::
+  -- | 'Urgent' price (deck: DP1).
+  InclusionPrice ->
+  -- | 'Optimistic' price (deck: DP2).
+  InclusionPrice ->
+  Maybe InclusionPrices
+mkInclusionPrices u@(InclusionPrice (Coin p)) o@(InclusionPrice (Coin s))
+  | p >= priceDiscriminationFloor * s = Just (InclusionPrices u o)
+  | otherwise = Nothing
+
+-- | Read the price of one inclusion strategy. Total — the protocol always
+-- quotes every strategy.
+priceOf :: Inclusion -> InclusionPrices -> InclusionPrice
+priceOf Urgent = urgent
+priceOf Optimistic = optimistic

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/DynamicPricing/State.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/DynamicPricing/State.hs
@@ -1,0 +1,274 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE UndecidableSuperClasses #-}
+
+-- | The era-indexed pricing state, following the codebase's established
+-- pattern for era-varying state (@EraGov\/GovState@, @EraCertState\/CertState@,
+-- @EraStake\/InstantStake@): a class bundling all the instances the state
+-- must provide, with an injective associated type family. Pre-dynamic-pricing
+-- eras instantiate the inert 'NoPricing'; the era that activates the
+-- mechanism instantiates 'DynamicPricing'.
+module Cardano.Ledger.DynamicPricing.State (
+  -- * The era family
+  EraPricing (..),
+
+  -- * Pre-dynamic-pricing eras
+  NoPricing (..),
+
+  -- * The live pricing state
+  DynamicPricing (..),
+  initialPricingState,
+  recordTx,
+  currentPrice,
+  addPendingRefund,
+  drainPendingRefunds,
+
+  -- * Per-block usage accounting
+  InclusionUsage (..),
+  emptyInclusionUsage,
+
+  -- * End-of-block repricing (DIVUP)
+  reprice,
+  endOfBlock,
+) where
+
+import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (
+  Decode (..),
+  Encode (..),
+  decode,
+  encode,
+  (!>),
+  (<!),
+ )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.DynamicPricing.InclusionStrategy (Inclusion (..))
+import Cardano.Ledger.DynamicPricing.Pricing (
+  InclusionPrice (..),
+  InclusionPrices,
+  TxSizeInBytes (..),
+  mkInclusionPrices,
+  optimistic,
+  priceOf,
+  urgent,
+ )
+import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
+import Control.DeepSeq (NFData)
+import Data.Aeson (ToJSON (..), object, (.=))
+import Data.Default (Default (..))
+import Data.Kind (Type)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Typeable (Typeable)
+import Data.Word (Word8)
+import Cardano.Ledger.Keys (KeyRole (Staking))
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+
+-- | Every era carries a pricing state; its shape is the era's choice.
+class
+  ( Eq (PricingState era)
+  , Show (PricingState era)
+  , NFData (PricingState era)
+  , NoThunks (PricingState era)
+  , EncCBOR (PricingState era)
+  , DecCBOR (PricingState era)
+  , Default (PricingState era)
+  , ToJSON (PricingState era)
+  ) =>
+  EraPricing era
+  where
+  type PricingState era = (r :: Type) | r -> era
+
+  -- | The pricing state an era starts with.
+  emptyPricing :: PricingState era
+  emptyPricing = def
+
+-- | The inert pricing state of the eras that predate dynamic pricing.
+data NoPricing era = NoPricing
+  deriving (Eq, Ord, Show, Generic)
+
+instance NoThunks (NoPricing era)
+
+instance NFData (NoPricing era)
+
+instance Default (NoPricing era) where
+  def = NoPricing
+
+instance ToJSON (NoPricing era) where
+  toJSON NoPricing = toJSON ()
+
+instance EncCBOR (NoPricing era) where
+  encCBOR NoPricing = encCBOR (0 :: Word8)
+
+instance Typeable era => DecCBOR (NoPricing era) where
+  decCBOR =
+    decCBOR >>= \case
+      (0 :: Word8) -> pure NoPricing
+      n -> fail $ "Invalid NoPricing encoding: " <> show n
+
+-- | The live pricing state (spec: @SDPolicy@): the published prices plus the
+-- usage counters of the block being processed.
+data DynamicPricing era = DynamicPricing
+  { publishedPrices :: !InclusionPrices
+  -- ^ The price of each inclusion strategy (deck: DP1\/DP2).
+  , blockUsage :: !(Map Inclusion InclusionUsage)
+  -- ^ Usage of the block currently being processed (spec: the
+  -- @totalSize\/totalFees\/totalExUnits@ maps).
+  , pendingRefunds :: !(Map (Credential Staking) Coin)
+  -- ^ Refunds owed to bidders (the unused headroom of their bids), flushed
+  -- into account balances by the LEDGER rule after every transaction
+  -- (spec: @feeRewards@).
+  }
+  deriving (Eq, Show, Generic)
+
+instance NoThunks (DynamicPricing era)
+
+instance NFData (DynamicPricing era)
+
+instance Default (DynamicPricing era) where
+  def = initialPricingState
+
+instance ToJSON (DynamicPricing era) where
+  toJSON dp =
+    object
+      [ "urgent" .= unInclusionPrice (urgent (publishedPrices dp))
+      , "optimistic" .= unInclusionPrice (optimistic (publishedPrices dp))
+      , "blockUsage" .= Map.toList (Map.mapKeys show (blockUsage dp))
+      , "pendingRefunds" .= pendingRefunds dp
+      ]
+
+instance EncCBOR (DynamicPricing era) where
+  encCBOR (DynamicPricing prices usage refunds) =
+    encode $
+      Rec mkDynamicPricing
+        !> To (urgent prices)
+        !> To (optimistic prices)
+        !> To usage
+        !> To refunds
+
+instance Typeable era => DecCBOR (DynamicPricing era) where
+  decCBOR = decode $ RecD mkDynamicPricing <! From <! From <! From <! From
+
+mkDynamicPricing ::
+  InclusionPrice ->
+  InclusionPrice ->
+  Map Inclusion InclusionUsage ->
+  Map (Credential Staking) Coin ->
+  DynamicPricing era
+mkDynamicPricing u o = DynamicPricing (unsafePrices u o)
+
+-- Decoding trusts the encoder: the floor invariant held when the state was
+-- produced. TODO(prototype): fail the decoder instead of clamping.
+unsafePrices :: InclusionPrice -> InclusionPrice -> InclusionPrices
+unsafePrices u o =
+  case mkInclusionPrices u o of
+    Just prices -> prices
+    Nothing -> error "DynamicPricing: decoded prices violate the price-discrimination floor"
+
+-- | Resources consumed within the current block by the transactions of one
+-- inclusion strategy. Reset at every block boundary by 'endOfBlock'.
+data InclusionUsage = InclusionUsage
+  { bytesUsed :: !TxSizeInBytes
+  , feesCollected :: !Coin
+  , exUnitsUsed :: !ExUnits
+  }
+  deriving (Eq, Show, Generic)
+
+instance NoThunks InclusionUsage
+
+instance NFData InclusionUsage
+
+instance ToJSON InclusionUsage where
+  toJSON (InclusionUsage b f e) =
+    object ["bytes" .= unTxSizeInBytes b, "fees" .= f, "exUnits" .= e]
+
+instance EncCBOR InclusionUsage where
+  encCBOR (InclusionUsage b f e) =
+    encode $ Rec InclusionUsage !> To b !> To f !> To e
+
+instance DecCBOR InclusionUsage where
+  decCBOR = decode $ RecD InclusionUsage <! From <! From <! From
+
+emptyInclusionUsage :: InclusionUsage
+emptyInclusionUsage = InclusionUsage 0 (Coin 0) mempty
+
+instance Semigroup InclusionUsage where
+  InclusionUsage b1 f1 e1 <> InclusionUsage b2 f2 e2 =
+    InclusionUsage (b1 + b2) (f1 <> f2) (e1 <> e2)
+
+instance Monoid InclusionUsage where
+  mempty = emptyInclusionUsage
+
+-- | Starting state. 'Optimistic' opens at today's @minFeeA@ rate
+-- (44 lovelace\/byte); 'Urgent' opens at 16× that (the sim's
+-- @initialCoefficient@ for the priority controller).
+initialPricingState :: DynamicPricing era
+initialPricingState =
+  DynamicPricing
+    { publishedPrices =
+        unsafePrices (InclusionPrice (Coin (16 * 44))) (InclusionPrice (Coin 44))
+    , blockUsage = Map.empty
+    , pendingRefunds = Map.empty
+    }
+
+-- | Record a refund owed to a bidder (U3 of the fee split): the unused
+-- headroom between the bid and the charged quote.
+addPendingRefund :: Credential Staking -> Coin -> DynamicPricing era -> DynamicPricing era
+addPendingRefund cred amount ps =
+  ps {pendingRefunds = Map.insertWith (<>) cred amount (pendingRefunds ps)}
+
+-- | Hand over all pending refunds (the LEDGER rule credits them to account
+-- balances after every transaction; spec: the @feeRewards@ flush).
+drainPendingRefunds :: DynamicPricing era -> (Map (Credential Staking) Coin, DynamicPricing era)
+drainPendingRefunds ps = (pendingRefunds ps, ps {pendingRefunds = Map.empty})
+
+-- | Account for one transaction delivered under an inclusion strategy
+-- (spec: @processTxTiers@).
+recordTx :: Inclusion -> TxSizeInBytes -> Coin -> ExUnits -> DynamicPricing era -> DynamicPricing era
+recordTx strategy size fee exUnits ps =
+  ps
+    { blockUsage =
+        Map.insertWith (<>) strategy (InclusionUsage size fee exUnits) (blockUsage ps)
+    }
+
+-- | The current public price of an inclusion strategy. Total — the protocol
+-- always has a price for every strategy.
+currentPrice :: Inclusion -> DynamicPricing era -> InclusionPrice
+currentPrice strategy = priceOf strategy . publishedPrices
+
+-- | End-of-block repricing (spec: @updateTiers@, still the identity there).
+--
+-- TODO(prototype): per-strategy EIP-1559 controller from the abstract-sim
+-- (@src\/Pricing.hs@):
+--
+-- @
+--   newPrice   = oldPrice × max 0 (1 + adjustment)
+--   adjustment = ((utilisation − target) ÷ target) ÷ maxChangeDenominator
+-- @
+--
+-- with target = 0.5, maxChangeDenominator = 8 (so at most ±12.5% per block,
+-- rounded deterministically on lovelace), republished through
+-- 'mkInclusionPrices' so the price-discrimination floor holds. Open question
+-- (Giorgos' deck, slide 12): the utilisation signal for 'Optimistic'.
+reprice :: DynamicPricing era -> InclusionPrices
+reprice = publishedPrices
+
+-- | Block boundary (spec: the @DIVUP@ rule): apply 'reprice', reset usage.
+-- The spec's @sdChecks@ premise (the optimistic usage fits RB limits) lives
+-- with the BBODY rule, not here.
+endOfBlock :: DynamicPricing era -> DynamicPricing era
+endOfBlock ps =
+  ps
+    { publishedPrices = reprice ps
+    , blockUsage = Map.empty
+    }

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Governance.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Governance.hs
@@ -31,6 +31,7 @@ import Cardano.Ledger.Binary (
 import Cardano.Ledger.Binary.Coders (Decode (..), Encode (..), decode, encode, (!>), (<!))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential)
+import Cardano.Ledger.DynamicPricing.State (EraPricing)
 import Cardano.Ledger.State.CertState (Obligations)
 import Control.DeepSeq (NFData (..))
 import Data.Aeson (ToJSON (..))
@@ -43,6 +44,7 @@ import NoThunks.Class (AllowThunk (..), NoThunks (..))
 
 class
   ( EraPParams era
+  , EraPricing era
   , Eq (GovState era)
   , Show (GovState era)
   , NoThunks (GovState era)


### PR DESCRIPTION
> **Draft — prototype for discussion at the weekly, not for merge.**
> Ledger-level implementation of the DP/DP ("two dynamic lanes") dynamic-pricing
> mechanism on Dijkstra, Praos-only (every block treated as an RB; the EB/RB
> distinction arrives with the consensus phase).

## Scope

The five ledger rules from the spec
(`Tiered Pricing/06_prototype/DYNAMIC_PRICING_LEDGER_RULES.md`), validated against
`formal-ledger-specifications@polina/dynamic` (b4c535b6). The tree builds with
`-Werror`. No tests yet, and `reprice = id` is stubbed (see Open questions).

## Commits

| Commit | Rule |
|---|---|
| `f36037c` | **State extension** — `EraPricing` era-family + `utxosPricing` on `UTxOState` (`NoPricing` Shelley→Conway, `DynamicPricing` Dijkstra), following the `EraGov`/`EraCertState` pattern. New domain in `cardano-ledger-core:Cardano.Ledger.DynamicPricing.*`. |
| `0ce66bd` | **TxBody** — `dtbInclusion` (CBOR key 27, default `Optimistic` omitted), `dtbFeeRefundAccount` (key 28), `dtbBidFee` (fee field read as a price cap). |
| `3f92b11` | **UTXO rule** — U1 `BidBelowQuote` (replaces the plain min-fee premise with `quoteFor`), U2 usage accounting, and the fee split (base → fee pot, premium → donation, refund → pending). |
| `e3ebdb8` | **LEDGER rule** — `flushPendingRefunds` credits registered accounts after each tx. |
| `27d8418` | **BBODY rule** — `divupTransition`: B1 `sdChecks` (optimistic bytes+ExUnits fit RB limits → `OptimisticOverflowsBlock{,ExUnits}`), B2 `endOfBlock` (reprice + reset). |

## Divergences from the Agda spec (for sign-off)

- **No declared quote** — a bid is fully described by `dtbInclusion` + `dtbBidFee` (max-fee + refund); the spec's declared `tierCoeff` / `checkPolicyState` strict equality is not implemented.
- **No `actualTier`/promotion** — charging and usage are by the *declared* strategy; placement (RB vs EB) is a consensus concern, not a ledger one.
- **Per-byte price** — `InclusionPrice` is lovelace/byte (`quote = max(minFee, txFeeFixed + rate × size)`) rather than a multiplier on the full min fee.
- **Fee pot keeps `base`** — the protocol minimum stays in the fee pot, deviating from the spec's fee-pot starvation.

## Open questions

1. **`reprice` formula** — currently identity, like the spec's `updateTiers`. The real EIP-1559 controller and the Optimistic-side utilisation signal depend on Will's experiment sweep. *Blocks a functionally-dynamic prototype.*
2. **Which resources urgency reprices** — bytes only (sim) vs full min fee incl. scripts (spec). Only `quoteFor` changes.
3. **Fee pot starvation** — long-term SPO incentive story under the split.
4. **RB cert/txs exclusivity** — if real, it's a BBODY premise to add.

## Not done / next

- Tests (CBOR round-trip for the new TxBody fields & `DynamicPricing` state; `BidBelowQuote` / `OptimisticOverflowsBlock` failure cases).
- The real `reprice` controller (pending Q1).
- The EB/consensus path (`blockType`, placement, reservation variant) — out of ledger scope.