### PR TITLE
(POC) Add TxInfo translation Imp tests for Plutus scripts

### DIFF
--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
@@ -19,6 +21,7 @@ import Cardano.Ledger.Alonzo.Plutus.Evaluate (
   TransactionScriptFailure (RedeemerPointsToUnknownScriptHash),
   evalTxExUnits,
  )
+import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo (transTxOut)
 import Cardano.Ledger.Alonzo.Rules (
   AlonzoUtxosPredFailure (..),
   TagMismatchDescription (..),
@@ -27,30 +30,45 @@ import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..), eraLanguages)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
 import Cardano.Ledger.BaseTypes (
   Globals (..),
+  Inject (..),
   ProtVer (..),
   SlotNo (..),
   StrictMaybe (..),
+  TxIx (..),
   natVersion,
  )
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Mary.Value (MaryValue (..), MultiAsset (..), PolicyID (..), filterMultiAsset)
 import Cardano.Ledger.Plutus (
   Data (..),
   ExUnits (..),
+  PlutusLanguage,
   SLanguage (..),
+  hashData,
   hashPlutusScript,
   withSLanguage,
  )
+import Cardano.Ledger.Plutus.TxInfo (transSafeHash, transTxIn)
 import Cardano.Ledger.Shelley.LedgerState (curPParamsEpochStateL, nesEsL)
+import Cardano.Ledger.Shelley.Scripts (ShelleyEraScript (..))
+import Cardano.Ledger.Tools (ensureMinCoinTxOut)
+import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Cardano.Slotting.Time (SystemStart (SystemStart))
 import Control.Monad.Reader (asks)
 import Data.Either (isLeft)
+import qualified Data.Foldable as F
 import qualified Data.Map.Merge.Strict as Map
 import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
+import Data.Sequence.Strict (fromList)
 import qualified Data.Set as Set
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 import Lens.Micro (set, to, (%~), (&), (.~), (<>~), (^.), _2)
 import Lens.Micro.Mtl (use)
 import qualified PlutusLedgerApi.Common as P
 import qualified PlutusLedgerApi.V1 as PV1
+import qualified PlutusLedgerApi.V2 as PV2
+import qualified PlutusLedgerApi.V3 as PV3
 import Test.Cardano.Ledger.Alonzo.ImpTest
 import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (
@@ -60,6 +78,7 @@ import Test.Cardano.Ledger.Plutus.Examples (
   inputsOutputsAreNotEmptyWithDatum,
   purposeIsWellformedWithDatum,
   redeemerSameAsDatum,
+  txInfoTranslationSpecScript,
  )
 
 spec :: forall era. AlonzoEraImp era => SpecWith (ImpInit (LedgerSpec era))
@@ -215,3 +234,179 @@ spec = describe "UTXOS" $ do
         it "Scripts with bootstrap addresses pass" $
           when (eraProtVerLow @era <= eraProtVerHigh @AlonzoEra) $ do
             mkTxWithPlutusAndBootstrapAddress slang >>= submitTx_
+
+        txInfoTranslationSpec slang
+
+-- | Tests the full Plutus evaluation pipeline E2E (translation -> script
+-- execution -> ledger acceptance) by passing expected values via the redeemer
+-- and verifying them on-chain.
+--
+-- The script uses a 'Constr' redeemer @(tag :: Integer, payload :: [BuiltinData])@
+-- where the tag selects which TxInfo field to check.
+txInfoTranslationSpec ::
+  forall era l.
+  ( AlonzoEraImp era
+  , PlutusLanguage l
+  ) =>
+  SLanguage l ->
+  SpecWith (ImpInit (LedgerSpec era))
+txInfoTranslationSpec slang =
+  describe "TxInfo translation" $ do
+    -- FIXME How to run this as property test?
+    it "txInfoInputs" $ alonzoBasedTxInfoInputsTranslationSpec slang
+    it "txInfoOutputs" $ alonzoBasedTxInfoOutputsTranslationSpec slang
+
+-- | Tag 0: verify txInfoInputs outRefs match expected refs
+alonzoBasedTxInfoInputsTranslationSpec ::
+  forall era l.
+  (AlonzoEraImp era, PlutusLanguage l) =>
+  SLanguage l ->
+  ImpTestM era ()
+alonzoBasedTxInfoInputsTranslationSpec slang =
+  alonzoBasedTxInfoTranslationSpec slang id $ \tx -> do
+    let inputs = Set.toList $ tx ^. bodyTxL . inputsTxBodyL
+        txOutRefsData = case slang of
+          SPlutusV3 -> PV1.toData $ fmap transV3TxIn inputs
+          _ -> PV1.toData $ fmap transTxIn inputs
+    pure $ PV1.Constr 0 [txOutRefsData]
+  where
+    -- Translate a TxIn to PV3.TxOutRef. PV3 uses a different TxId encoding
+    -- (newtype-derived, no Constr wrapper) compared to V1/V2.
+    transV3TxIn :: TxIn -> PV3.TxOutRef
+    transV3TxIn (TxIn txid (TxIx txIx)) =
+      PV3.TxOutRef
+        (PV3.TxId (transSafeHash (unTxId txid)))
+        (toInteger txIx)
+
+-- | Tag 1: verify txInfoOutputs match expected outputs
+alonzoBasedTxInfoOutputsTranslationSpec ::
+  forall era l.
+  (AlonzoEraImp era, PlutusLanguage l) =>
+  SLanguage l ->
+  ImpTestM era ()
+alonzoBasedTxInfoOutputsTranslationSpec slang = do
+  -- Generate a minting policy id in order to create `TxOut`s that have multiple
+  -- assets in the value.
+  mintPolicyId <- genMintPolicyId
+  txOuts <- resize 50 $ listOf1 (genTxOut mintPolicyId)
+
+  -- Compute the number of 'mintPolicyId' tokens that are going to be minted in
+  -- the tx, so that the tx balances.
+  let totalMint = getTotalMintedValue mintPolicyId txOuts
+      modifyTx tx =
+        tx
+          & bodyTxL . outputsTxBodyL .~ fromList txOuts
+          & bodyTxL . mintTxBodyL .~ totalMint
+
+  alonzoBasedTxInfoTranslationSpec slang modifyTx $ \tx -> do
+    let outputs = F.toList $ tx ^. bodyTxL . outputsTxBodyL
+        v1Outputs = mapMaybe Alonzo.transTxOut outputs
+        outputsData = case slang of
+          SPlutusV1 -> PV1.toData v1Outputs
+          -- For future Plutus versions that are included in Alonzo based
+          -- transactions, we need to translate 'PV1.TxOut' to
+          -- 'PV2.TxOut'. This is safe, because 'PV2.TxOut' extends `PV1.TxOut'
+          -- by simply adding inline datums and reference scripts.
+          _ -> PV1.toData $ fmap v1TxOutToV2TxOut v1Outputs
+    pure $ PV1.Constr 1 [outputsData]
+  where
+    getTotalMintedValue mintPolicyId =
+      F.foldMap
+        ( filterMultiAsset (\p _ _ -> p == mintPolicyId)
+            . (\case MaryValue _ ma -> ma)
+            . (^. valueTxOutL)
+        )
+    genTxOut mintPolicyId = do
+      addr <- genAddr
+      amount <- choose (2_000_000, 100_000_000)
+      ma <- oneof [pure mempty, genPositiveMultiAsset mintPolicyId]
+      datumM <- arbitrary @(StrictMaybe (Data era))
+      pp <- getsNES $ nesEsL . curPParamsEpochStateL
+      pure $
+        ensureMinCoinTxOut pp $
+          mkBasicTxOut addr (inject (MaryValue (Coin amount) ma))
+            & dataHashTxOutL .~ fmap hashData datumM
+    genAddr :: ImpTestM era Addr
+    genAddr
+      -- We can only use Bootstrap addresses in AlonzoEra.
+      | eraProtVerLow @era < natVersion @7 =
+          oneof
+            [ freshKeyAddr_
+            , AddrBootstrap <$> freshBootstapAddress
+            ]
+      | otherwise = freshKeyAddr_
+    genPositiveMultiAsset :: PolicyID -> ImpTestM era MultiAsset
+    genPositiveMultiAsset policyId = do
+      assetName <- arbitrary
+      amount <- choose (1, 1000)
+      pure $ MultiAsset $ Map.singleton policyId $ Map.singleton assetName amount
+    genMintPolicyId :: ImpTestM era PolicyID
+    genMintPolicyId = do
+      keyHash <- freshKeyHash
+      PolicyID <$> impAddNativeScript (mkRequireSignature keyHash)
+    -- Convert a V1 TxOut to a V2 TxOut. Valid for outputs without inline datums
+    -- or reference scripts.
+    v1TxOutToV2TxOut :: PV1.TxOut -> PV2.TxOut
+    v1TxOutToV2TxOut (PV1.TxOut addr val mDH) =
+      PV2.TxOut addr val (maybe PV2.NoOutputDatum PV2.OutputDatumHash mDH) Nothing
+
+-- | Common harness for TxInfo translation tests. Takes a tx modifier and a
+-- function that computes the tagged redeemer payload from the post-fixup tx.
+alonzoBasedTxInfoTranslationSpec ::
+  forall era l.
+  (AlonzoEraImp era, PlutusLanguage l) =>
+  SLanguage l ->
+  (Tx TopTx era -> Tx TopTx era) ->
+  (Tx TopTx era -> ImpTestM era PV1.Data) ->
+  ImpTestM era ()
+alonzoBasedTxInfoTranslationSpec slang modifyTx mkRedeemerData = do
+  txIn <- produceScript . hashPlutusScript $ txInfoTranslationSpecScript slang
+  withCustomFixup (\_ -> customFixup txIn) $
+    submitTxAnn_ "Submitting consuming transaction" $
+      modifyTx $
+        mkBasicTx mkBasicTxBody
+          & bodyTxL . inputsTxBodyL .~ Set.singleton txIn
+  where
+    -- Based on alonzoFixupTx, but with overrideRedeemer inserted at two points.
+    -- The redeemer must be set before alonzoFixupFees so the fee calculation
+    -- accounts for the actual (potentially large) redeemer size. It must be set
+    -- again after fixupRedeemers because alonzoFixupFees adds a change output,
+    -- which changes the outputs the redeemer encodes.
+    customFixup txIn =
+      addNativeScriptTxWits
+        >=> fixupAuxDataHash
+        >=> addCollateralInput
+        >=> addRootTxIn
+        >=> fixupScriptWits
+        >=> fixupOutputDatums
+        >=> fixupDatums
+        >=> fixupRedeemerIndices
+        >=> fixupTxOuts
+        -- Set redeemer before fee calculation in order to get more accurate fee
+        -- value.
+        >=> insertRedeemer txIn
+        >=> alonzoFixupFees
+        >=> fixupRedeemers
+        -- Update redeemer after change output is added in the transaction
+        -- outputs. Necessary for the TxInfo translation tests.
+        >=> updateRedeemer txIn
+        >=> fixupPPHash
+        >=> updateAddrTxWits
+    insertRedeemer txIn tx = do
+      redeemerData <- Data <$> mkRedeemerData tx
+      case redeemerPointer (tx ^. bodyTxL) (SpendingPurpose $ AsItem txIn) of
+        SNothing -> assertFailure "Could not find spending purpose for txIn"
+        SJust purpose -> do
+          -- Unfortunately, `fixupRedeemer` doesn't set the maxExUnits for
+          -- redeemers already part of the tx redeemers, so we need to do it
+          -- here.
+          maxExUnits <- getsNES $ nesEsL . curPParamsEpochStateL . ppMaxTxExUnitsL
+          let update = Map.insertWith (\(d, _) (_, eu) -> (d, eu)) purpose (redeemerData, maxExUnits)
+          pure $ tx & witsTxL . rdmrsTxWitsL . unRedeemersL %~ update
+    updateRedeemer txIn tx = do
+      redeemerData <- Data <$> mkRedeemerData tx
+      case redeemerPointer (tx ^. bodyTxL) (SpendingPurpose $ AsItem txIn) of
+        SNothing -> assertFailure "Could not find spending purpose for txIn"
+        SJust purpose ->
+          pure $
+            tx & witsTxL . rdmrsTxWitsL . unRedeemersL %~ Map.adjust (\(_, eu) -> (redeemerData, eu)) purpose

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -249,8 +249,15 @@ txWithMaxRedeemers tx = do
   pp <- getsNES $ nesEsL . curPParamsEpochStateL
   let
     maxExUnit = pp ^. ppMaxTxExUnitsL
+    existingRedeemers = tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL
     mkNewMaxRedeemers (prpIdx, _, ScriptTestContext _ (PlutusArgs dat _)) =
-      (hoistPlutusPurpose @era toAsIx prpIdx, (Data dat, maxExUnit))
+      let ptr = hoistPlutusPurpose @era toAsIx prpIdx
+          -- If the redeemer is already provided in the tx, use it. If not, use
+          -- the default one defined in 'impGetPlutusContexts'. This is
+          -- necessary when the existing redeemer is much larger than the
+          -- default one or else the computed fee value will be too low.
+          rdmrData = maybe (Data dat) fst $ Map.lookup ptr existingRedeemers
+       in (ptr, (rdmrData, maxExUnit))
     newMaxRedeemers = Map.fromList (mkNewMaxRedeemers <$> contexts)
   pure $ tx & witsTxL . rdmrsTxWitsL . unRedeemersL .~ newMaxRedeemers
 
@@ -409,6 +416,8 @@ plutusTestScripts lang =
     , mkScriptTestEntry (datumIsWellformed lang) $ PlutusArgs (P.I 221) (Just $ P.I 5)
     , mkScriptTestEntry (inputsOutputsAreNotEmptyNoDatum lang) $ PlutusArgs (P.I 122) Nothing
     , mkScriptTestEntry (inputsOutputsAreNotEmptyWithDatum lang) $ PlutusArgs (P.I 222) (Just $ P.I 5)
+    , mkScriptTestEntry (txInfoTranslationSpecScript lang) $
+        PlutusArgs (P.Constr 0 [P.List []]) (Just $ P.I 5)
     , mkScriptTestEntry guardrailScript $ PlutusArgs (P.I 0) Nothing
     ]
       ++ [ mkScriptTestEntry (inputsOverlapsWithRefInputs lang) $ PlutusArgs (P.I 0) Nothing

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus/Examples.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Plutus/Examples.hs
@@ -19,6 +19,7 @@ module Test.Cardano.Ledger.Plutus.Examples (
   inputsOutputsAreNotEmptyNoDatum,
   inputsOutputsAreNotEmptyWithDatum,
   inputsOverlapsWithRefInputs,
+  txInfoTranslationSpecScript,
 ) where
 
 import Cardano.Ledger.Plutus.Language (Plutus (..), PlutusBinary (..), SLanguage (..))
@@ -1239,4 +1240,137 @@ inputsOverlapsWithRefInputs =
       , "c80d8c068008c070004dd5000980c000980b800980b000980a800980a000980980098090009808800980800098"
       , "07800980700098068009806000980580098041baa300730083754008444b30010018801c4cc008c01c004c0280"
       , "050054526899319801a4810350543500800200c1"
+      ]
+
+-- | Script that validates TxInfo translation by comparing expected values passed via the redeemer
+-- Redeemer is Constr tag [payload]: tag 0 checks txInfoInputs outRefs, tag 1 checks txInfoOutputs
+txInfoTranslationSpecScript :: SLanguage l -> Plutus l
+txInfoTranslationSpecScript =
+  decodeHexPlutus . mconcat . \case
+    -- ScriptHash "1d1c632ec72a8dff173b93e8c6de29ce8e3d49a311fdd289d5358f0a"
+    -- Preprocessed PlutusV1 Script:
+    -- @@@
+    -- txInfoTranslationSpecScript_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
+    --                                  PlutusTx.Builtins.Internal.BuiltinData ->
+    --                                  PlutusTx.Builtins.Internal.BuiltinData -> ()
+    -- txInfoTranslationSpecScript_0 datum_1 redeemer_2 context_3 = case PlutusTx.IsData.Class.unsafeFromBuiltinData datum_1 of
+    --                                                              {PlutusLedgerApi.V1.Scripts.Datum _ -> case PlutusTx.IsData.Class.unsafeFromBuiltinData redeemer_2 of
+    --                                                                                                     {PlutusLedgerApi.V1.Scripts.Redeemer redData_4 -> case PlutusTx.IsData.Class.unsafeFromBuiltinData context_3 of
+    --                                                                                                                                                       {PlutusLedgerApi.V1.Data.Contexts.ScriptContext txInfo_5
+    --                                                                                                                                                                                                       (PlutusLedgerApi.V1.Data.Contexts.Spending _) -> let redConstr_6 = PlutusTx.Builtins.unsafeDataAsConstr redData_4
+    --                                                                                                                                                                                                                                                         in case redConstr_6 of
+    --                                                                                                                                                                                                                                                            {(0,
+    --                                                                                                                                                                                                                                                              payload_7 GHC.Types.: _) -> if PlutusTx.IsData.Class.unsafeFromBuiltinData payload_7 PlutusTx.Eq.Class.== PlutusTx.Data.List.map PlutusLedgerApi.V1.Data.Contexts.txInInfoOutRef (PlutusLedgerApi.V1.Data.Contexts.txInfoInputs txInfo_5)
+    --                                                                                                                                                                                                                                                                                           then GHC.Tuple.Prim.()
+    --                                                                                                                                                                                                                                                                                           else PlutusTx.Builtins.error GHC.Tuple.Prim.();
+    --                                                                                                                                                                                                                                                             (1,
+    --                                                                                                                                                                                                                                                              payload_8 GHC.Types.: _) -> if PlutusTx.IsData.Class.unsafeFromBuiltinData payload_8 PlutusTx.Eq.Class.== PlutusLedgerApi.V1.Data.Contexts.txInfoOutputs txInfo_5
+    --                                                                                                                                                                                                                                                                                           then GHC.Tuple.Prim.()
+    --                                                                                                                                                                                                                                                                                           else PlutusTx.Builtins.error GHC.Tuple.Prim.();
+    --                                                                                                                                                                                                                                                             _ -> PlutusTx.Builtins.error GHC.Tuple.Prim.()};
+    --                                                                                                                                                        _ -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
+    -- @@@
+    SPlutusV1 ->
+      [ "5901830100003333333222222232323232322223232533300e3370e900118089baa300c300f002132323232533"
+      , "30123370e90000018a99a80109800a4c442a66602866ebcdd39bac002374e601e66601c00e44444444440144c2"
+      , "01a2c26002931299980919b874800800c54cd4008588854ccc050cdd79ba737580046e9cccc03801c888888888"
+      , "80249840345858d4020c03c008c048004dd50020b180580098059baa0013233001001120012213300612200222"
+      , "321223300100500335330040041200100112001222323232323232323232333333333300b375860200126eb0c0"
+      , "40020dd598080039bab30100063758602000a6eb0c040010c04000cdd618080011bac301000132353330133370"
+      , "e9000180b000891bae3012001163012001375460206026002602400260220026020002601e002601c002601a00"
+      , "26018002601600260106ea800cc8c00400488ccc00d2f5c04466016600e60106ea8008cc0100100040048894cc"
+      , "c010004400c4cc008c014004c02000555ceaba05744ae6955cf2ba15573f"
+      ]
+    -- ScriptHash "343b8ed4662e6a098f20ebfc71a0f62a6e6717373d8805444d527669"
+    -- Preprocessed PlutusV2 Script:
+    -- @@@
+    -- txInfoTranslationSpecScript_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
+    --                                  PlutusTx.Builtins.Internal.BuiltinData ->
+    --                                  PlutusTx.Builtins.Internal.BuiltinData -> ()
+    -- txInfoTranslationSpecScript_0 datum_1 redeemer_2 context_3 = case PlutusTx.IsData.Class.unsafeFromBuiltinData datum_1 of
+    --                                                              {PlutusLedgerApi.V1.Scripts.Datum _ -> case PlutusTx.IsData.Class.unsafeFromBuiltinData redeemer_2 of
+    --                                                                                                     {PlutusLedgerApi.V1.Scripts.Redeemer redData_4 -> case PlutusTx.IsData.Class.unsafeFromBuiltinData context_3 of
+    --                                                                                                                                                       {PlutusLedgerApi.V2.Data.Contexts.ScriptContext txInfo_5
+    --                                                                                                                                                                                                       (PlutusLedgerApi.V1.Data.Contexts.Spending _) -> let redConstr_6 = PlutusTx.Builtins.unsafeDataAsConstr redData_4
+    --                                                                                                                                                                                                                                                         in case redConstr_6 of
+    --                                                                                                                                                                                                                                                            {(0,
+    --                                                                                                                                                                                                                                                              payload_7 GHC.Types.: _) -> if PlutusTx.IsData.Class.unsafeFromBuiltinData payload_7 PlutusTx.Eq.Class.== PlutusTx.Data.List.map PlutusLedgerApi.V2.Data.Contexts.txInInfoOutRef (PlutusLedgerApi.V2.Data.Contexts.txInfoInputs txInfo_5)
+    --                                                                                                                                                                                                                                                                                           then GHC.Tuple.Prim.()
+    --                                                                                                                                                                                                                                                                                           else PlutusTx.Builtins.error GHC.Tuple.Prim.();
+    --                                                                                                                                                                                                                                                             (1,
+    --                                                                                                                                                                                                                                                              payload_8 GHC.Types.: _) -> if PlutusTx.IsData.Class.unsafeFromBuiltinData payload_8 PlutusTx.Eq.Class.== PlutusLedgerApi.V2.Data.Contexts.txInfoOutputs txInfo_5
+    --                                                                                                                                                                                                                                                                                           then GHC.Tuple.Prim.()
+    --                                                                                                                                                                                                                                                                                           else PlutusTx.Builtins.error GHC.Tuple.Prim.();
+    --                                                                                                                                                                                                                                                             _ -> PlutusTx.Builtins.error GHC.Tuple.Prim.()};
+    --                                                                                                                                                        _ -> PlutusTx.Builtins.error GHC.Tuple.Prim.()}}}
+    -- @@@
+    SPlutusV2 ->
+      [ "59019a0100003333333222222232323232322223232533300e3370e900118089baa300c300f002132323232533"
+      , "30123370e90000018a99a80109800a4c442a66602866ebcdd39bac002374e601e66601c00e4444444444440184"
+      , "c201a2c26002931299980919b874800800c54cd4008588854ccc050cdd79ba737580046e9cccc03801c8888888"
+      , "888880289840345858d4020c03c008c048004dd50020b180580098059baa001323300100112001221330061220"
+      , "0222321223300100500335330040041200100112001222323232323232323232323233333333333300d3758602"
+      , "40166eb0c048028dd618090049bab30120083756602400e6eb0c048018dd5980900298090021bac30120033756"
+      , "60240046eacc048004c8d4ccc054cdc3a40006030002246eb8c05000458c050004dd51809180a800980a000980"
+      , "98009809000980880098080009807800980700098068009806000980580098041baa003323001001223330034b"
+      , "d701119805980398041baa0023300400400100122253330040011003133002300500130080015573aae815d12b"
+      , "9a5573cae8555cf9"
+      ]
+    -- ScriptHash "a7bb5d72ffc3260d7a71f7f3963fe897388126ac4c90d1c853f185d0"
+    -- Preprocessed PlutusV3 Script:
+    -- @@@
+    -- txInfoTranslationSpecScript_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
+    --                                  PlutusTx.Builtins.Internal.BuiltinUnit
+    -- txInfoTranslationSpecScript_0 arg_1 = PlutusTx.Prelude.check GHC.Base.$ (case PlutusTx.IsData.Class.unsafeFromBuiltinData arg_1 of
+    --                                                                          {PlutusLedgerApi.V3.Data.Contexts.ScriptContext (PlutusLedgerApi.V3.Data.Contexts.TxInfo {PlutusLedgerApi.V3.Data.Contexts.txInfoInputs = inputs_2,
+    --                                                                                                                                                                    PlutusLedgerApi.V3.Data.Contexts.txInfoOutputs = outputs_3})
+    --                                                                                                                          (PlutusLedgerApi.V1.Scripts.Redeemer redData_4)
+    --                                                                                                                          (PlutusLedgerApi.V3.Data.Contexts.SpendingScript _
+    --                                                                                                                                                                           (GHC.Maybe.Just _)) -> let redConstr_5 = PlutusTx.Builtins.unsafeDataAsConstr redData_4
+    --                                                                                                                                                                                                   in case redConstr_5 of
+    --                                                                                                                                                                                                      {(0,
+    --                                                                                                                                                                                                        payload_6 GHC.Types.: _) -> PlutusTx.IsData.Class.unsafeFromBuiltinData payload_6 PlutusTx.Eq.Class.== PlutusTx.Data.List.map PlutusLedgerApi.V3.Data.Contexts.txInInfoOutRef inputs_2;
+    --                                                                                                                                                                                                       (1,
+    --                                                                                                                                                                                                        payload_7 GHC.Types.: _) -> PlutusTx.IsData.Class.unsafeFromBuiltinData payload_7 PlutusTx.Eq.Class.== outputs_3;
+    --                                                                                                                                                                                                       _ -> GHC.Types.False};
+    --                                                                           _ -> GHC.Types.False})
+    -- @@@
+    SPlutusV3 ->
+      [ "59013f0101009800aab9daba0aba2ab9aaab9eaba1ab9caab9f488888888c8c8c896600264646464b30013370e"
+      , "90011808000c4c8ca4d6600266e1d2000001894004c03800515980099b8748008006250028b201e403c601c005"
+      , "2323232325980099b874800000e32005300149a4466ebcdd39bac002374e60206eb0c05002d1300149901412cc"
+      , "004cdc3a400400719002a509119baf374e6eb0008dd39bac30143017301700b452820283500b30110023014001"
+      , "3754601c00d4a0301100137546016601c601800314a08068dd51805180680118051baa3009002300b001300837"
+      , "54003149a264c6600c9201035054350080020123233001001120012213300480011400c00a6a66008008240020"
+      , "02323001001229800a5eb824466018601060126ea8008cc0100100060028018889660020031003899801180300"
+      , "09804800a00801"
+      ]
+    -- ScriptHash "98dac76ba3f36651b750ebf880d753414148a57f9e5be3ac63ac44bb"
+    -- Preprocessed PlutusV4 Script:
+    -- @@@
+    -- txInfoTranslationSpecScript_0 :: PlutusTx.Builtins.Internal.BuiltinData ->
+    --                                  PlutusTx.Builtins.Internal.BuiltinUnit
+    -- txInfoTranslationSpecScript_0 arg_1 = PlutusTx.Prelude.check GHC.Base.$ (case PlutusTx.IsData.Class.unsafeFromBuiltinData arg_1 of
+    --                                                                          {PlutusLedgerApi.V3.Data.Contexts.ScriptContext (PlutusLedgerApi.V3.Data.Contexts.TxInfo {PlutusLedgerApi.V3.Data.Contexts.txInfoInputs = inputs_2,
+    --                                                                                                                                                                    PlutusLedgerApi.V3.Data.Contexts.txInfoOutputs = outputs_3})
+    --                                                                                                                          (PlutusLedgerApi.V1.Scripts.Redeemer redData_4)
+    --                                                                                                                          (PlutusLedgerApi.V3.Data.Contexts.SpendingScript _
+    --                                                                                                                                                                           (GHC.Maybe.Just _)) -> let redConstr_5 = PlutusTx.Builtins.unsafeDataAsConstr redData_4
+    --                                                                                                                                                                                                   in case redConstr_5 of
+    --                                                                                                                                                                                                      {(0,
+    --                                                                                                                                                                                                        payload_6 GHC.Types.: _) -> PlutusTx.IsData.Class.unsafeFromBuiltinData payload_6 PlutusTx.Eq.Class.== PlutusTx.Data.List.map PlutusLedgerApi.V3.Data.Contexts.txInInfoOutRef inputs_2;
+    --                                                                                                                                                                                                       (1,
+    --                                                                                                                                                                                                        payload_7 GHC.Types.: _) -> PlutusTx.IsData.Class.unsafeFromBuiltinData payload_7 PlutusTx.Eq.Class.== outputs_3;
+    --                                                                                                                                                                                                       _ -> GHC.Types.False};
+    --                                                                           _ -> GHC.Types.False})
+    -- @@@
+    SPlutusV4 ->
+      [ "59013f0101009800aab9daba0aba2ab9aaab9eaba1ab9caab9f488888888c8c8c896600264646464b30013370e"
+      , "90011808000c4c8ca4d6600266e1d2000001894004c03800515980099b8748008006250028b201e403c601c005"
+      , "2323232325980099b874800000e32005300149a4466ebcdd39bac002374e60206eb0c05002d1300149901412cc"
+      , "004cdc3a400400719002a509119baf374e6eb0008dd39bac30143017301700b452820283500b30110023014001"
+      , "3754601c00d4a0301100137546016601c601800314a08068dd51805180680118051baa3009002300b001300837"
+      , "54003149a264c6600c9201035054350080020123233001001120012213300480011400c00a6a66008008240020"
+      , "02323001001229800a5eb824466018601060126ea8008cc0100100060028018889660020031003899801180300"
+      , "09804800a00801"
       ]

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor.hs
@@ -238,4 +238,15 @@ allTestScripts =
         PlutusV4 -> Just V3.inputsOverlapsWithRefInputsBytes
     , "Script that succeeds only if any the inputs also appears in the reference inputs" :| []
     )
+  ,
+    ( "txInfoTranslationSpecScript"
+    , \case
+        PlutusV1 -> Just V1.txInfoTranslationSpecScriptBytes
+        PlutusV2 -> Just V2.txInfoTranslationSpecScriptBytes
+        PlutusV3 -> Just V3.txInfoTranslationSpecScriptBytes
+        PlutusV4 -> Just V3.txInfoTranslationSpecScriptBytes
+    , "Script that validates TxInfo translation by comparing expected values passed via the redeemer"
+        :| [ "Redeemer is Constr tag [payload]: tag 0 checks txInfoInputs outRefs, tag 1 checks txInfoOutputs"
+           ]
+    )
   ]

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Binary/V1.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Binary/V1.hs
@@ -28,6 +28,7 @@ $purposeIsWellformedWithDatumQ
 $datumIsWellformedQ
 $inputsOutputsAreNotEmptyNoDatumQ
 $inputsOutputsAreNotEmptyWithDatumQ
+$txInfoTranslationSpecScriptQ
 
 -- ================================================================
 -- Compile and serialize the real functions as Plutus scripts.
@@ -109,4 +110,10 @@ inputsOutputsAreNotEmptyWithDatumBytes :: (Q [Dec], PlutusBinary)
 inputsOutputsAreNotEmptyWithDatumBytes =
   ( inputsOutputsAreNotEmptyWithDatumQ
   , PlutusBinary $ PV1.serialiseCompiledCode $$(P.compile [||inputsOutputsAreNotEmptyWithDatum||])
+  )
+
+txInfoTranslationSpecScriptBytes :: (Q [Dec], PlutusBinary)
+txInfoTranslationSpecScriptBytes =
+  ( txInfoTranslationSpecScriptQ
+  , PlutusBinary $ PV1.serialiseCompiledCode $$(P.compile [||txInfoTranslationSpecScript||])
   )

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Binary/V2.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Binary/V2.hs
@@ -28,6 +28,7 @@ $purposeIsWellformedWithDatumQ
 $datumIsWellformedQ
 $inputsOutputsAreNotEmptyNoDatumQ
 $inputsOutputsAreNotEmptyWithDatumQ
+$txInfoTranslationSpecScriptQ
 $inputsOverlapsWithRefInputsQ
 
 -- ================================================================
@@ -110,6 +111,12 @@ inputsOutputsAreNotEmptyWithDatumBytes :: (Q [Dec], PlutusBinary)
 inputsOutputsAreNotEmptyWithDatumBytes =
   ( inputsOutputsAreNotEmptyWithDatumQ
   , PlutusBinary $ PV2.serialiseCompiledCode $$(P.compile [||inputsOutputsAreNotEmptyWithDatum||])
+  )
+
+txInfoTranslationSpecScriptBytes :: (Q [Dec], PlutusBinary)
+txInfoTranslationSpecScriptBytes =
+  ( txInfoTranslationSpecScriptQ
+  , PlutusBinary $ PV2.serialiseCompiledCode $$(P.compile [||txInfoTranslationSpecScript||])
   )
 
 inputsOverlapsWithRefInputsBytes :: (Q [Dec], PlutusBinary)

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Binary/V3.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Binary/V3.hs
@@ -29,6 +29,7 @@ $datumIsWellformedQ
 $inputsOutputsAreNotEmptyNoDatumQ
 $inputsOutputsAreNotEmptyWithDatumQ
 $inputsOverlapsWithRefInputsQ
+$txInfoTranslationSpecScriptQ
 $ensureTreasuryReserveQ
 
 -- ================================================================
@@ -117,6 +118,12 @@ inputsOverlapsWithRefInputsBytes :: (Q [Dec], PlutusBinary)
 inputsOverlapsWithRefInputsBytes =
   ( inputsOverlapsWithRefInputsQ
   , PlutusBinary $ PV3.serialiseCompiledCode $$(P.compile [||inputsOverlapsWithRefInputs||])
+  )
+
+txInfoTranslationSpecScriptBytes :: (Q [Dec], PlutusBinary)
+txInfoTranslationSpecScriptBytes =
+  ( txInfoTranslationSpecScriptQ
+  , PlutusBinary $ PV3.serialiseCompiledCode $$(P.compile [||txInfoTranslationSpecScript||])
   )
 
 ensureTreasuryReserveBytes :: (Q [Dec], PlutusBinary)

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V1.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V1.hs
@@ -228,3 +228,33 @@ inputsOutputsAreNotEmptyWithDatumQ =
                     then P.error ()
                     else ()
     |]
+
+-- | Script for TxInfo translation tests. The redeemer encodes a tagged
+-- payload via @Constr tag [payload]@.
+--
+-- * Tag 0: check that @txInfoInputs@ outRefs match the expected list exactly
+-- * Tag 1: check that @txInfoOutputs@ match the expected list exactly
+txInfoTranslationSpecScriptQ :: Q [Dec]
+txInfoTranslationSpecScriptQ =
+  [d|
+    txInfoTranslationSpecScript :: P.BuiltinData -> P.BuiltinData -> P.BuiltinData -> ()
+    txInfoTranslationSpecScript datum redeemer context =
+      case unsafeFromBuiltinData datum of
+        PV1D.Datum _ ->
+          case unsafeFromBuiltinData redeemer of
+            PV1D.Redeemer redData ->
+              case unsafeFromBuiltinData context of
+                PV1D.ScriptContext txInfo (PV1D.Spending _) ->
+                  let redConstr = P.unsafeDataAsConstr redData
+                   in case redConstr of
+                        (0, payload : _) ->
+                          if unsafeFromBuiltinData payload P.== PLD.map PV1D.txInInfoOutRef (PV1D.txInfoInputs txInfo)
+                            then ()
+                            else P.error ()
+                        (1, payload : _) ->
+                          if unsafeFromBuiltinData payload P.== PV1D.txInfoOutputs txInfo
+                            then ()
+                            else P.error ()
+                        _ -> P.error ()
+                _ -> P.error ()
+    |]

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V2.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V2.hs
@@ -229,6 +229,36 @@ inputsOutputsAreNotEmptyWithDatumQ =
                     else ()
     |]
 
+-- | Script for TxInfo translation tests. The redeemer encodes a tagged
+-- payload via @Constr tag [payload]@.
+--
+-- * Tag 0: check that @txInfoInputs@ outRefs match the expected list exactly
+-- * Tag 1: check that @txInfoOutputs@ match the expected list exactly
+txInfoTranslationSpecScriptQ :: Q [Dec]
+txInfoTranslationSpecScriptQ =
+  [d|
+    txInfoTranslationSpecScript :: P.BuiltinData -> P.BuiltinData -> P.BuiltinData -> ()
+    txInfoTranslationSpecScript datum redeemer context =
+      case unsafeFromBuiltinData datum of
+        PV2D.Datum _ ->
+          case unsafeFromBuiltinData redeemer of
+            PV2D.Redeemer redData ->
+              case unsafeFromBuiltinData context of
+                PV2D.ScriptContext txInfo (PV2D.Spending _) ->
+                  let redConstr = P.unsafeDataAsConstr redData
+                   in case redConstr of
+                        (0, payload : _) ->
+                          if unsafeFromBuiltinData payload P.== PLD.map PV2D.txInInfoOutRef (PV2D.txInfoInputs txInfo)
+                            then ()
+                            else P.error ()
+                        (1, payload : _) ->
+                          if unsafeFromBuiltinData payload P.== PV2D.txInfoOutputs txInfo
+                            then ()
+                            else P.error ()
+                        _ -> P.error ()
+                _ -> P.error ()
+    |]
+
 inputsOverlapsWithRefInputsQ :: Q [Dec]
 inputsOverlapsWithRefInputsQ =
   [d|

--- a/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V3.hs
+++ b/libs/plutus-preprocessor/src/Cardano/Ledger/Plutus/Preprocessor/Source/V3.hs
@@ -212,6 +212,32 @@ inputsOutputsAreNotEmptyWithDatumQ =
             not $ PLD.null (PV3D.txInfoInputs txInfo) || PLD.null (PV3D.txInfoOutputs txInfo)
     |]
 
+-- | Script for TxInfo translation tests. The redeemer encodes a tagged
+-- payload via @Constr tag [payload]@.
+--
+-- * Tag 0: check that @txInfoInputs@ outRefs match the expected list exactly
+-- * Tag 1: check that @txInfoOutputs@ match the expected list exactly
+txInfoTranslationSpecScriptQ :: Q [Dec]
+txInfoTranslationSpecScriptQ =
+  [d|
+    txInfoTranslationSpecScript :: P.BuiltinData -> P.BuiltinUnit
+    txInfoTranslationSpecScript arg =
+      P.check $
+        case unsafeFromBuiltinData arg of
+          PV3D.ScriptContext
+            PV3D.TxInfo {PV3D.txInfoInputs = inputs, PV3D.txInfoOutputs = outputs}
+            (PV3D.Redeemer redData)
+            (PV3D.SpendingScript _ (Just _)) ->
+              let redConstr = P.unsafeDataAsConstr redData
+               in case redConstr of
+                    (0, payload : _) ->
+                      unsafeFromBuiltinData payload P.== PLD.map PV3D.txInInfoOutRef inputs
+                    (1, payload : _) ->
+                      unsafeFromBuiltinData payload P.== outputs
+                    _ -> False
+          _ -> False
+    |]
+
 inputsOverlapsWithRefInputsQ :: Q [Dec]
 inputsOverlapsWithRefInputsQ =
   [d|


### PR DESCRIPTION
# Description

**Proof of concept**

Add new Plutus scripts (V1-V3) and Imp tests that verify TxInfo translation by passing expected values via the redeemer and validating them on-chain.

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
