### PR TITLE
Allow agents to invoke `/update-changelogs`

### DIFF
--- a/.claude/skills/update-changelogs/SKILL.md
+++ b/.claude/skills/update-changelogs/SKILL.md
@@ -1,8 +1,12 @@
 ---
 name: update-changelogs
-description: Update CHANGELOG.md files and cabal version numbers for all packages changed since origin/master, following PVP and project RELEASING.md rules. Use when preparing a PR or when asked to update changelogs or version numbers.
+description: |
+  Update CHANGELOG.md files and cabal version numbers for cardano-ledger packages changed since origin/master, following PVP and project RELEASING.md rules.
+
+  TRIGGER when: about to add, modify, or remove an entry in any `CHANGELOG.md` under this repository; about to bump a `version:` field in any `*.cabal`; user asks to update changelogs, bump versions, or prepare a release/PR; finishing a task that modified Haskell source under `eras/<era>/impl`, `eras/<era>/test-suite`, or `libs/<lib>` (so a changelog entry is likely warranted).
+
+  SKIP: read-only inspection (no edits planned); only test scenarios changed (no API changes); only value/default changes; user is explicitly hand-editing a CHANGELOG and has not asked the agent to do it; the changed file is in an excluded package per RELEASING.md.
 argument-hint: "[package-root]"
-disable-model-invocation: true
 allowed-tools: Bash(git *), Read, Grep, Glob, Edit
 model: opus
 effort: max


### PR DESCRIPTION
# Description
Originally, I opted to disable agent invocation for the `/update-changelogs` skill. My reasoning was, that we might prefer to control when we want to do the `CHANGELOG` updates. However, since Claude usually wants to update the `CHANGELOG`s anyway when it finishes a task and usually messes up without using the skill, I'd rather make the skill agent invocable. 
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
