### PR TITLE
Fix Dijkstra CDDL for Leios changes to header_body

### DIFF
--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -60,8 +60,9 @@ header_body =
   , block_body_hash    : hash32                   ; merkle triple root
   , operational_cert
   , protocol_version
-  , leios_announcement : leios_announcement/ nil
-  , leios_certified    : bool
+  , leios_certified    : bool                     ; whether the block certifies the previous announcement
+  , leios_announcement : leios_announcement
+                         / nil ; optional announcement of an EB
   ]
 
 block_number = uint .size 8

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -50,16 +50,18 @@ certificate =
 header = [header_body, body_signature : kes_signature]
 
 header_body =
-  [ block_number     : block_number
-  , slot             : slot
-  , prev_hash        : hash32/ nil
-  , issuer_vkey      : vkey
-  , vrf_vkey         : vrf_vkey
-  , vrf_result       : vrf_cert
-  , block_body_size  : uint .size 4
-  , block_body_hash  : hash32       ; merkle triple root
+  [ block_number       : block_number
+  , slot               : slot
+  , prev_hash          : hash32/ nil
+  , issuer_vkey        : vkey
+  , vrf_vkey           : vrf_vkey
+  , vrf_result         : vrf_cert
+  , block_body_size    : uint .size 4
+  , block_body_hash    : hash32                   ; merkle triple root
   , operational_cert
   , protocol_version
+  , leios_announcement : leios_announcement/ nil
+  , leios_certified    : bool
   ]
 
 block_number = uint .size 8
@@ -92,6 +94,8 @@ signature = bytes .size 64
 protocol_version = [major_protocol_version, uint .size 4]
 
 major_protocol_version = 0 .. 13
+
+leios_announcement = [announced_eb : hash32, announced_eb_size : uint .size 4]
 
 ; Note that every transaction_index must be strictly smaller than the length of transaction_bodies
 block_body =

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -969,8 +969,13 @@ dijkstraHeaderBodyRule pname p =
       , "block_body_hash" ==> huddleRule @"hash32" p //- "merkle triple root"
       , a $ huddleRule @"operational_cert" p
       , a $ huddleRule @"protocol_version" p
-      , "leios_announcement" ==> huddleRule @"leios_announcement" p / VNil
-      , "leios_certified" ==> VBool
+      , "leios_certified"
+          ==> VBool
+          //- "whether the block certifies the previous announcement"
+      , "leios_announcement"
+          ==> huddleRule @"leios_announcement" p
+          / VNil
+          //- "optional announcement of an EB"
       ]
 
 instance HuddleRule "leios_announcement" DijkstraEra where

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -945,7 +945,41 @@ instance HuddleRule "update" DijkstraEra where
   huddleRuleNamed = updateRule
 
 instance HuddleRule "header_body" DijkstraEra where
-  huddleRuleNamed = babbageHeaderBodyRule
+  huddleRuleNamed = dijkstraHeaderBodyRule
+
+dijkstraHeaderBodyRule ::
+  forall era.
+  ( HuddleRule "operational_cert" era
+  , HuddleRule "protocol_version" era
+  , HuddleRule "leios_announcement" era
+  ) =>
+  Proxy "header_body" ->
+  Proxy era ->
+  Rule
+dijkstraHeaderBodyRule pname p =
+  pname
+    =.= arr
+      [ "block_number" ==> huddleRule @"block_number" p
+      , "slot" ==> huddleRule @"slot" p
+      , "prev_hash" ==> (huddleRule @"hash32" p / VNil)
+      , "issuer_vkey" ==> huddleRule @"vkey" p
+      , "vrf_vkey" ==> huddleRule @"vrf_vkey" p
+      , "vrf_result" ==> huddleRule @"vrf_cert" p
+      , "block_body_size" ==> VUInt `sized` (4 :: Word64)
+      , "block_body_hash" ==> huddleRule @"hash32" p //- "merkle triple root"
+      , a $ huddleRule @"operational_cert" p
+      , a $ huddleRule @"protocol_version" p
+      , "leios_announcement" ==> huddleRule @"leios_announcement" p / VNil
+      , "leios_certified" ==> VBool
+      ]
+
+instance HuddleRule "leios_announcement" DijkstraEra where
+  huddleRuleNamed pname p =
+    pname
+      =.= arr
+        [ "announced_eb" ==> huddleRule @"hash32" p
+        , "announced_eb_size" ==> VUInt `sized` (4 :: Word)
+        ]
 
 instance HuddleRule "header" DijkstraEra where
   huddleRuleNamed = headerRule


### PR DESCRIPTION
Contains the CDDL changes to `header_body` as what we believe the `leios-prototype` _should be_ doing.

The current prototype was not even creating this format, but having two optional elements in the array, where the announcement is a group and thus it _could_ be distinguished by array length. However, this is super fragile. @sandtreader and me came up with this design.

This PR here now switches to this encoding https://github.com/IntersectMBO/ouroboros-consensus/pull/2102

No changes needed to the ledger repository itself because header serialization is (still) in `ouroboros-consensus`

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
