### PR TITLE
Replace `CBORGroup`-derived `EncCBOR/DecCBOR` for StakePoolParams with manual instances

### DIFF
--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -123,6 +123,7 @@ library
     cardano-data ^>=1.3,
     cardano-ledger-binary ^>=1.9,
     cardano-ledger-byron,
+    cardano-ledger-core,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.21,
     cardano-slotting,
     cardano-strict-containers >=0.1.5,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -74,14 +74,11 @@ module Cardano.Ledger.Shelley.TxCert (
   isUnRegStakeTxCert,
 ) where
 
-import Cardano.Base.Proxy (asProxy)
 import Cardano.Ledger.BaseTypes (invalidKey, kindObjectValue)
 import Cardano.Ledger.Binary (
   DecCBOR (decCBOR),
-  DecCBORGroup (..),
   Decoder,
   EncCBOR (..),
-  EncCBORGroup (..),
   Encoding,
   FromCBOR (..),
   ToCBOR (..),
@@ -91,7 +88,6 @@ import Cardano.Ledger.Binary (
   decodeWord,
   encodeListLen,
   encodeWord8,
-  listLenInt,
   peekTokenType,
  )
 import Cardano.Ledger.Coin (Coin (..), DeltaCoin)
@@ -105,7 +101,11 @@ import Cardano.Ledger.Internal.Era (AllegraEra, AlonzoEra, BabbageEra, MaryEra)
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams ()
-import Cardano.Ledger.State (StakePoolParams (..))
+import Cardano.Ledger.State (
+  StakePoolParams (..),
+  decodeStakePoolParamsFlat,
+  withStakePoolParamsFlatEncoding,
+ )
 import Cardano.Ledger.Val ((<+>), (<×>))
 import Control.DeepSeq (NFData (..), rwhnf)
 import Data.Aeson (ToJSON (..), (.=))
@@ -437,9 +437,10 @@ encodeShelleyDelegCert = \case
 encodePoolCert :: PoolCert -> Encoding
 encodePoolCert = \case
   RegPool poolParams ->
-    encodeListLen (1 + listLen (asProxy poolParams))
-      <> encodeWord8 3
-      <> encCBORGroup poolParams
+    withStakePoolParamsFlatEncoding poolParams $ \stakePoolParamsListLen stakePoolParamsEncoding ->
+      encodeListLen (1 + fromIntegral stakePoolParamsListLen)
+        <> encodeWord8 3
+        <> stakePoolParamsEncoding
   RetirePool vk epoch ->
     encodeListLen 3
       <> encodeWord8 4
@@ -507,8 +508,8 @@ shelleyTxCertDelegDecoder = \case
 poolTxCertDecoder :: EraTxCert era => Word -> Decoder s (Int, TxCert era)
 poolTxCertDecoder = \case
   3 -> do
-    group <- decCBORGroup
-    pure (1 + listLenInt (Just group), RegPoolTxCert group)
+    (stakePoolParamLen, stakePoolParams) <- decodeStakePoolParamsFlat
+    pure (1 + stakePoolParamLen, RegPoolTxCert stakePoolParams)
   4 -> do
     a <- decCBOR
     b <- decCBOR

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Encoder.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/Encoder.hs
@@ -149,7 +149,7 @@ withCurrentEncodingVersion f =
 enforceEncodingVersion :: Version -> Encoding -> Encoding
 enforceEncodingVersion version encoding = fromPlainEncoding (toPlainEncoding version encoding)
 
--- | Conditionoly choose the encoder newer or older deceder, depending on the current
+-- | Conditionally choose the encoder newer or older deceder, depending on the current
 -- version. Supplied version acts as a pivot.
 --
 -- =====__Example__

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -10,6 +10,8 @@
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Conway.Pool where
 
 import Cardano.Ledger.BaseTypes (Network (Testnet))
+import Cardano.Ledger.Binary (EncCBOR (..))
+import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
 import Cardano.Ledger.Conway (ConwayEra)
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
@@ -35,6 +37,16 @@ instance SpecTranslate ConwayEra (PState ConwayEra) where
       <$> toSpecRepMap (Map.mapWithKey (stakePoolStateToStakePoolParams Testnet) psStakePools)
       <*> toSpecRepMap psFutureStakePoolParams
       <*> toSpecRepMap psRetiring
+
+-- | This instance is only used for conformance testing (e.g. @ExecSpecRule@).
+-- This instance uses arbitrary tags (0 and 1) that don't match the CDDL spec.
+--
+-- The actual spec-compliant CBOR encoding that follows the CDDL is handled by 'encodePoolCert'.
+instance EncCBOR PoolCert where
+  encCBOR =
+    encode . \case
+      RegPool pp -> Sum RegPool 0 !> To pp
+      RetirePool kh eNo -> Sum RetirePool 1 !> To kh !> To eNo
 
 instance SpecTranslate ConwayEra PoolCert where
   type SpecRep ConwayEra PoolCert = Agda.DCert

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Conway/Pool.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -35,6 +35,8 @@
 * Add `kindObject :: Text -> [Pair] -> Object` returning an `Aeson.Object`
 * Add `NFData (Script era)`, `ToJSON (Script era)`, `FromJSON (Script era)`, `ToJSON (NativeScript era)`, and `FromJSON (NativeScript era)` as superclass constraints to `EraScript`
 * Move `EncCBOR PoolCert` instance to `cardano-ledger-conformance`
+* Remove `[Enc|Dec]CBORGRoup` instances for `StakePoolParams`
+* Add `withStakePoolParamsFlatEncoding` and `decodeStakePoolParamsFlat` for flat (non-nested) CBOR encoding/decoding
 
 ### `cddl`
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -34,6 +34,7 @@
 * Rename `kindObject` (which returned `Value`) to `kindObjectValue`
 * Add `kindObject :: Text -> [Pair] -> Object` returning an `Aeson.Object`
 * Add `NFData (Script era)`, `ToJSON (Script era)`, `FromJSON (Script era)`, `ToJSON (NativeScript era)`, and `FromJSON (NativeScript era)` as superclass constraints to `EraScript`
+* Move `EncCBOR PoolCert` instance to `cardano-ledger-conformance`
 
 ### `cddl`
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -23,7 +23,6 @@ module Cardano.Ledger.Core.TxCert (
 
 import Cardano.Ledger.BaseTypes (kindObjectValue)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), FromCBOR, ToCBOR)
-import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Core.Era (Era)
 import Cardano.Ledger.Core.PParams (PParams)
@@ -134,12 +133,6 @@ data PoolCert
   | -- | A stake pool retirement certificate.
     RetirePool !(KeyHash StakePool) !EpochNo
   deriving (Show, Generic, Eq, Ord)
-
-instance EncCBOR PoolCert where
-  encCBOR =
-    encode . \case
-      RegPool pp -> Sum RegPool 0 !> To pp
-      RetirePool kh eNo -> Sum RetirePool 1 !> To kh !> To eNo
 
 instance NoThunks PoolCert
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/StakePool.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/StakePool.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -60,6 +61,8 @@ module Cardano.Ledger.State.StakePool (
     ppRelays,
     ppMetadata
   ),
+  withStakePoolParamsFlatEncoding,
+  decodeStakePoolParamsFlat,
   PoolMetadata (..),
   StakePoolRelay (..),
   SizeOfPoolRelays (..),
@@ -81,12 +84,11 @@ import Cardano.Ledger.BaseTypes (
   invalidKey,
  )
 import Cardano.Ledger.Binary (
-  CBORGroup (..),
   DecCBOR (..),
-  DecCBORGroup (..),
   DecShareCBOR (..),
+  Decoder,
   EncCBOR (..),
-  EncCBORGroup (..),
+  Encoding,
   Interns,
   decodeNullStrictMaybe,
   decodeRecordNamed,
@@ -94,6 +96,7 @@ import Cardano.Ledger.Binary (
   decodeRecordSum,
   encodeListLen,
   encodeNullStrictMaybe,
+  withCurrentEncodingVersion,
  )
 import Cardano.Ledger.Binary.Coders (
   Decode (..),
@@ -430,8 +433,6 @@ data StakePoolParams = StakePoolParams
   , sppMetadata :: !(StrictMaybe PoolMetadata)
   }
   deriving (Show, Generic, Eq, Ord)
-  deriving (EncCBOR) via CBORGroup StakePoolParams
-  deriving (DecCBOR) via CBORGroup StakePoolParams
 
 sppVrfL :: Lens' StakePoolParams (VRFVerKeyHash StakePoolVRF)
 sppVrfL = lens sppVrf (\spp u -> spp {sppVrf = u})
@@ -536,39 +537,53 @@ data SizeOfPoolRelays = SizeOfPoolRelays
 instance EncCBOR SizeOfPoolRelays where
   encCBOR = error "The `SizeOfPoolRelays` type cannot be encoded!"
 
-instance EncCBORGroup StakePoolParams where
-  encCBORGroup poolParams =
-    encCBOR (sppId poolParams)
-      <> encCBOR (sppVrf poolParams)
-      <> encCBOR (sppPledge poolParams)
-      <> encCBOR (sppCost poolParams)
-      <> encCBOR (sppMargin poolParams)
-      <> encCBOR (sppAccountAddress poolParams)
-      <> encCBOR (sppOwners poolParams)
-      <> encCBOR (sppRelays poolParams)
-      <> encodeNullStrictMaybe encCBOR (sppMetadata poolParams)
-  listLen _ = 9
+instance EncCBOR StakePoolParams where
+  encCBOR poolParams =
+    withStakePoolParamsFlatEncoding poolParams $ \stakePoolParamsListLen stakePoolParamsEncoding ->
+      encodeListLen (fromIntegral stakePoolParamsListLen)
+        <> stakePoolParamsEncoding
 
-instance DecCBORGroup StakePoolParams where
-  decCBORGroup = do
-    hk <- decCBOR
-    vrf <- decCBOR
-    pledge <- decCBOR
-    cost <- decCBOR
-    margin <- decCBOR
-    ra <- decCBOR
-    owners <- decCBOR
-    relays <- decCBOR
-    md <- decodeNullStrictMaybe decCBOR
-    pure $
-      StakePoolParams
-        { sppId = hk
-        , sppVrf = vrf
-        , sppPledge = pledge
-        , sppCost = cost
-        , sppMargin = margin
-        , sppAccountAddress = ra
-        , sppOwners = owners
-        , sppRelays = relays
-        , sppMetadata = md
-        }
+-- | Returns the 'StakePoolParams' in a flat structure such as `[operator, vrf,
+-- pledge, ...]`. Useful for combining with other encoding functions like
+-- 'encodePoolCert' so that those functions end up with a flat list encoding
+-- instead of a nested list.
+--
+-- We could have used 'EncCBORGroup' to achieve something similar. However, the
+-- `listLen` function is static and can't depend on the Encoding version.
+-- Instead, we want `StakePoolParams` to have a dynamic list length based on the
+-- protocol version.
+withStakePoolParamsFlatEncoding ::
+  StakePoolParams ->
+  -- | Function with stake pool params flat encoded list length and actual flat
+  -- encoded stake pool params
+  (Int -> Encoding -> Encoding) ->
+  Encoding
+withStakePoolParamsFlatEncoding poolParams f =
+  withCurrentEncodingVersion $ \_v ->
+    f 9 $
+      encCBOR (sppId poolParams)
+        <> encCBOR (sppVrf poolParams)
+        <> encCBOR (sppPledge poolParams)
+        <> encCBOR (sppCost poolParams)
+        <> encCBOR (sppMargin poolParams)
+        <> encCBOR (sppAccountAddress poolParams)
+        <> encCBOR (sppOwners poolParams)
+        <> encCBOR (sppRelays poolParams)
+        <> encodeNullStrictMaybe encCBOR (sppMetadata poolParams)
+
+instance DecCBOR StakePoolParams where
+  decCBOR = do
+    snd <$> decodeRecordNamed "StakePoolParams" fst decodeStakePoolParamsFlat
+
+decodeStakePoolParamsFlat :: Decoder s (Int, StakePoolParams)
+decodeStakePoolParamsFlat = do
+  sppId <- decCBOR
+  sppVrf <- decCBOR
+  sppPledge <- decCBOR
+  sppCost <- decCBOR
+  sppMargin <- decCBOR
+  sppAccountAddress <- decCBOR
+  sppOwners <- decCBOR
+  sppRelays <- decCBOR
+  sppMetadata <- decodeNullStrictMaybe decCBOR
+  pure (9, StakePoolParams {..})


### PR DESCRIPTION
# Description

Replace the `EncCBORGroup/DecCBORGroup`-derived instances with explicit `EncCBOR/DecCBOR` instances and flat encode/decode helpers. This prepares `StakePoolParams` for a dynamic CBOR list length based on the protocol version, which `CBORGroup`'s static listLen cannot support.

* Add `encodeStakePoolParamsFlat` / `decodeStakePoolParamsFlat` for inline (non-nested) encoding used in pool registration certificates.
* Update `encodePoolCert` / `poolTxCertDecoder` to use the flat helpers.
* Add clarifying comment on EncCBOR PoolCert (used in conformance-testing only).

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
