### PR TITLE
Add queryDelegationsAndRewards

### DIFF
--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.13.1.0
 
+* Add `queryDelegationsAndRewards` (`QueryResultDelegationsAndRewards`), superseding `queryStakePoolDelegsAndRewards`.
 * Rename `AnyEraRewardingPurpose` to `AnyEraWithdrawingPurpose` and `anyEraToRewardingPurpose` to `anyEraToWithdrawingPurpose`, deprecating the old names
 * Re-export the new `pattern WithdrawingPurpose` and `toWithdrawingPurpose`
 * Add `generate-cbor` executable.

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Account.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/State/Query/Account.hs
@@ -1,20 +1,32 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
 module Cardano.Ledger.Api.State.Query.Account (
   -- * @GetStakeDelegDeposits@
   queryAccountsDeposits,
 
   -- * @GetFilteredVoteDelegatees@
   queryDRepDelegatees,
+
+  -- * Delegations and reward accounts
+  queryDelegationsAndRewards,
+  QueryResultDelegationsAndRewards (..),
 ) where
 
+import Cardano.Ledger.Binary
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Conway.State (ConwayEraAccounts, dRepDelegationAccountStateL)
 import Cardano.Ledger.Credential (Credential)
-import Cardano.Ledger.Keys (KeyRole (..))
+import Cardano.Ledger.Keys (KeyHash, KeyRole (..))
 import Cardano.Ledger.Shelley.LedgerState (NewEpochState, esLStateL, lsCertStateL, nesEsL)
 import Cardano.Ledger.State (DRep, EraAccounts (..), EraCertState (..), accountsL)
+import Control.DeepSeq (NFData)
+import Data.Aeson (ToJSON)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import GHC.Generics (Generic)
 import Lens.Micro
 
 -- | Query staking delegation deposits.
@@ -49,3 +61,28 @@ queryDRepDelegatees nes creds =
         | Set.null creds = accountsMap
         | otherwise = accountsMap `Map.restrictKeys` creds
    in Map.mapMaybe (^. dRepDelegationAccountStateL) selected
+
+-- | Stake-pool delegation and reward balance for each registered staking credential.
+newtype QueryResultDelegationsAndRewards = QueryResultDelegationsAndRewards
+  { unQueryResultDelegationsAndRewards :: Map.Map (Credential Staking) (Maybe (KeyHash StakePool), Coin)
+  }
+  deriving (Eq, Show, Generic)
+  deriving newtype (NFData, ToJSON, EncCBOR, DecCBOR)
+
+-- | Stake-pool delegations and reward balances for the given registered credentials.
+-- An empty 'Set' selects all registered credentials.
+queryDelegationsAndRewards ::
+  EraCertState era =>
+  NewEpochState era ->
+  Set.Set (Credential Staking) ->
+  QueryResultDelegationsAndRewards
+queryDelegationsAndRewards nes creds =
+  let accountsMap = nes ^. nesEsL . esLStateL . lsCertStateL . certDStateL . accountsL . accountsMapL
+      accountsMapFiltered
+        | Set.null creds = accountsMap
+        | otherwise = accountsMap `Map.restrictKeys` creds
+      delegationAndReward account =
+        ( account ^. stakePoolDelegationAccountStateL
+        , fromCompact $ account ^. balanceAccountStateL
+        )
+   in QueryResultDelegationsAndRewards $ Map.map delegationAndReward accountsMapFiltered


### PR DESCRIPTION
# Description

Add `queryDelegationsAndRewards` returning a stable-type `QueryResultDelegationsAndRewards` which is a unified map replacing the pair-of-maps, reducing duplication in the result.

Supersedes `queryStakePoolDelegsAndRewards`.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
