### PR TITLE
Fix injected extraConfig cost models being ignored for PlutusV1/V3

### DIFF
--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
@@ -58,4 +58,8 @@ overrideCostModels ::
   NewEpochState era
 overrideCostModels = \case
   Nothing -> id
-  Just cms -> nesEsL . curPParamsEpochStateL . ppCostModelsL %~ updateCostModels cms
+  -- Injected cost models override the era-translated ones (the fixed-length
+  -- PlutusV1/PlutusV3 genesis fields), so a testnet can carry full cost models
+  -- without an on-chain parameter update. `cms` is passed second because
+  -- `updateCostModels` lets its second argument win. See #5342 and #5896.
+  Just cms -> nesEsL . curPParamsEpochStateL . ppCostModelsL %~ flip updateCostModels cms


### PR DESCRIPTION
`overrideCostModels` passed the injected `AlonzoExtraConfig` cost models as the first (overwritten) argument of `updateCostModels`, so the era-translated PParams cost models won every collision.

Fix for https://github.com/IntersectMBO/cardano-ledger/issues/5342 / https://github.com/IntersectMBO/cardano-ledger/pull/5379
