### PR TITLE
Update Conway conformance tests to PV 11

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: 1fabf46209b0388a2690c00a70863ce2d5757f60
+  tag: 16b0eb6ef3e4ebcf83dc9e6075cc1f1ce9bb8a13
 
 source-repository-package
   type: git

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/DelegSpec.hs
@@ -367,7 +367,9 @@ spec = describe "DELEG" $ do
       expectNotDelegatedVote cred
       expectNotDelegatedToAnyPool cred
 
-    it "Delegate vote and unregister after hardfork" $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1249
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "Delegate vote and unregister after hardfork" $ do
       let
         bootstrapVer = ProtVer (natVersion @9) 0
         setProtVer pv = modifyNES $ nesEsL . curPParamsEpochStateL . ppProtocolVersionL .~ pv

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxowSpec.hs
@@ -54,7 +54,7 @@ spec ::
   ConwayEraImp era =>
   SpecWith (ImpInit (LedgerSpec era))
 spec = describe "UTXOW" $ do
-  -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1029
+  -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1086
   -- TODO: Re-enable after issue is resolved, by removing this override
   disableInConformanceIt "Fails with PPViewHashesDontMatch before PV 11" . whenMajorVersionAtMost @10 $ do
     fixedTx <- fixupTx =<< setupBadPPViewHashTx
@@ -71,29 +71,33 @@ spec = describe "UTXOW" $ do
               , mismatchExpected = scriptIntegrityHash
               }
         ]
-  it "Fails with PPViewHashesDontMatchInformative after PV 11" . whenMajorVersionAtLeast @11 $ do
-    fixedTx <- fixupTx =<< setupBadPPViewHashTx
-    pp <- getsPParams id
-    badScriptIntegrityHash <- arbitrary
-    let
-      langView = [getLanguageView pp PlutusV2]
-      scriptIntegrity = ScriptIntegrity @era redeemers dats langView
-      redeemers = fixedTx ^. witsTxL . rdmrsTxWitsL
-      dats = fixedTx ^. witsTxL . datsTxWitsL
-    tx <- substituteIntegrityHashAndFixWits badScriptIntegrityHash fixedTx
-    scriptIntegrityHash <- computeScriptIntegrityHash tx
-    let
-      mismatch =
-        Mismatch
-          { mismatchSupplied = badScriptIntegrityHash
-          , mismatchExpected = scriptIntegrityHash
-          }
-    impAnn "Submit a transaction with an invalid script integrity hash"
-      . withNoFixup
-      $ submitFailingTx
-        tx
-        [ injectFailure $ ScriptIntegrityHashMismatch mismatch (SJust $ originalBytes scriptIntegrity)
-        ]
+  -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1086
+  -- TODO: Re-enable after issue is resolved, by removing this override
+  disableInConformanceIt "Fails with PPViewHashesDontMatchInformative after PV 11"
+    . whenMajorVersionAtLeast @11
+    $ do
+      fixedTx <- fixupTx =<< setupBadPPViewHashTx
+      pp <- getsPParams id
+      badScriptIntegrityHash <- arbitrary
+      let
+        langView = [getLanguageView pp PlutusV2]
+        scriptIntegrity = ScriptIntegrity @era redeemers dats langView
+        redeemers = fixedTx ^. witsTxL . rdmrsTxWitsL
+        dats = fixedTx ^. witsTxL . datsTxWitsL
+      tx <- substituteIntegrityHashAndFixWits badScriptIntegrityHash fixedTx
+      scriptIntegrityHash <- computeScriptIntegrityHash tx
+      let
+        mismatch =
+          Mismatch
+            { mismatchSupplied = badScriptIntegrityHash
+            , mismatchExpected = scriptIntegrityHash
+            }
+      impAnn "Submit a transaction with an invalid script integrity hash"
+        . withNoFixup
+        $ submitFailingTx
+          tx
+          [ injectFailure $ ScriptIntegrityHashMismatch mismatch (SJust $ originalBytes scriptIntegrity)
+          ]
   it "Transaction containing SPO vote but no witness for it fails" $ do
     spoKh <- freshKeyHash
     registerPool spoKh

--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1780383583,
-        "narHash": "sha256-wCCr782Inm5zbT3ZhsSZon6Yi41/Wub5PJyWSr9dq1o=",
+        "lastModified": 1782959197,
+        "narHash": "sha256-o7N5C5qhyysPpJSjTrC3uqpRj09OHAc8aIUQ/RWXSj0=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "1fabf46209b0388a2690c00a70863ce2d5757f60",
+        "rev": "16b0eb6ef3e4ebcf83dc9e6075cc1f1ce9bb8a13",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Conway.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Conway.hs
@@ -8,46 +8,39 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Conway (ConwayEra)
 import Test.Cardano.Ledger.Conformance.Imp.Conway.Ratify qualified as RatifySpec
 import Test.Cardano.Ledger.Conformance.Imp.Core
-import Test.Cardano.Ledger.Conway.Imp.BbodySpec qualified as Bbody
-import Test.Cardano.Ledger.Conway.Imp.CertsSpec qualified as Certs
-import Test.Cardano.Ledger.Conway.Imp.DelegSpec qualified as Deleg
-import Test.Cardano.Ledger.Conway.Imp.EnactSpec qualified as Enact
-import Test.Cardano.Ledger.Conway.Imp.EpochSpec qualified as Epoch
-import Test.Cardano.Ledger.Conway.Imp.GovCertSpec qualified as GovCert
-import Test.Cardano.Ledger.Conway.Imp.GovSpec qualified as Gov
-import Test.Cardano.Ledger.Conway.Imp.LedgerSpec qualified as Ledger
-import Test.Cardano.Ledger.Conway.Imp.RatifySpec qualified as Ratify
-import Test.Cardano.Ledger.Conway.Imp.UtxoSpec qualified as Utxo
-import Test.Cardano.Ledger.Conway.Imp.UtxosSpec qualified as Utxos
-import Test.Cardano.Ledger.Conway.Imp.UtxowSpec qualified as Utxow
+import Test.Cardano.Ledger.Conway.Imp.BbodySpec qualified as BBODY
+import Test.Cardano.Ledger.Conway.Imp.CertsSpec qualified as CERTS
+import Test.Cardano.Ledger.Conway.Imp.DelegSpec qualified as DELEG
+import Test.Cardano.Ledger.Conway.Imp.EnactSpec qualified as ENACT
+import Test.Cardano.Ledger.Conway.Imp.EpochSpec qualified as EPOCH
+import Test.Cardano.Ledger.Conway.Imp.GovCertSpec qualified as GOVCERT
+import Test.Cardano.Ledger.Conway.Imp.GovSpec qualified as GOV
+import Test.Cardano.Ledger.Conway.Imp.LedgerSpec qualified as LEDGER
+import Test.Cardano.Ledger.Conway.Imp.RatifySpec qualified as RATIFY
+import Test.Cardano.Ledger.Conway.Imp.UtxoSpec qualified as UTXO
+import Test.Cardano.Ledger.Conway.Imp.UtxosSpec qualified as UTXOS
+import Test.Cardano.Ledger.Conway.Imp.UtxowSpec qualified as UTXOW
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Imp.Common hiding (Args)
-import UnliftIO (evaluateDeep)
 
 spec :: Spec
 spec = do
   describe "Imp" $ do
     withImpInit @(LedgerSpec ConwayEra) $
-      modifyImpInitProtVer @ConwayEra (natVersion @10) $
+      modifyImpInitProtVer @ConwayEra (natVersion @11) $
         modifyImpInitPostSubmitTxHook submitTxConformanceHook $ do
           modifyImpInitPostEpochBoundaryHook epochBoundaryConformanceHook $ do
-            describe "Basic" $ do
-              it "Submit constitution" $ do
-                _ <- submitConstitution @ConwayEra SNothing
-                passNEpochs 2
-              it "Can elect a basic committee" $ do
-                void $ evaluateDeep =<< electBasicCommittee
-            describe "BBODY" Bbody.spec
-            describe "CERTS" Certs.spec
-            describe "DELEG" Deleg.spec
-            describe "ENACT" Enact.spec
-            describe "EPOCH" Epoch.spec
-            describe "GOV" Gov.spec
-            describe "GOVCERT" GovCert.spec
-            describe "LEDGER" Ledger.spec
-            describe "RATIFY" Ratify.spec
-            describe "UTXO" Utxo.spec
-            describe "UTXOW" Utxow.spec
-            describe "UTXOS" Utxos.spec
+            BBODY.spec
+            CERTS.spec
+            DELEG.spec
+            ENACT.spec
+            EPOCH.spec
+            GOV.spec
+            GOVCERT.spec
+            LEDGER.spec
+            RATIFY.spec
+            UTXO.spec
+            UTXOW.spec
+            UTXOS.spec
   describe "Imp (only spec)" $ do
     RatifySpec.spec


### PR DESCRIPTION
# Description

- Uppercase qualified imports to be consistent with `eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp.hs`
- Remove leftover test cases (which are covered by others)
- Disable failing tests

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
