### PR TITLE
Use non-empty list for fields without duplicate enforcement in Conway transaction_witness_set cddl rule

### DIFF
--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -62,6 +62,7 @@
 
 ### cddl
 
+* Use non-empty list instead of `nonempty_set` for fields 0 (`vkey_witness`), 1 (`native_script`), 2 (`bootstrap_witness`), 4 (`plutus_data`) in `transaction_witness_set` to match decoder behavior pre-Dijkstra
 * Change the second argument of `mkMaybeTaggedSet` to `Int`
 * Add `generateMaybeTaggedSet`
 * Extend `constr` CDDL rule to include tags 1280–1400 for Plutus `Data` constructor indexes

--- a/eras/conway/impl/cddl/data/conway.cddl
+++ b/eras/conway/impl/cddl/data/conway.cddl
@@ -758,15 +758,17 @@ constitution = [anchor, guardrails_script_hash/ nil]
 info_action = 6
 
 transaction_witness_set =
-  { ? 0 : nonempty_set<vkeywitness>
-  , ? 1 : nonempty_set<native_script>
-  , ? 2 : nonempty_set<bootstrap_witness>
+  { ? 0 : nonempty_list<vkeywitness>
+  , ? 1 : nonempty_list<native_script>
+  , ? 2 : nonempty_list<bootstrap_witness>
   , ? 3 : nonempty_set<plutus_v1_script>
-  , ? 4 : nonempty_set<plutus_data>
+  , ? 4 : nonempty_list<plutus_data>
   , ? 5 : redeemers
   , ? 6 : nonempty_set<plutus_v2_script>
   , ? 7 : nonempty_set<plutus_v3_script>
   }
+
+nonempty_list<a0> = #6.258([+ a0])/ [+ a0]
 
 vkeywitness = [vkey, signature]
 

--- a/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
+++ b/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
@@ -768,6 +768,13 @@ maybeTaggedNonemptySet pname = mkMaybeTaggedSet pname 1
 maybeTaggedNonemptyOset :: IsType0 a => Proxy "nonempty_oset" -> a -> GRuleCall
 maybeTaggedNonemptyOset pname = mkMaybeTaggedSet pname 1
 
+-- | A non-empty list with optional tag 258, without set uniqueness enforcement.
+-- Use this for fields where the decoder accepts the set tag but does not check
+-- for duplicate elements.
+maybeTaggedNonemptyList :: IsType0 a => Proxy "nonempty_list" -> a -> GRuleCall
+maybeTaggedNonemptyList pname = binding $ \x ->
+  pname =.= tag 258 (arr [1 <+ a x]) / sarr [1 <+ a x]
+
 instance HuddleRule "bounded_bytes" ConwayEra where
   huddleRuleNamed pname _ = boundedBytesRule pname
 
@@ -1275,11 +1282,11 @@ instance HuddleRule "transaction_witness_set" ConwayEra where
   huddleRuleNamed pname p =
     pname
       =.= mp
-        [ opt $ idx 0 ==> huddleRule1 @"nonempty_set" p (huddleRule @"vkeywitness" p)
-        , opt $ idx 1 ==> huddleRule1 @"nonempty_set" p (huddleRule @"native_script" p)
-        , opt $ idx 2 ==> huddleRule1 @"nonempty_set" p (huddleRule @"bootstrap_witness" p)
+        [ opt $ idx 0 ==> huddleRule1 @"nonempty_list" p (huddleRule @"vkeywitness" p)
+        , opt $ idx 1 ==> huddleRule1 @"nonempty_list" p (huddleRule @"native_script" p)
+        , opt $ idx 2 ==> huddleRule1 @"nonempty_list" p (huddleRule @"bootstrap_witness" p)
         , opt $ idx 3 ==> huddleRule1 @"nonempty_set" p (huddleRule @"plutus_v1_script" p)
-        , opt $ idx 4 ==> huddleRule1 @"nonempty_set" p (huddleRule @"plutus_data" p)
+        , opt $ idx 4 ==> huddleRule1 @"nonempty_list" p (huddleRule @"plutus_data" p)
         , opt $ idx 5 ==> huddleRule @"redeemers" p
         , opt $ idx 6 ==> huddleRule1 @"nonempty_set" p (huddleRule @"plutus_v2_script" p)
         , opt $ idx 7 ==> huddleRule1 @"nonempty_set" p (huddleRule @"plutus_v3_script" p)
@@ -1422,6 +1429,9 @@ instance HuddleRule1 "nonempty_set" ConwayEra where
 
 instance HuddleRule1 "nonempty_oset" ConwayEra where
   huddleRule1Named pname _ = maybeTaggedNonemptyOset pname
+
+instance HuddleRule1 "nonempty_list" ConwayEra where
+  huddleRule1Named pname _ = maybeTaggedNonemptyList pname
 
 instance HuddleRule1 "multiasset" ConwayEra where
   huddleRule1Named = conwayMultiasset


### PR DESCRIPTION
# Description

The transaction-witness-set decoder does not enforce set uniqueness for fields 0 (vkeywitness), 1 (native_script), 2 (bootstrap_witness), and 4 (plutus_data) before protocol version 12 (Dijkstra). Change the Conway Huddle spec to use `maybeTaggedNonemptyList` instead of `nonempty_set` for these fields, matching what the decoder actually accepts.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
