### PR TITLE
Remove DRep requirement for reward withdrawals

### DIFF
--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/LedgerSpec.hs
@@ -87,19 +87,22 @@ spec = describe "LEDGER" $ do
     let tx = mkBasicTx $ mkBasicTxBody & withdrawalsTxBodyL .~ Withdrawals [(ra, balance)]
 
     pv <- getProtVer
-    if hardforkConwayBootstrapPhase pv
-      then submitTx_ tx
-      else
+    -- In bootstrap phase and in post-Conway eras (CIP-181), the DRep delegation check
+    -- does not apply, so the withdrawal succeeds without delegation.
+    let drepCheckActive = not (hardforkConwayBootstrapPhase pv) && pvMajor pv < natVersion @12
+    if drepCheckActive
+      then
         submitFailingTx
           tx
           [injectFailure $ ConwayWdrlNotDelegatedToDRep [kh]]
+      else submitTx_ tx
     _ <- delegateToDRep cred (Coin 1_000_000) DRepAlwaysAbstain
     submitTx_ $
       mkBasicTx $
         mkBasicTxBody
           & withdrawalsTxBodyL
             .~ Withdrawals
-              [(ra, if hardforkConwayBootstrapPhase pv then mempty else balance)]
+              [(ra, if drepCheckActive then balance else mempty)]
 
   it "Withdraw from a key delegated to an unregistered DRep" $ do
     modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
@@ -119,8 +122,12 @@ spec = describe "LEDGER" $ do
               & withdrawalsTxBodyL
                 .~ Withdrawals
                   [(ra, balance)]
-    ifBootstrap (submitTx_ tx >> (getBalance cred `shouldReturn` mempty)) $ do
-      submitFailingTx tx [injectFailure $ ConwayWdrlNotDelegatedToDRep [kh]]
+    pv <- getProtVer
+    -- In bootstrap phase and post-Conway eras (CIP-181), the DRep delegation check
+    -- does not apply, so the withdrawal succeeds.
+    if not (hardforkConwayBootstrapPhase pv) && pvMajor pv < natVersion @12
+      then submitFailingTx tx [injectFailure $ ConwayWdrlNotDelegatedToDRep [kh]]
+      else submitTx_ tx >> (getBalance cred `shouldReturn` mempty)
 
   -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/923
   -- TODO: Re-enable after issue is resolved, by removing this override

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -113,6 +113,9 @@
 * Make `DijkstraContextError` constructors lazy
 * Add `ToJSON` and `FromJSON` instances for `DijkstraNativeScript era`
 * Export `dijkstraBasedEraNativeScriptToJSON` and `dijkstraBasedEraNativeScriptJSONParser` from `Cardano.Ledger.Dijkstra.Scripts`
+* Remove DRep requirement for reward withdrawals
+  - Remove `WdrlNotDelegatedToDRep` constructor from `EntitiesPredFailure`
+  - Remove `SubWdrlNotDelegatedToDRep` constructor from `SubEntitiesPredFailure`
 
 ### cddl
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -33,12 +32,10 @@ import Cardano.Ledger.Dijkstra.Era (DijkstraEra, ENTITIES)
 import Cardano.Ledger.Dijkstra.Rules.Certs ()
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody, directDepositsTxBodyL)
-import Cardano.Ledger.Rules.ValidationMode (runTest)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
-import Data.List.NonEmpty (NonEmpty)
 import Data.Map.NonEmpty (NonEmptyMap)
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
@@ -68,7 +65,6 @@ instance EraTx era => EncCBOR (EntitiesEnv era) where
 
 data EntitiesPredFailure era
   = CertsFailure (PredicateFailure (EraRule "CERTS" era))
-  | WdrlNotDelegatedToDRep (NonEmpty (KeyHash Staking))
   | WithdrawalsMissingAccounts Withdrawals
   | IncompleteWithdrawals (NonEmptyMap AccountAddress (Mismatch RelEQ Coin))
   | WithdrawalAmountsExceedAccountBalances (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
@@ -94,11 +90,10 @@ instance
   encCBOR =
     encode . \case
       CertsFailure x -> Sum (CertsFailure @era) 0 !> To x
-      WdrlNotDelegatedToDRep x -> Sum (WdrlNotDelegatedToDRep @era) 1 !> To x
-      WithdrawalsMissingAccounts x -> Sum (WithdrawalsMissingAccounts @era) 2 !> To x
-      IncompleteWithdrawals x -> Sum (IncompleteWithdrawals @era) 3 !> To x
-      WithdrawalAmountsExceedAccountBalances x -> Sum (WithdrawalAmountsExceedAccountBalances @era) 4 !> To x
-      DirectDepositsToMissingAccounts x -> Sum (DirectDepositsToMissingAccounts @era) 5 !> To x
+      WithdrawalsMissingAccounts x -> Sum (WithdrawalsMissingAccounts @era) 1 !> To x
+      IncompleteWithdrawals x -> Sum (IncompleteWithdrawals @era) 2 !> To x
+      WithdrawalAmountsExceedAccountBalances x -> Sum (WithdrawalAmountsExceedAccountBalances @era) 3 !> To x
+      DirectDepositsToMissingAccounts x -> Sum (DirectDepositsToMissingAccounts @era) 4 !> To x
 
 instance
   ( Era era
@@ -108,11 +103,10 @@ instance
   where
   decCBOR = decode . Summands "EntitiesPredFailure" $ \case
     0 -> SumD CertsFailure <! From
-    1 -> SumD WdrlNotDelegatedToDRep <! From
-    2 -> SumD WithdrawalsMissingAccounts <! From
-    3 -> SumD IncompleteWithdrawals <! From
-    4 -> SumD WithdrawalAmountsExceedAccountBalances <! From
-    5 -> SumD DirectDepositsToMissingAccounts <! From
+    1 -> SumD WithdrawalsMissingAccounts <! From
+    2 -> SumD IncompleteWithdrawals <! From
+    3 -> SumD WithdrawalAmountsExceedAccountBalances <! From
+    4 -> SumD DirectDepositsToMissingAccounts <! From
     n -> Invalid n
 
 newtype EntitiesEvent era = CertsEvent (Event (EraRule "CERTS" era))
@@ -194,8 +188,6 @@ dijkstraEntitiesTransition = do
       withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
       accounts = certState ^. certDStateL . accountsL
 
-  runTest $ Conway.validateWithdrawalsDelegated accounts tx
-
   network <- liftSTS $ asks networkId
 
   validateWithdrawals legacyMode network withdrawals accounts
@@ -245,7 +237,7 @@ validateWithdrawals legacyMode network withdrawals accounts = do
 conwayToDijkstraEntitiesPredFailure ::
   forall era. Conway.ConwayLedgerPredFailure era -> EntitiesPredFailure era
 conwayToDijkstraEntitiesPredFailure = \case
-  Conway.ConwayWdrlNotDelegatedToDRep khs -> WdrlNotDelegatedToDRep khs
+  Conway.ConwayWdrlNotDelegatedToDRep _ -> impossible "ConwayWdrlNotDelegatedToDRep"
   Conway.ConwayUtxowFailure _ -> impossible "ConwayUtxowFailure"
   Conway.ConwayCertsFailure _ -> impossible "ConwayCertsFailure"
   Conway.ConwayGovFailure _ -> impossible "ConwayGovFailure"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -221,9 +221,9 @@ instance
       DijkstraUtxowFailure x -> Sum (DijkstraUtxowFailure @era) 1 !> To x
       DijkstraEntitiesFailure x -> Sum (DijkstraEntitiesFailure @era) 2 !> To x
       DijkstraGovFailure x -> Sum (DijkstraGovFailure @era) 3 !> To x
-      DijkstraTreasuryValueMismatch mm -> Sum (DijkstraTreasuryValueMismatch @era) 5 !> To mm
-      DijkstraTxRefScriptsSizeTooBig mm -> Sum DijkstraTxRefScriptsSizeTooBig 6 !> To mm
-      DijkstraSubLedgersFailure w -> Sum DijkstraSubLedgersFailure 9 !> To w
+      DijkstraTreasuryValueMismatch mm -> Sum (DijkstraTreasuryValueMismatch @era) 4 !> To mm
+      DijkstraTxRefScriptsSizeTooBig mm -> Sum DijkstraTxRefScriptsSizeTooBig 5 !> To mm
+      DijkstraSubLedgersFailure w -> Sum DijkstraSubLedgersFailure 6 !> To w
 
 instance
   ( Era era
@@ -238,9 +238,9 @@ instance
     1 -> SumD DijkstraUtxowFailure <! From
     2 -> SumD DijkstraEntitiesFailure <! From
     3 -> SumD DijkstraGovFailure <! From
-    5 -> SumD DijkstraTreasuryValueMismatch <! From
-    6 -> SumD DijkstraTxRefScriptsSizeTooBig <! From
-    9 -> SumD DijkstraSubLedgersFailure <! From
+    4 -> SumD DijkstraTreasuryValueMismatch <! From
+    5 -> SumD DijkstraTxRefScriptsSizeTooBig <! From
+    6 -> SumD DijkstraSubLedgersFailure <! From
     n -> Invalid n
 
 data DijkstraLedgerEvent era
@@ -491,7 +491,7 @@ conwayToDijkstraLedgerPredFailure = \case
   Conway.ConwayUtxowFailure f -> DijkstraUtxowFailure f
   Conway.ConwayCertsFailure f -> DijkstraEntitiesFailure (CertsFailure f)
   Conway.ConwayGovFailure f -> DijkstraGovFailure f
-  Conway.ConwayWdrlNotDelegatedToDRep kh -> DijkstraEntitiesFailure (WdrlNotDelegatedToDRep kh)
+  Conway.ConwayWdrlNotDelegatedToDRep _ -> error "Impossible: WdrlNotDelegatedToDRep has been removed in Dijkstra"
   Conway.ConwayTreasuryValueMismatch mm -> DijkstraTreasuryValueMismatch mm
   Conway.ConwayTxRefScriptsSizeTooBig mm -> DijkstraTxRefScriptsSizeTooBig mm
   Conway.ConwayMempoolFailure _ -> error "Impossible: MempoolFailure has been moved to MEMPOOL rule in Dijkstra"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -34,11 +34,9 @@ import Cardano.Ledger.Dijkstra.Rules.SubCerts (
   SubCertsEnv (..),
  )
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody, directDepositsTxBodyL)
-import Cardano.Ledger.Rules.ValidationMode (runTest)
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
-import Data.List.NonEmpty (NonEmpty)
 import Data.Map.NonEmpty (NonEmptyMap)
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
@@ -48,7 +46,6 @@ import Lens.Micro
 
 data SubEntitiesPredFailure era
   = SubCertsFailure (PredicateFailure (EraRule "SUBCERTS" era))
-  | SubWdrlNotDelegatedToDRep (NonEmpty (KeyHash Staking))
   | SubWithdrawalsMissingAccounts Withdrawals
   | SubWithdrawalAmountsExceedAccountBalances (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
   | SubDirectDepositsToMissingAccounts DirectDeposits
@@ -73,10 +70,9 @@ instance
   encCBOR =
     encode . \case
       SubCertsFailure x -> Sum (SubCertsFailure @era) 0 !> To x
-      SubWdrlNotDelegatedToDRep x -> Sum (SubWdrlNotDelegatedToDRep @era) 1 !> To x
-      SubWithdrawalsMissingAccounts x -> Sum (SubWithdrawalsMissingAccounts @era) 2 !> To x
-      SubWithdrawalAmountsExceedAccountBalances x -> Sum (SubWithdrawalAmountsExceedAccountBalances @era) 3 !> To x
-      SubDirectDepositsToMissingAccounts x -> Sum (SubDirectDepositsToMissingAccounts @era) 4 !> To x
+      SubWithdrawalsMissingAccounts x -> Sum (SubWithdrawalsMissingAccounts @era) 1 !> To x
+      SubWithdrawalAmountsExceedAccountBalances x -> Sum (SubWithdrawalAmountsExceedAccountBalances @era) 2 !> To x
+      SubDirectDepositsToMissingAccounts x -> Sum (SubDirectDepositsToMissingAccounts @era) 3 !> To x
 
 instance
   ( Era era
@@ -86,10 +82,9 @@ instance
   where
   decCBOR = decode . Summands "SubEntitiesPredFailure" $ \case
     0 -> SumD SubCertsFailure <! From
-    1 -> SumD SubWdrlNotDelegatedToDRep <! From
-    2 -> SumD SubWithdrawalsMissingAccounts <! From
-    3 -> SumD SubWithdrawalAmountsExceedAccountBalances <! From
-    4 -> SumD SubDirectDepositsToMissingAccounts <! From
+    1 -> SumD SubWithdrawalsMissingAccounts <! From
+    2 -> SumD SubWithdrawalAmountsExceedAccountBalances <! From
+    3 -> SumD SubDirectDepositsToMissingAccounts <! From
     n -> Invalid n
 
 newtype SubEntitiesEvent era = SubCertsEvent (Event (EraRule "SUBCERTS" era))
@@ -160,8 +155,6 @@ dijkstraSubEntitiesTransition = do
       withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
       accounts = certState ^. certDStateL . accountsL
 
-  runTest $ Conway.validateWithdrawalsDelegated accounts tx
-
   network <- liftSTS $ asks networkId
   let (missingWithdrawals, exceededWithdrawals) =
         case withdrawalsThatExceedAccountBalance withdrawals network accounts of
@@ -189,7 +182,7 @@ dijkstraSubEntitiesTransition = do
 conwayToDijkstraSubEntitiesPredFailure ::
   forall era. Conway.ConwayLedgerPredFailure era -> SubEntitiesPredFailure era
 conwayToDijkstraSubEntitiesPredFailure = \case
-  Conway.ConwayWdrlNotDelegatedToDRep khs -> SubWdrlNotDelegatedToDRep khs
+  Conway.ConwayWdrlNotDelegatedToDRep _ -> impossible "ConwayWdrlNotDelegatedToDRep"
   Conway.ConwayUtxowFailure _ -> impossible "ConwayUtxowFailure"
   Conway.ConwayCertsFailure _ -> impossible "ConwayCertsFailure"
   Conway.ConwayGovFailure _ -> impossible "ConwayGovFailure"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -369,7 +369,7 @@ conwayToDijkstraSubLedgerPredFailure = \case
   Conway.ConwayUtxowFailure f -> SubUtxowFailure (injectFailure @"SUBUTXOW" f)
   Conway.ConwayCertsFailure f -> SubEntitiesFailure (injectFailure @"SUBENTITIES" f)
   Conway.ConwayGovFailure f -> SubGovFailure (injectFailure @"SUBGOV" f)
-  Conway.ConwayWdrlNotDelegatedToDRep x -> SubEntitiesFailure (SubWdrlNotDelegatedToDRep x)
+  Conway.ConwayWdrlNotDelegatedToDRep _ -> error "Impossible: `ConwayWdrlNotDelegatedToDRep` for SUBLEDGER"
   Conway.ConwayWithdrawalsMissingAccounts x -> SubEntitiesFailure (SubWithdrawalsMissingAccounts x)
   Conway.ConwayTreasuryValueMismatch x -> SubTreasuryValueMismatch x
   Conway.ConwayTxRefScriptsSizeTooBig _ -> error "Impossible: `ConwayTxRefScriptsSizeTooBig` for SUBLEDGER"

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertsSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertsSpec.hs
@@ -45,7 +45,6 @@ spec = describe "CERTS" $ do
             WithdrawalsExceedAccountBalance @era $
               NE.singleton accountAddress $
                 Mismatch (Coin 20) mempty
-        , injectFailure (WdrlNotDelegatedToDRep [stakeKey])
         , injectFailure . WithdrawalsMissingAccounts @era $
             Withdrawals [(accountAddress, Coin 20)]
         ]
@@ -59,8 +58,7 @@ spec = describe "CERTS" $ do
                 .~ Withdrawals [(accountAddress, zero), (registeredAccountAddress, reward)]
       submitFailingTx
         tx2
-        [ injectFailure (WdrlNotDelegatedToDRep [stakeKey])
-        , injectFailure . WithdrawalsMissingAccounts @era $
+        [ injectFailure . WithdrawalsMissingAccounts @era $
             Withdrawals [(accountAddress, zero)]
         ]
 


### PR DESCRIPTION
# Description

* Remove `WdrlNotDelegatedToDRep` constructor from `EntitiesPredFailure`
* Remove `SubWdrlNotDelegatedToDRep` constructor from `SubEntitiesPredFailure`

Fixes #5910 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
