### PR TITLE
Fix `getProducedValue`  for Dijkstra

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
@@ -28,8 +28,7 @@ instance EraUTxO AllegraEra where
 
   getConsumedValue pp lookupKeyDeposit _ = getConsumedCoin pp lookupKeyDeposit
 
-  getProducedValue pp isRegPoolId txBody =
-    withTopTxLevelOnly txBody (shelleyProducedValue pp isRegPoolId)
+  getProducedValue = shelleyProducedValue
 
   getScriptsProvided _ tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -104,8 +104,7 @@ instance EraUTxO AlonzoEra where
 
   getConsumedValue = getConsumedMaryValue
 
-  getProducedValue pp isRegPoolId txBody =
-    withTopTxLevelOnly txBody (getProducedMaryValue pp isRegPoolId)
+  getProducedValue = getProducedMaryValue
 
   getScriptsProvided _ tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -47,8 +47,7 @@ instance EraUTxO BabbageEra where
 
   getConsumedValue = getConsumedMaryValue
 
-  getProducedValue pp isRegPoolId txBody =
-    withTopTxLevelOnly txBody (getProducedMaryValue pp isRegPoolId)
+  getProducedValue = getProducedMaryValue
 
   getScriptsProvided = getBabbageScriptsProvided
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -137,8 +137,7 @@ instance EraUTxO ConwayEra where
 
   getConsumedValue = getConsumedMaryValue
 
-  getProducedValue pp isRegPoolId txBody =
-    withTopTxLevelOnly txBody (conwayProducedValue pp isRegPoolId)
+  getProducedValue = conwayProducedValue
 
   getScriptsProvided = getBabbageScriptsProvided
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -31,9 +31,9 @@ import Cardano.Ledger.Babbage.UTxO (
  )
 import Cardano.Ledger.BaseTypes (inject)
 import Cardano.Ledger.Coin (Coin)
+import Cardano.Ledger.Conway.TxBody (conwayProposalsDeposits)
 import Cardano.Ledger.Conway.UTxO (
   conwayConsumed,
-  conwayProducedValue,
   getConwayMinFeeTxUtxo,
   getConwayScriptsNeeded,
   getConwayWitsVKeyNeeded,
@@ -91,6 +91,7 @@ getConsumedDijkstraValue pp lookupStakingDeposit lookupDRepDeposit utxo txBody =
         (topTxBody ^. subTransactionsTxBodyL)
 
 dijkstraProducedValue ::
+  forall era.
   ( DijkstraEraTxBody era
   , EraUTxO era
   , Value era ~ MaryValue
@@ -99,11 +100,23 @@ dijkstraProducedValue ::
   (KeyHash StakePool -> Bool) ->
   TxBody TopTx era ->
   MaryValue
-dijkstraProducedValue pp isRegPoolId txBody =
-  conwayProducedValue pp isRegPoolId txBody
-    <> foldMap'
-      (getProducedValue pp isRegPoolId . view bodyTxL)
-      (txBody ^. subTransactionsTxBodyL)
+dijkstraProducedValue pp isRegPoolId topTxBody =
+  commonProduced topTxBody
+    <> foldMap' (commonProduced . (^. bodyTxL)) subTxs
+    <> inject (topTxBody ^. feeTxBodyL)
+    <> inject (getTotalDepositsTxCerts pp isRegPoolId batchTxCerts)
+  where
+    -- add all produced values that are common across transaction levels
+    commonProduced :: TxBody l era -> MaryValue
+    commonProduced txBody =
+      sumAllValue (txBody ^. outputsTxBodyL)
+        <> inject (txBody ^. treasuryDonationTxBodyL)
+        <> inject (conwayProposalsDeposits pp txBody)
+        <> burnedMultiAssets txBody
+    batchTxCerts =
+      foldMap' (^. bodyTxL . certsTxBodyL) subTxs
+        <> (topTxBody ^. certsTxBodyL)
+    subTxs = topTxBody ^. subTransactionsTxBodyL
 
 getProducedDijkstraValue ::
   ( STxLevel l era ~ STxBothLevels l era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -118,22 +118,6 @@ dijkstraProducedValue pp isRegPoolId topTxBody =
         <> (topTxBody ^. certsTxBodyL)
     subTxs = topTxBody ^. subTransactionsTxBodyL
 
-getProducedDijkstraValue ::
-  ( STxLevel l era ~ STxBothLevels l era
-  , DijkstraEraTxBody era
-  , EraUTxO era
-  , Value era ~ MaryValue
-  ) =>
-  PParams era ->
-  (KeyHash StakePool -> Bool) ->
-  TxBody l era ->
-  MaryValue
-getProducedDijkstraValue pp isRegPoolId txBody =
-  withBothTxLevels
-    txBody
-    (dijkstraProducedValue pp isRegPoolId)
-    (dijkstraSubTxProducedValue pp isRegPoolId)
-
 instance EraUTxO DijkstraEra where
   type ScriptsNeeded DijkstraEra = AlonzoScriptsNeeded DijkstraEra
 
@@ -141,7 +125,7 @@ instance EraUTxO DijkstraEra where
 
   getConsumedValue = getConsumedDijkstraValue
 
-  getProducedValue = getProducedDijkstraValue
+  getProducedValue = dijkstraProducedValue
 
   getScriptsProvided = getDijkstraScriptsProvided
 
@@ -261,17 +245,6 @@ instance DijkstraEraUTxO DijkstraEra where
 subTransactionsDijkstraStAnnTx ::
   DijkstraStAnnTx TopTx era -> [DijkstraStAnnTx SubTx era]
 subTransactionsDijkstraStAnnTx DijkstraStAnnTopTx {dsattSubTransactions} = dsattSubTransactions
-
-dijkstraSubTxProducedValue ::
-  (ConwayEraTxBody era, Value era ~ MaryValue) =>
-  PParams era ->
-  (KeyHash StakePool -> Bool) ->
-  TxBody SubTx era ->
-  Value era
-dijkstraSubTxProducedValue pp isRegPoolId txBody =
-  sumAllValue (txBody ^. outputsTxBodyL)
-    <> inject (getTotalDepositsTxBody pp isRegPoolId txBody <> txBody ^. treasuryDonationTxBodyL)
-    <> burnedMultiAssets txBody
 
 -- | Total size of reference scripts across a top-level transaction and all its subtransactions.
 batchNonDistinctRefScriptsSize ::

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -1,33 +1,39 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec (spec) where
 
-import Cardano.Ledger.Address (Addr (..))
-import Cardano.Ledger.BaseTypes (Inject (..), Network (..), StrictMaybe (..))
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
-import Cardano.Ledger.Dijkstra.Core (
-  BabbageEraTxBody (..),
-  EraTx (..),
-  EraTxBody (..),
-  EraTxOut (..),
-  InjectRuleFailure (..),
- )
+import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Rules (DijkstraUtxoPredFailure (..))
-import Cardano.Ledger.Tools (ensureMinCoinTxOut)
-import Lens.Micro ((&), (.~))
-import Test.Cardano.Ledger.Dijkstra.ImpTest (
-  DijkstraEraImp,
-  ImpInit,
-  LedgerSpec,
-  freshKeyHash,
-  getsPParams,
-  submitFailingTx,
+import Cardano.Ledger.Mary.Value (
+  AssetName,
+  MaryValue (..),
+  MultiAsset,
+  PolicyID,
+  multiAssetFromList,
  )
-import Test.Cardano.Ledger.Imp.Common (SpecWith, arbitrary, describe, it)
+import Cardano.Ledger.Shelley.LedgerState (
+  esLStateL,
+  lsCertStateL,
+  nesEsL,
+ )
+import Cardano.Ledger.Shelley.UTxO (produced)
+import Cardano.Ledger.Tools (ensureMinCoinTxOut)
+import Cardano.Ledger.TxIn (TxIn)
+import Cardano.Ledger.Val
+import Data.Typeable (Typeable)
+import Lens.Micro ((&), (.~), (^.))
+import Test.Cardano.Ledger.Dijkstra.ImpTest
+import Test.Cardano.Ledger.Imp.Common
 
 spec ::
   forall era.
@@ -46,3 +52,144 @@ spec = describe "UTXO" $ do
           mkBasicTx mkBasicTxBody
             & bodyTxL . collateralReturnTxBodyL .~ SJust ptrOutput
       submitFailingTx tx [injectFailure $ PtrPresentInCollateralReturn ptrOutput]
+
+  describe "value produced by a transaction" $ do
+    it "counts each new pool deposit at most once across the batch" $ do
+      poolDeposit <- (Coin 1 <>) <$> arbitrary
+      modifyPParams $ ppPoolDepositL .~ poolDeposit
+      cert <- RegPoolTxCert <$> arbitrary
+      txIn1 <- arbitrary
+      txIn2 <- arbitrary
+      let topTx =
+            mkBasicTx $
+              mkBasicTxBody
+                & certsTxBodyL .~ [cert]
+                -- distinguish subs by an input
+                & subTransactionsTxBodyL .~ [mkSubTx txIn1 cert, mkSubTx txIn2 cert]
+      pp <- getsPParams id
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      -- just the pool deposits are in `produced` because the transaction is not fixed up
+      produced pp certState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
+
+    it "counts distinct pool deposits in top and sub separately" $ do
+      poolDeposit <- (Coin 1 <>) <$> arbitrary
+      modifyPParams $ ppPoolDepositL .~ poolDeposit
+      poolA <- RegPoolTxCert <$> arbitrary
+      poolB <- RegPoolTxCert <$> arbitrary
+      txIn1 <- arbitrary
+      txIn2 <- arbitrary
+      txIn3 <- arbitrary
+      let topTx =
+            mkBasicTx $
+              mkBasicTxBody
+                & certsTxBodyL .~ [poolB, poolA, poolB]
+                & subTransactionsTxBodyL .~ [mkSubTx txIn1 poolA, mkSubTx txIn2 poolA, mkSubTx txIn3 poolB]
+      pp <- getsPParams id
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      produced pp certState (topTx ^. bodyTxL) `shouldBe` inject ((2 :: Int) <×> poolDeposit)
+
+    it "includes sub-tx cert deposits when top has no certs" $ do
+      poolDeposit <- (Coin 1 <>) <$> arbitrary
+      modifyPParams $ ppPoolDepositL .~ poolDeposit
+      poolParams <- arbitrary
+      let subTx = mkBasicTx $ mkBasicTxBody & certsTxBodyL .~ [RegPoolTxCert poolParams]
+          topTx =
+            mkBasicTx $
+              mkBasicTxBody
+                & subTransactionsTxBodyL .~ [subTx]
+      pp <- getsPParams id
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      produced pp certState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
+
+    it "does not count re-registrations of an already-registered pool across the batch" $ do
+      poolDeposit <- (Coin 1 <>) <$> arbitrary
+      modifyPParams $ ppPoolDepositL .~ poolDeposit
+      kh <- freshKeyHash
+      poolParams <- registerAccountAddress >>= freshPoolParams kh
+      let cert = RegPoolTxCert poolParams
+          regTx :: forall l. Typeable l => Tx l era
+          regTx = mkBasicTx $ mkBasicTxBody & certsTxBodyL .~ [cert]
+          topTx = regTx & bodyTxL . subTransactionsTxBodyL .~ [regTx :: Tx SubTx era]
+      submitTx_ (regTx :: Tx TopTx era)
+      pp <- getsPParams id
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      produced pp certState (topTx ^. bodyTxL) `shouldBe` mempty
+
+    it "dedupes across multiple subtransactions registering the same fresh pool" $ do
+      poolDeposit <- (Coin 1 <>) <$> arbitrary
+      modifyPParams $ ppPoolDepositL .~ poolDeposit
+      cert <- RegPoolTxCert <$> arbitrary
+      txInA <- arbitrary @TxIn
+      txInB <- arbitrary @TxIn
+      let topTx =
+            mkBasicTx $
+              mkBasicTxBody
+                & subTransactionsTxBodyL
+                  .~ [mkSubTx txInA cert, mkSubTx txInB cert]
+      pp <- getsPParams id
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      produced pp certState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
+
+    it "sums outputs, fee, treasury donations, pool/DRep deposits and burned assets across the batch" $ do
+      poolDeposit <- (Coin 1 <>) <$> arbitrary
+      drepDeposit <- (Coin 1 <>) <$> arbitrary
+      modifyPParams $ (ppPoolDepositL .~ poolDeposit) . (ppDRepDepositL .~ drepDeposit)
+      poolParams <- arbitrary
+      drepA <- arbitrary
+      drepB <- arbitrary
+      topAddr <- arbitrary
+      subAddr <- arbitrary
+      policyA <- arbitrary @PolicyID
+      asset <- arbitrary @AssetName
+      topOutValue <- arbitrary
+      subOutValue <- arbitrary
+      topFee <- arbitrary
+      topTreasury <- arbitrary
+      subTreasury <- arbitrary
+      topBurnAmount <- getPositive <$> arbitrary
+      subBurnAmount <- getPositive <$> arbitrary
+      let topMint = multiAssetFromList [(policyA, asset, -topBurnAmount)]
+          subMint = multiAssetFromList [(policyA, asset, -subBurnAmount)]
+          expectedBurned :: MultiAsset
+          expectedBurned =
+            multiAssetFromList
+              [ (policyA, asset, topBurnAmount + subBurnAmount)
+              ]
+          regPool :: TxCert era
+          regPool = RegPoolTxCert poolParams
+          topOut = mkBasicTxOut topAddr (inject topOutValue)
+          subOut = mkBasicTxOut subAddr (inject subOutValue)
+          subTx :: Tx SubTx era
+          subTx =
+            mkBasicTx $
+              mkBasicTxBody
+                & outputsTxBodyL .~ [subOut]
+                & certsTxBodyL
+                  .~ [regPool, RegDRepTxCert drepB drepDeposit SNothing]
+                & treasuryDonationTxBodyL .~ subTreasury
+                & mintTxBodyL .~ subMint
+          topTx :: Tx TopTx era
+          topTx =
+            mkBasicTx $
+              mkBasicTxBody
+                & outputsTxBodyL .~ [topOut]
+                & feeTxBodyL .~ topFee
+                & certsTxBodyL
+                  .~ [regPool, RegDRepTxCert drepA drepDeposit SNothing]
+                & treasuryDonationTxBodyL .~ topTreasury
+                & mintTxBodyL .~ topMint
+                & subTransactionsTxBodyL .~ [subTx]
+          expectedCoin =
+            topOutValue
+              <> subOutValue
+              <> topFee
+              <> topTreasury
+              <> subTreasury
+              <> poolDeposit
+              <> ((2 :: Int) <×> drepDeposit)
+          expected = MaryValue expectedCoin expectedBurned
+      pp <- getsPParams id
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      produced pp certState (topTx ^. bodyTxL) `shouldBe` expected
+  where
+    mkSubTx i cert = mkBasicTx $ mkBasicTxBody & certsTxBodyL .~ [cert] & inputsTxBodyL .~ [i]

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -44,8 +44,7 @@ instance EraUTxO MaryEra where
 
   getConsumedValue = getConsumedMaryValue
 
-  getProducedValue pp isRegPoolId txBody =
-    withTopTxLevelOnly txBody (getProducedMaryValue pp isRegPoolId)
+  getProducedValue = getProducedMaryValue
 
   getScriptsProvided _ tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Restrict `produced` to `TxBody TopTx era`.
 * Add `defaultApplyTxWithValidation` and `defaultReapplyValidatedTx` helpers to `Mempool` module
 * Deprecate:
   - `Validated`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -132,7 +132,7 @@ produced ::
   (EraUTxO era, EraCertState era) =>
   PParams era ->
   CertState era ->
-  TxBody l era ->
+  TxBody TopTx era ->
   Value era
 produced pp certState =
   getProducedValue pp (flip Map.member $ certState ^. certPStateL . psStakePoolsL)
@@ -177,8 +177,7 @@ instance EraUTxO ShelleyEra where
 
   getConsumedValue pp lookupKeyDeposit _ = getConsumedCoin pp lookupKeyDeposit
 
-  getProducedValue pp isRegPoolId txBody =
-    withTopTxLevelOnly txBody (shelleyProducedValue pp isRegPoolId)
+  getProducedValue = shelleyProducedValue
 
   getScriptsProvided _ tx = ScriptsProvided (tx ^. witsTxL . scriptTxWitsL)
 

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Version history for `cardano-ledger-api`
 
-## 1.13.1.0
+## 1.14.0.0
 
+* Restrict `evalBalanceTxBody` to `TxBody TopTx era`.
 * Rename `AnyEraRewardingPurpose` to `AnyEraWithdrawingPurpose` and `anyEraToRewardingPurpose` to `anyEraToWithdrawingPurpose`, deprecating the old names
 * Re-export the new `pattern WithdrawingPurpose` and `toWithdrawingPurpose`
 * Add `generate-cbor` executable.

--- a/libs/cardano-ledger-api/cardano-ledger-api.cabal
+++ b/libs/cardano-ledger-api/cardano-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-api
-version: 1.13.1.0
+version: 1.14.0.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
@@ -333,7 +333,7 @@ evalBalanceTxBody ::
   -- | The UTxO relevant to the transaction.
   UTxO era ->
   -- | The transaction being evaluated for balance.
-  TxBody l era ->
+  TxBody TopTx era ->
   -- | The difference between what the transaction consumes and what it produces.
   Value era
 evalBalanceTxBody pp lookupKeyRefund lookupDRepRefund isRegPoolId utxo txBody =

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Restrict `getProducedValue` to `TxBody TopTx era`.
 * Remove `Semigroup` and `Monoid` instances for `CostModels`
 * Change `updateCostModels` to take `CostModelsUpdate` as its second argument
 * Add `CostModelsUpdate`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
@@ -261,7 +261,7 @@ class EraTx era => EraUTxO era where
     PParams era ->
     -- | Check whether a pool with a supplied PoolStakeId is already registered.
     (KeyHash StakePool -> Bool) ->
-    TxBody t era ->
+    TxBody TopTx era ->
     Value era
 
   -- | Initial eras will look into witness set to find all of the available scripts, but


### PR DESCRIPTION
# Description

Currently on master there is a problem with `getProducedValue` implementation for Dijkstra: 
in order to determine whether the deposit of a pool registration certificate should contribute to the `produced` value (namely: NOT, if it's a duplicate certificate or a re-registration, YES otherwise), we examine only the list of certificates that are "local" to that particular top-level or subtransaction. Then we add the deposits of the top-level and subtransactions. 
However, in order to correctly de-duplicate across the whole batch (such that, for example, re-registrations are not counted twice), we need to look at the whole list of certificates from both levels when determining the sum of the deposits. 

To accomplish this, I chose to: 
 1) reimplement `getDijkstraValue` in a way that doesn't call itself for the produced value of the subtransactions
 2) restrict the transaction level of  `getProducedValue` to Top only (instead of being polymorphic in the level as it is now).

## Alternative considered
Keep the recursion, and only modify the function calculating the deposits, like this:

```
instance EraTxBody DijkstraEra where
  getTotalDepositsTxBody = dijkstraTotalDepositsTxBody

dijkstraTotalDepositsTxBody pp isPoolRegisted txBody =
  withBothTxLevels
    txBody
    ( \t ->
        getTotalDepositsTxCerts
          pp
          isPoolRegisted
          (t ^. certsTxBodyL <> foldMap (^. bodyTxL . certsTxBodyL) (t ^. subTransactionsTxBodyL))
    )
    mempty
    <+> conwayProposalsDeposits pp txBody
``` 

The problem with this is: to include certs of subtransaction in the argument of `getTotalDepositsTxCerts`, we need `bodyTxL`, which is a method of `EraTx`.
Requiring `EraTx` inside an `EraTxBody` method creates a cycle (because `EraTxBody => EraTx`)

Even if the cycle could be broken, for the produced value for the whole batch to be correct, the certs argument of `getTotalDepositsTxCerts` for subtransactions has to be an empty list. 
This would lead to a correct end result (produced), but calling produced on a subtransaction would still be possible and produce the incorrect value. 
I believe it's better to only support `produced` for top level transactions, since it's the only type for which we can produce a correct calculation.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
