### PR TITLE
Adjust `consumed` and `produced` interface

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxCert.hs
@@ -36,7 +36,7 @@ instance EraTxCert AllegraEra where
 
   getTotalDepositsTxCerts = shelleyTotalDepositsTxCerts
 
-  getTotalRefundsTxCerts pp lookupStakeDeposit _ = shelleyTotalRefundsTxCerts pp lookupStakeDeposit
+  getTotalRefundsTxCerts = shelleyTotalRefundsTxCerts
 
 instance ShelleyEraTxCert AllegraEra where
   mkRegTxCert = ShelleyTxCertDelegCert . ShelleyRegCert

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
@@ -15,7 +15,6 @@ import Cardano.Ledger.Shelley.UTxO (
   getShelleyMinFeeTxUtxo,
   getShelleyScriptsNeeded,
   getShelleyWitsVKeyNeeded,
-  shelleyConsumed,
   shelleyProducedValue,
  )
 import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided (..))
@@ -23,8 +22,6 @@ import Lens.Micro
 
 instance EraUTxO AllegraEra where
   type ScriptsNeeded AllegraEra = ShelleyScriptsNeeded AllegraEra
-
-  consumed = shelleyConsumed
 
   getConsumedValue pp lookupKeyDeposit = getConsumedCoin pp lookupKeyDeposit
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
@@ -26,7 +26,7 @@ instance EraUTxO AllegraEra where
 
   consumed = shelleyConsumed
 
-  getConsumedValue pp lookupKeyDeposit _ = getConsumedCoin pp lookupKeyDeposit
+  getConsumedValue pp lookupKeyDeposit = getConsumedCoin pp lookupKeyDeposit
 
   getProducedValue = shelleyProducedValue
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxBody.hs
@@ -165,7 +165,7 @@ data AlonzoTxBodyRaw l era where
     , atbrTxFee :: !Coin
     , atbrValidityInterval :: !ValidityInterval
     , atbrUpdate :: !(StrictMaybe (Update era))
-    , atbrReqSignerHashes :: Set (KeyHash Guard)
+    , atbrReqSignerHashes :: !(Set (KeyHash Guard))
     , atbrMint :: !MultiAsset
     , atbrScriptIntegrityHash :: !(StrictMaybe ScriptIntegrityHash)
     , atbrAuxDataHash :: !(StrictMaybe TxAuxDataHash)

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxCert.hs
@@ -36,7 +36,7 @@ instance EraTxCert AlonzoEra where
 
   getTotalDepositsTxCerts = shelleyTotalDepositsTxCerts
 
-  getTotalRefundsTxCerts pp lookupStakeDeposit _ = shelleyTotalRefundsTxCerts pp lookupStakeDeposit
+  getTotalRefundsTxCerts = shelleyTotalRefundsTxCerts
 
 instance ShelleyEraTxCert AlonzoEra where
   mkRegTxCert = ShelleyTxCertDelegCert . ShelleyRegCert

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -65,7 +65,6 @@ import Cardano.Ledger.Plutus.Data (Data, Datum (..))
 import Cardano.Ledger.Shelley.UTxO (
   getShelleyMinFeeTxUtxo,
   getShelleyWitsVKeyNeeded,
-  shelleyConsumed,
  )
 import Cardano.Ledger.State (
   EraCertState (..),
@@ -99,8 +98,6 @@ deriving instance AlonzoEraScript era => NFData (AlonzoScriptsNeeded era)
 
 instance EraUTxO AlonzoEra where
   type ScriptsNeeded AlonzoEra = AlonzoScriptsNeeded AlonzoEra
-
-  consumed = shelleyConsumed
 
   getConsumedValue = getConsumedMaryValue
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxCert.hs
@@ -36,7 +36,7 @@ instance EraTxCert BabbageEra where
 
   getTotalDepositsTxCerts = shelleyTotalDepositsTxCerts
 
-  getTotalRefundsTxCerts pp lookupStakeDeposit _ = shelleyTotalRefundsTxCerts pp lookupStakeDeposit
+  getTotalRefundsTxCerts = shelleyTotalRefundsTxCerts
 
 instance ShelleyEraTxCert BabbageEra where
   mkRegTxCert = ShelleyTxCertDelegCert . ShelleyRegCert

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -30,7 +30,7 @@ import Cardano.Ledger.BaseTypes (StrictMaybe (..), strictMaybeToMaybe)
 import Cardano.Ledger.Binary (sizedValue)
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue, getProducedMaryValue)
 import Cardano.Ledger.Plutus.Data (Data)
-import Cardano.Ledger.Shelley.UTxO (getShelleyMinFeeTxUtxo, shelleyConsumed)
+import Cardano.Ledger.Shelley.UTxO (getShelleyMinFeeTxUtxo)
 import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided (..), UTxO (..))
 import Cardano.Ledger.TxIn (TxIn)
 import Control.Applicative
@@ -42,8 +42,6 @@ import Lens.Micro
 
 instance EraUTxO BabbageEra where
   type ScriptsNeeded BabbageEra = AlonzoScriptsNeeded BabbageEra
-
-  consumed = shelleyConsumed
 
   getConsumedValue = getConsumedMaryValue
 

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.23.0.0
 
+* Remove `conwayCertsTotalRefundsTxBody` and `conwayConsumed`
 * Remove an unnecessary argument to `conwayDRepRefundsTxCerts` function.
 * Allow any tx level in `updateDormantDRepExpiries` and `updateVotingDRepExpiries`
 * Rename `ConwayRewarding` to `ConwayWithdrawing` and deprecate the old name

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.23.0.0
 
+* Remove an unnecessary argument to `conwayDRepRefundsTxCerts` function.
 * Allow any tx level in `updateDormantDRepExpiries` and `updateVotingDRepExpiries`
 * Rename `ConwayRewarding` to `ConwayWithdrawing` and deprecate the old name
 * Rename rule types and deprecate the old names:

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Governance.hs
@@ -566,9 +566,9 @@ defaultStakePoolVote ::
   -- | Delegations of staking credneitals to a DRep
   Accounts era ->
   DefaultVote
-defaultStakePoolVote poolId poolParams accounts =
+defaultStakePoolVote poolId stakePools accounts =
   toDefaultVote $ do
-    spp <- Map.lookup poolId poolParams
+    spp <- Map.lookup poolId stakePools
     accountState <- Map.lookup (unAccountId (spsAccountId spp)) (accounts ^. accountsMapL)
     accountState ^. dRepDelegationAccountStateL
   where

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/CertState.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/CertState.hs
@@ -23,7 +23,6 @@ module Cardano.Ledger.Conway.State.CertState (
   conwayCertVStateL,
   conwayObligationCertState,
   conwayCertsTotalDepositsTxBody,
-  conwayCertsTotalRefundsTxBody,
 ) where
 
 import Cardano.Ledger.BaseTypes (KeyValuePairs (..), ToKeyValuePairs (..))
@@ -121,14 +120,6 @@ conwayCertsTotalDepositsTxBody ::
 conwayCertsTotalDepositsTxBody pp ConwayCertState {conwayCertPState} =
   getTotalDepositsTxBody pp (`Map.member` psStakePools conwayCertPState)
 
-conwayCertsTotalRefundsTxBody ::
-  (EraTxBody era, EraAccounts era) => PParams era -> ConwayCertState era -> TxBody l era -> Coin
-conwayCertsTotalRefundsTxBody pp ConwayCertState {conwayCertDState, conwayCertVState} =
-  getTotalRefundsTxBody
-    pp
-    (lookupDepositDState conwayCertDState)
-    (lookupDepositVState conwayCertVState)
-
 instance EraCertState ConwayEra where
   type CertState ConwayEra = ConwayCertState ConwayEra
 
@@ -142,7 +133,7 @@ instance EraCertState ConwayEra where
 
   certsTotalDepositsTxBody = conwayCertsTotalDepositsTxBody
 
-  certsTotalRefundsTxBody = conwayCertsTotalRefundsTxBody
+  certsTotalRefundsTxBody = shelleyCertsTotalRefundsTxBody
 
 instance ConwayEraCertState ConwayEra where
   certVStateL = conwayCertVStateL

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxBody.hs
@@ -355,8 +355,8 @@ instance EraTxBody ConwayEra where
 
   getTotalDepositsTxBody = conwayTotalDepositsTxBody
 
-  getTotalRefundsTxBody pp lookupStakingDeposit lookupDRepDeposit txBody =
-    getTotalRefundsTxCerts pp lookupStakingDeposit lookupDRepDeposit (txBody ^. certsTxBodyL)
+  getTotalRefundsTxBody pp lookupStakingDeposit txBody =
+    getTotalRefundsTxCerts pp lookupStakingDeposit (txBody ^. certsTxBodyL)
 
 -- ==========================================
 -- Deposits and Refunds for Conway TxBody

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -91,8 +91,7 @@ import Cardano.Ledger.Shelley.TxCert (
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
 import Data.Aeson (FromJSON (..), ToJSON (..), withObject, (.:?), (.=))
-import Data.Foldable as F (foldMap', foldl')
-import qualified Data.Map.Strict as Map
+import Data.Foldable as F (foldMap')
 import Data.Monoid (Sum (getSum))
 import GHC.Generics (Generic)
 import Lens.Micro
@@ -842,11 +841,9 @@ conwayTotalRefundsTxCerts ::
   PParams era ->
   -- | Function that can lookup current deposit, in case when the Staking credential is registered.
   (Credential Staking -> Maybe Coin) ->
-  -- | Function that can lookup current deposit, in case when the DRep credential is registered.
-  (Credential DRepRole -> Maybe Coin) ->
   f (TxCert era) ->
   Coin
-conwayTotalRefundsTxCerts pp lookupStakingDeposit _lookupDRepDeposit certs =
+conwayTotalRefundsTxCerts pp lookupStakingDeposit certs =
   shelleyTotalRefundsTxCerts pp lookupStakingDeposit certs
     <+> conwayDRepRefundsTxCerts certs
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxCert.hs
@@ -846,27 +846,16 @@ conwayTotalRefundsTxCerts ::
   (Credential DRepRole -> Maybe Coin) ->
   f (TxCert era) ->
   Coin
-conwayTotalRefundsTxCerts pp lookupStakingDeposit lookupDRepDeposit certs =
+conwayTotalRefundsTxCerts pp lookupStakingDeposit _lookupDRepDeposit certs =
   shelleyTotalRefundsTxCerts pp lookupStakingDeposit certs
-    <+> conwayDRepRefundsTxCerts lookupDRepDeposit certs
+    <+> conwayDRepRefundsTxCerts certs
 
 -- | Compute the Refunds from a TxBody, given a function that computes a partial Coin for
 -- known Credentials.
 conwayDRepRefundsTxCerts ::
   (Foldable f, ConwayEraTxCert era) =>
-  (Credential DRepRole -> Maybe Coin) ->
   f (TxCert era) ->
   Coin
-conwayDRepRefundsTxCerts lookupDRepDeposit = snd . F.foldl' go (Map.empty, Coin 0)
-  where
-    go accum@(!drepRegsInTx, !totalRefund) = \case
-      RegDRepTxCert cred deposit _ ->
-        -- Track registrations
-        (Map.insert cred deposit drepRegsInTx, totalRefund)
-      UnRegDRepTxCert cred _
-        -- DRep previously registered in the same tx.
-        | Just deposit <- Map.lookup cred drepRegsInTx ->
-            (Map.delete cred drepRegsInTx, totalRefund <+> deposit)
-        -- DRep previously registered in some other tx.
-        | Just deposit <- lookupDRepDeposit cred -> (drepRegsInTx, totalRefund <+> deposit)
-      _ -> accum
+conwayDRepRefundsTxCerts = foldMap' $ \case
+  UnRegDRepTxCert _ refund -> refund
+  _ -> mempty

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -10,7 +10,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.UTxO (
-  conwayConsumed,
   conwayProducedValue,
   getConwayWitsVKeyNeeded,
   getConwayScriptsNeeded,
@@ -52,7 +51,7 @@ import Cardano.Ledger.Credential (credKeyHashWitness, credScriptHash)
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue, getProducedMaryValue)
 import Cardano.Ledger.Mary.Value (MaryValue)
-import Cardano.Ledger.Shelley.UTxO (getShelleyWitsVKeyNeededNoGov)
+import Cardano.Ledger.Shelley.UTxO (getShelleyWitsVKeyNeededNoGov, shelleyConsumed)
 import Cardano.Ledger.Val (Val (..), inject)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
@@ -105,19 +104,6 @@ getConwayScriptsNeeded utxo txBody =
             TreasuryWithdrawals _ (SJust guardrailsScriptHash) -> Just guardrailsScriptHash
             _ -> Nothing
 
-conwayConsumed ::
-  (EraUTxO era, ConwayEraCertState era) =>
-  PParams era ->
-  CertState era ->
-  UTxO era ->
-  TxBody l era ->
-  Value era
-conwayConsumed pp certState =
-  getConsumedValue
-    pp
-    (lookupDepositDState $ certState ^. certDStateL)
-    (lookupDepositVState $ certState ^. certVStateL)
-
 conwayProducedValue ::
   ( ConwayEraTxBody era
   , Value era ~ MaryValue
@@ -133,7 +119,7 @@ conwayProducedValue pp isStakePool txBody =
 instance EraUTxO ConwayEra where
   type ScriptsNeeded ConwayEra = AlonzoScriptsNeeded ConwayEra
 
-  consumed = conwayConsumed
+  consumed = shelleyConsumed
 
   getConsumedValue = getConsumedMaryValue
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -51,7 +51,7 @@ import Cardano.Ledger.Credential (credKeyHashWitness, credScriptHash)
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue, getProducedMaryValue)
 import Cardano.Ledger.Mary.Value (MaryValue)
-import Cardano.Ledger.Shelley.UTxO (getShelleyWitsVKeyNeededNoGov, shelleyConsumed)
+import Cardano.Ledger.Shelley.UTxO (getShelleyWitsVKeyNeededNoGov)
 import Cardano.Ledger.Val (Val (..), inject)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes)
@@ -118,8 +118,6 @@ conwayProducedValue pp isStakePool txBody =
 
 instance EraUTxO ConwayEra where
   type ScriptsNeeded ConwayEra = AlonzoScriptsNeeded ConwayEra
-
-  consumed = shelleyConsumed
 
   getConsumedValue = getConsumedMaryValue
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
@@ -25,6 +25,7 @@ import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Plutus.Language (SLanguage (..))
 import Cardano.Ledger.Shelley.LedgerState
+import qualified Cardano.Ledger.Shelley.Rules as Shelley (ShelleyUtxoPredFailure (..))
 import Cardano.Ledger.Shelley.Scripts (
   pattern RequireSignature,
  )
@@ -117,7 +118,9 @@ spec = describe "UTXO" $ do
       let txAmount = Coin 2000000
       txIn <- sendCoinTo addr1 txAmount
       addr2 <- freshKeyAddr_
+      (_, rootTxOut) <- getImpRootTxOut
       let
+        rootTxOutValue = rootTxOut ^. valueTxOutL
         txBody =
           mkBasicTxBody
             & inputsTxBodyL .~ [txIn]
@@ -130,7 +133,12 @@ spec = describe "UTXO" $ do
       withPostFixup (updateAddrTxWits . addUnRegDRepTxCert) $
         submitFailingTx
           (mkBasicTx txBody)
-          [ injectFailure $ Conway.ConwayDRepNotRegistered dRepCred
+          [ injectFailure $
+              Shelley.ValueNotConservedUTxO $
+                Mismatch
+                  (rootTxOutValue <> inject txAmount <> inject dRepDeposit)
+                  (rootTxOutValue <> inject txAmount)
+          , injectFailure $ Conway.ConwayDRepNotRegistered dRepCred
           ]
   describe "Reference scripts" $ do
     let

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Imp/UtxoSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -19,6 +20,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.PParams (ppMinFeeRefScriptCostPerByteL)
+import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Conway.TxCert
 import Cardano.Ledger.Credential
 import Cardano.Ledger.Plutus.Language (SLanguage (..))
@@ -31,7 +33,7 @@ import Cardano.Ledger.State
 import Cardano.Ledger.Val
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Sequence.Strict as SSeq
-import Lens.Micro ((&), (.~), (^.))
+import Lens.Micro
 import Test.Cardano.Ledger.Conway.ImpTest
 import Test.Cardano.Ledger.Core.Rational ((%!))
 import Test.Cardano.Ledger.Imp.Common
@@ -107,6 +109,29 @@ spec = describe "UTXO" $ do
       passEpoch
       -- Check for successfull pool refund
       getBalance cred0 `shouldReturn` stakePoolDeposit
+    it "DRepNotRegistered" $ do
+      dRepCred <- KeyHashObj <$> freshKeyHash
+      -- Make sure deposit is positive
+      dRepDeposit <- (<> Coin 1) <$> arbitrary
+      addr1 <- freshKeyAddr_
+      let txAmount = Coin 2000000
+      txIn <- sendCoinTo addr1 txAmount
+      addr2 <- freshKeyAddr_
+      let
+        txBody =
+          mkBasicTxBody
+            & inputsTxBodyL .~ [txIn]
+            & outputsTxBodyL .~ [mkBasicTxOut addr2 mempty]
+        addUnRegDRepTxCert :: Tx TopTx era -> Tx TopTx era
+        addUnRegDRepTxCert tx =
+          tx
+            & bodyTxL . certsTxBodyL <>~ [UnRegDRepTxCert dRepCred dRepDeposit :: TxCert era]
+            & witsTxL .~ mkBasicTxWits
+      withPostFixup (updateAddrTxWits . addUnRegDRepTxCert) $
+        submitFailingTx
+          (mkBasicTx txBody)
+          [ injectFailure $ Conway.ConwayDRepNotRegistered dRepCred
+          ]
   describe "Reference scripts" $ do
     let
       nativeScript = RequireSignature @era <$> freshKeyHash

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -1804,18 +1804,19 @@ showConwayTxBalance pp certState utxo tx =
     , "\tDonations: \t" <> show (txBody ^. treasuryDonationTxBodyL)
     , "\tDeposits:  \t" <> show (getTotalDepositsTxBody pp isRegPoolId txBody)
     , "\tFees:      \t" <> show (txBody ^. feeTxBodyL)
-    , "\tTotal:     \t" <> show (coin $ produced pp certState txBody)
+    , "\tTotal:     \t" <> show (coin $ produced pp pState txBody)
     ]
   where
     txBody = tx ^. bodyTxL
     inputs = sumUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
     accounts = certState ^. certDStateL . accountsL
+    pState = certState ^. certPStateL
     refunds =
       getTotalRefundsTxBody
         pp
         (fmap (fromCompact . (^. depositAccountStateL)) . (`lookupAccountState` accounts))
         txBody
-    isRegPoolId = (`Map.member` (certState ^. certPStateL . psStakePoolsL))
+    isRegPoolId = (`Map.member` (pState ^. psStakePoolsL))
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
 
 logConwayTxBalance ::

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -1797,7 +1797,7 @@ showConwayTxBalance pp certState utxo tx =
     , "\tInputs:     \t" <> show (coin inputs)
     , "\tRefunds:    \t" <> show refunds
     , "\tWithdrawals \t" <> show withdrawals
-    , "\tTotal:      \t" <> (show . coin $ consumed pp certState utxo txBody)
+    , "\tTotal:      \t" <> (show . coin $ consumed pp accounts utxo txBody)
     , ""
     , "Produced:"
     , "\tOutputs:   \t" <> show (coin $ sumAllValue (txBody ^. outputsTxBodyL))
@@ -1809,11 +1809,11 @@ showConwayTxBalance pp certState utxo tx =
   where
     txBody = tx ^. bodyTxL
     inputs = sumUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
+    accounts = certState ^. certDStateL . accountsL
     refunds =
       getTotalRefundsTxBody
         pp
-        (lookupDepositDState $ certState ^. certDStateL)
-        (lookupDepositVState $ certState ^. certVStateL)
+        (fmap (fromCompact . (^. depositAccountStateL)) . (`lookupAccountState` accounts))
         txBody
     isRegPoolId = (`Map.member` (certState ^. certPStateL . psStakePoolsL))
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -1811,11 +1811,7 @@ showConwayTxBalance pp certState utxo tx =
     inputs = sumUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
     accounts = certState ^. certDStateL . accountsL
     pState = certState ^. certPStateL
-    refunds =
-      getTotalRefundsTxBody
-        pp
-        (fmap (fromCompact . (^. depositAccountStateL)) . (`lookupAccountState` accounts))
-        txBody
+    refunds = getTotalRefundsTxBody pp (`lookupAccountDeposit` accounts) txBody
     isRegPoolId = (`Map.member` (pState ^. psStakePoolsL))
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
 

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/ImpTest.hs
@@ -201,10 +201,10 @@ import Cardano.Ledger.Shelley.LedgerState (
   nesEsL,
   nesPdL,
   newEpochStateGovStateL,
-  produced,
   utxosGovStateL,
  )
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Cardano.Ledger.Shelley.UTxO (produced, shelleyConsumed)
 import Cardano.Ledger.TxIn (TxId (..))
 import Cardano.Ledger.Val (Val (..), (<->))
 import Control.Monad (forM)
@@ -1797,14 +1797,14 @@ showConwayTxBalance pp certState utxo tx =
     , "\tInputs:     \t" <> show (coin inputs)
     , "\tRefunds:    \t" <> show refunds
     , "\tWithdrawals \t" <> show withdrawals
-    , "\tTotal:      \t" <> (show . coin $ consumed pp accounts utxo txBody)
+    , "\tTotal:      \t" <> show (coin $ shelleyConsumed pp accounts utxo txBody)
     , ""
     , "Produced:"
     , "\tOutputs:   \t" <> show (coin $ sumAllValue (txBody ^. outputsTxBodyL))
     , "\tDonations: \t" <> show (txBody ^. treasuryDonationTxBodyL)
     , "\tDeposits:  \t" <> show (getTotalDepositsTxBody pp isRegPoolId txBody)
     , "\tFees:      \t" <> show (txBody ^. feeTxBodyL)
-    , "\tTotal:     \t" <> (show . coin $ produced pp certState txBody)
+    , "\tTotal:     \t" <> show (coin $ produced pp certState txBody)
     ]
   where
     txBody = tx ^. bodyTxL

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Revision history for cardano-ledger-dijkstra
+# Revision history for `cardano-ledger-dijkstra`
 
 ## 0.3.0.0
 

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0.0
 
+* Add `dijkstraConsumed` and `validateValueNotConservedUTxO`
 * Make `requiredTopLevelGuards` available on the top-level transaction body:
   - Change the type of `requiredTopLevelGuardsL` to `Lens' (TxBody l era) (Map (Credential Guard) (StrictMaybe (Data era)))`
   - Change the type of `requiredTopLevelGuardsDijkstraTxBodyRawL` to `Lens' (DijkstraTxBodyRaw l era) (Map (Credential Guard) (StrictMaybe (Data era)))`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -323,13 +323,13 @@ validateWrongNetworkInDirectDeposit netId txb =
 --
 -- > consumed pp utxo txb = produced pp poolParams txb
 validateValueNotConservedUTxO ::
-  (EraUTxO era, EraCertState era) =>
+  EraUTxO era =>
   PParams era ->
   UTxO era ->
-  CertState era ->
+  PState era ->
   TxBody TopTx era ->
   Test (Shelley.ShelleyUtxoPredFailure era)
-validateValueNotConservedUTxO pp utxo certState txBody =
+validateValueNotConservedUTxO pp utxo pState txBody =
   failureUnless (consumedValue == producedValue) $
     Shelley.ValueNotConservedUTxO
       Mismatch
@@ -338,7 +338,7 @@ validateValueNotConservedUTxO pp utxo certState txBody =
         }
   where
     consumedValue = dijkstraConsumed pp utxo txBody
-    producedValue = produced pp certState txBody
+    producedValue = produced pp pState txBody
 
 dijkstraUtxoTransition ::
   forall era.
@@ -371,6 +371,7 @@ dijkstraUtxoTransition = do
   let tx = stAnnTx ^. txStAnnTxG
   -- this is the original Accounts, before any transactions were applied
   let accounts = certState ^. certDStateL . accountsL
+  let originalPState = certState ^. certPStateL
 
   let txBody = tx ^. bodyTxL
 
@@ -403,7 +404,7 @@ dijkstraUtxoTransition = do
   runTest $ validateBatchWithdrawals accounts tx
 
   {- consumed pp utxo₀ txb = produced pp certState txb -}
-  runTest $ validateValueNotConservedUTxO pp originalUtxo certState txBody
+  runTest $ validateValueNotConservedUTxO pp originalUtxo originalPState txBody
 
   {- ∀ txout ∈ allOuts txb, getValue txout ≥ inject (serSize txout * coinsPerUTxOByte pp) -}
   let allSizedOutputs = txBody ^. allSizedOutputsTxBodyF

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -61,10 +61,12 @@ import Cardano.Ledger.Credential (StakeReference (..))
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra, UTXO)
 import Cardano.Ledger.Dijkstra.Rules.Utxos ()
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
+import Cardano.Ledger.Dijkstra.UTxO (dijkstraConsumed)
 import Cardano.Ledger.Plutus (ExUnits)
 import Cardano.Ledger.Rules.ValidationMode (Test, failOnJustStatic, runTest, runTestOnSignal)
 import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Cardano.Ledger.Shelley.UTxO (produced)
 import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.Monad (when)
@@ -90,6 +92,7 @@ import Data.Set.NonEmpty (NonEmptySet)
 import Data.Word (Word16, Word32)
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
+import Validation (failureUnless)
 
 data DijkstraUtxoEnv era = DijkstraUtxoEnv
   { dueSlot :: SlotNo
@@ -315,6 +318,28 @@ validateWrongNetworkInDirectDeposit netId txb =
           (\a _ -> aaNetworkId a /= netId)
           (unDirectDeposits $ txb ^. directDepositsTxBodyL)
 
+-- | Ensure that value consumed and produced matches up exactly,  aggregated across the entire batch
+-- (top-level transaction and all its sub-transactions).
+--
+-- > consumed pp utxo txb = produced pp poolParams txb
+validateValueNotConservedUTxO ::
+  (EraUTxO era, EraCertState era) =>
+  PParams era ->
+  UTxO era ->
+  CertState era ->
+  TxBody TopTx era ->
+  Test (Shelley.ShelleyUtxoPredFailure era)
+validateValueNotConservedUTxO pp utxo certState txBody =
+  failureUnless (consumedValue == producedValue) $
+    Shelley.ValueNotConservedUTxO
+      Mismatch
+        { mismatchSupplied = consumedValue
+        , mismatchExpected = producedValue
+        }
+  where
+    consumedValue = dijkstraConsumed pp utxo txBody
+    producedValue = produced pp certState txBody
+
 dijkstraUtxoTransition ::
   forall era.
   ( EraUTxO era
@@ -378,7 +403,7 @@ dijkstraUtxoTransition = do
   runTest $ validateBatchWithdrawals accounts tx
 
   {- consumed pp utxo₀ txb = produced pp certState txb -}
-  runTest $ Shelley.validateValueNotConservedUTxO pp originalUtxo certState txBody
+  runTest $ validateValueNotConservedUTxO pp originalUtxo certState txBody
 
   {- ∀ txout ∈ allOuts txb, getValue txout ≥ inject (serSize txout * coinsPerUTxOByte pp) -}
   let allSizedOutputs = txBody ^. allSizedOutputsTxBodyF

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
@@ -3,17 +3,7 @@
 
 module Cardano.Ledger.Dijkstra.State.CertState () where
 
-import Cardano.Ledger.Conway.State (
-  ConwayCertState,
-  ConwayEraCertState (..),
-  EraCertState (..),
-  conwayCertDStateL,
-  conwayCertPStateL,
-  conwayCertVStateL,
-  conwayCertsTotalDepositsTxBody,
-  conwayCertsTotalRefundsTxBody,
-  conwayObligationCertState,
- )
+import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Dijkstra.State.Account ()
 
@@ -30,7 +20,7 @@ instance EraCertState DijkstraEra where
 
   certsTotalDepositsTxBody = conwayCertsTotalDepositsTxBody
 
-  certsTotalRefundsTxBody = conwayCertsTotalRefundsTxBody
+  certsTotalRefundsTxBody = shelleyCertsTotalRefundsTxBody
 
 instance ConwayEraCertState DijkstraEra where
   certVStateL = conwayCertVStateL

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
@@ -985,8 +985,8 @@ instance
 
   getTotalDepositsTxBody = dijkstraTotalDepositsTxBody
 
-  getTotalRefundsTxBody pp lookupStakingDeposit lookupDRepDeposit txBody =
-    getTotalRefundsTxCerts pp lookupStakingDeposit lookupDRepDeposit (txBody ^. certsTxBodyL)
+  getTotalRefundsTxBody pp lookupStakingDeposit txBody =
+    getTotalRefundsTxCerts pp lookupStakingDeposit (txBody ^. certsTxBodyL)
 
 upgradeGovAction ::
   forall era.

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxCert.hs
@@ -225,7 +225,8 @@ instance Era era => EncCBOR (DijkstraTxCert era) where
     DijkstraTxCertPool poolCert -> encodePoolCert poolCert
     DijkstraTxCertGov govCert -> encCBOR govCert
 
--- | Unlike previous eras, we no longer need to lookup refunds from the ledger state, since all of the certificates specify the actual refund and ledger rules will validate that they are accurate.
+-- | Unlike previous eras, we no longer need to lookup refunds from the ledger state, since all of
+-- the certificates specify the actual refund and ledger rules will validate that they are accurate.
 dijkstraTotalRefundsTxCerts ::
   ( Foldable f
   , ConwayEraTxCert era
@@ -282,7 +283,7 @@ instance EraTxCert DijkstraEra where
     UnRegDepositTxCert c _ -> Just c
     _ -> Nothing
 
-  getTotalRefundsTxCerts _ _ _ = dijkstraTotalRefundsTxCerts
+  getTotalRefundsTxCerts _ _ = dijkstraTotalRefundsTxCerts
 
   getTotalDepositsTxCerts = conwayTotalDepositsTxCerts
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -11,6 +11,7 @@
 
 module Cardano.Ledger.Dijkstra.UTxO (
   DijkstraEraUTxO (..),
+  dijkstraConsumed,
   getDijkstraScriptsNeeded,
   getDijkstraScriptsProvided,
   scriptsProvidedDijkstraStAnnTx,
@@ -33,7 +34,6 @@ import Cardano.Ledger.BaseTypes (inject)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.TxBody (conwayProposalsDeposits)
 import Cardano.Ledger.Conway.UTxO (
-  conwayProducedValue,
   getConwayMinFeeTxUtxo,
   getConwayScriptsNeeded,
   getConwayWitsVKeyNeeded,
@@ -61,6 +61,17 @@ import Lens.Micro.Extras (view)
 class AlonzoEraUTxO era => DijkstraEraUTxO era where
   subTransactionsStAnnTx :: StAnnTx TopTx era -> [StAnnTx SubTx era]
   plutusLegacyModeStAnnTxG :: SimpleGetter (StAnnTx TopTx era) Bool
+
+-- | Unlike `shelleyConsumed`, this function does not need access to `Accounts` to produce accurate
+-- information about refunds, hence is this simplification. Note that using `shelleyConsumed` in
+-- Dijkstra era onwards will produce the same result as this one.
+dijkstraConsumed ::
+  EraUTxO era =>
+  PParams era ->
+  UTxO era ->
+  TxBody l era ->
+  Value era
+dijkstraConsumed pp = getConsumedValue pp (const Nothing)
 
 getConsumedDijkstraValue ::
   forall era l.

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -33,7 +33,7 @@ import Cardano.Ledger.BaseTypes (inject)
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.TxBody (conwayProposalsDeposits)
 import Cardano.Ledger.Conway.UTxO (
-  conwayConsumed,
+  conwayProducedValue,
   getConwayMinFeeTxUtxo,
   getConwayScriptsNeeded,
   getConwayWitsVKeyNeeded,
@@ -48,6 +48,7 @@ import Cardano.Ledger.Dijkstra.Tx (DijkstraStAnnTx (..))
 import Cardano.Ledger.Mary.UTxO (burnedMultiAssets, getConsumedMaryValue)
 import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Plutus (Language, PlutusWithContext)
+import Cardano.Ledger.Shelley.UTxO (shelleyConsumed)
 import Data.Foldable (Foldable (..))
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
@@ -71,11 +72,10 @@ getConsumedDijkstraValue ::
   ) =>
   PParams era ->
   (Credential Staking -> Maybe Coin) ->
-  (Credential DRepRole -> Maybe Coin) ->
   UTxO era ->
   TxBody l era ->
   Value era
-getConsumedDijkstraValue pp lookupStakingDeposit lookupDRepDeposit utxo txBody =
+getConsumedDijkstraValue pp lookupStakingDeposit utxo txBody =
   withBothTxLevels
     txBody
     ( \topTxBody ->
@@ -84,10 +84,10 @@ getConsumedDijkstraValue pp lookupStakingDeposit lookupDRepDeposit utxo txBody =
     txBodyConsumedValue
   where
     txBodyConsumedValue :: forall m. TxBody m era -> Value era
-    txBodyConsumedValue = getConsumedMaryValue pp lookupStakingDeposit lookupDRepDeposit utxo
+    txBodyConsumedValue = getConsumedMaryValue pp lookupStakingDeposit utxo
     subTransactionsConsumedValue topTxBody =
       foldMap'
-        (getConsumedValue pp lookupStakingDeposit lookupDRepDeposit utxo . view bodyTxL)
+        (getConsumedValue pp lookupStakingDeposit utxo . view bodyTxL)
         (topTxBody ^. subTransactionsTxBodyL)
 
 dijkstraProducedValue ::
@@ -121,7 +121,7 @@ dijkstraProducedValue pp isRegPoolId topTxBody =
 instance EraUTxO DijkstraEra where
   type ScriptsNeeded DijkstraEra = AlonzoScriptsNeeded DijkstraEra
 
-  consumed = conwayConsumed
+  consumed = shelleyConsumed
 
   getConsumedValue = getConsumedDijkstraValue
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -48,7 +48,6 @@ import Cardano.Ledger.Dijkstra.Tx (DijkstraStAnnTx (..))
 import Cardano.Ledger.Mary.UTxO (burnedMultiAssets, getConsumedMaryValue)
 import Cardano.Ledger.Mary.Value (MaryValue (..))
 import Cardano.Ledger.Plutus (Language, PlutusWithContext)
-import Cardano.Ledger.Shelley.UTxO (shelleyConsumed)
 import Data.Foldable (Foldable (..))
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
@@ -120,8 +119,6 @@ dijkstraProducedValue pp isRegPoolId topTxBody =
 
 instance EraUTxO DijkstraEra where
   type ScriptsNeeded DijkstraEra = AlonzoScriptsNeeded DijkstraEra
-
-  consumed = shelleyConsumed
 
   getConsumedValue = getConsumedDijkstraValue
 

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -14,6 +14,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Rules (DijkstraUtxoPredFailure (..))
+import Cardano.Ledger.Dijkstra.State
 import Cardano.Ledger.Mary.Value (
   AssetName,
   MaryValue (..),
@@ -67,9 +68,9 @@ spec = describe "UTXO" $ do
                 -- distinguish subs by an input
                 & subTransactionsTxBodyL .~ [mkSubTx txIn1 cert, mkSubTx txIn2 cert]
       pp <- getsPParams id
-      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
       -- just the pool deposits are in `produced` because the transaction is not fixed up
-      produced pp certState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
+      produced pp pState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
 
     it "counts distinct pool deposits in top and sub separately" $ do
       poolDeposit <- (Coin 1 <>) <$> arbitrary
@@ -85,8 +86,8 @@ spec = describe "UTXO" $ do
                 & certsTxBodyL .~ [poolB, poolA, poolB]
                 & subTransactionsTxBodyL .~ [mkSubTx txIn1 poolA, mkSubTx txIn2 poolA, mkSubTx txIn3 poolB]
       pp <- getsPParams id
-      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
-      produced pp certState (topTx ^. bodyTxL) `shouldBe` inject ((2 :: Int) <×> poolDeposit)
+      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
+      produced pp pState (topTx ^. bodyTxL) `shouldBe` inject ((2 :: Int) <×> poolDeposit)
 
     it "includes sub-tx cert deposits when top has no certs" $ do
       poolDeposit <- (Coin 1 <>) <$> arbitrary
@@ -98,8 +99,8 @@ spec = describe "UTXO" $ do
               mkBasicTxBody
                 & subTransactionsTxBodyL .~ [subTx]
       pp <- getsPParams id
-      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
-      produced pp certState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
+      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
+      produced pp pState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
 
     it "does not count re-registrations of an already-registered pool across the batch" $ do
       poolDeposit <- (Coin 1 <>) <$> arbitrary
@@ -112,8 +113,8 @@ spec = describe "UTXO" $ do
           topTx = regTx & bodyTxL . subTransactionsTxBodyL .~ [regTx :: Tx SubTx era]
       submitTx_ (regTx :: Tx TopTx era)
       pp <- getsPParams id
-      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
-      produced pp certState (topTx ^. bodyTxL) `shouldBe` mempty
+      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
+      produced pp pState (topTx ^. bodyTxL) `shouldBe` mempty
 
     it "dedupes across multiple subtransactions registering the same fresh pool" $ do
       poolDeposit <- (Coin 1 <>) <$> arbitrary
@@ -127,13 +128,13 @@ spec = describe "UTXO" $ do
                 & subTransactionsTxBodyL
                   .~ [mkSubTx txInA cert, mkSubTx txInB cert]
       pp <- getsPParams id
-      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
-      produced pp certState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
+      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
+      produced pp pState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
 
     it "sums outputs, fee, treasury donations, pool/DRep deposits and burned assets across the batch" $ do
       poolDeposit <- (Coin 1 <>) <$> arbitrary
-      drepDeposit <- (Coin 1 <>) <$> arbitrary
-      modifyPParams $ (ppPoolDepositL .~ poolDeposit) . (ppDRepDepositL .~ drepDeposit)
+      dRepDeposit <- (Coin 1 <>) <$> arbitrary
+      modifyPParams $ (ppPoolDepositL .~ poolDeposit) . (ppDRepDepositL .~ dRepDeposit)
       poolParams <- arbitrary
       drepA <- arbitrary
       drepB <- arbitrary
@@ -165,7 +166,7 @@ spec = describe "UTXO" $ do
               mkBasicTxBody
                 & outputsTxBodyL .~ [subOut]
                 & certsTxBodyL
-                  .~ [regPool, RegDRepTxCert drepB drepDeposit SNothing]
+                  .~ [regPool, RegDRepTxCert drepB dRepDeposit SNothing]
                 & treasuryDonationTxBodyL .~ subTreasury
                 & mintTxBodyL .~ subMint
           topTx :: Tx TopTx era
@@ -175,7 +176,7 @@ spec = describe "UTXO" $ do
                 & outputsTxBodyL .~ [topOut]
                 & feeTxBodyL .~ topFee
                 & certsTxBodyL
-                  .~ [regPool, RegDRepTxCert drepA drepDeposit SNothing]
+                  .~ [regPool, RegDRepTxCert drepA dRepDeposit SNothing]
                 & treasuryDonationTxBodyL .~ topTreasury
                 & mintTxBodyL .~ topMint
                 & subTransactionsTxBodyL .~ [subTx]
@@ -186,10 +187,10 @@ spec = describe "UTXO" $ do
               <> topTreasury
               <> subTreasury
               <> poolDeposit
-              <> ((2 :: Int) <×> drepDeposit)
+              <> ((2 :: Int) <×> dRepDeposit)
           expected = MaryValue expectedCoin expectedBurned
       pp <- getsPParams id
-      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
-      produced pp certState (topTx ^. bodyTxL) `shouldBe` expected
+      pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
+      produced pp pState (topTx ^. bodyTxL) `shouldBe` expected
   where
     mkSubTx i cert = mkBasicTx $ mkBasicTxBody & certsTxBodyL .~ [cert] & inputsTxBodyL .~ [i]

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxCert.hs
@@ -50,7 +50,7 @@ instance EraTxCert MaryEra where
 
   getTotalDepositsTxCerts = shelleyTotalDepositsTxCerts
 
-  getTotalRefundsTxCerts pp lookupStakeDeposit _ = shelleyTotalRefundsTxCerts pp lookupStakeDeposit
+  getTotalRefundsTxCerts = shelleyTotalRefundsTxCerts
 
 instance ShelleyEraTxCert MaryEra where
   mkRegTxCert = ShelleyTxCertDelegCert . ShelleyRegCert

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -69,11 +69,10 @@ getConsumedMaryValue ::
   (MaryEraTxBody era, Value era ~ MaryValue) =>
   PParams era ->
   (Credential Staking -> Maybe Coin) ->
-  (Credential DRepRole -> Maybe Coin) ->
   UTxO era ->
   TxBody l era ->
   MaryValue
-getConsumedMaryValue pp lookupStakingDeposit lookupDRepDeposit utxo txBody =
+getConsumedMaryValue pp lookupStakingDeposit utxo txBody =
   consumedValue <> MaryValue mempty mintedMultiAsset
   where
     mintedMultiAsset = filterMultiAsset (\_ _ -> (> 0)) $ txBody ^. mintTxBodyL
@@ -81,7 +80,7 @@ getConsumedMaryValue pp lookupStakingDeposit lookupDRepDeposit utxo txBody =
     consumedValue =
       sumUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
         <> inject (refunds <> withdrawals)
-    refunds = getTotalRefundsTxBody pp lookupStakingDeposit lookupDRepDeposit txBody
+    refunds = getTotalRefundsTxBody pp lookupStakingDeposit txBody
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
 
 getProducedMaryValue ::

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -22,7 +22,6 @@ import Cardano.Ledger.Shelley.UTxO (
   getShelleyMinFeeTxUtxo,
   getShelleyScriptsNeeded,
   getShelleyWitsVKeyNeeded,
-  shelleyConsumed,
   shelleyProducedValue,
  )
 import Cardano.Ledger.State (
@@ -39,8 +38,6 @@ import Lens.Micro
 
 instance EraUTxO MaryEra where
   type ScriptsNeeded MaryEra = ShelleyScriptsNeeded MaryEra
-
-  consumed = shelleyConsumed
 
   getConsumedValue = getConsumedMaryValue
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Change `produced` to accept `PState`, instead of `CertState`
 * Remove `consumed` in favor of `shelleyConsumed`
 * Restrict `produced` to `TxBody TopTx era`.
 * Add `defaultApplyTxWithValidation` and `defaultReapplyValidatedTx` helpers to `Mempool` module

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Remove `consumed` in favor of `shelleyConsumed`
 * Restrict `produced` to `TxBody TopTx era`.
 * Add `defaultApplyTxWithValidation` and `defaultReapplyValidatedTx` helpers to `Mempool` module
 * Deprecate:

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/AdaPots.hs
@@ -139,11 +139,11 @@ consumedTxBody ::
   CertState era ->
   UTxO era ->
   Consumed
-consumedTxBody txBody pp dpstate utxo =
+consumedTxBody txBody pp certState utxo =
   Consumed
     { conInputs =
         sumCoinUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
-    , conRefunds = certsTotalRefundsTxBody pp dpstate txBody
+    , conRefunds = certsTotalRefundsTxBody pp (certState ^. certDStateL . accountsL) txBody
     , conWithdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
     }
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/LedgerState.hs
@@ -36,10 +36,6 @@ module Cardano.Ledger.Shelley.LedgerState (
   -- * Genesis State
   genesisState,
 
-  -- * Validation
-  consumed,
-  produced,
-
   -- * DelegationState
   totalObligation,
   allObligations,
@@ -125,4 +121,3 @@ import Cardano.Ledger.Shelley.PParams (pvCanFollow)
 import Cardano.Ledger.Shelley.RewardUpdate
 import Cardano.Ledger.Shelley.Rules.Ppup (ShelleyGovState (..))
 import Cardano.Ledger.Shelley.State
-import Cardano.Ledger.Shelley.UTxO (produced)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -65,7 +65,7 @@ import Cardano.Ledger.Shelley.Rules.Ppup (
   ShelleyPpupPredFailure,
  )
 import Cardano.Ledger.Shelley.Rules.Reports (showTxCerts)
-import Cardano.Ledger.Shelley.UTxO (produced)
+import Cardano.Ledger.Shelley.UTxO (produced, shelleyConsumed)
 import Cardano.Ledger.Slot (SlotNo)
 import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxIn)
@@ -515,7 +515,7 @@ validateValueNotConservedUTxO pp utxo certState txBody =
     ValueNotConservedUTxO Mismatch {mismatchSupplied = consumedValue, mismatchExpected = producedValue}
   where
     accounts = certState ^. certDStateL . accountsL
-    consumedValue = consumed pp accounts utxo txBody
+    consumedValue = shelleyConsumed pp accounts utxo txBody
     producedValue = produced pp certState txBody
 
 -- | Ensure there are no `TxOut`s that have less than @minUTxOValue@

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -514,7 +514,8 @@ validateValueNotConservedUTxO pp utxo certState txBody =
   failureUnless (consumedValue == producedValue) $
     ValueNotConservedUTxO Mismatch {mismatchSupplied = consumedValue, mismatchExpected = producedValue}
   where
-    consumedValue = consumed pp certState utxo txBody
+    accounts = certState ^. certDStateL . accountsL
+    consumedValue = consumed pp accounts utxo txBody
     producedValue = produced pp certState txBody
 
 -- | Ensure there are no `TxOut`s that have less than @minUTxOValue@
@@ -624,7 +625,7 @@ updateUTxOStateNoFees pp utxos txBody certState govState depositChangeEvent txUt
       {- newUTxO = (txins txb ⋪ utxo) ∪ outs txb -}
       newUTxO = utxoWithout `Map.union` unUTxO utxoAdd
       deletedUTxO = UTxO utxoDel
-      totalRefunds = certsTotalRefundsTxBody pp certState txBody
+      totalRefunds = certsTotalRefundsTxBody pp (certState ^. certDStateL . accountsL) txBody
       totalDeposits = certsTotalDepositsTxBody pp certState txBody
       depositChange = totalDeposits <-> totalRefunds
   depositChangeEvent depositChange

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -516,7 +516,7 @@ validateValueNotConservedUTxO pp utxo certState txBody =
   where
     accounts = certState ^. certDStateL . accountsL
     consumedValue = shelleyConsumed pp accounts utxo txBody
-    producedValue = produced pp certState txBody
+    producedValue = produced pp (certState ^. certPStateL) txBody
 
 -- | Ensure there are no `TxOut`s that have less than @minUTxOValue@
 --

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/State/CertState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/State/CertState.hs
@@ -89,12 +89,11 @@ shelleyCertsTotalDepositsTxBody pp ShelleyCertState {shelleyCertPState} =
   getTotalDepositsTxBody pp (`Map.member` psStakePools shelleyCertPState)
 
 shelleyCertsTotalRefundsTxBody ::
-  (EraTxBody era, EraAccounts era) => PParams era -> ShelleyCertState era -> TxBody t era -> Coin
-shelleyCertsTotalRefundsTxBody pp ShelleyCertState {shelleyCertDState} =
+  (EraTxBody era, EraAccounts era) => PParams era -> Accounts era -> TxBody t era -> Coin
+shelleyCertsTotalRefundsTxBody pp accounts =
   getTotalRefundsTxBody
     pp
-    (lookupDepositDState shelleyCertDState)
-    (const Nothing)
+    (fmap (fromCompact . (^. depositAccountStateL)) . (`lookupAccountState` accounts))
 
 instance EraCertState ShelleyEra where
   type CertState ShelleyEra = ShelleyCertState ShelleyEra

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/State/CertState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/State/CertState.hs
@@ -91,9 +91,7 @@ shelleyCertsTotalDepositsTxBody pp ShelleyCertState {shelleyCertPState} =
 shelleyCertsTotalRefundsTxBody ::
   (EraTxBody era, EraAccounts era) => PParams era -> Accounts era -> TxBody t era -> Coin
 shelleyCertsTotalRefundsTxBody pp accounts =
-  getTotalRefundsTxBody
-    pp
-    (fmap (fromCompact . (^. depositAccountStateL)) . (`lookupAccountState` accounts))
+  getTotalRefundsTxBody pp (`lookupAccountDeposit` accounts)
 
 instance EraCertState ShelleyEra where
   type CertState ShelleyEra = ShelleyCertState ShelleyEra

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs
@@ -148,7 +148,7 @@ instance EraTxCert ShelleyEra where
 
   getTotalDepositsTxCerts = shelleyTotalDepositsTxCerts
 
-  getTotalRefundsTxCerts pp lookupStakeDeposit _ = shelleyTotalRefundsTxCerts pp lookupStakeDeposit
+  getTotalRefundsTxCerts = shelleyTotalRefundsTxCerts
 
 -- | All of the Shelley related certificate functionality that has been fully deprecated in Dijkstra.
 class (EraTxCert era, AtMostEra "Conway" era) => ShelleyEraTxCert era where

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -32,6 +32,7 @@ module Cardano.Ledger.Shelley.UTxO (
 import Cardano.Ledger.Address (accountAddressCredentialL, bootstrapKeyHash)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Credential (Credential (..), credKeyHashWitness, credScriptHash)
 import Cardano.Ledger.Keys (
   GenDelegs (..),
@@ -42,13 +43,7 @@ import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra)
 import Cardano.Ledger.Shelley.PParams (ProposedPPUpdates (ProposedPPUpdates), Update (..))
 import Cardano.Ledger.Shelley.State ()
-import Cardano.Ledger.State (
-  EraCertState (..),
-  StakePoolParams (..),
-  dsGenDelegs,
-  lookupDepositDState,
-  psStakePoolsL,
- )
+import Cardano.Ledger.State
 import Cardano.Ledger.State as UTxO (
   CanGetUTxO (..),
   CanSetUTxO (..),
@@ -116,15 +111,13 @@ getShelleyScriptsNeeded u txBody =
 shelleyConsumed ::
   (EraUTxO era, EraCertState era) =>
   PParams era ->
-  CertState era ->
+  Accounts era ->
   UTxO era ->
   TxBody l era ->
   Value era
-shelleyConsumed pp certState =
-  getConsumedValue
-    pp
-    (lookupDepositDState $ certState ^. certDStateL)
-    (const Nothing)
+shelleyConsumed pp accounts =
+  getConsumedValue pp $
+    fmap (fromCompact . (^. depositAccountStateL)) . (`lookupAccountState` accounts)
 
 -- | Compute the lovelace which are created by the transaction
 -- For eras before Conway, VState is expected to have an empty Map for vsDReps, and so deposit summed up is zero.
@@ -164,7 +157,7 @@ getConsumedCoin pp lookupRefund utxo txBody =
     <> refunds
     <> withdrawals
   where
-    refunds = getTotalRefundsTxBody pp lookupRefund (const Nothing) txBody
+    refunds = getTotalRefundsTxBody pp lookupRefund txBody
     withdrawals = fold . unWithdrawals $ txBody ^. withdrawalsTxBodyL
 
 newtype ShelleyScriptsNeeded era = ShelleyScriptsNeeded (Set ScriptHash)
@@ -175,7 +168,7 @@ instance EraUTxO ShelleyEra where
 
   consumed = shelleyConsumed
 
-  getConsumedValue pp lookupKeyDeposit _ = getConsumedCoin pp lookupKeyDeposit
+  getConsumedValue = getConsumedCoin
 
   getProducedValue = shelleyProducedValue
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -32,7 +32,6 @@ module Cardano.Ledger.Shelley.UTxO (
 import Cardano.Ledger.Address (accountAddressCredentialL, bootstrapKeyHash)
 import Cardano.Ledger.BaseTypes (StrictMaybe (..))
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Compactible (fromCompact)
 import Cardano.Ledger.Credential (Credential (..), credKeyHashWitness, credScriptHash)
 import Cardano.Ledger.Keys (
   GenDelegs (..),
@@ -116,9 +115,7 @@ shelleyConsumed ::
   UTxO era ->
   TxBody l era ->
   Value era
-shelleyConsumed pp accounts =
-  getConsumedValue pp $
-    fmap (fromCompact . (^. depositAccountStateL)) . (`lookupAccountState` accounts)
+shelleyConsumed pp accounts = getConsumedValue pp (`lookupAccountDeposit` accounts)
 
 -- | Compute the lovelace which are created by the transaction
 -- For eras before Conway, VState is expected to have an empty Map for vsDReps, and so deposit summed up is zero.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -123,13 +123,13 @@ shelleyConsumed pp accounts =
 -- | Compute the lovelace which are created by the transaction
 -- For eras before Conway, VState is expected to have an empty Map for vsDReps, and so deposit summed up is zero.
 produced ::
-  (EraUTxO era, EraCertState era) =>
+  EraUTxO era =>
   PParams era ->
-  CertState era ->
+  PState era ->
   TxBody TopTx era ->
   Value era
-produced pp certState =
-  getProducedValue pp (flip Map.member $ certState ^. certPStateL . psStakePoolsL)
+produced pp pState =
+  getProducedValue pp (flip Map.member $ pState ^. psStakePoolsL)
 
 shelleyProducedValue ::
   EraTxBody era =>

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -107,7 +107,8 @@ getShelleyScriptsNeeded u txBody =
     scriptHashes = txinsScriptHashes (txBody ^. inputsTxBodyL) u
     certificates = toList (txBody ^. certsTxBodyL)
 
--- | For eras before Conway, VState is expected to have an empty Map for vsDReps, and so deposit summed up is zero.
+-- | Shelley version of consumed will work for all eras, however, starting with Dijkstra era it
+-- becomes simpler, because it will no longer require access to Accounts.
 shelleyConsumed ::
   (EraUTxO era, EraCertState era) =>
   PParams era ->
@@ -165,8 +166,6 @@ newtype ShelleyScriptsNeeded era = ShelleyScriptsNeeded (Set ScriptHash)
 
 instance EraUTxO ShelleyEra where
   type ScriptsNeeded ShelleyEra = ShelleyScriptsNeeded ShelleyEra
-
-  consumed = shelleyConsumed
 
   getConsumedValue = getConsumedCoin
 

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1159,7 +1159,8 @@ fixupFees txOriginal = impAnn "fixupFees" $ do
   nativeScriptKeyPairs <- impNativeScriptKeyPairs tx
   let
     nativeScriptKeyWits = Map.keysSet nativeScriptKeyPairs
-    consumedValue = consumed pp certState utxo (tx ^. bodyTxL)
+    accounts = certState ^. certDStateL . accountsL
+    consumedValue = consumed pp accounts utxo (tx ^. bodyTxL)
     producedValue = produced pp certState (tx ^. bodyTxL)
     ensureNonNegativeCoin v
       | pointwise (<=) zero v = pure v

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1161,7 +1161,7 @@ fixupFees txOriginal = impAnn "fixupFees" $ do
     nativeScriptKeyWits = Map.keysSet nativeScriptKeyPairs
     accounts = certState ^. certDStateL . accountsL
     consumedValue = shelleyConsumed pp accounts utxo (tx ^. bodyTxL)
-    producedValue = produced pp certState (tx ^. bodyTxL)
+    producedValue = produced pp (certState ^. certPStateL) (tx ^. bodyTxL)
     ensureNonNegativeCoin v
       | pointwise (<=) zero v = pure v
       | otherwise = do

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -224,7 +224,6 @@ import Cardano.Ledger.Shelley.LedgerState (
   nesELL,
   nesEsL,
   prevPParamsEpochStateL,
-  produced,
   utxosDonationL,
   utxosUtxo,
  )
@@ -247,6 +246,7 @@ import Cardano.Ledger.Shelley.Scripts (
  )
 import Cardano.Ledger.Shelley.State
 import Cardano.Ledger.Shelley.Translation (toFromByronTranslationContext)
+import Cardano.Ledger.Shelley.UTxO (produced, shelleyConsumed)
 import Cardano.Ledger.Slot (epochFromSlot, epochInfoFirst, getTheSlotOfNoReturn)
 import Cardano.Ledger.Tools (
   calcMinFeeTxNativeScriptWits,
@@ -1160,7 +1160,7 @@ fixupFees txOriginal = impAnn "fixupFees" $ do
   let
     nativeScriptKeyWits = Map.keysSet nativeScriptKeyPairs
     accounts = certState ^. certDStateL . accountsL
-    consumedValue = consumed pp accounts utxo (tx ^. bodyTxL)
+    consumedValue = shelleyConsumed pp accounts utxo (tx ^. bodyTxL)
     producedValue = produced pp certState (tx ^. bodyTxL)
     ensureNonNegativeCoin v
       | pointwise (<=) zero v = pure v

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
@@ -19,7 +19,6 @@ module Test.Cardano.Ledger.Shelley.Generator.Trace.TxCert (
 
 import Cardano.Ledger.BaseTypes (CertIx, Globals, ShelleyBase, SlotNo (..), TxIx)
 import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (SlotNo32 (..))
@@ -232,11 +231,7 @@ genTxCerts
         keyCreds' = concat (keyCreds : map scriptWitnesses scriptCreds)
 
         accounts = certState ^. certDStateL . accountsL
-        refunds =
-          getTotalRefundsTxCerts
-            pp
-            (fmap (fromCompact . (^. depositAccountStateL)) . (`lookupAccountState` accounts))
-            certs
+        refunds = getTotalRefundsTxCerts pp (`lookupAccountDeposit` accounts) certs
 
         deposits = getTotalDepositsTxCerts pp (`Map.member` psStakePools certPState) certs
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/TxCert.hs
@@ -19,6 +19,7 @@ module Test.Cardano.Ledger.Shelley.Generator.Trace.TxCert (
 
 import Cardano.Ledger.BaseTypes (CertIx, Globals, ShelleyBase, SlotNo (..), TxIx)
 import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Compactible
 import Cardano.Ledger.Core
 import qualified Cardano.Ledger.Core as Core
 import Cardano.Ledger.Credential (SlotNo32 (..))
@@ -219,7 +220,6 @@ genTxCerts
   acnt = do
     let env = (slot, txIx, pp, acnt)
         st0 = (certState, minBound)
-        certDState = certState ^. certDStateL
         certPState = certState ^. certPStateL
 
     certsTrace <-
@@ -231,11 +231,11 @@ genTxCerts
         (scriptCreds, keyCreds) = partition isScript creds
         keyCreds' = concat (keyCreds : map scriptWitnesses scriptCreds)
 
+        accounts = certState ^. certDStateL . accountsL
         refunds =
           getTotalRefundsTxCerts
             pp
-            (lookupDepositDState certDState)
-            (const Nothing)
+            (fmap (fromCompact . (^. depositAccountStateL)) . (`lookupAccountState` accounts))
             certs
 
         deposits = getTotalDepositsTxCerts pp (`Map.member` psStakePools certPState) certs

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/AdaPreservation.hs
@@ -295,7 +295,7 @@ checkPreservation SourceSignalTarget {source, target, signal = block} count =
         ++ "total deposits "
         ++ show (certsTotalDepositsTxBody currPP oldCertState (tx ^. bodyTxL))
         ++ "\ntotal refunds "
-        ++ show (certsTotalRefundsTxBody currPP oldCertState (tx ^. bodyTxL))
+        ++ show (certsTotalRefundsTxBody currPP oldAccounts (tx ^. bodyTxL))
 
 -- If we are not at an Epoch Boundary (i.e. epoch source == epoch target)
 -- then the total rewards should change only by withdrawals
@@ -503,9 +503,10 @@ preserveBalance SourceSignalTarget {source = chainSt, signal = block} =
           sumCoinUTxO u'
             <+> (txb ^. feeTxBodyL)
             <+> certsTotalDepositsTxBody pp_ certState txb
+        accounts = certState ^. certDStateL . accountsL
         consumed_ =
           sumCoinUTxO u
-            <+> certsTotalRefundsTxBody pp_ certState txb
+            <+> certsTotalRefundsTxBody pp_ accounts txb
             <+> fold (unWithdrawals (txb ^. withdrawalsTxBodyL))
 
 -- | Preserve balance restricted to TxIns and TxOuts of the Tx
@@ -538,9 +539,10 @@ preserveBalanceRestricted SourceSignalTarget {source = chainSt, signal = block} 
         inps === outs
         where
           txb = stAnnTx ^. txStAnnTxG . bodyTxL
+          accounts = certState ^. certDStateL . accountsL
           inps =
             sumCoinUTxO @era (txInsFilter utxo (txb ^. inputsTxBodyL))
-              <> certsTotalRefundsTxBody pp_ certState txb
+              <> certsTotalRefundsTxBody pp_ accounts txb
               <> fold (unWithdrawals (txb ^. withdrawalsTxBodyL))
           outs =
             sumCoinUTxO (txouts @era txb)

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Remove a no longer necessary argument to `evalBalanceTxBody` that looked up DRep deposits
 * Restrict `evalBalanceTxBody` to `TxBody TopTx era`.
 * Rename `AnyEraRewardingPurpose` to `AnyEraWithdrawingPurpose` and `anyEraToRewardingPurpose` to `anyEraToWithdrawingPurpose`, deprecating the old names
 * Re-export the new `pattern WithdrawingPurpose` and `toWithdrawingPurpose`

--- a/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/src/Cardano/Ledger/Api/Tx/Body.hs
@@ -320,12 +320,6 @@ evalBalanceTxBody ::
   -- there is no requirement to know about all of the delegation certificates in the
   -- ledger state, just the ones this transaction cares about.
   (Credential Staking -> Maybe Coin) ->
-  -- | Lookup current deposit amount for a registered DRep credential. This
-  -- function must produce valid answer for all of the DRep credentials present in any of
-  -- the `UnRegDRep` certificates in the supplied `TxBody`. In other words,
-  -- there is no requirement to know about all of the DRep registrations in the
-  -- ledger state, just the ones this transaction cares about.
-  (Credential DRepRole -> Maybe Coin) ->
   -- | Check whether a pool with a supplied PoolStakeId is already registered. There is no
   -- requirement to answer this question for all stake pool credentials, just for the ones
   -- that have the registration certificates included in the supplied `TxBody`
@@ -336,6 +330,6 @@ evalBalanceTxBody ::
   TxBody TopTx era ->
   -- | The difference between what the transaction consumes and what it produces.
   Value era
-evalBalanceTxBody pp lookupKeyRefund lookupDRepRefund isRegPoolId utxo txBody =
-  getConsumedValue pp lookupKeyRefund lookupDRepRefund utxo txBody
+evalBalanceTxBody pp lookupKeyRefund isRegPoolId utxo txBody =
+  getConsumedValue pp lookupKeyRefund utxo txBody
     <-> getProducedValue pp isRegPoolId txBody

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
@@ -14,7 +14,7 @@ import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin
 import Cardano.Ledger.Compactible
 import Cardano.Ledger.Shelley.Core
-import Cardano.Ledger.State hiding (consumed)
+import Cardano.Ledger.State
 import Cardano.Ledger.Val
 import Data.Foldable
 import qualified Data.Map.Strict as Map

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
@@ -148,7 +148,7 @@ propEvalBalanceTxBody pp certState utxo = do
   property $
     forAll (genTxBodyFrom @_ @TopTx certState utxo) $ \txBody ->
       forAll arbitrary $ \network ->
-        evalBalanceTxBody pp lookupKeyDeposit (const Nothing) isRegPoolId utxo txBody
+        evalBalanceTxBody pp lookupKeyDeposit isRegPoolId utxo txBody
           `shouldBe` evaluateTransactionBalance network pp certState utxo txBody
   where
     lookupKeyDeposit = lookupDepositDState (certState ^. certDStateL)
@@ -164,7 +164,7 @@ propEvalBalanceShelleyTxBody ::
 propEvalBalanceShelleyTxBody network pp certState utxo =
   property $
     forAll (genTxBodyFrom @_ @TopTx certState utxo) $ \txBody ->
-      evalBalanceTxBody pp lookupKeyDeposit (const Nothing) isRegPoolId utxo txBody
+      evalBalanceTxBody pp lookupKeyDeposit isRegPoolId utxo txBody
         `shouldBe` evaluateTransactionBalanceShelley network pp certState utxo txBody
   where
     lookupKeyDeposit = lookupDepositDState (certState ^. certDStateL)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.21.0.0
 
+* Remove no longer needed `(Credential DRepRole -> Maybe Coin)` argument from:
+  - `getTotalRefundsTxCerts`
+  - `getTotalRefundsTxBody`
+  - `getConsumedValue`
+* Change `certsTotalRefundsTxBody` to accept `Accounts` instead of `CertState`
 * Restrict `getProducedValue` to `TxBody TopTx era`.
 * Remove `Semigroup` and `Monoid` instances for `CostModels`
 * Change `updateCostModels` to take `CostModelsUpdate` as its second argument

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Add `lookupAccountDeposit`
 * Remove `consumed ` from `EraUTxO`
 * Remove no longer needed `(Credential DRepRole -> Maybe Coin)` argument from:
   - `getTotalRefundsTxCerts`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Remove `consumed ` from `EraUTxO`
 * Remove no longer needed `(Credential DRepRole -> Maybe Coin)` argument from:
   - `getTotalRefundsTxCerts`
   - `getTotalRefundsTxBody`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -276,12 +276,10 @@ class
     PParams era ->
     -- | Lookup current deposit for Staking credential if one is registered
     (Credential Staking -> Maybe Coin) ->
-    -- | Lookup current deposit for DRep credential if one is registered
-    (Credential DRepRole -> Maybe Coin) ->
     TxBody l era ->
     Coin
-  getTotalRefundsTxBody pp lookupStakingDeposit lookupDRepDeposit txBody =
-    getTotalRefundsTxCerts pp lookupStakingDeposit lookupDRepDeposit (txBody ^. certsTxBodyL)
+  getTotalRefundsTxBody pp lookupStakingDeposit txBody =
+    getTotalRefundsTxCerts pp lookupStakingDeposit (txBody ^. certsTxBodyL)
 
   -- | This function is not used in the ledger rules. It is only used by the downstream
   -- tooling to figure out how many witnesses should be supplied for Genesis keys.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core/TxCert.hs
@@ -102,8 +102,6 @@ class
     PParams era ->
     -- | Lookup current deposit for Staking credential if one is registered
     (Credential Staking -> Maybe Coin) ->
-    -- | Lookup current deposit for DRep credential if one is registered
-    (Credential DRepRole -> Maybe Coin) ->
     f (TxCert era) ->
     Coin
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Hashes.hs
@@ -359,17 +359,15 @@ unsafeMakeSafeHash = SafeHash
 
 -- =====================================================================
 
--- | Only Types that preserve their serialisation bytes are members of the
---   class 'SafeToHash'. There are only a limited number of primitive direct
---   instances of 'SafeToHash', all but two of them are present in this file. Instead
---   of making explicit instances, we almost always use a newtype (around a type @S@)
---   where their is already an instance @(SafeToHash S)@. In that case the newtype
---   has its SafeToHash instance derived using newtype deriving. The prime example of @s@ is 'MemoBytes'.
---   The only exceptions are the legacy Shelley types: @Metadata@ and @ShelleyTx@, that
---   preserve their serialization bytes
---   using a different mechanism than the use of 'MemoBytes'.  'SafeToHash' is a superclass
---   requirement of the classes 'HashAnnotated' which
---   provide more convenient ways to construct SafeHashes than using 'makeHashWithExplicitProxys'.
+-- | Only Types that preserve their serialisation bytes are members of the class 'SafeToHash'. There
+--   are only a limited number of primitive direct instances of 'SafeToHash', all but two of them
+--   are present in this file. Instead of making explicit instances, we almost always use a newtype
+--   (around a type @S@) where there is already an instance @(SafeToHash S)@. In that case the
+--   newtype has its SafeToHash instance derived using newtype deriving. The prime example of @s@ is
+--   'MemoBytes'.
+--
+--  'SafeToHash' is a superclass requirement of the 'HashAnnotated' class which provides more
+--   convenient ways to construct SafeHashes than using 'makeHashWithExplicitProxys'.
 class SafeToHash t where
   -- | Extract the original bytes from 't'
   originalBytes :: t -> ByteString

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
@@ -16,6 +16,7 @@ module Cardano.Ledger.State.Account (
   EraAccounts (..),
   lookupAccountState,
   lookupAccountStateIntern,
+  lookupAccountDeposit,
   updateLookupAccountState,
   isAccountRegistered,
   adjustAccountState,
@@ -156,6 +157,11 @@ lookupAccountStateIntern ::
   Credential Staking -> Accounts era -> Maybe (Credential Staking, AccountState era)
 lookupAccountStateIntern cred accounts =
   lookupInternMap cred (accounts ^. accountsMapL)
+
+-- | Lookup an account state by its credential and return the deposit amount.
+lookupAccountDeposit :: EraAccounts era => Credential Staking -> Accounts era -> Maybe Coin
+lookupAccountDeposit cred accounts =
+  fromCompact . (^. depositAccountStateL) <$> lookupAccountState cred accounts
 
 -- | Update account state. Returns Nothing if the value is not present and modified value otherwise
 updateLookupAccountState ::

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
@@ -397,7 +397,7 @@ class
   --
   -- This is the contribution of a TxBody towards the total 'Obligations' of the system
   -- See `Obligations` and `obligationCertState` for more information.
-  certsTotalRefundsTxBody :: EraTxBody era => PParams era -> CertState era -> TxBody t era -> Coin
+  certsTotalRefundsTxBody :: EraTxBody era => PParams era -> Accounts era -> TxBody t era -> Coin
 
 instance EncCBOR InstantaneousRewards where
   encCBOR (InstantaneousRewards irR irT dR dT) =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
@@ -55,6 +55,7 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Keys (verifySignedDSIGN)
 import Cardano.Ledger.Keys.WitVKey (WitVKey (..))
+import Cardano.Ledger.State.Account (Accounts)
 import Cardano.Ledger.State.CertState (CertState)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData)
@@ -244,15 +245,13 @@ class EraTx era => EraUTxO era where
   -- scripts needed for the transaction.
   type ScriptsNeeded era = (r :: Type) | r -> era
 
-  consumed :: PParams era -> CertState era -> UTxO era -> TxBody t era -> Value era
+  consumed :: PParams era -> Accounts era -> UTxO era -> TxBody t era -> Value era
 
   -- | Calculate all the value that is being consumed by the transaction.
   getConsumedValue ::
     PParams era ->
     -- | Function that can lookup current delegation deposits
     (Credential Staking -> Maybe Coin) ->
-    -- | Function that can lookup current drep deposits
-    (Credential DRepRole -> Maybe Coin) ->
     UTxO era ->
     TxBody t era ->
     Value era

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
@@ -55,7 +55,6 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Keys (verifySignedDSIGN)
 import Cardano.Ledger.Keys.WitVKey (WitVKey (..))
-import Cardano.Ledger.State.Account (Accounts)
 import Cardano.Ledger.State.CertState (CertState)
 import Cardano.Ledger.TxIn (TxIn (..))
 import Control.DeepSeq (NFData)
@@ -244,8 +243,6 @@ class EraTx era => EraUTxO era where
   -- | A customizable type on per era basis for the information required to find all
   -- scripts needed for the transaction.
   type ScriptsNeeded era = (r :: Type) | r -> era
-
-  consumed :: PParams era -> Accounts era -> UTxO era -> TxBody t era -> Value era
 
   -- | Calculate all the value that is being consumed by the transaction.
   getConsumedValue ::

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/TxBodySpec.hs
@@ -91,11 +91,10 @@ getDepositRefund ::
   PParams era -> CertState era -> [TxCert era] -> (DeltaCoin, DeltaCoin)
 getDepositRefund pp certState certs =
   ( delta $ getTotalDepositsTxCerts pp (`Map.member` psStakePools ps) certs
-  , delta $ getTotalRefundsTxCerts pp (lookupDepositDState ds) (lookupDepositVState vs) certs
+  , delta $ getTotalRefundsTxCerts pp (lookupDepositDState ds) certs
   )
   where
     delta (Coin n) = DeltaCoin n
-    vs = certState ^. certVStateL
     ps = certState ^. certPStateL
     ds = certState ^. certDStateL
 


### PR DESCRIPTION
# Description

This PR simplifies consumed and produced computation.

For Conway consumed no longer used state of DReps to figure out refunds, and instead relies on information in the certificate itself

For Dijkstra we no longer accept CertState at all for consumed, for the same reason and for produced we only need PState, not the whole CertState

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
