### PR TITLE
Fix/allow thunks in Alonzo/Conway geneses

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Change `extraConfig` and `agExtraConfig` from `Maybe` to `StrictMaybe`
 * Remove `ueUtxo` field from `UtxoEnv`
 * Introduce `LEDGERS` and `STS` instance and wire it to `EraRule LEDGERS`
 * Export `alonzoPlutusScriptDecoder` from `Cardano.Ledger.Alonzo.TxWits`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Genesis.hs
@@ -49,7 +49,12 @@ import Cardano.Ledger.Alonzo.Scripts (
   flattenCostModels,
   mkCostModels,
  )
-import Cardano.Ledger.BaseTypes (KeyValuePairs (..), ToKeyValuePairs (..))
+import Cardano.Ledger.BaseTypes (
+  KeyValuePairs (..),
+  StrictMaybe (..),
+  ToKeyValuePairs (..),
+  maybeToStrictMaybe,
+ )
 import Cardano.Ledger.Binary (
   DecCBOR (..),
   EncCBOR (..),
@@ -75,8 +80,8 @@ import NoThunks.Class (NoThunks)
 
 -- | All configuration that is necessary to bootstrap AlonzoEra from ShelleyGenesis
 data AlonzoGenesis = AlonzoGenesisWrapper
-  { unAlonzoGenesisWrapper :: UpgradeAlonzoPParams Identity
-  , extraConfig :: Maybe AlonzoExtraConfig
+  { unAlonzoGenesisWrapper :: !(UpgradeAlonzoPParams Identity)
+  , extraConfig :: !(StrictMaybe AlonzoExtraConfig)
   }
   deriving stock (Eq, Show, Generic)
   deriving (ToJSON) via KeyValuePairs AlonzoGenesis
@@ -120,7 +125,7 @@ pattern AlonzoGenesis ::
   Word32 ->
   Word16 ->
   Word16 ->
-  Maybe AlonzoExtraConfig ->
+  StrictMaybe AlonzoExtraConfig ->
   AlonzoGenesis
 pattern AlonzoGenesis
   { agCoinsPerUTxOWord
@@ -224,7 +229,7 @@ instance FromJSON AlonzoGenesis where
     agMaxValSize <- o .: "maxValueSize"
     agCollateralPercentage <- o .: "collateralPercentage"
     agMaxCollateralInputs <- o .: "maxCollateralInputs"
-    agExtraConfig <- o .:? "extraConfig"
+    agExtraConfig <- maybeToStrictMaybe <$> o .:? "extraConfig"
     agPlutusV1CostModel <-
       case Map.toList (costModelsValid cms) of
         [] -> fail "Expected \"PlutusV1\" cost model to be supplied"
@@ -247,4 +252,4 @@ instance ToKeyValuePairs AlonzoGenesis where
     , "collateralPercentage" .= agCollateralPercentage ag
     , "maxCollateralInputs" .= agMaxCollateralInputs ag
     ]
-      ++ ["extraConfig" .= extraConfig | Just extraConfig <- [agExtraConfig ag]]
+      ++ ["extraConfig" .= extraConfig | SJust extraConfig <- [agExtraConfig ag]]

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Transition.hs
@@ -14,6 +14,7 @@ import Cardano.Ledger.Alonzo.Core (AlonzoEraPParams, ppCostModelsL)
 import Cardano.Ledger.Alonzo.Era
 import Cardano.Ledger.Alonzo.Genesis
 import Cardano.Ledger.Alonzo.Translation ()
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Mary
 import Cardano.Ledger.Mary.Transition (TransitionConfig (MaryTransitionConfig))
 import Cardano.Ledger.Plutus.CostModels (CostModels, CostModelsUpdate (..), updateCostModels)
@@ -48,8 +49,8 @@ alonzoInjectCostModels ::
   TransitionConfig AlonzoEra -> NewEpochState era -> NewEpochState era
 alonzoInjectCostModels cfg =
   case agExtraConfig $ cfg ^. tcTranslationContextL of
-    Nothing -> id
-    Just aec -> overrideCostModels (aecCostModels aec)
+    SNothing -> id
+    SJust aec -> overrideCostModels (aecCostModels aec)
 
 overrideCostModels ::
   (EraTransition era, AlonzoEraPParams era) =>

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Examples.hs
@@ -105,7 +105,7 @@ ledgerExamples =
         , agMaxValSize = 1234
         , agCollateralPercentage = 20
         , agMaxCollateralInputs = 30
-        , agExtraConfig = Nothing
+        , agExtraConfig = SNothing
         }
 
 exampleAlonzoTx :: Tx TopTx AlonzoEra

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/ImpTest.hs
@@ -442,7 +442,7 @@ instance ShelleyEraImp AlonzoEra where
         , agMaxValSize = 5000
         , agCollateralPercentage = 150
         , agMaxCollateralInputs = 3
-        , agExtraConfig = Nothing
+        , agExtraConfig = SNothing
         }
 
   impSatisfyNativeScript = impAllegraSatisfyNativeScript

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/Golden.hs
@@ -333,7 +333,7 @@ expectedGenesis =
     , agMaxValSize = 5000
     , agCollateralPercentage = 150
     , agMaxCollateralInputs = 3
-    , agExtraConfig = Nothing
+    , agExtraConfig = SNothing
     }
 
 expectedCostModel :: CostModel

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.23.0.0
 
+* Fix `NoThunks` instance for `ConwayGenesis`
 * Remove `conwayCertsTotalRefundsTxBody` and `conwayConsumed`
 * Remove an unnecessary argument to `conwayDRepRefundsTxCerts` function.
 * Allow any tx level in `updateDormantDRepExpiries` and `updateVotingDRepExpiries`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Genesis.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -56,7 +57,7 @@ import Data.Functor.Identity (Identity)
 import Data.ListMap (ListMap)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens)
-import NoThunks.Class (NoThunks)
+import NoThunks.Class (AllowThunksIn (..), NoThunks)
 
 -- | Extra configuration for injecting Conway-specific Genesis data
 data ConwayExtraConfig = ConwayExtraConfig
@@ -122,7 +123,10 @@ cgExtraConfigL = lens cgExtraConfig (\x y -> x {cgExtraConfig = y})
 instance EraGenesis ConwayEra where
   type Genesis ConwayEra = ConwayGenesis
 
-instance NoThunks ConwayGenesis
+deriving via
+  AllowThunksIn '["cgDelegs", "cgInitialDReps"] ConwayGenesis
+  instance
+    NoThunks ConwayGenesis
 
 instance NFData ConwayGenesis
 


### PR DESCRIPTION
# Description

These were found by `nothunks` tests in Consensus

```
StrictTVar invariant violation: ThunkInfo
    { thunkContext =
        [ "ListMap"
        , "cgDelegs"
        , "ConwayGenesis"
        , ...
        ]
    , thunkInfo = Nothing
    }

StrictTVar invariant violation: ThunkInfo
    { thunkContext =
        [ "UpgradeAlonzoPParams"
        , "unAlonzoGenesisWrapper"
        , "AlonzoGenesis"
        , ...
        ]
    , thunkInfo = Nothing
    }
```

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
