### PR TITLE
Update hackage index-state version to get latest cuddle release

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -27,7 +27,7 @@ source-repository-package
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
 index-state:
-  , hackage.haskell.org 2026-05-26T19:31:06Z
+  , hackage.haskell.org 2026-07-15T21:58:35Z
   , cardano-haskell-packages 2026-06-29T12:05:19Z
 
 packages:

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Arbitrary.hs
@@ -59,10 +59,10 @@ import Cardano.Ledger.HKD (HKD, NoUpdate (..))
 import Cardano.Ledger.Plutus (Language (PlutusV3))
 import Control.Monad (forM)
 import Control.State.Transition.Extended (STS (Event))
+import Data.Containers.ListUtils (nubOrdOn)
 import Data.Default (def)
 import Data.Foldable (toList)
 import Data.Functor.Identity (Identity)
-import Data.List (nubBy)
 import qualified Data.ListMap as ListMap
 import qualified Data.Map.Strict as Map
 import qualified Data.Sequence as Seq
@@ -282,7 +282,7 @@ instance
 _uniqueIdGovActions ::
   (Era era, Arbitrary (PParamsUpdate era)) =>
   Gen (SSeq.StrictSeq (GovActionState era))
-_uniqueIdGovActions = SSeq.fromList . nubBy (\x y -> gasId x == gasId y) <$> arbitrary
+_uniqueIdGovActions = SSeq.fromList . nubOrdOn gasId <$> arbitrary
 
 instance
   (forall p. Arbitrary (f (GovPurposeId (p :: GovActionPurpose)))) =>

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Arbitrary.hs
@@ -85,6 +85,7 @@ import Cardano.Ledger.Shelley.TxWits (ShelleyTxWits (ShelleyTxWits))
 import Control.Exception (assert)
 import Control.Monad.Identity (Identity)
 import Control.State.Transition (PredicateFailure)
+import Data.Containers.ListUtils (nubOrdOn)
 import qualified Data.ListMap as LM
 import qualified Data.Map.Strict as Map (fromList)
 import Data.Sequence.Strict (fromList)
@@ -428,7 +429,8 @@ genMetadatumList = List <$> vectorOfMetadatumSimple
 -- | Generate a 'MD.Map ('[(Metadatum, Metadatum)]')
 genMetadatumMap :: Gen Metadatum
 genMetadatumMap =
-  Map <$> (zip <$> vectorOfMetadatumSimple <*> vectorOfMetadatumSimple)
+  Map . nubOrdOn fst
+    <$> (zip <$> vectorOfMetadatumSimple <*> vectorOfMetadatumSimple)
 
 vectorOfMetadatumSimple :: Gen [Metadatum]
 vectorOfMetadatumSimple = do
@@ -549,7 +551,7 @@ sizedMetadatum 0 =
 sizedMetadatum n =
   let xsGen = listOf (sizedMetadatum (n - 1))
    in oneof
-        [ Map <$> (zip <$> resize maxMetadatumListLens xsGen <*> xsGen)
+        [ Map . nubOrdOn fst <$> (zip <$> resize maxMetadatumListLens xsGen <*> xsGen)
         , List <$> resize maxMetadatumListLens xsGen
         , I <$> arbitrary
         , genMetadatumByteArray

--- a/flake.lock
+++ b/flake.lock
@@ -292,11 +292,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1779824738,
-        "narHash": "sha256-o4W05VYZ0hlIA/BXxL6hYsQ9HL6JsawxepFnCh429R8=",
+        "lastModified": 1784153046,
+        "narHash": "sha256-W6/dzXu2M1bIJI2zIWkcd7npfzxDKyHS2ALhm4KhHOQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "decbe184cfce30ea802ea95c874511f776a4b48a",
+        "rev": "4740f5a1e2c33fdde1fcea79d3063289c82db1e0",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Arbitrary.hs
@@ -95,6 +95,7 @@ import Cardano.Ledger.TxIn (TxId (..), TxIn (..))
 import Control.Monad (replicateM)
 import Control.Monad.Identity (Identity)
 import Control.Monad.Trans.Fail.String (errorFail)
+import Data.Containers.ListUtils (nubOrdOn)
 import Data.Foldable (toList)
 import Data.GenValidity
 import Data.Int (Int64)
@@ -834,7 +835,8 @@ instance Arbitrary PV1.Data where
             oneof
               [ PV1.I <$> arbitrary
               , PV1.B <$> arbitrary
-              , PV1.Map <$> listOf ((,) <$> genData (n `div` 2) <*> genData (n `div` 2))
+              , PV1.Map . nubOrdOn fst
+                  <$> listOf ((,) <$> genData (n `div` 2) <*> genData (n `div` 2))
               , PV1.Constr
                   <$> fmap fromIntegral (arbitrary :: Gen Natural)
                   <*> listOf (genData (n `div` 2))


### PR DESCRIPTION
# Description

The upgraded cuddle now validates that CBOR maps do not contain duplicate keys (per RFC 7049/8949). This caused CDDL round-trip tests to fail because the Arbitrary instances for PV1.Data (PlutusData) and Metadatum were generating maps with duplicate keys.

Fix the generators by deduplicating map entries with nubBy on the key.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
