### PR TITLE
Fix deposits in AdaPots calculations  - [TYPECLASS RESOLUTION LOOP]

### DIFF
--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
@@ -1,11 +1,19 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Dijkstra.State.CertState () where
 
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.State
+import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Dijkstra.State.Account ()
+import Cardano.Ledger.Dijkstra.Tx ()
+import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
+import Data.Foldable (foldMap')
+import Lens.Micro ((^.))
 
 instance EraCertState DijkstraEra where
   type CertState DijkstraEra = ConwayCertState DijkstraEra
@@ -20,8 +28,29 @@ instance EraCertState DijkstraEra where
 
   certsTotalDepositsTxBody = conwayCertsTotalDepositsTxBody
 
-  certsTotalRefundsTxBody = shelleyCertsTotalRefundsTxBody
+  certsTotalRefundsTxBody = dijkstraCertsTotalRefundsTxBody
 
 instance ConwayEraCertState DijkstraEra where
   certVStateL = conwayCertVStateL
   {-# INLINE certVStateL #-}
+
+-- | Total refunds for a transaction, summed across the top-level tx and its subtransactions
+dijkstraCertsTotalRefundsTxBody ::
+  forall era l.
+  ( EraTx era
+  , DijkstraEraTxBody era
+  , STxLevel l era ~ STxBothLevels l era
+  ) =>
+  PParams era ->
+  Accounts era ->
+  TxBody l era ->
+  Coin
+dijkstraCertsTotalRefundsTxBody pp _ txBody =
+  getTotalRefundsTxCerts pp (const Nothing) $
+    withBothTxLevels
+      txBody
+      ( \topTxBody ->
+          (topTxBody ^. certsTxBodyL)
+            <> foldMap' (^. bodyTxL . certsTxBodyL) (topTxBody ^. subTransactionsTxBodyL)
+      )
+      (^. certsTxBodyL)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
@@ -16,6 +16,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -146,6 +147,7 @@ import Cardano.Ledger.TxIn (TxId, TxIn)
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData (..), deepseq)
 import Data.Coerce (coerce)
+import Data.Foldable (foldMap')
 import Data.Map.Strict (Map)
 import Data.OMap.Strict (OMap)
 import qualified Data.OMap.Strict as OMap
@@ -213,11 +215,7 @@ data DijkstraTxBodyRaw l era where
 deriving instance (EraTxBody era, Eq (Tx SubTx era)) => Eq (DijkstraTxBodyRaw l era)
 
 instance
-  ( Eq (Tx SubTx DijkstraEra)
-  , NFData (Tx SubTx DijkstraEra)
-  , Show (Tx SubTx DijkstraEra)
-  , EncCBOR (Tx SubTx DijkstraEra)
-  , DecCBOR (Annotator (Tx SubTx DijkstraEra))
+  ( EraTx DijkstraEra
   , OMap.HasOKey TxId (Tx SubTx DijkstraEra)
   ) =>
   EqRaw (TxBody l DijkstraEra)
@@ -533,47 +531,32 @@ instance
 
 deriving instance
   ( Typeable l
-  , Eq (Tx SubTx DijkstraEra)
-  , NFData (Tx SubTx DijkstraEra)
-  , Show (Tx SubTx DijkstraEra)
-  , EncCBOR (Tx SubTx DijkstraEra)
-  , DecCBOR (Annotator (Tx SubTx DijkstraEra))
+  , EraTx DijkstraEra
   , OMap.HasOKey TxId (Tx SubTx DijkstraEra)
   ) =>
   NoThunks (TxBody l DijkstraEra)
 
 deriving instance
-  ( Eq (Tx SubTx DijkstraEra)
-  , NFData (Tx SubTx DijkstraEra)
-  , Show (Tx SubTx DijkstraEra)
-  , EncCBOR (Tx SubTx DijkstraEra)
-  , DecCBOR (Annotator (Tx SubTx DijkstraEra))
+  ( EraTx DijkstraEra
   , OMap.HasOKey TxId (Tx SubTx DijkstraEra)
   ) =>
   Eq (TxBody l DijkstraEra)
 
 deriving newtype instance
-  ( NFData (Tx SubTx DijkstraEra)
-  , Eq (Tx SubTx DijkstraEra)
-  , Show (Tx SubTx DijkstraEra)
-  , EncCBOR (Tx SubTx DijkstraEra)
-  , DecCBOR (Annotator (Tx SubTx DijkstraEra))
+  ( EraTx DijkstraEra
   , OMap.HasOKey TxId (Tx SubTx DijkstraEra)
   ) =>
   NFData (TxBody l DijkstraEra)
 
 deriving instance
-  ( Show (Tx SubTx DijkstraEra)
-  , Eq (Tx SubTx DijkstraEra)
-  , NFData (Tx SubTx DijkstraEra)
-  , EncCBOR (Tx SubTx DijkstraEra)
-  , DecCBOR (Annotator (Tx SubTx DijkstraEra))
+  ( EraTx DijkstraEra
   , OMap.HasOKey TxId (Tx SubTx DijkstraEra)
   ) =>
   Show (TxBody l DijkstraEra)
 
 pattern DijkstraTxBody ::
-  ( EncCBOR (Tx SubTx DijkstraEra)
+  ( EraTx DijkstraEra
+  , EncCBOR (Tx SubTx DijkstraEra)
   , Eq (Tx SubTx DijkstraEra)
   , NFData (Tx SubTx DijkstraEra)
   , Show (Tx SubTx DijkstraEra)
@@ -708,7 +691,8 @@ pattern DijkstraTxBody
             accountBalanceIntervals
 
 pattern DijkstraSubTxBody ::
-  ( EncCBOR (Tx SubTx DijkstraEra)
+  ( EraTx DijkstraEra
+  , EncCBOR (Tx SubTx DijkstraEra)
   , Eq (Tx SubTx DijkstraEra)
   , NFData (Tx SubTx DijkstraEra)
   , Show (Tx SubTx DijkstraEra)
@@ -833,11 +817,7 @@ deriving via
   Mem (DijkstraTxBodyRaw l DijkstraEra)
   instance
     ( Typeable l
-    , Eq (Tx SubTx DijkstraEra)
-    , NFData (Tx SubTx DijkstraEra)
-    , Show (Tx SubTx DijkstraEra)
-    , EncCBOR (Tx SubTx DijkstraEra)
-    , DecCBOR (Annotator (Tx SubTx DijkstraEra))
+    , EraTx DijkstraEra
     , OMap.HasOKey TxId (Tx SubTx DijkstraEra)
     ) =>
     DecCBOR (Annotator (TxBody l DijkstraEra))
@@ -941,7 +921,8 @@ accountBalanceIntervalsDijkstraTxBodyRawL =
     )
 
 instance
-  ( Eq (Tx SubTx DijkstraEra)
+  ( EraTx DijkstraEra
+  , Eq (Tx SubTx DijkstraEra)
   , NFData (Tx SubTx DijkstraEra)
   , Show (Tx SubTx DijkstraEra)
   , EncCBOR (Tx SubTx DijkstraEra)
@@ -1011,11 +992,34 @@ upgradeProposals ProposalProcedure {..} =
     , pProcAnchor = pProcAnchor
     }
 
+-- | Batch-aware total deposits for a transaction.
 dijkstraTotalDepositsTxBody ::
-  ConwayEraTxBody era => PParams era -> (KeyHash StakePool -> Bool) -> TxBody l era -> Coin
-dijkstraTotalDepositsTxBody pp isPoolRegisted txBody =
-  getTotalDepositsTxCerts pp isPoolRegisted (txBody ^. certsTxBodyL)
-    <+> conwayProposalsDeposits pp txBody
+  forall era l.
+  ( EraTx era
+  , DijkstraEraTxBody era
+  , STxLevel l era ~ STxBothLevels l era
+  ) =>
+  PParams era ->
+  (KeyHash StakePool -> Bool) ->
+  TxBody l era ->
+  Coin
+dijkstraTotalDepositsTxBody pp isPoolRegistered txBody =
+  -- TODO: restrict to TopTx, once certsTotalDepositsTxBody is restricted to TopTx
+  withBothTxLevels
+    txBody
+    ( \topTxBody ->
+        let subTxs = topTxBody ^. subTransactionsTxBodyL
+            batchTxCerts =
+              foldMap' (^. bodyTxL . certsTxBodyL) subTxs
+                <> (topTxBody ^. certsTxBodyL)
+         in getTotalDepositsTxCerts pp isPoolRegistered batchTxCerts
+              <+> conwayProposalsDeposits pp topTxBody
+              <+> foldMap' (conwayProposalsDeposits pp . (^. bodyTxL)) subTxs
+    )
+    ( \subTxBody ->
+        getTotalDepositsTxCerts pp isPoolRegistered (subTxBody ^. certsTxBodyL)
+          <+> conwayProposalsDeposits pp subTxBody
+    )
 
 -- | This newtype wrapper lets us index into the guards with a ScriptHash. It
 -- will return the index of the credential when using `indexOf` and the `fromIndex`
@@ -1088,7 +1092,8 @@ vldtDijkstraTxBodyRawL =
     )
 
 instance
-  ( Eq (Tx SubTx DijkstraEra)
+  ( EraTx DijkstraEra
+  , Eq (Tx SubTx DijkstraEra)
   , NFData (Tx SubTx DijkstraEra)
   , Show (Tx SubTx DijkstraEra)
   , EncCBOR (Tx SubTx DijkstraEra)
@@ -1113,7 +1118,8 @@ mintDijkstraTxBodyRawL =
     )
 
 instance
-  ( Eq (Tx SubTx DijkstraEra)
+  ( EraTx DijkstraEra
+  , Eq (Tx SubTx DijkstraEra)
   , NFData (Tx SubTx DijkstraEra)
   , Show (Tx SubTx DijkstraEra)
   , EncCBOR (Tx SubTx DijkstraEra)
@@ -1155,7 +1161,8 @@ networkIdDijkstraTxBodyRawL =
     )
 
 instance
-  ( Eq (Tx SubTx DijkstraEra)
+  ( EraTx DijkstraEra
+  , Eq (Tx SubTx DijkstraEra)
   , NFData (Tx SubTx DijkstraEra)
   , Show (Tx SubTx DijkstraEra)
   , EncCBOR (Tx SubTx DijkstraEra)
@@ -1212,7 +1219,8 @@ referenceInputsDijkstraTxBodyRawL =
     )
 
 instance
-  ( NFData (Tx SubTx DijkstraEra)
+  ( EraTx DijkstraEra
+  , NFData (Tx SubTx DijkstraEra)
   , Eq (Tx SubTx DijkstraEra)
   , Show (Tx SubTx DijkstraEra)
   , EncCBOR (Tx SubTx DijkstraEra)
@@ -1301,7 +1309,8 @@ currentTreasuryValueDijkstraTxBodyRawL =
     )
 
 instance
-  ( NFData (Tx SubTx DijkstraEra)
+  ( EraTx DijkstraEra
+  , NFData (Tx SubTx DijkstraEra)
   , Eq (Tx SubTx DijkstraEra)
   , Show (Tx SubTx DijkstraEra)
   , EncCBOR (Tx SubTx DijkstraEra)
@@ -1360,7 +1369,8 @@ requiredTopLevelGuardsDijkstraTxBodyRawL =
     )
 
 instance
-  ( NFData (Tx SubTx DijkstraEra)
+  ( EraTx DijkstraEra
+  , NFData (Tx SubTx DijkstraEra)
   , Eq (Tx SubTx DijkstraEra)
   , Show (Tx SubTx DijkstraEra)
   , EncCBOR (Tx SubTx DijkstraEra)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -111,18 +111,19 @@ dijkstraProducedValue ::
   TxBody TopTx era ->
   MaryValue
 dijkstraProducedValue pp isRegPoolId topTxBody =
-  commonProduced topTxBody
-    <> foldMap' (commonProduced . (^. bodyTxL)) subTxs
+  producedPerTxBody topTxBody
+    <> foldMap' (producedPerTxBody . (^. bodyTxL)) subTxs
     <> inject (topTxBody ^. feeTxBodyL)
     <> inject (getTotalDepositsTxCerts pp isRegPoolId batchTxCerts)
   where
-    -- add all produced values that are common across transaction levels
-    commonProduced :: TxBody l era -> MaryValue
-    commonProduced txBody =
+    -- add all values that are produced by both top and sub-transactions
+    producedPerTxBody :: TxBody l era -> MaryValue
+    producedPerTxBody txBody =
       sumAllValue (txBody ^. outputsTxBodyL)
         <> inject (txBody ^. treasuryDonationTxBodyL)
         <> inject (conwayProposalsDeposits pp txBody)
         <> burnedMultiAssets txBody
+        <> inject (fold (unDirectDeposits (txBody ^. directDepositsTxBodyL)))
     batchTxCerts =
       foldMap' (^. bodyTxL . certsTxBodyL) subTxs
         <> (topTxBody ^. certsTxBodyL)

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -22,15 +22,13 @@ import Cardano.Ledger.Mary.Value (
   PolicyID,
   multiAssetFromList,
  )
-import Cardano.Ledger.Shelley.LedgerState (
-  esLStateL,
-  lsCertStateL,
-  nesEsL,
- )
+import qualified Cardano.Ledger.Shelley.AdaPots as AdaPots
+import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.UTxO (produced)
 import Cardano.Ledger.Tools (ensureMinCoinTxOut)
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.Val
+import qualified Data.Map.Strict as Map
 import Data.Typeable (Typeable)
 import Lens.Micro ((&), (.~), (^.))
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -131,7 +129,7 @@ spec = describe "UTXO" $ do
       pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
       produced pp pState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
 
-    it "sums outputs, fee, treasury donations, pool/DRep deposits and burned assets across the batch" $ do
+    it "sums outputs, fee, treasury donations, deposits and burned assets across the batch" $ do
       poolDeposit <- (Coin 1 <>) <$> arbitrary
       dRepDeposit <- (Coin 1 <>) <$> arbitrary
       modifyPParams $ (ppPoolDepositL .~ poolDeposit) . (ppDRepDepositL .~ dRepDeposit)
@@ -149,6 +147,10 @@ spec = describe "UTXO" $ do
       subTreasury <- arbitrary
       topBurnAmount <- getPositive <$> arbitrary
       subBurnAmount <- getPositive <$> arbitrary
+      topDDAddr <- arbitrary
+      subDDAddr <- arbitrary
+      topDDAmount <- (Coin 1 <>) <$> arbitrary
+      subDDAmount <- (Coin 1 <>) <$> arbitrary
       let topMint = multiAssetFromList [(policyA, asset, -topBurnAmount)]
           subMint = multiAssetFromList [(policyA, asset, -subBurnAmount)]
           expectedBurned :: MultiAsset
@@ -169,6 +171,7 @@ spec = describe "UTXO" $ do
                   .~ [regPool, RegDRepTxCert drepB dRepDeposit SNothing]
                 & treasuryDonationTxBodyL .~ subTreasury
                 & mintTxBodyL .~ subMint
+                & directDepositsTxBodyL .~ DirectDeposits [(subDDAddr, subDDAmount)]
           topTx :: Tx TopTx era
           topTx =
             mkBasicTx $
@@ -179,6 +182,7 @@ spec = describe "UTXO" $ do
                   .~ [regPool, RegDRepTxCert drepA dRepDeposit SNothing]
                 & treasuryDonationTxBodyL .~ topTreasury
                 & mintTxBodyL .~ topMint
+                & directDepositsTxBodyL .~ DirectDeposits [(topDDAddr, topDDAmount)]
                 & subTransactionsTxBodyL .~ [subTx]
           expectedCoin =
             topOutValue
@@ -188,9 +192,24 @@ spec = describe "UTXO" $ do
               <> subTreasury
               <> poolDeposit
               <> ((2 :: Int) <×> dRepDeposit)
+              <> topDDAmount
+              <> subDDAmount
           expected = MaryValue expectedCoin expectedBurned
       pp <- getsPParams id
       pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
       produced pp pState (topTx ^. bodyTxL) `shouldBe` expected
+      checkDepositCalculation
+        (topTx ^. bodyTxL)
+        (poolDeposit <> ((2 :: Int) <×> dRepDeposit))
+        (poolDeposit <> dRepDeposit)
   where
     mkSubTx i cert = mkBasicTx $ mkBasicTxBody & certsTxBodyL .~ [cert] & inputsTxBodyL .~ [i]
+    -- Check that `certsTotalDepositsTxBody` (used to set deposits in `UTxOState` and `AdaPots` calculations)
+    -- returns the batch deposits, while `getTotalDepositsTxBody` returns the top-level deposits
+    checkDepositCalculation topBody batchDeposits topLevelDeposits = do
+      pp <- getsPParams id
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      AdaPots.proDeposits (AdaPots.producedTxBody topBody pp certState)
+        `shouldBe` batchDeposits
+      let isPoolReg = (`Map.member` (certState ^. certPStateL . psStakePoolsL))
+      getTotalDepositsTxBody pp isPoolReg topBody `shouldBe` topLevelDeposits


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->


EDIT: 
Alas! This PR compiles, but doesn't run correctly. 
It is producing a loop at runtime, when running the tests. 
Like this: 
    Test suite tests: RUNNING...
    tests: <<loop>>
    Test suite tests: FAIL
    Test suite logged to:
    /home/teo/iohk/projects/cardano-ledger/dist-newstyle/build/x86_64-linux/ghc-9.6.7/cardano-ledger-
    dijkstra-0.3.0.0/t/tests/noopt/test/cardano-ledger-dijkstra-0.3.0.0-tests.log
    0 of 1 test suites (0 of 1 test cases) passed.
    Error: [Cabal-7125]
    Tests failed for test:tests from cardano-ledger-dijkstra-0.3.0.0.

The cause seems to be adding `EraTx DijkstraEra` constraint to `EraTxBody DijkstraEra`.

I have implemented an alternative here:  https://github.com/IntersectMBO/cardano-ledger/pull/5930
If you know how to fix this loop, please let me know! 

---------------------------------


In this PR, I'm fixing some things related to deposits and refunds, in a way that enables the rules to call them correctly (in a subsequent PR).
## Context
We have two typeclasses with parallel methods:

```
  class  EraCertState era where
    certsTotalDepositsTxBody :: ..
    certsTotalRefundsTxBody ::
```
  and

```
  class EraTxBody era where
    getTotalDepositsTxBody :: ..
    getTotalRefundsTxBody :: ...
```

The methods from `EraTxBody` are used in the calculation of produced value (excluding Dijkstra, before this PR).
The methods from `EraCertState` are used to set `utxosDeposited` field in `UTxOState` and for calculation of `AdaPots`. 

From shelley until conway, they return the exact same values, respectively - the implementations `EraCertState` are just wrappers over the ones in `EraTxBody`.

At the moment in master,  the values returned by `EraCertState` methods are incorrect - in light of the fact that `utxosDeposited` and `AdaPots` will be used at the top level and have to calculate the values for the whole batch.
Neither `certsTotalDepositsTxBody` nor `certsTotalRefundsTxBody` are "batch-aware" - so they do not traverse the subtransactions, which means that at the moment they only return these value for the top level. 

In this PR I'm introducing "batch-aware" Dijkstra implementations for 
* `getTotalDepositsTxBody`. 
	This will not only fix `certsTotalDepositsTxBody`, but also enable us to re-use this function in `getProducedValue` and to remove the duplicated logic of summing up all the deposits.
	(because at the moment, `getProducedValue` in dijkstra bypasses `getTotalDepositsTxBody`, unlike the other eras)
* `certsTotalRefundsTxBody`
	Because `getConsumedValue` is calculated recursively using `getTotalRefundsTxBody`, I can't modify `getTotalRefundsTxBody` to make it batch aware. 
	So the batch-awareness logic has to come then in an implementation of this method - which is not being called in the `getConsumedValue` computation.
	It's the first time that the values in these two parallel instances diverge. 
	If we make `getConsumedValue` non-recursive and restrict it to the top-level, then we can do the same as above and move the "batch-awareness" to `getTotalRefundsTxBody`.
	Perhaps we can even get rid of these methods in `EraCertState` which seem to add no extra logic, but tons of confusion. 


I also fixed `getTotalDepositsTxBody` by adding hte missing Direct Deposits - which have to go both in produced and in `utxosDeposited`. 

With the changes from this PR, I'll be able to correctly decouple setting of `utxosDeposited` (at the top level) with updating of utxo (which has to happen at both levels).
(https://github.com/IntersectMBO/cardano-ledger/pull/5920/commits)



# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
