### PR TITLE
Fix deposits in AdaPots calculations

### DIFF
--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
@@ -1,11 +1,23 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Dijkstra.State.CertState () where
 
+import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.State
+import Cardano.Ledger.Conway.TxBody (conwayProposalsDeposits)
+import Cardano.Ledger.Core
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Dijkstra.State.Account ()
+import Cardano.Ledger.Dijkstra.Tx ()
+import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody (..))
+import Cardano.Ledger.Val ((<+>))
+import Data.Foldable (foldMap')
+import qualified Data.Map.Strict as Map
+import Lens.Micro ((^.))
 
 instance EraCertState DijkstraEra where
   type CertState DijkstraEra = ConwayCertState DijkstraEra
@@ -18,10 +30,38 @@ instance EraCertState DijkstraEra where
 
   obligationCertState = conwayObligationCertState
 
-  certsTotalDepositsTxBody = conwayCertsTotalDepositsTxBody
+  certsTotalDepositsTxBody = dijkstraCertsTotalDepositsTxBody
 
   certsTotalRefundsTxBody = shelleyCertsTotalRefundsTxBody
 
 instance ConwayEraCertState DijkstraEra where
   certVStateL = conwayCertVStateL
   {-# INLINE certVStateL #-}
+
+-- | Total deposits for a transaction, summed across the top-level tx and its subtransactions
+dijkstraCertsTotalDepositsTxBody ::
+  forall era l.
+  ( EraTx era
+  , DijkstraEraTxBody era
+  , STxLevel l era ~ STxBothLevels l era
+  ) =>
+  PParams era ->
+  ConwayCertState era ->
+  TxBody l era ->
+  Coin
+dijkstraCertsTotalDepositsTxBody pp certState = \txBody ->
+  -- TODO: restrict to TopTx, once certsTotalDepositsTxBody is restricted to TopTx
+  withBothTxLevels
+    txBody
+    ( \topTxBody ->
+        let subTxs = topTxBody ^. subTransactionsTxBodyL
+            batchTxCerts =
+              foldMap' (^. bodyTxL . certsTxBodyL) subTxs
+                <> (topTxBody ^. certsTxBodyL)
+         in getTotalDepositsTxCerts pp isPoolReg batchTxCerts
+              <+> conwayProposalsDeposits pp topTxBody
+              <+> foldMap' (conwayProposalsDeposits pp . (^. bodyTxL)) subTxs
+    )
+    (getTotalDepositsTxBody pp isPoolReg)
+  where
+    isPoolReg = (`Map.member` psStakePools (conwayCertPState certState))

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
@@ -32,7 +32,7 @@ instance EraCertState DijkstraEra where
 
   certsTotalDepositsTxBody = dijkstraCertsTotalDepositsTxBody
 
-  certsTotalRefundsTxBody = shelleyCertsTotalRefundsTxBody
+  certsTotalRefundsTxBody = dijkstraCertsTotalRefundsTxBody
 
 instance ConwayEraCertState DijkstraEra where
   certVStateL = conwayCertVStateL
@@ -65,3 +65,24 @@ dijkstraCertsTotalDepositsTxBody pp certState = \txBody ->
     (getTotalDepositsTxBody pp isPoolReg)
   where
     isPoolReg = (`Map.member` psStakePools (conwayCertPState certState))
+
+-- | Total refunds for a transaction, summed across the top-level tx and its subtransactions
+dijkstraCertsTotalRefundsTxBody ::
+  forall era l.
+  ( EraTx era
+  , DijkstraEraTxBody era
+  , STxLevel l era ~ STxBothLevels l era
+  ) =>
+  PParams era ->
+  Accounts era ->
+  TxBody l era ->
+  Coin
+dijkstraCertsTotalRefundsTxBody pp _ txBody =
+  getTotalRefundsTxCerts pp (const Nothing) $
+    withBothTxLevels
+      txBody
+      ( \topTxBody ->
+          foldMap' (^. bodyTxL . certsTxBodyL) (topTxBody ^. subTransactionsTxBodyL)
+            <> (topTxBody ^. certsTxBodyL)
+      )
+      (^. certsTxBodyL)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -111,18 +111,21 @@ dijkstraProducedValue ::
   TxBody TopTx era ->
   MaryValue
 dijkstraProducedValue pp isRegPoolId topTxBody =
-  commonProduced topTxBody
-    <> foldMap' (commonProduced . (^. bodyTxL)) subTxs
+  producedPerTxBodyWithoutCerts topTxBody
+    <> foldMap' (producedPerTxBodyWithoutCerts . (^. bodyTxL)) subTxs
     <> inject (topTxBody ^. feeTxBodyL)
     <> inject (getTotalDepositsTxCerts pp isRegPoolId batchTxCerts)
   where
-    -- add all produced values that are common across transaction levels
-    commonProduced :: TxBody l era -> MaryValue
-    commonProduced txBody =
+    -- add all values that are produced by both top and sub-transactions
+    -- Certs are excluded, since they need to be processed separately
+    -- while maintaining the state through all of the certs of a transactions.
+    producedPerTxBodyWithoutCerts :: TxBody l era -> MaryValue
+    producedPerTxBodyWithoutCerts txBody =
       sumAllValue (txBody ^. outputsTxBodyL)
         <> inject (txBody ^. treasuryDonationTxBodyL)
         <> inject (conwayProposalsDeposits pp txBody)
         <> burnedMultiAssets txBody
+        <> inject (fold (unDirectDeposits (txBody ^. directDepositsTxBodyL)))
     batchTxCerts =
       foldMap' (^. bodyTxL . certsTxBodyL) subTxs
         <> (topTxBody ^. certsTxBodyL)

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -22,15 +22,13 @@ import Cardano.Ledger.Mary.Value (
   PolicyID,
   multiAssetFromList,
  )
-import Cardano.Ledger.Shelley.LedgerState (
-  esLStateL,
-  lsCertStateL,
-  nesEsL,
- )
+import qualified Cardano.Ledger.Shelley.AdaPots as AdaPots
+import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.UTxO (produced)
 import Cardano.Ledger.Tools (ensureMinCoinTxOut)
 import Cardano.Ledger.TxIn (TxIn)
 import Cardano.Ledger.Val
+import qualified Data.Map.Strict as Map
 import Data.Typeable (Typeable)
 import Lens.Micro ((&), (.~), (^.))
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -133,7 +131,7 @@ spec = describe "UTXO" $ do
       pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
       produced pp pState (topTx ^. bodyTxL) `shouldBe` inject poolDeposit
 
-    it "sums outputs, fee, treasury donations, pool/DRep deposits and burned assets across the batch" $ do
+    it "sums outputs, fee, treasury donations, deposits and burned assets across the batch" $ do
       poolDeposit <- (Coin 1 <>) <$> arbitrary
       dRepDeposit <- (Coin 1 <>) <$> arbitrary
       modifyPParams $ (ppPoolDepositL .~ poolDeposit) . (ppDRepDepositL .~ dRepDeposit)
@@ -151,6 +149,10 @@ spec = describe "UTXO" $ do
       subTreasury <- arbitrary
       topBurnAmount <- getPositive <$> arbitrary
       subBurnAmount <- getPositive <$> arbitrary
+      topDDAddr <- arbitrary
+      subDDAddr <- arbitrary
+      topDDAmount <- (Coin 1 <>) <$> arbitrary
+      subDDAmount <- (Coin 1 <>) <$> arbitrary
       let topMint = multiAssetFromList [(policyA, asset, -topBurnAmount)]
           subMint = multiAssetFromList [(policyA, asset, -subBurnAmount)]
           expectedBurned :: MultiAsset
@@ -171,6 +173,7 @@ spec = describe "UTXO" $ do
                   .~ [regPool, RegDRepTxCert drepB dRepDeposit SNothing]
                 & treasuryDonationTxBodyL .~ subTreasury
                 & mintTxBodyL .~ subMint
+                & directDepositsTxBodyL .~ DirectDeposits [(subDDAddr, subDDAmount)]
           topTx :: Tx TopTx era
           topTx =
             mkBasicTx $
@@ -181,6 +184,7 @@ spec = describe "UTXO" $ do
                   .~ [regPool, RegDRepTxCert drepA dRepDeposit SNothing]
                 & treasuryDonationTxBodyL .~ topTreasury
                 & mintTxBodyL .~ topMint
+                & directDepositsTxBodyL .~ DirectDeposits [(topDDAddr, topDDAmount)]
                 & subTransactionsTxBodyL .~ [subTx]
           expectedCoin =
             topOutValue
@@ -190,9 +194,24 @@ spec = describe "UTXO" $ do
               <> subTreasury
               <> poolDeposit
               <> ((2 :: Int) <×> dRepDeposit)
+              <> topDDAmount
+              <> subDDAmount
           expected = MaryValue expectedCoin expectedBurned
       pp <- getsPParams id
       pState <- getsNES $ nesEsL . esLStateL . lsCertStateL . certPStateL
       produced pp pState (topTx ^. bodyTxL) `shouldBe` expected
+      checkDepositCalculation
+        (topTx ^. bodyTxL)
+        (poolDeposit <> ((2 :: Int) <×> dRepDeposit))
+        (poolDeposit <> dRepDeposit)
   where
     mkSubTx i cert = mkBasicTx $ mkBasicTxBody & certsTxBodyL .~ [cert] & inputsTxBodyL .~ [i]
+    -- Check that `certsTotalDepositsTxBody` (used to set deposits in `UTxOState` and `AdaPots` calculations)
+    -- returns the batch deposits, while `getTotalDepositsTxBody` returns the top-level deposits
+    checkDepositCalculation topBody batchDeposits topLevelDeposits = do
+      pp <- getsPParams id
+      certState <- getsNES $ nesEsL . esLStateL . lsCertStateL
+      AdaPots.proDeposits (AdaPots.producedTxBody topBody pp certState)
+        `shouldBe` batchDeposits
+      let isPoolReg = (`Map.member` (certState ^. certPStateL . psStakePoolsL))
+      getTotalDepositsTxBody pp isPoolReg topBody `shouldBe` topLevelDeposits


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->


This is an alternative to this PR : https://github.com/IntersectMBO/cardano-ledger/pull/5929 (which compiles but unfortunately doesn't run correctly)
Please read the description of that PR first, to understand the context. 

TL;DR
Provides implementations for the typeclass methods used for Ada pots calculations and UTxOState deposits (`certsTotalDepositsTxBody`, `certsTotalRefundsTxBody` from `EraCertState`) that are returning the deposits from the whole batch: top transactions + subtransactions.

Couldn't do this in the parallel methods from `EraTxBody` .

------

This constraint causing the loop in the other PR was needed in order to access `topTxBody ^. subTransactionsTxBodyL` within `dijkstraTotalDepositsTxBody`, in `EraTxBody`. 
In order to avoid this loop, I had to forgo  implementing `getTotalDepositsTxBody` at the batch-level, and instead, move the batch implementation to `certsTotalDepositsTxBody`,
analogously to the consumed side (`certsTotalRefundsTxBody`).
In order to prevent crude duplication between `certsTotalDepositsTxBody` and `getProducedValue`, I extracted the logic in a helper, which I use in both functions.


# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
