### PR TITLE
Add `AccountBalanceExact` constructor to `AccountBalanceInterval`

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0.0
 
 * Add `dijkstraConsumed` and `validateValueNotConservedUTxO`
+* Add `AccountBalanceExact` constructor to `AccountBalanceInterval`
 * Make `requiredTopLevelGuards` available on the top-level transaction body:
   - Change the type of `requiredTopLevelGuardsL` to `Lens' (TxBody l era) (Map (Credential Guard) (StrictMaybe (Data era)))`
   - Change the type of `requiredTopLevelGuardsDijkstraTxBodyRawL` to `Lens' (DijkstraTxBodyRaw l era) (Map (Credential Guard) (StrictMaybe (Data era)))`

--- a/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+++ b/eras/dijkstra/impl/cddl/data/dijkstra.cddl
@@ -815,9 +815,9 @@ direct_deposits = {+ reward_account => coin}
 account_balance_intervals = {+ credential => account_balance_interval}
 
 account_balance_interval =
-  [  inclusive_lower_bound : coin, exclusive_upper_bound : coin/ nil
-  // inclusive_lower_bound : coin/ nil, exclusive_upper_bound : coin
-  ]
+  [inclusive_lower_bound : coin, exclusive_upper_bound : coin/ nil]
+  / [inclusive_lower_bound : coin/ nil, exclusive_upper_bound : coin]
+  / coin
 
 transaction_witness_set =
   { ? 0 : nonempty_set<vkeywitness>

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -272,14 +272,15 @@ accountBalanceIntervalRule ::
   Rule
 accountBalanceIntervalRule pname p =
   pname
-    =.= arr
+    =.= sarr
       [ "inclusive_lower_bound" ==> huddleRule @"coin" p
       , "exclusive_upper_bound" ==> huddleRule @"coin" p / VNil
       ]
-    / arr
+    / sarr
       [ "inclusive_lower_bound" ==> huddleRule @"coin" p / VNil
       , "exclusive_upper_bound" ==> huddleRule @"coin" p
       ]
+    / huddleRule @"coin" p
 
 scriptRequireGuardGroup ::
   forall era.
@@ -844,12 +845,12 @@ instance HuddleRule "transaction_mempool" DijkstraEra where
   huddleRuleNamed pname p =
     comment
       [str| In Dijkstra we're deprecating the `is_valid` flag, but for backwards
-          | compatibility we still allow this flag to be present in incoming 
+          | compatibility we still allow this flag to be present in incoming
           | transactions. Once the transaction is added to a block, the flag will
           | be stripped, so the `is_valid` flag cannot appear in transactions that
           | are in a block.
           |
-          | In the next era `is_valid` flags will not be allowed even in mempool 
+          | In the next era `is_valid` flags will not be allowed even in mempool
           | transactions, so it's strongly recommended to encode transactions
           | according to the `transaction` rule.
           |]

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Scripts.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Scripts.hs
@@ -57,14 +57,16 @@ import Cardano.Ledger.Binary (
   EncCBOR (encCBOR),
   EncCBORGroup (..),
   ToCBOR (..),
+  TokenType (..),
   cborError,
   decodeNullMaybe,
+  decodeRecordNamed,
   decodeRecordSum,
   decodeWord8,
   encodeListLen,
   encodeNull,
   encodeWord8,
-  enforceSize,
+  peekTokenType,
  )
 import Cardano.Ledger.Binary.Coders (
   Encode (..),
@@ -632,6 +634,7 @@ data AccountBalanceInterval era
   = AccountBalanceLowerBound !(Inclusive Coin)
   | AccountBalanceUpperBound !(Exclusive Coin)
   | AccountBalanceBothBounds !(Inclusive Coin) !(Exclusive Coin)
+  | AccountBalanceExact !Coin
   deriving (Generic, Show, Eq, Ord, NoThunks, NFData)
 
 instance EncCBOR (AccountBalanceInterval era) where
@@ -639,17 +642,21 @@ instance EncCBOR (AccountBalanceInterval era) where
     AccountBalanceLowerBound l -> encodeListLen 2 <> encCBOR l <> encodeNull
     AccountBalanceUpperBound u -> encodeListLen 2 <> encodeNull <> encCBOR u
     AccountBalanceBothBounds l u -> encodeListLen 2 <> encCBOR l <> encCBOR u
+    AccountBalanceExact exactCoin -> encCBOR exactCoin
 
 instance Typeable era => DecCBOR (AccountBalanceInterval era) where
-  decCBOR = do
-    enforceSize "AccountBalanceInterval" 2
-    lower <- decodeNullMaybe decCBOR
-    upper <- decodeNullMaybe decCBOR
-    case (lower, upper) of
-      (Just l, Just u) -> pure $ AccountBalanceBothBounds l u
-      (Just l, Nothing) -> pure $ AccountBalanceLowerBound l
-      (Nothing, Just u) -> pure $ AccountBalanceUpperBound u
-      _ -> cborError $ DecoderErrorCustom "AccountBalanceInterval" "Both interval bounds cannot be nil."
+  decCBOR =
+    peekTokenType >>= \case
+      TypeUInt -> AccountBalanceExact <$> decCBOR
+      TypeUInt64 -> AccountBalanceExact <$> decCBOR
+      _ -> decodeRecordNamed "AccountBalanceInterval" (const 2) $ do
+        lower <- decodeNullMaybe decCBOR
+        upper <- decodeNullMaybe decCBOR
+        case (lower, upper) of
+          (Just l, Just u) -> pure $! AccountBalanceBothBounds l u
+          (Just l, Nothing) -> pure $! AccountBalanceLowerBound l
+          (Nothing, Just u) -> pure $! AccountBalanceUpperBound u
+          _ -> cborError $ DecoderErrorCustom "AccountBalanceInterval" "Both interval bounds cannot be nil."
 
 newtype AccountBalanceIntervals era
   = AccountBalanceIntervals

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Base.hs
@@ -196,6 +196,9 @@ instance SpecTranslate DijkstraEra (AccountBalanceInterval DijkstraEra) where
       pure $ Agda.Upper u
     AccountBalanceBothBounds (Inclusive (Coin l)) (Exclusive (Coin u)) ->
       pure $ Agda.Both l u
+    AccountBalanceExact (Coin c) ->
+      -- TODO Future task to replace with new formal spec type
+      pure $ Agda.Both c (c + 1)
 
 instance SpecTranslate DijkstraEra (AccountBalanceIntervals DijkstraEra) where
   type


### PR DESCRIPTION
# Description

Fixes #5922

* Modify Dijkstra CDDL for `account_balance_interval` rule to include exact balance
* Add constructor `AccountBalanceExact` to data type `AccountBalanceInterval`
* Modify CBOR encoding/decoding of `AccountBalanceInterval`

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
