### PR TITLE
Switch minor protocol version to `Word32`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,14 +8,14 @@ to the issue. -->
 
 - [ ] Commits in meaningful sequence and with useful messages.
 - [ ] Tests added or updated when needed.
-- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.  
+- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
       **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
 - [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
       [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
-- [ ] Version bounds in `.cabal` files updated when necessary.  
+- [ ] Version bounds in `.cabal` files updated when necessary.
       **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
 - [x] Code formatted (use `scripts/fourmolize.sh`).
 - [x] Cabal files formatted (use `scripts/cabal-format.sh`).
-- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
+- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
 - [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
 - [ ] Self-reviewed the diff.

--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### `cddl`
 
+* Remove re-exported `genByteString`, `distinct`, `genHash28`, `majorProtocolVersionRule`, `ipRule` and `ipValidator`
 * Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 
 ### `testlib`

--- a/eras/allegra/impl/cddl/data/allegra.cddl
+++ b/eras/allegra/impl/cddl/data/allegra.cddl
@@ -50,7 +50,7 @@ kes_period = uint .size 8
 
 signature = bytes .size 64
 
-protocol_version = (major_protocol_version, uint)
+protocol_version = (major_protocol_version, uint .size 4)
 
 major_protocol_version = 0 .. 4
 

--- a/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
+++ b/eras/allegra/impl/cddl/lib/Cardano/Ledger/Allegra/HuddleSpec.hs
@@ -174,12 +174,6 @@ scriptInvalidHereafterGroup pname p =
     $ pname
       =.~ grp [5, a (huddleRule @"slot" p)]
 
-instance HuddleRule "major_protocol_version" AllegraEra where
-  huddleRuleNamed = majorProtocolVersionRule
-
-instance HuddleGroup "protocol_version" AllegraEra where
-  huddleGroupNamed = shelleyProtocolVersionGroup
-
 instance HuddleRule "protocol_param_update" AllegraEra where
   huddleRuleNamed = protocolParamUpdateRule
 

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -61,6 +61,7 @@
 
 ### `cddl`
 
+* Remove re-exported `genByteString`, `distinct`, `genHash28`, `majorProtocolVersionRule`, `ipRule` and `ipValidator`
 * Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 * Fix `ex_unit_prices` CDDL to use `nonnegative_interval` instead of `positive_interval`
 * Extend `constr` CDDL rule to include tags 1280–1400 for Plutus `Data` constructor indexes

--- a/eras/alonzo/impl/cddl/data/alonzo.cddl
+++ b/eras/alonzo/impl/cddl/data/alonzo.cddl
@@ -56,7 +56,7 @@ kes_period = uint .size 8
 
 signature = bytes .size 64
 
-protocol_version = (major_protocol_version, uint)
+protocol_version = (major_protocol_version, uint .size 4)
 
 major_protocol_version = 0 .. 7
 

--- a/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
+++ b/eras/alonzo/impl/cddl/lib/Cardano/Ledger/Alonzo/HuddleSpec.hs
@@ -327,12 +327,6 @@ instance HuddleRule "header" AlonzoEra where
 instance HuddleRule "header_body" AlonzoEra where
   huddleRuleNamed = shelleyHeaderBodyRule
 
-instance HuddleGroup "protocol_version" AlonzoEra where
-  huddleGroupNamed = shelleyProtocolVersionGroup
-
-instance HuddleRule "major_protocol_version" AlonzoEra where
-  huddleRuleNamed = majorProtocolVersionRule
-
 instance HuddleRule "transaction" AlonzoEra where
   huddleRuleNamed pname p =
     pname

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 ### `cddl`
 
+* Remove re-exported `genByteString`, `distinct`, `genHash28`, `majorProtocolVersionRule`, `ipRule` and `ipValidator`
+* Remove `babbageProtocolVersionRule`
 * Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 * Fix `ex_unit_prices` CDDL to use `nonnegative_interval` instead of `positive_interval`
 * Extend `constr` CDDL rule to include tags 1280–1400 for Plutus `Data` constructor indexes

--- a/eras/babbage/impl/cddl/data/babbage.cddl
+++ b/eras/babbage/impl/cddl/data/babbage.cddl
@@ -56,7 +56,7 @@ kes_period = uint .size 8
 
 signature = bytes .size 64
 
-protocol_version = [major_protocol_version, uint]
+protocol_version = [major_protocol_version, uint .size 4]
 
 major_protocol_version = 0 .. 9
 

--- a/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
+++ b/eras/babbage/impl/cddl/lib/Cardano/Ledger/Babbage/HuddleSpec.hs
@@ -17,7 +17,6 @@ module Cardano.Ledger.Babbage.HuddleSpec (
   BabbageEra,
   babbageCDDL,
   babbageOperationalCertRule,
-  babbageProtocolVersionRule,
   babbageTransactionOutput,
   babbageScript,
   alonzoTransactionOutputRule,
@@ -30,7 +29,6 @@ module Cardano.Ledger.Babbage.HuddleSpec (
 import Cardano.Ledger.Alonzo.HuddleSpec hiding (
   shelleyHeaderBodyRule,
   shelleyOperationalCertGroup,
-  shelleyProtocolVersionGroup,
  )
 import Cardano.Ledger.Babbage (BabbageEra)
 import Data.Proxy (Proxy (..))
@@ -47,15 +45,6 @@ babbageCDDL =
     , HIRule $ huddleRule @"language" (Proxy @BabbageEra)
     , HIRule $ huddleRule @"signkey_kes" (Proxy @BabbageEra)
     ]
-
--- | Babbage changed protocol_version from GroupDef to Rule to match actual block
--- serialization. See 'header_body' instance for full explanation.
--- Ref: PR #3762, Issue #3559
-babbageProtocolVersionRule ::
-  forall era.
-  HuddleRule "major_protocol_version" era => Proxy "protocol_version" -> Proxy era -> Rule
-babbageProtocolVersionRule pname p =
-  pname =.= arr [a $ huddleRule @"major_protocol_version" p, a VUInt]
 
 -- | Babbage changed operational_cert from GroupDef to Rule to match actual block
 -- serialization. See 'header_body' instance for full explanation.
@@ -307,12 +296,6 @@ instance HuddleRule "positive_interval" BabbageEra where
 instance HuddleRule "operational_cert" BabbageEra where
   huddleRuleNamed = babbageOperationalCertRule
 
-instance HuddleRule "protocol_version" BabbageEra where
-  huddleRuleNamed = babbageProtocolVersionRule
-
-instance HuddleRule "major_protocol_version" BabbageEra where
-  huddleRuleNamed = majorProtocolVersionRule
-
 instance HuddleRule "block" BabbageEra where
   huddleRuleNamed pname p =
     comment
@@ -357,7 +340,7 @@ instance HuddleRule "header" BabbageEra where
 -- blocks serialize with Rule (nested arrays). This change corrects the CDDL spec to
 -- match the actual CBOR serialization.
 --
--- See 'babbageProtocolVersionRule' and 'operational_cert' instance for details.
+-- See 'babbageOperationalCertRule' for details.
 -- References: PR #3762, Issue #3559
 instance HuddleRule "header_body" BabbageEra where
   huddleRuleNamed pname p = babbageHeaderBodyRule pname p //- "nonce_vrf and leader_vrf are replaced by vrf_result"

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -65,6 +65,7 @@
 
 ### cddl
 
+* Remove re-exported `genByteString`, `distinct`, `genHash28`, `majorProtocolVersionRule`, `ipRule` and `ipValidator`
 * Use non-empty list instead of `nonempty_set` for fields 0 (`vkey_witness`), 1 (`native_script`), 2 (`bootstrap_witness`), 4 (`plutus_data`) in `transaction_witness_set` to match decoder behavior pre-Dijkstra
 * Change the second argument of `mkMaybeTaggedSet` to `Int`
 * Add `generateMaybeTaggedSet`

--- a/eras/conway/impl/cddl/data/conway.cddl
+++ b/eras/conway/impl/cddl/data/conway.cddl
@@ -100,7 +100,7 @@ kes_period = uint .size 8
 
 signature = bytes .size 64
 
-protocol_version = [major_protocol_version, uint]
+protocol_version = [major_protocol_version, uint .size 4]
 
 major_protocol_version = 0 .. 12
 

--- a/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
+++ b/eras/conway/impl/cddl/lib/Cardano/Ledger/Conway/HuddleSpec.hs
@@ -467,7 +467,7 @@ parameterChangeActionGroup pname p =
 
 hardForkInitiationActionGroup ::
   forall era.
-  (HuddleRule "gov_action_id" era, HuddleRule "protocol_version" era) =>
+  HuddleRule "gov_action_id" era =>
   Proxy "hard_fork_initiation_action" ->
   Proxy era ->
   GroupDef
@@ -796,9 +796,6 @@ instance HuddleRule "dns_name" ConwayEra where
 instance HuddleRule "url" ConwayEra where
   huddleRuleNamed pname _ = urlRule pname
 
-instance HuddleRule "major_protocol_version" ConwayEra where
-  huddleRuleNamed = majorProtocolVersionRule
-
 instance HuddleRule "genesis_hash" ConwayEra where
   huddleRuleNamed = genesisHashRule
 
@@ -854,9 +851,6 @@ instance (Era era, HuddleRule "transaction_id" era) => HuddleRule "gov_action_id
 
 instance HuddleRule "operational_cert" ConwayEra where
   huddleRuleNamed = babbageOperationalCertRule
-
-instance HuddleRule "protocol_version" ConwayEra where
-  huddleRuleNamed = babbageProtocolVersionRule
 
 instance Era era => HuddleRule "plutus_v3_script" era where
   huddleRuleNamed pname _ =

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -120,6 +120,8 @@
 
 ### cddl
 
+* Remove re-exported `genByteString`, `distinct`, `genHash28`, `majorProtocolVersionRule`, `ipRule` and `ipValidator`
+* Remove `dijkstraProtocolVersionRule`
 * Add `transaction_mempool` rule
 * Add `peras_certificate`, `block_body`
 * Extend `constr` CDDL rule to include tags 1280–1400 for Plutus `Data` constructor indexes

--- a/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
+++ b/eras/dijkstra/impl/cddl/lib/Cardano/Ledger/Dijkstra/HuddleSpec.hs
@@ -80,13 +80,6 @@ dijkstraCDDL =
     , HIRule $ huddleRule @"certificate" (Proxy @DijkstraEra)
     ]
 
--- | Dijkstra constrains the minor protocol version to Word32 (uint .size 4).
-dijkstraProtocolVersionRule ::
-  forall era.
-  HuddleRule "major_protocol_version" era => Proxy "protocol_version" -> Proxy era -> Rule
-dijkstraProtocolVersionRule pname p =
-  pname =.= arr [a $ huddleRule @"major_protocol_version" p, a $ VUInt `sized` (4 :: Word64)]
-
 guardsRule ::
   forall era.
   ( HuddleRule "addr_keyhash" era
@@ -481,9 +474,6 @@ instance HuddleRule "dns_name" DijkstraEra where
 instance HuddleRule "url" DijkstraEra where
   huddleRuleNamed pname _ = urlRule pname
 
-instance HuddleRule "major_protocol_version" DijkstraEra where
-  huddleRuleNamed = majorProtocolVersionRule
-
 instance HuddleRule "genesis_hash" DijkstraEra where
   huddleRuleNamed = genesisHashRule
 
@@ -541,9 +531,6 @@ instance HuddleRule "voter" DijkstraEra where
 
 instance HuddleRule "operational_cert" DijkstraEra where
   huddleRuleNamed = babbageOperationalCertRule
-
-instance HuddleRule "protocol_version" DijkstraEra where
-  huddleRuleNamed = dijkstraProtocolVersionRule
 
 instance HuddleRule "policy_id" DijkstraEra where
   huddleRuleNamed pname p = pname =.= huddleRule @"script_hash" p

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### `cddl`
 
+* Remove re-exported `genByteString`, `distinct`, `genHash28`, `majorProtocolVersionRule`, `ipRule` and `ipValidator`
 * Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 
 ### `testlib`

--- a/eras/mary/impl/cddl/data/mary.cddl
+++ b/eras/mary/impl/cddl/data/mary.cddl
@@ -50,7 +50,7 @@ kes_period = uint .size 8
 
 signature = bytes .size 64
 
-protocol_version = (major_protocol_version, uint)
+protocol_version = (major_protocol_version, uint .size 4)
 
 major_protocol_version = 0 .. 5
 

--- a/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
+++ b/eras/mary/impl/cddl/lib/Cardano/Ledger/Mary/HuddleSpec.hs
@@ -85,12 +85,6 @@ instance HuddleRule "header" MaryEra where
 instance HuddleRule "header_body" MaryEra where
   huddleRuleNamed = shelleyHeaderBodyRule
 
-instance HuddleGroup "protocol_version" MaryEra where
-  huddleGroupNamed = shelleyProtocolVersionGroup
-
-instance HuddleRule "major_protocol_version" MaryEra where
-  huddleRuleNamed = majorProtocolVersionRule
-
 instance HuddleRule "transaction_id" MaryEra where
   huddleRuleNamed = transactionIdRule
 

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -118,6 +118,8 @@
 
 ### `cddl`
 
+* Remove `shelleyProtocolVersionGroup`
+* Remove re-exported `genByteString`, `distinct`, `genHash28`, `majorProtocolVersionRule`, `ipRule` and `ipValidator`
 * Remove `withAntiGen` re-export, since it's deprecated
 * Change `ipv4` and `ipv6` to use exact byte sizes (4 and 16 respectively), no longer allowing leftover bytes
 

--- a/eras/shelley/impl/cddl/data/shelley.cddl
+++ b/eras/shelley/impl/cddl/data/shelley.cddl
@@ -50,7 +50,7 @@ kes_period = uint .size 8
 
 signature = bytes .size 64
 
-protocol_version = (major_protocol_version, uint)
+protocol_version = (major_protocol_version, uint .size 4)
 
 major_protocol_version = 0 .. 3
 

--- a/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
+++ b/eras/shelley/impl/cddl/lib/Cardano/Ledger/Shelley/HuddleSpec.hs
@@ -15,7 +15,6 @@ module Cardano.Ledger.Shelley.HuddleSpec (
   module Cardano.Ledger.Core.HuddleSpec,
   ShelleyEra,
   shelleyCDDL,
-  shelleyProtocolVersionGroup,
   headerRule,
   proposedProtocolParameterUpdatesRule,
   updateRule,
@@ -55,7 +54,7 @@ module Cardano.Ledger.Shelley.HuddleSpec (
   untaggedSet,
 ) where
 
-import Cardano.Ledger.Core.HuddleSpec (majorProtocolVersionRule, plutusScriptGen)
+import Cardano.Ledger.Core.HuddleSpec (plutusScriptGen)
 import Cardano.Ledger.Huddle
 import Cardano.Ledger.Shelley (ShelleyEra)
 import Data.Int (Int32)
@@ -71,11 +70,6 @@ shelleyCDDL =
     , HIRule $ huddleRule @"transaction" (Proxy @ShelleyEra)
     , HIRule $ huddleRule @"signkey_kes" (Proxy @ShelleyEra)
     ]
-
-shelleyProtocolVersionGroup ::
-  forall era.
-  HuddleRule "major_protocol_version" era => Proxy "protocol_version" -> Proxy era -> GroupDef
-shelleyProtocolVersionGroup pname p = pname =.~ grp [a $ huddleRule @"major_protocol_version" p, a VUInt]
 
 headerRule ::
   forall era. HuddleRule "header_body" era => Proxy "header" -> Proxy era -> Rule
@@ -100,8 +94,7 @@ updateRule pname p =
     =.= arr [a $ huddleRule @"proposed_protocol_parameter_updates" p, a $ huddleRule @"epoch" p]
 
 protocolParamUpdateRule ::
-  forall era.
-  HuddleGroup "protocol_version" era => Proxy "protocol_param_update" -> Proxy era -> Rule
+  forall era. Era era => Proxy "protocol_param_update" -> Proxy era -> Rule
 protocolParamUpdateRule pname p =
   pname
     =.= mp
@@ -126,9 +119,7 @@ protocolParamUpdateRule pname p =
 
 shelleyHeaderBodyRule ::
   forall era.
-  ( HuddleGroup "operational_cert" era
-  , HuddleGroup "protocol_version" era
-  ) =>
+  HuddleGroup "operational_cert" era =>
   Proxy "header_body" ->
   Proxy era ->
   Rule
@@ -491,12 +482,6 @@ instance HuddleRule "certificate" ShelleyEra where
 
 instance HuddleRule "withdrawals" ShelleyEra where
   huddleRuleNamed = shelleyWithdrawalsRule
-
-instance HuddleRule "major_protocol_version" ShelleyEra where
-  huddleRuleNamed = majorProtocolVersionRule
-
-instance HuddleGroup "protocol_version" ShelleyEra where
-  huddleGroupNamed = shelleyProtocolVersionGroup
 
 instance HuddleRule "protocol_param_update" ShelleyEra where
   huddleRuleNamed = protocolParamUpdateRule

--- a/eras/shelley/impl/golden/pparams-update.json
+++ b/eras/shelley/impl/golden/pparams-update.json
@@ -9,7 +9,7 @@
     "poolRetireMaxEpoch": 3903347188,
     "protocolVersion": {
         "major": 2,
-        "minor": 46
+        "minor": 561278773
     },
     "stakePoolDeposit": 751882,
     "stakePoolTargetNum": 31910,

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -2197,18 +2197,17 @@ genCantFollow pv@ProtVer {pvMajor, pvMinor} =
     , cantFollowMinor
     , do
         Positive newMinor <- arbitrary
-        pure $ (majorFollow pv) {pvMinor = fromIntegral @Word32 @Natural newMinor}
+        pure $ (majorFollow pv) {pvMinor = newMinor}
     ]
   where
-    maxMinor = fromIntegral @Word32 @Natural maxBound
+    maxMinor = maxBound @Word32
     cantFollowMinor
-      | pvMinor > maxMinor = error $ "Minor version is too big: " ++ show pvMinor
       | pvMinor == pred maxMinor = do
-          newMinor <- choose (minBound, pred $ fromIntegral @Natural @Word32 pvMinor)
-          pure pv {pvMinor = fromIntegral @Word32 @Natural newMinor}
+          newMinor <- choose (minBound, pred $ pvMinor)
+          pure pv {pvMinor = newMinor}
       | otherwise = do
-          newMinor <- choose (succ $ succ $ fromIntegral @Natural @Word32 pvMinor, maxBound)
-          pure pv {pvMinor = fromIntegral @Word32 @Natural newMinor}
+          newMinor <- choose (succ $ succ $ pvMinor, maxBound)
+          pure pv {pvMinor = newMinor}
     -- For major version we can only go backwards
     cantFollowMajor = do
       let pvMajor32 = getVersion32 pvMajor

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Update.hs
@@ -216,7 +216,7 @@ genDecentralisationParam = unsafeBoundRational <$> QC.elements [0.1, 0.2 .. 1]
 
 genProtocolVersion :: HasCallStack => Version -> Version -> Gen ProtVer
 genProtocolVersion minMajPV maxMajPV =
-  ProtVer <$> genVersion minMajPV maxMajPV <*> genNatural 1 50
+  ProtVer <$> genVersion minMajPV maxMajPV <*> choose (1, 50)
 
 genMinUTxOValue :: HasCallStack => Gen Coin
 genMinUTxOValue = Coin <$> genInteger 1 20

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -55,6 +55,9 @@
 
 ### `cddl`
 
+* Add `HuddleRule` instance for `"protocol_version"` and `"major_protocol_version"`
+* Add `HuddleGroup` instance for `"protocol_version"`
+* Remove `genByteString`, `distinct`, `genHash28`, `majorProtocolVersionRule`, `ipRule` and `ipValidator`
 * Added various custom generator and validator helpers:
   - `validateFromName`
   - `validateFromGRef`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Change `pvMinor` type to `Word32`
 * Add `lookupAccountDeposit`
 * Remove `consumed ` from `EraUTxO`
 * Remove no longer needed `(Credential DRepRole -> Maybe Coin)` argument from:

--- a/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
+++ b/libs/cardano-ledger-core/cddl/Cardano/Ledger/Core/HuddleSpec.hs
@@ -16,33 +16,28 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Core.HuddleSpec where
+module Cardano.Ledger.Core.HuddleSpec (
+  plutusScriptGen,
+) where
 
 import Cardano.Ledger.BaseTypes (getVersion)
 import Cardano.Ledger.Core (ByronEra, eraProtVerHigh, eraProtVerLow)
 import Cardano.Ledger.Huddle
 import Cardano.Ledger.Huddle.Gen (
-  CBORGen,
-  CustomValidatorResult (..),
-  MonadGen (..),
+  MonadGen (choose),
   RuleTerm (..),
   arbitrary,
   genArrayTerm,
-  liftAntiGen,
   oneof,
   vectorOf,
-  (|!),
  )
-import Codec.CBOR.Cuddle.CDDL (Name (..))
 import Codec.CBOR.Cuddle.Huddle as H
 import Codec.CBOR.Term (Term (..))
 import Data.Bits (Bits (..))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
 import Data.MemPack (VarLen (..), packByteString)
 import Data.Proxy (Proxy (..))
-import qualified Data.Text as T
 import Data.Word (Word16, Word32, Word64)
 import GHC.TypeLits (KnownSymbol, Symbol)
 import Text.Heredoc
@@ -107,28 +102,6 @@ instance Era era => HuddleRule "unit_interval" era where
 instance Era era => HuddleRule "nonnegative_interval" era where
   huddleRuleNamed pname p =
     pname =.= tag 30 (arr [a VUInt, a (huddleRule @"positive_int" p)])
-
-distinct :: IsSizeable s => Value s -> HuddleItem
-distinct x =
-  HIRule
-    $ comment
-      [str| A type for distinct values.
-          | The type parameter must support .size, for example: bytes or uint
-          |]
-    $ "distinct_"
-      <> Name (show' x)
-        =:= (x `H.sized` (8 :: Word64))
-        / (x `H.sized` (16 :: Word64))
-        / (x `H.sized` (20 :: Word64))
-        / (x `H.sized` (24 :: Word64))
-        / (x `H.sized` (30 :: Word64))
-        / (x `H.sized` (32 :: Word64))
-  where
-    show' :: Value s -> T.Text
-    show' = \case
-      VBytes -> T.pack "bytes"
-      VUInt -> T.pack "uint"
-      _ -> error "Unsupported Value for `distinct`"
 
 instance Era era => HuddleRule "nonce" era where
   huddleRuleNamed pname p = pname =.= arr [0] / arr [1, a (huddleRule @"hash32" p)]
@@ -313,19 +286,6 @@ instance Era era => HuddleRule "stake_credential" era where
 instance Era era => HuddleRule "port" era where
   huddleRuleNamed pname _ = pname =.= VUInt `le` 65535
 
-ipGen :: Int -> CBORGen RuleTerm
-ipGen n = do
-  l <- liftAntiGen $ choose (n, 1024) |! choose (0, pred n)
-  bs <- genByteString l
-  -- TODO Also generate with TBytesI
-  pure . SingleTerm $ TBytes bs
-
-ipValidator :: Int -> Term -> CustomValidatorResult
-ipValidator n = \case
-  TBytes bs | BS.length bs >= n -> CustomValidatorSuccess
-  TBytesI bs | LBS.length bs >= fromIntegral n -> CustomValidatorSuccess
-  _ -> CustomValidatorFailure $ "Expected bytes with length >=" <> T.pack (show n)
-
 ipRule ::
   forall era (r :: Symbol).
   KnownSymbol r => Int -> Proxy r -> Proxy era -> Rule
@@ -337,9 +297,16 @@ instance Era era => HuddleRule "ipv4" era where
 instance Era era => HuddleRule "ipv6" era where
   huddleRuleNamed = ipRule 16
 
-majorProtocolVersionRule ::
-  forall era. Era era => Proxy "major_protocol_version" -> Proxy era -> Rule
-majorProtocolVersionRule pname _ =
-  pname
-    =.= getVersion @Integer (eraProtVerLow @ByronEra)
-    ... succ (getVersion @Integer (eraProtVerHigh @era))
+instance Era era => HuddleRule "major_protocol_version" era where
+  huddleRuleNamed pname _ =
+    pname
+      =.= getVersion @Integer (eraProtVerLow @ByronEra)
+      ... succ (getVersion @Integer (eraProtVerHigh @era))
+
+instance Era era => HuddleRule "protocol_version" era where
+  huddleRuleNamed pname p =
+    pname =.= arr [a $ huddleRule @"major_protocol_version" p, a $ VUInt `sized` (4 :: Word64)]
+
+instance Era era => HuddleGroup "protocol_version" era where
+  huddleGroupNamed pname p =
+    pname =.~ grp [a $ huddleRule @"major_protocol_version" p, a $ VUInt `sized` (4 :: Word64)]

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/BaseTypes.hs
@@ -208,7 +208,7 @@ import System.Random.Stateful (isInRangeOrd)
 maxDecimalsWord64 :: Int
 maxDecimalsWord64 = 19
 
-data ProtVer = ProtVer {pvMajor :: !Version, pvMinor :: !Natural}
+data ProtVer = ProtVer {pvMajor :: !Version, pvMinor :: !Word32}
   deriving (Show, Eq, Generic, Ord, NFData)
   deriving (EncCBOR) via (CBORGroup ProtVer)
   deriving (DecCBOR) via (CBORGroup ProtVer)
@@ -241,13 +241,7 @@ instance EncCBORGroup ProtVer where
   listLen _ = 2
 
 instance DecCBORGroup ProtVer where
-  decCBORGroup =
-    ProtVer
-      <$> decCBOR
-      <*> ifDecoderVersionAtLeast
-        (natVersion @12)
-        (fromIntegral @Word32 @Natural <$> decCBOR @Word32)
-        (decCBOR @Natural)
+  decCBORGroup = ProtVer <$> decCBOR <*> decCBOR
 
 -- | Decoder for `ProtVer` that only accepts versions where the major fits in
 -- the bounds of what's allowed for the provided Era.

--- a/libs/cardano-ledger-core/test/Test/Cardano/Ledger/BinarySpec.hs
+++ b/libs/cardano-ledger-core/test/Test/Cardano/Ledger/BinarySpec.hs
@@ -11,8 +11,6 @@ import Cardano.Ledger.DRep (DRep (..), DRepState (..))
 import Cardano.Ledger.Hashes (EraIndependentData, SafeHash, ScriptHash)
 import Cardano.Ledger.Keys
 import Cardano.Ledger.TxIn
-import Data.Word (Word32, Word64)
-import Numeric.Natural (Natural)
 import qualified PlutusLedgerApi.V1 as PV1
 import Test.Cardano.Ledger.Binary (decoderEquivalenceSpec)
 import Test.Cardano.Ledger.Binary.RoundTrip
@@ -30,15 +28,6 @@ spec = do
     prop "Encode Coin - Decode CompactCoin" $
       roundTripExpectation @Coin (mkTrip encCBOR (fromCompact <$> decCBOR))
     roundTripCborSpec @ProtVer
-    prop "ProtVer/Word32" $ do
-      let badProtVerGen =
-            ProtVer
-              <$> arbitrary
-              <*> ( fromIntegral @Word64 @Natural
-                      <$> choose (fromIntegral (maxBound :: Word32) + 1, fromIntegral (maxBound :: Word64) * 2)
-                  )
-      forAll badProtVerGen $
-        roundTripCborRangeFailureExpectation (natVersion @12) maxBound
     roundTripCborSpec @Nonce
     roundTripCborSpec @Url
     roundTripCborSpec @DnsName


### PR DESCRIPTION
# Description

This PR changes minor protocol version to a more sensible type.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.  
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.  
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `scripts/gen-cddl.sh`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
