### PR TITLE
Enable Conway conformance tests in Dijkstra

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,7 +16,7 @@ source-repository-package
   subdir: hs
   -- !WARNING!:
   -- MAKE SURE THIS POINTS TO A COMMIT IN `*-artifacts` BEFORE MERGE!
-  tag: 16b0eb6ef3e4ebcf83dc9e6075cc1f1ce9bb8a13
+  tag: b3a4fd47a1144ff1fb994f89b1045e78159e07ae
 
 source-repository-package
   type: git

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxoSpec.hs
@@ -42,7 +42,9 @@ spec ::
   SpecWith (ImpInit (LedgerSpec era))
 spec = describe "UTXO" $ do
   describe "Collaterals" $ do
-    it "Fails to submit a transaction containing a Ptr in collateral return" $ do
+    -- https://github.com/IntersectMBO/formal-ledger-specifications/issues/1264
+    -- TODO: Re-enable after issue is resolved, by removing this override
+    disableInConformanceIt "Fails to submit a transaction containing a Ptr in collateral return" $ do
       cred <- KeyHashObj <$> freshKeyHash
       ptr <- arbitrary
       pp <- getsPParams id

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/UtxowSpec.hs
@@ -46,7 +46,8 @@ spec = describe "UTXOW" $ do
       let guardScript = RequireAllOf []
       let guardScriptHash = hashScript @era $ fromNativeScript guardScript
       scriptHash <- impAddNativeScript $ RequireGuard (ScriptHashObj guardScriptHash)
-      tx <- mkTokenMintingTx scriptHash
+      txIn <- produceScript scriptHash
+      let tx = mkBasicTx (mkBasicTxBody & inputsTxBodyL .~ [txIn])
       submitFailingTx
         tx
         [injectFailure $ Conway.ScriptWitnessNotValidatingUTXOW $ NES.singleton scriptHash]
@@ -82,10 +83,9 @@ spec = describe "UTXOW" $ do
       guardKeyHash <- KeyHashObj <$> freshKeyHash
       let guardScript = RequireGuard guardKeyHash
       let guardScriptHash = hashScript @era $ fromNativeScript guardScript
-
       scriptHash <- impAddNativeScript $ RequireGuard (ScriptHashObj guardScriptHash)
-
-      tx <- mkTokenMintingTx scriptHash
+      txIn <- produceScript scriptHash
+      let tx = mkBasicTx (mkBasicTxBody & inputsTxBodyL .~ [txIn])
       submitFailingTx
         tx
         [injectFailure $ Conway.ScriptWitnessNotValidatingUTXOW $ NES.singleton scriptHash]

--- a/flake.lock
+++ b/flake.lock
@@ -222,11 +222,11 @@
     "formal-ledger-specifications": {
       "flake": false,
       "locked": {
-        "lastModified": 1782959197,
-        "narHash": "sha256-o7N5C5qhyysPpJSjTrC3uqpRj09OHAc8aIUQ/RWXSj0=",
+        "lastModified": 1785150760,
+        "narHash": "sha256-M70WiOG2Zr9XNGUr5/735Dv5tKh6u42Dy7UncHNWynk=",
         "owner": "IntersectMBO",
         "repo": "formal-ledger-specifications",
-        "rev": "16b0eb6ef3e4ebcf83dc9e6075cc1f1ce9bb8a13",
+        "rev": "b3a4fd47a1144ff1fb994f89b1045e78159e07ae",
         "type": "github"
       },
       "original": {

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Base.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Base.hs
@@ -109,7 +109,7 @@ instance SpecTranslate DijkstraEra Language where
     PlutusV1 -> return Agda.PV1
     PlutusV2 -> return Agda.PV2
     PlutusV3 -> return Agda.PV3
-    PlutusV4 -> error "PlutusV4 not supported"
+    PlutusV4 -> return Agda.PV4
 
 instance SpecTranslate DijkstraEra CostModels where
   type SpecRep DijkstraEra CostModels = Agda.LanguageCostModels

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Deleg.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Deleg.hs
@@ -38,7 +38,7 @@ instance SpecTranslate DijkstraEra DijkstraDelegCert where
   toSpecRep (DijkstraUnRegCert c d) =
     Agda.Dereg
       <$> toSpecRep c
-      <*> toSpecRep (Just d)
+      <*> toSpecRep d
   toSpecRep (DijkstraDelegCert c d) =
     Agda.Delegate
       <$> toSpecRep c

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/GovCert.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/GovCert.hs
@@ -12,8 +12,6 @@
 module Test.Cardano.Ledger.Conformance.SpecTranslate.Dijkstra.GovCert () where
 
 import Cardano.Ledger.BaseTypes
-import Cardano.Ledger.Coin (Coin (..))
-import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Conway.State
@@ -21,7 +19,7 @@ import Cardano.Ledger.Conway.TxCert (ConwayGovCert (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Data.Default (Default (..))
-import Data.Map.Strict (Map, keysSet)
+import Data.Map.Strict (keysSet)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
 import qualified MAlonzo.Code.Ledger.Dijkstra.Foreign.API as Agda
@@ -56,14 +54,8 @@ instance SpecTranslate DijkstraEra ConwayGovCert where
 
 instance SpecTranslate DijkstraEra (Conway.ConwayGovCertEnv DijkstraEra) where
   type SpecRep DijkstraEra (Conway.ConwayGovCertEnv DijkstraEra) = Agda.CertEnv
-  type
-    SpecContext DijkstraEra (Conway.ConwayGovCertEnv DijkstraEra) =
-      (VotingProcedures DijkstraEra, Map AccountAddress Coin)
 
-  -- TODO Dijkstra: the new ceDirectDeposits field defaults to empty here; the
-  -- value should be plumbed from the transaction body's directDeposits.
   toSpecRep Conway.ConwayGovCertEnv {..} = do
-    (votes, withdrawals) <- askSpecTransM
     let propGetCCMembers (UpdateCommittee _ _ x _) = Just $ keysSet x
         propGetCCMembers _ = Nothing
         potentialCCMembers =
@@ -77,10 +69,7 @@ instance SpecTranslate DijkstraEra (Conway.ConwayGovCertEnv DijkstraEra) where
       Agda.MkCertEnv
         <$> toSpecRep cgceCurrentEpoch
         <*> toSpecRep cgcePParams
-        <*> toSpecRep votes
-        <*> toSpecRepMap withdrawals
         <*> toSpecRep ccColdCreds
-        <*> pure (Agda.MkHSMap [])
 
 instance SpecTranslate DijkstraEra (VState DijkstraEra) where
   type SpecRep DijkstraEra (VState DijkstraEra) = Agda.GState

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/SpecTranslate/Dijkstra/Ledger.hs
@@ -106,6 +106,7 @@ instance SpecTranslate DijkstraEra (TxBody TopTx DijkstraEra) where
         <*> pure 0
         <*> fmap (fmap (const 0)) (toSpecRep (txb ^. scriptIntegrityHashTxBodyL))
         <*> traverse toSpecRep (toList $ OMap.toMap $ txb ^. subTransactionsTxBodyL)
+        <*> (Agda.MkHSSet <$> traverse toSpecRepTuple (Map.toList $ txb ^. requiredTopLevelGuardsL))
         <*> (Agda.MkHSSet <$> toSpecRep (txb ^. guardsTxBodyL))
         <*> toSpecRep (txb ^. directDepositsTxBodyL)
         <*> toSpecRep (txb ^. accountBalanceIntervalsTxBodyL)

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wwarn #-}
 
 module Test.Cardano.Ledger.Conformance.Imp.Dijkstra (spec) where
 
@@ -9,6 +10,17 @@ import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Dijkstra ()
 import Test.Cardano.Ledger.Conformance.Imp.Core
+import Test.Cardano.Ledger.Conway.Imp.BbodySpec qualified as ConwayBbody
+import Test.Cardano.Ledger.Conway.Imp.CertsSpec qualified as ConwayCerts
+import Test.Cardano.Ledger.Conway.Imp.DelegSpec qualified as ConwayDeleg
+import Test.Cardano.Ledger.Conway.Imp.EnactSpec qualified as ConwayEnact
+import Test.Cardano.Ledger.Conway.Imp.EpochSpec qualified as ConwayEpoch
+import Test.Cardano.Ledger.Conway.Imp.GovCertSpec qualified as ConwayGovCert
+import Test.Cardano.Ledger.Conway.Imp.GovSpec qualified as ConwayGov
+import Test.Cardano.Ledger.Conway.Imp.LedgerSpec qualified as ConwayLedger
+import Test.Cardano.Ledger.Conway.Imp.RatifySpec qualified as ConwayRatify
+import Test.Cardano.Ledger.Conway.Imp.UtxoSpec qualified as ConwayUtxo
+import Test.Cardano.Ledger.Conway.Imp.UtxowSpec qualified as ConwayUtxow
 import Test.Cardano.Ledger.Dijkstra.Imp.CertSpec qualified as CERT
 import Test.Cardano.Ledger.Dijkstra.Imp.CertsSpec qualified as CERTS
 import Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec qualified as LEDGER
@@ -21,11 +33,23 @@ spec :: Spec
 spec = do
   describe "Imp" $ do
     withImpInit @(LedgerSpec DijkstraEra) $
-      modifyImpInitProtVer @DijkstraEra (natVersion @11) $
+      modifyImpInitProtVer @DijkstraEra (natVersion @12) $
         modifyImpInitPostSubmitTxHook submitTxConformanceHook $ do
           modifyImpInitPostEpochBoundaryHook epochBoundaryConformanceHook $ do
-            describe "LEDGER" LEDGER.spec
-            describe "CERT" CERT.spec
-            xdescribe "CERTS" CERTS.spec
-            xdescribe "UTXOW" UTXOW.spec
-            xdescribe "UTXO" UTXO.spec
+            LEDGER.spec
+            CERT.spec
+            CERTS.spec
+            UTXOW.spec
+            UTXO.spec
+            describe "Conway" $ do
+              ConwayBbody.spec
+              xdescribe "disabled" ConwayCerts.spec
+              ConwayDeleg.spec
+              ConwayEnact.spec
+              ConwayEpoch.spec
+              ConwayGov.spec
+              ConwayGovCert.spec
+              ConwayLedger.spec
+              ConwayRatify.spec
+              ConwayUtxo.spec
+              ConwayUtxow.spec

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -Wwarn #-}
 
 module Test.Cardano.Ledger.Conformance.Imp.Dijkstra (spec) where
 
@@ -10,17 +9,18 @@ import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Tx (Tx (..))
 import Test.Cardano.Ledger.Conformance.ExecSpecRule.Dijkstra ()
 import Test.Cardano.Ledger.Conformance.Imp.Core
-import Test.Cardano.Ledger.Conway.Imp.BbodySpec qualified as ConwayBbody
-import Test.Cardano.Ledger.Conway.Imp.CertsSpec qualified as ConwayCerts
-import Test.Cardano.Ledger.Conway.Imp.DelegSpec qualified as ConwayDeleg
-import Test.Cardano.Ledger.Conway.Imp.EnactSpec qualified as ConwayEnact
-import Test.Cardano.Ledger.Conway.Imp.EpochSpec qualified as ConwayEpoch
-import Test.Cardano.Ledger.Conway.Imp.GovCertSpec qualified as ConwayGovCert
-import Test.Cardano.Ledger.Conway.Imp.GovSpec qualified as ConwayGov
-import Test.Cardano.Ledger.Conway.Imp.LedgerSpec qualified as ConwayLedger
-import Test.Cardano.Ledger.Conway.Imp.RatifySpec qualified as ConwayRatify
-import Test.Cardano.Ledger.Conway.Imp.UtxoSpec qualified as ConwayUtxo
-import Test.Cardano.Ledger.Conway.Imp.UtxowSpec qualified as ConwayUtxow
+import Test.Cardano.Ledger.Conway.Imp.BbodySpec qualified as ConwayBBODY
+import Test.Cardano.Ledger.Conway.Imp.CertsSpec qualified as ConwayCERTS
+import Test.Cardano.Ledger.Conway.Imp.DelegSpec qualified as ConwayDELEG
+import Test.Cardano.Ledger.Conway.Imp.EnactSpec qualified as ConwayENACT
+import Test.Cardano.Ledger.Conway.Imp.EpochSpec qualified as ConwayEPOCH
+import Test.Cardano.Ledger.Conway.Imp.GovCertSpec qualified as ConwayGOVCERT
+import Test.Cardano.Ledger.Conway.Imp.GovSpec qualified as ConwayGOV
+import Test.Cardano.Ledger.Conway.Imp.LedgerSpec qualified as ConwayLEDGER
+import Test.Cardano.Ledger.Conway.Imp.RatifySpec qualified as ConwayRATIFY
+import Test.Cardano.Ledger.Conway.Imp.UtxoSpec qualified as ConwayUTXO
+import Test.Cardano.Ledger.Conway.Imp.UtxosSpec qualified as ConwayUTXOS
+import Test.Cardano.Ledger.Conway.Imp.UtxowSpec qualified as ConwayUTXOW
 import Test.Cardano.Ledger.Dijkstra.Imp.CertSpec qualified as CERT
 import Test.Cardano.Ledger.Dijkstra.Imp.CertsSpec qualified as CERTS
 import Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec qualified as LEDGER
@@ -36,20 +36,20 @@ spec = do
       modifyImpInitProtVer @DijkstraEra (natVersion @12) $
         modifyImpInitPostSubmitTxHook submitTxConformanceHook $ do
           modifyImpInitPostEpochBoundaryHook epochBoundaryConformanceHook $ do
-            LEDGER.spec
+            ConwayBBODY.spec
             CERT.spec
+            xdescribe "disabled" ConwayCERTS.spec
             CERTS.spec
-            UTXOW.spec
+            ConwayDELEG.spec
+            ConwayENACT.spec
+            ConwayEPOCH.spec
+            ConwayGOV.spec
+            ConwayGOVCERT.spec
+            ConwayLEDGER.spec
+            LEDGER.spec
+            ConwayRATIFY.spec
+            ConwayUTXO.spec
             UTXO.spec
-            describe "Conway" $ do
-              ConwayBbody.spec
-              xdescribe "disabled" ConwayCerts.spec
-              ConwayDeleg.spec
-              ConwayEnact.spec
-              ConwayEpoch.spec
-              ConwayGov.spec
-              ConwayGovCert.spec
-              ConwayLedger.spec
-              ConwayRatify.spec
-              ConwayUtxo.spec
-              ConwayUtxow.spec
+            ConwayUTXOW.spec
+            UTXOW.spec
+            xdescribe "disabled" ConwayUTXOS.spec


### PR DESCRIPTION
# Description

This PR enables (most of) Conway's conformance Imp tests for Dijkstra.

It also,
- modifies two Dijkstra tests to use spending scripts instead of minting scripts (so they can be tested against the spec).
- updates `formal-ledger-specifications` and fixes translation issues

_This PR is blocked by https://github.com/IntersectMBO/formal-ledger-specifications/pull/1263._

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
