### PR TITLE
Fix updating of `UTxOState`

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -218,11 +218,11 @@ utxoTransition = do
 
   Shelley.updateUTxOState
     pp
-    (utxos & utxosGovStateL .~ govStateAfterPPUP)
     txBody
     certState
     (tellEvent . TotalDeposits (hashAnnotated txBody))
     (\a b -> tellEvent $ TxUTxODiff a b)
+    (utxos & utxosGovStateL .~ govStateAfterPPUP)
 
 -- | Ensure the transaction is within the validity window.
 --

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Rules/Utxo.hs
@@ -39,6 +39,7 @@ import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..), serialize)
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Rules.ValidationMode (Test, runTest)
+import Cardano.Ledger.Shelley.LedgerState (utxosGovStateL)
 import qualified Cardano.Ledger.Shelley.LedgerState as Shelley
 import Cardano.Ledger.Shelley.PParams (Update)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
@@ -195,7 +196,7 @@ utxoTransition = do
   runTest $ Shelley.validateValueNotConservedUTxO pp utxo certState txBody
 
   -- process Protocol Parameter Update Proposals
-  ppup' <-
+  govStateAfterPPUP <-
     trans @(EraRule "PPUP" era) $ TRC (Shelley.PPUPEnv slot pp genDelegs, ppup, txBody ^. updateTxBodyL)
 
   {- adaPolicy ∉ supp mint tx
@@ -217,10 +218,9 @@ utxoTransition = do
 
   Shelley.updateUTxOState
     pp
-    utxos
+    (utxos & utxosGovStateL .~ govStateAfterPPUP)
     txBody
     certState
-    ppup'
     (tellEvent . TotalDeposits (hashAnnotated txBody))
     (\a b -> tellEvent $ TxUTxODiff a b)
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -88,7 +88,7 @@ import Cardano.Ledger.Rules.ValidationMode (
   runTest,
   runTestOnSignal,
  )
-import Cardano.Ledger.Shelley.LedgerState (ShelleyGovState, UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxIn)
@@ -577,10 +577,9 @@ utxoTransition = do
     IsValid True ->
       Shelley.updateUTxOState
         pp
-        utxos
+        (utxos & utxosGovStateL .~ updatedGovState)
         txBody
         certState
-        updatedGovState
         (tellEvent . TotalDeposits (hashAnnotated txBody))
         (\a b -> tellEvent (TxUTxODiff a b))
     IsValid False ->

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -573,25 +573,7 @@ utxoTransition = do
     trans @(EraRule "UTXOS" era) $
       TRC (UtxosEnv slot pp certState, utxosGovState utxos, stAnnTx)
 
-  case tx ^. isValidTxL of
-    IsValid True ->
-      Shelley.updateUTxOState
-        pp
-        txBody
-        certState
-        (tellEvent . TotalDeposits (hashAnnotated txBody))
-        (\a b -> tellEvent (TxUTxODiff a b))
-        (utxos & utxosGovStateL .~ updatedGovState)
-    IsValid False ->
-      {- utxoKeep = txBody ^. collateralInputsTxBodyL ⋪ utxo -}
-      {- utxoDel  = txBody ^. collateralInputsTxBodyL ◁ utxo -}
-      let !(utxoKeep, utxoDel) = extractKeys (unUTxO utxo) (txBody ^. collateralInputsTxBodyL)
-       in pure $!
-            utxos
-              { utxosUtxo = UTxO utxoKeep
-              , utxosFees = (utxosFees utxos) <> sumAllCoin utxoDel
-              , utxosInstantStake = deleteInstantStake (UTxO utxoDel) (utxos ^. instantStakeL)
-              }
+  updateUTxOState pp certState tx (utxos & utxosGovStateL .~ updatedGovState)
 
 --------------------------------------------------------------------------------
 -- UTXO STS
@@ -765,3 +747,38 @@ allegraToAlonzoUtxoPredFailure = \case
   Allegra.UpdateFailure x -> UtxosFailure (injectFailure @"UTXOS" @t x)
   Allegra.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs
   Allegra.OutputTooBigUTxO xs -> OutputTooBigUTxO (fmap (0,0,) xs)
+
+updateUTxOState ::
+  forall era.
+  ( AlonzoEraTx era
+  , EraStake era
+  , EraCertState era
+  , Event (EraRule "UTXO" era) ~ AlonzoUtxoEvent era
+  ) =>
+  PParams era ->
+  CertState era ->
+  Tx TopTx era ->
+  UTxOState era ->
+  Rule (EraRule "UTXO" era) 'Transition (UTxOState era)
+updateUTxOState pp certState tx utxoState =
+  let txBody = tx ^. bodyTxL
+      utxo = utxosUtxo utxoState
+   in case tx ^. isValidTxL of
+        IsValid True ->
+          Shelley.updateUTxOState
+            pp
+            txBody
+            certState
+            (tellEvent . TotalDeposits (hashAnnotated txBody))
+            (\a b -> tellEvent (TxUTxODiff a b))
+            utxoState
+        IsValid False ->
+          {- utxoKeep = txBody ^. collateralInputsTxBodyL ⋪ utxo -}
+          {- utxoDel  = txBody ^. collateralInputsTxBodyL ◁ utxo -}
+          let !(utxoKeep, utxoDel) = extractKeys (unUTxO utxo) (txBody ^. collateralInputsTxBodyL)
+           in pure $!
+                utxoState
+                  { utxosUtxo = UTxO utxoKeep
+                  , utxosFees = utxosFees utxoState <> sumAllCoin utxoDel
+                  , utxosInstantStake = deleteInstantStake (UTxO utxoDel) (utxoState ^. instantStakeL)
+                  }

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxo.hs
@@ -577,11 +577,11 @@ utxoTransition = do
     IsValid True ->
       Shelley.updateUTxOState
         pp
-        (utxos & utxosGovStateL .~ updatedGovState)
         txBody
         certState
         (tellEvent . TotalDeposits (hashAnnotated txBody))
         (\a b -> tellEvent (TxUTxODiff a b))
+        (utxos & utxosGovStateL .~ updatedGovState)
     IsValid False ->
       {- utxoKeep = txBody ^. collateralInputsTxBodyL ⋪ utxo -}
       {- utxoDel  = txBody ^. collateralInputsTxBodyL ◁ utxo -}

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* Rename `updateUTxOStateByTxValidity` to `updateUTxOState`
 * `validateScriptsWellFormed` / `validateScriptsWellFormedTxOuts` gained a cache parameter
 * Introduce `LEDGERS` rule with `STS` and `Embed (LEDGER era) (LEDGERS era)` instances, and wire it to `EraRule "LEDGERS" BabbageEra` (previously `Shelley.LEDGERS`)
 * Export `LEDGERS` from `Cardano.Ledger.Babbage.Era` and `Cardano.Ledger.Babbage.Rules`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -27,7 +27,7 @@ module Cardano.Ledger.Babbage.Rules.Utxo (
   validateCollateralEqBalance,
   validateOutputTooSmallUTxO,
   disjointRefInputs,
-  updateUTxOStateByTxValidity,
+  updateUTxOState,
 ) where
 
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
@@ -444,9 +444,9 @@ utxoTransition = do
   updatedGovState <-
     trans @(EraRule "UTXOS" era) $
       TRC (Alonzo.UtxosEnv slot pp certState, utxosGovState utxos, stAnnTx)
-  updateUTxOStateByTxValidity pp certState tx (utxos & utxosGovStateL .~ updatedGovState)
+  updateUTxOState pp certState tx (utxos & utxosGovStateL .~ updatedGovState)
 
-updateUTxOStateByTxValidity ::
+updateUTxOState ::
   forall era.
   ( AlonzoEraTx era
   , BabbageEraTxBody era
@@ -459,7 +459,7 @@ updateUTxOStateByTxValidity ::
   Tx TopTx era ->
   UTxOState era ->
   Rule (EraRule "UTXO" era) 'Transition (UTxOState era)
-updateUTxOStateByTxValidity pp certState tx utxoState =
+updateUTxOState pp certState tx utxoState =
   let txBody = tx ^. bodyTxL
       utxo = utxosUtxo utxoState
    in case tx ^. isValidTxL of

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -54,7 +54,7 @@ import Cardano.Ledger.Rules.ValidationMode (
   runTest,
   runTestOnSignal,
  )
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxIn)
@@ -444,7 +444,7 @@ utxoTransition = do
   updatedGovState <-
     trans @(EraRule "UTXOS" era) $
       TRC (Alonzo.UtxosEnv slot pp certState, utxosGovState utxos, stAnnTx)
-  updateUTxOStateByTxValidity pp certState updatedGovState tx utxos
+  updateUTxOStateByTxValidity pp certState tx (utxos & utxosGovStateL .~ updatedGovState)
 
 updateUTxOStateByTxValidity ::
   forall era.
@@ -456,11 +456,10 @@ updateUTxOStateByTxValidity ::
   ) =>
   PParams era ->
   CertState era ->
-  GovState era ->
   Tx TopTx era ->
   UTxOState era ->
   Rule (EraRule "UTXO" era) 'Transition (UTxOState era)
-updateUTxOStateByTxValidity pp certState govState tx utxoState =
+updateUTxOStateByTxValidity pp certState tx utxoState =
   let txBody = tx ^. bodyTxL
       utxo = utxosUtxo utxoState
    in case tx ^. isValidTxL of
@@ -470,7 +469,6 @@ updateUTxOStateByTxValidity pp certState govState tx utxoState =
             utxoState
             txBody
             certState
-            govState
             (tellEvent . Alonzo.TotalDeposits (hashAnnotated txBody))
             (\a b -> tellEvent $ Alonzo.TxUTxODiff a b)
         IsValid False ->

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxo.hs
@@ -466,11 +466,11 @@ updateUTxOStateByTxValidity pp certState tx utxoState =
         IsValid True ->
           Shelley.updateUTxOState
             pp
-            utxoState
             txBody
             certState
             (tellEvent . Alonzo.TotalDeposits (hashAnnotated txBody))
             (\a b -> tellEvent $ Alonzo.TxUTxODiff a b)
+            utxoState
         IsValid False ->
           {- utxoKeep = txBody ^. collateralInputsTxBodyL ⋪ utxo -}
           {- utxoDel  = txBody ^. collateralInputsTxBodyL ◁ utxo -}

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.23.0.0
 
+* Restrict `conwayCertsTotalDepositsTxBody` to `TxBody TopTx era` type
 * Change `EraRule "LEDGERS" ConwayEra` from `Shelley.LEDGERS` to `Babbage.LEDGERS`
 * Add `TranslateEra` instance for `SnapShots`
 * Fix `NoThunks` instance for `ConwayGenesis`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -237,7 +237,7 @@ conwayUtxoTransition = do
   let tx = stAnnTx ^. txStAnnTxG
   Babbage.babbageUtxoValidation
   () <- trans @(EraRule "UTXOS" era) $ TRC ((), (), stAnnTx)
-  Babbage.updateUTxOStateByTxValidity
+  Babbage.updateUTxOState
     pp
     certState
     tx

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxo.hs
@@ -240,7 +240,6 @@ conwayUtxoTransition = do
   Babbage.updateUTxOStateByTxValidity
     pp
     certState
-    (utxosGovState utxos)
     tx
     (updateTreasuryDonation tx utxos)
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/State/CertState.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/State/CertState.hs
@@ -116,7 +116,7 @@ conwayObligationCertState certState =
         }
 
 conwayCertsTotalDepositsTxBody ::
-  EraTxBody era => PParams era -> ConwayCertState era -> TxBody l era -> Coin
+  EraTxBody era => PParams era -> ConwayCertState era -> TxBody TopTx era -> Coin
 conwayCertsTotalDepositsTxBody pp ConwayCertState {conwayCertPState} =
   getTotalDepositsTxBody pp (`Map.member` psStakePools conwayCertPState)
 

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0.0
 
+* Restrict `dijkstraCertsTotalDepositsTxBody` to `TxBody TopTx era` type
 * Add `encodeLeiosCert`, `decodeLeiosCert`
 * Add `startingAccountBalanceIntervals` to the top-level transaction body:
   - Add `startingAccountBalanceIntervalsTxBodyL` to the `DijkstraEraTxBody` typeclass

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -47,7 +47,7 @@ import Cardano.Ledger.Dijkstra.Rules.Utxo (
  )
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody)
 import Cardano.Ledger.Rules.ValidationMode
-import Cardano.Ledger.Shelley.LedgerState (UTxOState, utxosDonationL, utxosGovState, utxosUtxo)
+import Cardano.Ledger.Shelley.LedgerState (UTxOState, utxosDonationL, utxosUtxo)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.State
 import Cardano.Ledger.TxIn (TxIn)
@@ -270,7 +270,6 @@ dijkstraSubUtxoTransition = do
           utxoState
           txBody
           certState
-          (utxosGovState utxoState)
           (tellEvent . TotalDeposits (hashAnnotated txBody))
           (\a b -> tellEvent $ TxUTxODiff a b)
       pure $ newState & utxosDonationL <>~ txBody ^. treasuryDonationTxBodyL

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -216,7 +216,6 @@ dijkstraSubUtxoTransition ::
   forall era.
   ( EraTx era
   , EraStake era
-  , EraCertState era
   , DijkstraEraTxBody era
   , AlonzoEraTxWits era
   , STS (EraRule "SUBUTXO" era)
@@ -229,7 +228,7 @@ dijkstraSubUtxoTransition ::
   ) =>
   TransitionRule (EraRule "SUBUTXO" era)
 dijkstraSubUtxoTransition = do
-  TRC (SubUtxoEnv slot pp certState originalUtxo (IsValid isValid), utxoState, stAnnTx) <-
+  TRC (SubUtxoEnv slot pp _ originalUtxo (IsValid isValid), utxoState, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
 
@@ -263,16 +262,11 @@ dijkstraSubUtxoTransition = do
   runTestOnSignal $ Alonzo.validateWrongNetworkInTxBody netId txBody
 
   if isValid
-    then do
-      newState <-
-        Shelley.updateUTxOStateNoFees
-          pp
-          utxoState
-          txBody
-          certState
-          (tellEvent . TotalDeposits (hashAnnotated txBody))
-          (\a b -> tellEvent $ TxUTxODiff a b)
-      pure $ newState & utxosDonationL <>~ txBody ^. treasuryDonationTxBodyL
+    then
+      Shelley.updateUTxOAndInstantStake
+        txBody
+        (\a b -> tellEvent $ TxUTxODiff a b)
+        (utxoState & utxosDonationL <>~ txBody ^. treasuryDonationTxBodyL)
     else
       pure utxoState
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -447,7 +447,6 @@ dijkstraUtxoTransition = do
   Babbage.updateUTxOStateByTxValidity
     pp
     certState
-    (utxosGovState utxos)
     tx
     (Conway.updateTreasuryDonation tx utxos)
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -444,7 +444,7 @@ dijkstraUtxoTransition = do
   runTest $ Alonzo.validateTooManyCollateralInputs pp txBody
 
   () <- trans @(EraRule "UTXOS" era) $ TRC ((), (), stAnnTx)
-  Babbage.updateUTxOStateByTxValidity
+  Babbage.updateUTxOState
     pp
     certState
     tx

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/State/CertState.hs
@@ -40,30 +40,23 @@ instance ConwayEraCertState DijkstraEra where
 
 -- | Total deposits for a transaction, summed across the top-level tx and its subtransactions
 dijkstraCertsTotalDepositsTxBody ::
-  forall era l.
+  forall era.
   ( EraTx era
   , DijkstraEraTxBody era
-  , STxLevel l era ~ STxBothLevels l era
   ) =>
   PParams era ->
   ConwayCertState era ->
-  TxBody l era ->
+  TxBody TopTx era ->
   Coin
-dijkstraCertsTotalDepositsTxBody pp certState = \txBody ->
-  -- TODO: restrict to TopTx, once certsTotalDepositsTxBody is restricted to TopTx
-  withBothTxLevels
-    txBody
-    ( \topTxBody ->
-        let subTxs = topTxBody ^. subTransactionsTxBodyL
-            batchTxCerts =
-              foldMap' (^. bodyTxL . certsTxBodyL) subTxs
-                <> (topTxBody ^. certsTxBodyL)
-         in getTotalDepositsTxCerts pp isPoolReg batchTxCerts
-              <+> conwayProposalsDeposits pp topTxBody
-              <+> foldMap' (conwayProposalsDeposits pp . (^. bodyTxL)) subTxs
-    )
-    (getTotalDepositsTxBody pp isPoolReg)
+dijkstraCertsTotalDepositsTxBody pp certState topTxBody =
+  getTotalDepositsTxCerts pp isPoolReg batchTxCerts
+    <+> conwayProposalsDeposits pp topTxBody
+    <+> foldMap' (conwayProposalsDeposits pp . (^. bodyTxL)) subTxs
   where
+    subTxs = topTxBody ^. subTransactionsTxBodyL
+    batchTxCerts =
+      foldMap' (^. bodyTxL . certsTxBodyL) subTxs
+        <> (topTxBody ^. certsTxBodyL)
     isPoolReg = (`Map.member` psStakePools (conwayCertPState certState))
 
 -- | Total refunds for a transaction, summed across the top-level tx and its subtransactions

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxBody.hs
@@ -1037,8 +1037,9 @@ upgradeProposals ProposalProcedure {..} =
     , pProcAnchor = pProcAnchor
     }
 
+-- | Total deposits for a single tx body. It does NOT batch across subtransactions.
 dijkstraTotalDepositsTxBody ::
-  ConwayEraTxBody era => PParams era -> (KeyHash StakePool -> Bool) -> TxBody l era -> Coin
+  ConwayEraTxBody era => PParams era -> (KeyHash StakePool -> Bool) -> TxBody TopTx era -> Coin
 dijkstraTotalDepositsTxBody pp isPoolRegisted txBody =
   getTotalDepositsTxCerts pp isPoolRegisted (txBody ^. certsTxBodyL)
     <+> conwayProposalsDeposits pp txBody

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Restrict `shelleyCertsTotalDepositsTxBody` to `TxBody TopTx era` type
 * Switch parameter order of `updateUTxOState`
 * Add `updateUTxOStateDeposits` and `updateUTxOAndInstantStake`
 * Remove `GovState` parameter from `updateUTxOState`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Remove `GovState` parameter from `updateUTxOState`
 * Change argument to `validateMetadata` from `Tx` to `StAnnTx`
 * Add `EraUTxO era` as a superclass constraint to `ApplyTx`
 * Change `produced` to accept `PState`, instead of `CertState`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -81,7 +81,6 @@
 * Remove `ToCBOR` and `FromCBOR` instances for `UTxOState`, `LedgerState`, `ShelleyTxOut`
 * Add `ApplyTick` typeclass with `applyTick` method, extracted from `ApplyBlock`.
 * Remove `validMetadata` from `SoftForks`
-* Add `updateUTxOStateNoFees`
 * Add `Shelley.API.Forecast` and `Shelley.Forecast`:
   - Add `EraForecast` and `ShelleyEraForecast` typeclasses to deprecate `GetLedgerView` from `cardano-ledger-tpraos`.
   - Add `currentForecast` and `futureForecast` functions to deprecate `currentLedgerView` and `futureLedgerView`.

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Switch parameter order of `updateUTxOState`
 * Add `updateUTxOStateDeposits` and `updateUTxOAndInstantStake`
 * Remove `GovState` parameter from `updateUTxOState`
 * Change argument to `validateMetadata` from `Tx` to `StAnnTx`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `updateUTxOStateDeposits` and `updateUTxOAndInstantStake`
 * Remove `GovState` parameter from `updateUTxOState`
 * Change argument to `validateMetadata` from `Tx` to `StAnnTx`
 * Add `EraUTxO era` as a superclass constraint to `ApplyTx`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -24,6 +24,8 @@ module Cardano.Ledger.Shelley.Rules.Utxo (
   UtxoEvent (..),
   validSizeComputationCheck,
   updateUTxOState,
+  updateUTxOStateDeposits,
+  updateUTxOAndInstantStake,
   updateUTxOStateNoFees,
 
   -- * Validations
@@ -593,10 +595,10 @@ updateUTxOState ::
   (Coin -> m ()) ->
   (UTxO era -> UTxO era -> m ()) ->
   m (UTxOState era)
-updateUTxOState pp utxos txBody certState depositChangeEvent txUtxODiffEvent = do
-  newUtxoState <-
-    updateUTxOStateNoFees pp utxos txBody certState depositChangeEvent txUtxODiffEvent
-  pure $ newUtxoState {utxosFees = utxosFees newUtxoState <> txBody ^. feeTxBodyL}
+updateUTxOState pp utxoState txBody certState depositChangeEvent utxoDiffEvent = do
+  withDeposits <- updateUTxOStateDeposits pp certState txBody depositChangeEvent utxoState
+  withUtxo <- updateUTxOAndInstantStake txBody utxoDiffEvent withDeposits
+  pure $ withUtxo & utxosFeesL <>~ (txBody ^. feeTxBodyL)
 
 -- | Like 'updateUTxOState', but does not collect fees. This is used for sub-transactions
 -- where fees are not applicable.
@@ -613,26 +615,56 @@ updateUTxOStateNoFees ::
   (Coin -> m ()) ->
   (UTxO era -> UTxO era -> m ()) ->
   m (UTxOState era)
-updateUTxOStateNoFees pp utxos txBody certState depositChangeEvent txUtxODiffEvent = do
-  let UTxO utxo = utxosUtxo utxos
-      !utxoAdd = txouts txBody -- These will be inserted into the UTxO
+updateUTxOStateNoFees pp utxoState txBody certState depositChangeEvent utxoDiffEvent = do
+  withDeposits <- updateUTxOStateDeposits pp certState txBody depositChangeEvent utxoState
+  updateUTxOAndInstantStake txBody utxoDiffEvent withDeposits
+
+-- | Apply the txBody's inputs/outputs to the UTxO map and to the instant stake,
+-- firing the diff event.
+updateUTxOAndInstantStake ::
+  ( EraTxBody era
+  , EraStake era
+  , Monad m
+  ) =>
+  TxBody l era ->
+  (UTxO era -> UTxO era -> m ()) ->
+  UTxOState era ->
+  m (UTxOState era)
+updateUTxOAndInstantStake txBody utxoDiffEvent utxoState = do
+  let !utxoAdd = txouts txBody
       {- utxoDel  = txins txb ◁ utxo -}
-      !(utxoWithout, utxoDel) = extractKeys utxo (txBody ^. inputsTxBodyL)
+      !(utxoWithout, utxoDel) = extractKeys (unUTxO (utxoState ^. utxoL)) (txBody ^. inputsTxBodyL)
       {- newUTxO = (txins txb ⋪ utxo) ∪ outs txb -}
-      newUTxO = utxoWithout `Map.union` unUTxO utxoAdd
-      deletedUTxO = UTxO utxoDel
+      newUtxo = utxoWithout `Map.union` unUTxO utxoAdd
+      deletedUtxo = UTxO utxoDel
       newInstantStake =
-        deleteInstantStake deletedUTxO (addInstantStake utxoAdd (utxos ^. instantStakeL))
-      totalRefunds = certsTotalRefundsTxBody pp (certState ^. certDStateL . accountsL) txBody
-      totalDeposits = certsTotalDepositsTxBody pp certState txBody
-      depositChange = totalDeposits <-> totalRefunds
-  depositChangeEvent depositChange
-  txUtxODiffEvent deletedUTxO utxoAdd
+        deleteInstantStake
+          deletedUtxo
+          (addInstantStake utxoAdd (utxoState ^. instantStakeL))
+  utxoDiffEvent deletedUtxo utxoAdd
   pure $!
-    utxos
-      & utxoL .~ UTxO newUTxO
+    utxoState
+      & utxoL .~ UTxO newUtxo
       & instantStakeL .~ newInstantStake
-      & utxosDepositedL %~ (<> depositChange)
+
+updateUTxOStateDeposits ::
+  ( EraTxBody era
+  , EraCertState era
+  , Monad m
+  ) =>
+  PParams era ->
+  CertState era ->
+  TxBody l era ->
+  (Coin -> m ()) ->
+  UTxOState era ->
+  m (UTxOState era)
+updateUTxOStateDeposits pp certState txBody depositChangeEvent utxoState = do
+  depositChangeEvent depositChange
+  pure $! utxoState & utxosDepositedL <>~ depositChange
+  where
+    depositChange = totalDeposits <-> totalRefunds
+    totalDeposits = certsTotalDepositsTxBody pp certState txBody
+    totalRefunds = certsTotalRefundsTxBody pp (certState ^. certDStateL. accountsL) txBody
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -355,10 +355,10 @@ utxoInductive ::
   ) =>
   TransitionRule (EraRule "UTXO" era)
 utxoInductive = do
-  TRC (UtxoEnv slot pp certState, utxos, stAnnTx) <- judgmentContext
+  TRC (UtxoEnv slot pp certState, utxoState, stAnnTx) <- judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
-      utxo = utxos ^. utxoL
-      UTxOState _ _ _ ppup _ _ = utxos
+      utxo = utxoState ^. utxoL
+      UTxOState _ _ _ ppup _ _ = utxoState
       txBody = tx ^. bodyTxL
       outputs = txBody ^. outputsTxBodyL
       genDelegs = dsGenDelegs (certState ^. certDStateL)
@@ -405,7 +405,7 @@ utxoInductive = do
     certState
     (tellEvent . TotalDeposits (hashAnnotated txBody))
     (\a b -> tellEvent $ TxUTxODiff a b)
-    (utxos & utxosGovStateL .~ govStateAfterPPUP)
+    (utxoState & utxosGovStateL .~ govStateAfterPPUP)
 
 -- | The ttl field marks the top of an open interval, so it must be strictly
 -- less than the slot, so fail if it is (>=).

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -401,11 +401,11 @@ utxoInductive = do
 
   updateUTxOState
     pp
-    (utxos & utxosGovStateL .~ govStateAfterPPUP)
     txBody
     certState
     (tellEvent . TotalDeposits (hashAnnotated txBody))
     (\a b -> tellEvent $ TxUTxODiff a b)
+    (utxos & utxosGovStateL .~ govStateAfterPPUP)
 
 -- | The ttl field marks the top of an open interval, so it must be strictly
 -- less than the slot, so fail if it is (>=).
@@ -588,13 +588,13 @@ updateUTxOState ::
   , Monad m
   ) =>
   PParams era ->
-  UTxOState era ->
   TxBody TopTx era ->
   CertState era ->
   (Coin -> m ()) ->
   (UTxO era -> UTxO era -> m ()) ->
+  UTxOState era ->
   m (UTxOState era)
-updateUTxOState pp utxoState txBody certState depositChangeEvent utxoDiffEvent = do
+updateUTxOState pp txBody certState depositChangeEvent utxoDiffEvent utxoState = do
   withDeposits <- updateUTxOStateDeposits pp certState txBody depositChangeEvent utxoState
   withUtxo <- updateUTxOAndInstantStake txBody utxoDiffEvent withDeposits
   pure $ withUtxo & utxosFeesL <>~ (txBody ^. feeTxBodyL)
@@ -644,7 +644,7 @@ updateUTxOStateDeposits pp certState txBody depositChangeEvent utxoState = do
   where
     depositChange = totalDeposits <-> totalRefunds
     totalDeposits = certsTotalDepositsTxBody pp certState txBody
-    totalRefunds = certsTotalRefundsTxBody pp (certState ^. certDStateL. accountsL) txBody
+    totalRefunds = certsTotalRefundsTxBody pp (certState ^. certDStateL . accountsL) txBody
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -56,7 +56,7 @@ import Cardano.Ledger.Rules.ValidationMode (Test, runTest)
 import Cardano.Ledger.Shelley.AdaPots (consumedTxBody, producedTxBody)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.Era (ShelleyEra, UTXO)
-import Cardano.Ledger.Shelley.LedgerState (UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState
 import Cardano.Ledger.Shelley.PParams (Update)
 import Cardano.Ledger.Shelley.Rules.Ppup (
   PPUP,
@@ -386,7 +386,7 @@ utxoInductive = do
   runTest $ validateValueNotConservedUTxO pp utxo certState txBody
 
   -- process Protocol Parameter Update Proposals
-  ppup' <-
+  govStateAfterPPUP <-
     trans @(EraRule "PPUP" era) $ TRC (PPUPEnv slot pp genDelegs, ppup, txBody ^. updateTxBodyL)
 
   {- ∀(_ → (_, c)) ∈ txouts txb, c ≥ (minUTxOValue pp) -}
@@ -400,10 +400,9 @@ utxoInductive = do
 
   updateUTxOState
     pp
-    utxos
+    (utxos & utxosGovStateL .~ govStateAfterPPUP)
     txBody
     certState
-    ppup'
     (tellEvent . TotalDeposits (hashAnnotated txBody))
     (\a b -> tellEvent $ TxUTxODiff a b)
 
@@ -591,13 +590,12 @@ updateUTxOState ::
   UTxOState era ->
   TxBody TopTx era ->
   CertState era ->
-  GovState era ->
   (Coin -> m ()) ->
   (UTxO era -> UTxO era -> m ()) ->
   m (UTxOState era)
-updateUTxOState pp utxos txBody certState govState depositChangeEvent txUtxODiffEvent = do
+updateUTxOState pp utxos txBody certState depositChangeEvent txUtxODiffEvent = do
   newUtxoState <-
-    updateUTxOStateNoFees pp utxos txBody certState govState depositChangeEvent txUtxODiffEvent
+    updateUTxOStateNoFees pp utxos txBody certState depositChangeEvent txUtxODiffEvent
   pure $ newUtxoState {utxosFees = utxosFees newUtxoState <> txBody ^. feeTxBodyL}
 
 -- | Like 'updateUTxOState', but does not collect fees. This is used for sub-transactions
@@ -612,34 +610,29 @@ updateUTxOStateNoFees ::
   UTxOState era ->
   TxBody l era ->
   CertState era ->
-  GovState era ->
   (Coin -> m ()) ->
   (UTxO era -> UTxO era -> m ()) ->
   m (UTxOState era)
-updateUTxOStateNoFees pp utxos txBody certState govState depositChangeEvent txUtxODiffEvent = do
-  let UTxOState {utxosUtxo, utxosDeposited, utxosFees, utxosDonation} = utxos
-      UTxO utxo = utxosUtxo
+updateUTxOStateNoFees pp utxos txBody certState depositChangeEvent txUtxODiffEvent = do
+  let UTxO utxo = utxosUtxo utxos
       !utxoAdd = txouts txBody -- These will be inserted into the UTxO
       {- utxoDel  = txins txb ◁ utxo -}
       !(utxoWithout, utxoDel) = extractKeys utxo (txBody ^. inputsTxBodyL)
       {- newUTxO = (txins txb ⋪ utxo) ∪ outs txb -}
       newUTxO = utxoWithout `Map.union` unUTxO utxoAdd
       deletedUTxO = UTxO utxoDel
+      newInstantStake =
+        deleteInstantStake deletedUTxO (addInstantStake utxoAdd (utxos ^. instantStakeL))
       totalRefunds = certsTotalRefundsTxBody pp (certState ^. certDStateL . accountsL) txBody
       totalDeposits = certsTotalDepositsTxBody pp certState txBody
       depositChange = totalDeposits <-> totalRefunds
   depositChangeEvent depositChange
   txUtxODiffEvent deletedUTxO utxoAdd
   pure $!
-    UTxOState
-      { utxosUtxo = UTxO newUTxO
-      , utxosDeposited = utxosDeposited <> depositChange
-      , utxosFees = utxosFees
-      , utxosGovState = govState
-      , utxosInstantStake =
-          deleteInstantStake deletedUTxO (addInstantStake utxoAdd (utxos ^. instantStakeL))
-      , utxosDonation = utxosDonation
-      }
+    utxos
+      & utxoL .~ UTxO newUTxO
+      & instantStakeL .~ newInstantStake
+      & utxosDepositedL %~ (<> depositChange)
 
 instance
   ( Era era

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -634,7 +634,7 @@ updateUTxOStateDeposits ::
   ) =>
   PParams era ->
   CertState era ->
-  TxBody l era ->
+  TxBody TopTx era ->
   (Coin -> m ()) ->
   UTxOState era ->
   m (UTxOState era)

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxo.hs
@@ -26,7 +26,6 @@ module Cardano.Ledger.Shelley.Rules.Utxo (
   updateUTxOState,
   updateUTxOStateDeposits,
   updateUTxOAndInstantStake,
-  updateUTxOStateNoFees,
 
   -- * Validations
   validateInputSetEmptyUTxO,
@@ -599,25 +598,6 @@ updateUTxOState pp utxoState txBody certState depositChangeEvent utxoDiffEvent =
   withDeposits <- updateUTxOStateDeposits pp certState txBody depositChangeEvent utxoState
   withUtxo <- updateUTxOAndInstantStake txBody utxoDiffEvent withDeposits
   pure $ withUtxo & utxosFeesL <>~ (txBody ^. feeTxBodyL)
-
--- | Like 'updateUTxOState', but does not collect fees. This is used for sub-transactions
--- where fees are not applicable.
-updateUTxOStateNoFees ::
-  ( EraTxBody era
-  , EraStake era
-  , EraCertState era
-  , Monad m
-  ) =>
-  PParams era ->
-  UTxOState era ->
-  TxBody l era ->
-  CertState era ->
-  (Coin -> m ()) ->
-  (UTxO era -> UTxO era -> m ()) ->
-  m (UTxOState era)
-updateUTxOStateNoFees pp utxoState txBody certState depositChangeEvent utxoDiffEvent = do
-  withDeposits <- updateUTxOStateDeposits pp certState txBody depositChangeEvent utxoState
-  updateUTxOAndInstantStake txBody utxoDiffEvent withDeposits
 
 -- | Apply the txBody's inputs/outputs to the UTxO map and to the instant stake,
 -- firing the diff event.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/State/CertState.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/State/CertState.hs
@@ -84,7 +84,7 @@ shelleyObligationCertState certState =
     }
 
 shelleyCertsTotalDepositsTxBody ::
-  EraTxBody era => PParams era -> ShelleyCertState era -> TxBody t era -> Coin
+  EraTxBody era => PParams era -> ShelleyCertState era -> TxBody TopTx era -> Coin
 shelleyCertsTotalDepositsTxBody pp ShelleyCertState {shelleyCertPState} =
   getTotalDepositsTxBody pp (`Map.member` psStakePools shelleyCertPState)
 

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Restrict `getTotalDepositsTxBody` and `certsTotalDepositsTxBody` to `TxBody TopTx era` type
 * Add `StAnnTxCache` as an argument to `validateTxAuxData`
 * Add `isValidPlutusRunnable`
 * Add `StAnnTxCache` associated type and `cacheStAnnTxG` method to `EraTx`, together with a new `Monoid (StAnnTxCache era)` superclass constraint

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -271,7 +271,7 @@ class
     PParams era ->
     -- | Check whether stake pool is registered or not
     (KeyHash StakePool -> Bool) ->
-    TxBody l era ->
+    TxBody TopTx era ->
     Coin
   getTotalDepositsTxBody pp isPoolRegisted txBody =
     getTotalDepositsTxCerts pp isPoolRegisted (txBody ^. certsTxBodyL)

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/CertState.hs
@@ -391,7 +391,8 @@ class
   --
   -- This is the contribution of a TxBody towards the deposit pot (utxosDeposit field of
   -- the UTxOState) of the system
-  certsTotalDepositsTxBody :: EraTxBody era => PParams era -> CertState era -> TxBody t era -> Coin
+  certsTotalDepositsTxBody ::
+    EraTxBody era => PParams era -> CertState era -> TxBody TopTx era -> Coin
 
   -- | Compute the total refunds from the Certs of a TxBody.
   --


### PR DESCRIPTION
# Description

Currently in master `Shelley.updateUTxOState` is doing several things: 
1. updates the UTXO Map and InstantStake based on consumed inputs
2. updates the `deposited` field 
3. updates the fees 
4. updates  the govState with a given parameter 

In Dijkstra, for the top-level transaction we need to do 1-3, however for the subtransactions, we need to do only 1.

This is what this PR is doing.
It also refactors `updateUTxOState` and unifies it across eras, removing helpers that combine these actions in arbitrary ways. 
4.  is completely useless and can be removed by setting the `govState`  in `UTxOState`  before calling the function. 


Depends on the https://github.com/IntersectMBO/cardano-ledger/pull/5930: for the the  implementations of `certsTotalDepositsTxBody` and `certsTotalRefundsTxBody`  that sum up all deposits from the batch. 


<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
