### PR TITLE
Optimize plutus script preparation

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra.hs
@@ -40,7 +40,7 @@ instance ApplyTx AllegraEra where
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
 
-  mkStAnnTx _ _ _ _ = id
+  mkStAnnTx _ _ _ _ _ = id
 
   internalApplyTxWithValidation = defaultApplyTxWithValidation @"LEDGER" AllegraApplyTxError
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
@@ -22,6 +22,7 @@ import Lens.Micro
 
 instance EraUTxO AllegraEra where
   type ScriptsNeeded AllegraEra = ShelleyScriptsNeeded AllegraEra
+  type StAnnTxCache AllegraEra = ()
 
   getConsumedValue pp lookupKeyDeposit = getConsumedCoin pp lookupKeyDeposit
 
@@ -36,3 +37,5 @@ instance EraUTxO AllegraEra where
   getWitsVKeyNeeded = getShelleyWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
+
+  getCacheStAnnTx _ = mempty

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -32,7 +32,8 @@
 * Change `Signal` to `StAnnTx TopTx era` for: `AlonzoLEDGER`, `AlonzoUTXOW`, `AlonzoUTXO`, `AlonzoUTXOS`
 * Add `FromJSON` instance for `IsValid`
 * Add `ltiMemoizedSubTransactions` to `LedgerTxInfo`
-* Add `resolveNeededPlutusScriptsWithPurpose`, which takes a `ProtVer` and returns `[(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)]`
+* Add `resolveNeededPlutusScriptsWithPurpose`, which takes a `ProtVer` and a `Map ScriptHash (SupportedPlutusRunnable era)` cache of previously resolved scripts, and returns the updated cache together with `[(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)]`
+* Add `unAlonzoScriptsNeeded` record accessor to `AlonzoScriptsNeeded`
 * Add `scriptsWithContextFromLedgerTxInfo` and `scriptsWithContextFromLedgerTxInfoWithResult`
 * Add `AlonzoStAnnTx`
 * Move and rename `toPlutusWithContext` from `Cardano.Ledger.Alonzo.Plutus.Context` to `mkPlutusWithContext` in `Cardano.Ledger.Alonzo.Plutus.TxInfo`, changing its signature to accept a `SupportedPlutusRunnable era` with separate `Data era` and `ExUnits` arguments

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.16.0.0
 
+* Add `SupportedPlutusRunnable` type and add `mkSupportedPlutusRunnable` to `EraPlutusContext`
+* Remove `mkPlutusWithContext` from `EraPlutusContext`
 * Make `AlonzoTx` decoder that used for Mempool backwards compatible with prior-eras
 * Add `TranslateEra` instance for `SnapShots`
 * Change `extraConfig` and `agExtraConfig` from `Maybe` to `StrictMaybe`
@@ -30,10 +32,10 @@
 * Change `Signal` to `StAnnTx TopTx era` for: `AlonzoLEDGER`, `AlonzoUTXOW`, `AlonzoUTXO`, `AlonzoUTXOS`
 * Add `FromJSON` instance for `IsValid`
 * Add `ltiMemoizedSubTransactions` to `LedgerTxInfo`
-* Add `resolveNeededPlutusScriptsWithPurpose`
+* Add `resolveNeededPlutusScriptsWithPurpose`, which takes a `ProtVer` and returns `[(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)]`
 * Add `scriptsWithContextFromLedgerTxInfo` and `scriptsWithContextFromLedgerTxInfoWithResult`
 * Add `AlonzoStAnnTx`
-* Move `toPlutusWithContext` from `Cardano.Ledger.Alonzo.Plutus.Context` to `Cardano.Ledger.Alonzo.Plutus.TxInfo`
+* Move and rename `toPlutusWithContext` from `Cardano.Ledger.Alonzo.Plutus.Context` to `mkPlutusWithContext` in `Cardano.Ledger.Alonzo.Plutus.TxInfo`, changing its signature to accept a `SupportedPlutusRunnable era` with separate `Data era` and `ExUnits` arguments
 * Add `scriptsProvidedStAnnTx` to `AlonzoEraUTxO` and a helper to implement it `scriptsProvidedAlonzoStAnnTx`
 * Remove `ToCBOR` and `FromCBOR` instances for `AlonzoExtraConfig` and `AlonzoTxOut`
 * Add `ApplyTick` instance for `AlonzoEra`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Add `asatPlutusRunnableCache` field to `AlonzoStAnnTx`, holding `Map ScriptHash (SupportedPlutusRunnable era)`
 * Add `SupportedPlutusRunnable` type and add `mkSupportedPlutusRunnable` to `EraPlutusContext`
 * Remove `mkPlutusWithContext` from `EraPlutusContext`
 * Make `AlonzoTx` decoder that used for Mempool backwards compatible with prior-eras

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -133,7 +133,8 @@ mkAlonzoStAnnTx ei sysStart pp utxo tx =
     protVer = pp ^. ppProtocolVersionL
     scriptsNeeded = getScriptsNeeded utxo (tx ^. bodyTxL)
     scriptsProvided = getScriptsProvided utxo tx
-    plutusScriptsUsed = resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded
+    (_, plutusScriptsUsed) =
+      resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded mempty
     ledgerTxInfo =
       LedgerTxInfo
         { ltiProtVer = protVer

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -68,6 +68,7 @@ import Cardano.Slotting.Time (SystemStart)
 import Control.State.Transition.Extended (ValidationPolicy (..))
 import Data.Bifunctor (Bifunctor (first))
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -87,6 +88,7 @@ instance ApplyTx AlonzoEra where
             (systemStart globals)
             (env ^. ledgerPpL)
             (state ^. utxoG)
+            mempty
             tx
      in first AlonzoApplyTxError $
           ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx
@@ -126,15 +128,16 @@ mkAlonzoStAnnTx ::
   SystemStart ->
   PParams era ->
   UTxO era ->
+  Map.Map ScriptHash (SupportedPlutusRunnable era) ->
   Tx TopTx era ->
   AlonzoStAnnTx TopTx era
-mkAlonzoStAnnTx ei sysStart pp utxo tx =
+mkAlonzoStAnnTx ei sysStart pp utxo stAnnTxCache tx =
   let
     protVer = pp ^. ppProtocolVersionL
     scriptsNeeded = getScriptsNeeded utxo (tx ^. bodyTxL)
     scriptsProvided = getScriptsProvided utxo tx
-    (_, plutusScriptsUsed) =
-      resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded mempty
+    (newStAnnTxCache, plutusScriptsUsed) =
+      resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded stAnnTxCache
     ledgerTxInfo =
       LedgerTxInfo
         { ltiProtVer = protVer
@@ -149,6 +152,7 @@ mkAlonzoStAnnTx ei sysStart pp utxo tx =
       { asatTx = tx
       , asatScriptsNeeded = scriptsNeeded
       , asatScriptsProvided = scriptsProvided
+      , asatPlutusRunnableCache = newStAnnTxCache
       , asatPlutusLanguagesUsed =
           Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr) <- plutusScriptsUsed]
       , asatPlutusScriptsWithContext =

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -30,13 +30,17 @@ import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Era
 import Cardano.Ledger.Alonzo.Forecast ()
 import Cardano.Ledger.Alonzo.PParams ()
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext, LedgerTxInfo (..))
+import Cardano.Ledger.Alonzo.Plutus.Context (
+  EraPlutusContext,
+  LedgerTxInfo (..),
+  SupportedPlutusRunnable (..),
+ )
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
   scriptsWithContextFromLedgerTxInfo,
  )
 import Cardano.Ledger.Alonzo.Plutus.TxInfo ()
 import Cardano.Ledger.Alonzo.Rules ()
-import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..), plutusScriptLanguage)
+import Cardano.Ledger.Alonzo.Scripts (AlonzoScript (..))
 import Cardano.Ledger.Alonzo.State ()
 import Cardano.Ledger.Alonzo.Transition ()
 import Cardano.Ledger.Alonzo.Translation ()
@@ -52,7 +56,7 @@ import Cardano.Ledger.Alonzo.UTxO (
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
 import Cardano.Ledger.Mary.Value (MaryValue)
-import Cardano.Ledger.Plutus.Data ()
+import Cardano.Ledger.Plutus (plutusLanguage)
 import Cardano.Ledger.Rules.ValidationMode (lblStatic)
 import Cardano.Ledger.Shelley.API
 import Cardano.Ledger.Shelley.Rules (ledgerPpL, ledgerSlotNoL)
@@ -126,12 +130,13 @@ mkAlonzoStAnnTx ::
   AlonzoStAnnTx TopTx era
 mkAlonzoStAnnTx ei sysStart pp utxo tx =
   let
+    protVer = pp ^. ppProtocolVersionL
     scriptsNeeded = getScriptsNeeded utxo (tx ^. bodyTxL)
     scriptsProvided = getScriptsProvided utxo tx
-    plutusScriptsUsed = resolveNeededPlutusScriptsWithPurpose scriptsProvided scriptsNeeded
+    plutusScriptsUsed = resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded
     ledgerTxInfo =
       LedgerTxInfo
-        { ltiProtVer = pp ^. ppProtocolVersionL
+        { ltiProtVer = protVer
         , ltiEpochInfo = ei
         , ltiSystemStart = sysStart
         , ltiUTxO = utxo
@@ -144,7 +149,7 @@ mkAlonzoStAnnTx ei sysStart pp utxo tx =
       , asatScriptsNeeded = scriptsNeeded
       , asatScriptsProvided = scriptsProvided
       , asatPlutusLanguagesUsed =
-          Set.fromList [plutusScriptLanguage s | (_, _, s) <- plutusScriptsUsed]
+          Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr) <- plutusScriptsUsed]
       , asatPlutusScriptsWithContext =
           scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL) plutusScriptsUsed
       }

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -64,7 +64,7 @@ import Cardano.Ledger.Plutus (
   PlutusArgs,
   PlutusBinary,
   PlutusLanguage,
-  PlutusRunnable,
+  PlutusRunnable (..),
   PlutusScriptContext,
   SLanguage (..),
   asSLanguage,
@@ -74,7 +74,7 @@ import Cardano.Ledger.State (UTxO (..))
 import Cardano.Ledger.TxIn (TxId, TxIn)
 import Cardano.Slotting.EpochInfo (EpochInfo)
 import Cardano.Slotting.Time (SystemStart)
-import Control.DeepSeq (NFData)
+import Control.DeepSeq (NFData (..))
 import Control.Monad (join)
 import Control.Monad.Trans.Fail.String (errorFail)
 import Data.Aeson (ToJSON (..), (.=), pattern String)
@@ -288,10 +288,27 @@ mkSupportedBinaryPlutusScript supportedLanguage plutus =
     SupportedLanguage sLang ->
       mkSupportedPlutusScript (asSLanguage sLang (Plutus plutus))
 
+-- | Invariant of this type is that it cannot be used between different protocol versions. In other
+-- words `SupportedPlutusRunnable` constructed from the same script, but two separate protocol
+-- versions, is not guaranteed to be the same, i.e. one of the could fail decoding, while the other
+-- would not.
 data SupportedPlutusRunnable era where
   SupportedPlutusRunnable ::
     EraPlutusTxInfo l era =>
     !(PlutusRunnable l) -> SupportedPlutusRunnable era
+
+instance Show (SupportedPlutusRunnable era) where
+  show (SupportedPlutusRunnable spr) = "(SupportedPlutusRunnable (" ++ show spr ++ "))"
+
+-- | As long as the language and the script hash are the same, we can conclude equality, because of
+-- the type invariant
+instance Eq (SupportedPlutusRunnable era) where
+  SupportedPlutusRunnable spr1 == SupportedPlutusRunnable spr2 =
+    plutusLanguage spr1 == plutusLanguage spr2
+      && plutusRunnableScriptHash spr1 == plutusRunnableScriptHash spr2
+
+instance NFData (SupportedPlutusRunnable era) where
+  rnf (SupportedPlutusRunnable spr) = rnf spr
 
 data SupportedLanguage era where
   SupportedLanguage :: EraPlutusTxInfo l era => SLanguage l -> SupportedLanguage era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -29,6 +29,7 @@ module Cardano.Ledger.Alonzo.Plutus.Context (
   toPlutusTxInfoForPurpose,
   EraPlutusContext (..),
   lookupTxInfoResultImpossible,
+  SupportedPlutusRunnable (..),
   SupportedLanguage (..),
   mkSupportedLanguageM,
   supportedLanguages,
@@ -52,21 +53,19 @@ import Cardano.Ledger.Alonzo.Scripts (
   PlutusPurpose,
   PlutusScript (..),
  )
-import Cardano.Ledger.BaseTypes (ProtVer (..), kindObjectValue)
+import Cardano.Ledger.BaseTypes (ProtVer (..), Version, kindObjectValue)
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Core
 import Cardano.Ledger.Plutus (
-  CostModel,
   Data,
-  ExUnits,
   Language (..),
   Plutus (..),
   PlutusArgs,
   PlutusBinary,
   PlutusLanguage,
+  PlutusRunnable,
   PlutusScriptContext,
-  PlutusWithContext (..),
   SLanguage (..),
   asSLanguage,
   plutusLanguage,
@@ -204,6 +203,8 @@ class
 
   mkSupportedLanguage :: Language -> Maybe (SupportedLanguage era)
 
+  mkSupportedPlutusRunnable :: Version -> PlutusScript era -> SupportedPlutusRunnable era
+
   -- | Construct `PlutusTxInfo` for all supported languages in this era.
   mkTxInfoResult :: LedgerTxInfo era -> TxInfoResult era
 
@@ -217,16 +218,6 @@ class
     SLanguage l ->
     TxInfoResult era ->
     PlutusTxInfoResult l era
-
-  mkPlutusWithContext ::
-    PlutusScript era ->
-    ScriptHash ->
-    PlutusPurpose AsIxItem era ->
-    LedgerTxInfo era ->
-    TxInfoResult era ->
-    (Data era, ExUnits) ->
-    CostModel ->
-    Either (ContextError era) PlutusWithContext
 
 -- | Helper function to use when implementing `lookupTxInfoResult` for plutus languages that are not
 -- supported by the era.
@@ -296,6 +287,11 @@ mkSupportedBinaryPlutusScript supportedLanguage plutus =
   case supportedLanguage of
     SupportedLanguage sLang ->
       mkSupportedPlutusScript (asSLanguage sLang (Plutus plutus))
+
+data SupportedPlutusRunnable era where
+  SupportedPlutusRunnable ::
+    EraPlutusTxInfo l era =>
+    !(PlutusRunnable l) -> SupportedPlutusRunnable era
 
 data SupportedLanguage era where
   SupportedLanguage :: EraPlutusTxInfo l era => SLanguage l -> SupportedLanguage era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
@@ -108,11 +108,12 @@ collectPlutusScriptsWithContext epochInfo systemStart pp tx utxo =
         , ltiTx = tx
         , ltiMemoizedSubTransactions = mempty
         }
-    neededPlutusScripts =
+    (_, neededPlutusScripts) =
       resolveNeededPlutusScriptsWithPurpose
         protVer
         (getScriptsProvided utxo tx)
         (getScriptsNeeded utxo (tx ^. bodyTxL))
+        mempty
 
 scriptsWithContextFromLedgerTxInfo ::
   forall era.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
@@ -38,7 +38,9 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   ContextError,
   EraPlutusContext (..),
   LedgerTxInfo (..),
+  SupportedPlutusRunnable (..),
  )
+import Cardano.Ledger.Alonzo.Plutus.TxInfo (mkPlutusWithContext)
 import Cardano.Ledger.Alonzo.Scripts (lookupPlutusScript, plutusScriptLanguage, toAsItem, toAsIx)
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
 import Cardano.Ledger.Alonzo.UTxO (
@@ -46,6 +48,7 @@ import Cardano.Ledger.Alonzo.UTxO (
   AlonzoScriptsNeeded (..),
   resolveNeededPlutusScriptsWithPurpose,
  )
+import Cardano.Ledger.BaseTypes (ProtVer (..))
 import Cardano.Ledger.Plutus.CostModels (CostModels, costModelsValid)
 import Cardano.Ledger.Plutus.Evaluate (
   PlutusWithContext (..),
@@ -54,7 +57,7 @@ import Cardano.Ledger.Plutus.Evaluate (
   runPlutusScriptWithLogs,
  )
 import Cardano.Ledger.Plutus.ExUnits
-import Cardano.Ledger.Plutus.Language (Language (..))
+import Cardano.Ledger.Plutus.Language (Language (..), plutusLanguage)
 import Cardano.Ledger.Plutus.TxInfo (exBudgetToExUnits)
 import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided (..), UTxO (..))
 import Cardano.Ledger.TxIn (TxIn)
@@ -107,6 +110,7 @@ collectPlutusScriptsWithContext epochInfo systemStart pp tx utxo =
         }
     neededPlutusScripts =
       resolveNeededPlutusScriptsWithPurpose
+        protVer
         (getScriptsProvided utxo tx)
         (getScriptsNeeded utxo (tx ^. bodyTxL))
 
@@ -118,7 +122,7 @@ scriptsWithContextFromLedgerTxInfo ::
   ) =>
   LedgerTxInfo era ->
   CostModels ->
-  [(ScriptHash, PlutusPurpose AsIxItem era, PlutusScript era)] ->
+  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)] ->
   Either (NonEmpty (CollectError era)) [PlutusWithContext]
 scriptsWithContextFromLedgerTxInfo lti =
   scriptsWithContextFromLedgerTxInfoWithResult lti (mkTxInfoResult lti)
@@ -127,12 +131,11 @@ scriptsWithContextFromLedgerTxInfoWithResult ::
   forall era.
   ( AlonzoEraTxWits era
   , AlonzoEraUTxO era
-  , EraPlutusContext era
   ) =>
   LedgerTxInfo era ->
   TxInfoResult era ->
   CostModels ->
-  [(ScriptHash, PlutusPurpose AsIxItem era, PlutusScript era)] ->
+  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)] ->
   Either (NonEmpty (CollectError era)) [PlutusWithContext]
 scriptsWithContextFromLedgerTxInfoWithResult lti txInfoResult costModels plutusScriptsUsed =
   merge
@@ -143,22 +146,24 @@ scriptsWithContextFromLedgerTxInfoWithResult lti txInfoResult costModels plutusS
     redeemers =
       case lti of
         LedgerTxInfo {ltiTx} -> ltiTx ^. witsTxL . rdmrsTxWitsL . unRedeemersL
-    getScriptWithRedeemer (plutusScriptHash, plutusPurpose, plutusScript) =
+    getScriptWithRedeemer (plutusPurpose, plutusScriptRunnable) =
       let redeemerIndex = hoistPlutusPurpose toAsIx plutusPurpose
        in case Map.lookup redeemerIndex redeemers of
-            Just (d, exUnits) -> Right (plutusScript, plutusPurpose, d, exUnits, plutusScriptHash)
+            Just (d, exUnits) -> Right (plutusScriptRunnable, plutusPurpose, d, exUnits)
             Nothing -> Left (NoRedeemer (hoistPlutusPurpose toAsItem plutusPurpose))
-    apply (plutusScript, plutusPurpose, redeemerData, exUnits, plutusScriptHash) = do
-      let lang = plutusScriptLanguage plutusScript
+    apply (plutusScriptRunnable, plutusPurpose, redeemerData, exUnits) = do
+      let lang =
+            case plutusScriptRunnable of
+              SupportedPlutusRunnable srp -> plutusLanguage srp
       costModel <- maybe (Left (NoCostModel lang)) Right $ Map.lookup lang $ costModelsValid costModels
       first BadTranslation $
         mkPlutusWithContext
-          plutusScript
-          plutusScriptHash
+          plutusScriptRunnable
           plutusPurpose
           lti
           txInfoResult
-          (redeemerData, exUnits)
+          redeemerData
+          exUnits
           costModel
 
     -- Merge two lists (the first of which may have failures, i.e. (Left _)), collect all the failures
@@ -278,7 +283,7 @@ type RedeemerReportWithLogs era =
 evalTxExUnits ::
   forall era.
   ( AlonzoEraTx era
-  , EraUTxO era
+  , AlonzoEraUTxO era
   , EraPlutusContext era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
@@ -305,7 +310,7 @@ evalTxExUnits pp tx utxo epochInfo systemStart =
 evalTxExUnitsWithLogs ::
   forall era.
   ( AlonzoEraTx era
-  , EraUTxO era
+  , AlonzoEraUTxO era
   , EraPlutusContext era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   ) =>
@@ -370,12 +375,12 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo systemStart = Map.mapWithKey findAndC
       pwc <-
         first ContextError $
           mkPlutusWithContext
-            plutusScript
-            plutusScriptHash
+            (mkSupportedPlutusRunnable (pvMajor protVer) plutusScript)
             plutusPurpose
             ledgerTxInfo
             txInfoResult
-            (redeemerData, maxBudget)
+            redeemerData
+            maxBudget
             costModel
       case evaluatePlutusWithContext P.Verbose pwc of
         (logs, Left err) -> Left $ ValidationFailure exUnits err logs pwc

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -19,7 +19,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Alonzo.Plutus.TxInfo (
-  toPlutusWithContext,
+  mkPlutusWithContext,
   AlonzoContextError (..),
   TxOutSource (..),
   transLookupTxOut,
@@ -97,34 +97,35 @@ import Lens.Micro ((^.))
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 
-toPlutusWithContext ::
-  forall l era.
-  (EraPlutusTxInfo l era, AlonzoEraUTxO era) =>
-  Either (Plutus l) (PlutusRunnable l) ->
-  ScriptHash ->
+mkPlutusWithContext ::
+  forall era.
+  AlonzoEraUTxO era =>
+  SupportedPlutusRunnable era ->
   PlutusPurpose AsIxItem era ->
   LedgerTxInfo era ->
   TxInfoResult era ->
-  (Data era, ExUnits) ->
+  Data era ->
+  ExUnits ->
   CostModel ->
   Either (ContextError era) PlutusWithContext
-toPlutusWithContext script scriptHash plutusPurpose lti@LedgerTxInfo {ltiTx} txInfoResult (redeemerData, exUnits) costModel = do
-  let slang = isLanguage @l
-      maybeSpendingDatum =
-        getSpendingDatum (ltiUTxO lti) ltiTx (hoistPlutusPurpose toAsItem plutusPurpose)
-  mkTxInfo <- unPlutusTxInfoResult $ lookupTxInfoResult slang txInfoResult
-  txInfo <- mkTxInfo $ hoistPlutusPurpose toAsPurpose plutusPurpose
-  plutusArgs <-
-    toPlutusArgs slang (ltiProtVer lti) txInfo plutusPurpose maybeSpendingDatum redeemerData
-  pure $
-    PlutusWithContext
-      { pwcProtocolVersion = pvMajor (ltiProtVer lti)
-      , pwcScript = script
-      , pwcScriptHash = scriptHash
-      , pwcArgs = plutusArgs
-      , pwcExUnits = exUnits
-      , pwcCostModel = costModel
-      }
+mkPlutusWithContext script plutusPurpose lti@LedgerTxInfo {ltiTx} txInfoResult redeemerData exUnits costModel =
+  case script of
+    SupportedPlutusRunnable plutusRunnable -> do
+      let slang = isLanguage `asSameLanguage` plutusRunnable
+          maybeSpendingDatum =
+            getSpendingDatum (ltiUTxO lti) ltiTx (hoistPlutusPurpose toAsItem plutusPurpose)
+      mkTxInfo <- unPlutusTxInfoResult $ lookupTxInfoResult slang txInfoResult
+      txInfo <- mkTxInfo $ hoistPlutusPurpose toAsPurpose plutusPurpose
+      plutusArgs <-
+        toPlutusArgs slang (ltiProtVer lti) txInfo plutusPurpose maybeSpendingDatum redeemerData
+      pure $
+        PlutusWithContext
+          { pwcProtocolVersion = pvMajor (ltiProtVer lti)
+          , pwcScript = plutusRunnable
+          , pwcArgs = plutusArgs
+          , pwcExUnits = exUnits
+          , pwcCostModel = costModel
+          }
 
 instance EraPlutusTxInfo 'PlutusV1 AlonzoEra where
   toPlutusTxCert _ _ = pure . transTxCert
@@ -201,12 +202,13 @@ instance EraPlutusContext AlonzoEra where
     PlutusV1 -> Just $ SupportedLanguage SPlutusV1
     _lang -> Nothing
 
+  mkSupportedPlutusRunnable v = \case
+    AlonzoPlutusV1 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+
   mkTxInfoResult = AlonzoTxInfoResult . toPlutusTxInfo SPlutusV1
 
   lookupTxInfoResult SPlutusV1 (AlonzoTxInfoResult tirPlutusV1) = tirPlutusV1
   lookupTxInfoResult slang _ = lookupTxInfoResultImpossible slang
-
-  mkPlutusWithContext (AlonzoPlutusV1 p) = toPlutusWithContext (Left p)
 
 data AlonzoContextError era
   = TranslationLogicMissingInput TxIn

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledgers.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledgers.hs
@@ -25,7 +25,6 @@ import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
 import Cardano.Ledger.Shelley.Core (EraGov)
 import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), UTxOState (..))
-import Cardano.Ledger.Shelley.Rules (LedgerEnv (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Cardano.Ledger.State (CertState, EraStake)
 import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
@@ -90,7 +89,7 @@ instance
   , EraStake era
   , Default (CertState era)
   , Embed (EraRule "LEDGER" era) (LEDGERS era)
-  , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
+  , Environment (EraRule "LEDGER" era) ~ Shelley.LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   , Default (LedgerState era)
@@ -113,7 +112,7 @@ alonzoLedgersTransition ::
   , EraStake era
   , Default (CertState era)
   , Embed (EraRule "LEDGER" era) (LEDGERS era)
-  , Environment (EraRule "LEDGER" era) ~ LedgerEnv era
+  , Environment (EraRule "LEDGER" era) ~ Shelley.LedgerEnv era
   , State (EraRule "LEDGER" era) ~ LedgerState era
   , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
@@ -127,7 +126,7 @@ alonzoLedgersTransition = do
         let utxo = utxosUtxo (lsUTxOState ls')
             stAnnTx = mkStAnnTx (unsafeLinearExtendEpochInfo slot ei) sysStart pp utxo tx
          in trans @(EraRule "LEDGER" era) $
-              TRC (LedgerEnv slot (Just epochNo) ix pp account, ls', stAnnTx)
+              TRC (Shelley.LedgerEnv slot (Just epochNo) ix pp account, ls', stAnnTx)
     )
     ls
     $ zip [minBound ..]

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledgers.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledgers.hs
@@ -23,10 +23,9 @@ import Cardano.Ledger.Alonzo.Rules.Utxow (AlonzoUtxowPredFailure)
 import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfo, systemStart)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
-import Cardano.Ledger.Shelley.Core (EraGov)
-import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
-import Cardano.Ledger.State (CertState, EraStake)
+import Cardano.Ledger.State
 import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
 import Control.Monad (foldM)
 import Control.Monad.Trans.Reader (asks)
@@ -42,6 +41,7 @@ import Control.State.Transition (
 import Data.Default (Default)
 import Data.Foldable (toList)
 import Data.Sequence (Seq)
+import Lens.Micro ((^.))
 
 type instance EraRuleFailure "LEDGERS" AlonzoEra = Shelley.ShelleyLedgersPredFailure AlonzoEra
 
@@ -118,19 +118,24 @@ alonzoLedgersTransition ::
   ) =>
   TransitionRule (LEDGERS era)
 alonzoLedgersTransition = do
-  TRC (Shelley.LedgersEnv slot epochNo pp account, ls, txs) <- judgmentContext
+  TRC (Shelley.LedgersEnv slot epochNo pp account, initLedgerState, txs) <- judgmentContext
   ei <- liftSTS $ asks epochInfo
   sysStart <- liftSTS $ asks systemStart
-  foldM
-    ( \ !ls' (ix, tx) ->
-        let utxo = utxosUtxo (lsUTxOState ls')
-            stAnnTx = mkStAnnTx (unsafeLinearExtendEpochInfo slot ei) sysStart pp utxo tx
-         in trans @(EraRule "LEDGER" era) $
-              TRC (Shelley.LedgerEnv slot (Just epochNo) ix pp account, ls', stAnnTx)
-    )
-    ls
-    $ zip [minBound ..]
-    $ toList txs
+  (finalLedgerState, _) <-
+    foldM -- cache is lazy on purpose, since it is unused when validation is off
+      ( \(!curLedgerState, stAnnTxCache) (ix, tx) -> do
+          let utxo = curLedgerState ^. utxoL
+              stAnnTx =
+                mkStAnnTx (unsafeLinearExtendEpochInfo slot ei) sysStart pp utxo stAnnTxCache tx
+          newLedgerState <-
+            trans @(EraRule "LEDGER" era) $
+              TRC (Shelley.LedgerEnv slot (Just epochNo) ix pp account, curLedgerState, stAnnTx)
+          pure (newLedgerState, getCacheStAnnTx stAnnTx)
+      )
+      (initLedgerState, mempty)
+      $ zip [minBound ..]
+      $ toList txs
+  pure finalLedgerState
 
 instance
   ( Era era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -76,7 +76,7 @@ import Cardano.Ledger.Alonzo.PParams (
   getLanguageView,
   ppPricesL,
  )
-import Cardano.Ledger.Alonzo.Plutus.Context (CollectError, ContextError)
+import Cardano.Ledger.Alonzo.Plutus.Context (CollectError, ContextError, SupportedPlutusRunnable)
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (..),
   CostModel,
@@ -130,6 +130,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Map.Strict as Map
 import Data.Maybe.Strict (StrictMaybe (..))
 import Data.Set (Set)
 import qualified Data.Set as Set
@@ -488,6 +489,7 @@ data AlonzoStAnnTx l era where
     , asatScriptsNeeded :: ScriptsNeeded era
     , asatScriptsProvided :: ScriptsProvided era
     , asatPlutusLanguagesUsed :: Set Language
+    , asatPlutusRunnableCache :: Map.Map ScriptHash (SupportedPlutusRunnable era)
     , asatPlutusScriptsWithContext :: Either (NonEmpty (CollectError era)) [PlutusWithContext]
     } ->
     AlonzoStAnnTx TopTx era
@@ -525,10 +527,11 @@ instance
   ) =>
   NFData (AlonzoStAnnTx l era)
   where
-  rnf stAnnTx@(AlonzoStAnnTx _ _ _ _ _) =
+  rnf stAnnTx@(AlonzoStAnnTx _ _ _ _ _ _) =
     let AlonzoStAnnTx {..} = stAnnTx
      in asatTx `deepseq`
           asatScriptsNeeded `deepseq`
             asatScriptsProvided `deepseq`
-              asatPlutusLanguagesUsed `deepseq`
-                rnf asatPlutusScriptsWithContext
+              asatPlutusRunnableCache `deepseq`
+                asatPlutusLanguagesUsed `deepseq`
+                  rnf asatPlutusScriptsWithContext

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -100,7 +100,7 @@ import Lens.Micro.Extras (view)
 
 -- | Alonzo era style `ScriptsNeeded` require also a `PlutusPurpose`, not only the `ScriptHash`
 newtype AlonzoScriptsNeeded era
-  = AlonzoScriptsNeeded [(PlutusPurpose AsIxItem era, ScriptHash)]
+  = AlonzoScriptsNeeded {unAlonzoScriptsNeeded :: [(PlutusPurpose AsIxItem era, ScriptHash)]}
   deriving (Monoid, Semigroup, Generic)
 
 deriving instance AlonzoEraScript era => Eq (AlonzoScriptsNeeded era)
@@ -433,16 +433,30 @@ resolveNeededPlutusScriptsWithPurpose ::
   ProtVer ->
   ScriptsProvided era ->
   AlonzoScriptsNeeded era ->
-  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)]
-resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided (AlonzoScriptsNeeded scriptsNeeded) =
-  [(sp, s) | (sp, sh) <- scriptsNeeded, Just s <- [lookupPlutusScriptRunnable sh]]
+  -- | These are cached scripts. Make sure they were constructed using the exact same protocol
+  -- version as the one supplied to this function.
+  Map.Map ScriptHash (SupportedPlutusRunnable era) ->
+  ( Map.Map ScriptHash (SupportedPlutusRunnable era)
+  , [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)]
+  )
+resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded plutusScriptsCache =
+  (updatedPlutusScriptCache, neededPlutusScriptsWithPurpose)
   where
+    updatedPlutusScriptCache = plutusScriptsCache `Map.union` plutusScriptsProvided
+    neededPlutusScriptsWithPurpose =
+      [ (sp, s)
+      | (sp, sh) <- unAlonzoScriptsNeeded scriptsNeeded
+      , Just s <- [lookupPlutusScriptRunnable sh]
+      ]
     version = pvMajor protVer
     lookupPlutusScriptRunnable sh =
       Map.lookup sh plutusScriptsProvided <&> \case
-        SupportedPlutusRunnable pr ->
-          -- Avoid recomputing script hash
-          SupportedPlutusRunnable $ pr {plutusRunnableScriptHash = sh}
+        SupportedPlutusRunnable plutusRunnable ->
+          case Map.lookup sh plutusScriptsCache of
+            Just cachedPlutusRunnable -> cachedPlutusRunnable
+            Nothing ->
+              -- Avoid recomputing script hash
+              SupportedPlutusRunnable $ plutusRunnable {plutusRunnableScriptHash = sh}
     plutusScriptsProvided =
       Map.mapMaybe (fmap (mkSupportedPlutusRunnable version) . toPlutusScript) $
         unScriptsProvided scriptsProvided

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
@@ -50,18 +52,28 @@ module Cardano.Ledger.Alonzo.UTxO (
 import Cardano.Ledger.Address (accountAddressCredentialL)
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
-import Cardano.Ledger.Alonzo.Plutus.Context (CollectError)
+import Cardano.Ledger.Alonzo.Plutus.Context (
+  CollectError,
+  EraPlutusContext,
+  SupportedPlutusRunnable (..),
+  mkSupportedPlutusRunnable,
+ )
 import Cardano.Ledger.Alonzo.Scripts (lookupPlutusScript, plutusScriptLanguage)
 import Cardano.Ledger.Alonzo.State ()
 import Cardano.Ledger.Alonzo.Tx (AlonzoStAnnTx (..))
 import Cardano.Ledger.Alonzo.TxWits (unTxDatsL)
-import Cardano.Ledger.BaseTypes (StrictMaybe (..))
+import Cardano.Ledger.BaseTypes (ProtVer (..), StrictMaybe (..))
 import Cardano.Ledger.Credential (credScriptHash)
 import Cardano.Ledger.Keys (asWitness)
 import Cardano.Ledger.Mary.UTxO (getConsumedMaryValue, getProducedMaryValue)
 import Cardano.Ledger.Mary.Value (PolicyID (..))
-import Cardano.Ledger.Plutus (Language (..), PlutusWithContext)
-import Cardano.Ledger.Plutus.Data (Data, Datum (..))
+import Cardano.Ledger.Plutus (
+  Data,
+  Datum (..),
+  Language (..),
+  PlutusRunnable (..),
+  PlutusWithContext,
+ )
 import Cardano.Ledger.Shelley.UTxO (
   getShelleyMinFeeTxUtxo,
   getShelleyWitsVKeyNeeded,
@@ -76,6 +88,7 @@ import Cardano.Ledger.State (
 import Cardano.Ledger.TxIn
 import Control.DeepSeq (NFData)
 import Data.Foldable as F (foldl', toList)
+import Data.Functor ((<&>))
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, fromMaybe, isJust)
@@ -416,9 +429,20 @@ getAlonzoWitsVKeyNeeded certState utxo txBody =
 {-# INLINEABLE getAlonzoWitsVKeyNeeded #-}
 
 resolveNeededPlutusScriptsWithPurpose ::
-  AlonzoEraScript era =>
+  EraPlutusContext era =>
+  ProtVer ->
   ScriptsProvided era ->
   AlonzoScriptsNeeded era ->
-  [(ScriptHash, PlutusPurpose AsIxItem era, PlutusScript era)]
-resolveNeededPlutusScriptsWithPurpose (ScriptsProvided scriptsProvided) (AlonzoScriptsNeeded scriptsNeeded) =
-  [(sh, sp, s) | (sp, sh) <- scriptsNeeded, Just s <- [lookupPlutusScript sh scriptsProvided]]
+  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)]
+resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided (AlonzoScriptsNeeded scriptsNeeded) =
+  [(sp, s) | (sp, sh) <- scriptsNeeded, Just s <- [lookupPlutusScriptRunnable sh]]
+  where
+    version = pvMajor protVer
+    lookupPlutusScriptRunnable sh =
+      Map.lookup sh plutusScriptsProvided <&> \case
+        SupportedPlutusRunnable pr ->
+          -- Avoid recomputing script hash
+          SupportedPlutusRunnable $ pr {plutusRunnableScriptHash = sh}
+    plutusScriptsProvided =
+      Map.mapMaybe (fmap (mkSupportedPlutusRunnable version) . toPlutusScript) $
+        unScriptsProvided scriptsProvided

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -111,6 +111,7 @@ deriving instance AlonzoEraScript era => NFData (AlonzoScriptsNeeded era)
 
 instance EraUTxO AlonzoEra where
   type ScriptsNeeded AlonzoEra = AlonzoScriptsNeeded AlonzoEra
+  type StAnnTxCache AlonzoEra = Map.Map ScriptHash (SupportedPlutusRunnable AlonzoEra)
 
   getConsumedValue = getConsumedMaryValue
 
@@ -125,6 +126,8 @@ instance EraUTxO AlonzoEra where
   getWitsVKeyNeeded = getAlonzoWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
+
+  getCacheStAnnTx = asatPlutusRunnableCache
 
 class EraUTxO era => AlonzoEraUTxO era where
   -- | Get data hashes for a transaction that are not required. Such datums are optional,
@@ -450,6 +453,9 @@ resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded plut
       ]
     version = pvMajor protVer
     lookupPlutusScriptRunnable sh =
+      -- We must look into `plutusScriptsProvided`, before we can look for the same script in the
+      -- `plutusScriptsCache`, since that cache can contain scripts from prior transactions in a
+      -- block
       Map.lookup sh plutusScriptsProvided <&> \case
         SupportedPlutusRunnable plutusRunnable ->
           case Map.lookup sh plutusScriptsCache of

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -29,7 +29,7 @@ import Cardano.Ledger.Alonzo.TxWits
 import Cardano.Ledger.Alonzo.UTxO
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Compactible
-import Cardano.Ledger.Plutus.Evaluate (PlutusWithContext (..))
+import Cardano.Ledger.Plutus (PlutusWithContext (..))
 import Cardano.Ledger.State (EraUTxO (..), ScriptsProvided)
 import Control.State.Transition (Event, PredicateFailure)
 import Data.Functor.Identity (Identity)
@@ -214,19 +214,6 @@ instance
   , ToExpr PlutusWithContext
   ) =>
   ToExpr (AlonzoUtxosEvent era)
-
-instance
-  ToExpr ScriptHash =>
-  ToExpr PlutusWithContext
-  where
-  toExpr PlutusWithContext {..} =
-    Rec "PlutusWithContext" $
-      OMap.fromList
-        [ ("pwcProtocolVersion", toExpr pwcProtocolVersion)
-        , ("pwcScriptHash", toExpr pwcScriptHash)
-        , ("pwcExUnits", toExpr pwcExUnits)
-        , ("pwcCostModel", toExpr pwcCostModel)
-        ]
 
 instance
   ToExpr (PredicateFailure (EraRule "LEDGERS" era)) =>

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/TreeDiff.hs
@@ -153,16 +153,20 @@ instance
   ) =>
   ToExpr (AlonzoStAnnTx TopTx era)
   where
-  toExpr stAnnTx@(AlonzoStAnnTx _ _ _ _ _) =
+  toExpr stAnnTx@(AlonzoStAnnTx _ _ _ _ _ _) =
     let AlonzoStAnnTx {..} = stAnnTx
      in Rec "AlonzoStAnnTx" $
           OMap.fromList
             [ ("asatTx", toExpr asatTx)
             , ("asatScriptsNeeded", toExpr asatScriptsNeeded)
             , ("asatScriptsProvided", toExpr asatScriptsProvided)
+            , ("asatPlutusRunnableCache", toExpr asatPlutusRunnableCache)
             , ("asatPlutusLanguagesUsed", toExpr asatPlutusLanguagesUsed)
             , ("asatPlutusScriptsWithContext", toExpr asatPlutusScriptsWithContext)
             ]
+
+instance ToExpr (SupportedPlutusRunnable era) where
+  toExpr (SupportedPlutusRunnable spr) = toExpr spr
 
 -- Plutus/TxInfo
 instance ToExpr (AlonzoContextError era)

--- a/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
+++ b/eras/alonzo/test-suite/src/Test/Cardano/Ledger/Alonzo/Trace.hs
@@ -84,6 +84,7 @@ instance
         (systemStart testGlobals)
         pParams
         (utxosUtxo (lsUTxOState ls))
+        mempty
         tx
 
   shrinkSignal _ = [] -- TODO add some kind of Shrinker?

--- a/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/ChainTrace.hs
+++ b/eras/alonzo/test-suite/test/Test/Cardano/Ledger/Alonzo/ChainTrace.hs
@@ -110,7 +110,7 @@ alonzoSpecificProps SourceSignalTarget {source = chainSt, signal = block} =
               Set.fromList
                 [ plutus
                 | PlutusWithContext {pwcScript} <- collected
-                , Just plutus <- [mkPlutusScript $ either id plutusFromRunnable pwcScript]
+                , Just plutus <- [mkPlutusScript $ plutusFromRunnable pwcScript]
                 ]
             suppliedPScrpts = Set.fromList [plutus | PlutusScript plutus <- Map.elems allScripts]
             expectedPScripts = collectedScripts == suppliedPScrpts

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.14.0.0
 
+* Introduce `LEDGERS` rule with `STS` and `Embed (LEDGER era) (LEDGERS era)` instances, and wire it to `EraRule "LEDGERS" BabbageEra` (previously `Shelley.LEDGERS`)
+* Export `LEDGERS` from `Cardano.Ledger.Babbage.Era` and `Cardano.Ledger.Babbage.Rules`
 * Add `TranslateEra` instance for `SnapShots`
 * Rename rule types and deprecate the old names:
   - `BabbageLEDGER` -> `LEDGER`

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -99,6 +99,7 @@ library
     cardano-ledger-shelley ^>=1.19,
     cardano-strict-containers,
     containers,
+    data-default,
     deepseq,
     mempack,
     microlens,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Era.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Era.hs
@@ -12,6 +12,7 @@ module Cardano.Ledger.Babbage.Era (
   UTXOS,
   UTXOW,
   LEDGER,
+  LEDGERS,
 
   -- * Deprecated
   BabbageUTXO,
@@ -74,6 +75,10 @@ type BabbageLEDGER = LEDGER
 
 type instance EraRule "LEDGER" BabbageEra = LEDGER BabbageEra
 
+data LEDGERS c
+
+type instance EraRule "LEDGERS" BabbageEra = LEDGERS BabbageEra
+
 -- Rules inherited from Alonzo
 
 type instance EraRule "BBODY" BabbageEra = Alonzo.BBODY BabbageEra
@@ -87,8 +92,6 @@ type instance EraRule "DELEGS" BabbageEra = Shelley.DELEGS BabbageEra
 type instance EraRule "DELPL" BabbageEra = Shelley.DELPL BabbageEra
 
 type instance EraRule "EPOCH" BabbageEra = Shelley.EPOCH BabbageEra
-
-type instance EraRule "LEDGERS" BabbageEra = Shelley.LEDGERS BabbageEra
 
 type instance EraRule "MIR" BabbageEra = Shelley.MIR BabbageEra
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules.hs
@@ -4,6 +4,7 @@
 
 module Cardano.Ledger.Babbage.Rules (
   module Cardano.Ledger.Babbage.Rules.Ledger,
+  module Cardano.Ledger.Babbage.Rules.Ledgers,
   module Cardano.Ledger.Babbage.Rules.Utxo,
   module Cardano.Ledger.Babbage.Rules.Utxos,
   module Cardano.Ledger.Babbage.Rules.Utxow,
@@ -16,7 +17,7 @@ import Cardano.Ledger.Babbage.Rules.Deleg ()
 import Cardano.Ledger.Babbage.Rules.Delegs ()
 import Cardano.Ledger.Babbage.Rules.Delpl ()
 import Cardano.Ledger.Babbage.Rules.Ledger
-import Cardano.Ledger.Babbage.Rules.Ledgers ()
+import Cardano.Ledger.Babbage.Rules.Ledgers
 import Cardano.Ledger.Babbage.Rules.Pool ()
 import Cardano.Ledger.Babbage.Rules.Ppup ()
 import Cardano.Ledger.Babbage.Rules.Utxo

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledgers.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledgers.hs
@@ -1,18 +1,44 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Cardano.Ledger.Babbage.Rules.Ledgers () where
+module Cardano.Ledger.Babbage.Rules.Ledgers (LEDGERS) where
 
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
-import Cardano.Ledger.Babbage.Era (BabbageEra)
+import Cardano.Ledger.Babbage.Era (BabbageEra, LEDGER, LEDGERS)
 import Cardano.Ledger.Babbage.Rules.Ledger ()
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUtxoPredFailure)
 import Cardano.Ledger.Babbage.Rules.Utxow (BabbageUtxowPredFailure)
+import Cardano.Ledger.Babbage.State
+import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfo, systemStart)
 import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), UTxOState (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Control.Monad (foldM)
+import Control.Monad.Trans.Reader (asks)
+import Control.State.Transition (
+  Embed (..),
+  STS (..),
+  TRC (..),
+  TransitionRule,
+  judgmentContext,
+  liftSTS,
+  trans,
+ )
+import Data.Default (Default)
+import Data.Foldable (toList)
+import Data.Sequence (Seq)
 
 type instance EraRuleFailure "LEDGERS" BabbageEra = Shelley.ShelleyLedgersPredFailure BabbageEra
 
@@ -59,3 +85,63 @@ instance InjectRuleFailure "LEDGERS" Shelley.ShelleyPoolPredFailure BabbageEra w
 
 instance InjectRuleFailure "LEDGERS" Shelley.ShelleyDelegPredFailure BabbageEra where
   injectFailure = Shelley.LedgerFailure . injectFailure
+
+instance
+  ( ApplyTx era
+  , EraGov era
+  , EraStake era
+  , Default (CertState era)
+  , Embed (EraRule "LEDGER" era) (LEDGERS era)
+  , Environment (EraRule "LEDGER" era) ~ Shelley.LedgerEnv era
+  , State (EraRule "LEDGER" era) ~ LedgerState era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  , Default (LedgerState era)
+  ) =>
+  STS (LEDGERS era)
+  where
+  type State (LEDGERS era) = LedgerState era
+  type Signal (LEDGERS era) = Seq (Tx TopTx era)
+  type Environment (LEDGERS era) = Shelley.ShelleyLedgersEnv era
+  type BaseM (LEDGERS era) = ShelleyBase
+  type PredicateFailure (LEDGERS era) = Shelley.ShelleyLedgersPredFailure era
+  type Event (LEDGERS era) = Shelley.ShelleyLedgersEvent era
+
+  transitionRules = [ledgersTransition]
+
+ledgersTransition ::
+  forall era.
+  ( ApplyTx era
+  , EraGov era
+  , EraStake era
+  , Default (CertState era)
+  , Embed (EraRule "LEDGER" era) (LEDGERS era)
+  , Environment (EraRule "LEDGER" era) ~ Shelley.LedgerEnv era
+  , State (EraRule "LEDGER" era) ~ LedgerState era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  ) =>
+  TransitionRule (LEDGERS era)
+ledgersTransition = do
+  TRC (Shelley.LedgersEnv slot epochNo pp account, ls, txs) <- judgmentContext
+  ei <- liftSTS $ asks epochInfo
+  sysStart <- liftSTS $ asks systemStart
+  foldM
+    ( \ !ls' (ix, tx) ->
+        let utxo = utxosUtxo (lsUTxOState ls')
+            stAnnTx = mkStAnnTx ei sysStart pp utxo tx
+         in trans @(EraRule "LEDGER" era) $
+              TRC (Shelley.LedgerEnv slot (Just epochNo) ix pp account, ls', stAnnTx)
+    )
+    ls
+    $ zip [minBound ..]
+    $ toList txs
+
+instance
+  ( Era era
+  , STS (LEDGER era)
+  , PredicateFailure (EraRule "LEDGER" era) ~ Shelley.ShelleyLedgerPredFailure era
+  , Event (EraRule "LEDGER" era) ~ Shelley.ShelleyLedgerEvent era
+  ) =>
+  Embed (LEDGER era) (LEDGERS era)
+  where
+  wrapFailed = Shelley.LedgerFailure
+  wrapEvent = Shelley.LedgerEvent

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledgers.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledgers.hs
@@ -19,12 +19,12 @@ import Cardano.Ledger.Babbage.Era (BabbageEra, LEDGER, LEDGERS)
 import Cardano.Ledger.Babbage.Rules.Ledger ()
 import Cardano.Ledger.Babbage.Rules.Utxo (BabbageUtxoPredFailure)
 import Cardano.Ledger.Babbage.Rules.Utxow (BabbageUtxowPredFailure)
-import Cardano.Ledger.Babbage.State
 import Cardano.Ledger.BaseTypes (ShelleyBase, epochInfo, systemStart)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
-import Cardano.Ledger.Shelley.LedgerState (LedgerState (..), UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..))
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
+import Cardano.Ledger.State
 import Control.Monad (foldM)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition (
@@ -39,6 +39,7 @@ import Control.State.Transition (
 import Data.Default (Default)
 import Data.Foldable (toList)
 import Data.Sequence (Seq)
+import Lens.Micro ((^.))
 
 type instance EraRuleFailure "LEDGERS" BabbageEra = Shelley.ShelleyLedgersPredFailure BabbageEra
 
@@ -121,19 +122,24 @@ ledgersTransition ::
   ) =>
   TransitionRule (LEDGERS era)
 ledgersTransition = do
-  TRC (Shelley.LedgersEnv slot epochNo pp account, ls, txs) <- judgmentContext
+  TRC (Shelley.LedgersEnv slot epochNo pp account, initLedgerState, txs) <- judgmentContext
   ei <- liftSTS $ asks epochInfo
   sysStart <- liftSTS $ asks systemStart
-  foldM
-    ( \ !ls' (ix, tx) ->
-        let utxo = utxosUtxo (lsUTxOState ls')
-            stAnnTx = mkStAnnTx ei sysStart pp utxo tx
-         in trans @(EraRule "LEDGER" era) $
-              TRC (Shelley.LedgerEnv slot (Just epochNo) ix pp account, ls', stAnnTx)
-    )
-    ls
-    $ zip [minBound ..]
-    $ toList txs
+  (finalLedgerState, _) <-
+    foldM -- cache is lazy on purpose, since it is unused when validation is off
+      ( \(!curLedgerState, stAnnTxCache) (ix, tx) -> do
+          let
+            utxo = curLedgerState ^. utxoL
+            stAnnTx = mkStAnnTx ei sysStart pp utxo stAnnTxCache tx
+          newLedgerState <-
+            trans @(EraRule "LEDGER" era) $
+              TRC (Shelley.LedgerEnv slot (Just epochNo) ix pp account, curLedgerState, stAnnTx)
+          pure (newLedgerState, getCacheStAnnTx stAnnTx)
+      )
+      (initLedgerState, mempty)
+      $ zip [minBound ..]
+      $ toList txs
+  pure finalLedgerState
 
 instance
   ( Era era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -34,12 +34,12 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   PlutusScriptPurpose,
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
+  SupportedPlutusRunnable (..),
   lookupTxInfoResultImpossible,
  )
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (
   AlonzoContextError (..),
   toLegacyPlutusArgs,
-  toPlutusWithContext,
  )
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
 import Cardano.Ledger.Alonzo.Tx (Data)
@@ -67,7 +67,12 @@ import Cardano.Ledger.Binary.Coders (
 import Cardano.Ledger.Mary.Value (MaryValue)
 import Cardano.Ledger.Plutus.Data (Datum (..), binaryDataToData, getPlutusData)
 import Cardano.Ledger.Plutus.ExUnits (ExUnits (..))
-import Cardano.Ledger.Plutus.Language (Language (..), PlutusArgs (..), SLanguage (..))
+import Cardano.Ledger.Plutus.Language (
+  Language (..),
+  PlutusArgs (..),
+  SLanguage (..),
+  decodePlutusRunnable,
+ )
 import Cardano.Ledger.Plutus.TxInfo (
   TxOutSource (..),
   transAddr,
@@ -232,6 +237,10 @@ instance EraPlutusContext BabbageEra where
     PlutusV2 -> Just $ SupportedLanguage SPlutusV2
     _lang -> Nothing
 
+  mkSupportedPlutusRunnable v = \case
+    BabbagePlutusV1 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+    BabbagePlutusV2 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+
   mkTxInfoResult lti =
     BabbageTxInfoResult
       (toPlutusTxInfo SPlutusV1 lti)
@@ -240,10 +249,6 @@ instance EraPlutusContext BabbageEra where
   lookupTxInfoResult SPlutusV1 (BabbageTxInfoResult tirPlutusV1 _) = tirPlutusV1
   lookupTxInfoResult SPlutusV2 (BabbageTxInfoResult _ tirPlutusV2) = tirPlutusV2
   lookupTxInfoResult slang _ = lookupTxInfoResultImpossible slang
-
-  mkPlutusWithContext = \case
-    BabbagePlutusV1 p -> toPlutusWithContext $ Left p
-    BabbagePlutusV2 p -> toPlutusWithContext $ Left p
 
 data BabbageContextError era
   = AlonzoContextError (AlonzoContextError era)

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -11,6 +11,8 @@ module Cardano.Ledger.Babbage.UTxO (
   getReferenceScriptsNonDistinct,
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable)
+import Cardano.Ledger.Alonzo.Tx (AlonzoStAnnTx (..))
 import Cardano.Ledger.Alonzo.TxWits (unTxDatsL)
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
@@ -42,6 +44,7 @@ import Lens.Micro
 
 instance EraUTxO BabbageEra where
   type ScriptsNeeded BabbageEra = AlonzoScriptsNeeded BabbageEra
+  type StAnnTxCache BabbageEra = Map.Map ScriptHash (SupportedPlutusRunnable BabbageEra)
 
   getConsumedValue = getConsumedMaryValue
 
@@ -57,6 +60,8 @@ instance EraUTxO BabbageEra where
   getWitsVKeyNeeded = getAlonzoWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
+
+  getCacheStAnnTx = asatPlutusRunnableCache
 
 instance AlonzoEraUTxO BabbageEra where
   getSupplementalDataHashes = getBabbageSupplementalDataHashes

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.23.0.0
 
+* Change `EraRule "LEDGERS" ConwayEra` from `Shelley.LEDGERS` to `Babbage.LEDGERS`
 * Add `TranslateEra` instance for `SnapShots`
 * Fix `NoThunks` instance for `ConwayGenesis`
 * Remove `conwayCertsTotalRefundsTxBody` and `conwayConsumed`

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Era.hs
@@ -51,6 +51,7 @@ module Cardano.Ledger.Conway.Era (
   ConwayRATIFY,
 ) where
 
+import qualified Cardano.Ledger.Babbage.Rules as Babbage
 import Cardano.Ledger.BaseTypes (ProtVer (pvMajor), natVersion)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Internal.Era (ConwayEra)
@@ -240,7 +241,7 @@ type instance EraRule "HARDFORK" ConwayEra = HARDFORK ConwayEra
 
 -- Rules inherited from Shelley
 
-type instance EraRule "LEDGERS" ConwayEra = Shelley.LEDGERS ConwayEra
+type instance EraRule "LEDGERS" ConwayEra = Babbage.LEDGERS ConwayEra
 
 type instance EraRule "POOLREAP" ConwayEra = Shelley.POOLREAP ConwayEra
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Ledger.hs
@@ -581,7 +581,7 @@ instance
   , InjectRuleFailure "LEDGER" ConwayLedgerPredFailure era
   , InjectRuleFailure "LEDGER" ConwayCertsPredFailure era
   ) =>
-  Embed (LEDGER era) (Shelley.LEDGERS era)
+  Embed (LEDGER era) (Babbage.LEDGERS era)
   where
   wrapFailed = Shelley.LedgerFailure
   wrapEvent = Shelley.LedgerEvent

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -51,12 +51,12 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   PlutusTxCert,
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
+  SupportedPlutusRunnable (..),
   lookupTxInfoResultImpossible,
  )
 import Cardano.Ledger.Alonzo.Plutus.TxInfo (
   AlonzoContextError (..),
   TxOutSource (..),
-  toPlutusWithContext,
  )
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (AlonzoPlutusPurpose (..), toAsItem)
@@ -105,7 +105,12 @@ import Cardano.Ledger.Credential (Credential)
 import Cardano.Ledger.Mary (MaryValue)
 import Cardano.Ledger.Mary.Value (MultiAsset)
 import Cardano.Ledger.Plutus.Data (Data)
-import Cardano.Ledger.Plutus.Language (Language (..), PlutusArgs (..), SLanguage (..))
+import Cardano.Ledger.Plutus.Language (
+  Language (..),
+  PlutusArgs (..),
+  SLanguage (..),
+  decodePlutusRunnable,
+ )
 import Cardano.Ledger.Plutus.ToPlutusData (ToPlutusData (..))
 import Cardano.Ledger.Plutus.TxInfo (
   slotToPOSIXTime,
@@ -156,6 +161,11 @@ instance EraPlutusContext ConwayEra where
     PlutusV3 -> Just $ SupportedLanguage SPlutusV3
     _ -> Nothing
 
+  mkSupportedPlutusRunnable v = \case
+    ConwayPlutusV1 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+    ConwayPlutusV2 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+    ConwayPlutusV3 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+
   mkTxInfoResult lti =
     ConwayTxInfoResult
       (toPlutusTxInfo SPlutusV1 lti)
@@ -166,11 +176,6 @@ instance EraPlutusContext ConwayEra where
   lookupTxInfoResult SPlutusV2 (ConwayTxInfoResult _ tirPlutusV2 _) = tirPlutusV2
   lookupTxInfoResult SPlutusV3 (ConwayTxInfoResult _ _ tirPlutusV3) = tirPlutusV3
   lookupTxInfoResult slang _ = lookupTxInfoResultImpossible slang
-
-  mkPlutusWithContext = \case
-    ConwayPlutusV1 p -> toPlutusWithContext $ Left p
-    ConwayPlutusV2 p -> toPlutusWithContext $ Left p
-    ConwayPlutusV3 p -> toPlutusWithContext $ Left p
 
 data ConwayContextError era
   = BabbageContextError (BabbageContextError era)

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -17,6 +17,8 @@ module Cardano.Ledger.Conway.UTxO (
   getConwayMinFeeTxUtxo,
 ) where
 
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable)
+import Cardano.Ledger.Alonzo.Tx (AlonzoStAnnTx (..))
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
   AlonzoScriptsNeeded (..),
@@ -118,6 +120,7 @@ conwayProducedValue pp isStakePool txBody =
 
 instance EraUTxO ConwayEra where
   type ScriptsNeeded ConwayEra = AlonzoScriptsNeeded ConwayEra
+  type StAnnTxCache ConwayEra = Map.Map ScriptHash (SupportedPlutusRunnable ConwayEra)
 
   getConsumedValue = getConsumedMaryValue
 
@@ -132,6 +135,8 @@ instance EraUTxO ConwayEra where
   getWitsVKeyNeeded _ = getConwayWitsVKeyNeeded
 
   getMinFeeTxUtxo = getConwayMinFeeTxUtxo
+
+  getCacheStAnnTx = asatPlutusRunnableCache
 
 instance AlonzoEraUTxO ConwayEra where
   getSupplementalDataHashes = getBabbageSupplementalDataHashes

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0.0
 
+* Change `EraRule "LEDGERS" DijkstraEra` from `Shelley.LEDGERS` to `Babbage.LEDGERS`
 * Add `TranslateEra` instance for `SnapShots`
 * Add `dijkstraConsumed` and `validateValueNotConservedUTxO`
 * Add `AccountBalanceExact` constructor to `AccountBalanceInterval`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0.0
 
+* Add `dsattPlutusRunnableCache` field to `DijkstraStAnnTx TopTx`, holding `Map ScriptHash (SupportedPlutusRunnable era)`
 * Change `EraRule "LEDGERS" DijkstraEra` from `Shelley.LEDGERS` to `Babbage.LEDGERS`
 * Add `TranslateEra` instance for `SnapShots`
 * Add `dijkstraConsumed` and `validateValueNotConservedUTxO`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -120,10 +120,11 @@ mkDijkstraStAnnTopTx ei sysStart pp utxo tx =
     protVer = pp ^. ppProtocolVersionL
     scriptsNeeded = getScriptsNeeded utxo txBody
     scriptsProvided = getScriptsProvided utxo tx
-    plutusScriptsUsed = resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded
+    (plutusScriptsCache, plutusScriptsUsed) =
+      resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded mempty
     stAnnSubTxs =
       map
-        (mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided)
+        (mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided plutusScriptsCache)
         (toList (txBody ^. subTransactionsTxBodyL))
     ledgerTxInfo =
       LedgerTxInfo
@@ -163,13 +164,15 @@ mkDijkstraStAnnSubTx ::
   PParams era ->
   UTxO era ->
   ScriptsProvided era ->
+  Map.Map ScriptHash (SupportedPlutusRunnable era) ->
   Tx SubTx era ->
   DijkstraStAnnTx SubTx era
-mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided tx =
+mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided plutusScriptsCache tx =
   let
     protVer = pp ^. ppProtocolVersionL
     scriptsNeeded = getScriptsNeeded utxo (tx ^. bodyTxL)
-    plutusScriptsUsed = resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded
+    (_, plutusScriptsUsed) =
+      resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded plutusScriptsCache
     ledgerTxInfo =
       LedgerTxInfo
         { ltiProtVer = protVer

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -112,19 +112,22 @@ mkDijkstraStAnnTopTx ::
   SystemStart ->
   PParams era ->
   UTxO era ->
+  Map.Map ScriptHash (SupportedPlutusRunnable era) ->
   Tx TopTx era ->
   DijkstraStAnnTx TopTx era
-mkDijkstraStAnnTopTx ei sysStart pp utxo tx =
+mkDijkstraStAnnTopTx ei sysStart pp utxo stAnnTxCache tx =
   let
     txBody = tx ^. bodyTxL
     protVer = pp ^. ppProtocolVersionL
     scriptsNeeded = getScriptsNeeded utxo txBody
     scriptsProvided = getScriptsProvided utxo tx
-    (plutusScriptsCache, plutusScriptsUsed) =
-      resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded mempty
+    (newStAnnTxCache, plutusScriptsUsed) =
+      resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded stAnnTxCache
+    -- We do not need to fold over sub-transactions in order to get updated cache, since
+    -- `getScriptsProvided` is recursive and will collect all scripts from sub-transactions
     stAnnSubTxs =
       map
-        (mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided plutusScriptsCache)
+        (mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided newStAnnTxCache)
         (toList (txBody ^. subTransactionsTxBodyL))
     ledgerTxInfo =
       LedgerTxInfo
@@ -147,6 +150,7 @@ mkDijkstraStAnnTopTx ei sysStart pp utxo tx =
       , dsattScriptsNeeded = scriptsNeeded
       , dsattScriptsProvided = scriptsProvided
       , dsattPlutusLegacyMode = not $ Set.null $ Set.filter (<= PlutusV3) languagesUsed
+      , dsattPlutusRunnableCache = newStAnnTxCache
       , dsattPlutusLanguagesUsed = languagesUsed
       , dsattPlutusScriptsWithContext =
           scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL) plutusScriptsUsed

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -18,12 +18,15 @@ module Cardano.Ledger.Dijkstra (
   mkDijkstraStAnnTopTx,
 ) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext (mkTxInfoResult), LedgerTxInfo (..))
+import Cardano.Ledger.Alonzo.Plutus.Context (
+  EraPlutusContext (mkTxInfoResult),
+  LedgerTxInfo (..),
+  SupportedPlutusRunnable (..),
+ )
 import Cardano.Ledger.Alonzo.Plutus.Evaluate (
   scriptsWithContextFromLedgerTxInfo,
   scriptsWithContextFromLedgerTxInfoWithResult,
  )
-import Cardano.Ledger.Alonzo.Scripts (plutusScriptLanguage)
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO,
   AlonzoScriptsNeeded,
@@ -53,7 +56,7 @@ import Cardano.Ledger.Dijkstra.TxBody ()
 import Cardano.Ledger.Dijkstra.TxInfo ()
 import Cardano.Ledger.Dijkstra.TxWits ()
 import Cardano.Ledger.Dijkstra.UTxO ()
-import Cardano.Ledger.Plutus (Language (..))
+import Cardano.Ledger.Plutus (Language (..), plutusLanguage)
 import Cardano.Ledger.Shelley.API (
   ApplyBlock (..),
   ApplyTick (..),
@@ -114,16 +117,17 @@ mkDijkstraStAnnTopTx ::
 mkDijkstraStAnnTopTx ei sysStart pp utxo tx =
   let
     txBody = tx ^. bodyTxL
+    protVer = pp ^. ppProtocolVersionL
     scriptsNeeded = getScriptsNeeded utxo txBody
     scriptsProvided = getScriptsProvided utxo tx
-    plutusScriptsUsed = resolveNeededPlutusScriptsWithPurpose scriptsProvided scriptsNeeded
+    plutusScriptsUsed = resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded
     stAnnSubTxs =
       map
         (mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided)
         (toList (txBody ^. subTransactionsTxBodyL))
     ledgerTxInfo =
       LedgerTxInfo
-        { ltiProtVer = pp ^. ppProtocolVersionL
+        { ltiProtVer = protVer
         , ltiEpochInfo = ei
         , ltiSystemStart = sysStart
         , ltiUTxO = utxo
@@ -134,7 +138,8 @@ mkDijkstraStAnnTopTx ei sysStart pp utxo tx =
               | DijkstraStAnnSubTx {dsastTx, dsastTxInfoResult} <- stAnnSubTxs
               ]
         }
-    languagesUsed = Set.fromList [plutusScriptLanguage s | (_, _, s) <- plutusScriptsUsed]
+    languagesUsed =
+      Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr) <- plutusScriptsUsed]
    in
     DijkstraStAnnTopTx
       { dsattTx = tx
@@ -162,11 +167,12 @@ mkDijkstraStAnnSubTx ::
   DijkstraStAnnTx SubTx era
 mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided tx =
   let
+    protVer = pp ^. ppProtocolVersionL
     scriptsNeeded = getScriptsNeeded utxo (tx ^. bodyTxL)
-    plutusScriptsUsed = resolveNeededPlutusScriptsWithPurpose scriptsProvided scriptsNeeded
+    plutusScriptsUsed = resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded
     ledgerTxInfo =
       LedgerTxInfo
-        { ltiProtVer = pp ^. ppProtocolVersionL
+        { ltiProtVer = protVer
         , ltiEpochInfo = ei
         , ltiSystemStart = sysStart
         , ltiUTxO = utxo
@@ -181,7 +187,7 @@ mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided tx =
       , dsastScriptsProvided = scriptsProvided
       , dsastTxInfoResult = txInfoResult
       , dsastPlutusLanguagesUsed =
-          Set.fromList [plutusScriptLanguage s | (_, _, s) <- plutusScriptsUsed]
+          Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr) <- plutusScriptsUsed]
       , dsastPlutusScriptsWithContext =
           scriptsWithContextFromLedgerTxInfoWithResult
             ledgerTxInfo

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Era.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Era.hs
@@ -55,6 +55,7 @@ module Cardano.Ledger.Dijkstra.Era (
   DijkstraUTXOW,
 ) where
 
+import qualified Cardano.Ledger.Babbage.Rules as Babbage
 import Cardano.Ledger.BaseTypes (Nonce)
 import Cardano.Ledger.Block (Block, EraBlockHeader)
 import Cardano.Ledger.Conway.Core
@@ -285,7 +286,7 @@ type instance EraRule "HARDFORK" DijkstraEra = Conway.HARDFORK DijkstraEra
 
 -- Rules inherited from Shelley
 
-type instance EraRule "LEDGERS" DijkstraEra = Shelley.LEDGERS DijkstraEra
+type instance EraRule "LEDGERS" DijkstraEra = Babbage.LEDGERS DijkstraEra
 
 type instance EraRule "POOLREAP" DijkstraEra = Shelley.POOLREAP DijkstraEra
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -468,7 +468,7 @@ instance
   , PredicateFailure (EraRule "LEDGER" era) ~ DijkstraLedgerPredFailure era
   , Event (EraRule "LEDGER" era) ~ DijkstraLedgerEvent era
   ) =>
-  Embed (LEDGER era) (Shelley.LEDGERS era)
+  Embed (LEDGER era) (Babbage.LEDGERS era)
   where
   wrapFailed = Shelley.LedgerFailure
   wrapEvent = Shelley.LedgerEvent

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -28,7 +28,12 @@ module Cardano.Ledger.Dijkstra.Tx (
 ) where
 
 import Cardano.Ledger.Allegra.TxBody (AllegraEraTxBody (..), StrictMaybe)
-import Cardano.Ledger.Alonzo.Plutus.Context (CollectError, ContextError, TxInfoResult)
+import Cardano.Ledger.Alonzo.Plutus.Context (
+  CollectError,
+  ContextError,
+  SupportedPlutusRunnable,
+  TxInfoResult,
+ )
 import Cardano.Ledger.Alonzo.Tx (
   AlonzoEraTx,
   IsValid (..),
@@ -71,6 +76,7 @@ import Control.Monad.Trans.Fail.String (errorFail)
 import qualified Data.ByteString.Lazy as LBS
 import Data.Int (Int64)
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Data.Typeable (Typeable)
@@ -374,6 +380,7 @@ data DijkstraStAnnTx l era where
     , dsattScriptsProvided :: ScriptsProvided era
     , dsattPlutusLegacyMode :: Bool
     , dsattPlutusLanguagesUsed :: Set Language
+    , dsattPlutusRunnableCache :: Map.Map ScriptHash (SupportedPlutusRunnable era)
     , dsattPlutusScriptsWithContext :: Either (NonEmpty (CollectError era)) [PlutusWithContext]
     , dsattSubTransactions :: [DijkstraStAnnTx SubTx era]
     } ->

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -30,6 +30,7 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   PlutusTxInfo,
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
+  SupportedPlutusRunnable (..),
  )
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
 import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..))
@@ -68,6 +69,7 @@ import Cardano.Ledger.Plutus (
   PlutusLanguage,
   SLanguage (..),
   TxOutSource (..),
+  decodePlutusRunnable,
   plutusLanguage,
   plutusSLanguage,
   transCoinToLovelace,
@@ -246,6 +248,12 @@ instance EraPlutusContext DijkstraEra where
     PlutusV3 -> Just $ SupportedLanguage SPlutusV3
     PlutusV4 -> Just $ SupportedLanguage SPlutusV4
 
+  mkSupportedPlutusRunnable v = \case
+    DijkstraPlutusV1 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+    DijkstraPlutusV2 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+    DijkstraPlutusV3 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+    DijkstraPlutusV4 p -> SupportedPlutusRunnable $ decodePlutusRunnable v p
+
   mkTxInfoResult lti =
     DijkstraTxInfoResult
       (toPlutusTxInfo SPlutusV1 lti)
@@ -257,12 +265,6 @@ instance EraPlutusContext DijkstraEra where
   lookupTxInfoResult SPlutusV2 (DijkstraTxInfoResult _ tirPlutusV2 _ _) = tirPlutusV2
   lookupTxInfoResult SPlutusV3 (DijkstraTxInfoResult _ _ tirPlutusV3 _) = tirPlutusV3
   lookupTxInfoResult SPlutusV4 (DijkstraTxInfoResult _ _ _ tirPlutusV4) = tirPlutusV4
-
-  mkPlutusWithContext = \case
-    DijkstraPlutusV1 p -> Alonzo.toPlutusWithContext $ Left p
-    DijkstraPlutusV2 p -> Alonzo.toPlutusWithContext $ Left p
-    DijkstraPlutusV3 p -> Alonzo.toPlutusWithContext $ Left p
-    DijkstraPlutusV4 p -> Alonzo.toPlutusWithContext $ Left p
 
 instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
   toPlutusTxCert _ _ = transTxCertV1V2

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -18,7 +18,7 @@ module Cardano.Ledger.Dijkstra.UTxO (
   batchNonDistinctRefScriptsSize,
 ) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (CollectError)
+import Cardano.Ledger.Alonzo.Plutus.Context (CollectError, SupportedPlutusRunnable)
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
   AlonzoScriptsNeeded (..),
@@ -130,6 +130,7 @@ dijkstraProducedValue pp isRegPoolId topTxBody =
 
 instance EraUTxO DijkstraEra where
   type ScriptsNeeded DijkstraEra = AlonzoScriptsNeeded DijkstraEra
+  type StAnnTxCache DijkstraEra = Map.Map ScriptHash (SupportedPlutusRunnable DijkstraEra)
 
   getConsumedValue = getConsumedDijkstraValue
 
@@ -144,6 +145,8 @@ instance EraUTxO DijkstraEra where
   getWitsVKeyNeeded _ = getConwayWitsVKeyNeeded
 
   getMinFeeTxUtxo = getConwayMinFeeTxUtxo
+
+  getCacheStAnnTx = dsattPlutusRunnableCache
 
 -- | Like 'getBabbageScriptsProvided', but for 'TopTx' also aggregates
 -- scripts from all subtransactions.

--- a/eras/mary/impl/src/Cardano/Ledger/Mary.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary.hs
@@ -46,7 +46,7 @@ instance ApplyTx MaryEra where
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
 
-  mkStAnnTx _ _ _ _ = id
+  mkStAnnTx _ _ _ _ _ = id
 
   internalApplyTxWithValidation = defaultApplyTxWithValidation @"LEDGER" MaryApplyTxError
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -38,6 +38,7 @@ import Lens.Micro
 
 instance EraUTxO MaryEra where
   type ScriptsNeeded MaryEra = ShelleyScriptsNeeded MaryEra
+  type StAnnTxCache MaryEra = ()
 
   getConsumedValue = getConsumedMaryValue
 
@@ -52,6 +53,8 @@ instance EraUTxO MaryEra where
   getWitsVKeyNeeded = getShelleyWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
+
+  getCacheStAnnTx _ = mempty
 
 -- | Calculate the value consumed by the transation.
 --

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Add `EraUTxO era` as a superclass constraint to `ApplyTx`
 * Change `produced` to accept `PState`, instead of `CertState`
 * Remove `consumed` in favor of `shelleyConsumed`
 * Restrict `produced` to `TxBody TopTx era`.

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/API/Mempool.hs
@@ -144,6 +144,7 @@ unsafeMakeValidatedTx globals env state tx =
           (systemStart globals)
           (env ^. ledgerPpL)
           (state ^. utxoG)
+          mempty
           tx
     , vtProtocolVersion = env ^. ledgerPpL . ppProtocolVersionL
     , vtSlotNo = env ^. ledgerSlotNoL
@@ -167,6 +168,7 @@ translateValidated ctx (Validated tx) = Validated <$> translateEra @era ctx tx
 
 class
   ( EraTx era
+  , EraUTxO era
   , Eq (ApplyTxError era)
   , Show (ApplyTxError era)
   , Typeable (ApplyTxError era)
@@ -183,6 +185,7 @@ class
     SystemStart ->
     PParams era ->
     UTxO era ->
+    StAnnTxCache era ->
     Tx TopTx era ->
     StAnnTx TopTx era
 
@@ -284,6 +287,7 @@ defaultApplyTxWithValidation wrap validationPolicy globals env state tx =
           (systemStart globals)
           (env ^. ledgerPpL)
           (state ^. utxoG)
+          mempty
           tx
    in first wrap $
         ruleApplyTxValidation @rule validationPolicy globals env state stAnnTx
@@ -323,7 +327,7 @@ instance ApplyTx ShelleyEra where
     deriving (Eq, Show)
     deriving newtype (EncCBOR, DecCBOR, Semigroup, Generic)
 
-  mkStAnnTx _ _ _ _ = id
+  mkStAnnTx _ _ _ _ _ = id
 
   internalApplyTxWithValidation validationPolicy globals env state tx =
     let stAnnTx =
@@ -332,6 +336,7 @@ instance ApplyTx ShelleyEra where
             (systemStart globals)
             (env ^. ledgerPpL)
             (state ^. utxoG)
+            mempty
             tx
      in first ShelleyApplyTxError $
           ruleApplyTxValidation @"LEDGER" validationPolicy globals env state stAnnTx

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Ledgers.hs
@@ -26,9 +26,8 @@ import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders (Encode (..), encode, (!>))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API.Mempool (ApplyTx (..))
-import Cardano.Ledger.Shelley.Core (EraGov)
 import Cardano.Ledger.Shelley.Era (LEDGERS, ShelleyEra)
-import Cardano.Ledger.Shelley.LedgerState (ChainAccountState, LedgerState (..), UTxOState (..))
+import Cardano.Ledger.Shelley.LedgerState (LedgerState (..))
 import Cardano.Ledger.Shelley.Rules.Deleg (ShelleyDelegPredFailure)
 import Cardano.Ledger.Shelley.Rules.Delegs (ShelleyDelegsPredFailure)
 import Cardano.Ledger.Shelley.Rules.Delpl (ShelleyDelplPredFailure)
@@ -43,7 +42,7 @@ import Cardano.Ledger.Shelley.Rules.Ppup (ShelleyPpupPredFailure)
 import Cardano.Ledger.Shelley.Rules.Utxo (ShelleyUtxoPredFailure)
 import Cardano.Ledger.Shelley.Rules.Utxow (ShelleyUtxowPredFailure)
 import Cardano.Ledger.Slot (SlotNo)
-import Cardano.Ledger.State (CertState, EraStake)
+import Cardano.Ledger.State
 import Control.DeepSeq (NFData)
 import Control.Monad (foldM)
 import Control.Monad.Trans.Reader (asks)
@@ -61,6 +60,7 @@ import Data.Foldable (toList)
 import Data.Functor.Identity (Identity)
 import Data.Sequence (Seq)
 import GHC.Generics (Generic)
+import Lens.Micro ((^.))
 
 data ShelleyLedgersEnv era = LedgersEnv
   { ledgersSlotNo :: SlotNo
@@ -195,18 +195,18 @@ ledgersTransition ::
   ) =>
   TransitionRule (LEDGERS era)
 ledgersTransition = do
-  TRC (LedgersEnv slot epochNo pp account, ls, txs) <- judgmentContext
+  TRC (LedgersEnv slot epochNo pp account, initLedgerState, txs) <- judgmentContext
   ei <- liftSTS $ asks epochInfo
   sysStart <- liftSTS $ asks systemStart
   foldM
-    ( \ !ls' (ix, tx) ->
+    ( \ !curLedgerState (ix, tx) ->
         -- build the annotations against the same utxo snapshot that the rule will validate against
-        let utxo = utxosUtxo (lsUTxOState ls')
-            stAnnTx = mkStAnnTx ei sysStart pp utxo tx
+        let utxo = curLedgerState ^. utxoL
+            stAnnTx = mkStAnnTx ei sysStart pp utxo mempty tx
          in trans @(EraRule "LEDGER" era) $
-              TRC (LedgerEnv slot (Just epochNo) ix pp account, ls', stAnnTx)
+              TRC (LedgerEnv slot (Just epochNo) ix pp account, curLedgerState, stAnnTx)
     )
-    ls
+    initLedgerState
     $ zip [minBound ..]
     $ toList txs
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -163,6 +163,7 @@ newtype ShelleyScriptsNeeded era = ShelleyScriptsNeeded (Set ScriptHash)
 
 instance EraUTxO ShelleyEra where
   type ScriptsNeeded ShelleyEra = ShelleyScriptsNeeded ShelleyEra
+  type StAnnTxCache ShelleyEra = ()
 
   getConsumedValue = getConsumedCoin
 
@@ -177,6 +178,8 @@ instance EraUTxO ShelleyEra where
   getWitsVKeyNeeded = getShelleyWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
+
+  getCacheStAnnTx _ = mempty
 
 -- We don't consider the reference scripts in the calculation before Conway
 getShelleyMinFeeTxUtxo :: EraTx era => PParams era -> Tx l era -> Coin

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/ImpTest.hs
@@ -1274,6 +1274,7 @@ trySubmitTx tx = do
           (systemStart globals)
           (lEnv ^. ledgerPpL)
           (utxosUtxo (lsUTxOState lState))
+          mempty
           txFixed
   res <- tryRunImpRule @"LEDGER" lEnv lState stAnnTx
 

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Generator/Trace/Ledger.hs
@@ -115,6 +115,7 @@ instance
         (systemStart testGlobals)
         pParams
         (utxosUtxo (lsUTxOState ls))
+        mempty
         tx
 
   shrinkSignal _ = [] -- TODO add some kind of Shrinker?
@@ -127,7 +128,6 @@ ledgersSigGen ::
   ( Crypto c
   , ApplyTx era
   , EraGen era
-  , EraUTxO era
   , ShelleyEraAccounts era
   , MinLEDGER_STS era
   , Embed (EraRule "DELPL" era) (CERTS era)
@@ -167,6 +167,7 @@ ledgersSigGen
                 (systemStart testGlobals)
                 pParams
                 utxo
+                mempty
                 tx
             res =
               runShelleyBase $

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/TestChain.hs
@@ -162,13 +162,13 @@ ledgerTraceFromBlock chainSt block =
       Trace.closureWith @(EraRule "LEDGER" era)
         ledgerEnv
         ledgerSt0
-        ( \ls tx ->
+        ( \ls ->
             mkStAnnTx
               (epochInfo testGlobals)
               (systemStart testGlobals)
               (ledgerEnv ^. ledgerPpL)
               (ls ^. lsUTxOStateL . utxoG)
-              tx
+              mempty
         )
         txs
   )
@@ -197,13 +197,13 @@ ledgerTraceFromBlockWithRestrictedUTxO chainSt block =
       Trace.closureWith @(EraRule "LEDGER" era)
         ledgerEnv
         restrictedSt0
-        ( \ls tx ->
+        ( \ls ->
             mkStAnnTx
               (epochInfo testGlobals)
               (systemStart testGlobals)
               (ledgerEnv ^. ledgerPpL)
               (ls ^. lsUTxOStateL . utxoG)
-              tx
+              mempty
         )
         txs
   )

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Dijkstra/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Dijkstra/Ledger.hs
@@ -125,15 +125,16 @@ instance
   ) =>
   NFData (DijkstraStAnnTx TopTx era)
   where
-  rnf stAnnTx@(DijkstraStAnnTopTx _ _ _ _ _ _ _) =
+  rnf stAnnTx@(DijkstraStAnnTopTx _ _ _ _ _ _ _ _) =
     let DijkstraStAnnTopTx {..} = stAnnTx
      in dsattTx `deepseq`
           dsattScriptsNeeded `deepseq`
             dsattScriptsProvided `deepseq`
               dsattPlutusLegacyMode `deepseq`
-                dsattPlutusLanguagesUsed `deepseq`
-                  dsattPlutusScriptsWithContext `deepseq`
-                    rnf dsattSubTransactions
+                dsattPlutusRunnableCache `deepseq`
+                  dsattPlutusLanguagesUsed `deepseq`
+                    dsattPlutusScriptsWithContext `deepseq`
+                      rnf dsattSubTransactions
 
 instance
   ( AlonzoEraTx era
@@ -167,7 +168,7 @@ instance
   ) =>
   ToExpr (DijkstraStAnnTx TopTx era)
   where
-  toExpr stAnnTx@(DijkstraStAnnTopTx _ _ _ _ _ _ _) =
+  toExpr stAnnTx@(DijkstraStAnnTopTx _ _ _ _ _ _ _ _) =
     let DijkstraStAnnTopTx {..} = stAnnTx
      in TD.Rec "DijkstraStAnnTopTx" $
           OMap.fromList
@@ -175,6 +176,7 @@ instance
             , ("dsattScriptsNeeded", toExpr dsattScriptsNeeded)
             , ("dsattScriptsProvided", toExpr dsattScriptsProvided)
             , ("dsattPlutusLegacyMode", toExpr dsattPlutusLegacyMode)
+            , ("dsattPlutusRunnableCache", toExpr dsattPlutusRunnableCache)
             , ("dsattPlutusLanguagesUsed", toExpr dsattPlutusLanguagesUsed)
             , ("dsattPlutusScriptsWithContext", toExpr dsattPlutusScriptsWithContext)
             , ("dsattSubTransactions", toExpr dsattSubTransactions)

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 1.21.0.0
 
+* Restructure `PlutusRunnable` from a `newtype` over `ScriptForEvaluation` into a record with fields `plutusRunnableBinary`, `plutusRunnableScriptHash` and `plutusRunnableResult`
+* Change `decodePlutusRunnable` to return `PlutusRunnable l` instead of `Either ScriptDecodeError (PlutusRunnable l)`
+* Change `evaluatePlutusRunnable`, `evaluatePlutusRunnableBudget` and `mkTermToEvaluate` to accept a `ScriptForEvaluation` instead of a `PlutusRunnable l`
+* Add `asSameLanguage`
+* Change `pwcScript` field of `PlutusWithContext` to `PlutusRunnable l`, previously `Either (Plutus l) (PlutusRunnable l)`
+* Remove `pwcScriptHash` field from `PlutusWithContext` and add `pwcScriptHash` as a function instead
+* Change the continuation argument of `withRunnablePlutusWithContext` to receive a `ScriptForEvaluation`
+* Change the binary serialization of `PlutusWithContext`: the script hash is no longer stored, making the encoding not backwards compatible
 * Make `SnapShots` parametric in `era`
 * Add `EraIndependentEb`
 * Change `pvMinor` type to `Word32`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Add `StAnnTxCache` associated type and `getCacheStAnnTx` method to `EraUTxO`, together with a new `Monoid (StAnnTxCache era)` superclass constraint
 * Restructure `PlutusRunnable` from a `newtype` over `ScriptForEvaluation` into a record with fields `plutusRunnableBinary`, `plutusRunnableScriptHash` and `plutusRunnableResult`
 * Change `decodePlutusRunnable` to return `PlutusRunnable l` instead of `Either ScriptDecodeError (PlutusRunnable l)`
 * Change `evaluatePlutusRunnable`, `evaluatePlutusRunnableBudget` and `mkTermToEvaluate` to accept a `ScriptForEvaluation` instead of a `PlutusRunnable l`

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -268,6 +268,7 @@ library testlib
     mtl,
     nothunks <0.3.2,
     plutus-ledger-api:{plutus-ledger-api, plutus-ledger-api-testlib},
+    prettyprinter,
     primitive,
     quickcheck-transformer,
     random >=1.2,

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Evaluate.hs
@@ -18,6 +18,7 @@
 
 module Cardano.Ledger.Plutus.Evaluate (
   PlutusWithContext (..),
+  pwcScriptHash,
   ScriptFailure (..),
   ScriptResult (..),
   scriptPass,
@@ -61,15 +62,12 @@ import Cardano.Ledger.Plutus.Language (
   PlutusLanguage (..),
   PlutusRunnable (..),
   decodeWithPlutus,
-  hashPlutusScript,
-  plutusFromRunnable,
   plutusLanguage,
   withSamePlutusLanguage,
  )
 import Cardano.Ledger.Plutus.TxInfo
 import Codec.Extras.SerialiseViaFlat (DeserialiseFailureInfo (..), DeserialiseFailureReason (..))
 import Control.DeepSeq (NFData (..), deepseq, ($!!))
-import Control.Monad (unless)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Base64 as B64
@@ -89,6 +87,7 @@ import qualified PlutusLedgerApi.Common as P (
   EvaluationError (..),
   ExBudget,
   ScriptDecodeError (..),
+  ScriptForEvaluation,
   VerboseMode (..),
  )
 import Prettyprinter (Pretty (..))
@@ -100,14 +99,11 @@ data PlutusWithContext where
     PlutusLanguage l =>
     { pwcProtocolVersion :: !Version
     -- ^ Major protocol version that is necessary for [de]serialization
-    , pwcScript :: !(Either (Plutus l) (PlutusRunnable l))
+    , pwcScript :: !(PlutusRunnable l)
     -- ^ Actual plutus script that will be evaluated. Script is allowed to be in two forms:
     -- serialized and deserialized. This is necesary for implementing the opptimization
     -- that preserves deserialized `PlutusRunnable` after verifying wellformedness of
     -- plutus scripts during transaction validation (yet to be implemented).
-    , pwcScriptHash :: !ScriptHash
-    -- ^ Hash of the above script as it would appear on-chain. In other words it is not
-    -- just a hash of the script contents. (See `Cardano.Ledger.Core.hashScript` for more info)
     , pwcArgs :: !(PlutusArgs l)
     -- ^ All of the arguments to the Plutus scripts, including the redeemer and the
     -- Plutus context that was obtained from the transaction translation
@@ -125,26 +121,27 @@ instance NFData PlutusWithContext where
   rnf PlutusWithContext {..} =
     rnf pwcProtocolVersion `seq`
       rnf pwcScript `seq`
-        rnf pwcScriptHash `seq`
-          rnf pwcArgs `seq`
-            rnf pwcExUnits `seq`
-              rnf pwcCostModel
+        rnf pwcArgs `seq`
+          rnf pwcExUnits `seq`
+            rnf pwcCostModel
 
 instance Eq PlutusWithContext where
   pwc1@(PlutusWithContext {pwcScript = s1, pwcArgs = args1})
     == pwc2@(PlutusWithContext {pwcScript = s2, pwcArgs = args2}) =
       pwcProtocolVersion pwc1 == pwcProtocolVersion pwc2
-        && pwcScriptHash pwc1 == pwcScriptHash pwc2
         && fromMaybe False (withSamePlutusLanguage args1 args2 (==))
         && pwcExUnits pwc1 == pwcExUnits pwc2
         && pwcCostModel pwc1 == pwcCostModel pwc2
         && eqScripts s1 s2
       where
-        eqScripts (Left p1) (Left p2) =
-          plutusLanguage p1 == plutusLanguage p2 && plutusBinary p1 == plutusBinary p2
-        eqScripts (Right p1) (Right p2) =
-          plutusLanguage p1 == plutusLanguage p2 && plutusRunnable p1 == plutusRunnable p2
-        eqScripts _ _ = False
+        eqScripts p1 p2 =
+          plutusLanguage p1 == plutusLanguage p2
+            && plutusBinary (plutusRunnableBinary p1) == plutusBinary (plutusRunnableBinary p2)
+            && plutusRunnableScriptHash p1 == plutusRunnableScriptHash p2
+            && plutusRunnableResult p1 == plutusRunnableResult p2
+
+pwcScriptHash :: PlutusWithContext -> ScriptHash
+pwcScriptHash PlutusWithContext {pwcScript} = plutusRunnableScriptHash pwcScript
 
 data ScriptFailure = ScriptFailure
   { scriptFailureMessage :: Text
@@ -167,15 +164,12 @@ withRunnablePlutusWithContext ::
   PlutusWithContext ->
   -- | Handle the decoder failure
   (P.EvaluationError -> a) ->
-  (forall l. PlutusLanguage l => PlutusRunnable l -> PlutusArgs l -> a) ->
+  (forall l. PlutusLanguage l => P.ScriptForEvaluation -> PlutusArgs l -> a) ->
   a
-withRunnablePlutusWithContext PlutusWithContext {pwcProtocolVersion, pwcScript, pwcArgs} onError f =
-  case pwcScript of
+withRunnablePlutusWithContext PlutusWithContext {pwcScript, pwcArgs} onError f =
+  case plutusRunnableResult pwcScript of
     Right pr -> f pr pwcArgs
-    Left plutus ->
-      case decodePlutusRunnable pwcProtocolVersion plutus of
-        Right pr -> f pr pwcArgs
-        Left err -> onError (P.CodecError err)
+    Left err -> onError (P.CodecError err)
 
 instance Semigroup ScriptResult where
   Passes ps <> Passes qs = Passes (ps <> qs)
@@ -191,28 +185,19 @@ instance Monoid ScriptResult where
 -- other fields in a version-aware way.
 instance ToCBOR PlutusWithContext where
   toCBOR (PlutusWithContext {..}) =
-    Plain.encodeListLen 6
+    Plain.encodeListLen 5
       <> toCBOR pwcProtocolVersion
-      <> toPlainEncoding pwcProtocolVersion (either encCBOR encCBOR pwcScript)
-      <> toPlainEncoding pwcProtocolVersion (encCBOR pwcScriptHash)
+      <> toPlainEncoding pwcProtocolVersion (encCBOR (plutusRunnableBinary pwcScript))
       <> toPlainEncoding pwcProtocolVersion (encCBOR pwcArgs)
       <> toPlainEncoding pwcProtocolVersion (encCBOR pwcExUnits)
       <> toPlainEncoding pwcProtocolVersion (encodeCostModel pwcCostModel)
 
 instance FromCBOR PlutusWithContext where
-  fromCBOR = Plain.decodeRecordNamed "PlutusWithContext" (const 6) $ do
+  fromCBOR = Plain.decodeRecordNamed "PlutusWithContext" (const 5) $ do
     pwcProtocolVersion <- fromCBOR
     toPlainDecoder Nothing pwcProtocolVersion $ decodeWithPlutus $ \plutus -> do
       let lang = plutusLanguage plutus
-          pwcScript = Left plutus
-          scriptHash = hashPlutusScript plutus
-      pwcScriptHash <- decCBOR
-      unless (pwcScriptHash == scriptHash) $
-        fail $
-          "ScriptHash mismatch. Encoded: "
-            <> show pwcScriptHash
-            <> " doesn't match the actual: "
-            <> show scriptHash
+          pwcScript = decodePlutusRunnable pwcProtocolVersion plutus
       pwcArgs <- decCBOR
       pwcExUnits <- decCBOR
       pwcCostModel <- decodeCostModel lang
@@ -317,14 +302,14 @@ overrideContext PlutusWithContext {..} PlutusDebugOverrides {..} =
   -- copy all the fields. Otherwise GHC will greet us with
   -- `Record update for insufficiently polymorphic field...` error
   PlutusWithContext
-    { pwcProtocolVersion = fromMaybe pwcProtocolVersion pdoProtocolVersion
+    { pwcProtocolVersion = overrideProtocolVersion
     , pwcScript = overrideScript
     , pwcExUnits = overrideExUnits
     , pwcCostModel = overrideCostModel
-    , pwcScriptHash = overrideSriptHash
     , ..
     }
   where
+    overrideProtocolVersion = fromMaybe pwcProtocolVersion pdoProtocolVersion
     overrideExUnits =
       ExUnits
         (fromMaybe (exUnitsMem pwcExUnits) pdoExUnitsMem)
@@ -334,13 +319,13 @@ overrideContext PlutusWithContext {..} PlutusDebugOverrides {..} =
         mkCostModel
           (fromMaybe (getCostModelLanguage pwcCostModel) pdoLanguage)
           (fromMaybe (getCostModelParams pwcCostModel) pdoCostModelValues)
-    (overrideSriptHash, overrideScript) =
+    overrideScript =
       case pdoScript of
-        Nothing -> (pwcScriptHash, pwcScript)
+        Nothing -> pwcScript
         Just hexScript ->
           case Plutus . PlutusBinary . SBS.toShort <$> B16.decode (BSC.filter (/= '\n') hexScript) of
             Left err -> error $ "Failed hex decoding of the custom script: " <> err
-            Right script -> (hashPlutusScript script, Left script)
+            Right script -> decodePlutusRunnable overrideProtocolVersion script
 
 -- | Execute a hex encoded script with the context that was produced within the ledger predicate
 -- failure. Using `PlutusDebugOverrides` it is possible to override any part of the execution.
@@ -418,13 +403,13 @@ explainPlutusEvaluationError ::
   P.EvaluationError ->
   ScriptResult
 explainPlutusEvaluationError pwc@PlutusWithContext {pwcProtocolVersion, pwcScript, pwcArgs} e =
-  let lang = either plutusLanguage plutusLanguage pwcScript
-      Plutus binaryScript = either id plutusFromRunnable pwcScript
+  let lang = plutusLanguage pwcScript
+      Plutus binaryScript = plutusRunnableBinary pwcScript
       firstLines =
         [ "The " ++ show lang ++ " script failed:"
         , "Base64-encoded script bytes:"
         ]
-      shLine = "The script hash is:" ++ show (pwcScriptHash pwc)
+      shLine = "The script hash is:" ++ show (plutusRunnableScriptHash pwcScript)
       pvLine = "The protocol version is: " ++ show pwcProtocolVersion
       plutusError = "The plutus evaluation error is: " ++ show e
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -47,6 +48,7 @@ module Cardano.Ledger.Plutus.Language (
   toSLanguage,
   withSLanguage,
   asSLanguage,
+  asSameLanguage,
   withSamePlutusLanguage,
 
   -- * Plutus Script Context
@@ -73,6 +75,10 @@ import Cardano.Ledger.Binary (
   unlessDecoderVersionAtLeast,
  )
 import Cardano.Ledger.Hashes (SafeToHash (..), ScriptHash (..))
+import qualified Codec.Extras.SerialiseViaFlat as PlutusCore (
+  DeserialiseFailureInfo (..),
+  DeserialiseFailureReason (..),
+ )
 import Control.DeepSeq (NFData (..), deepseq)
 import Control.Monad (when)
 import Data.Aeson (
@@ -98,7 +104,7 @@ import qualified Data.Text.Encoding as T
 import Data.Typeable (Typeable, gcast)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
-import NoThunks.Class (NoThunks)
+import NoThunks.Class (AllowThunksIn (..), NoThunks (..))
 import PlutusCore (DefaultFun, DefaultUni)
 import qualified PlutusLedgerApi.Common as P (
   Data,
@@ -108,11 +114,10 @@ import qualified PlutusLedgerApi.Common as P (
   LogOutput,
   MajorProtocolVersion (..),
   PlutusLedgerLanguage (PlutusV1, PlutusV2, PlutusV3),
-  ScriptDecodeError,
+  ScriptDecodeError (..),
   ScriptForEvaluation,
   VerboseMode,
   mkTermToEvaluate,
-  serialisedScript,
  )
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
@@ -126,11 +131,36 @@ import qualified UntypedPlutusCore as UPLC
 --
 -- The only way to obtain this type is by the means of deserializing `Plutus` with
 -- `decodePlutusRunnable`
-newtype PlutusRunnable (l :: Language) = PlutusRunnable
-  { plutusRunnable :: P.ScriptForEvaluation
+data PlutusRunnable (l :: Language) = PlutusRunnable
+  { plutusRunnableBinary :: !(Plutus l)
+  , plutusRunnableScriptHash :: ScriptHash
+  -- ^ Hash of the script. Lazy on purpose
+  , plutusRunnableResult :: Either P.ScriptDecodeError P.ScriptForEvaluation
+  -- ^ Decoded version of the script. Lazy on purpose
   }
-  deriving stock (Show, Generic)
-  deriving newtype (Eq, NFData, NoThunks)
+  deriving stock (Eq, Show, Generic)
+
+deriving via
+  AllowThunksIn '["plutusRunnableScriptHash", "plutusRunnableResult"] (PlutusRunnable l)
+  instance
+    Typeable l => NoThunks (PlutusRunnable l)
+
+instance NFData (PlutusRunnable l) where
+  rnf (PlutusRunnable prb prsh prr) =
+    prb `deepseq`
+      prsh `deepseq`
+        either rnfScriptDecodeError rnf prr
+
+rnfScriptDecodeError :: P.ScriptDecodeError -> ()
+rnfScriptDecodeError = \case
+  P.CBORDeserialiseError (PlutusCore.DeserialiseFailureInfo byteOffset reason) ->
+    byteOffset `deepseq` case reason of
+      PlutusCore.EndOfInput -> ()
+      PlutusCore.ExpectedBytes -> ()
+      PlutusCore.OtherReason rStr -> rnf rStr
+  P.RemainderError err -> rnf err
+  P.LedgerLanguageNotAvailableError {} -> ()
+  P.PlutusCoreLanguageNotAvailableError {} -> ()
 
 toMajorProtocolVersion :: Version -> P.MajorProtocolVersion
 toMajorProtocolVersion = P.MajorProtocolVersion . getVersion
@@ -139,7 +169,7 @@ instance PlutusLanguage l => DecCBOR (PlutusRunnable l) where
   decCBOR = do
     plutus <- decCBOR
     pv <- getDecoderVersion
-    either (fail . show) pure $ decodePlutusRunnable pv plutus
+    pure $ decodePlutusRunnable pv plutus
 
 instance PlutusLanguage l => EncCBOR (PlutusRunnable l) where
   encCBOR = encCBOR . plutusFromRunnable
@@ -200,13 +230,13 @@ instance PlutusLanguage l => EncCBOR (Plutus l) where
 
 -- | Verify that the binary version of the Plutus script is deserializable.
 isValidPlutus :: PlutusLanguage l => Version -> Plutus l -> Bool
-isValidPlutus v = isRight . decodePlutusRunnable v
+isValidPlutus v = isRight . plutusRunnableResult . decodePlutusRunnable v
 
 -- | Serialize the runnable version of the plutus script
 --
 -- > decodePlutusRunnable majVer (plutusFromRunnable pr) == Right pr
 plutusFromRunnable :: PlutusRunnable l -> Plutus l
-plutusFromRunnable = Plutus . PlutusBinary . P.serialisedScript . plutusRunnable
+plutusFromRunnable = plutusRunnableBinary
 
 -- | Binary representation of a Plutus script.
 newtype PlutusBinary = PlutusBinary {unPlutusBinary :: ShortByteString}
@@ -434,7 +464,7 @@ class
     Version ->
     -- | Binary version of the script that will be deserialized
     Plutus l ->
-    Either P.ScriptDecodeError (PlutusRunnable l)
+    PlutusRunnable l
 
   evaluatePlutusRunnable ::
     -- | Which major protocol version to use for script execution
@@ -446,7 +476,7 @@ class
     -- | The resource budget which must not be exceeded during evaluation
     P.ExBudget ->
     -- | The script to evaluate
-    PlutusRunnable l ->
+    P.ScriptForEvaluation ->
     -- | The arguments to the script
     PlutusArgs l ->
     (P.LogOutput, Either P.EvaluationError P.ExBudget)
@@ -462,7 +492,7 @@ class
     -- | Includes the cost model to use for tallying up the execution costs
     P.EvaluationContext ->
     -- | The script to evaluate
-    PlutusRunnable l ->
+    P.ScriptForEvaluation ->
     -- | The arguments to the script
     PlutusArgs l ->
     (P.LogOutput, Either P.EvaluationError P.ExBudget)
@@ -471,7 +501,7 @@ class
     -- | Which major protocol version to use for script execution
     Version ->
     -- | The script to evaluate
-    PlutusRunnable l ->
+    P.ScriptForEvaluation ->
     -- | The arguments to the script
     PlutusArgs l ->
     Either P.EvaluationError (UPLC.Term UPLC.NamedDeBruijn DefaultUni DefaultFun ())
@@ -481,17 +511,17 @@ instance PlutusLanguage 'PlutusV1 where
     deriving newtype (Eq, Show, Pretty, EncCBOR, DecCBOR, NFData)
   isLanguage = SPlutusV1
   plutusLanguageTag _ = 0x01
-  decodePlutusRunnable pv (Plutus (PlutusBinary bs)) =
-    PlutusRunnable <$> PV1.deserialiseScript (toMajorProtocolVersion pv) bs
-  evaluatePlutusRunnable pv vm ec exBudget (PlutusRunnable rs) =
+  decodePlutusRunnable pv p@(Plutus (PlutusBinary bs)) =
+    PlutusRunnable p (hashPlutusScript p) $ PV1.deserialiseScript (toMajorProtocolVersion pv) bs
+  evaluatePlutusRunnable pv vm ec exBudget rs =
     PV1.evaluateScriptRestricting (toMajorProtocolVersion pv) vm ec exBudget rs
       . legacyPlutusArgsToData
       . unPlutusV1Args
-  evaluatePlutusRunnableBudget pv vm ec (PlutusRunnable rs) =
+  evaluatePlutusRunnableBudget pv vm ec rs =
     PV1.evaluateScriptCounting (toMajorProtocolVersion pv) vm ec rs
       . legacyPlutusArgsToData
       . unPlutusV1Args
-  mkTermToEvaluate pv (PlutusRunnable rs) =
+  mkTermToEvaluate pv rs =
     P.mkTermToEvaluate P.PlutusV1 (toMajorProtocolVersion pv) rs
       . legacyPlutusArgsToData
       . unPlutusV1Args
@@ -501,17 +531,17 @@ instance PlutusLanguage 'PlutusV2 where
     deriving newtype (Eq, Show, Pretty, EncCBOR, DecCBOR, NFData)
   isLanguage = SPlutusV2
   plutusLanguageTag _ = 0x02
-  decodePlutusRunnable pv (Plutus (PlutusBinary bs)) =
-    PlutusRunnable <$> PV2.deserialiseScript (toMajorProtocolVersion pv) bs
-  evaluatePlutusRunnable pv vm ec exBudget (PlutusRunnable rs) =
+  decodePlutusRunnable pv p@(Plutus (PlutusBinary bs)) =
+    PlutusRunnable p (hashPlutusScript p) $ PV2.deserialiseScript (toMajorProtocolVersion pv) bs
+  evaluatePlutusRunnable pv vm ec exBudget rs =
     PV2.evaluateScriptRestricting (toMajorProtocolVersion pv) vm ec exBudget rs
       . legacyPlutusArgsToData
       . unPlutusV2Args
-  evaluatePlutusRunnableBudget pv vm ec (PlutusRunnable rs) =
+  evaluatePlutusRunnableBudget pv vm ec rs =
     PV2.evaluateScriptCounting (toMajorProtocolVersion pv) vm ec rs
       . legacyPlutusArgsToData
       . unPlutusV2Args
-  mkTermToEvaluate pv (PlutusRunnable rs) =
+  mkTermToEvaluate pv rs =
     P.mkTermToEvaluate P.PlutusV2 (toMajorProtocolVersion pv) rs
       . legacyPlutusArgsToData
       . unPlutusV2Args
@@ -521,17 +551,17 @@ instance PlutusLanguage 'PlutusV3 where
     deriving newtype (Eq, Show, Pretty, EncCBOR, DecCBOR, NFData)
   isLanguage = SPlutusV3
   plutusLanguageTag _ = 0x03
-  decodePlutusRunnable pv (Plutus (PlutusBinary bs)) =
-    PlutusRunnable <$> PV3.deserialiseScript (toMajorProtocolVersion pv) bs
-  evaluatePlutusRunnable pv vm ec exBudget (PlutusRunnable rs) =
+  decodePlutusRunnable pv p@(Plutus (PlutusBinary bs)) =
+    PlutusRunnable p (hashPlutusScript p) $ PV3.deserialiseScript (toMajorProtocolVersion pv) bs
+  evaluatePlutusRunnable pv vm ec exBudget rs =
     PV3.evaluateScriptRestricting (toMajorProtocolVersion pv) vm ec exBudget rs
       . PV3.toData
       . unPlutusV3Args
-  evaluatePlutusRunnableBudget pv vm ec (PlutusRunnable rs) =
+  evaluatePlutusRunnableBudget pv vm ec rs =
     PV3.evaluateScriptCounting (toMajorProtocolVersion pv) vm ec rs
       . PV3.toData
       . unPlutusV3Args
-  mkTermToEvaluate pv (PlutusRunnable rs) =
+  mkTermToEvaluate pv rs =
     P.mkTermToEvaluate P.PlutusV3 (toMajorProtocolVersion pv) rs
       . pure
       . PV3.toData
@@ -542,16 +572,17 @@ instance PlutusLanguage 'PlutusV4 where
     deriving newtype (Eq, Show, Pretty, EncCBOR, DecCBOR, NFData)
   isLanguage = SPlutusV4
   plutusLanguageTag _ = 0x04
-  decodePlutusRunnable pv (Plutus (PlutusBinary bs)) = PlutusRunnable <$> PV3.deserialiseScript (toMajorProtocolVersion pv) bs
-  evaluatePlutusRunnable pv vm ec exBudget (PlutusRunnable rs) =
+  decodePlutusRunnable pv p@(Plutus (PlutusBinary bs)) =
+    PlutusRunnable p (hashPlutusScript p) $ PV3.deserialiseScript (toMajorProtocolVersion pv) bs
+  evaluatePlutusRunnable pv vm ec exBudget rs =
     PV3.evaluateScriptRestricting (toMajorProtocolVersion pv) vm ec exBudget rs
       . PV3.toData
       . unPlutusV4Args
-  evaluatePlutusRunnableBudget pv vm ec (PlutusRunnable rs) =
+  evaluatePlutusRunnableBudget pv vm ec rs =
     PV3.evaluateScriptCounting (toMajorProtocolVersion pv) vm ec rs
       . PV3.toData
       . unPlutusV4Args
-  mkTermToEvaluate pv (PlutusRunnable rs) =
+  mkTermToEvaluate pv rs =
     P.mkTermToEvaluate P.PlutusV3 (toMajorProtocolVersion pv) rs
       . pure
       . PV3.toData
@@ -570,8 +601,22 @@ toSLanguage lang
     thisLanguage :: SLanguage l
     thisLanguage = isLanguage
 
+-- | This is similar to `asSameLanguage`, but with arguments flipped and one of those proxies
+-- monomorphized to `SLanguage`.
 asSLanguage :: SLanguage l -> proxy l -> proxy l
 asSLanguage _ = id
+
+-- | This is similar to `Data.Proxy.asProxyTypeOf`, but for `Language`. Restrict type of language in
+-- one proxy type to the same of another.
+--
+-- >>> :seti -XDataKinds
+-- >>> let plutusRunnable = error "Some well formed PlutusV1 script" :: PlutusRunnable 'PlutusV1
+-- >>> isLanguage `asSameLanguage` plutusRunnable
+-- SPlutusV1
+asSameLanguage :: PlutusLanguage l => proxy l -> proxyAs l -> proxy l
+asSameLanguage x _ = x
+  where
+    _ = isLanguage `asSLanguage` x
 
 withSLanguage :: Language -> (forall l. PlutusLanguage l => SLanguage l -> a) -> a
 withSLanguage l f =

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
@@ -239,10 +239,13 @@ deriving instance (Era era, Show (Script era)) => Show (ScriptsProvided era)
 
 deriving instance (Era era, NFData (Script era)) => NFData (ScriptsProvided era)
 
-class EraTx era => EraUTxO era where
+class (Monoid (StAnnTxCache era), EraTx era) => EraUTxO era where
   -- | A customizable type on per era basis for the information required to find all
   -- scripts needed for the transaction.
   type ScriptsNeeded era = (r :: Type) | r -> era
+
+  -- | Cache that can be shared between different `StAnnTx`s
+  type StAnnTxCache era :: Type
 
   -- | Calculate all the value that is being consumed by the transaction.
   getConsumedValue ::
@@ -283,3 +286,6 @@ class EraTx era => EraUTxO era where
 
   -- | Minimum fee computation, excluding witnesses and including ref scripts size
   getMinFeeTxUtxo :: PParams era -> Tx t era -> UTxO era -> Coin
+
+  -- | Pull out cache from `StAnnTx`
+  getCacheStAnnTx :: StAnnTx TopTx era -> StAnnTxCache era

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -33,6 +33,7 @@ import Cardano.Ledger.TxIn
 import Data.Functor.Identity
 import qualified Data.TreeDiff.OMap as OMap
 import GHC.TypeLits
+import Prettyprinter
 import Test.Cardano.Data.TreeDiff ()
 import Test.Cardano.Ledger.Binary.TreeDiff
 import Test.Cardano.Ledger.BlockHeader (TestBlockHeader)
@@ -82,6 +83,22 @@ instance ToExpr (SafeHash i) where
 
 -- Language
 instance ToExpr (Plutus l)
+
+instance ToExpr (PlutusRunnable l) where
+  toExpr pr@(PlutusRunnable _ _ _) =
+    let PlutusRunnable {..} = pr
+     in Rec "PlutusRunnable" $
+          OMap.fromList
+            [ ("plutusRunnableBinary", toExpr plutusRunnableBinary)
+            , ("plutusRunnableScriptHash", toExpr plutusRunnableScriptHash)
+            ,
+              ( "plutusRunnableResult"
+              , case plutusRunnableResult of
+                  Left err -> App "Left" [toExpr $ show $ pretty err]
+                  -- There is no point in showing plutus AST when debugging tests
+                  Right _sfe -> App "Right" [toExpr ("<ScriptForEvaluation>" :: String)]
+              )
+            ]
 
 instance ToExpr PlutusBinary
 

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/TreeDiff.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -26,11 +27,7 @@ import Cardano.Ledger.Credential
 import Cardano.Ledger.HKD
 import Cardano.Ledger.Keys
 import Cardano.Ledger.MemoBytes
-import Cardano.Ledger.Plutus.CostModels
-import Cardano.Ledger.Plutus.Data
-import Cardano.Ledger.Plutus.ExUnits
-import Cardano.Ledger.Plutus.Language
-import Cardano.Ledger.Plutus.TxInfo
+import Cardano.Ledger.Plutus
 import Cardano.Ledger.State
 import Cardano.Ledger.TxIn
 import Data.Functor.Identity
@@ -89,6 +86,19 @@ instance ToExpr (Plutus l)
 instance ToExpr PlutusBinary
 
 instance ToExpr Language
+
+instance
+  ToExpr ScriptHash =>
+  ToExpr PlutusWithContext
+  where
+  toExpr PlutusWithContext {..} =
+    Rec "PlutusWithContext" $
+      OMap.fromList
+        [ ("pwcProtocolVersion", toExpr pwcProtocolVersion)
+        , ("pwcScript", toExpr (plutusRunnableScriptHash pwcScript))
+        , ("pwcExUnits", toExpr pwcExUnits)
+        , ("pwcCostModel", toExpr pwcCostModel)
+        ]
 
 -- MemoBytes
 instance ToExpr t => ToExpr (MemoBytes t)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/MiniTrace.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Constrained/Conway/MiniTrace.hs
@@ -583,6 +583,7 @@ constrainedUtxo =
             (systemStart testGlobals)
             (uePParams uecUtxoEnv)
             uecUTxO
+            mempty
             tx
     )
 

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -45,8 +45,8 @@ import Cardano.Ledger.Plutus (
   ExUnits (..),
   Language (..),
   PlutusWithContext (..),
+  decodePlutusRunnable,
   hashData,
-  hashPlutusScript,
  )
 import Cardano.Ledger.State (EraUTxO (..), UTxO (..))
 import Cardano.Ledger.Val (inject)
@@ -91,9 +91,8 @@ collectTwoPhaseScriptInputsOutputOrdering = do
   collectInputs @AlonzoEra testEpochInfo testSystemStart defaultPParams validatingTx initUTxO
     `shouldBe` Right
       [ PlutusWithContext
-          { pwcProtocolVersion = pvMajor (defaultPParams @AlonzoEra ^. ppProtocolVersionL)
-          , pwcScript = Left plutus
-          , pwcScriptHash = hashPlutusScript plutus
+          { pwcProtocolVersion = pvMajor protVer
+          , pwcScript = decodePlutusRunnable (pvMajor protVer) plutus
           , pwcArgs = either (error . show) id $ do
               txInfo <-
                 toPlutusTxInfoForPurpose plutus lti $
@@ -110,10 +109,12 @@ collectTwoPhaseScriptInputsOutputOrdering = do
           }
       ]
   where
+    protVer = defaultPParams @AlonzoEra ^. ppProtocolVersionL
     plutus = alwaysSucceedsPlutus @'PlutusV1 3
+    lti :: LedgerTxInfo AlonzoEra
     lti =
       LedgerTxInfo
-        { ltiProtVer = defaultPParams @AlonzoEra ^. ppProtocolVersionL
+        { ltiProtVer = protVer
         , ltiEpochInfo = testEpochInfo
         , ltiSystemStart = testSystemStart
         , ltiUTxO = initUTxO

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/MockChain.hs
@@ -18,6 +18,7 @@
 module Test.Cardano.Ledger.Generic.MockChain where
 
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
+import qualified Cardano.Ledger.Babbage.Rules as Babbage
 import Cardano.Ledger.BaseTypes (BlocksMade (..), ShelleyBase)
 import Cardano.Ledger.Shelley.Core
 import Cardano.Ledger.Shelley.LedgerState (
@@ -197,6 +198,17 @@ instance
   , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
   ) =>
   Embed (Alonzo.LEDGERS era) (MOCKCHAIN era)
+  where
+  wrapFailed = MockChainFromLedgersFailure
+  wrapEvent = MockChainFromLedgersEvent
+
+instance
+  ( STS (Babbage.LEDGERS era)
+  , State (EraRule "LEDGER" era) ~ LedgerState era
+  , Environment (EraRule "LEDGER" era) ~ Shelley.LedgerEnv era
+  , Signal (EraRule "LEDGER" era) ~ StAnnTx TopTx era
+  ) =>
+  Embed (Babbage.LEDGERS era) (MOCKCHAIN era)
   where
   wrapFailed = MockChainFromLedgersFailure
   wrapEvent = MockChainFromLedgersEvent

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Generic/Properties.hs
@@ -120,6 +120,7 @@ genTxAndLEDGERState sizes = do
                 (systemStart testGlobals)
                 pp
                 (utxosUtxo (lsUTxOState ledgerState))
+                mempty
                 tx
         pure $ TRC (ledgerEnv, ledgerState, stAnnTx)
   (trc, genstate) <- runGenRS sizes (initStableFields >> genT)

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/STS.hs
@@ -232,6 +232,7 @@ prop_UTXOS =
             (systemStart testGlobals)
             pp
             utxo
+            mempty
             tx
     )
     $ \_env _st _sig _st' -> True
@@ -334,6 +335,7 @@ prop_UTXOW =
             (systemStart testGlobals)
             (Shelley.uePParams env)
             (utxosUtxo st)
+            mempty
             tx
     )
     $ \_env _st _sig _st' -> True


### PR DESCRIPTION
# Description

Introduces a per-block Plutus script cache so that scripts resolved for one transaction can be reused by subsequent transactions in the same `LEDGERS` fold, avoiding repeated decoding.

**Main changes**

- **Restructure `PlutusRunnable`** (`cardano-ledger-core`) from a `newtype` over `ScriptForEvaluation` into a record carrying the binary, script hash, and decode result; make `decodePlutusRunnable` total; drop the separate script-hash field from `PlutusWithContext`.
- **Add a script cache to `EraUTxO`** via a new `StAnnTxCache` associated type and `getCacheStAnnTx` method (with a `Monoid` superclass), thread it through `ApplyTx`'s `mkStAnnTx`, and wire per-era caches (`Map ScriptHash (SupportedPlutusRunnable era)` in Alonzo–Dijkstra; `()` in the pre-Plutus eras).
- **Thread the cache through resolution**: `resolveNeededPlutusScriptsWithPurpose` now takes a `ProtVer` and an incoming cache and returns the updated cache alongside the resolved scripts; add the `SupportedPlutusRunnable` wrapper and `mkSupportedPlutusRunnable`.
- **Give Babbage its own `LEDGERS` rule** (previously inherited from Shelley) that folds the cache across transactions, and rewire Conway and Dijkstra to use `Babbage.LEDGERS`.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
