### PR TITLE
Fix JSON roundtrip for InjectionData

### DIFF
--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Genesis.hs
@@ -841,8 +841,7 @@ instance (FromJSON k, FromJSON v, Aeson.FromJSONKey k, Ord k) => FromJSON (Injec
           Nothing -> fail $ "Invalid hash format: " <> show hashText
           Just h -> pure $ InjectionFromFile (fsPathFromList segments) h
       (Nothing, Just d) -> pure $ EmbeddedInjection d
-      (Nothing, Nothing) ->
-        fail "InjectionData: No injection was provided. Expected either \"file\" or \"data\""
+      (Nothing, Nothing) -> pure NoInjection
       (Just _, Just _) ->
         fail "InjectionData: cannot specify both \"file\" and \"data\" fields"
 


### PR DESCRIPTION
# Description

We have some roundtrip tests for the config downstream in `cli` and `node`, and I have stumbled on this a few times: `toJSON NoInjection` is a `{}`, but `fromJSON` of `{}` fails.
This patch removes this wrinkle and deserialises `{}` to `NoInjection`.

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
