### PR TITLE
Make `AlonzoTx` mempool decoder backwards compatible

### DIFF
--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Make `AlonzoTx` decoder that used for Mempool backwards compatible with prior-eras
 * Add `TranslateEra` instance for `SnapShots`
 * Change `extraConfig` and `agExtraConfig` from `Maybe` to `StrictMaybe`
 * Remove `ueUtxo` field from `UtxoEnv`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -102,15 +102,12 @@ import Cardano.Ledger.BaseTypes (integralToBounded)
 import Cardano.Ledger.Binary (
   Annotator,
   DecCBOR (..),
-  Decoder,
   EncCBOR (encCBOR),
   Encoding,
   ToCBOR (..),
   decodeNullStrictMaybe,
   encodeListLen,
   encodeNullStrictMaybe,
-  ifDecoderVersionAtLeast,
-  natVersion,
   serialize,
   serialize',
  )
@@ -453,21 +450,6 @@ instance
   where
   toCBOR = toEraCBOR @era
 
-decodeAlonzoTxPv12 ::
-  forall era s.
-  ( DecCBOR (Annotator (TxBody TopTx era))
-  , DecCBOR (Annotator (TxWits era))
-  , DecCBOR (Annotator (TxAuxData era))
-  ) =>
-  Decoder s (Annotator (AlonzoTx TopTx era))
-decodeAlonzoTxPv12 = decodeRecordNamed "AlonzoTx" (const 4) $ do
-  body <- decCBOR
-  wits <- decCBOR
-  isValid <- decCBOR
-  auxData <- decodeNullStrictMaybe decCBOR
-  pure $ AlonzoTx <$> body <*> wits <*> pure isValid <*> sequence auxData
-{-# INLINE decodeAlonzoTxPv12 #-}
-
 instance
   ( Typeable l
   , Era era
@@ -483,13 +465,12 @@ instance
   decCBOR =
     withSTxTopLevelM @l @era $ \case
       STopTxOnly ->
-        ifDecoderVersionAtLeast (natVersion @12) decodeAlonzoTxPv12 $
-          decode $
-            Ann (RecD AlonzoTx)
-              <*! From
-              <*! From
-              <*! Ann From
-              <*! D (sequence <$> decodeNullStrictMaybe decCBOR)
+        decodeRecordNamed "AlonzoTx" (const 4) $ do
+          body <- decCBOR
+          wits <- decCBOR
+          isValid <- decCBOR
+          auxData <- decodeNullStrictMaybe decCBOR
+          pure $ AlonzoTx <$> body <*> wits <*> pure isValid <*> sequence auxData
   {-# INLINE decCBOR #-}
 
 data AlonzoStAnnTx l era where

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -105,9 +105,11 @@ import Cardano.Ledger.Binary (
   EncCBOR (encCBOR),
   Encoding,
   ToCBOR (..),
+  TokenType (..),
   decodeNullStrictMaybe,
   encodeListLen,
   encodeNullStrictMaybe,
+  peekTokenType,
   serialize,
   serialize',
  )
@@ -465,12 +467,19 @@ instance
   decCBOR =
     withSTxTopLevelM @l @era $ \case
       STopTxOnly ->
-        decodeRecordNamed "AlonzoTx" (const 4) $ do
+        fmap snd $ decodeRecordNamed "AlonzoTx" fst $ do
           body <- decCBOR
           wits <- decCBOR
-          isValid <- decCBOR
+          (isValidFlagSupplied, isValid) <-
+            peekTokenType >>= \case
+              TypeBool -> do
+                isValid <- decCBOR
+                pure (True, isValid)
+              _ -> pure (False, IsValid True)
           auxData <- decodeNullStrictMaybe decCBOR
-          pure $ AlonzoTx <$> body <*> wits <*> pure isValid <*> sequence auxData
+          let
+            tx = AlonzoTx <$> body <*> wits <*> pure isValid <*> sequence auxData
+          pure (if isValidFlagSupplied then 4 else 3, tx)
   {-# INLINE decCBOR #-}
 
 data AlonzoStAnnTx l era where

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -131,28 +131,26 @@ instance EraTx era => EncCBOR (DijkstraTx l era) where
 
 decodeDijkstraTopTx :: EraTx era => Bool -> Decoder s (Annotator (DijkstraTx TopTx era))
 decodeDijkstraTopTx allowIsValid =
-  fst <$> do
-    let isValidBackwardsCompatibleLength isValidFlagSupplied = if isValidFlagSupplied then 4 else 3
-    decodeRecordNamed "DijkstraTx" (isValidBackwardsCompatibleLength . snd) $ do
-      bodyAnn <- decCBOR
-      witsAnn <- decCBOR
-      isValidFlagSupplied <-
-        if allowIsValid
-          then
-            peekTokenType >>= \case
-              TypeBool ->
-                decCBOR >>= \case
-                  True -> pure True
-                  False -> fail "Value `false` not allowed for `isValid`"
-              _ -> pure False
-          else pure False
-      auxAnn <- decodeNullStrictMaybe decCBOR
-      let
-        -- `isValid == False` can no longer be supplied in an encoded transaction.
-        isValid = IsValid True
-        dijkstraTopTx =
-          DijkstraTx <$> bodyAnn <*> witsAnn <*> pure isValid <*> sequence auxAnn
-      pure (dijkstraTopTx, isValidFlagSupplied)
+  fmap snd $ decodeRecordNamed "DijkstraTx" fst $ do
+    bodyAnn <- decCBOR
+    witsAnn <- decCBOR
+    isValidFlagSupplied <-
+      if allowIsValid
+        then
+          peekTokenType >>= \case
+            TypeBool ->
+              decCBOR >>= \case
+                True -> pure True
+                False -> fail "Value `false` not allowed for `isValid`"
+            _ -> pure False
+        else pure False
+    auxAnn <- decodeNullStrictMaybe decCBOR
+    let
+      -- `isValid == False` can no longer be supplied in an encoded transaction.
+      isValid = IsValid True
+      dijkstraTopTx =
+        DijkstraTx <$> bodyAnn <*> witsAnn <*> pure isValid <*> sequence auxAnn
+    pure (if isValidFlagSupplied then 4 else 3, dijkstraTopTx)
 
 instance (EraTx era, Typeable l) => DecCBOR (Annotator (DijkstraTx l era)) where
   decCBOR = withSTxBothLevels @l $ \case


### PR DESCRIPTION
# Description

Decoder for transaction, when submitted into mempool should accept transactions without isValid flag, in order to be compatible with prior eras. It is safe to make this change, because it does not affect Block decoder

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
