### PR TITLE
Drop `EncCBORGroup BlockBody` in Dijkstra

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Version history for `cardano-ledger-allegra`
 
-## 1.10.0.1
+## 1.10.1.0
 
-*
+* Add `EncCBOR`, `ToCBOR` for `Block`
+* Add `DecCBOR` instances for `Annotator Block`
+
+### `testlib`
+
+* Add `DecCBOR` instance for `Block`
 
 ## 1.10.0.0
 

--- a/eras/allegra/impl/cardano-ledger-allegra.cabal
+++ b/eras/allegra/impl/cardano-ledger-allegra.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-allegra
-version: 1.10.0.0
+version: 1.10.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -79,7 +79,7 @@ library
     bytestring,
     cardano-data,
     cardano-ledger-binary >=1.4,
-    cardano-ledger-core:{cardano-ledger-core, internal} >=1.20,
+    cardano-ledger-core:{cardano-ledger-core, internal} >=1.21,
     cardano-ledger-shelley ^>=1.19,
     cardano-slotting,
     cardano-strict-containers,

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/BlockBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/BlockBody.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -12,8 +14,19 @@ module Cardano.Ledger.Allegra.BlockBody () where
 import Cardano.Ledger.Allegra.Era (AllegraEra)
 import Cardano.Ledger.Allegra.Tx ()
 import Cardano.Ledger.BaseTypes (ProtVer (..))
-import Cardano.Ledger.Binary (EncCBORGroup (..), serialize')
-import Cardano.Ledger.Core (EraBlockBody (..))
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (decCBOR),
+  EncCBOR (..),
+  EncCBORGroup (..),
+  decodeRecordNamed,
+  encodeListLen,
+  serialize',
+  toPlainEncoding,
+ )
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import Cardano.Ledger.Block (Block (..))
+import Cardano.Ledger.Core (EraBlockBody (..), eraProtVerLow)
 import Cardano.Ledger.Shelley.BlockBody (
   ShelleyBlockBody,
   mkBasicBlockBodyShelley,
@@ -21,6 +34,7 @@ import Cardano.Ledger.Shelley.BlockBody (
   txSeqBlockBodyShelleyL,
  )
 import qualified Data.ByteString as BS
+import Data.Typeable (Typeable)
 
 instance EraBlockBody AllegraEra where
   type BlockBody AllegraEra = ShelleyBlockBody AllegraEra
@@ -28,3 +42,20 @@ instance EraBlockBody AllegraEra where
   txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = shelleyBlockBodyHash
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
+
+instance EncCBOR h => EncCBOR (Block h AllegraEra) where
+  encCBOR (Block h txns) =
+    encodeListLen 4 <> encCBOR h <> encCBORGroup txns
+
+instance (EncCBOR h, Typeable h) => Plain.ToCBOR (Block h AllegraEra) where
+  toCBOR = toPlainEncoding (eraProtVerLow @AllegraEra) . encCBOR
+
+instance
+  (DecCBOR (Annotator h), Typeable h) =>
+  DecCBOR (Annotator (Block h AllegraEra))
+  where
+  decCBOR =
+    decodeRecordNamed "Block" (const 4) $ do
+      header <- decCBOR
+      txns <- decCBOR
+      pure $ Block <$> header <*> txns

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/BlockBody.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/BlockBody.hs
@@ -27,5 +27,4 @@ instance EraBlockBody AllegraEra where
   mkBasicBlockBody = mkBasicBlockBodyShelley
   txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = shelleyBlockBodyHash
-  numSegComponents = 3
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup

--- a/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Binary/Annotator.hs
+++ b/eras/allegra/impl/testlib/Test/Cardano/Ledger/Allegra/Binary/Annotator.hs
@@ -20,6 +20,7 @@ import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Allegra.TxAuxData
 import Cardano.Ledger.Allegra.TxBody
 import Cardano.Ledger.Binary
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.MemoBytes (decodeMemoized)
 import qualified Data.Sequence.Strict as StrictSeq
@@ -82,3 +83,7 @@ instance Era era => DecCBOR (Timelock era) where
   decCBOR = MkTimelock <$> decodeMemoized decCBOR
 
 deriving newtype instance DecCBOR (Tx TopTx AllegraEra)
+
+instance DecCBOR h => DecCBOR (Block h AllegraEra) where
+  decCBOR =
+    decodeRecordNamed "Block" (const 4) $ Block <$> decCBOR <*> decCBOR

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Version history for `cardano-ledger-alonzo`
 
-## 1.16.0.1
+## 1.16.1.0
 
-*
+* Add `EncCBOR`, `ToCBOR` for `Block`
+* Add `DecCBOR` instances for `Annotator Block`
+
+### `testlib`
+
+* Add `DecCBOR` instance for `Block`
 
 ## 1.16.0.0
 

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -27,6 +27,7 @@ source-repository head
 library
   exposed-modules:
     Cardano.Ledger.Alonzo
+    Cardano.Ledger.Alonzo.Block
     Cardano.Ledger.Alonzo.BlockBody
     Cardano.Ledger.Alonzo.BlockBody.Internal
     Cardano.Ledger.Alonzo.Core

--- a/eras/alonzo/impl/cardano-ledger-alonzo.cabal
+++ b/eras/alonzo/impl/cardano-ledger-alonzo.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-alonzo
-version: 1.16.0.1
+version: 1.16.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -27,7 +27,6 @@ source-repository head
 library
   exposed-modules:
     Cardano.Ledger.Alonzo
-    Cardano.Ledger.Alonzo.Block
     Cardano.Ledger.Alonzo.BlockBody
     Cardano.Ledger.Alonzo.BlockBody.Internal
     Cardano.Ledger.Alonzo.Core
@@ -50,6 +49,7 @@ library
 
   hs-source-dirs: src
   other-modules:
+    Cardano.Ledger.Alonzo.Block
     Cardano.Ledger.Alonzo.Era
     Cardano.Ledger.Alonzo.Forecast
     Cardano.Ledger.Alonzo.Rules.Bbody

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Alonzo (
   mkAlonzoStAnnTx,
 ) where
 
+import Cardano.Ledger.Alonzo.Block ()
 import Cardano.Ledger.Alonzo.BlockBody ()
 import Cardano.Ledger.Alonzo.Core
 import Cardano.Ledger.Alonzo.Era

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Block.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Block.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Alonzo.Block () where
+
+import Cardano.Ledger.Alonzo.BlockBody ()
+import Cardano.Ledger.Alonzo.Era
+import Cardano.Ledger.Alonzo.Tx ()
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (decCBOR),
+  EncCBOR (..),
+  EncCBORGroup (..),
+  decodeRecordNamed,
+  encodeListLen,
+  toPlainEncoding,
+ )
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import Cardano.Ledger.Block (Block (..))
+import Cardano.Ledger.Core
+import Data.Typeable (Typeable)
+
+instance EncCBOR h => EncCBOR (Block h AlonzoEra) where
+  encCBOR (Block h txns) =
+    encodeListLen 5 <> encCBOR h <> encCBORGroup txns
+
+instance (EncCBOR h, Typeable h) => Plain.ToCBOR (Block h AlonzoEra) where
+  toCBOR = toPlainEncoding (eraProtVerLow @AlonzoEra) . encCBOR
+
+instance
+  (DecCBOR (Annotator h), Typeable h) =>
+  DecCBOR (Annotator (Block h AlonzoEra))
+  where
+  decCBOR =
+    decodeRecordNamed "Block" (const 5) $ do
+      header <- decCBOR
+      txns <- decCBOR
+      pure $ Block <$> header <*> txns

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/BlockBody/Internal.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/BlockBody/Internal.hs
@@ -99,7 +99,6 @@ instance EraBlockBody AlonzoEra where
   mkBasicBlockBody = mkBasicBlockBodyAlonzo
   txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = abbHash
-  numSegComponents = 4
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
 
 mkBasicBlockBodyAlonzo ::

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Binary/Annotator.hs
@@ -27,6 +27,7 @@ import Cardano.Ledger.Alonzo.TxAuxData
 import Cardano.Ledger.Alonzo.TxBody
 import Cardano.Ledger.Alonzo.TxWits
 import Cardano.Ledger.Binary
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.Plutus
 import Cardano.Ledger.Shelley.BlockBody (auxDataSeqDecoder)
@@ -355,3 +356,7 @@ instance Era era => DecCBOR (TxDatsRaw era) where
 deriving newtype instance Era era => DecCBOR (TxDats era)
 
 deriving newtype instance DecCBOR (Tx TopTx AlonzoEra)
+
+instance DecCBOR h => DecCBOR (Block h AlonzoEra) where
+  decCBOR =
+    decodeRecordNamed "Block" (const 5) $ Block <$> decCBOR <*> decCBOR

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Version history for `cardano-ledger-babbage`
 
-## 1.14.0.1
+## 1.14.1.0
 
-*
+* Add `EncCBOR`, `ToCBOR` for `Block`
+* Add `DecCBOR` instances for `Annotator Block`
+
+### `testlib`
+
+* Add `DecCBOR` instance for `Block`
 
 ## 1.14.0.0
 

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-babbage
-version: 1.14.0.0
+version: 1.14.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -94,7 +94,7 @@ library
     cardano-ledger-allegra ^>=1.10,
     cardano-ledger-alonzo ^>=1.16,
     cardano-ledger-binary >=1.9,
-    cardano-ledger-core:{cardano-ledger-core, internal} >=1.20,
+    cardano-ledger-core:{cardano-ledger-core, internal} >=1.22,
     cardano-ledger-mary ^>=1.11,
     cardano-ledger-shelley ^>=1.19,
     cardano-strict-containers,

--- a/eras/babbage/impl/cardano-ledger-babbage.cabal
+++ b/eras/babbage/impl/cardano-ledger-babbage.cabal
@@ -96,7 +96,7 @@ library
     cardano-ledger-binary >=1.9,
     cardano-ledger-core:{cardano-ledger-core, internal} >=1.22,
     cardano-ledger-mary ^>=1.11,
-    cardano-ledger-shelley ^>=1.19,
+    cardano-ledger-shelley ^>=1.19.1,
     cardano-strict-containers,
     containers,
     data-default,

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/BlockBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/BlockBody.hs
@@ -1,4 +1,11 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Babbage.BlockBody where
@@ -7,9 +14,21 @@ import Cardano.Ledger.Alonzo.BlockBody
 import Cardano.Ledger.Babbage.Era
 import Cardano.Ledger.Babbage.Tx ()
 import Cardano.Ledger.BaseTypes (ProtVer (..))
-import Cardano.Ledger.Binary (EncCBORGroup (..), serialize')
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (decCBOR),
+  EncCBOR (..),
+  EncCBORGroup (..),
+  decodeRecordNamed,
+  encodeListLen,
+  serialize',
+  toPlainEncoding,
+ )
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Core
 import qualified Data.ByteString as BS
+import Data.Typeable (Typeable)
 
 instance EraBlockBody BabbageEra where
   type BlockBody BabbageEra = AlonzoBlockBody BabbageEra
@@ -17,3 +36,20 @@ instance EraBlockBody BabbageEra where
   txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = alonzoBlockBodyHash
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
+
+instance EncCBOR h => EncCBOR (Block h BabbageEra) where
+  encCBOR (Block h txns) =
+    encodeListLen 5 <> encCBOR h <> encCBORGroup txns
+
+instance (EncCBOR h, Typeable h) => Plain.ToCBOR (Block h BabbageEra) where
+  toCBOR = toPlainEncoding (eraProtVerLow @BabbageEra) . encCBOR
+
+instance
+  (DecCBOR (Annotator h), Typeable h) =>
+  DecCBOR (Annotator (Block h BabbageEra))
+  where
+  decCBOR =
+    decodeRecordNamed "Block" (const 5) $ do
+      header <- decCBOR
+      txns <- decCBOR
+      pure $ Block <$> header <*> txns

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/BlockBody.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/BlockBody.hs
@@ -16,5 +16,4 @@ instance EraBlockBody BabbageEra where
   mkBasicBlockBody = mkBasicBlockBodyAlonzo
   txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = alonzoBlockBodyHash
-  numSegComponents = 4
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Binary/Annotator.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/Binary/Annotator.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -15,8 +16,13 @@ import Cardano.Ledger.Babbage (BabbageEra, Tx (..))
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.TxBody
 import Cardano.Ledger.Binary
+import Cardano.Ledger.Block (Block (..))
 import Test.Cardano.Ledger.Alonzo.Binary.Annotator
 
 deriving newtype instance DecCBOR (TxBody TopTx BabbageEra)
 
 deriving newtype instance DecCBOR (Tx TopTx BabbageEra)
+
+instance DecCBOR h => DecCBOR (Block h BabbageEra) where
+  decCBOR =
+    decodeRecordNamed "Block" (const 5) $ Block <$> decCBOR <*> decCBOR

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Version history for `cardano-ledger-conway`
 
-## 1.23.0.1
+## 1.23.1.0
 
-*
+* Add `EncCBOR`, `ToCBOR` for `Block`
+* Add `DecCBOR` instances for `Annotator Block`
+
+### `testlib`
+
+* Add `DecCBOR` instance for `Block`
 
 ## 1.23.0.0
 

--- a/eras/conway/impl/cardano-ledger-conway.cabal
+++ b/eras/conway/impl/cardano-ledger-conway.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-conway
-version: 1.23.0.1
+version: 1.23.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/BlockBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/BlockBody.hs
@@ -1,15 +1,34 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.BlockBody where
 
 import Cardano.Ledger.Alonzo.BlockBody
 import Cardano.Ledger.BaseTypes (ProtVer (..))
-import Cardano.Ledger.Binary (EncCBORGroup (..), serialize')
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (decCBOR),
+  EncCBOR (..),
+  EncCBORGroup (..),
+  decodeRecordNamed,
+  encodeListLen,
+  serialize',
+  toPlainEncoding,
+ )
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Conway.Tx ()
 import Cardano.Ledger.Core
 import qualified Data.ByteString as BS
+import Data.Typeable (Typeable)
 
 instance EraBlockBody ConwayEra where
   type BlockBody ConwayEra = AlonzoBlockBody ConwayEra
@@ -17,3 +36,20 @@ instance EraBlockBody ConwayEra where
   txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = alonzoBlockBodyHash
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
+
+instance EncCBOR h => EncCBOR (Block h ConwayEra) where
+  encCBOR (Block h txns) =
+    encodeListLen 5 <> encCBOR h <> encCBORGroup txns
+
+instance (EncCBOR h, Typeable h) => Plain.ToCBOR (Block h ConwayEra) where
+  toCBOR = toPlainEncoding (eraProtVerLow @ConwayEra) . encCBOR
+
+instance
+  (DecCBOR (Annotator h), Typeable h) =>
+  DecCBOR (Annotator (Block h ConwayEra))
+  where
+  decCBOR =
+    decodeRecordNamed "Block" (const 5) $ do
+      header <- decCBOR
+      txns <- decCBOR
+      pure $ Block <$> header <*> txns

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/BlockBody.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/BlockBody.hs
@@ -16,5 +16,4 @@ instance EraBlockBody ConwayEra where
   mkBasicBlockBody = mkBasicBlockBodyAlonzo
   txSeqBlockBodyL = txSeqBlockBodyAlonzoL
   hashBlockBody = alonzoBlockBodyHash
-  numSegComponents = 4
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup

--- a/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Annotator.hs
+++ b/eras/conway/impl/testlib/Test/Cardano/Ledger/Conway/Binary/Annotator.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -12,6 +13,7 @@ module Test.Cardano.Ledger.Conway.Binary.Annotator (
 ) where
 
 import Cardano.Ledger.Binary
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Conway (ConwayEra, Tx (..))
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.TxBody
@@ -20,3 +22,7 @@ import Test.Cardano.Ledger.Babbage.Binary.Annotator
 deriving newtype instance DecCBOR (TxBody TopTx ConwayEra)
 
 deriving newtype instance DecCBOR (Tx TopTx ConwayEra)
+
+instance DecCBOR h => DecCBOR (Block h ConwayEra) where
+  decCBOR =
+    decodeRecordNamed "Block" (const 5) $ Block <$> decCBOR <*> decCBOR

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.4.0.0
 
+* Add `EncCBOR`, `ToCBOR` for `Block`
+* Add `DecCBOR` instances for `Annotator Block`
+* Remove `EncCBORGroup` instance for `DijkstraBlockBody`
 * Add the `maxPledgeLeverage` protocol parameter (serializes as `nonnegative_interval / nil`):
   - Add `dppMaxPledgeLeverage` field to `DijkstraPParams`
   - Add `udppMaxPledgeLeverage` field to `UpgradeDijkstraPParams`
@@ -29,6 +32,7 @@
 
 ### testlib
 
+* Add `DecCBOR` instance for `Block`
 * Add `DijkstraEraPParams` as a superclass of `DijkstraEraTest`
 * Add `Test.Cardano.Ledger.Dijkstra.Imp.PoolSpec`
 

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -30,6 +30,7 @@ flag asserts
 library
   exposed-modules:
     Cardano.Ledger.Dijkstra
+    Cardano.Ledger.Dijkstra.Block
     Cardano.Ledger.Dijkstra.BlockBody
     Cardano.Ledger.Dijkstra.BlockBody.Internal
     Cardano.Ledger.Dijkstra.Core

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -117,7 +117,7 @@ library
     cardano-ledger-babbage ^>=1.14,
     cardano-ledger-binary ^>=1.9,
     cardano-ledger-conway ^>=1.23,
-    cardano-ledger-core:{cardano-ledger-core, internal} >=1.22,
+    cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.22,
     cardano-ledger-mary,
     cardano-ledger-shelley,
     cardano-slotting,

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -119,7 +119,7 @@ library
     cardano-ledger-conway ^>=1.23,
     cardano-ledger-core:{cardano-ledger-core, internal} ^>=1.22,
     cardano-ledger-mary,
-    cardano-ledger-shelley,
+    cardano-ledger-shelley ^>=1.19.1,
     cardano-slotting,
     cardano-strict-containers,
     containers,

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -36,6 +36,7 @@ import Cardano.Ledger.BaseTypes (Inject (inject))
 import Cardano.Ledger.Binary (DecCBOR, EncCBOR)
 import Cardano.Ledger.Block (EraBlockHeader)
 import Cardano.Ledger.Conway.Governance (RunConwayRatify)
+import Cardano.Ledger.Dijkstra.Block ()
 import Cardano.Ledger.Dijkstra.BlockBody ()
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Block.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Block.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Dijkstra.Block () where
+
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (decCBOR),
+  EncCBOR (..),
+  decodeRecordNamed,
+  encodeListLen,
+  toPlainEncoding,
+ )
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import Cardano.Ledger.Block (Block (..))
+import Cardano.Ledger.Core (EraBlockBody, eraProtVerLow)
+import Cardano.Ledger.Dijkstra.BlockBody.Internal ()
+import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
+import Data.Typeable (Typeable)
+
+instance EncCBOR h => EncCBOR (Block h DijkstraEra) where
+  encCBOR (Block h body) =
+    encodeListLen 2 <> encCBOR h <> encCBOR body
+
+instance (EncCBOR h, Typeable h) => Plain.ToCBOR (Block h DijkstraEra) where
+  toCBOR = toPlainEncoding (eraProtVerLow @DijkstraEra) . encCBOR
+
+instance
+  (DecCBOR (Annotator h), Typeable h, EraBlockBody DijkstraEra) =>
+  DecCBOR (Annotator (Block h DijkstraEra))
+  where
+  decCBOR =
+    decodeRecordNamed "Block" (const 2) $ do
+      header <- decCBOR
+      body <- decCBOR
+      pure $ Block <$> header <*> body

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -44,7 +44,6 @@ import Cardano.Ledger.Binary (
   Annotator (..),
   DecCBOR (..),
   EncCBOR,
-  EncCBORGroup (..),
   decodeNonEmptySetLikeEnforceNoDuplicates,
   decodeNullMaybe,
   decodeNullStrictMaybe,
@@ -246,19 +245,6 @@ deriving via
     , DecCBOR (Annotator (TxWits era))
     ) =>
     DecCBOR (Annotator (DijkstraBlockBody era))
-
-instance (AlonzoEraTx era, EncCBOR (Tx TopTx era)) => EncCBORGroup (DijkstraBlockBody era) where
-  encCBORGroup (DijkstraBlockBody txs mbLeiosCert mbPerasCert) = do
-    encodeListLen 4
-      <> encodeNullMaybe encCBOR invalidIndices
-      <> encCBOR txs
-      <> encodeNullStrictMaybe encCBOR mbLeiosCert
-      <> encodeNullStrictMaybe encCBOR mbPerasCert
-    where
-      invalidIndices =
-        NonEmptySet.fromFoldable $
-          StrictSeq.findIndicesL (\tx -> tx ^. isPhase2ValidTxL == Phase2Invalid) txs
-  listLen _ = 1
 
 --------------------------------------------------------------------------------
 -- Internal utility functions

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/BlockBody/Internal.hs
@@ -119,7 +119,6 @@ instance EraBlockBody DijkstraEra where
   mkBasicBlockBody = mkBasicBlockBodyDijkstra
   txSeqBlockBodyL = lensMemoRawType @DijkstraEra dbbrTxs (\bb p -> bb {dbbrTxs = p})
   hashBlockBody (MkDijkstraBlockBody m) = extractHash $ getMemoBytesHash m
-  numSegComponents = 1
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBOR
 
 mkBasicBlockBodyDijkstra :: forall era. AlonzoEraTx era => DijkstraBlockBody era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Binary/Annotator.hs
@@ -19,6 +19,7 @@ import Cardano.Base.Typeable (TypeName (TypeName))
 import Cardano.Ledger.Allegra.Scripts (invalidBeforeL, invalidHereAfterL)
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Coin (decodePositiveCoin)
 import Cardano.Ledger.Conway.Governance (VotingProcedures (..))
 import Cardano.Ledger.Dijkstra (DijkstraEra)
@@ -264,3 +265,7 @@ instance DecCBOR (DijkstraBlockBodyRaw DijkstraEra) where
 
 instance DecCBOR (DijkstraBlockBody DijkstraEra) where
   decCBOR = MkDijkstraBlockBody <$> decodeMemoized decCBOR
+
+instance DecCBOR h => DecCBOR (Block h DijkstraEra) where
+  decCBOR =
+    decodeRecordNamed "Block" (const 2) $ Block <$> decCBOR <*> decCBOR

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Version history for `cardano-ledger-mary`
 
-## 1.11.0.1
+## 1.11.1.0
 
-*
+* Add `EncCBOR`, `ToCBOR` for `Block`
+* Add `DecCBOR` instances for `Annotator Block`
+
+### `testlib`
+
+* Add `DecCBOR` instance for `Block`
 
 ## 1.11.0.0
 

--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-mary
-version: 1.11.0.0
+version: 1.11.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK
@@ -88,7 +88,7 @@ library
     cardano-data ^>=1.3,
     cardano-ledger-allegra ^>=1.10,
     cardano-ledger-binary >=1.4,
-    cardano-ledger-core:{cardano-ledger-core, internal} >=1.20,
+    cardano-ledger-core:{cardano-ledger-core, internal} >=1.22,
     cardano-ledger-shelley ^>=1.19,
     cardano-strict-containers,
     containers,

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/BlockBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/BlockBody.hs
@@ -27,5 +27,4 @@ instance EraBlockBody MaryEra where
   mkBasicBlockBody = mkBasicBlockBodyShelley
   txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = shelleyBlockBodyHash
-  numSegComponents = 3
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/BlockBody.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/BlockBody.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -10,8 +12,19 @@
 module Cardano.Ledger.Mary.BlockBody () where
 
 import Cardano.Ledger.BaseTypes (ProtVer (..))
-import Cardano.Ledger.Binary (EncCBORGroup (..), serialize')
-import Cardano.Ledger.Core (EraBlockBody (..))
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (decCBOR),
+  EncCBOR (..),
+  EncCBORGroup (..),
+  decodeRecordNamed,
+  encodeListLen,
+  serialize',
+  toPlainEncoding,
+ )
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import Cardano.Ledger.Block (Block (..))
+import Cardano.Ledger.Core (EraBlockBody (..), eraProtVerLow)
 import Cardano.Ledger.Mary.Era (MaryEra)
 import Cardano.Ledger.Mary.Tx ()
 import Cardano.Ledger.Shelley.BlockBody (
@@ -21,6 +34,7 @@ import Cardano.Ledger.Shelley.BlockBody (
   txSeqBlockBodyShelleyL,
  )
 import qualified Data.ByteString as BS
+import Data.Typeable (Typeable)
 
 instance EraBlockBody MaryEra where
   type BlockBody MaryEra = ShelleyBlockBody MaryEra
@@ -28,3 +42,20 @@ instance EraBlockBody MaryEra where
   txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = shelleyBlockBodyHash
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
+
+instance EncCBOR h => EncCBOR (Block h MaryEra) where
+  encCBOR (Block h txns) =
+    encodeListLen 4 <> encCBOR h <> encCBORGroup txns
+
+instance (EncCBOR h, Typeable h) => Plain.ToCBOR (Block h MaryEra) where
+  toCBOR = toPlainEncoding (eraProtVerLow @MaryEra) . encCBOR
+
+instance
+  (DecCBOR (Annotator h), Typeable h) =>
+  DecCBOR (Annotator (Block h MaryEra))
+  where
+  decCBOR =
+    decodeRecordNamed "Block" (const 4) $ do
+      header <- decCBOR
+      txns <- decCBOR
+      pure $ Block <$> header <*> txns

--- a/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Binary/Annotator.hs
+++ b/eras/mary/impl/testlib/Test/Cardano/Ledger/Mary/Binary/Annotator.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -9,6 +10,7 @@ module Test.Cardano.Ledger.Mary.Binary.Annotator (
 ) where
 
 import Cardano.Ledger.Binary
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Core (TxLevel (..))
 import Cardano.Ledger.Mary (MaryEra, Tx (..))
 import Cardano.Ledger.Mary.TxBody
@@ -17,3 +19,7 @@ import Test.Cardano.Ledger.Allegra.Binary.Annotator
 deriving newtype instance DecCBOR (TxBody TopTx MaryEra)
 
 deriving newtype instance DecCBOR (Tx TopTx MaryEra)
+
+instance DecCBOR h => DecCBOR (Block h MaryEra) where
+  decCBOR =
+    decodeRecordNamed "Block" (const 4) $ Block <$> decCBOR <*> decCBOR

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## 1.19.1.0
 
+* Add `EncCBOR`, `ToCBOR` for `Block`
+* Add `DecCBOR` instances for `Annotator Block`
 * Cap the reward pot of an over-leveraged stake pool in `mkPoolRewardInfo`, whenever the
   maximum pledge leverage is set in the protocol parameters
 
 ### `testlib`
 
+* Add `DecCBOR` instance for `Block`
 * Add `registerPoolWithParams`, which registers a stake pool with adjusted parameters
 
 ## 1.19.0.0

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -34,6 +34,7 @@ library
     Cardano.Ledger.Shelley.API.Validation
     Cardano.Ledger.Shelley.API.Wallet
     Cardano.Ledger.Shelley.AdaPots
+    Cardano.Ledger.Shelley.Block
     Cardano.Ledger.Shelley.BlockBody
     Cardano.Ledger.Shelley.BlockBody.Internal
     Cardano.Ledger.Shelley.Core

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -34,7 +34,6 @@ library
     Cardano.Ledger.Shelley.API.Validation
     Cardano.Ledger.Shelley.API.Wallet
     Cardano.Ledger.Shelley.AdaPots
-    Cardano.Ledger.Shelley.Block
     Cardano.Ledger.Shelley.BlockBody
     Cardano.Ledger.Shelley.BlockBody.Internal
     Cardano.Ledger.Shelley.Core
@@ -65,6 +64,7 @@ library
 
   hs-source-dirs: src
   other-modules:
+    Cardano.Ledger.Shelley.Block
     Cardano.Ledger.Shelley.Era
     Cardano.Ledger.Shelley.Forecast
     Cardano.Ledger.Shelley.LedgerState.IncrementalStake

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley.hs
@@ -23,6 +23,7 @@ module Cardano.Ledger.Shelley (
   sfExtraEntropyL,
 ) where
 
+import Cardano.Ledger.Shelley.Block ()
 import Cardano.Ledger.Shelley.BlockBody ()
 import Cardano.Ledger.Shelley.Era (
   ShelleyEra,

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Block.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Block.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Cardano.Ledger.Shelley.Block () where
+
+import Cardano.Ledger.Binary (
+  Annotator,
+  DecCBOR (decCBOR),
+  EncCBOR (..),
+  EncCBORGroup (..),
+  decodeRecordNamed,
+  encodeListLen,
+  toPlainEncoding,
+ )
+import qualified Cardano.Ledger.Binary.Plain as Plain
+import Cardano.Ledger.Block (Block (..))
+import Cardano.Ledger.Core
+import Cardano.Ledger.Shelley.BlockBody ()
+import Cardano.Ledger.Shelley.Era
+import Cardano.Ledger.Shelley.Tx ()
+import Data.Typeable (Typeable)
+
+instance EncCBOR h => EncCBOR (Block h ShelleyEra) where
+  encCBOR (Block h txns) =
+    encodeListLen 4 <> encCBOR h <> encCBORGroup txns
+
+instance (EncCBOR h, Typeable h) => Plain.ToCBOR (Block h ShelleyEra) where
+  toCBOR = toPlainEncoding (eraProtVerLow @ShelleyEra) . encCBOR
+
+instance
+  (DecCBOR (Annotator h), Typeable h) =>
+  DecCBOR (Annotator (Block h ShelleyEra))
+  where
+  decCBOR =
+    decodeRecordNamed "Block" (const 4) $ do
+      header <- decCBOR
+      txns <- decCBOR
+      pure $ Block <$> header <*> txns

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody/Internal.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/BlockBody/Internal.hs
@@ -108,7 +108,6 @@ instance EraBlockBody ShelleyEra where
   mkBasicBlockBody = mkBasicBlockBodyShelley
   txSeqBlockBodyL = txSeqBlockBodyShelleyL
   hashBlockBody = sbbHash
-  numSegComponents = 3
   blockBodySize (ProtVer v _) = BS.length . serialize' v . encCBORGroup
 
 mkBasicBlockBodyShelley ::

--- a/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Annotator.hs
+++ b/eras/shelley/impl/testlib/Test/Cardano/Ledger/Shelley/Binary/Annotator.hs
@@ -18,6 +18,7 @@ module Test.Cardano.Ledger.Shelley.Binary.Annotator (
 import Cardano.Base.Typeable (TypeName (TypeName))
 import Cardano.Ledger.BaseTypes (maybeToStrictMaybe)
 import Cardano.Ledger.Binary
+import Cardano.Ledger.Block (Block (..))
 import Cardano.Ledger.Core
 import Cardano.Ledger.MemoBytes (decodeMemoized)
 import Cardano.Ledger.Shelley (ShelleyEra)
@@ -126,3 +127,7 @@ instance Era era => DecCBOR (MultiSigRaw era) where
       2 -> (,) 2 . MultiSigAnyOf <$> decCBOR
       3 -> (,) 3 <$> (MultiSigMOf <$> decCBOR <*> decCBOR)
       k -> invalidKey k
+
+instance DecCBOR h => DecCBOR (Block h ShelleyEra) where
+  decCBOR =
+    decodeRecordNamed "Block" (const 4) $ Block <$> decCBOR <*> decCBOR

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/PropertyTests.hs
@@ -13,7 +13,6 @@ module Test.Cardano.Ledger.Shelley.PropertyTests (
 ) where
 
 import Cardano.Ledger.BaseTypes (Globals, ShelleyBase, SlotNo)
-import Cardano.Ledger.Binary (EncCBORGroup)
 import Cardano.Ledger.Block (BbodySignal)
 import Cardano.Ledger.Core
 import Cardano.Ledger.Shelley.API (ApplyBlock, ShelleyEraForecast)
@@ -100,7 +99,6 @@ commonTests ::
   , EraRule "POOL" era ~ POOL era
   , InjectRuleFailure "POOL" ShelleyPoolPredFailure era
   , InjectRuleEvent "POOL" PoolEvent era
-  , EncCBORGroup (BlockBody era)
   ) =>
   [TestTree]
 commonTests =

--- a/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
+++ b/eras/shelley/test-suite/src/Test/Cardano/Ledger/Shelley/Rules/Chain.hs
@@ -33,7 +33,6 @@ import Cardano.Ledger.BaseTypes (
   ShelleyBase,
   StrictMaybe (..),
  )
-import Cardano.Ledger.Binary (EncCBORGroup)
 import Cardano.Ledger.Block (BbodySignal (..), Block (..), EraBlockHeader)
 import Cardano.Ledger.Chain (
   ChainPredicateFailure (..),
@@ -252,7 +251,6 @@ instance
   , State (EraRule "TICK" era) ~ NewEpochState era
   , Signal (EraRule "TICK" era) ~ SlotNo
   , Embed (PRTCL MockCrypto) (CHAIN era)
-  , EncCBORGroup (BlockBody era)
   , AtMostEra "Alonzo" era
   , State (EraRule "LEDGERS" era) ~ LedgerState era
   , EraCertState era

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 1.22.0.0
 
+* Remove `numSegComponents` from `EraBlockBody`
+* Remove generic `EncCBOR`, `ToCBOR`, and `DecCBOR` instances for `Block` in favor of per-era instances
 * Add `ToPlutusData` instance for `StrictMaybe`
 * Add `MaxPledgeLeverage`, the maximum pledge leverage introduced in CIP-50
 * Add `ppMaxPledgeLeverageG` method to `EraPParams`, which defaults to `MaxPledgeLeverage SNothing` for eras up to Conway
@@ -121,6 +123,7 @@
 
 ### `testlib`
 
+* Remove generic `DecCBOR` instance for `Block`
 * Add `EraRulesWithFailures` type family to `EraTest`
 * Remove `roundTripAllPredicateFailures`, `EraRuleProof` and `RuleListEra`
 * Add `examplePParams` and `examplePParamsUpdate` to `EraTest`.

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Block.hs
@@ -26,18 +26,7 @@ module Cardano.Ledger.Block (
   neededTxInsForBlock,
 ) where
 
-import Cardano.Base.Proxy (asProxy)
 import Cardano.Ledger.BaseTypes (ProtVer)
-import Cardano.Ledger.Binary (
-  Annotator,
-  DecCBOR (decCBOR),
-  EncCBOR (..),
-  EncCBORGroup (..),
-  decodeRecordNamed,
-  encodeListLen,
-  toPlainEncoding,
- )
-import qualified Cardano.Ledger.Binary.Plain as Plain
 import Cardano.Ledger.Core
 import Cardano.Ledger.TxIn (TxIn (..))
 import Cardano.Slotting.Slot (SlotNo)
@@ -45,7 +34,6 @@ import Control.DeepSeq (NFData)
 import Data.Foldable (toList)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Data.Typeable (Typeable)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', SimpleGetter, (^.))
@@ -73,42 +61,6 @@ deriving anyclass instance
   NoThunks (Block h era)
 
 instance (NFData h, NFData (BlockBody era)) => NFData (Block h era)
-
-instance
-  forall era h.
-  ( Era era
-  , EncCBORGroup (BlockBody era)
-  , EncCBOR h
-  ) =>
-  EncCBOR (Block h era)
-  where
-  encCBOR (Block h txns) =
-    encodeListLen (1 + listLen (asProxy txns)) <> encCBOR h <> encCBORGroup txns
-
-instance
-  forall era h.
-  ( Era era
-  , EncCBORGroup (BlockBody era)
-  , EncCBOR h
-  , Typeable h
-  ) =>
-  Plain.ToCBOR (Block h era)
-  where
-  toCBOR = toPlainEncoding (eraProtVerLow @era) . encCBOR
-
-instance
-  ( EraBlockBody era
-  , DecCBOR (Annotator h)
-  , Typeable h
-  ) =>
-  DecCBOR (Annotator (Block h era))
-  where
-  decCBOR = decodeRecordNamed "Block" (const blockSize) $ do
-    header <- decCBOR
-    txns <- decCBOR
-    pure $ Block <$> header <*> txns
-    where
-      blockSize = 1 + fromIntegral (numSegComponents @era)
 
 bheader ::
   Block h era ->

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -653,9 +653,6 @@ class
   -- Merkle tree.
   hashBlockBody :: BlockBody era -> Hash.Hash HASH EraIndependentBlockBody
 
-  -- | The number of segregated components
-  numSegComponents :: Word64
-
   blockBodySize :: ProtVer -> BlockBody era -> Int
   default blockBodySize :: SafeToHash (BlockBody era) => ProtVer -> BlockBody era -> Int
   blockBodySize _ = originalBytesSize

--- a/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/Annotator.hs
+++ b/libs/cardano-ledger-core/testlib/Test/Cardano/Ledger/Core/Binary/Annotator.hs
@@ -15,24 +15,11 @@ module Test.Cardano.Ledger.Core.Binary.Annotator (
 ) where
 
 import Cardano.Ledger.Binary
-import Cardano.Ledger.Block
 import Cardano.Ledger.Core
 import Cardano.Ledger.Plutus
 import Test.Cardano.Ledger.Binary (decoderEquivalenceSpec)
 import Test.Cardano.Ledger.Common
 import Test.Cardano.Ledger.Core.Arbitrary ()
-
-instance
-  ( EraBlockBody era
-  , DecCBOR h
-  , DecCBOR (BlockBody era)
-  ) =>
-  DecCBOR (Block h era)
-  where
-  decCBOR =
-    decodeRecordNamed "Block" (const blockSize) $ Block <$> decCBOR <*> decCBOR
-    where
-      blockSize = 1 + fromIntegral (numSegComponents @era)
 
 decoderEquivalenceEraSpec ::
   forall era t.

--- a/libs/cardano-protocol-tpraos/test/Test/Cardano/Protocol/Binary/BinarySpec.hs
+++ b/libs/cardano-protocol-tpraos/test/Test/Cardano/Protocol/Binary/BinarySpec.hs
@@ -8,7 +8,7 @@ module Test.Cardano.Protocol.Binary.BinarySpec (spec) where
 
 import Cardano.Ledger.Allegra (AllegraEra)
 import Cardano.Ledger.Alonzo (AlonzoEra)
-import Cardano.Ledger.Binary (EncCBORGroup)
+import Cardano.Ledger.Binary (Annotator, DecCBOR, ToCBOR)
 import Cardano.Ledger.Block
 import Cardano.Ledger.Core
 import Cardano.Ledger.Mary (MaryEra)
@@ -39,7 +39,8 @@ blockEraSpec ::
   ( EraBlockBody era
   , Arbitrary (Tx TopTx era)
   , Arbitrary (BlockBody era)
-  , EncCBORGroup (BlockBody era)
+  , ToCBOR (Block (BHeader StandardCrypto) era)
+  , DecCBOR (Annotator (Block (BHeader StandardCrypto) era))
   ) =>
   Spec
 blockEraSpec =

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
@@ -6,7 +6,7 @@
 
 module Test.Cardano.Protocol.Binary.RoundTrip (roundTripBlockSpec) where
 
-import Cardano.Ledger.Binary (Annotator, DecCBOR, ToCBOR)
+import Cardano.Ledger.Binary (Annotator, DecCBOR, EncCBOR, ToCBOR)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
 import Data.Typeable
@@ -20,10 +20,10 @@ roundTripBlockSpec ::
   forall h era.
   ( Eq h
   , Show h
-  , DecCBOR h
-  , DecCBOR (Annotator h)
   , EraBlockBody era
   , Arbitrary (Block h era)
+  , EncCBOR (Block h era)
+  , DecCBOR (Block h era)
   , ToCBOR (Block h era)
   , DecCBOR (Annotator (Block h era))
   ) =>
@@ -31,4 +31,7 @@ roundTripBlockSpec ::
 roundTripBlockSpec =
   prop (show (typeRep $ Proxy @(Block h era))) $ do
     BaseQC.withNumTests 3 $
-      roundTripAnnEraExpectation @era @(Block h era)
+      conjoin
+        [ roundTripEraExpectation @era @(Block h era)
+        , roundTripAnnEraExpectation @era @(Block h era)
+        ]

--- a/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
+++ b/libs/cardano-protocol-tpraos/testlib/Test/Cardano/Protocol/Binary/RoundTrip.hs
@@ -6,13 +6,12 @@
 
 module Test.Cardano.Protocol.Binary.RoundTrip (roundTripBlockSpec) where
 
-import Cardano.Ledger.Binary (Annotator, DecCBOR, EncCBOR, EncCBORGroup)
+import Cardano.Ledger.Binary (Annotator, DecCBOR, ToCBOR)
 import Cardano.Ledger.Block (Block)
 import Cardano.Ledger.Core
 import Data.Typeable
 import qualified Test.Cardano.Base.QuickCheck as BaseQC
 import Test.Cardano.Ledger.Common
-import Test.Cardano.Ledger.Core.Binary.Annotator ()
 import Test.Cardano.Ledger.Core.Binary.RoundTrip
 import Test.Cardano.Protocol.Binary.Annotator ()
 import Test.Cardano.Protocol.TPraos.Arbitrary ()
@@ -23,17 +22,13 @@ roundTripBlockSpec ::
   , Show h
   , DecCBOR h
   , DecCBOR (Annotator h)
-  , EncCBOR h
   , EraBlockBody era
   , Arbitrary (Block h era)
-  , DecCBOR (BlockBody era)
-  , EncCBORGroup (BlockBody era)
+  , ToCBOR (Block h era)
+  , DecCBOR (Annotator (Block h era))
   ) =>
   Spec
 roundTripBlockSpec =
   prop (show (typeRep $ Proxy @(Block h era))) $ do
-    BaseQC.withNumTests 3 $ do
-      conjoin
-        [ roundTripEraExpectation @era @(Block h era)
-        , roundTripAnnEraExpectation @era @(Block h era)
-        ]
+    BaseQC.withNumTests 3 $
+      roundTripAnnEraExpectation @era @(Block h era)


### PR DESCRIPTION
# Description
Resolves #5937
<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [x] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [x] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
