### PR TITLE
Reuse script cache for script validation

### DIFF
--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/Tx.hs
@@ -47,7 +47,7 @@ import Control.DeepSeq (NFData)
 import qualified Data.Set as Set (map)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
-import Lens.Micro (Lens', lens, (^.))
+import Lens.Micro (Lens', lens, to, (^.))
 import NoThunks.Class (NoThunks)
 
 -- ========================================
@@ -59,7 +59,11 @@ instance EraTx AllegraEra where
 
   type StAnnTx l AllegraEra = Tx l AllegraEra
 
+  type StAnnTxCache AllegraEra = ()
+
   txStAnnTxG = id
+
+  cacheStAnnTxG = to (const ())
 
   mkBasicTx = MkAllegraTx . mkBasicShelleyTx
 

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/TxAuxData.hs
@@ -101,7 +101,7 @@ instance EraTxAuxData AllegraEra where
 
   metadataTxAuxDataL = metadataAllegraTxAuxDataL
 
-  validateTxAuxData _ (AllegraTxAuxData _ as) = as `deepseq` True
+  validateTxAuxData _ _ (AllegraTxAuxData _ as) = as `deepseq` True
 
 metadataAllegraTxAuxDataL ::
   forall era.

--- a/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
+++ b/eras/allegra/impl/src/Cardano/Ledger/Allegra/UTxO.hs
@@ -22,7 +22,6 @@ import Lens.Micro
 
 instance EraUTxO AllegraEra where
   type ScriptsNeeded AllegraEra = ShelleyScriptsNeeded AllegraEra
-  type StAnnTxCache AllegraEra = ()
 
   getConsumedValue pp lookupKeyDeposit = getConsumedCoin pp lookupKeyDeposit
 
@@ -37,5 +36,3 @@ instance EraUTxO AllegraEra where
   getWitsVKeyNeeded = getShelleyWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
-
-  getCacheStAnnTx _ = mempty

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.16.0.0
 
+* Rename `validScript` to `isValidScript` and move it to `Cardano.Ledger.Alonzo.TxAuxData`
 * Add `asatPlutusRunnableCache` field to `AlonzoStAnnTx`, holding `Map ScriptHash (SupportedPlutusRunnable era)`
 * Add `SupportedPlutusRunnable` type and add `mkSupportedPlutusRunnable` to `EraPlutusContext`
 * Remove `mkPlutusWithContext` from `EraPlutusContext`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.16.0.0
 
-* Rename `validScript` to `isValidScript` and move it to `Cardano.Ledger.Alonzo.TxAuxData`
+* Rename `validScript` to `isValidScript`, move it to `Cardano.Ledger.Alonzo.TxAuxData` and add two more arguments to it.
 * Add `asatPlutusRunnableCache` field to `AlonzoStAnnTx`, holding `Map ScriptHash (SupportedPlutusRunnable era)`
 * Add `SupportedPlutusRunnable` type and add `mkSupportedPlutusRunnable` to `EraPlutusContext`
 * Remove `mkPlutusWithContext` from `EraPlutusContext`

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledgers.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Ledgers.hs
@@ -130,7 +130,7 @@ alonzoLedgersTransition = do
           newLedgerState <-
             trans @(EraRule "LEDGER" era) $
               TRC (Shelley.LedgerEnv slot (Just epochNo) ix pp account, curLedgerState, stAnnTx)
-          pure (newLedgerState, getCacheStAnnTx stAnnTx)
+          pure (newLedgerState, stAnnTx ^. cacheStAnnTxG)
       )
       (initLedgerState, mempty)
       $ zip [minBound ..]

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs
@@ -361,7 +361,7 @@ alonzoStyleWitness = do
   -- check metadata hash
   {-   adh := txADhash txb;  ad := auxiliaryData tx                      -}
   {-  ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)                          -}
-  runTestOnSignal $ Shelley.validateMetadata pp tx
+  runTestOnSignal $ Shelley.validateMetadata pp stAnnTx
 
   {- languages txw ⊆ dom(costmdls pp)  -}
   -- This check is checked when building the TxInfo using collectTwoPhaseScriptInputs, if it fails

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Scripts.hs
@@ -27,7 +27,6 @@ module Cardano.Ledger.Alonzo.Scripts (
   AlonzoScript (NativeScript, PlutusScript),
   Script,
   isPlutusScript,
-  validScript,
   eqAlonzoScriptRaw,
   AlonzoEraScript (..),
   eraLanguages,
@@ -66,7 +65,7 @@ module Cardano.Ledger.Alonzo.Scripts (
 import Cardano.Ledger.Allegra.Scripts
 import Cardano.Ledger.Alonzo.Era (AlonzoEra)
 import Cardano.Ledger.Alonzo.TxCert ()
-import Cardano.Ledger.BaseTypes (ProtVer (..), invalidKey, kindObjectValue)
+import Cardano.Ledger.BaseTypes (invalidKey, kindObjectValue)
 import Cardano.Ledger.Binary (
   Annotator,
   CBORGroup (..),
@@ -135,7 +134,6 @@ import qualified Data.Text as Text
 import Data.Typeable
 import Data.Word (Word32)
 import GHC.Generics (Generic)
-import GHC.Stack
 import NoThunks.Class (NoThunks (..))
 
 class
@@ -722,18 +720,6 @@ instance AlonzoEraScript era => DecCBOR (Annotator (AlonzoScript era)) where
         n -> invalidKey n
       {-# INLINE decodeAlonzoScript #-}
   {-# INLINE decCBOR #-}
-
--- | Verify that every `Script` represents a valid script. Force native scripts to Normal
--- Form, to ensure that there are no bottoms and deserialize `Plutus` scripts into a
--- `Cardano.Ledger.Plutus.Language.PlutusRunnable`.
-validScript :: (HasCallStack, AlonzoEraScript era) => ProtVer -> Script era -> Bool
-validScript pv script =
-  case toPlutusScript script of
-    Just plutusScript -> isValidPlutusScript (pvMajor pv) plutusScript
-    Nothing ->
-      case getNativeScript script of
-        Just timelockScript -> deepseq timelockScript True
-        Nothing -> error "Impossible: There are only Native and Plutus scripts available"
 
 -- | Check the equality of two underlying types, while ignoring their binary
 -- representation, which `Eq` instance normally does. This is used for testing.

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Tx.hs
@@ -168,7 +168,11 @@ instance EraTx AlonzoEra where
 
   type StAnnTx l AlonzoEra = AlonzoStAnnTx l AlonzoEra
 
+  type StAnnTxCache AlonzoEra = Map.Map ScriptHash (SupportedPlutusRunnable AlonzoEra)
+
   txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
+
+  cacheStAnnTxG = to $ \AlonzoStAnnTx {asatPlutusRunnableCache} -> asatPlutusRunnableCache
 
   mkBasicTx = MkAlonzoTx . mkBasicAlonzoTx
 

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -44,6 +44,7 @@ module Cardano.Ledger.Alonzo.TxAuxData (
   addPlutusScripts,
   decodeTxAuxDataByTokenType,
   emptyAlonzoTxAuxDataRaw,
+  isValidScript,
 
   -- * Deprecated
   atadPlutus,
@@ -56,12 +57,12 @@ import Cardano.Ledger.Alonzo.Era
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (..),
   AlonzoScript (..),
+  isValidPlutusScript,
   mkBinaryPlutusScript,
   plutusScriptBinary,
   plutusScriptLanguage,
-  validScript,
  )
-import Cardano.Ledger.BaseTypes (ProtVer)
+import Cardano.Ledger.BaseTypes (ProtVer (..))
 import Cardano.Ledger.Binary (
   Annotator,
   DecCBOR (..),
@@ -354,7 +355,7 @@ validateAlonzoTxAuxData ::
   AlonzoTxAuxData era ->
   Bool
 validateAlonzoTxAuxData pv auxData =
-  all (validScript pv) (getAlonzoTxAuxDataScripts auxData)
+  all (isValidScript pv) (getAlonzoTxAuxDataScripts auxData)
 
 instance AllegraEraTxAuxData AlonzoEra where
   nativeScriptsTxAuxDataL = nativeScriptsAlonzoTxAuxDataL
@@ -465,3 +466,15 @@ atadPlutus (MkAlonzoTxAuxData (Memo raw _)) = atadrPlutusScripts raw
 atadPlutus' :: AlonzoTxAuxData era -> Map Language (NE.NonEmpty PlutusBinary)
 atadPlutus' (MkAlonzoTxAuxData (Memo raw _)) = atadrPlutusScripts raw
 {-# DEPRECATED atadPlutus' "In favor of `atadPlutusScripts'`" #-}
+
+-- | Verify that every `Script` represents a valid script. Force native scripts to Normal
+-- Form, to ensure that there are no bottoms and deserialize `Plutus` scripts into a
+-- `Cardano.Ledger.Plutus.Language.PlutusRunnable`.
+isValidScript :: (HasCallStack, AlonzoEraScript era) => ProtVer -> Script era -> Bool
+isValidScript pv script =
+  case toPlutusScript script of
+    Just plutusScript -> isValidPlutusScript (pvMajor pv) plutusScript
+    Nothing ->
+      case getNativeScript script of
+        Just timelockScript -> deepseq timelockScript True
+        Nothing -> error "Impossible: There are only Native and Plutus scripts available"

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxAuxData.hs
@@ -54,6 +54,7 @@ module Cardano.Ledger.Alonzo.TxAuxData (
 import Cardano.Base.Typeable (TypeName (TypeName))
 import Cardano.Ledger.Allegra.TxAuxData (AllegraEraTxAuxData (..))
 import Cardano.Ledger.Alonzo.Era
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable (..))
 import Cardano.Ledger.Alonzo.Scripts (
   AlonzoEraScript (..),
   AlonzoScript (..),
@@ -90,7 +91,12 @@ import Cardano.Ledger.MemoBytes (
   lensMemoRawType,
   mkMemoizedEra,
  )
-import Cardano.Ledger.Plutus.Language (Language (..), PlutusBinary (..), guardPlutus)
+import Cardano.Ledger.Plutus.Language (
+  Language (..),
+  PlutusBinary (..),
+  guardPlutus,
+  isValidPlutusRunnable,
+ )
 import Cardano.Ledger.Shelley.TxAuxData (Metadatum)
 import Control.DeepSeq (NFData, deepseq)
 import Control.Monad (forM)
@@ -100,7 +106,9 @@ import Data.List (intercalate)
 import qualified Data.List.NonEmpty as NE
 import Data.Map (Map)
 import qualified Data.Map.Strict as Map
+import Data.MapExtras as Map (fromElems)
 import Data.Maybe (isNothing, mapMaybe)
+import Data.Semigroup (All (..))
 import Data.Sequence.Strict (StrictSeq ((:<|)))
 import qualified Data.Sequence.Strict as StrictSeq
 import Data.Typeable (Typeable)
@@ -333,7 +341,10 @@ deriving via
 
 instance Eq (NativeScript era) => EqRaw (AlonzoTxAuxData era)
 
-instance EraTxAuxData AlonzoEra where
+instance
+  StAnnTxCache AlonzoEra ~ Map ScriptHash (SupportedPlutusRunnable AlonzoEra) =>
+  EraTxAuxData AlonzoEra
+  where
   type TxAuxData AlonzoEra = AlonzoTxAuxData AlonzoEra
 
   mkBasicTxAuxData = AlonzoTxAuxData mempty mempty mempty
@@ -351,13 +362,20 @@ metadataAlonzoTxAuxDataL =
 
 validateAlonzoTxAuxData ::
   (AlonzoEraScript era, Script era ~ AlonzoScript era) =>
+  Map ScriptHash (SupportedPlutusRunnable era) ->
   ProtVer ->
   AlonzoTxAuxData era ->
   Bool
-validateAlonzoTxAuxData pv auxData =
-  all (isValidScript pv) (getAlonzoTxAuxDataScripts auxData)
+validateAlonzoTxAuxData plutusScriptsCache pv auxData =
+  getAll $
+    Map.foldMapWithKey (\scriptHash -> All . isValidScript plutusScriptsCache pv scriptHash) $
+      Map.fromElems hashScript $
+        getAlonzoTxAuxDataScripts auxData
 
-instance AllegraEraTxAuxData AlonzoEra where
+instance
+  StAnnTxCache AlonzoEra ~ Map ScriptHash (SupportedPlutusRunnable AlonzoEra) =>
+  AllegraEraTxAuxData AlonzoEra
+  where
   nativeScriptsTxAuxDataL = nativeScriptsAlonzoTxAuxDataL
 
 nativeScriptsAlonzoTxAuxDataL ::
@@ -367,7 +385,10 @@ nativeScriptsAlonzoTxAuxDataL =
   lensMemoRawType @era atadrNativeScripts $
     \txAuxDataRaw ts -> txAuxDataRaw {atadrNativeScripts = ts}
 
-instance AlonzoEraTxAuxData AlonzoEra where
+instance
+  StAnnTxCache AlonzoEra ~ Map ScriptHash (SupportedPlutusRunnable AlonzoEra) =>
+  AlonzoEraTxAuxData AlonzoEra
+  where
   plutusScriptsTxAuxDataL = plutusScriptsAllegraTxAuxDataL
 
 plutusScriptsAllegraTxAuxDataL ::
@@ -470,10 +491,24 @@ atadPlutus' (MkAlonzoTxAuxData (Memo raw _)) = atadrPlutusScripts raw
 -- | Verify that every `Script` represents a valid script. Force native scripts to Normal
 -- Form, to ensure that there are no bottoms and deserialize `Plutus` scripts into a
 -- `Cardano.Ledger.Plutus.Language.PlutusRunnable`.
-isValidScript :: (HasCallStack, AlonzoEraScript era) => ProtVer -> Script era -> Bool
-isValidScript pv script =
+isValidScript ::
+  (HasCallStack, AlonzoEraScript era) =>
+  -- | Decoded plutus scripts cache, that can be utilized to avoid redundant deserialization of
+  -- plutus scripts for the sole purpose of their validation
+  Map ScriptHash (SupportedPlutusRunnable era) ->
+  -- | Protocol version to be used by the Plutus decoder
+  ProtVer ->
+  -- | It is important that the hash is of the supplied script to be validated
+  ScriptHash ->
+  -- | Script to be validated
+  Script era ->
+  Bool
+isValidScript plutusScriptsCache pv scriptHash script =
   case toPlutusScript script of
-    Just plutusScript -> isValidPlutusScript (pvMajor pv) plutusScript
+    Just plutusScript ->
+      case Map.lookup scriptHash plutusScriptsCache of
+        Just (SupportedPlutusRunnable plutusRunnable) -> isValidPlutusRunnable plutusRunnable
+        Nothing -> isValidPlutusScript (pvMajor pv) plutusScript
     Nothing ->
       case getNativeScript script of
         Just timelockScript -> deepseq timelockScript True

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -111,7 +111,6 @@ deriving instance AlonzoEraScript era => NFData (AlonzoScriptsNeeded era)
 
 instance EraUTxO AlonzoEra where
   type ScriptsNeeded AlonzoEra = AlonzoScriptsNeeded AlonzoEra
-  type StAnnTxCache AlonzoEra = Map.Map ScriptHash (SupportedPlutusRunnable AlonzoEra)
 
   getConsumedValue = getConsumedMaryValue
 
@@ -126,8 +125,6 @@ instance EraUTxO AlonzoEra where
   getWitsVKeyNeeded = getAlonzoWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
-
-  getCacheStAnnTx = asatPlutusRunnableCache
 
 class EraUTxO era => AlonzoEraUTxO era where
   -- | Get data hashes for a transaction that are not required. Such datums are optional,

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.14.0.0
 
+* `validateScriptsWellFormed` / `validateScriptsWellFormedTxOuts` gained a cache parameter
 * Introduce `LEDGERS` rule with `STS` and `Embed (LEDGER era) (LEDGERS era)` instances, and wire it to `EraRule "LEDGERS" BabbageEra` (previously `Shelley.LEDGERS`)
 * Export `LEDGERS` from `Cardano.Ledger.Babbage.Era` and `Cardano.Ledger.Babbage.Rules`
 * Add `TranslateEra` instance for `SnapShots`

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledgers.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Ledgers.hs
@@ -134,7 +134,7 @@ ledgersTransition = do
           newLedgerState <-
             trans @(EraRule "LEDGER" era) $
               TRC (Shelley.LedgerEnv slot (Just epochNo) ix pp account, curLedgerState, stAnnTx)
-          pure (newLedgerState, getCacheStAnnTx stAnnTx)
+          pure (newLedgerState, stAnnTx ^. cacheStAnnTxG)
       )
       (initLedgerState, mempty)
       $ zip [minBound ..]

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -376,7 +376,7 @@ babbageUtxowTransition = do
   {- ∀x ∈ range(txdats txw) ∪ range(txwitscripts txw) ∪ (⋃ ( , ,d,s) ∈ txouts tx {s, d}),
                          x ∈ Script ∪ Datum ⇒ isWellFormed x
   -}
-  runTest $ validateScriptsWellFormed pp stAnnTx
+  runTestOnSignal $ validateScriptsWellFormed pp stAnnTx
   -- Note that Datum validation is done during deserialization,
   -- as given by the decoders in the Plutus library
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Babbage.Rules.Utxow (
 ) where
 
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable (..))
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.TxAuxData (isValidScript)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..), AlonzoScriptsNeeded)
@@ -64,6 +65,7 @@ import Control.State.Transition.Extended (
 import Data.ByteString (ByteString)
 import Data.Foldable (sequenceA_, toList)
 import qualified Data.Map.Strict as Map
+import Data.MapExtras as Map (fromElems)
 import Data.Maybe (mapMaybe)
 import Data.Maybe.Strict (StrictMaybe (..))
 import qualified Data.Sequence.Strict as StrictSeq (singleton)
@@ -233,16 +235,19 @@ validateScriptsWellFormed ::
   forall era.
   ( EraTx era
   , BabbageEraTxBody era
+  , StAnnTxCache era ~ Map.Map ScriptHash (SupportedPlutusRunnable era)
   ) =>
   PParams era ->
-  Tx TopTx era ->
+  StAnnTx TopTx era ->
   Test (BabbageUtxowPredFailure era)
-validateScriptsWellFormed pp tx =
+validateScriptsWellFormed pp stAnnTx =
   validateScriptsWellFormedTxOuts
+    (stAnnTx ^. cacheStAnnTxG)
     pp
     (tx ^. witsTxL . scriptTxWitsL)
     (normalOuts <> foldMap StrictSeq.singleton returnOut)
   where
+    tx = stAnnTx ^. txStAnnTxG
     normalOuts = tx ^. bodyTxL . outputsTxBodyL
     returnOut = tx ^. bodyTxL . collateralReturnTxBodyL
 
@@ -251,20 +256,24 @@ validateScriptsWellFormedTxOuts ::
   ( BabbageEraTxOut era
   , Foldable f
   ) =>
+  Map.Map ScriptHash (SupportedPlutusRunnable era) ->
   PParams era ->
   Map.Map ScriptHash (Script era) ->
   f (TxOut era) ->
   Test (BabbageUtxowPredFailure era)
-validateScriptsWellFormedTxOuts pp scriptWits txOuts =
+validateScriptsWellFormedTxOuts plutusScriptsCache pp witScripts txOuts =
   sequenceA_
-    [ failureOnNonEmptySet (Map.keysSet invalidScriptWits) MalformedScriptWitnesses
-    , failureOnNonEmptySet invalidRefScriptHashes MalformedReferenceScripts
+    [ failureOnNonEmptySet (filterInvalidScripts witScripts) MalformedScriptWitnesses
+    , failureOnNonEmptySet (filterInvalidScripts refScripts) MalformedReferenceScripts
     ]
   where
-    invalidScriptWits = Map.filter (not . isValidScript (pp ^. ppProtocolVersionL)) scriptWits
-    rScripts = mapMaybe (strictMaybeToMaybe . view referenceScriptTxOutL) (toList txOuts)
-    invalidRefScripts = filter (not . isValidScript (pp ^. ppProtocolVersionL)) rScripts
-    invalidRefScriptHashes = Set.fromList $ map (hashScript @era) invalidRefScripts
+    filterInvalidScripts =
+      Map.keysSet
+        . Map.filterWithKey
+          (\scriptHash -> not . isValidScript plutusScriptsCache (pp ^. ppProtocolVersionL) scriptHash)
+    refScripts =
+      Map.fromElems hashScript $
+        mapMaybe (strictMaybeToMaybe . view referenceScriptTxOutL) (toList txOuts)
 
 -- ==============================================================
 -- Here we define the transition function, using reusable tests.
@@ -300,8 +309,9 @@ babbageUtxowTransition ::
   forall era.
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , BabbageEraTxBody era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , StAnnTxCache era ~ Map.Map ScriptHash (SupportedPlutusRunnable era)
   , Environment (EraRule "UTXOW" era) ~ Shelley.UtxoEnv era
   , Signal (EraRule "UTXOW" era) ~ StAnnTx TopTx era
   , State (EraRule "UTXOW" era) ~ UTxOState era
@@ -361,12 +371,12 @@ babbageUtxowTransition = do
   -- check metadata hash
   {-   adh := txADhash txb;  ad := auxiliaryData tx                      -}
   {-  ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)                          -}
-  runTestOnSignal $ Shelley.validateMetadata pp tx
+  runTestOnSignal $ Shelley.validateMetadata pp stAnnTx
 
   {- ∀x ∈ range(txdats txw) ∪ range(txwitscripts txw) ∪ (⋃ ( , ,d,s) ∈ txouts tx {s, d}),
                          x ∈ Script ∪ Datum ⇒ isWellFormed x
   -}
-  runTest $ validateScriptsWellFormed pp tx
+  runTest $ validateScriptsWellFormed pp stAnnTx
   -- Note that Datum validation is done during deserialization,
   -- as given by the decoders in the Plutus library
 
@@ -388,6 +398,7 @@ instance
   , AlonzoEraUTxO era
   , ShelleyEraTxBody era
   , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , StAnnTxCache era ~ Map.Map ScriptHash (SupportedPlutusRunnable era)
   , BabbageEraTxBody era
   , EraRule "UTXOW" era ~ UTXOW era
   , InjectRuleFailure "UTXOW" Shelley.ShelleyUtxowPredFailure era

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Rules/Utxow.hs
@@ -26,7 +26,7 @@ module Cardano.Ledger.Babbage.Rules.Utxow (
 
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
-import Cardano.Ledger.Alonzo.Scripts (validScript)
+import Cardano.Ledger.Alonzo.TxAuxData (isValidScript)
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..), AlonzoScriptsNeeded)
 import Cardano.Ledger.Babbage.Core
 import Cardano.Ledger.Babbage.Era (BabbageEra, UTXOW)
@@ -261,9 +261,9 @@ validateScriptsWellFormedTxOuts pp scriptWits txOuts =
     , failureOnNonEmptySet invalidRefScriptHashes MalformedReferenceScripts
     ]
   where
-    invalidScriptWits = Map.filter (not . validScript (pp ^. ppProtocolVersionL)) scriptWits
+    invalidScriptWits = Map.filter (not . isValidScript (pp ^. ppProtocolVersionL)) scriptWits
     rScripts = mapMaybe (strictMaybeToMaybe . view referenceScriptTxOutL) (toList txOuts)
-    invalidRefScripts = filter (not . validScript (pp ^. ppProtocolVersionL)) rScripts
+    invalidRefScripts = filter (not . isValidScript (pp ^. ppProtocolVersionL)) rScripts
     invalidRefScriptHashes = Set.fromList $ map (hashScript @era) invalidRefScripts
 
 -- ==============================================================

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/Tx.hs
@@ -17,6 +17,7 @@ module Cardano.Ledger.Babbage.Tx (
 ) where
 
 import Cardano.Ledger.Allegra.Tx (validateTimelock)
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable)
 import Cardano.Ledger.Alonzo.Tx as X
 import Cardano.Ledger.Babbage.Era (BabbageEra)
 import Cardano.Ledger.Babbage.TxAuxData ()
@@ -26,6 +27,7 @@ import Cardano.Ledger.Binary (Annotator, DecCBOR (..), EncCBOR, ToCBOR)
 import Cardano.Ledger.Core
 import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Control.DeepSeq (NFData)
+import qualified Data.Map.Strict as Map
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
 import Lens.Micro (Lens', lens, to)
@@ -41,7 +43,11 @@ instance EraTx BabbageEra where
 
   type StAnnTx l BabbageEra = AlonzoStAnnTx l BabbageEra
 
+  type StAnnTxCache BabbageEra = Map.Map ScriptHash (SupportedPlutusRunnable BabbageEra)
+
   txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
+
+  cacheStAnnTxG = to $ \AlonzoStAnnTx {asatPlutusRunnableCache} -> asatPlutusRunnableCache
 
   mkBasicTx = MkBabbageTx . mkBasicAlonzoTx
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxAuxData.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Babbage.TxAuxData () where
 
 import Cardano.Ledger.Alonzo.Core
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable (..))
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData (..),
   metadataAlonzoTxAuxDataL,
@@ -13,8 +15,12 @@ import Cardano.Ledger.Alonzo.TxAuxData (
  )
 import Cardano.Ledger.Babbage.Era
 import Cardano.Ledger.Babbage.Scripts ()
+import Data.Map (Map)
 
-instance EraTxAuxData BabbageEra where
+instance
+  StAnnTxCache BabbageEra ~ Map ScriptHash (SupportedPlutusRunnable BabbageEra) =>
+  EraTxAuxData BabbageEra
+  where
   type TxAuxData BabbageEra = AlonzoTxAuxData BabbageEra
 
   mkBasicTxAuxData = AlonzoTxAuxData mempty mempty mempty
@@ -22,8 +28,14 @@ instance EraTxAuxData BabbageEra where
   metadataTxAuxDataL = metadataAlonzoTxAuxDataL
   validateTxAuxData = validateAlonzoTxAuxData
 
-instance AllegraEraTxAuxData BabbageEra where
+instance
+  StAnnTxCache BabbageEra ~ Map ScriptHash (SupportedPlutusRunnable BabbageEra) =>
+  AllegraEraTxAuxData BabbageEra
+  where
   nativeScriptsTxAuxDataL = nativeScriptsAlonzoTxAuxDataL
 
-instance AlonzoEraTxAuxData BabbageEra where
+instance
+  StAnnTxCache BabbageEra ~ Map ScriptHash (SupportedPlutusRunnable BabbageEra) =>
+  AlonzoEraTxAuxData BabbageEra
+  where
   plutusScriptsTxAuxDataL = plutusScriptsAllegraTxAuxDataL

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/UTxO.hs
@@ -11,8 +11,6 @@ module Cardano.Ledger.Babbage.UTxO (
   getReferenceScriptsNonDistinct,
 ) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable)
-import Cardano.Ledger.Alonzo.Tx (AlonzoStAnnTx (..))
 import Cardano.Ledger.Alonzo.TxWits (unTxDatsL)
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
@@ -44,7 +42,6 @@ import Lens.Micro
 
 instance EraUTxO BabbageEra where
   type ScriptsNeeded BabbageEra = AlonzoScriptsNeeded BabbageEra
-  type StAnnTxCache BabbageEra = Map.Map ScriptHash (SupportedPlutusRunnable BabbageEra)
 
   getConsumedValue = getConsumedMaryValue
 
@@ -60,8 +57,6 @@ instance EraUTxO BabbageEra where
   getWitsVKeyNeeded = getAlonzoWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
-
-  getCacheStAnnTx = asatPlutusRunnableCache
 
 instance AlonzoEraUTxO BabbageEra where
   getSupplementalDataHashes = getBabbageSupplementalDataHashes

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Utxow.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Conway.Rules.Utxow (
 
 import Cardano.Crypto.Hash (ByteString)
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable (..))
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO, AlonzoScriptsNeeded)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage
@@ -46,6 +47,7 @@ import Control.State.Transition.Extended (
   STS (..),
  )
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
@@ -169,8 +171,9 @@ instance
   forall era.
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , ConwayEraTxBody era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , StAnnTxCache era ~ Map.Map ScriptHash (SupportedPlutusRunnable era)
   , EraRule "UTXOW" era ~ UTXOW era
   , InjectRuleFailure "UTXOW" Shelley.ShelleyUtxowPredFailure era
   , InjectRuleFailure "UTXOW" Alonzo.AlonzoUtxowPredFailure era

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/Tx.hs
@@ -20,6 +20,7 @@ module Cardano.Ledger.Conway.Tx (
 
 import Cardano.Ledger.Allegra.Tx (validateTimelock)
 import Cardano.Ledger.Alonzo.Core
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable)
 import Cardano.Ledger.Alonzo.Tx (
   AlonzoStAnnTx (..),
   alonzoMinFeeTx,
@@ -47,6 +48,7 @@ import Cardano.Ledger.Conway.TxWits ()
 import Cardano.Ledger.MemoBytes (EqRaw (..))
 import Cardano.Ledger.Val (Val (..))
 import Control.DeepSeq (NFData)
+import qualified Data.Map.Strict as Map
 import Data.Typeable (Typeable)
 import Data.Word (Word32)
 import GHC.Generics (Generic)
@@ -64,7 +66,11 @@ instance EraTx ConwayEra where
 
   type StAnnTx l ConwayEra = AlonzoStAnnTx l ConwayEra
 
+  type StAnnTxCache ConwayEra = Map.Map ScriptHash (SupportedPlutusRunnable ConwayEra)
+
   txStAnnTxG = to $ \AlonzoStAnnTx {asatTx} -> asatTx
+
+  cacheStAnnTxG = to $ \AlonzoStAnnTx {asatPlutusRunnableCache} -> asatPlutusRunnableCache
 
   mkBasicTx = MkConwayTx . mkBasicAlonzoTx
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxAuxData.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Conway.TxAuxData () where
 
 import Cardano.Ledger.Alonzo.Core
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable (..))
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData (..),
   metadataAlonzoTxAuxDataL,
@@ -13,8 +15,12 @@ import Cardano.Ledger.Alonzo.TxAuxData (
  )
 import Cardano.Ledger.Conway.Era
 import Cardano.Ledger.Conway.Scripts ()
+import Data.Map.Strict (Map)
 
-instance EraTxAuxData ConwayEra where
+instance
+  StAnnTxCache ConwayEra ~ Map ScriptHash (SupportedPlutusRunnable ConwayEra) =>
+  EraTxAuxData ConwayEra
+  where
   type TxAuxData ConwayEra = AlonzoTxAuxData ConwayEra
 
   mkBasicTxAuxData = AlonzoTxAuxData mempty mempty mempty
@@ -23,8 +29,14 @@ instance EraTxAuxData ConwayEra where
 
   validateTxAuxData = validateAlonzoTxAuxData
 
-instance AllegraEraTxAuxData ConwayEra where
+instance
+  StAnnTxCache ConwayEra ~ Map ScriptHash (SupportedPlutusRunnable ConwayEra) =>
+  AllegraEraTxAuxData ConwayEra
+  where
   nativeScriptsTxAuxDataL = nativeScriptsAlonzoTxAuxDataL
 
-instance AlonzoEraTxAuxData ConwayEra where
+instance
+  StAnnTxCache ConwayEra ~ Map ScriptHash (SupportedPlutusRunnable ConwayEra) =>
+  AlonzoEraTxAuxData ConwayEra
+  where
   plutusScriptsTxAuxDataL = plutusScriptsAllegraTxAuxDataL

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs
@@ -17,8 +17,6 @@ module Cardano.Ledger.Conway.UTxO (
   getConwayMinFeeTxUtxo,
 ) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable)
-import Cardano.Ledger.Alonzo.Tx (AlonzoStAnnTx (..))
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
   AlonzoScriptsNeeded (..),
@@ -120,7 +118,6 @@ conwayProducedValue pp isStakePool txBody =
 
 instance EraUTxO ConwayEra where
   type ScriptsNeeded ConwayEra = AlonzoScriptsNeeded ConwayEra
-  type StAnnTxCache ConwayEra = Map.Map ScriptHash (SupportedPlutusRunnable ConwayEra)
 
   getConsumedValue = getConsumedMaryValue
 
@@ -135,8 +132,6 @@ instance EraUTxO ConwayEra where
   getWitsVKeyNeeded _ = getConwayWitsVKeyNeeded
 
   getMinFeeTxUtxo = getConwayMinFeeTxUtxo
-
-  getCacheStAnnTx = asatPlutusRunnableCache
 
 instance AlonzoEraUTxO ConwayEra where
   getSupplementalDataHashes = getBabbageSupplementalDataHashes

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.3.0.0
 
-* Add `dsattPlutusRunnableCache` field to `DijkstraStAnnTx TopTx`, holding `Map ScriptHash (SupportedPlutusRunnable era)`
+* Add `dsastPlutusRunnableCache` field to `DijkstraStAnnTx SubTx` and `dsattPlutusRunnableCache` field to `DijkstraStAnnTx TopTx`, holding `Map ScriptHash (SupportedPlutusRunnable era)`
 * Change `EraRule "LEDGERS" DijkstraEra` from `Shelley.LEDGERS` to `Babbage.LEDGERS`
 * Add `TranslateEra` instance for `SnapShots`
 * Add `dijkstraConsumed` and `validateValueNotConservedUTxO`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -195,6 +195,7 @@ mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided plutusScriptsCache tx =
       , dsastTxInfoResult = txInfoResult
       , dsastPlutusLanguagesUsed =
           Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr) <- plutusScriptsUsed]
+      , dsastPlutusRunnableCache = plutusScriptsCache
       , dsastPlutusScriptsWithContext =
           scriptsWithContextFromLedgerTxInfoWithResult
             ledgerTxInfo

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -247,7 +247,7 @@ dijkstraSubUtxowTransition = do
 
   runTest $ Alonzo.hasExactSetOfRedeemers tx scriptsProvided scriptsNeeded
 
-  runTest $
+  runTestOnSignal $
     Babbage.validateScriptsWellFormedTxOuts
       (stAnnTx ^. cacheStAnnTxG)
       pp

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxow.hs
@@ -22,7 +22,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubUtxow (
 ) where
 
 import Cardano.Crypto.Hash (ByteString)
-import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext)
+import Cardano.Ledger.Alonzo.Plutus.Context (EraPlutusContext, SupportedPlutusRunnable (..))
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.UTxO (AlonzoEraUTxO (..), AlonzoScriptsNeeded)
 import qualified Cardano.Ledger.Babbage.Rules as Babbage
@@ -58,6 +58,7 @@ import Cardano.Ledger.TxIn (TxIn)
 import Control.DeepSeq (NFData)
 import Control.State.Transition.Extended
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.Map.Strict as Map
 import Data.Set (Set)
 import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
@@ -178,6 +179,7 @@ instance
   , ConwayEraTxBody era
   , DijkstraEraTxBody era
   , EraPlutusContext era
+  , StAnnTxCache era ~ Map.Map ScriptHash (SupportedPlutusRunnable era)
   , EraRule "SUBUTXO" era ~ SUBUTXO era
   , EraRule "SUBUTXOW" era ~ SUBUTXOW era
   , Embed (EraRule "SUBUTXO" era) (SUBUTXOW era)
@@ -203,6 +205,7 @@ dijkstraSubUtxowTransition ::
   ( AlonzoEraTx era
   , AlonzoEraUTxO era
   , DijkstraEraTxBody era
+  , StAnnTxCache era ~ Map.Map ScriptHash (SupportedPlutusRunnable era)
   , EraRule "SUBUTXO" era ~ SUBUTXO era
   , EraRule "SUBUTXOW" era ~ SUBUTXOW era
   , Embed (EraRule "SUBUTXO" era) (SUBUTXOW era)
@@ -237,7 +240,7 @@ dijkstraSubUtxowTransition = do
   runTest $ Alonzo.missingRequiredDatums scriptsProvided originalUtxo tx
 
   {- txADhash ≡ map hash txAuxData -}
-  runTestOnSignal $ Shelley.validateMetadata pp tx
+  runTestOnSignal $ Shelley.validateMetadata pp stAnnTx
 
   let scriptIntegrity = mkScriptIntegrity pp tx (plutusLanguagesUsedStAnnTx stAnnTx)
   runTest $ Alonzo.checkScriptIntegrityHash tx pp scriptIntegrity
@@ -246,6 +249,7 @@ dijkstraSubUtxowTransition = do
 
   runTest $
     Babbage.validateScriptsWellFormedTxOuts
+      (stAnnTx ^. cacheStAnnTxG)
       pp
       (tx ^. witsTxL . scriptTxWitsL)
       (tx ^. bodyTxL . outputsTxBodyL)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -287,7 +287,7 @@ dijkstraUtxowTransition = do
 
   {- ∀x ∈ range(txdats txw) ∪ range(txwitscripts txw) ∪ (⋃ ( , ,d,s) ∈ txouts tx {s, d}),
                        x ∈ Script ∪ Datum ⇒ isWellFormed x -}
-  runTest $ Babbage.validateScriptsWellFormed pp stAnnTx
+  runTestOnSignal $ Babbage.validateScriptsWellFormed pp stAnnTx
 
   {- scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw) -}
   -- Per-level: script integrity is per-tx (depends on that tx's redeemers and language views)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Dijkstra.Rules.Utxow (
 
 import Cardano.Crypto.Hash (ByteString)
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable (..))
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
@@ -205,8 +206,9 @@ dijkstraUtxowTransition ::
   forall era.
   ( AlonzoEraTx era
   , DijkstraEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , DijkstraEraTxBody era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , StAnnTxCache era ~ Map.Map ScriptHash (SupportedPlutusRunnable era)
   , EraRule "UTXOW" era ~ UTXOW era
   , InjectRuleFailure "UTXOW" Shelley.ShelleyUtxowPredFailure era
   , InjectRuleFailure "UTXOW" Alonzo.AlonzoUtxowPredFailure era
@@ -281,11 +283,11 @@ dijkstraUtxowTransition = do
 
   -- check metadata hash
   {- ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad) -}
-  runTestOnSignal $ Shelley.validateMetadata pp tx
+  runTestOnSignal $ Shelley.validateMetadata pp stAnnTx
 
   {- ∀x ∈ range(txdats txw) ∪ range(txwitscripts txw) ∪ (⋃ ( , ,d,s) ∈ txouts tx {s, d}),
                        x ∈ Script ∪ Datum ⇒ isWellFormed x -}
-  runTest $ Babbage.validateScriptsWellFormed pp tx
+  runTest $ Babbage.validateScriptsWellFormed pp stAnnTx
 
   {- scriptIntegrityHash txb = hashScriptIntegrity pp (languages txw) (txrdmrs txw) -}
   -- Per-level: script integrity is per-tx (depends on that tx's redeemers and language views)
@@ -311,8 +313,9 @@ instance
   forall era.
   ( AlonzoEraTx era
   , DijkstraEraUTxO era
-  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
   , DijkstraEraTxBody era
+  , ScriptsNeeded era ~ AlonzoScriptsNeeded era
+  , StAnnTxCache era ~ Map.Map ScriptHash (SupportedPlutusRunnable era)
   , EraRule "UTXOW" era ~ UTXOW era
   , InjectRuleFailure "UTXOW" Shelley.ShelleyUtxowPredFailure era
   , InjectRuleFailure "UTXOW" Alonzo.AlonzoUtxowPredFailure era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs
@@ -197,9 +197,15 @@ instance EraTx DijkstraEra where
 
   type StAnnTx l DijkstraEra = DijkstraStAnnTx l DijkstraEra
 
+  type StAnnTxCache DijkstraEra = Map.Map ScriptHash (SupportedPlutusRunnable DijkstraEra)
+
   txStAnnTxG = to $ \case
     DijkstraStAnnTopTx {dsattTx} -> dsattTx
     DijkstraStAnnSubTx {dsastTx} -> dsastTx
+
+  cacheStAnnTxG = to $ \case
+    DijkstraStAnnTopTx {dsattPlutusRunnableCache} -> dsattPlutusRunnableCache
+    DijkstraStAnnSubTx {dsastPlutusRunnableCache} -> dsastPlutusRunnableCache
 
   mkBasicTx = MkDijkstraTx . mkBasicDijkstraTx
 
@@ -391,6 +397,7 @@ data DijkstraStAnnTx l era where
     , dsastScriptsProvided :: ScriptsProvided era
     , dsastTxInfoResult :: TxInfoResult era
     , dsastPlutusLanguagesUsed :: Set Language
+    , dsastPlutusRunnableCache :: Map.Map ScriptHash (SupportedPlutusRunnable era)
     , dsastPlutusScriptsWithContext :: Either (NonEmpty (CollectError era)) [PlutusWithContext]
     } ->
     DijkstraStAnnTx SubTx era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxAuxData.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxAuxData.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Dijkstra.TxAuxData () where
 
+import Cardano.Ledger.Alonzo.Core
+import Cardano.Ledger.Alonzo.Plutus.Context (SupportedPlutusRunnable (..))
 import Cardano.Ledger.Alonzo.TxAuxData (
   AlonzoTxAuxData (..),
   metadataAlonzoTxAuxDataL,
@@ -10,15 +13,14 @@ import Cardano.Ledger.Alonzo.TxAuxData (
   plutusScriptsAllegraTxAuxDataL,
   validateAlonzoTxAuxData,
  )
-import Cardano.Ledger.Conway.Core (
-  AllegraEraTxAuxData (..),
-  AlonzoEraTxAuxData (..),
-  EraTxAuxData (..),
- )
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Scripts ()
+import Data.Map.Strict (Map)
 
-instance EraTxAuxData DijkstraEra where
+instance
+  StAnnTxCache DijkstraEra ~ Map ScriptHash (SupportedPlutusRunnable DijkstraEra) =>
+  EraTxAuxData DijkstraEra
+  where
   type TxAuxData DijkstraEra = AlonzoTxAuxData DijkstraEra
 
   mkBasicTxAuxData = AlonzoTxAuxData mempty mempty mempty
@@ -27,8 +29,14 @@ instance EraTxAuxData DijkstraEra where
 
   validateTxAuxData = validateAlonzoTxAuxData
 
-instance AllegraEraTxAuxData DijkstraEra where
+instance
+  StAnnTxCache DijkstraEra ~ Map ScriptHash (SupportedPlutusRunnable DijkstraEra) =>
+  AllegraEraTxAuxData DijkstraEra
+  where
   nativeScriptsTxAuxDataL = nativeScriptsAlonzoTxAuxDataL
 
-instance AlonzoEraTxAuxData DijkstraEra where
+instance
+  StAnnTxCache DijkstraEra ~ Map ScriptHash (SupportedPlutusRunnable DijkstraEra) =>
+  AlonzoEraTxAuxData DijkstraEra
+  where
   plutusScriptsTxAuxDataL = plutusScriptsAllegraTxAuxDataL

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs
@@ -18,7 +18,7 @@ module Cardano.Ledger.Dijkstra.UTxO (
   batchNonDistinctRefScriptsSize,
 ) where
 
-import Cardano.Ledger.Alonzo.Plutus.Context (CollectError, SupportedPlutusRunnable)
+import Cardano.Ledger.Alonzo.Plutus.Context (CollectError)
 import Cardano.Ledger.Alonzo.UTxO (
   AlonzoEraUTxO (..),
   AlonzoScriptsNeeded (..),
@@ -130,7 +130,6 @@ dijkstraProducedValue pp isRegPoolId topTxBody =
 
 instance EraUTxO DijkstraEra where
   type ScriptsNeeded DijkstraEra = AlonzoScriptsNeeded DijkstraEra
-  type StAnnTxCache DijkstraEra = Map.Map ScriptHash (SupportedPlutusRunnable DijkstraEra)
 
   getConsumedValue = getConsumedDijkstraValue
 
@@ -145,8 +144,6 @@ instance EraUTxO DijkstraEra where
   getWitsVKeyNeeded _ = getConwayWitsVKeyNeeded
 
   getMinFeeTxUtxo = getConwayMinFeeTxUtxo
-
-  getCacheStAnnTx = dsattPlutusRunnableCache
 
 -- | Like 'getBabbageScriptsProvided', but for 'TopTx' also aggregates
 -- scripts from all subtransactions.

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/Tx.hs
@@ -35,7 +35,7 @@ import Cardano.Ledger.Shelley.Tx (
 import Control.DeepSeq (NFData)
 import Data.Typeable (Typeable)
 import GHC.Generics (Generic)
-import Lens.Micro (Lens', lens)
+import Lens.Micro (Lens', lens, to)
 import NoThunks.Class (NoThunks)
 
 -- ========================================
@@ -50,7 +50,11 @@ instance EraTx MaryEra where
 
   type StAnnTx l MaryEra = Tx l MaryEra
 
+  type StAnnTxCache MaryEra = ()
+
   txStAnnTxG = id
+
+  cacheStAnnTxG = to (const ())
 
   mkBasicTx = MkMaryTx . mkBasicShelleyTx
 

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/TxAuxData.hs
@@ -31,7 +31,7 @@ instance EraTxAuxData MaryEra where
 
   metadataTxAuxDataL = metadataAllegraTxAuxDataL
 
-  validateTxAuxData _ (AllegraTxAuxData _ as) = as `deepseq` True
+  validateTxAuxData _ _ (AllegraTxAuxData _ as) = as `deepseq` True
 
 instance AllegraEraTxAuxData MaryEra where
   nativeScriptsTxAuxDataL = nativeScriptsAllegraTxAuxDataL

--- a/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
+++ b/eras/mary/impl/src/Cardano/Ledger/Mary/UTxO.hs
@@ -38,7 +38,6 @@ import Lens.Micro
 
 instance EraUTxO MaryEra where
   type ScriptsNeeded MaryEra = ShelleyScriptsNeeded MaryEra
-  type StAnnTxCache MaryEra = ()
 
   getConsumedValue = getConsumedMaryValue
 
@@ -53,8 +52,6 @@ instance EraUTxO MaryEra where
   getWitsVKeyNeeded = getShelleyWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
-
-  getCacheStAnnTx _ = mempty
 
 -- | Calculate the value consumed by the transation.
 --

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.19.0.0
 
+* Change argument to `validateMetadata` from `Tx` to `StAnnTx`
 * Add `EraUTxO era` as a superclass constraint to `ApplyTx`
 * Change `produced` to accept `PState`, instead of `CertState`
 * Remove `consumed` in favor of `shelleyConsumed`

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Utxow.hs
@@ -313,7 +313,7 @@ transitionRulesUTXOW = do
 
   -- check metadata hash
   {-  ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)                          -}
-  runTestOnSignal $ validateMetadata pp tx
+  runTestOnSignal $ validateMetadata pp stAnnTx
 
   -- check genesis keys signatures for instantaneous rewards certificates
   {-  genSig := { hashKey gkey | gkey ∈ dom(genDelegs)} ∩ witsKeyHashes  -}
@@ -424,9 +424,10 @@ validateNeededWitnesses witsKeyHashes certState utxo txBody =
 
 -- | check metadata hash
 --   ((adh = ◇) ∧ (ad= ◇)) ∨ (adh = hashAD ad)
-validateMetadata :: EraTx era => PParams era -> Tx l era -> Test (ShelleyUtxowPredFailure era)
-validateMetadata pp tx =
-  let txBody = tx ^. bodyTxL
+validateMetadata :: EraTx era => PParams era -> StAnnTx l era -> Test (ShelleyUtxowPredFailure era)
+validateMetadata pp stAnnTx =
+  let tx = stAnnTx ^. txStAnnTxG
+      txBody = tx ^. bodyTxL
       pv = pp ^. ppProtocolVersionL
    in case (txBody ^. auxDataHashTxBodyL, tx ^. auxDataTxL) of
         (SNothing, SNothing) -> pure ()
@@ -438,7 +439,7 @@ validateMetadata pp tx =
             [ failureUnless (hashTxAuxData md' == mdh) $
                 ConflictingMetadataHash $
                   Mismatch {mismatchSupplied = mdh, mismatchExpected = hashTxAuxData md'}
-            , failureUnless (validateTxAuxData pv md') InvalidMetadata
+            , failureUnless (validateTxAuxData (stAnnTx ^. cacheStAnnTxG) pv md') InvalidMetadata
             ]
 
 -- | check genesis keys signatures for instantaneous rewards certificates

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/Tx.hs
@@ -203,7 +203,11 @@ instance EraTx ShelleyEra where
 
   type StAnnTx l ShelleyEra = Tx l ShelleyEra
 
+  type StAnnTxCache ShelleyEra = ()
+
   txStAnnTxG = id
+
+  cacheStAnnTxG = to (const ())
 
   mkBasicTx = MkShelleyTx . mkBasicShelleyTx
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/TxAuxData.hs
@@ -94,7 +94,7 @@ instance EraTxAuxData ShelleyEra where
     lensMemoRawType @ShelleyEra stadrMetadata $
       \txAuxDataRaw md -> txAuxDataRaw {stadrMetadata = md}
 
-  validateTxAuxData _ _ = True
+  validateTxAuxData _ _ _ = True
 
 instance EqRaw (ShelleyTxAuxData era)
 

--- a/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
+++ b/eras/shelley/impl/src/Cardano/Ledger/Shelley/UTxO.hs
@@ -163,7 +163,6 @@ newtype ShelleyScriptsNeeded era = ShelleyScriptsNeeded (Set ScriptHash)
 
 instance EraUTxO ShelleyEra where
   type ScriptsNeeded ShelleyEra = ShelleyScriptsNeeded ShelleyEra
-  type StAnnTxCache ShelleyEra = ()
 
   getConsumedValue = getConsumedCoin
 
@@ -178,8 +177,6 @@ instance EraUTxO ShelleyEra where
   getWitsVKeyNeeded = getShelleyWitsVKeyNeeded
 
   getMinFeeTxUtxo pp tx _ = getShelleyMinFeeTxUtxo pp tx
-
-  getCacheStAnnTx _ = mempty
 
 -- We don't consider the reference scripts in the calculation before Conway
 getShelleyMinFeeTxUtxo :: EraTx era => PParams era -> Tx l era -> Coin

--- a/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Dijkstra/Ledger.hs
+++ b/libs/cardano-ledger-conformance/src/Test/Cardano/Ledger/Conformance/ExecSpecRule/Dijkstra/Ledger.hs
@@ -131,8 +131,8 @@ instance
           dsattScriptsNeeded `deepseq`
             dsattScriptsProvided `deepseq`
               dsattPlutusLegacyMode `deepseq`
-                dsattPlutusRunnableCache `deepseq`
-                  dsattPlutusLanguagesUsed `deepseq`
+                dsattPlutusLanguagesUsed `deepseq`
+                  dsattPlutusRunnableCache `deepseq`
                     dsattPlutusScriptsWithContext `deepseq`
                       rnf dsattSubTransactions
 
@@ -145,14 +145,15 @@ instance
   ) =>
   NFData (DijkstraStAnnTx SubTx era)
   where
-  rnf stAnnTx@(DijkstraStAnnSubTx _ _ _ _ _ _) =
+  rnf stAnnTx@(DijkstraStAnnSubTx _ _ _ _ _ _ _) =
     let DijkstraStAnnSubTx {..} = stAnnTx
      in dsastTx `deepseq`
           dsastScriptsNeeded `deepseq`
             dsastScriptsProvided `deepseq`
               dsastTxInfoResult `seq`
                 dsastPlutusLanguagesUsed `deepseq`
-                  rnf dsastPlutusScriptsWithContext
+                  dsastPlutusRunnableCache `deepseq`
+                    rnf dsastPlutusScriptsWithContext
 
 instance EncCBOR (Tx TopTx era) => EncCBOR (DijkstraStAnnTx TopTx era) where
   encCBOR DijkstraStAnnTopTx {dsattTx} = encCBOR dsattTx
@@ -194,7 +195,7 @@ instance
   ) =>
   ToExpr (DijkstraStAnnTx SubTx era)
   where
-  toExpr stAnnTx@(DijkstraStAnnSubTx _ _ _ _ _ _) =
+  toExpr stAnnTx@(DijkstraStAnnSubTx _ _ _ _ _ _ _) =
     let DijkstraStAnnSubTx {..} = stAnnTx
      in TD.Rec "DijkstraStAnnSubTx" $
           OMap.fromList
@@ -202,6 +203,7 @@ instance
             , ("dsastScriptsNeeded", toExpr dsastScriptsNeeded)
             , ("dsastScriptsProvided", toExpr dsastScriptsProvided)
             , ("dsastTxInfoResult", TD.App "<TxInfoResult>" [])
+            , ("dsastPlutusRunnableCache", toExpr dsastPlutusRunnableCache)
             , ("dsastPlutusLanguagesUsed", toExpr dsastPlutusLanguagesUsed)
             , ("dsastPlutusScriptsWithContext", toExpr dsastPlutusScriptsWithContext)
             ]

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Add `StAnnTxCache` as an argument to `validateTxAuxData`
 * Add `isValidPlutusRunnable`
 * Add `StAnnTxCache` associated type and `cacheStAnnTxG` method to `EraTx`, together with a new `Monoid (StAnnTxCache era)` superclass constraint
 * Restructure `PlutusRunnable` from a `newtype` over `ScriptForEvaluation` into a record with fields `plutusRunnableBinary`, `plutusRunnableScriptHash` and `plutusRunnableResult`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.21.0.0
 
+* Add `isValidPlutusRunnable`
 * Add `StAnnTxCache` associated type and `getCacheStAnnTx` method to `EraUTxO`, together with a new `Monoid (StAnnTxCache era)` superclass constraint
 * Restructure `PlutusRunnable` from a `newtype` over `ScriptForEvaluation` into a record with fields `plutusRunnableBinary`, `plutusRunnableScriptHash` and `plutusRunnableResult`
 * Change `decodePlutusRunnable` to return `PlutusRunnable l` instead of `Either ScriptDecodeError (PlutusRunnable l)`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.21.0.0
 
 * Add `isValidPlutusRunnable`
-* Add `StAnnTxCache` associated type and `getCacheStAnnTx` method to `EraUTxO`, together with a new `Monoid (StAnnTxCache era)` superclass constraint
+* Add `StAnnTxCache` associated type and `cacheStAnnTxG` method to `EraTx`, together with a new `Monoid (StAnnTxCache era)` superclass constraint
 * Restructure `PlutusRunnable` from a `newtype` over `ScriptForEvaluation` into a record with fields `plutusRunnableBinary`, `plutusRunnableScriptHash` and `plutusRunnableResult`
 * Change `decodePlutusRunnable` to return `PlutusRunnable l` instead of `Either ScriptDecodeError (PlutusRunnable l)`
 * Change `evaluatePlutusRunnable`, `evaluatePlutusRunnableBudget` and `mkTermToEvaluate` to accept a `ScriptForEvaluation` instead of a `PlutusRunnable l`

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -153,6 +153,7 @@ class
   , EraTxAuxData era
   , EraPParams era
   , HasEraTxLevel Tx era
+  , Monoid (StAnnTxCache era)
   , forall l. Typeable l => NoThunks (Tx l era)
   , forall l. Typeable l => DecCBOR (Annotator (Tx l era))
   , forall l. Typeable l => ToCBOR (Tx l era)
@@ -178,7 +179,13 @@ class
   -- missing output, regardless if data from reference inputs is still present in the `StAnnTx`
   type StAnnTx (l :: TxLevel) era = (r :: Type) | r -> l era
 
+  -- | Cache that can be shared between different `StAnnTx`s
+  type StAnnTxCache era :: Type
+
   txStAnnTxG :: SimpleGetter (StAnnTx l era) (Tx l era)
+
+  -- | Pull out cache from `StAnnTx`
+  cacheStAnnTxG :: SimpleGetter (StAnnTx l era) (StAnnTxCache era)
 
   mkBasicTx :: TxBody l era -> Tx l era
 

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -486,7 +486,7 @@ class
 
   metadataTxAuxDataL :: Lens' (TxAuxData era) (Map Word64 Metadatum)
 
-  validateTxAuxData :: ProtVer -> TxAuxData era -> Bool
+  validateTxAuxData :: StAnnTxCache era -> ProtVer -> TxAuxData era -> Bool
 
 modifyTxAuxData ::
   EraTx era =>

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Plutus.Language (
   -- * Plutus Script
   Plutus (..),
   isValidPlutus,
+  isValidPlutusRunnable,
   PlutusBinary (..),
   PlutusRunnable (..),
   plutusFromRunnable,
@@ -228,9 +229,16 @@ instance PlutusLanguage l => EncCBOR (Plutus l) where
     where
       lang = plutusLanguage plutus
 
--- | Verify that the binary version of the Plutus script is deserializable.
+-- | Verify that the binary version of the Plutus script is deserializable. If instead you have
+-- `PlutusRunnable` already available it will be better to use `isValidPlutusRunnable`, since then
+-- runnable version of plutus ` P.ScriptForEvaluation` can be reused later without redundant
+-- subsequent decoding.
 isValidPlutus :: PlutusLanguage l => Version -> Plutus l -> Bool
-isValidPlutus v = isRight . plutusRunnableResult . decodePlutusRunnable v
+isValidPlutus v = isValidPlutusRunnable . decodePlutusRunnable v
+
+-- | Verify that PlutusRunnable was successfully decoded.
+isValidPlutusRunnable :: PlutusRunnable l -> Bool
+isValidPlutusRunnable = isRight . plutusRunnableResult
 
 -- | Serialize the runnable version of the plutus script
 --

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/UTxO.hs
@@ -239,13 +239,10 @@ deriving instance (Era era, Show (Script era)) => Show (ScriptsProvided era)
 
 deriving instance (Era era, NFData (Script era)) => NFData (ScriptsProvided era)
 
-class (Monoid (StAnnTxCache era), EraTx era) => EraUTxO era where
+class EraTx era => EraUTxO era where
   -- | A customizable type on per era basis for the information required to find all
   -- scripts needed for the transaction.
   type ScriptsNeeded era = (r :: Type) | r -> era
-
-  -- | Cache that can be shared between different `StAnnTx`s
-  type StAnnTxCache era :: Type
 
   -- | Calculate all the value that is being consumed by the transaction.
   getConsumedValue ::
@@ -286,6 +283,3 @@ class (Monoid (StAnnTxCache era), EraTx era) => EraUTxO era where
 
   -- | Minimum fee computation, excluding witnesses and including ref scripts size
   getMinFeeTxUtxo :: PParams era -> Tx t era -> UTxO era -> Coin
-
-  -- | Pull out cache from `StAnnTx`
-  getCacheStAnnTx :: StAnnTx TopTx era -> StAnnTxCache era


### PR DESCRIPTION
# Description

1. **Script caching for validation.** It threads a `StAnnTxCache era` (a `Map ScriptHash (SupportedPlutusRunnable era)`) through the annotated transaction so that already-decoded Plutus scripts can be reused during well-formedness validation instead of being re-deserialized. `validScript` is renamed to `isValidScript`, moved from `Alonzo.Scripts` to `Alonzo.TxAuxData` (to break an import cycle), and gains a cache and a `ScriptHash` argument. On a cache hit it uses `isValidPlutusRunnable` on the pre-decoded runnable; on a miss it falls back to the old `isValidPlutusScript` path.
2. **Making the checks "static."** `validateMetadata` and the script well-formedness checks now take `StAnnTx` rather than `Tx`, and the well-formedness check is switched from `runTest` to `runTestOnSignal`.
3. Add `runTest → runTestOnSignal` for well-formedness optimization, which is safe because script well-formedness does not depend on anything except the transaction itself 

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [x] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
