### PR TITLE
Remove unnecessary setup of the `DRepPulser`

### DIFF
--- a/eras/allegra/impl/CHANGELOG.md
+++ b/eras/allegra/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-allegra`
 
+## 1.10.0.1
+
+*
+
 ## 1.10.0.0
 
 * Add `TranslateEra` instance for `SnapShots`

--- a/eras/alonzo/impl/CHANGELOG.md
+++ b/eras/alonzo/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-alonzo`
 
+## 1.16.0.1
+
+*
+
 ## 1.16.0.0
 
 * Convert `IsValid` into the `IsPhase2Valid` sum type (`Phase2Valid`/`Phase2Invalid`) and rename its lens and field, deprecating the old names:

--- a/eras/babbage/impl/CHANGELOG.md
+++ b/eras/babbage/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-babbage`
 
+## 1.14.0.1
+
+*
+
 ## 1.14.0.0
 
 * Rename `updateUTxOStateByTxValidity` to `updateUTxOState`

--- a/eras/byron/chain/executable-spec/CHANGELOG.md
+++ b/eras/byron/chain/executable-spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `byron-spec-chain`
 
+## 1.0.1.3
+
+*
+
 ## 1.0.1.2
 
 *

--- a/eras/byron/ledger/executable-spec/CHANGELOG.md
+++ b/eras/byron/ledger/executable-spec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `byron-spec-ledger`
 
+## 1.1.0.3
+
+*
+
 ## 1.1.0.2
 
 *

--- a/eras/conway/impl/CHANGELOG.md
+++ b/eras/conway/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-conway`
 
+## 1.23.0.1
+
+*
+
 ## 1.23.0.0
 
 * Restrict `conwayCertsTotalDepositsTxBody` to `TxBody TopTx era` type

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for `cardano-ledger-dijkstra`
 
+## 0.3.0.1
+
+*
+
 ## 0.3.0.0
 
 * Rename constructors of `SubEntitiesPredFailure`:

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/PParams.hs
@@ -128,8 +128,7 @@ data DijkstraPParams f era = DijkstraPParams
   -- including non-native scripts.
   , dppMaxCollateralInputs :: !(THKD ('PPGroups 'NetworkGroup 'NoStakePoolGroup) f Word16)
   -- ^ Maximum number of collateral inputs allowed in a transaction
-  , -- New ones for Dijkstra:
-    dppPoolVotingThresholds :: !(THKD ('PPGroups 'GovGroup 'NoStakePoolGroup) f PoolVotingThresholds)
+  , dppPoolVotingThresholds :: !(THKD ('PPGroups 'GovGroup 'NoStakePoolGroup) f PoolVotingThresholds)
   -- ^ Thresholds for SPO votes
   , dppDRepVotingThresholds :: !(THKD ('PPGroups 'GovGroup 'NoStakePoolGroup) f DRepVotingThresholds)
   -- ^ Thresholds for DRep votes
@@ -149,7 +148,8 @@ data DijkstraPParams f era = DijkstraPParams
       !(THKD ('PPGroups 'EconomicGroup 'SecurityGroup) f NonNegativeInterval)
   -- ^ Reference scripts fee for the minimum fee calculation
   -- TODO ensure that the groups here make sense
-  , dppMaxRefScriptSizePerBlock :: !(THKD ('PPGroups 'NetworkGroup 'SecurityGroup) f Word32)
+  , -- New ones for Dijkstra:
+    dppMaxRefScriptSizePerBlock :: !(THKD ('PPGroups 'NetworkGroup 'SecurityGroup) f Word32)
   -- ^ Limit on the total number of bytes of all reference scripts combined from
   -- all transactions within a block.
   , dppMaxRefScriptSizePerTx :: !(THKD ('PPGroups 'NetworkGroup 'SecurityGroup) f Word32)

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Translation.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Translation.hs
@@ -25,9 +25,6 @@ import Cardano.Ledger.Conway.Governance (
   PulsingSnapshot,
   RatifyState (..),
   finishDRepPulser,
-  mkEnactState,
-  rsEnactStateL,
-  setCompleteDRepPulsingState,
   translateProposals,
  )
 import Cardano.Ledger.Conway.Governance.DRepPulser (PulsingSnapshot (..))
@@ -44,12 +41,10 @@ import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   NewEpochState (..),
   UTxOState (..),
-  epochStateGovStateL,
   lsCertStateL,
   lsUTxOStateL,
  )
 import Data.Coerce (coerce)
-import Data.Default (Default (..))
 import qualified Data.Map.Strict as Map
 import Lens.Micro ((&), (.~), (^.))
 
@@ -74,19 +69,12 @@ instance TranslateEra DijkstraEra (Tx TopTx) where
 
 instance TranslateEra DijkstraEra NewEpochState where
   translateEra ctxt nes = do
-    let es = translateEra' ctxt $ nesEs nes
-        -- We need to ensure that we have the same initial EnactState in the pulser as
-        -- well as in the current EnactState, otherwise in the very first EPOCH rule call
-        -- the pulser will reset it.
-        ratifyState =
-          def
-            & rsEnactStateL .~ mkEnactState (es ^. epochStateGovStateL)
     pure $
       NewEpochState
         { nesEL = nesEL nes
         , nesBprev = nesBprev nes
         , nesBcur = nesBcur nes
-        , nesEs = setCompleteDRepPulsingState def ratifyState es
+        , nesEs = translateEra' ctxt $ nesEs nes
         , nesRu = nesRu nes
         , nesPd = nesPd nes
         , stashedAVVMAddresses = ()

--- a/eras/mary/impl/CHANGELOG.md
+++ b/eras/mary/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-mary`
 
+## 1.11.0.1
+
+*
+
 ## 1.11.0.0
 
 * Add `TranslateEra` instance for `SnapShots`

--- a/eras/shelley/impl/CHANGELOG.md
+++ b/eras/shelley/impl/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley`
 
+## 1.19.0.1
+
+*
+
 ## 1.19.0.0
 
 * Restrict `shelleyCertsTotalDepositsTxBody` to `TxBody TopTx era` type

--- a/eras/shelley/test-suite/CHANGELOG.md
+++ b/eras/shelley/test-suite/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-shelley-test`
 
+## 1.9.0.1
+
+*
+
 ## 1.9.0.0
 
 * Add `ledgersSigGen`

--- a/libs/cardano-ledger-api/CHANGELOG.md
+++ b/libs/cardano-ledger-api/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-api`
 
+## 1.14.0.1
+
+*
+
 ## 1.14.0.0
 
 * Rename `isValidTxG` to `isPhase2ValidTxG` in `AnyEraTx`, deprecating the old name

--- a/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
+++ b/libs/cardano-ledger-api/test/Test/Cardano/Ledger/Api/Tx/Body.hs
@@ -27,23 +27,21 @@ import Test.Cardano.Ledger.Common
 
 totalTxDeposits ::
   (EraTxBody era, EraCertState era) =>
-  Network ->
   PParams era ->
   CertState era ->
   TxBody l era ->
   Coin
-totalTxDeposits network pp dpstate txb =
+totalTxDeposits pp dpstate txb =
   numKeys <×> pp ^. ppKeyDepositL <+> snd (foldl' accum (regpools, Coin 0) certs)
   where
     certs = toList (txb ^. certsTxBodyL)
     numKeys = length $ filter isRegStakeTxCert certs
-    regpools =
-      Map.mapWithKey (stakePoolStateToStakePoolParams network) $ psStakePools (dpstate ^. certPStateL)
+    regpools = Map.keysSet $ psStakePools (dpstate ^. certPStateL)
     accum (!pools, !ans) (RegPoolTxCert stakePoolParams) =
       -- We don't pay a deposit on a pool that is already registered
-      if Map.member (sppId stakePoolParams) pools
+      if Set.member (sppId stakePoolParams) pools
         then (pools, ans)
-        else (Map.insert (sppId stakePoolParams) stakePoolParams pools, ans <+> pp ^. ppPoolDepositL)
+        else (Set.insert (sppId stakePoolParams) pools, ans <+> pp ^. ppPoolDepositL)
     accum ans _ = ans
 
 keyTxRefunds ::
@@ -77,28 +75,26 @@ keyTxRefunds pp dpstate tx =
 -- the produced result hasn't changed
 evaluateTransactionBalance ::
   (MaryEraTxBody era, ShelleyEraTxCert era, EraCertState era) =>
-  Network ->
   PParams era ->
   CertState era ->
   UTxO era ->
   TxBody TopTx era ->
   Value era
-evaluateTransactionBalance network pp dpstate utxo txBody =
-  evaluateTransactionBalanceShelley network pp dpstate utxo txBody <> (txBody ^. mintValueTxBodyF)
+evaluateTransactionBalance pp dpstate utxo txBody =
+  evaluateTransactionBalanceShelley pp dpstate utxo txBody <> (txBody ^. mintValueTxBodyF)
 
 evaluateTransactionBalanceShelley ::
   (EraTxBody era, ShelleyEraTxCert era, EraCertState era) =>
-  Network ->
   PParams era ->
   CertState era ->
   UTxO era ->
   TxBody TopTx era ->
   Value era
-evaluateTransactionBalanceShelley network pp dpstate utxo txBody = consumed <-> produced
+evaluateTransactionBalanceShelley pp dpstate utxo txBody = consumed <-> produced
   where
     produced =
       sumUTxO (txouts txBody)
-        <+> inject (txBody ^. feeTxBodyL <+> totalTxDeposits network pp dpstate txBody)
+        <+> inject (txBody ^. feeTxBodyL <+> totalTxDeposits pp dpstate txBody)
     consumed =
       sumUTxO (txInsFilter utxo (txBody ^. inputsTxBodyL))
         <> inject (refunds <> withdrawals)
@@ -147,25 +143,23 @@ propEvalBalanceTxBody ::
 propEvalBalanceTxBody pp certState utxo = do
   property $
     forAll (genTxBodyFrom @_ @TopTx certState utxo) $ \txBody ->
-      forAll arbitrary $ \network ->
-        evalBalanceTxBody pp lookupKeyDeposit isRegPoolId utxo txBody
-          `shouldBe` evaluateTransactionBalance network pp certState utxo txBody
+      evalBalanceTxBody pp lookupKeyDeposit isRegPoolId utxo txBody
+        `shouldBe` evaluateTransactionBalance pp certState utxo txBody
   where
     lookupKeyDeposit = lookupDepositDState (certState ^. certDStateL)
     isRegPoolId = (`Map.member` psStakePools (certState ^. certPStateL))
 
 propEvalBalanceShelleyTxBody ::
   (EraUTxO era, ShelleyEraTxCert era, Arbitrary (TxBody TopTx era), EraCertState era) =>
-  Network ->
   PParams era ->
   CertState era ->
   UTxO era ->
   Property
-propEvalBalanceShelleyTxBody network pp certState utxo =
+propEvalBalanceShelleyTxBody pp certState utxo =
   property $
     forAll (genTxBodyFrom @_ @TopTx certState utxo) $ \txBody ->
       evalBalanceTxBody pp lookupKeyDeposit isRegPoolId utxo txBody
-        `shouldBe` evaluateTransactionBalanceShelley network pp certState utxo txBody
+        `shouldBe` evaluateTransactionBalanceShelley pp certState utxo txBody
   where
     lookupKeyDeposit = lookupDepositDState (certState ^. certDStateL)
     isRegPoolId = (`Map.member` psStakePools (certState ^. certPStateL))

--- a/libs/cardano-ledger-binary/CHANGELOG.md
+++ b/libs/cardano-ledger-binary/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-binary`
 
+## 1.9.0.1
+
+*
+
 ## 1.9.0.0
 
 * Re-export `fixedSize`, `guardFixedSized`

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-ledger-core`
 
+## 1.21.0.1
+
+*
+
 ## 1.21.0.0
 
 * Restrict `getTotalDepositsTxBody` and `certsTotalDepositsTxBody` to `TxBody TopTx era` type

--- a/libs/cardano-protocol-tpraos/CHANGELOG.md
+++ b/libs/cardano-protocol-tpraos/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-protocol-tpraos`
 
+## 1.6.0.1
+
+*
+
 ## 1.6.0.0
 
 * Move `Cardano.Protocol.Crypto` and `Cardano.Protocol.TPraos.OCert` to the new `cardano-protocol` package. They are re-exported here unchanged.

--- a/libs/cardano-protocol/CHANGELOG.md
+++ b/libs/cardano-protocol/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `cardano-protocol`
 
+## 0.1.0.1
+
+*
+
 ## 0.1.0.0
 
 * Add `Cardano.Protocol.Leios.BlockHeader`

--- a/libs/small-steps/CHANGELOG.md
+++ b/libs/small-steps/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `small-steps`
 
+## 1.1.4.1
+
+*
+
 ## 1.1.4.0
 
 ### `testlib`

--- a/libs/vector-map/CHANGELOG.md
+++ b/libs/vector-map/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history for `vector-map`
 
+## 1.2.1.1
+
+*
+
 ## 1.2.1.0
 
 * Add `lookupIndex`


### PR DESCRIPTION


# Description

This copy pasted logic from Conway is erroneous for `DijkstraEra`, because unlike upon entry `ConwayEra`, DRepPulser and RatifyState are correctly populated and simply need to be translated. REst of the rotation will be taken care of by the `EPOCH` rule

# Checklist

- [x] Commits in meaningful sequence and with useful messages.
- [x] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [x] Self-reviewed the diff.
