### PR TITLE
Move network checks of deposits and withdrawals  to (SUB)ENTITIES

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.0.0
 
+* Remove `WrongNetworkWithdrawal` constructor from `DijkstraUtxoPredFailure`
+* Remove `SubWrongNetworkWithdrawal` constructor from `DijkstraSubUtxoPredFailure`
 * Remove `sleTxIx` from `SubLedgerEnv`
 * Rename the phase-2 validity field on `DijkstraTx`: `dtIsValid` -> `dtIsPhase2Valid`
 * Add `dsattPlutusRunnableCache` field to `DijkstraStAnnTx TopTx`, holding `Map ScriptHash (SupportedPlutusRunnable era)`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## 0.3.0.0
 
+* Rename constructors of `SubEntitiesPredFailure`:
+  - `SubWithdrawalsMissingAccounts` -> `SubMissingAccountsInWithdrawals`
+  - `SubWithdrawalAmountsExceedAccountBalances` -> `SubExceededBalancesInWithdrawals`
+  - `SubDirectDepositsToMissingAccounts` -> `SubMissingAccountsInDirectDeposits`
+* Add `SubWrongNetworkInWithdrawals` and `SubWrongNetworkInDirectDeposits` constructors to `SubEntitiesPredFailure`
+* Rename constructors of `EntitiesPredFailure`:
+  - `WithdrawalsMissingAccounts` -> `MissingAccountsInWithdrawals`
+  - `WithdrawalAmountsExceedAccountBalances` -> `ExceededBalancesInWithdrawals`
+  - `DirectDepositsToMissingAccounts` -> `MissingAccountsInDirectDeposits`
+* Add `WrongNetworkInWithdrawals` and `WrongNetworkInDirectDeposits` constructors to `EntitiesPredFailure`
 * Add `validateWrongNetworkInDirectDeposit`
 * Remove `WrongNetworkWithdrawal` and `WrongNetworkInDirectDeposit `constructors from `DijkstraUtxoPredFailure`
 * Remove `SubWrongNetworkWithdrawal` and `SubWrongNetworkInDirectDeposit` constructors from `DijkstraSubUtxoPredFailure`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 0.3.0.0
 
-* Remove `WrongNetworkWithdrawal` constructor from `DijkstraUtxoPredFailure`
-* Remove `SubWrongNetworkWithdrawal` constructor from `DijkstraSubUtxoPredFailure`
+* Add `validateWrongNetworkInDirectDeposit`
+* Remove `WrongNetworkWithdrawal` and `WrongNetworkInDirectDeposit `constructors from `DijkstraUtxoPredFailure`
+* Remove `SubWrongNetworkWithdrawal` and `SubWrongNetworkInDirectDeposit` constructors from `DijkstraSubUtxoPredFailure`
 * Remove `sleTxIx` from `SubLedgerEnv`
 * Rename the phase-2 validity field on `DijkstraTx`: `dtIsValid` -> `dtIsPhase2Valid`
 * Add `dsattPlutusRunnableCache` field to `DijkstraStAnnTx TopTx`, holding `Map ScriptHash (SupportedPlutusRunnable era)`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0.0
 
+* Remove `sleTxIx` from `SubLedgerEnv`
 * Rename the phase-2 validity field on `DijkstraTx`: `dtIsValid` -> `dtIsPhase2Valid`
 * Add `dsattPlutusRunnableCache` field to `DijkstraStAnnTx TopTx`, holding `Map ScriptHash (SupportedPlutusRunnable era)`
 * Restrict `dijkstraCertsTotalDepositsTxBody` to `TxBody TopTx era` type

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -149,7 +149,7 @@ library testlib
     Test.Cardano.Ledger.Dijkstra.Examples
     Test.Cardano.Ledger.Dijkstra.Imp
     Test.Cardano.Ledger.Dijkstra.Imp.CertSpec
-    Test.Cardano.Ledger.Dijkstra.Imp.CertsSpec
+    Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec
     Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec
     Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -32,6 +32,7 @@ import Cardano.Ledger.Dijkstra.Era (DijkstraEra, ENTITIES)
 import Cardano.Ledger.Dijkstra.Rules.Certs ()
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody, directDepositsTxBodyL)
+import Cardano.Ledger.Rules.ValidationMode (runTest)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
@@ -40,6 +41,7 @@ import Data.Map.NonEmpty (NonEmptyMap)
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
+import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
 import Lens.Micro
 
@@ -69,6 +71,11 @@ data EntitiesPredFailure era
   | IncompleteWithdrawals (NonEmptyMap AccountAddress (Mismatch RelEQ Coin))
   | WithdrawalAmountsExceedAccountBalances (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
   | DirectDepositsToMissingAccounts DirectDeposits
+  | WrongNetworkWithdrawal
+      -- | Expected network id
+      Network
+      -- | Withdrawal accounts with wrong network id
+      (NonEmptySet AccountAddress)
   deriving (Generic)
 
 deriving stock instance
@@ -94,6 +101,7 @@ instance
       IncompleteWithdrawals x -> Sum (IncompleteWithdrawals @era) 2 !> To x
       WithdrawalAmountsExceedAccountBalances x -> Sum (WithdrawalAmountsExceedAccountBalances @era) 3 !> To x
       DirectDepositsToMissingAccounts x -> Sum (DirectDepositsToMissingAccounts @era) 4 !> To x
+      WrongNetworkWithdrawal x y -> Sum (WrongNetworkWithdrawal @era) 5 !> To x !> To y
 
 instance
   ( Era era
@@ -107,6 +115,7 @@ instance
     2 -> SumD IncompleteWithdrawals <! From
     3 -> SumD WithdrawalAmountsExceedAccountBalances <! From
     4 -> SumD DirectDepositsToMissingAccounts <! From
+    5 -> SumD WrongNetworkWithdrawal <! From <! From
     n -> Invalid n
 
 newtype EntitiesEvent era = CertsEvent (Event (EraRule "CERTS" era))
@@ -143,6 +152,9 @@ instance InjectRuleFailure "ENTITIES" DijkstraGovCertPredFailure DijkstraEra whe
 instance InjectRuleFailure "ENTITIES" Conway.ConwayLedgerPredFailure DijkstraEra where
   injectFailure = conwayToDijkstraEntitiesPredFailure
 
+instance InjectRuleFailure "ENTITIES" Shelley.ShelleyUtxoPredFailure DijkstraEra where
+  injectFailure = shelleyUtxoToDijkstraEntitiesPredFailure
+
 instance
   ( EraTx era
   , DijkstraEraTxBody era
@@ -154,6 +166,7 @@ instance
   , Environment (EraRule "CERTS" era) ~ Conway.CertsEnv era
   , EraRule "ENTITIES" era ~ ENTITIES era
   , InjectRuleFailure "ENTITIES" EntitiesPredFailure era
+  , InjectRuleFailure "ENTITIES" Shelley.ShelleyUtxoPredFailure era
   , InjectRuleFailure "ENTITIES" Conway.ConwayLedgerPredFailure era
   ) =>
   STS (ENTITIES era)
@@ -179,6 +192,7 @@ dijkstraEntitiesTransition ::
   , Environment (EraRule "CERTS" era) ~ Conway.CertsEnv era
   , EraRule "ENTITIES" era ~ ENTITIES era
   , InjectRuleFailure "ENTITIES" EntitiesPredFailure era
+  , InjectRuleFailure "ENTITIES" Shelley.ShelleyUtxoPredFailure era
   , InjectRuleFailure "ENTITIES" Conway.ConwayLedgerPredFailure era
   ) =>
   TransitionRule (ENTITIES era)
@@ -189,6 +203,8 @@ dijkstraEntitiesTransition = do
       accounts = certState ^. certDStateL . accountsL
 
   network <- liftSTS $ asks networkId
+
+  runTest $ Shelley.validateWrongNetworkWithdrawal network (tx ^. bodyTxL)
 
   validateWithdrawals legacyMode network withdrawals accounts
 
@@ -246,6 +262,23 @@ conwayToDijkstraEntitiesPredFailure = \case
   Conway.ConwayMempoolFailure _ -> impossible "ConwayMempoolFailure"
   Conway.ConwayWithdrawalsMissingAccounts _ -> impossible "ConwayWithdrawalsMissingAccounts"
   Conway.ConwayIncompleteWithdrawals _ -> impossible "ConwayIncompleteWithdrawals"
+  where
+    impossible name = error $ "Impossible: `" <> name <> "` for ENTITIES"
+
+shelleyUtxoToDijkstraEntitiesPredFailure ::
+  Shelley.ShelleyUtxoPredFailure era -> EntitiesPredFailure era
+shelleyUtxoToDijkstraEntitiesPredFailure = \case
+  Shelley.WrongNetworkWithdrawal net addrs -> WrongNetworkWithdrawal net addrs
+  Shelley.BadInputsUTxO _ -> impossible "BadInputsUTxO"
+  Shelley.ExpiredUTxO _ -> impossible "ExpiredUTxO"
+  Shelley.MaxTxSizeUTxO _ -> impossible "MaxTxSizeUTxO"
+  Shelley.InputSetEmptyUTxO -> impossible "InputSetEmptyUTxO"
+  Shelley.FeeTooSmallUTxO _ -> impossible "FeeTooSmallUTxO"
+  Shelley.ValueNotConservedUTxO _ -> impossible "ValueNotConservedUTxO"
+  Shelley.WrongNetwork _ _ -> impossible "WrongNetwork"
+  Shelley.OutputTooSmallUTxO _ -> impossible "OutputTooSmallUTxO"
+  Shelley.UpdateFailure _ -> impossible "UpdateFailure"
+  Shelley.OutputBootAddrAttrsTooBig _ -> impossible "OutputBootAddrAttrsTooBig"
   where
     impossible name = error $ "Impossible: `" <> name <> "` for ENTITIES"
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -68,16 +68,16 @@ instance EraTx era => EncCBOR (EntitiesEnv era) where
 
 data EntitiesPredFailure era
   = CertsFailure (PredicateFailure (EraRule "CERTS" era))
-  | WithdrawalsMissingAccounts Withdrawals
+  | MissingAccountsInWithdrawals Withdrawals
   | IncompleteWithdrawals (NonEmptyMap AccountAddress (Mismatch RelEQ Coin))
-  | WithdrawalAmountsExceedAccountBalances (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
-  | DirectDepositsToMissingAccounts DirectDeposits
-  | WrongNetworkWithdrawal
+  | ExceededBalancesInWithdrawals (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
+  | MissingAccountsInDirectDeposits DirectDeposits
+  | WrongNetworkInWithdrawals
       -- | Expected network id
       Network
       -- | Withdrawal accounts with wrong network id
       (NonEmptySet AccountAddress)
-  | WrongNetworkInDirectDeposit
+  | WrongNetworkInDirectDeposits
       -- | Expected network id
       Network
       -- | Direct-deposit accounts with wrong network id
@@ -103,12 +103,12 @@ instance
   encCBOR =
     encode . \case
       CertsFailure x -> Sum (CertsFailure @era) 0 !> To x
-      WithdrawalsMissingAccounts x -> Sum (WithdrawalsMissingAccounts @era) 1 !> To x
+      MissingAccountsInWithdrawals x -> Sum (MissingAccountsInWithdrawals @era) 1 !> To x
       IncompleteWithdrawals x -> Sum (IncompleteWithdrawals @era) 2 !> To x
-      WithdrawalAmountsExceedAccountBalances x -> Sum (WithdrawalAmountsExceedAccountBalances @era) 3 !> To x
-      DirectDepositsToMissingAccounts x -> Sum (DirectDepositsToMissingAccounts @era) 4 !> To x
-      WrongNetworkWithdrawal x y -> Sum (WrongNetworkWithdrawal @era) 5 !> To x !> To y
-      WrongNetworkInDirectDeposit x y -> Sum (WrongNetworkInDirectDeposit @era) 6 !> To x !> To y
+      ExceededBalancesInWithdrawals x -> Sum (ExceededBalancesInWithdrawals @era) 3 !> To x
+      MissingAccountsInDirectDeposits x -> Sum (MissingAccountsInDirectDeposits @era) 4 !> To x
+      WrongNetworkInWithdrawals x y -> Sum (WrongNetworkInWithdrawals @era) 5 !> To x !> To y
+      WrongNetworkInDirectDeposits x y -> Sum (WrongNetworkInDirectDeposits @era) 6 !> To x !> To y
 
 instance
   ( Era era
@@ -118,12 +118,12 @@ instance
   where
   decCBOR = decode . Summands "EntitiesPredFailure" $ \case
     0 -> SumD CertsFailure <! From
-    1 -> SumD WithdrawalsMissingAccounts <! From
+    1 -> SumD MissingAccountsInWithdrawals <! From
     2 -> SumD IncompleteWithdrawals <! From
-    3 -> SumD WithdrawalAmountsExceedAccountBalances <! From
-    4 -> SumD DirectDepositsToMissingAccounts <! From
-    5 -> SumD WrongNetworkWithdrawal <! From <! From
-    6 -> SumD WrongNetworkInDirectDeposit <! From <! From
+    3 -> SumD ExceededBalancesInWithdrawals <! From
+    4 -> SumD MissingAccountsInDirectDeposits <! From
+    5 -> SumD WrongNetworkInWithdrawals <! From <! From
+    6 -> SumD WrongNetworkInDirectDeposits <! From <! From
     n -> Invalid n
 
 newtype EntitiesEvent era = CertsEvent (Event (EraRule "CERTS" era))
@@ -228,7 +228,7 @@ dijkstraEntitiesTransition = do
   let directDeposits = tx ^. bodyTxL . directDepositsTxBodyL
       accountsAfterCerts = certStateAfterCerts ^. certDStateL . accountsL
   failOnJust (directDepositsMissingAccounts directDeposits accountsAfterCerts) $
-    injectFailure . DirectDepositsToMissingAccounts
+    injectFailure . MissingAccountsInDirectDeposits
 
   pure $ certStateAfterCerts & certDStateL . accountsL %~ applyDirectDeposits directDeposits
 
@@ -238,7 +238,7 @@ validateWrongNetworkInDirectDeposit ::
   TxBody t era ->
   Test (EntitiesPredFailure era)
 validateWrongNetworkInDirectDeposit netId txb =
-  failureOnNonEmptySet depositsWrongNetwork (WrongNetworkInDirectDeposit netId)
+  failureOnNonEmptySet depositsWrongNetwork (WrongNetworkInDirectDeposits netId)
   where
     depositsWrongNetwork =
       Map.keysSet $
@@ -268,10 +268,10 @@ validateWithdrawals legacyMode network withdrawals accounts = do
               case withdrawalsThatExceedAccountBalance withdrawals network accounts of
                 Nothing -> (Map.empty, Map.empty)
                 Just (missing, exceeded) -> (unWithdrawals missing, exceeded)
-        failOnNonEmptyMap exceededWithdrawals WithdrawalAmountsExceedAccountBalances
+        failOnNonEmptyMap exceededWithdrawals ExceededBalancesInWithdrawals
         pure missingWithdrawals
   failOnNonEmptyMap missingWithdrawals $
-    WithdrawalsMissingAccounts . Withdrawals . NEM.toMap
+    MissingAccountsInWithdrawals . Withdrawals . NEM.toMap
 
 conwayToDijkstraEntitiesPredFailure ::
   forall era. Conway.ConwayLedgerPredFailure era -> EntitiesPredFailure era
@@ -291,7 +291,7 @@ conwayToDijkstraEntitiesPredFailure = \case
 shelleyUtxoToDijkstraEntitiesPredFailure ::
   Shelley.ShelleyUtxoPredFailure era -> EntitiesPredFailure era
 shelleyUtxoToDijkstraEntitiesPredFailure = \case
-  Shelley.WrongNetworkWithdrawal net addrs -> WrongNetworkWithdrawal net addrs
+  Shelley.WrongNetworkWithdrawal net addrs -> WrongNetworkInWithdrawals net addrs
   Shelley.BadInputsUTxO _ -> impossible "BadInputsUTxO"
   Shelley.ExpiredUTxO _ -> impossible "ExpiredUTxO"
   Shelley.MaxTxSizeUTxO _ -> impossible "MaxTxSizeUTxO"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -18,6 +18,7 @@ module Cardano.Ledger.Dijkstra.Rules.Entities (
   EntitiesEnv (..),
   EntitiesPredFailure (..),
   EntitiesEvent (..),
+  validateWrongNetworkInDirectDeposit,
 ) where
 
 import Cardano.Ledger.Address (DirectDeposits (..))
@@ -32,7 +33,7 @@ import Cardano.Ledger.Dijkstra.Era (DijkstraEra, ENTITIES)
 import Cardano.Ledger.Dijkstra.Rules.Certs ()
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody, directDepositsTxBodyL)
-import Cardano.Ledger.Rules.ValidationMode (runTest)
+import Cardano.Ledger.Rules.ValidationMode (Test, runTest)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
@@ -76,6 +77,11 @@ data EntitiesPredFailure era
       Network
       -- | Withdrawal accounts with wrong network id
       (NonEmptySet AccountAddress)
+  | WrongNetworkInDirectDeposit
+      -- | Expected network id
+      Network
+      -- | Direct-deposit accounts with wrong network id
+      (NonEmptySet AccountAddress)
   deriving (Generic)
 
 deriving stock instance
@@ -102,6 +108,7 @@ instance
       WithdrawalAmountsExceedAccountBalances x -> Sum (WithdrawalAmountsExceedAccountBalances @era) 3 !> To x
       DirectDepositsToMissingAccounts x -> Sum (DirectDepositsToMissingAccounts @era) 4 !> To x
       WrongNetworkWithdrawal x y -> Sum (WrongNetworkWithdrawal @era) 5 !> To x !> To y
+      WrongNetworkInDirectDeposit x y -> Sum (WrongNetworkInDirectDeposit @era) 6 !> To x !> To y
 
 instance
   ( Era era
@@ -116,6 +123,7 @@ instance
     3 -> SumD WithdrawalAmountsExceedAccountBalances <! From
     4 -> SumD DirectDepositsToMissingAccounts <! From
     5 -> SumD WrongNetworkWithdrawal <! From <! From
+    6 -> SumD WrongNetworkInDirectDeposit <! From <! From
     n -> Invalid n
 
 newtype EntitiesEvent era = CertsEvent (Event (EraRule "CERTS" era))
@@ -205,6 +213,7 @@ dijkstraEntitiesTransition = do
   network <- liftSTS $ asks networkId
 
   runTest $ Shelley.validateWrongNetworkWithdrawal network (tx ^. bodyTxL)
+  runTest $ validateWrongNetworkInDirectDeposit network (tx ^. bodyTxL)
 
   validateWithdrawals legacyMode network withdrawals accounts
 
@@ -222,6 +231,20 @@ dijkstraEntitiesTransition = do
     injectFailure . DirectDepositsToMissingAccounts
 
   pure $ certStateAfterCerts & certDStateL . accountsL %~ applyDirectDeposits directDeposits
+
+validateWrongNetworkInDirectDeposit ::
+  DijkstraEraTxBody era =>
+  Network ->
+  TxBody t era ->
+  Test (EntitiesPredFailure era)
+validateWrongNetworkInDirectDeposit netId txb =
+  failureOnNonEmptySet depositsWrongNetwork (WrongNetworkInDirectDeposit netId)
+  where
+    depositsWrongNetwork =
+      Map.keysSet $
+        Map.filterWithKey
+          (\a _ -> aaNetworkId a /= netId)
+          (unDirectDeposits $ txb ^. directDepositsTxBodyL)
 
 validateWithdrawals ::
   EraAccounts era =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -494,7 +494,7 @@ conwayToDijkstraLedgerPredFailure = \case
   Conway.ConwayTreasuryValueMismatch mm -> DijkstraTreasuryValueMismatch mm
   Conway.ConwayTxRefScriptsSizeTooBig mm -> DijkstraTxRefScriptsSizeTooBig mm
   Conway.ConwayMempoolFailure _ -> error "Impossible: MempoolFailure has been moved to MEMPOOL rule in Dijkstra"
-  Conway.ConwayWithdrawalsMissingAccounts ws -> DijkstraEntitiesFailure (WithdrawalsMissingAccounts ws)
+  Conway.ConwayWithdrawalsMissingAccounts ws -> DijkstraEntitiesFailure (MissingAccountsInWithdrawals ws)
   Conway.ConwayIncompleteWithdrawals ws -> DijkstraEntitiesFailure (IncompleteWithdrawals ws)
 
 shelleyToDijkstraLedgerPredFailure ::
@@ -504,7 +504,7 @@ shelleyToDijkstraLedgerPredFailure ::
 shelleyToDijkstraLedgerPredFailure = \case
   Shelley.UtxowFailure x -> DijkstraUtxowFailure x
   Shelley.DelegsFailure _ -> error "Impossible: DELEGS has been removed in Dijkstra"
-  Shelley.ShelleyWithdrawalsMissingAccounts x -> DijkstraEntitiesFailure (WithdrawalsMissingAccounts x)
+  Shelley.ShelleyWithdrawalsMissingAccounts x -> DijkstraEntitiesFailure (MissingAccountsInWithdrawals x)
   Shelley.ShelleyIncompleteWithdrawals x -> DijkstraEntitiesFailure (IncompleteWithdrawals x)
 
 instance

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -63,6 +63,7 @@ import Cardano.Ledger.Dijkstra.Rules.Entities (
  )
 import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.GovCert (DijkstraGovCertPredFailure)
+import Cardano.Ledger.Dijkstra.Rules.SubEntities (SubEntitiesPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubLedger
 import Cardano.Ledger.Dijkstra.Rules.SubLedgers
 import Cardano.Ledger.Dijkstra.Rules.Utxo (DijkstraUtxoEnv (..), DijkstraUtxoPredFailure)
@@ -179,6 +180,12 @@ instance InjectRuleFailure "LEDGER" Conway.ConwayGovPredFailure DijkstraEra wher
 
 instance InjectRuleFailure "LEDGER" DijkstraSubLedgersPredFailure DijkstraEra where
   injectFailure = DijkstraSubLedgersFailure . injectFailure
+
+instance InjectRuleFailure "LEDGER" SubEntitiesPredFailure DijkstraEra where
+  injectFailure =
+    injectFailure @"LEDGER" @DijkstraSubLedgersPredFailure
+      . SubLedgerFailure
+      . SubEntitiesFailure
 
 deriving instance
   ( Era era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -356,7 +356,7 @@ dijkstraLedgerTransition ::
   ) =>
   TransitionRule (LEDGER era)
 dijkstraLedgerTransition = do
-  TRC (Shelley.LedgerEnv slot mbCurEpochNo txIx pp chainAccountState, ledgerState, stAnnTx) <-
+  TRC (Shelley.LedgerEnv slot mbCurEpochNo _txIx pp chainAccountState, ledgerState, stAnnTx) <-
     judgmentContext
   let tx = stAnnTx ^. txStAnnTxG
 
@@ -373,7 +373,6 @@ dijkstraLedgerTransition = do
         ( SubLedgerEnv
             slot
             mbCurEpochNo
-            txIx
             pp
             chainAccountState
             originalUtxo

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -30,6 +30,7 @@ import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra, SUBCERTS, SUBENTITIES)
 import Cardano.Ledger.Dijkstra.Rules.Entities (
   EntitiesPredFailure (..),
+  validateWrongNetworkInDirectDeposit,
  )
 import Cardano.Ledger.Dijkstra.Rules.SubCerts (
   DijkstraSubCertsEvent,
@@ -60,6 +61,11 @@ data SubEntitiesPredFailure era
       Network
       -- | Withdrawal accounts with wrong network id
       (NonEmptySet AccountAddress)
+  | SubWrongNetworkInDirectDeposit
+      -- | Expected network id
+      Network
+      -- | Direct-deposit accounts with wrong network id
+      (NonEmptySet AccountAddress)
   deriving (Generic)
 
 deriving stock instance
@@ -85,6 +91,7 @@ instance
       SubWithdrawalAmountsExceedAccountBalances x -> Sum (SubWithdrawalAmountsExceedAccountBalances @era) 2 !> To x
       SubDirectDepositsToMissingAccounts x -> Sum (SubDirectDepositsToMissingAccounts @era) 3 !> To x
       SubWrongNetworkWithdrawal expected wrongs -> Sum (SubWrongNetworkWithdrawal @era) 4 !> To expected !> To wrongs
+      SubWrongNetworkInDirectDeposit expected wrongs -> Sum (SubWrongNetworkInDirectDeposit @era) 5 !> To expected !> To wrongs
 
 instance
   ( Era era
@@ -98,6 +105,7 @@ instance
     2 -> SumD SubWithdrawalAmountsExceedAccountBalances <! From
     3 -> SumD SubDirectDepositsToMissingAccounts <! From
     4 -> SumD SubWrongNetworkWithdrawal <! From <! From
+    5 -> SumD SubWrongNetworkInDirectDeposit <! From <! From
     n -> Invalid n
 
 newtype SubEntitiesEvent era = SubCertsEvent (Event (EraRule "SUBCERTS" era))
@@ -138,6 +146,7 @@ instance
   , Environment (EraRule "SUBCERTS" era) ~ SubCertsEnv era
   , EraRule "SUBENTITIES" era ~ SUBENTITIES era
   , InjectRuleFailure "SUBENTITIES" SubEntitiesPredFailure era
+  , InjectRuleFailure "SUBENTITIES" EntitiesPredFailure era
   , InjectRuleFailure "SUBENTITIES" Shelley.ShelleyUtxoPredFailure era
   , InjectRuleFailure "SUBENTITIES" Conway.ConwayLedgerPredFailure era
   ) =>
@@ -164,6 +173,7 @@ dijkstraSubEntitiesTransition ::
   , Environment (EraRule "SUBCERTS" era) ~ SubCertsEnv era
   , EraRule "SUBENTITIES" era ~ SUBENTITIES era
   , InjectRuleFailure "SUBENTITIES" SubEntitiesPredFailure era
+  , InjectRuleFailure "SUBENTITIES" EntitiesPredFailure era
   , InjectRuleFailure "SUBENTITIES" Shelley.ShelleyUtxoPredFailure era
   , InjectRuleFailure "SUBENTITIES" Conway.ConwayLedgerPredFailure era
   ) =>
@@ -179,6 +189,7 @@ dijkstraSubEntitiesTransition = do
   network <- liftSTS $ asks networkId
 
   runTest $ Shelley.validateWrongNetworkWithdrawal network (tx ^. bodyTxL)
+  runTest $ validateWrongNetworkInDirectDeposit network (tx ^. bodyTxL)
 
   let (missingWithdrawals, exceededWithdrawals) =
         case withdrawalsThatExceedAccountBalance withdrawals network accounts of
@@ -222,6 +233,7 @@ entitiesToSubEntitiesPredFailure ::
   EntitiesPredFailure era -> SubEntitiesPredFailure era
 entitiesToSubEntitiesPredFailure = \case
   WrongNetworkWithdrawal net addrs -> SubWrongNetworkWithdrawal net addrs
+  WrongNetworkInDirectDeposit net addrs -> SubWrongNetworkInDirectDeposit net addrs
   CertsFailure _ -> impossible "CertsFailure"
   WithdrawalsMissingAccounts _ -> impossible "WithdrawalsMissingAccounts"
   IncompleteWithdrawals _ -> impossible "IncompleteWithdrawals"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -53,15 +53,15 @@ import Lens.Micro
 
 data SubEntitiesPredFailure era
   = SubCertsFailure (PredicateFailure (EraRule "SUBCERTS" era))
-  | SubWithdrawalsMissingAccounts Withdrawals
-  | SubWithdrawalAmountsExceedAccountBalances (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
-  | SubDirectDepositsToMissingAccounts DirectDeposits
-  | SubWrongNetworkWithdrawal
+  | SubMissingAccountsInWithdrawals Withdrawals
+  | SubExceededBalancesInWithdrawals (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
+  | SubMissingAccountsInDirectDeposits DirectDeposits
+  | SubWrongNetworkInWithdrawals
       -- | Expected network id
       Network
       -- | Withdrawal accounts with wrong network id
       (NonEmptySet AccountAddress)
-  | SubWrongNetworkInDirectDeposit
+  | SubWrongNetworkInDirectDeposits
       -- | Expected network id
       Network
       -- | Direct-deposit accounts with wrong network id
@@ -87,11 +87,11 @@ instance
   encCBOR =
     encode . \case
       SubCertsFailure x -> Sum (SubCertsFailure @era) 0 !> To x
-      SubWithdrawalsMissingAccounts x -> Sum (SubWithdrawalsMissingAccounts @era) 1 !> To x
-      SubWithdrawalAmountsExceedAccountBalances x -> Sum (SubWithdrawalAmountsExceedAccountBalances @era) 2 !> To x
-      SubDirectDepositsToMissingAccounts x -> Sum (SubDirectDepositsToMissingAccounts @era) 3 !> To x
-      SubWrongNetworkWithdrawal expected wrongs -> Sum (SubWrongNetworkWithdrawal @era) 4 !> To expected !> To wrongs
-      SubWrongNetworkInDirectDeposit expected wrongs -> Sum (SubWrongNetworkInDirectDeposit @era) 5 !> To expected !> To wrongs
+      SubMissingAccountsInWithdrawals x -> Sum (SubMissingAccountsInWithdrawals @era) 1 !> To x
+      SubExceededBalancesInWithdrawals x -> Sum (SubExceededBalancesInWithdrawals @era) 2 !> To x
+      SubMissingAccountsInDirectDeposits x -> Sum (SubMissingAccountsInDirectDeposits @era) 3 !> To x
+      SubWrongNetworkInWithdrawals expected wrongs -> Sum (SubWrongNetworkInWithdrawals @era) 4 !> To expected !> To wrongs
+      SubWrongNetworkInDirectDeposits expected wrongs -> Sum (SubWrongNetworkInDirectDeposits @era) 5 !> To expected !> To wrongs
 
 instance
   ( Era era
@@ -101,11 +101,11 @@ instance
   where
   decCBOR = decode . Summands "SubEntitiesPredFailure" $ \case
     0 -> SumD SubCertsFailure <! From
-    1 -> SumD SubWithdrawalsMissingAccounts <! From
-    2 -> SumD SubWithdrawalAmountsExceedAccountBalances <! From
-    3 -> SumD SubDirectDepositsToMissingAccounts <! From
-    4 -> SumD SubWrongNetworkWithdrawal <! From <! From
-    5 -> SumD SubWrongNetworkInDirectDeposit <! From <! From
+    1 -> SumD SubMissingAccountsInWithdrawals <! From
+    2 -> SumD SubExceededBalancesInWithdrawals <! From
+    3 -> SumD SubMissingAccountsInDirectDeposits <! From
+    4 -> SumD SubWrongNetworkInWithdrawals <! From <! From
+    5 -> SumD SubWrongNetworkInDirectDeposits <! From <! From
     n -> Invalid n
 
 newtype SubEntitiesEvent era = SubCertsEvent (Event (EraRule "SUBCERTS" era))
@@ -196,8 +196,8 @@ dijkstraSubEntitiesTransition = do
           Nothing -> (Map.empty, Map.empty)
           Just (missing, exceeded) -> (unWithdrawals missing, exceeded)
   failOnNonEmptyMap missingWithdrawals $
-    injectFailure . SubWithdrawalsMissingAccounts . Withdrawals . NEM.toMap
-  failOnNonEmptyMap exceededWithdrawals $ injectFailure . SubWithdrawalAmountsExceedAccountBalances
+    injectFailure . SubMissingAccountsInWithdrawals . Withdrawals . NEM.toMap
+  failOnNonEmptyMap exceededWithdrawals $ injectFailure . SubExceededBalancesInWithdrawals
 
   let certStateBeforeSubCerts =
         certState
@@ -210,7 +210,7 @@ dijkstraSubEntitiesTransition = do
   let directDeposits = tx ^. bodyTxL . directDepositsTxBodyL
       accountsAfterSubCerts = certStateAfterSubCerts ^. certDStateL . accountsL
   failOnJust (directDepositsMissingAccounts directDeposits accountsAfterSubCerts) $
-    injectFailure . SubDirectDepositsToMissingAccounts
+    injectFailure . SubMissingAccountsInDirectDeposits
 
   pure $ certStateAfterSubCerts & certDStateL . accountsL %~ applyDirectDeposits directDeposits
 
@@ -232,13 +232,13 @@ conwayToDijkstraSubEntitiesPredFailure = \case
 entitiesToSubEntitiesPredFailure ::
   EntitiesPredFailure era -> SubEntitiesPredFailure era
 entitiesToSubEntitiesPredFailure = \case
-  WrongNetworkWithdrawal net addrs -> SubWrongNetworkWithdrawal net addrs
-  WrongNetworkInDirectDeposit net addrs -> SubWrongNetworkInDirectDeposit net addrs
+  WrongNetworkInWithdrawals net addrs -> SubWrongNetworkInWithdrawals net addrs
+  WrongNetworkInDirectDeposits net addrs -> SubWrongNetworkInDirectDeposits net addrs
   CertsFailure _ -> impossible "CertsFailure"
-  WithdrawalsMissingAccounts _ -> impossible "WithdrawalsMissingAccounts"
+  MissingAccountsInWithdrawals _ -> impossible "MissingAccountsInWithdrawals"
   IncompleteWithdrawals _ -> impossible "IncompleteWithdrawals"
-  WithdrawalAmountsExceedAccountBalances _ -> impossible "WithdrawalAmountsExceedAccountBalances"
-  DirectDepositsToMissingAccounts _ -> impossible "DirectDepositsToMissingAccounts"
+  ExceededBalancesInWithdrawals _ -> impossible "ExceededBalancesInWithdrawals"
+  MissingAccountsInDirectDeposits _ -> impossible "MissingAccountsInDirectDeposits"
   where
     impossible name = error $ "Impossible: `" <> name <> "` for SUBENTITIES"
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -20,7 +20,7 @@ module Cardano.Ledger.Dijkstra.Rules.SubEntities (
 ) where
 
 import Cardano.Ledger.Address (DirectDeposits (..))
-import Cardano.Ledger.BaseTypes (Globals (networkId), Mismatch (..), Relation (..), ShelleyBase)
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin (Coin)
@@ -28,12 +28,17 @@ import Cardano.Ledger.Conway.Core
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra, SUBCERTS, SUBENTITIES)
+import Cardano.Ledger.Dijkstra.Rules.Entities (
+  EntitiesPredFailure (..),
+ )
 import Cardano.Ledger.Dijkstra.Rules.SubCerts (
   DijkstraSubCertsEvent,
   DijkstraSubCertsPredFailure,
   SubCertsEnv (..),
  )
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody, directDepositsTxBodyL)
+import Cardano.Ledger.Rules.ValidationMode (runTest)
+import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
@@ -41,6 +46,7 @@ import Data.Map.NonEmpty (NonEmptyMap)
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
+import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
 import Lens.Micro
 
@@ -49,6 +55,11 @@ data SubEntitiesPredFailure era
   | SubWithdrawalsMissingAccounts Withdrawals
   | SubWithdrawalAmountsExceedAccountBalances (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
   | SubDirectDepositsToMissingAccounts DirectDeposits
+  | SubWrongNetworkWithdrawal
+      -- | Expected network id
+      Network
+      -- | Withdrawal accounts with wrong network id
+      (NonEmptySet AccountAddress)
   deriving (Generic)
 
 deriving stock instance
@@ -73,6 +84,7 @@ instance
       SubWithdrawalsMissingAccounts x -> Sum (SubWithdrawalsMissingAccounts @era) 1 !> To x
       SubWithdrawalAmountsExceedAccountBalances x -> Sum (SubWithdrawalAmountsExceedAccountBalances @era) 2 !> To x
       SubDirectDepositsToMissingAccounts x -> Sum (SubDirectDepositsToMissingAccounts @era) 3 !> To x
+      SubWrongNetworkWithdrawal expected wrongs -> Sum (SubWrongNetworkWithdrawal @era) 4 !> To expected !> To wrongs
 
 instance
   ( Era era
@@ -85,6 +97,7 @@ instance
     1 -> SumD SubWithdrawalsMissingAccounts <! From
     2 -> SumD SubWithdrawalAmountsExceedAccountBalances <! From
     3 -> SumD SubDirectDepositsToMissingAccounts <! From
+    4 -> SumD SubWrongNetworkWithdrawal <! From <! From
     n -> Invalid n
 
 newtype SubEntitiesEvent era = SubCertsEvent (Event (EraRule "SUBCERTS" era))
@@ -109,6 +122,12 @@ instance InjectRuleFailure "SUBENTITIES" Conway.ConwayCertsPredFailure DijkstraE
 instance InjectRuleFailure "SUBENTITIES" Conway.ConwayLedgerPredFailure DijkstraEra where
   injectFailure = conwayToDijkstraSubEntitiesPredFailure
 
+instance InjectRuleFailure "SUBENTITIES" EntitiesPredFailure DijkstraEra where
+  injectFailure = entitiesToSubEntitiesPredFailure
+
+instance InjectRuleFailure "SUBENTITIES" Shelley.ShelleyUtxoPredFailure DijkstraEra where
+  injectFailure = injectFailure @"SUBENTITIES" @EntitiesPredFailure . injectFailure @"ENTITIES"
+
 instance
   ( EraTx era
   , DijkstraEraTxBody era
@@ -119,6 +138,7 @@ instance
   , Environment (EraRule "SUBCERTS" era) ~ SubCertsEnv era
   , EraRule "SUBENTITIES" era ~ SUBENTITIES era
   , InjectRuleFailure "SUBENTITIES" SubEntitiesPredFailure era
+  , InjectRuleFailure "SUBENTITIES" Shelley.ShelleyUtxoPredFailure era
   , InjectRuleFailure "SUBENTITIES" Conway.ConwayLedgerPredFailure era
   ) =>
   STS (SUBENTITIES era)
@@ -144,6 +164,7 @@ dijkstraSubEntitiesTransition ::
   , Environment (EraRule "SUBCERTS" era) ~ SubCertsEnv era
   , EraRule "SUBENTITIES" era ~ SUBENTITIES era
   , InjectRuleFailure "SUBENTITIES" SubEntitiesPredFailure era
+  , InjectRuleFailure "SUBENTITIES" Shelley.ShelleyUtxoPredFailure era
   , InjectRuleFailure "SUBENTITIES" Conway.ConwayLedgerPredFailure era
   ) =>
   TransitionRule (SUBENTITIES era)
@@ -156,6 +177,9 @@ dijkstraSubEntitiesTransition = do
       accounts = certState ^. certDStateL . accountsL
 
   network <- liftSTS $ asks networkId
+
+  runTest $ Shelley.validateWrongNetworkWithdrawal network (tx ^. bodyTxL)
+
   let (missingWithdrawals, exceededWithdrawals) =
         case withdrawalsThatExceedAccountBalance withdrawals network accounts of
           Nothing -> (Map.empty, Map.empty)
@@ -191,6 +215,18 @@ conwayToDijkstraSubEntitiesPredFailure = \case
   Conway.ConwayMempoolFailure _ -> impossible "ConwayMempoolFailure"
   Conway.ConwayWithdrawalsMissingAccounts _ -> impossible "ConwayWithdrawalsMissingAccounts"
   Conway.ConwayIncompleteWithdrawals _ -> impossible "ConwayIncompleteWithdrawals"
+  where
+    impossible name = error $ "Impossible: `" <> name <> "` for SUBENTITIES"
+
+entitiesToSubEntitiesPredFailure ::
+  EntitiesPredFailure era -> SubEntitiesPredFailure era
+entitiesToSubEntitiesPredFailure = \case
+  WrongNetworkWithdrawal net addrs -> SubWrongNetworkWithdrawal net addrs
+  CertsFailure _ -> impossible "CertsFailure"
+  WithdrawalsMissingAccounts _ -> impossible "WithdrawalsMissingAccounts"
+  IncompleteWithdrawals _ -> impossible "IncompleteWithdrawals"
+  WithdrawalAmountsExceedAccountBalances _ -> impossible "WithdrawalAmountsExceedAccountBalances"
+  DirectDepositsToMissingAccounts _ -> impossible "DirectDepositsToMissingAccounts"
   where
     impossible name = error $ "Impossible: `" <> name <> "` for SUBENTITIES"
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -95,7 +95,6 @@ import Lens.Micro
 data SubLedgerEnv era = SubLedgerEnv
   { sleSlotNo :: SlotNo
   , sleEpochNo :: Maybe EpochNo
-  , sleTxIx :: TxIx
   , slePParams :: PParams era
   , sleAccount :: ChainAccountState
   , sleOriginalUtxo :: UTxO era
@@ -232,7 +231,7 @@ dijkstraSubLedgersTransition ::
   TransitionRule (EraRule "SUBLEDGER" era)
 dijkstraSubLedgersTransition = do
   TRC
-    ( SubLedgerEnv slot mbCurEpochNo _ pp chainAccountState originalUtxo topIsPhase2Valid
+    ( SubLedgerEnv slot mbCurEpochNo pp chainAccountState originalUtxo topIsPhase2Valid
       , LedgerState utxoState certState
       , stAnnTx
       ) <-

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -369,7 +369,7 @@ conwayToDijkstraSubLedgerPredFailure = \case
   Conway.ConwayCertsFailure f -> SubEntitiesFailure (injectFailure @"SUBENTITIES" f)
   Conway.ConwayGovFailure f -> SubGovFailure (injectFailure @"SUBGOV" f)
   Conway.ConwayWdrlNotDelegatedToDRep _ -> error "Impossible: `ConwayWdrlNotDelegatedToDRep` for SUBLEDGER"
-  Conway.ConwayWithdrawalsMissingAccounts x -> SubEntitiesFailure (SubWithdrawalsMissingAccounts x)
+  Conway.ConwayWithdrawalsMissingAccounts x -> SubEntitiesFailure (SubMissingAccountsInWithdrawals x)
   Conway.ConwayTreasuryValueMismatch x -> SubTreasuryValueMismatch x
   Conway.ConwayTxRefScriptsSizeTooBig _ -> error "Impossible: `ConwayTxRefScriptsSizeTooBig` for SUBLEDGER"
   Conway.ConwayMempoolFailure _ -> error "Impossible: `ConwayMempoolFailure` for SUBLEDGER"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -85,11 +85,6 @@ data DijkstraSubUtxoPredFailure era
       Network
       -- | the set of addresses with incorrect network IDs
       (NonEmptySet Addr)
-  | SubWrongNetworkWithdrawal
-      -- | the expected network id
-      Network
-      -- | the set of reward addresses with incorrect network IDs
-      (NonEmptySet AccountAddress)
   | -- | list of supplied bad transaction outputs
     SubOutputBootAddrAttrsTooBig (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
@@ -257,7 +252,6 @@ dijkstraSubUtxoTransition = do
 
   netId <- liftSTS $ asks networkId
   runTestOnSignal $ Shelley.validateWrongNetwork netId allOutputs
-  runTestOnSignal $ Shelley.validateWrongNetworkWithdrawal netId txBody
   runTestOnSignal $ validateWrongNetworkInDirectDeposit netId txBody
   runTestOnSignal $ Alonzo.validateWrongNetworkInTxBody netId txBody
 
@@ -283,7 +277,6 @@ instance
       SubMaxTxSizeUTxO mm -> Sum SubMaxTxSizeUTxO 2 !> To mm
       SubInputSetEmptyUTxO -> Sum SubInputSetEmptyUTxO 3
       SubWrongNetwork right wrongs -> Sum (SubWrongNetwork @era) 4 !> To right !> To wrongs
-      SubWrongNetworkWithdrawal right wrongs -> Sum (SubWrongNetworkWithdrawal @era) 5 !> To right !> To wrongs
       SubOutputBootAddrAttrsTooBig outs -> Sum (SubOutputBootAddrAttrsTooBig @era) 6 !> To outs
       SubOutputTooBigUTxO outs -> Sum (SubOutputTooBigUTxO @era) 7 !> To outs
       SubWrongNetworkInTxBody mm -> Sum SubWrongNetworkInTxBody 8 !> To mm
@@ -305,7 +298,6 @@ instance
     2 -> SumD SubMaxTxSizeUTxO <! From
     3 -> SumD SubInputSetEmptyUTxO
     4 -> SumD SubWrongNetwork <! From <! From
-    5 -> SumD SubWrongNetworkWithdrawal <! From <! From
     6 -> SumD SubOutputBootAddrAttrsTooBig <! From
     7 -> SumD SubOutputTooBigUTxO <! From
     8 -> SumD SubWrongNetworkInTxBody <! From
@@ -325,7 +317,6 @@ dijkstraUtxoToDijkstraSubUtxoPredFailure = \case
   FeeTooSmallUTxO _ -> error "Impossible: `FeeTooSmallUTxO` for SUBUTXO"
   ValueNotConservedUTxO _ -> error "Impossible: `ValueNotConservedUTxO` for SUBUTXO"
   WrongNetwork x y -> SubWrongNetwork x y
-  WrongNetworkWithdrawal x y -> SubWrongNetworkWithdrawal x y
   OutputBootAddrAttrsTooBig xs -> SubOutputBootAddrAttrsTooBig xs
   OutputTooBigUTxO xs -> SubOutputTooBigUTxO xs
   InsufficientCollateral _ _ -> error "Impossible: `InsufficientCollateral` for SUBUTXO"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubUtxo.hs
@@ -43,7 +43,6 @@ import Cardano.Ledger.Dijkstra.Era (
 import Cardano.Ledger.Dijkstra.Rules.Utxo (
   DijkstraUtxoPredFailure (..),
   conwayToDijkstraUtxoPredFailure,
-  validateWrongNetworkInDirectDeposit,
  )
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody)
 import Cardano.Ledger.Rules.ValidationMode
@@ -97,11 +96,6 @@ data DijkstraSubUtxoPredFailure era
   | -- | list of supplied transaction outputs that are too small,
     -- together with the minimum value for the given output.
     SubBabbageOutputTooSmallUTxO (NonEmpty (TxOut era, Coin))
-  | SubWrongNetworkInDirectDeposit
-      -- | the expected network id
-      Network
-      -- | the set of account addresses with incorrect network IDs
-      (NonEmptySet AccountAddress)
   deriving (Generic)
 
 deriving stock instance
@@ -194,7 +188,6 @@ instance
   , InjectRuleFailure "SUBUTXO" Allegra.AllegraUtxoPredFailure era
   , InjectRuleFailure "SUBUTXO" Alonzo.AlonzoUtxoPredFailure era
   , InjectRuleFailure "SUBUTXO" Babbage.BabbageUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" DijkstraUtxoPredFailure era
   ) =>
   STS (SUBUTXO era)
   where
@@ -219,7 +212,6 @@ dijkstraSubUtxoTransition ::
   , InjectRuleFailure "SUBUTXO" Allegra.AllegraUtxoPredFailure era
   , InjectRuleFailure "SUBUTXO" Alonzo.AlonzoUtxoPredFailure era
   , InjectRuleFailure "SUBUTXO" Babbage.BabbageUtxoPredFailure era
-  , InjectRuleFailure "SUBUTXO" DijkstraUtxoPredFailure era
   ) =>
   TransitionRule (EraRule "SUBUTXO" era)
 dijkstraSubUtxoTransition = do
@@ -252,7 +244,6 @@ dijkstraSubUtxoTransition = do
 
   netId <- liftSTS $ asks networkId
   runTestOnSignal $ Shelley.validateWrongNetwork netId allOutputs
-  runTestOnSignal $ validateWrongNetworkInDirectDeposit netId txBody
   runTestOnSignal $ Alonzo.validateWrongNetworkInTxBody netId txBody
 
   case topTxIsPhase2Valid of
@@ -282,7 +273,6 @@ instance
       SubWrongNetworkInTxBody mm -> Sum SubWrongNetworkInTxBody 8 !> To mm
       SubOutsideForecast a -> Sum SubOutsideForecast 9 !> To a
       SubBabbageOutputTooSmallUTxO x -> Sum SubBabbageOutputTooSmallUTxO 10 !> To x
-      SubWrongNetworkInDirectDeposit right wrongs -> Sum (SubWrongNetworkInDirectDeposit @era) 11 !> To right !> To wrongs
 
 instance
   ( Era era
@@ -303,7 +293,6 @@ instance
     8 -> SumD SubWrongNetworkInTxBody <! From
     9 -> SumD SubOutsideForecast <! From
     10 -> SumD SubBabbageOutputTooSmallUTxO <! From
-    11 -> SumD SubWrongNetworkInDirectDeposit <! From <! From
     n -> Invalid n
 
 dijkstraUtxoToDijkstraSubUtxoPredFailure ::
@@ -331,5 +320,4 @@ dijkstraUtxoToDijkstraSubUtxoPredFailure = \case
   BabbageOutputTooSmallUTxO outs -> SubBabbageOutputTooSmallUTxO outs
   BabbageNonDisjointRefInputs _ -> error "Impossible: `BabbageNonDisjointRefInputs` for SUBUTXO"
   PtrPresentInCollateralReturn _ -> error "Impossible: `PtrPresentInCollateralReturn` for SUBUTXO"
-  WrongNetworkInDirectDeposit x y -> SubWrongNetworkInDirectDeposit x y
   WithdrawalsExceedAccountBalance _ -> error "Impossible: `WithdrawalsExceedAccountBalance` for SUBUTXO"

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -20,10 +20,8 @@ module Cardano.Ledger.Dijkstra.Rules.Utxo (
   DijkstraUtxoEnv (..),
   DijkstraUtxoPredFailure (..),
   conwayToDijkstraUtxoPredFailure,
-  validateWrongNetworkInDirectDeposit,
 ) where
 
-import Cardano.Ledger.Address (DirectDeposits (..))
 import qualified Cardano.Ledger.Allegra.Rules as Allegra
 import qualified Cardano.Ledger.Alonzo.Rules as Alonzo
 import Cardano.Ledger.Alonzo.TxWits (unRedeemersL)
@@ -78,7 +76,6 @@ import Control.State.Transition.Extended (
   TRC (..),
   TransitionRule,
   failureOnNonEmptyMap,
-  failureOnNonEmptySet,
   judgmentContext,
   liftSTS,
   trans,
@@ -160,11 +157,6 @@ data DijkstraUtxoPredFailure era
   | -- | TxIns that appear in both inputs and reference inputs
     BabbageNonDisjointRefInputs (NonEmpty TxIn)
   | PtrPresentInCollateralReturn (TxOut era)
-  | WrongNetworkInDirectDeposit
-      -- | the expected network id
-      Network
-      -- | the set of account addresses with incorrect network IDs
-      (NonEmptySet AccountAddress)
   | -- | Total withdrawals per account that exceed the original account balance
     WithdrawalsExceedAccountBalance (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
   deriving (Generic)
@@ -299,20 +291,6 @@ validateBatchCollateral pp tx (UTxO utxo) =
       hasRedeemers t || any hasRedeemers (t ^. bodyTxL . subTransactionsTxBodyL)
     hasRedeemers = not . null . (^. witsTxL . rdmrsTxWitsL . unRedeemersL)
 
-validateWrongNetworkInDirectDeposit ::
-  DijkstraEraTxBody era =>
-  Network ->
-  TxBody t era ->
-  Test (DijkstraUtxoPredFailure era)
-validateWrongNetworkInDirectDeposit netId txb =
-  failureOnNonEmptySet depositsWrongNetwork (WrongNetworkInDirectDeposit netId)
-  where
-    depositsWrongNetwork =
-      Map.keysSet $
-        Map.filterWithKey
-          (\a _ -> aaNetworkId a /= netId)
-          (unDirectDeposits $ txb ^. directDepositsTxBodyL)
-
 -- | Ensure that value consumed and produced matches up exactly,  aggregated across the entire batch
 -- (top-level transaction and all its sub-transactions).
 --
@@ -419,9 +397,6 @@ dijkstraUtxoTransition = do
 
   {- (txnetworkid txb = NetworkId) ∨ (txnetworkid txb = ◇) -}
   runTestOnSignal $ Alonzo.validateWrongNetworkInTxBody netId txBody
-
-  {- direct deposit network IDs -}
-  runTestOnSignal $ validateWrongNetworkInDirectDeposit netId txBody
 
   {- no Ptr in collateral return -}
   validateNoPtrInCollateralReturn txBody
@@ -535,7 +510,6 @@ instance
       BabbageOutputTooSmallUTxO x -> Sum BabbageOutputTooSmallUTxO 20 !> To x
       BabbageNonDisjointRefInputs x -> Sum BabbageNonDisjointRefInputs 21 !> To x
       PtrPresentInCollateralReturn x -> Sum PtrPresentInCollateralReturn 22 !> To x
-      WrongNetworkInDirectDeposit right wrongs -> Sum (WrongNetworkInDirectDeposit @era) 23 !> To right !> To wrongs
       WithdrawalsExceedAccountBalance mm -> Sum WithdrawalsExceedAccountBalance 24 !> To mm
 
 instance
@@ -570,7 +544,6 @@ instance
     20 -> SumD BabbageOutputTooSmallUTxO <! From
     21 -> SumD BabbageNonDisjointRefInputs <! From
     22 -> SumD PtrPresentInCollateralReturn <! From
-    23 -> SumD WrongNetworkInDirectDeposit <! From <! From
     24 -> SumD WithdrawalsExceedAccountBalance <! From
     n -> Invalid n
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxo.hs
@@ -124,11 +124,6 @@ data DijkstraUtxoPredFailure era
       Network
       -- | the set of addresses with incorrect network IDs
       (NonEmptySet Addr)
-  | WrongNetworkWithdrawal
-      -- | the expected network id
-      Network
-      -- | the set of reward addresses with incorrect network IDs
-      (NonEmptySet AccountAddress)
   | -- | list of supplied bad transaction outputs
     OutputBootAddrAttrsTooBig (NonEmpty (TxOut era))
   | -- | list of supplied bad transaction output triples (actualSize,PParameterMaxValue,TxOut)
@@ -422,9 +417,6 @@ dijkstraUtxoTransition = do
   {- ∀(_ → (a, _)) ∈ allOuts txb, netId a = NetworkId -}
   runTestOnSignal $ Shelley.validateWrongNetwork netId allOutputs
 
-  {- ∀(a → ) ∈ txwdrls txb, netId a = NetworkId -}
-  runTestOnSignal $ Shelley.validateWrongNetworkWithdrawal netId txBody
-
   {- (txnetworkid txb = NetworkId) ∨ (txnetworkid txb = ◇) -}
   runTestOnSignal $ Alonzo.validateWrongNetworkInTxBody netId txBody
 
@@ -529,7 +521,6 @@ instance
       FeeTooSmallUTxO mm -> Sum FeeTooSmallUTxO 5 !> To mm
       ValueNotConservedUTxO mm -> Sum (ValueNotConservedUTxO @era) 6 !> To mm
       WrongNetwork right wrongs -> Sum (WrongNetwork @era) 7 !> To right !> To wrongs
-      WrongNetworkWithdrawal right wrongs -> Sum (WrongNetworkWithdrawal @era) 8 !> To right !> To wrongs
       OutputBootAddrAttrsTooBig outs -> Sum (OutputBootAddrAttrsTooBig @era) 9 !> To outs
       OutputTooBigUTxO outs -> Sum (OutputTooBigUTxO @era) 10 !> To outs
       InsufficientCollateral a b -> Sum InsufficientCollateral 11 !> To a !> To b
@@ -565,7 +556,6 @@ instance
     5 -> SumD FeeTooSmallUTxO <! From
     6 -> SumD ValueNotConservedUTxO <! From
     7 -> SumD WrongNetwork <! From <! From
-    8 -> SumD WrongNetworkWithdrawal <! From <! From
     9 -> SumD OutputBootAddrAttrsTooBig <! From
     10 -> SumD OutputTooBigUTxO <! From
     11 -> SumD InsufficientCollateral <! From <! From
@@ -599,7 +589,7 @@ conwayToDijkstraUtxoPredFailure = \case
   Conway.FeeTooSmallUTxO m -> FeeTooSmallUTxO m
   Conway.ValueNotConservedUTxO m -> ValueNotConservedUTxO m
   Conway.WrongNetwork x y -> WrongNetwork x y
-  Conway.WrongNetworkWithdrawal x y -> WrongNetworkWithdrawal x y
+  Conway.WrongNetworkWithdrawal _ _ -> error "Impossible: `WrongNetworkWithdrawal` for UTXO"
   Conway.OutputTooSmallUTxO _ -> error "Impossible: `OutputTooSmallUTxO` for UTXO"
   Conway.UtxosFailure x -> UtxosFailure x
   Conway.OutputBootAddrAttrsTooBig xs -> OutputBootAddrAttrsTooBig xs

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp.hs
@@ -12,7 +12,7 @@ import Control.State.Transition (Event)
 import Test.Cardano.Ledger.Common
 import qualified Test.Cardano.Ledger.Conway.Imp as ConwayImp
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertSpec as CERT
-import qualified Test.Cardano.Ledger.Dijkstra.Imp.CertsSpec as CERTS
+import qualified Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec as ENTITIES
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec as LEDGER
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec as UTXO
 import qualified Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec as UTXOW
@@ -32,6 +32,6 @@ spec era = do
   describe "DijkstraEra Onwards" $ withImpInitEachEraVersion era $ do
     LEDGER.spec
     CERT.spec
-    CERTS.spec
+    ENTITIES.spec
     UTXOW.spec
     UTXO.spec

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertsSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/CertsSpec.hs
@@ -45,7 +45,7 @@ spec = describe "CERTS" $ do
             WithdrawalsExceedAccountBalance @era $
               NE.singleton accountAddress $
                 Mismatch (Coin 20) mempty
-        , injectFailure . WithdrawalsMissingAccounts @era $
+        , injectFailure . MissingAccountsInWithdrawals @era $
             Withdrawals [(accountAddress, Coin 20)]
         ]
       (registeredAccountAddress, reward, stakeKey2) <- setupAccountAddress
@@ -58,7 +58,7 @@ spec = describe "CERTS" $ do
                 .~ Withdrawals [(accountAddress, zero), (registeredAccountAddress, reward)]
       submitFailingTx
         tx2
-        [ injectFailure . WithdrawalsMissingAccounts @era $
+        [ injectFailure . MissingAccountsInWithdrawals @era $
             Withdrawals [(accountAddress, zero)]
         ]
 
@@ -83,7 +83,7 @@ spec = describe "CERTS" $ do
               NE.singleton accountAddress1 $
                 Mismatch (reward1 <+> Coin 1) reward1
         , injectFailure $
-            WithdrawalAmountsExceedAccountBalances @era $
+            ExceededBalancesInWithdrawals @era $
               NE.singleton accountAddress1 $
                 Mismatch (reward1 <+> Coin 1) reward1
         ]

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Test.Cardano.Ledger.Dijkstra.Imp.CertsSpec (spec) where
+module Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec (spec) where
 
 import Cardano.Ledger.BaseTypes (EpochInterval (..), Mismatch (..))
 import Cardano.Ledger.Coin (Coin (..))
@@ -26,7 +26,7 @@ import Test.Cardano.Ledger.Imp.Common
 import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum)
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
-spec = describe "CERTS" $ do
+spec = describe "ENTITIES" $ do
   describe "Withdrawals" $ do
     it "Withdrawing from an unregistered staking address" $ do
       modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -8,7 +8,9 @@
 
 module Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec (spec) where
 
-import Cardano.Ledger.BaseTypes (EpochInterval (..), Mismatch (..))
+import Cardano.Base.Typeable (Typeable)
+import Cardano.Ledger.Address
+import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Coin (Coin (..))
 import Cardano.Ledger.Credential (Credential (..))
 import Cardano.Ledger.DRep (DRep (..))
@@ -16,10 +18,14 @@ import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Rules (
   DijkstraUtxoPredFailure (..),
   EntitiesPredFailure (..),
+  SubEntitiesPredFailure (..),
  )
 import Cardano.Ledger.Plutus
 import Cardano.Ledger.Val (Val (..))
+import qualified Data.Foldable as Foldable
+import Data.List ((\\))
 import qualified Data.Map.NonEmpty as NE
+import qualified Data.Set.NonEmpty as NES
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Dijkstra.ImpTest
 import Test.Cardano.Ledger.Imp.Common
@@ -109,6 +115,32 @@ spec = describe "ENTITIES" $ do
             & withdrawalsTxBodyL
               .~ Withdrawals
                 [(accountAddress1, zero)]
+
+    it "Rejects withdrawals and direct deposits with wrong network id" $ do
+      stakeKey <- freshKeyHash
+      accountAddress <- registerStakeCredential (KeyHashObj stakeKey)
+      let wrongNetworkAccount = accountAddress & accountAddressNetworkIdL .~ Mainnet
+      let txBody :: forall l. Typeable l => TxBody l era
+          txBody =
+            mkBasicTxBody
+              & withdrawalsTxBodyL
+                .~ Withdrawals [(wrongNetworkAccount, mempty)]
+              & directDepositsTxBodyL
+                .~ DirectDeposits [(wrongNetworkAccount, Coin 50)]
+
+      submitFailingTx
+        (mkBasicTx txBody)
+        [ injectFailure . WrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
+        , injectFailure . WrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
+        , injectFailure . MissingAccountsInWithdrawals @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+        ]
+
+      submitFailingTxIncluding
+        (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody])
+        [ injectFailure . SubWrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
+        , injectFailure . SubWrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
+        , injectFailure . SubMissingAccountsInWithdrawals @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+        ]
   where
     setupAccountAddress :: ImpTestM era (AccountAddress, Coin, KeyHash Staking)
     setupAccountAddress = do
@@ -118,3 +150,13 @@ spec = describe "ENTITIES" $ do
       submitAndExpireProposalToMakeReward cred
       b <- getBalance cred
       pure (ra, b, kh)
+
+    -- Poor man's `submitFailingTx` - only checking that the given predicate failures
+    -- are part of all the failures returned by submitting the transaction.
+    -- TOOD: to be replaced by `submitFailingTx` when the Imp fixup for nested transaction is done.
+    submitFailingTxIncluding tx expected = do
+      result <- trySubmitTx tx
+      case result of
+        Left (predFailures, _) ->
+          (expected \\ Foldable.toList predFailures) `shouldBe` []
+        Right _ -> expectationFailure "Expected submission to fail, but it succeeded"

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/ImpTest.hs
@@ -35,6 +35,7 @@ import Cardano.Ledger.Dijkstra.Rules (
   DijkstraUtxoPredFailure,
   DijkstraUtxowPredFailure,
   EntitiesPredFailure (..),
+  SubEntitiesPredFailure (..),
  )
 import Cardano.Ledger.Dijkstra.Scripts (
   DijkstraNativeScript,
@@ -99,6 +100,7 @@ class
   , DijkstraEraTest era
   , InjectRuleFailure "LEDGER" DijkstraLedgerPredFailure era
   , InjectRuleFailure "LEDGER" EntitiesPredFailure era
+  , InjectRuleFailure "LEDGER" SubEntitiesPredFailure era
   , InjectRuleFailure "LEDGER" DijkstraUtxoPredFailure era
   , InjectRuleFailure "LEDGER" DijkstraUtxowPredFailure era
   , InjectRuleFailure "MEMPOOL" DijkstraMempoolPredFailure era

--- a/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
+++ b/libs/cardano-ledger-conformance/test/Test/Cardano/Ledger/Conformance/Imp/Dijkstra.hs
@@ -22,7 +22,7 @@ import Test.Cardano.Ledger.Conway.Imp.UtxoSpec qualified as ConwayUTXO
 import Test.Cardano.Ledger.Conway.Imp.UtxosSpec qualified as ConwayUTXOS
 import Test.Cardano.Ledger.Conway.Imp.UtxowSpec qualified as ConwayUTXOW
 import Test.Cardano.Ledger.Dijkstra.Imp.CertSpec qualified as CERT
-import Test.Cardano.Ledger.Dijkstra.Imp.CertsSpec qualified as CERTS
+import Test.Cardano.Ledger.Dijkstra.Imp.EntitiesSpec qualified as ENTITIES
 import Test.Cardano.Ledger.Dijkstra.Imp.LedgerSpec qualified as LEDGER
 import Test.Cardano.Ledger.Dijkstra.Imp.UtxoSpec qualified as UTXO
 import Test.Cardano.Ledger.Dijkstra.Imp.UtxowSpec qualified as UTXOW
@@ -39,7 +39,7 @@ spec = do
             ConwayBBODY.spec
             CERT.spec
             xdescribe "disabled" ConwayCERTS.spec
-            CERTS.spec
+            ENTITIES.spec
             ConwayDELEG.spec
             ConwayENACT.spec
             ConwayEPOCH.spec

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Core.hs
@@ -266,7 +266,7 @@ class
 
   -- | Compute the total deposits from the certificates in a TxBody.
   --
-  -- This is the contribution of a TxBody towards the consumed amount by the transaction
+  -- This is the contribution of a TxBody towards the produced amount by the transaction
   getTotalDepositsTxBody ::
     PParams era ->
     -- | Check whether stake pool is registered or not
@@ -278,7 +278,7 @@ class
 
   -- | Compute the total refunds from the Certs of a TxBody.
   --
-  -- This is the contribution of a TxBody towards produced amount by the transaction
+  -- This is the contribution of a TxBody towards consumed amount by the transaction
   getTotalRefundsTxBody ::
     PParams era ->
     -- | Lookup current deposit for Staking credential if one is registered


### PR DESCRIPTION
# Description

In master these checks (alongside the corresponding PredicateFailures) are in (SUB)UTXO. 
According to the spec, they should be in (SUB)ENTITIES, which is what this PR is doing.
It also renames these failures for consistency. 
`CertsSpec` is renamed to `EntitiesSpec`, since it's doing checks on withdrawals (now handled by ENTITIES) and is enriched with a test of the network checks.

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
