### PR TITLE
Restore <2.6 bound for cardano-crypto-class

### DIFF
--- a/eras/mary/impl/cardano-ledger-mary.cabal
+++ b/eras/mary/impl/cardano-ledger-mary.cabal
@@ -84,7 +84,7 @@ library
     base >=4.18 && <5,
     base16-bytestring,
     bytestring,
-    cardano-crypto-class >=2.3 && <2.7,
+    cardano-crypto-class >=2.3 && <2.6,
     cardano-data ^>=1.3,
     cardano-ledger-allegra ^>=1.10,
     cardano-ledger-binary >=1.4,

--- a/eras/shelley/impl/cardano-ledger-shelley.cabal
+++ b/eras/shelley/impl/cardano-ledger-shelley.cabal
@@ -118,7 +118,7 @@ library
     base >=4.18 && <5,
     bytestring,
     cardano-base >=0.1.1.0,
-    cardano-crypto-class >=2.3 && <2.7,
+    cardano-crypto-class >=2.3 && <2.6,
     cardano-crypto-wrapper,
     cardano-data ^>=1.3,
     cardano-ledger-binary ^>=1.9,

--- a/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
+++ b/libs/cardano-ledger-binary/cardano-ledger-binary.cabal
@@ -57,7 +57,7 @@ library
     bytestring,
     cardano-base >=0.1.2,
     cardano-binary >=1.9.1,
-    cardano-crypto-class >=2.3 && <2.7,
+    cardano-crypto-class >=2.3 && <2.6,
     cardano-crypto-leios >=0.2.0,
     cardano-crypto-praos >=2.2.2,
     cardano-slotting >=0.2,

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -119,7 +119,7 @@ library
     bytestring >=0.10 && <0.11.3 || >=0.11.4,
     cardano-base >=0.1.6,
     cardano-crypto,
-    cardano-crypto-class >=2.4 && <2.7,
+    cardano-crypto-class >=2.4 && <2.6,
     cardano-crypto-wrapper,
     cardano-data >=1.3,
     cardano-ledger-binary ^>=1.9,

--- a/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
+++ b/libs/cardano-protocol-tpraos/cardano-protocol-tpraos.cabal
@@ -45,7 +45,7 @@ library
       -Wredundant-constraints
   build-depends:
     base >=4.18 && <5,
-    cardano-crypto-class >=2.5 && <2.7,
+    cardano-crypto-class >=2.5 && <2.6,
     cardano-ledger-allegra >=1.10,
     cardano-ledger-alonzo >=1.16,
     cardano-ledger-babbage >=1.13.1,

--- a/libs/cardano-protocol/cardano-protocol.cabal
+++ b/libs/cardano-protocol/cardano-protocol.cabal
@@ -42,7 +42,7 @@ library
     bytestring,
     cardano-base >=0.1.2,
     cardano-binary,
-    cardano-crypto-class >=2.5 && <2.7,
+    cardano-crypto-class >=2.5 && <2.6,
     cardano-crypto-praos ^>=2.2,
     cardano-ledger-binary >=1.8,
     cardano-ledger-core >=1.21,


### PR DESCRIPTION
# Description

..that was accidentally bumped in #5874

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
