### PR TITLE
 Withdrawals rework in SubEntities

### DIFF
--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.0
 
+* Add `SubMissingOriginalAccountsInWithdrawals` constructor to `SubEntitiesPredFailure`
 * Add `SubEntitiesEnv` and use it as `Environment` in the `SUBENTITIES` `STS` instance
 * Change the `STS` `Signal` of `SUBENTITIES` to `Tx SubTx era`
 * Add `sleOriginalAccounts` to `SubLedgerEnv`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.0
 
+* Add `validateMissingAccountsInDirectDeposits`
 * Remove `SubExceededBalancesInWithdrawals` constructor from `SubEntitiesPredFailure`
 * Add `SubMissingOriginalAccountsInWithdrawals` constructor to `SubEntitiesPredFailure`
 * Add `SubEntitiesEnv` and use it as `Environment` in the `SUBENTITIES` `STS` instance

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.4.0.0
 
+* Remove `SubExceededBalancesInWithdrawals` constructor from `SubEntitiesPredFailure`
 * Add `SubMissingOriginalAccountsInWithdrawals` constructor to `SubEntitiesPredFailure`
 * Add `SubEntitiesEnv` and use it as `Environment` in the `SUBENTITIES` `STS` instance
 * Change the `STS` `Signal` of `SUBENTITIES` to `Tx SubTx era`

--- a/eras/dijkstra/impl/CHANGELOG.md
+++ b/eras/dijkstra/impl/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.4.0.0
 
+* Add `SubEntitiesEnv` and use it as `Environment` in the `SUBENTITIES` `STS` instance
+* Change the `STS` `Signal` of `SUBENTITIES` to `Tx SubTx era`
+* Add `sleOriginalAccounts` to `SubLedgerEnv`
 * Memoize `getScriptsHashesNeeded` for subtransactions:
   - Add `dsastScriptsHashesNeeded` field to `DijkstraStAnnTx SubTx`, holding `Set ScriptHash`
   - Add `scriptsHashesNeededStAnnTx` method to `DijkstraEraUTxO`

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Entities.hs
@@ -19,6 +19,7 @@ module Cardano.Ledger.Dijkstra.Rules.Entities (
   EntitiesPredFailure (..),
   EntitiesEvent (..),
   validateWrongNetworkInDirectDeposit,
+  validateMissingAccountsInDirectDeposits,
 ) where
 
 import Cardano.Ledger.Address (DirectDeposits (..))
@@ -227,8 +228,7 @@ dijkstraEntitiesTransition = do
 
   let directDeposits = tx ^. bodyTxL . directDepositsTxBodyL
       accountsAfterCerts = certStateAfterCerts ^. certDStateL . accountsL
-  failOnJust (directDepositsMissingAccounts directDeposits accountsAfterCerts) $
-    injectFailure . MissingAccountsInDirectDeposits
+  runTest $ validateMissingAccountsInDirectDeposits directDeposits accountsAfterCerts
 
   pure $ certStateAfterCerts & certDStateL . accountsL %~ applyDirectDeposits directDeposits
 
@@ -245,6 +245,16 @@ validateWrongNetworkInDirectDeposit netId txb =
         Map.filterWithKey
           (\a _ -> aaNetworkId a /= netId)
           (unDirectDeposits $ txb ^. directDepositsTxBodyL)
+
+validateMissingAccountsInDirectDeposits ::
+  EraAccounts era =>
+  DirectDeposits ->
+  Accounts era ->
+  Test (EntitiesPredFailure era)
+validateMissingAccountsInDirectDeposits dds accounts =
+  failureOnJust
+    (directDepositsMissingAccounts dds accounts)
+    MissingAccountsInDirectDeposits
 
 validateWithdrawals ::
   EraAccounts era =>

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Ledger.hs
@@ -74,6 +74,7 @@ import Cardano.Ledger.Rules.ValidationMode (Test, runTest)
 import Cardano.Ledger.Shelley.LedgerState (
   LedgerState (..),
   UTxOState (..),
+  lsCertState,
   lsUTxOStateL,
   utxosGovStateL,
   utxosUtxo,
@@ -338,6 +339,7 @@ validateAllRefScriptSize pp utxo tx =
 dijkstraLedgerTransition ::
   forall era.
   ( AlonzoEraTx era
+  , ConwayEraCertState era
   , ConwayEraGov era
   , DijkstraEraTxBody era
   , DijkstraEraUTxO era
@@ -383,6 +385,7 @@ dijkstraLedgerTransition = do
             pp
             chainAccountState
             originalUtxo
+            (lsCertState ledgerState ^. certDStateL . accountsL)
             (tx ^. isPhase2ValidTxL)
         , ledgerState
         , subStAnnTxs

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -241,6 +241,7 @@ dijkstraSubEntitiesTransition = do
   runTest $ Shelley.validateWrongNetworkWithdrawal network (tx ^. bodyTxL)
   runTest $ validateWrongNetworkInDirectDeposit network (tx ^. bodyTxL)
   runTest $ validateMissingOriginalAccountsInWithdrawals withdrawals originalAccounts
+  runTest $ validateMissingAccountsInWithdrawals withdrawals accounts
 
   let (missingWithdrawals, exceededWithdrawals) =
         case withdrawalsThatExceedAccountBalance withdrawals network accounts of
@@ -275,6 +276,16 @@ validateMissingOriginalAccountsInWithdrawals wdrls originalAccounts =
   failureOnJust
     (withdrawalsMissingAccounts wdrls originalAccounts)
     SubMissingOriginalAccountsInWithdrawals
+
+validateMissingAccountsInWithdrawals ::
+  EraAccounts era =>
+  Withdrawals ->
+  Accounts era ->
+  Test (SubEntitiesPredFailure era)
+validateMissingAccountsInWithdrawals wdrls accounts =
+  failureOnJust
+    (withdrawalsMissingAccounts wdrls accounts)
+    SubMissingAccountsInWithdrawals
 
 conwayToDijkstraSubEntitiesPredFailure ::
   forall era. Conway.ConwayLedgerPredFailure era -> SubEntitiesPredFailure era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -25,7 +25,6 @@ import Cardano.Ledger.Address (DirectDeposits (..))
 import Cardano.Ledger.BaseTypes
 import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
-import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Core
 import Cardano.Ledger.Conway.Governance (
   Committee,
@@ -51,8 +50,6 @@ import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
 import Control.State.Transition.Extended
-import Data.Map.NonEmpty (NonEmptyMap)
-import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
 import qualified Data.Sequence.Strict as StrictSeq
@@ -103,7 +100,6 @@ data SubEntitiesPredFailure era
   = SubCertsFailure (PredicateFailure (EraRule "SUBCERTS" era))
   | SubMissingAccountsInWithdrawals Withdrawals
   | SubMissingOriginalAccountsInWithdrawals Withdrawals
-  | SubExceededBalancesInWithdrawals (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
   | SubMissingAccountsInDirectDeposits DirectDeposits
   | SubWrongNetworkInWithdrawals
       -- | Expected network id
@@ -138,10 +134,9 @@ instance
       SubCertsFailure x -> Sum (SubCertsFailure @era) 0 !> To x
       SubMissingAccountsInWithdrawals x -> Sum (SubMissingAccountsInWithdrawals @era) 1 !> To x
       SubMissingOriginalAccountsInWithdrawals x -> Sum (SubMissingOriginalAccountsInWithdrawals @era) 2 !> To x
-      SubExceededBalancesInWithdrawals x -> Sum (SubExceededBalancesInWithdrawals @era) 3 !> To x
-      SubMissingAccountsInDirectDeposits x -> Sum (SubMissingAccountsInDirectDeposits @era) 4 !> To x
-      SubWrongNetworkInWithdrawals expected wrongs -> Sum (SubWrongNetworkInWithdrawals @era) 5 !> To expected !> To wrongs
-      SubWrongNetworkInDirectDeposits expected wrongs -> Sum (SubWrongNetworkInDirectDeposits @era) 6 !> To expected !> To wrongs
+      SubMissingAccountsInDirectDeposits x -> Sum (SubMissingAccountsInDirectDeposits @era) 3 !> To x
+      SubWrongNetworkInWithdrawals expected wrongs -> Sum (SubWrongNetworkInWithdrawals @era) 4 !> To expected !> To wrongs
+      SubWrongNetworkInDirectDeposits expected wrongs -> Sum (SubWrongNetworkInDirectDeposits @era) 5 !> To expected !> To wrongs
 
 instance
   ( Era era
@@ -153,10 +148,9 @@ instance
     0 -> SumD SubCertsFailure <! From
     1 -> SumD SubMissingAccountsInWithdrawals <! From
     2 -> SumD SubMissingOriginalAccountsInWithdrawals <! From
-    3 -> SumD SubExceededBalancesInWithdrawals <! From
-    4 -> SumD SubMissingAccountsInDirectDeposits <! From
-    5 -> SumD SubWrongNetworkInWithdrawals <! From <! From
-    6 -> SumD SubWrongNetworkInDirectDeposits <! From <! From
+    3 -> SumD SubMissingAccountsInDirectDeposits <! From
+    4 -> SumD SubWrongNetworkInWithdrawals <! From <! From
+    5 -> SumD SubWrongNetworkInDirectDeposits <! From <! From
     n -> Invalid n
 
 newtype SubEntitiesEvent era = SubCertsEvent (Event (EraRule "SUBCERTS" era))
@@ -242,14 +236,6 @@ dijkstraSubEntitiesTransition = do
   runTest $ validateWrongNetworkInDirectDeposit network (tx ^. bodyTxL)
   runTest $ validateMissingOriginalAccountsInWithdrawals withdrawals originalAccounts
   runTest $ validateMissingAccountsInWithdrawals withdrawals accounts
-
-  let (missingWithdrawals, exceededWithdrawals) =
-        case withdrawalsThatExceedAccountBalance withdrawals network accounts of
-          Nothing -> (Map.empty, Map.empty)
-          Just (missing, exceeded) -> (unWithdrawals missing, exceeded)
-  failOnNonEmptyMap missingWithdrawals $
-    injectFailure . SubMissingAccountsInWithdrawals . Withdrawals . NEM.toMap
-  failOnNonEmptyMap exceededWithdrawals $ injectFailure . SubExceededBalancesInWithdrawals
 
   let certStateBeforeSubCerts =
         certState

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -15,6 +16,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.Ledger.Dijkstra.Rules.SubEntities (
+  SubEntitiesEnv (..),
   SubEntitiesPredFailure (..),
   SubEntitiesEvent (..),
 ) where
@@ -25,6 +27,12 @@ import Cardano.Ledger.Binary (DecCBOR (..), EncCBOR (..))
 import Cardano.Ledger.Binary.Coders
 import Cardano.Ledger.Coin (Coin)
 import Cardano.Ledger.Conway.Core
+import Cardano.Ledger.Conway.Governance (
+  Committee,
+  GovActionPurpose (..),
+  GovActionState,
+  GovPurposeId,
+ )
 import qualified Cardano.Ledger.Conway.Rules as Conway
 import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra, SUBCERTS, SUBENTITIES)
@@ -47,9 +55,49 @@ import Data.Map.NonEmpty (NonEmptyMap)
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
 import Data.Sequence (Seq)
+import qualified Data.Sequence.Strict as StrictSeq
 import Data.Set.NonEmpty (NonEmptySet)
 import GHC.Generics (Generic)
 import Lens.Micro
+
+data SubEntitiesEnv era = SubEntitiesEnv
+  { seeCurrentEpoch :: EpochNo
+  , seePParams :: PParams era
+  , seeCurrentCommittee :: StrictMaybe (Committee era)
+  , seeCommitteeProposals :: Map.Map (GovPurposeId 'CommitteePurpose) (GovActionState era)
+  , seeOriginalAccounts :: Accounts era
+  }
+  deriving (Generic)
+
+deriving instance
+  (EraPParams era, Eq (Committee era), Eq (GovActionState era), Eq (Accounts era)) =>
+  Eq (SubEntitiesEnv era)
+
+deriving instance
+  (EraPParams era, Show (Committee era), Show (GovActionState era), Show (Accounts era)) =>
+  Show (SubEntitiesEnv era)
+
+instance
+  (EraPParams era, NFData (Committee era), NFData (GovActionState era), NFData (Accounts era)) =>
+  NFData (SubEntitiesEnv era)
+
+instance
+  ( EraPParams era
+  , EncCBOR (Committee era)
+  , EncCBOR (GovActionState era)
+  , EncCBOR (Accounts era)
+  ) =>
+  EncCBOR (SubEntitiesEnv era)
+  where
+  encCBOR x@(SubEntitiesEnv _ _ _ _ _) =
+    let SubEntitiesEnv {..} = x
+     in encode $
+          Rec SubEntitiesEnv
+            !> To seeCurrentEpoch
+            !> To seePParams
+            !> To seeCurrentCommittee
+            !> To seeCommitteeProposals
+            !> To seeOriginalAccounts
 
 data SubEntitiesPredFailure era
   = SubCertsFailure (PredicateFailure (EraRule "SUBCERTS" era))
@@ -153,8 +201,8 @@ instance
   STS (SUBENTITIES era)
   where
   type State (SUBENTITIES era) = CertState era
-  type Signal (SUBENTITIES era) = Seq (TxCert era)
-  type Environment (SUBENTITIES era) = SubCertsEnv era
+  type Signal (SUBENTITIES era) = Tx SubTx era
+  type Environment (SUBENTITIES era) = SubEntitiesEnv era
   type BaseM (SUBENTITIES era) = ShelleyBase
   type PredicateFailure (SUBENTITIES era) = SubEntitiesPredFailure era
   type Event (SUBENTITIES era) = SubEntitiesEvent era
@@ -179,12 +227,11 @@ dijkstraSubEntitiesTransition ::
   ) =>
   TransitionRule (SUBENTITIES era)
 dijkstraSubEntitiesTransition = do
-  TRC (subCertsEnv, certState, certificates) <- judgmentContext
-  let tx = certsTx subCertsEnv
-      pp = certsPParams subCertsEnv
-      curEpoch = certsCurrentEpoch subCertsEnv
-      withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
+  TRC (SubEntitiesEnv curEpoch pp committee committeeProposals _originalAccounts, certState, tx) <-
+    judgmentContext
+  let withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
       accounts = certState ^. certDStateL . accountsL
+      subCertsEnv = SubCertsEnv tx pp curEpoch committee committeeProposals
 
   network <- liftSTS $ asks networkId
 
@@ -205,7 +252,8 @@ dijkstraSubEntitiesTransition = do
           & Conway.updateVotingDRepExpiries tx curEpoch (pp ^. ppDRepActivityL)
           & certDStateL . accountsL %~ applyWithdrawals withdrawals
   certStateAfterSubCerts <-
-    trans @(EraRule "SUBCERTS" era) $ TRC (subCertsEnv, certStateBeforeSubCerts, certificates)
+    trans @(EraRule "SUBCERTS" era) $
+      TRC (subCertsEnv, certStateBeforeSubCerts, StrictSeq.fromStrict $ tx ^. bodyTxL . certsTxBodyL)
 
   let directDeposits = tx ^. bodyTxL . directDepositsTxBodyL
       accountsAfterSubCerts = certStateAfterSubCerts ^. certDStateL . accountsL

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -46,7 +46,7 @@ import Cardano.Ledger.Dijkstra.Rules.SubCerts (
   SubCertsEnv (..),
  )
 import Cardano.Ledger.Dijkstra.TxBody (DijkstraEraTxBody, directDepositsTxBodyL)
-import Cardano.Ledger.Rules.ValidationMode (runTest)
+import Cardano.Ledger.Rules.ValidationMode (Test, runTest)
 import qualified Cardano.Ledger.Shelley.Rules as Shelley
 import Control.DeepSeq (NFData)
 import Control.Monad.Trans.Reader (asks)
@@ -102,6 +102,7 @@ instance
 data SubEntitiesPredFailure era
   = SubCertsFailure (PredicateFailure (EraRule "SUBCERTS" era))
   | SubMissingAccountsInWithdrawals Withdrawals
+  | SubMissingOriginalAccountsInWithdrawals Withdrawals
   | SubExceededBalancesInWithdrawals (NonEmptyMap AccountAddress (Mismatch RelLTEQ Coin))
   | SubMissingAccountsInDirectDeposits DirectDeposits
   | SubWrongNetworkInWithdrawals
@@ -136,10 +137,11 @@ instance
     encode . \case
       SubCertsFailure x -> Sum (SubCertsFailure @era) 0 !> To x
       SubMissingAccountsInWithdrawals x -> Sum (SubMissingAccountsInWithdrawals @era) 1 !> To x
-      SubExceededBalancesInWithdrawals x -> Sum (SubExceededBalancesInWithdrawals @era) 2 !> To x
-      SubMissingAccountsInDirectDeposits x -> Sum (SubMissingAccountsInDirectDeposits @era) 3 !> To x
-      SubWrongNetworkInWithdrawals expected wrongs -> Sum (SubWrongNetworkInWithdrawals @era) 4 !> To expected !> To wrongs
-      SubWrongNetworkInDirectDeposits expected wrongs -> Sum (SubWrongNetworkInDirectDeposits @era) 5 !> To expected !> To wrongs
+      SubMissingOriginalAccountsInWithdrawals x -> Sum (SubMissingOriginalAccountsInWithdrawals @era) 2 !> To x
+      SubExceededBalancesInWithdrawals x -> Sum (SubExceededBalancesInWithdrawals @era) 3 !> To x
+      SubMissingAccountsInDirectDeposits x -> Sum (SubMissingAccountsInDirectDeposits @era) 4 !> To x
+      SubWrongNetworkInWithdrawals expected wrongs -> Sum (SubWrongNetworkInWithdrawals @era) 5 !> To expected !> To wrongs
+      SubWrongNetworkInDirectDeposits expected wrongs -> Sum (SubWrongNetworkInDirectDeposits @era) 6 !> To expected !> To wrongs
 
 instance
   ( Era era
@@ -150,10 +152,11 @@ instance
   decCBOR = decode . Summands "SubEntitiesPredFailure" $ \case
     0 -> SumD SubCertsFailure <! From
     1 -> SumD SubMissingAccountsInWithdrawals <! From
-    2 -> SumD SubExceededBalancesInWithdrawals <! From
-    3 -> SumD SubMissingAccountsInDirectDeposits <! From
-    4 -> SumD SubWrongNetworkInWithdrawals <! From <! From
-    5 -> SumD SubWrongNetworkInDirectDeposits <! From <! From
+    2 -> SumD SubMissingOriginalAccountsInWithdrawals <! From
+    3 -> SumD SubExceededBalancesInWithdrawals <! From
+    4 -> SumD SubMissingAccountsInDirectDeposits <! From
+    5 -> SumD SubWrongNetworkInWithdrawals <! From <! From
+    6 -> SumD SubWrongNetworkInDirectDeposits <! From <! From
     n -> Invalid n
 
 newtype SubEntitiesEvent era = SubCertsEvent (Event (EraRule "SUBCERTS" era))
@@ -227,7 +230,7 @@ dijkstraSubEntitiesTransition ::
   ) =>
   TransitionRule (SUBENTITIES era)
 dijkstraSubEntitiesTransition = do
-  TRC (SubEntitiesEnv curEpoch pp committee committeeProposals _originalAccounts, certState, tx) <-
+  TRC (SubEntitiesEnv curEpoch pp committee committeeProposals originalAccounts, certState, tx) <-
     judgmentContext
   let withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
       accounts = certState ^. certDStateL . accountsL
@@ -237,6 +240,7 @@ dijkstraSubEntitiesTransition = do
 
   runTest $ Shelley.validateWrongNetworkWithdrawal network (tx ^. bodyTxL)
   runTest $ validateWrongNetworkInDirectDeposit network (tx ^. bodyTxL)
+  runTest $ validateMissingOriginalAccountsInWithdrawals withdrawals originalAccounts
 
   let (missingWithdrawals, exceededWithdrawals) =
         case withdrawalsThatExceedAccountBalance withdrawals network accounts of
@@ -261,6 +265,16 @@ dijkstraSubEntitiesTransition = do
     injectFailure . SubMissingAccountsInDirectDeposits
 
   pure $ certStateAfterSubCerts & certDStateL . accountsL %~ applyDirectDeposits directDeposits
+
+validateMissingOriginalAccountsInWithdrawals ::
+  EraAccounts era =>
+  Withdrawals ->
+  Accounts era ->
+  Test (SubEntitiesPredFailure era)
+validateMissingOriginalAccountsInWithdrawals wdrls originalAccounts =
+  failureOnJust
+    (withdrawalsMissingAccounts wdrls originalAccounts)
+    SubMissingOriginalAccountsInWithdrawals
 
 conwayToDijkstraSubEntitiesPredFailure ::
   forall era. Conway.ConwayLedgerPredFailure era -> SubEntitiesPredFailure era

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubEntities.hs
@@ -37,6 +37,7 @@ import Cardano.Ledger.Conway.State
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra, SUBCERTS, SUBENTITIES)
 import Cardano.Ledger.Dijkstra.Rules.Entities (
   EntitiesPredFailure (..),
+  validateMissingAccountsInDirectDeposits,
   validateWrongNetworkInDirectDeposit,
  )
 import Cardano.Ledger.Dijkstra.Rules.SubCerts (
@@ -227,6 +228,7 @@ dijkstraSubEntitiesTransition = do
   TRC (SubEntitiesEnv curEpoch pp committee committeeProposals originalAccounts, certState, tx) <-
     judgmentContext
   let withdrawals = tx ^. bodyTxL . withdrawalsTxBodyL
+      directDeposits = tx ^. bodyTxL . directDepositsTxBodyL
       accounts = certState ^. certDStateL . accountsL
       subCertsEnv = SubCertsEnv tx pp curEpoch committee committeeProposals
 
@@ -237,21 +239,21 @@ dijkstraSubEntitiesTransition = do
   runTest $ validateMissingOriginalAccountsInWithdrawals withdrawals originalAccounts
   runTest $ validateMissingAccountsInWithdrawals withdrawals accounts
 
+  let appliedWithdrawals = applyWithdrawals withdrawals accounts
   let certStateBeforeSubCerts =
         certState
           & Conway.updateDormantDRepExpiries tx curEpoch
           & Conway.updateVotingDRepExpiries tx curEpoch (pp ^. ppDRepActivityL)
-          & certDStateL . accountsL %~ applyWithdrawals withdrawals
+          & certDStateL . accountsL .~ appliedWithdrawals
   certStateAfterSubCerts <-
     trans @(EraRule "SUBCERTS" era) $
       TRC (subCertsEnv, certStateBeforeSubCerts, StrictSeq.fromStrict $ tx ^. bodyTxL . certsTxBodyL)
 
-  let directDeposits = tx ^. bodyTxL . directDepositsTxBodyL
-      accountsAfterSubCerts = certStateAfterSubCerts ^. certDStateL . accountsL
-  failOnJust (directDepositsMissingAccounts directDeposits accountsAfterSubCerts) $
-    injectFailure . SubMissingAccountsInDirectDeposits
+  let accountsAfterSubCerts = certStateAfterSubCerts ^. certDStateL . accountsL
+  runTest $ validateMissingAccountsInDirectDeposits directDeposits accountsAfterSubCerts
 
-  pure $ certStateAfterSubCerts & certDStateL . accountsL %~ applyDirectDeposits directDeposits
+  let appliedDirectDeposits = applyDirectDeposits directDeposits accountsAfterSubCerts
+  pure $ certStateAfterSubCerts & certDStateL . accountsL .~ appliedDirectDeposits
 
 validateMissingOriginalAccountsInWithdrawals ::
   EraAccounts era =>
@@ -297,7 +299,7 @@ entitiesToSubEntitiesPredFailure = \case
   MissingAccountsInWithdrawals _ -> impossible "MissingAccountsInWithdrawals"
   IncompleteWithdrawals _ -> impossible "IncompleteWithdrawals"
   ExceededBalancesInWithdrawals _ -> impossible "ExceededBalancesInWithdrawals"
-  MissingAccountsInDirectDeposits _ -> impossible "MissingAccountsInDirectDeposits"
+  MissingAccountsInDirectDeposits dds -> SubMissingAccountsInDirectDeposits dds
   where
     impossible name = error $ "Impossible: `" <> name <> "` for SUBENTITIES"
 

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/SubLedger.hs
@@ -50,10 +50,10 @@ import Cardano.Ledger.Dijkstra.Era (
 import Cardano.Ledger.Dijkstra.Rules.Gov (DijkstraGovPredFailure (..))
 import Cardano.Ledger.Dijkstra.Rules.SubCerts (
   DijkstraSubCertsPredFailure (..),
-  SubCertsEnv (..),
  )
 import Cardano.Ledger.Dijkstra.Rules.SubDeleg (DijkstraSubDelegPredFailure)
 import Cardano.Ledger.Dijkstra.Rules.SubEntities (
+  SubEntitiesEnv (..),
   SubEntitiesEvent,
   SubEntitiesPredFailure (..),
  )
@@ -88,7 +88,6 @@ import Control.State.Transition.Extended (
   trans,
   transitionRules,
  )
-import qualified Data.Sequence.Strict as StrictSeq
 import GHC.Generics (Generic)
 import Lens.Micro
 
@@ -98,6 +97,7 @@ data SubLedgerEnv era = SubLedgerEnv
   , slePParams :: PParams era
   , sleAccount :: ChainAccountState
   , sleOriginalUtxo :: UTxO era
+  , sleOriginalAccounts :: Accounts era
   , sleTopTxIsPhase2Valid :: IsPhase2Valid
   }
 
@@ -231,7 +231,7 @@ dijkstraSubLedgersTransition ::
   TransitionRule (EraRule "SUBLEDGER" era)
 dijkstraSubLedgersTransition = do
   TRC
-    ( SubLedgerEnv slot mbCurEpochNo pp chainAccountState originalUtxo topIsPhase2Valid
+    ( SubLedgerEnv slot mbCurEpochNo pp chainAccountState originalUtxo originalAccounts topIsPhase2Valid
       , LedgerState utxoState certState
       , stAnnTx
       ) <-
@@ -252,9 +252,14 @@ dijkstraSubLedgersTransition = do
         certStateAfterSubEntities <-
           trans @(EraRule "SUBENTITIES" era) $
             TRC
-              ( SubCertsEnv tx pp curEpochNo committee (proposalsWithPurpose grCommitteeL proposals)
+              ( SubEntitiesEnv
+                  curEpochNo
+                  pp
+                  committee
+                  (proposalsWithPurpose grCommitteeL proposals)
+                  originalAccounts
               , certState
-              , StrictSeq.fromStrict $ txBody ^. certsTxBodyL
+              , tx
               )
         let govEnv =
               Conway.GovEnv

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -33,113 +33,112 @@ import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum)
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
 spec = describe "ENTITIES" $ do
-  describe "Withdrawals" $ do
-    it "Withdrawing from an unregistered staking address" $ do
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
+  it "Withdrawing from an unregistered staking address" $ do
+    modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
 
-      stakeKey <- freshKeyHash
-      accountAddress <- getAccountAddressFor $ KeyHashObj stakeKey
-      let
-        tx =
-          mkBasicTx $
-            mkBasicTxBody
-              & withdrawalsTxBodyL
-                .~ Withdrawals [(accountAddress, Coin 20)]
-      submitFailingTx
-        tx
-        [ injectFailure $
-            WithdrawalsExceedAccountBalance @era $
-              NE.singleton accountAddress $
-                Mismatch (Coin 20) mempty
-        , injectFailure . MissingAccountsInWithdrawals @era $
-            Withdrawals [(accountAddress, Coin 20)]
-        ]
-      (registeredAccountAddress, reward, stakeKey2) <- setupAccountAddress
-      void $ delegateToDRep (KeyHashObj stakeKey2) (Coin 1_000_000) DRepAlwaysNoConfidence
-      let
-        tx2 =
-          mkBasicTx $
-            mkBasicTxBody
-              & withdrawalsTxBodyL
-                .~ Withdrawals [(accountAddress, zero), (registeredAccountAddress, reward)]
-      submitFailingTx
-        tx2
-        [ injectFailure . MissingAccountsInWithdrawals @era $
-            Withdrawals [(accountAddress, zero)]
-        ]
-
-    it "Withdrawing the wrong amount" $ do
-      modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
-
-      (accountAddress1, reward1, stakeKey1) <- setupAccountAddress
-      (accountAddress2, reward2, stakeKey2) <- setupAccountAddress
-      void $ delegateToDRep (KeyHashObj stakeKey1) (Coin 1_000_000) DRepAlwaysAbstain
-      void $ delegateToDRep (KeyHashObj stakeKey2) (Coin 1_000_000) DRepAlwaysAbstain
-      submitFailingTx
-        ( mkBasicTx $
-            mkBasicTxBody
-              & withdrawalsTxBodyL
-                .~ Withdrawals
-                  [ (accountAddress1, reward1 <+> Coin 1)
-                  , (accountAddress2, reward2)
-                  ]
-        )
-        [ injectFailure $
-            WithdrawalsExceedAccountBalance @era $
-              NE.singleton accountAddress1 $
-                Mismatch (reward1 <+> Coin 1) reward1
-        , injectFailure $
-            ExceededBalancesInWithdrawals @era $
-              NE.singleton accountAddress1 $
-                Mismatch (reward1 <+> Coin 1) reward1
-        ]
-
-      -- in legacy mode, we produce `IncompleteWithdrawals` failure
-      txIn <- produceScript . hashPlutusScript $ alwaysSucceedsWithDatum SPlutusV2
-      submitFailingTx
-        ( mkBasicTx $
-            mkBasicTxBody
-              & withdrawalsTxBodyL
-                .~ Withdrawals
-                  [(accountAddress1, zero)]
-              & inputsTxBodyL .~ [txIn]
-        )
-        [ injectFailure . IncompleteWithdrawals @era $
-            NE.singleton accountAddress1 $
-              Mismatch zero reward1
-        ]
-
-      submitTx_ $
+    stakeKey <- freshKeyHash
+    accountAddress <- getAccountAddressFor $ KeyHashObj stakeKey
+    let
+      tx =
         mkBasicTx $
+          mkBasicTxBody
+            & withdrawalsTxBodyL
+              .~ Withdrawals [(accountAddress, Coin 20)]
+    submitFailingTx
+      tx
+      [ injectFailure $
+          WithdrawalsExceedAccountBalance @era $
+            NE.singleton accountAddress $
+              Mismatch (Coin 20) mempty
+      , injectFailure . MissingAccountsInWithdrawals @era $
+          Withdrawals [(accountAddress, Coin 20)]
+      ]
+    (registeredAccountAddress, reward, stakeKey2) <- setupAccountAddress
+    void $ delegateToDRep (KeyHashObj stakeKey2) (Coin 1_000_000) DRepAlwaysNoConfidence
+    let
+      tx2 =
+        mkBasicTx $
+          mkBasicTxBody
+            & withdrawalsTxBodyL
+              .~ Withdrawals [(accountAddress, zero), (registeredAccountAddress, reward)]
+    submitFailingTx
+      tx2
+      [ injectFailure . MissingAccountsInWithdrawals @era $
+          Withdrawals [(accountAddress, zero)]
+      ]
+
+  it "Withdrawing the wrong amount" $ do
+    modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
+
+    (accountAddress1, reward1, stakeKey1) <- setupAccountAddress
+    (accountAddress2, reward2, stakeKey2) <- setupAccountAddress
+    void $ delegateToDRep (KeyHashObj stakeKey1) (Coin 1_000_000) DRepAlwaysAbstain
+    void $ delegateToDRep (KeyHashObj stakeKey2) (Coin 1_000_000) DRepAlwaysAbstain
+    submitFailingTx
+      ( mkBasicTx $
+          mkBasicTxBody
+            & withdrawalsTxBodyL
+              .~ Withdrawals
+                [ (accountAddress1, reward1 <+> Coin 1)
+                , (accountAddress2, reward2)
+                ]
+      )
+      [ injectFailure $
+          WithdrawalsExceedAccountBalance @era $
+            NE.singleton accountAddress1 $
+              Mismatch (reward1 <+> Coin 1) reward1
+      , injectFailure $
+          ExceededBalancesInWithdrawals @era $
+            NE.singleton accountAddress1 $
+              Mismatch (reward1 <+> Coin 1) reward1
+      ]
+
+    -- in legacy mode, we produce `IncompleteWithdrawals` failure
+    txIn <- produceScript . hashPlutusScript $ alwaysSucceedsWithDatum SPlutusV2
+    submitFailingTx
+      ( mkBasicTx $
           mkBasicTxBody
             & withdrawalsTxBodyL
               .~ Withdrawals
                 [(accountAddress1, zero)]
+            & inputsTxBodyL .~ [txIn]
+      )
+      [ injectFailure . IncompleteWithdrawals @era $
+          NE.singleton accountAddress1 $
+            Mismatch zero reward1
+      ]
 
-    it "Rejects withdrawals and direct deposits with wrong network id" $ do
-      stakeKey <- freshKeyHash
-      accountAddress <- registerStakeCredential (KeyHashObj stakeKey)
-      let wrongNetworkAccount = accountAddress & accountAddressNetworkIdL .~ Mainnet
-      let txBody :: forall l. Typeable l => TxBody l era
-          txBody =
-            mkBasicTxBody
-              & withdrawalsTxBodyL
-                .~ Withdrawals [(wrongNetworkAccount, mempty)]
-              & directDepositsTxBodyL
-                .~ DirectDeposits [(wrongNetworkAccount, Coin 50)]
+    submitTx_ $
+      mkBasicTx $
+        mkBasicTxBody
+          & withdrawalsTxBodyL
+            .~ Withdrawals
+              [(accountAddress1, zero)]
 
-      submitFailingTx
-        (mkBasicTx txBody)
-        [ injectFailure . WrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
-        , injectFailure . WrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
-        , injectFailure . MissingAccountsInWithdrawals @era $ Withdrawals [(wrongNetworkAccount, mempty)]
-        ]
+  it "Rejects withdrawals and direct deposits with wrong network id" $ do
+    stakeKey <- freshKeyHash
+    accountAddress <- registerStakeCredential (KeyHashObj stakeKey)
+    let wrongNetworkAccount = accountAddress & accountAddressNetworkIdL .~ Mainnet
+    let txBody :: forall l. Typeable l => TxBody l era
+        txBody =
+          mkBasicTxBody
+            & withdrawalsTxBodyL
+              .~ Withdrawals [(wrongNetworkAccount, mempty)]
+            & directDepositsTxBodyL
+              .~ DirectDeposits [(wrongNetworkAccount, Coin 50)]
 
-      submitFailingTxIncluding
-        (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody])
-        [ injectFailure . SubWrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
-        , injectFailure . SubWrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
-        ]
+    submitFailingTx
+      (mkBasicTx txBody)
+      [ injectFailure . WrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
+      , injectFailure . WrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
+      , injectFailure . MissingAccountsInWithdrawals @era $ Withdrawals [(wrongNetworkAccount, mempty)]
+      ]
+
+    submitFailingTxIncluding
+      (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody])
+      [ injectFailure . SubWrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
+      , injectFailure . SubWrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
+      ]
   where
     setupAccountAddress :: ImpTestM era (AccountAddress, Coin, KeyHash Staking)
     setupAccountAddress = do

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -139,7 +139,6 @@ spec = describe "ENTITIES" $ do
         (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody])
         [ injectFailure . SubWrongNetworkInWithdrawals @era Testnet $ NES.singleton wrongNetworkAccount
         , injectFailure . SubWrongNetworkInDirectDeposits @era Testnet $ NES.singleton wrongNetworkAccount
-        , injectFailure . SubMissingAccountsInWithdrawals @era $ Withdrawals [(wrongNetworkAccount, mempty)]
         ]
   where
     setupAccountAddress :: ImpTestM era (AccountAddress, Coin, KeyHash Staking)

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Imp/EntitiesSpec.hs
@@ -25,6 +25,8 @@ import Cardano.Ledger.Val (Val (..))
 import qualified Data.Foldable as Foldable
 import Data.List ((\\))
 import qualified Data.Map.NonEmpty as NE
+import qualified Data.Map.Strict as Map
+import Data.Maybe (fromJust)
 import qualified Data.Set.NonEmpty as NES
 import Lens.Micro ((&), (.~))
 import Test.Cardano.Ledger.Dijkstra.ImpTest
@@ -33,41 +35,82 @@ import Test.Cardano.Ledger.Plutus.Examples (alwaysSucceedsWithDatum)
 
 spec :: forall era. DijkstraEraImp era => SpecWith (ImpInit (LedgerSpec era))
 spec = describe "ENTITIES" $ do
-  it "Withdrawing from an unregistered staking address" $ do
+  it "Withdrawals from an unregistered staking address" $ do
     modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
 
-    stakeKey <- freshKeyHash
-    accountAddress <- getAccountAddressFor $ KeyHashObj stakeKey
+    account1 <- freshKeyHash >>= getAccountAddressFor . KeyHashObj
+    account2 <- freshKeyHash >>= getAccountAddressFor . KeyHashObj
+    amountX <- Coin . getPositive <$> arbitrary
     let
-      tx =
-        mkBasicTx $
-          mkBasicTxBody
-            & withdrawalsTxBodyL
-              .~ Withdrawals [(accountAddress, Coin 20)]
+      txBody :: forall l. Typeable l => TxBody l era
+      txBody =
+        mkBasicTxBody
+          & withdrawalsTxBodyL .~ Withdrawals [(account1, amountX), (account2, zero)]
     submitFailingTx
-      tx
+      (mkBasicTx txBody)
       [ injectFailure $
           WithdrawalsExceedAccountBalance @era $
-            NE.singleton accountAddress $
-              Mismatch (Coin 20) mempty
+            NE.singleton account1 $
+              Mismatch amountX mempty
       , injectFailure . MissingAccountsInWithdrawals @era $
-          Withdrawals [(accountAddress, Coin 20)]
-      ]
-    (registeredAccountAddress, reward, stakeKey2) <- setupAccountAddress
-    void $ delegateToDRep (KeyHashObj stakeKey2) (Coin 1_000_000) DRepAlwaysNoConfidence
-    let
-      tx2 =
-        mkBasicTx $
-          mkBasicTxBody
-            & withdrawalsTxBodyL
-              .~ Withdrawals [(accountAddress, zero), (registeredAccountAddress, reward)]
-    submitFailingTx
-      tx2
-      [ injectFailure . MissingAccountsInWithdrawals @era $
-          Withdrawals [(accountAddress, zero)]
+          Withdrawals [(account1, amountX), (account2, zero)]
       ]
 
-  it "Withdrawing the wrong amount" $ do
+    account3 <- freshKeyHash >>= getAccountAddressFor . KeyHashObj
+    amountY <- Coin . getPositive <$> arbitrary
+    let subTxOnlyWithdrawal =
+          mkBasicTx $
+            mkBasicTxBody
+              & withdrawalsTxBodyL .~ Withdrawals [(account3, amountY)]
+    submitFailingTxIncluding
+      (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody, subTxOnlyWithdrawal])
+      [ injectFailure . SubMissingAccountsInWithdrawals @era $
+          Withdrawals [(account1, amountX), (account2, zero)]
+      , injectFailure . SubMissingOriginalAccountsInWithdrawals @era $
+          Withdrawals [(account1, amountX), (account2, zero)]
+      , injectFailure $
+          WithdrawalsExceedAccountBalance @era $
+            fromJust $
+              NE.fromMap $
+                Map.fromList
+                  [ (account1, Mismatch (amountX <> amountX) mempty) -- accumulated from top and sub transaction
+                  , (account3, Mismatch amountY mempty)
+                  ]
+      , injectFailure . SubMissingAccountsInWithdrawals @era $
+          Withdrawals [(account3, amountY)]
+      , injectFailure . SubMissingOriginalAccountsInWithdrawals @era $
+          Withdrawals [(account3, amountY)]
+      ]
+
+  it "Direct deposits to an unregistered account" $ do
+    account <- freshKeyHash >>= getAccountAddressFor . KeyHashObj
+    amountX <- Coin . getPositive <$> arbitrary
+    let
+    let
+      txBody :: forall l. Typeable l => TxBody l era
+      txBody = mkBasicTxBody & directDepositsTxBodyL .~ DirectDeposits [(account, amountX)]
+    submitFailingTx
+      (mkBasicTx txBody)
+      [ injectFailure . MissingAccountsInDirectDeposits @era $
+          DirectDeposits [(account, amountX)]
+      ]
+
+    account2 <- freshKeyHash >>= getAccountAddressFor . KeyHashObj
+    amountY <- Coin . getPositive <$> arbitrary
+    amountZ <- Coin . getPositive <$> arbitrary
+    let
+    let subTxOnlyDirectDeposit =
+          mkBasicTx $
+            mkBasicTxBody & directDepositsTxBodyL .~ DirectDeposits [(account, amountY), (account2, amountZ)]
+    submitFailingTxIncluding
+      (mkBasicTx $ txBody & subTransactionsTxBodyL .~ [mkBasicTx txBody, subTxOnlyDirectDeposit])
+      [ injectFailure . SubMissingAccountsInDirectDeposits @era $
+          DirectDeposits [(account, amountX)]
+      , injectFailure . SubMissingAccountsInDirectDeposits @era $
+          DirectDeposits [(account, amountY), (account2, amountZ)]
+      ]
+
+  it "Withdrawals of the wrong amount" $ do
     modifyPParams $ ppGovActionLifetimeL .~ EpochInterval 2
 
     (accountAddress1, reward1, stakeKey1) <- setupAccountAddress
@@ -115,7 +158,7 @@ spec = describe "ENTITIES" $ do
             .~ Withdrawals
               [(accountAddress1, zero)]
 
-  it "Rejects withdrawals and direct deposits with wrong network id" $ do
+  it "Withdrawals and direct deposits with wrong network id" $ do
     stakeKey <- freshKeyHash
     accountAddress <- registerStakeCredential (KeyHashObj stakeKey)
     let wrongNetworkAccount = accountAddress & accountAddressNetworkIdL .~ Mainnet

--- a/libs/cardano-ledger-core/CHANGELOG.md
+++ b/libs/cardano-ledger-core/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Version history for `cardano-ledger-core`
 
-## 1.21.0.1
+## 1.21.1.0
 
-*
+* Add `withdrawalsMissingAccounts` to `Account`
 
 ## 1.21.0.0
 

--- a/libs/cardano-ledger-core/cardano-ledger-core.cabal
+++ b/libs/cardano-ledger-core/cardano-ledger-core.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-ledger-core
-version: 1.21.0.0
+version: 1.21.1.0
 license: Apache-2.0
 maintainer: operations@iohk.io
 author: IOHK

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/State/Account.hs
@@ -30,6 +30,7 @@ module Cardano.Ledger.State.Account (
   applyWithdrawals,
   applyDirectDeposits,
   directDepositsMissingAccounts,
+  withdrawalsMissingAccounts,
   removeStakePoolDelegations,
 ) where
 
@@ -337,12 +338,31 @@ directDepositsMissingAccounts ::
   DirectDeposits ->
   Accounts era ->
   Maybe DirectDeposits
-directDepositsMissingAccounts (DirectDeposits dds) accounts
-  | Map.foldrWithKey' checkRegistered True dds = Nothing
-  | otherwise = Just $ DirectDeposits $ Map.foldrWithKey' collectMissing Map.empty dds
+directDepositsMissingAccounts (DirectDeposits dds) accounts =
+  DirectDeposits <$> missingAccounts dds accounts
+
+-- | Returns `Nothing` iff every credential targeted by the supplied
+-- `Withdrawals` is a registered account. Otherwise it returns the subset of
+-- withdrawals whose target credential is not registered.
+withdrawalsMissingAccounts ::
+  EraAccounts era =>
+  Withdrawals ->
+  Accounts era ->
+  Maybe Withdrawals
+withdrawalsMissingAccounts (Withdrawals wdrls) accounts =
+  Withdrawals <$> missingAccounts wdrls accounts
+
+missingAccounts ::
+  EraAccounts era =>
+  Map AccountAddress a ->
+  Accounts era ->
+  Maybe (Map AccountAddress a)
+missingAccounts accountAddresses accounts
+  | Map.foldrWithKey' checkRegistered True accountAddresses = Nothing
+  | otherwise = Just $ Map.foldrWithKey' collectMissing Map.empty accountAddresses
   where
-    isRegistered (AccountAddress _ (AccountId credential)) =
-      isAccountRegistered credential accounts
+    isRegistered (AccountAddress _ (AccountId cred)) =
+      isAccountRegistered cred accounts
     checkRegistered addr _ acc = acc && isRegistered addr
     collectMissing addr amount acc
       | isRegistered addr = acc


### PR DESCRIPTION
# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

According to the spec,  SUBENTITIES has the following responsibilities with respect to withdrawals:

  1. networkId check
  2. pre-batch existence  (every withdrawal cred exists in original accounts)
  3. threaded existence (every withdrawal cred exists in the accounts state as it stands when this sub-tx runs)
  4.  applying: withdrawals are subtracted from threaded rewards before running CERTS.

This is what this PR is achieving, alongside some tests and some clean-up. 

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
