### PR TITLE
Implement `PV4.ScriptContext` translation for Dijkstra era.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -24,6 +24,13 @@ source-repository-package
   --sha256: sha256-h0bJTwdfJG84XrERJJoBBi5ZzRHgeVoZWS2yW/z7LiU=
   tag: 966f65f3c28cb22fc45220dbd1408baea93b53d8
 
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/plutus.git
+  subdir: plutus-core plutus-tx plutus-ledger-api
+  --sha256: sha256-1X9fa0+8yiHevY3zYqRaV2BMtUsTFqNIbibCdby/mFc=
+  tag: fdbe32b20bd02a4f27a9654ecc3648a2c8fa2968
+
 -- NOTE: If you would like to update the above,
 -- see CONTRIBUTING.md#to-update-the-referenced-agda-ledger-spec
 index-state:
@@ -94,7 +101,15 @@ benchmarks: true
 test-show-details: streaming
 allow-newer:
   -- Drop this when the bounds in plutus-core are updated
-  plutus-core:cardano-crypto-class
+  , plutus-core:cardano-crypto-class
+  , inline-r:aeson
+  -- Allow aeson 2.3 (needed by plutus-core-1.66.0.0)
+  , persistent:aeson
+  , microstache:aeson
+  , deriving-aeson:aeson
+  -- Allow CHaP's plutus-tx-plugin to work with source plutus packages
+  , plutus-tx-plugin:plutus-core
+  , plutus-tx-plugin:plutus-tx
 
 if impl(ghc >=9.12)
   allow-newer:

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo.hs
@@ -154,7 +154,7 @@ mkAlonzoStAnnTx ei sysStart pp utxo stAnnTxCache tx =
       , asatScriptsProvided = scriptsProvided
       , asatPlutusRunnableCache = newStAnnTxCache
       , asatPlutusLanguagesUsed =
-          Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr) <- plutusScriptsUsed]
+          Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr, _) <- plutusScriptsUsed]
       , asatPlutusScriptsWithContext =
           scriptsWithContextFromLedgerTxInfo ledgerTxInfo (pp ^. ppCostModelsL) plutusScriptsUsed
       }

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Context.hs
@@ -38,6 +38,7 @@ module Cardano.Ledger.Alonzo.Plutus.Context (
 
   -- * Language dependent translation
   PlutusTxInfo,
+  PlutusTopTxInfo,
   PlutusTxCert,
   PlutusScriptPurpose,
   PlutusScriptContext,
@@ -87,6 +88,7 @@ import GHC.Stack
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
+import qualified PlutusLedgerApi.V4 as PV4
 
 -- | All information that is necessary from the ledger to construct Plutus' TxInfo.
 data LedgerTxInfo era where
@@ -120,6 +122,7 @@ class
   toPlutusScriptPurpose ::
     proxy l ->
     ProtVer ->
+    ScriptHash ->
     PlutusPurpose AsIxItem era ->
     Either (ContextError era) (PlutusScriptPurpose l)
 
@@ -131,9 +134,11 @@ class
   toPlutusArgs ::
     proxy l ->
     ProtVer ->
+    ScriptHash ->
     PlutusTxInfo l ->
     PlutusPurpose AsIxItem era ->
     Maybe (Data era) ->
+    PlutusTopTxInfo l ->
     Data era ->
     Either (ContextError era) (PlutusArgs l)
 
@@ -159,7 +164,7 @@ newtype PlutusTxInfoResult l era
       Either
         (ContextError era)
         ( PlutusPurpose AsPurpose era ->
-          Either (ContextError era) (PlutusTxInfo l)
+          Either (ContextError era) (PlutusTxInfo l, PlutusTopTxInfo l)
         )
   }
 
@@ -167,7 +172,7 @@ newtype PlutusTxInfoResult l era
 mkPlutusTxInfoFromResult ::
   PlutusPurpose AsPurpose era ->
   PlutusTxInfoResult l era ->
-  Either (ContextError era) (PlutusTxInfo l)
+  Either (ContextError era) (PlutusTxInfo l, PlutusTopTxInfo l)
 mkPlutusTxInfoFromResult sp (PlutusTxInfoResult txInfoResult) =
   join $ ($ sp) <$> txInfoResult
 
@@ -180,7 +185,7 @@ toPlutusTxInfoForPurpose ::
   proxy l ->
   LedgerTxInfo era ->
   PlutusPurpose AsPurpose era ->
-  Either (ContextError era) (PlutusTxInfo l)
+  Either (ContextError era) (PlutusTxInfo l, PlutusTopTxInfo l)
 toPlutusTxInfoForPurpose proxy lti sp =
   mkPlutusTxInfoFromResult sp $ toPlutusTxInfo proxy lti
 
@@ -233,19 +238,25 @@ type family PlutusTxCert (l :: Language) where
   PlutusTxCert 'PlutusV1 = PV1.DCert
   PlutusTxCert 'PlutusV2 = PV2.DCert
   PlutusTxCert 'PlutusV3 = PV3.TxCert
-  PlutusTxCert 'PlutusV4 = PV3.TxCert
+  PlutusTxCert 'PlutusV4 = PV4.TxCert
 
 type family PlutusScriptPurpose (l :: Language) where
   PlutusScriptPurpose 'PlutusV1 = PV1.ScriptPurpose
   PlutusScriptPurpose 'PlutusV2 = PV2.ScriptPurpose
   PlutusScriptPurpose 'PlutusV3 = PV3.ScriptPurpose
-  PlutusScriptPurpose 'PlutusV4 = PV3.ScriptPurpose
+  PlutusScriptPurpose 'PlutusV4 = PV4.ScriptPurpose
 
 type family PlutusTxInfo (l :: Language) where
   PlutusTxInfo 'PlutusV1 = PV1.TxInfo
   PlutusTxInfo 'PlutusV2 = PV2.TxInfo
   PlutusTxInfo 'PlutusV3 = PV3.TxInfo
-  PlutusTxInfo 'PlutusV4 = PV3.TxInfo
+  PlutusTxInfo 'PlutusV4 = PV4.TxInfo
+
+type family PlutusTopTxInfo (l :: Language) where
+  PlutusTopTxInfo 'PlutusV1 = ()
+  PlutusTopTxInfo 'PlutusV2 = ()
+  PlutusTopTxInfo 'PlutusV3 = ()
+  PlutusTopTxInfo 'PlutusV4 = Maybe PV4.TopTxInfo
 
 type family PlutusTxInInfo era (l :: Language) where
   -- This special case is here because Alonzo does not have a ContextError
@@ -254,7 +265,7 @@ type family PlutusTxInInfo era (l :: Language) where
   PlutusTxInInfo _ 'PlutusV1 = PV1.TxInInfo
   PlutusTxInInfo _ 'PlutusV2 = PV2.TxInInfo
   PlutusTxInInfo _ 'PlutusV3 = PV3.TxInInfo
-  PlutusTxInInfo _ 'PlutusV4 = PV3.TxInInfo
+  PlutusTxInInfo _ 'PlutusV4 = PV4.TxInInfo
 
 -- | This is just like `mkPlutusScript`, except it is guaranteed to be total through the enforcement
 -- of support by the type system and `EraPlutusTxInfo` type class instances for supported plutus

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/Evaluate.hs
@@ -123,7 +123,7 @@ scriptsWithContextFromLedgerTxInfo ::
   ) =>
   LedgerTxInfo era ->
   CostModels ->
-  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)] ->
+  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era, ScriptHash)] ->
   Either (NonEmpty (CollectError era)) [PlutusWithContext]
 scriptsWithContextFromLedgerTxInfo lti =
   scriptsWithContextFromLedgerTxInfoWithResult lti (mkTxInfoResult lti)
@@ -136,7 +136,7 @@ scriptsWithContextFromLedgerTxInfoWithResult ::
   LedgerTxInfo era ->
   TxInfoResult era ->
   CostModels ->
-  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)] ->
+  [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era, ScriptHash)] ->
   Either (NonEmpty (CollectError era)) [PlutusWithContext]
 scriptsWithContextFromLedgerTxInfoWithResult lti txInfoResult costModels plutusScriptsUsed =
   merge
@@ -147,12 +147,12 @@ scriptsWithContextFromLedgerTxInfoWithResult lti txInfoResult costModels plutusS
     redeemers =
       case lti of
         LedgerTxInfo {ltiTx} -> ltiTx ^. witsTxL . rdmrsTxWitsL . unRedeemersL
-    getScriptWithRedeemer (plutusPurpose, plutusScriptRunnable) =
+    getScriptWithRedeemer (plutusPurpose, plutusScriptRunnable, scriptHash) =
       let redeemerIndex = hoistPlutusPurpose toAsIx plutusPurpose
        in case Map.lookup redeemerIndex redeemers of
-            Just (d, exUnits) -> Right (plutusScriptRunnable, plutusPurpose, d, exUnits)
+            Just (d, exUnits) -> Right (plutusScriptRunnable, scriptHash, plutusPurpose, d, exUnits)
             Nothing -> Left (NoRedeemer (hoistPlutusPurpose toAsItem plutusPurpose))
-    apply (plutusScriptRunnable, plutusPurpose, redeemerData, exUnits) = do
+    apply (plutusScriptRunnable, scriptHash, plutusPurpose, redeemerData, exUnits) = do
       let lang =
             case plutusScriptRunnable of
               SupportedPlutusRunnable srp -> plutusLanguage srp
@@ -160,6 +160,7 @@ scriptsWithContextFromLedgerTxInfoWithResult lti txInfoResult costModels plutusS
       first BadTranslation $
         mkPlutusWithContext
           plutusScriptRunnable
+          scriptHash
           plutusPurpose
           lti
           txInfoResult
@@ -377,6 +378,7 @@ evalTxExUnitsWithLogs pp tx utxo epochInfo systemStart = Map.mapWithKey findAndC
         first ContextError $
           mkPlutusWithContext
             (mkSupportedPlutusRunnable (pvMajor protVer) plutusScript)
+            plutusScriptHash
             plutusPurpose
             ledgerTxInfo
             txInfoResult

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Plutus/TxInfo.hs
@@ -101,6 +101,7 @@ mkPlutusWithContext ::
   forall era.
   AlonzoEraUTxO era =>
   SupportedPlutusRunnable era ->
+  ScriptHash ->
   PlutusPurpose AsIxItem era ->
   LedgerTxInfo era ->
   TxInfoResult era ->
@@ -108,16 +109,16 @@ mkPlutusWithContext ::
   ExUnits ->
   CostModel ->
   Either (ContextError era) PlutusWithContext
-mkPlutusWithContext script plutusPurpose lti@LedgerTxInfo {ltiTx} txInfoResult redeemerData exUnits costModel =
+mkPlutusWithContext script scriptHash plutusPurpose lti@LedgerTxInfo {ltiTx} txInfoResult redeemerData exUnits costModel =
   case script of
     SupportedPlutusRunnable plutusRunnable -> do
       let slang = isLanguage `asSameLanguage` plutusRunnable
           maybeSpendingDatum =
             getSpendingDatum (ltiUTxO lti) ltiTx (hoistPlutusPurpose toAsItem plutusPurpose)
       mkTxInfo <- unPlutusTxInfoResult $ lookupTxInfoResult slang txInfoResult
-      txInfo <- mkTxInfo $ hoistPlutusPurpose toAsPurpose plutusPurpose
+      (txInfo, topTxInfo) <- mkTxInfo $ hoistPlutusPurpose toAsPurpose plutusPurpose
       plutusArgs <-
-        toPlutusArgs slang (ltiProtVer lti) txInfo plutusPurpose maybeSpendingDatum redeemerData
+        toPlutusArgs slang (ltiProtVer lti) scriptHash txInfo plutusPurpose maybeSpendingDatum topTxInfo redeemerData
       pure $
         PlutusWithContext
           { pwcProtocolVersion = pvMajor (ltiProtVer lti)
@@ -156,7 +157,7 @@ instance EraPlutusTxInfo 'PlutusV1 AlonzoEra where
             , PV1.txInfoData = transTxWitsDatums (tx ^. witsTxL)
             , PV1.txInfoId = transTxBodyId txBody
             }
-      Right $ \_ -> Right txInfo
+      Right $ \_ -> Right (txInfo, ())
 
   toPlutusArgs = toPlutusV1Args
 
@@ -168,26 +169,29 @@ toPlutusV1Args ::
   EraPlutusTxInfo 'PlutusV1 era =>
   proxy 'PlutusV1 ->
   ProtVer ->
+  ScriptHash ->
   PV1.TxInfo ->
   PlutusPurpose AsIxItem era ->
   Maybe (Data era) ->
+  () ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV1)
-toPlutusV1Args proxy pv txInfo scriptPurpose maybeSpendingData redeemerData =
+toPlutusV1Args proxy pv scriptHash txInfo scriptPurpose maybeSpendingData _topTxInfo redeemerData =
   PlutusV1Args
-    <$> toLegacyPlutusArgs proxy pv (PV1.ScriptContext txInfo) scriptPurpose maybeSpendingData redeemerData
+    <$> toLegacyPlutusArgs proxy pv scriptHash (PV1.ScriptContext txInfo) scriptPurpose maybeSpendingData redeemerData
 
 toLegacyPlutusArgs ::
   EraPlutusTxInfo l era =>
   proxy l ->
   ProtVer ->
+  ScriptHash ->
   (PlutusScriptPurpose l -> PlutusScriptContext l) ->
   PlutusPurpose AsIxItem era ->
   Maybe (Data era) ->
   Data era ->
   Either (ContextError era) (LegacyPlutusArgs l)
-toLegacyPlutusArgs proxy pv mkScriptContext scriptPurpose maybeSpendingData redeemerData = do
-  scriptContext <- mkScriptContext <$> toPlutusScriptPurpose proxy pv scriptPurpose
+toLegacyPlutusArgs proxy pv scriptHash mkScriptContext scriptPurpose maybeSpendingData redeemerData = do
+  scriptContext <- mkScriptContext <$> toPlutusScriptPurpose proxy pv scriptHash scriptPurpose
   let redeemer = getPlutusData redeemerData
   pure $ case maybeSpendingData of
     Nothing -> LegacyPlutusArgs2 redeemer scriptContext
@@ -382,9 +386,10 @@ transPlutusPurpose ::
   (EraPlutusTxInfo l era, PlutusTxCert l ~ PV1.DCert) =>
   proxy l ->
   ProtVer ->
+  ScriptHash ->
   AlonzoPlutusPurpose AsIxItem era ->
   Either (ContextError era) PV1.ScriptPurpose
-transPlutusPurpose proxy pv = \case
+transPlutusPurpose proxy pv _scriptHash = \case
   AlonzoSpending (AsIxItem _ txIn) -> pure $ PV1.Spending (transTxIn txIn)
   AlonzoMinting (AsIxItem _ policyId) -> pure $ PV1.Minting (transPolicyID policyId)
   AlonzoCertifying (AsIxItem _ txCert) -> PV1.Certifying <$> toPlutusTxCert proxy pv txCert

--- a/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
+++ b/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs
@@ -437,14 +437,14 @@ resolveNeededPlutusScriptsWithPurpose ::
   -- version as the one supplied to this function.
   Map.Map ScriptHash (SupportedPlutusRunnable era) ->
   ( Map.Map ScriptHash (SupportedPlutusRunnable era)
-  , [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era)]
+  , [(PlutusPurpose AsIxItem era, SupportedPlutusRunnable era, ScriptHash)]
   )
 resolveNeededPlutusScriptsWithPurpose protVer scriptsProvided scriptsNeeded plutusScriptsCache =
   (updatedPlutusScriptCache, neededPlutusScriptsWithPurpose)
   where
     updatedPlutusScriptCache = plutusScriptsCache `Map.union` plutusScriptsProvided
     neededPlutusScriptsWithPurpose =
-      [ (sp, s)
+      [ (sp, s, sh)
       | (sp, sh) <- unAlonzoScriptsNeeded scriptsNeeded
       , Just s <- [lookupPlutusScriptRunnable sh]
       ]

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Imp/UtxosSpec.hs
@@ -91,7 +91,7 @@ spec = describe "UTXOS" $ do
               }
       case toPlutusTxInfoForPurpose SPlutusV1 lti (SpendingPurpose AsPurpose) of
         Left e -> assertFailure $ "No translation error was expected, but got: " <> show e
-        Right txInfo ->
+        Right (txInfo, _) ->
           PV1.txInfoValidRange txInfo
             `shouldBe` PV1.Interval
               (PV1.LowerBound PV1.NegInf True)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslatableGen.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslatableGen.hs
@@ -114,7 +114,7 @@ mkPlutusTxInfo ::
   (HasCallStack, EraPlutusTxInfo l era) =>
   SLanguage l -> LedgerTxInfo era -> PlutusPurpose AsIx era -> PlutusTxInfo l
 mkPlutusTxInfo slang lti plutusPurpose =
-  either (error . show) id $
+  either (error . show) fst $
     toPlutusTxInfoForPurpose slang lti (hoistPlutusPurpose toAsPurpose plutusPurpose)
 
 epochInfo :: EpochInfo (Either a)

--- a/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslationInstance.hs
+++ b/eras/alonzo/impl/testlib/Test/Cardano/Ledger/Alonzo/Translation/TranslationInstance.hs
@@ -39,12 +39,13 @@ import GHC.Generics (Generic)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
+import qualified PlutusLedgerApi.V4 as PV4
 
 data VersionedTxInfo
   = TxInfoPV1 PV1.TxInfo
   | TxInfoPV2 PV2.TxInfo
   | TxInfoPV3 PV3.TxInfo
-  | TxInfoPV4 PV3.TxInfo
+  | TxInfoPV4 PV4.TxInfo
   deriving (Show, Eq, Generic)
 
 -- | Represents arguments passed to `alonzoTxInfo` along with the produced result.
@@ -165,6 +166,18 @@ instance Cborg.Serialise a => Cborg.Serialise (PV3.LowerBound a)
 instance Cborg.Serialise a => Cborg.Serialise (PV3.UpperBound a)
 
 instance Cborg.Serialise PV3.Rational
+
+instance Cborg.Serialise PV4.AccountId
+
+instance Cborg.Serialise PV4.TxCert
+
+instance Cborg.Serialise PV4.AccountBalanceIntervals
+
+instance Cborg.Serialise PV4.AccountBalanceInterval
+
+instance Cborg.Serialise PV4.ScriptPurpose
+
+instance Cborg.Serialise PV4.TxInfo
 
 instance Cborg.Serialise VersionedTxInfo
 

--- a/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
+++ b/eras/babbage/impl/src/Cardano/Ledger/Babbage/TxInfo.hs
@@ -25,6 +25,7 @@ module Cardano.Ledger.Babbage.TxInfo (
   transTxRedeemers,
   transRedeemer,
   toPlutusV2Args,
+  noScriptHash,
 ) where
 
 import Cardano.Ledger.Alonzo.Plutus.Context (
@@ -196,14 +197,15 @@ transRedeemerPtr ::
   ) =>
   proxy l ->
   ProtVer ->
+  (PlutusPurpose AsIx era -> ScriptHash) ->
   TxBody t era ->
   (PlutusPurpose AsIx era, (Data era, ExUnits)) ->
   Either (ContextError era) (PlutusScriptPurpose l, PV2.Redeemer)
-transRedeemerPtr proxy pv txBody (ptr, (d, _)) =
+transRedeemerPtr proxy pv lookupScriptHash txBody (ptr, (d, _)) =
   case redeemerPointerInverse txBody ptr of
     SNothing -> Left $ inject $ RedeemerPointerPointsToNothing ptr
     SJust sp -> do
-      plutusScriptPurpose <- toPlutusScriptPurpose proxy pv sp
+      plutusScriptPurpose <- toPlutusScriptPurpose proxy pv (lookupScriptHash ptr) sp
       Right (plutusScriptPurpose, transRedeemer d)
 
 -- | Translate all `Redeemers` from within a `Tx` into a Map from a `PlutusScriptPurpose`
@@ -217,13 +219,20 @@ transTxRedeemers ::
   ) =>
   proxy l ->
   ProtVer ->
+  (PlutusPurpose AsIx era -> ScriptHash) ->
   Tx t era ->
   Either (ContextError era) (PV2.Map (PlutusScriptPurpose l) PV2.Redeemer)
-transTxRedeemers proxy pv tx =
+transTxRedeemers proxy pv lookupScriptHash tx =
   PV2.unsafeFromList
     <$> mapM
-      (transRedeemerPtr proxy pv $ tx ^. bodyTxL)
+      (transRedeemerPtr proxy pv lookupScriptHash $ tx ^. bodyTxL)
       (Map.toList $ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL)
+
+-- | A placeholder for Plutus versions (V1-V3) that do not use the script hash
+-- in their ScriptPurpose. The value is never forced because `toPlutusScriptPurpose`
+-- ignores the `ScriptHash` parameter for those versions.
+noScriptHash :: a -> ScriptHash
+noScriptHash = const $ error "noScriptHash: ScriptHash should not be used for this Plutus version"
 
 instance EraPlutusContext BabbageEra where
   type ContextError BabbageEra = BabbageContextError BabbageEra
@@ -352,7 +361,7 @@ instance EraPlutusTxInfo 'PlutusV1 BabbageEra where
             , PV1.txInfoData = Alonzo.transTxWitsDatums (tx ^. witsTxL)
             , PV1.txInfoId = Alonzo.transTxBodyId txBody
             }
-      Right $ \_ -> Right txInfo
+      Right $ \_ -> Right (txInfo, ())
 
   toPlutusArgs = Alonzo.toPlutusV1Args
 
@@ -376,7 +385,7 @@ instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- transTxRedeemers proxy ltiProtVer noScriptHash tx
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -394,7 +403,7 @@ instance EraPlutusTxInfo 'PlutusV2 BabbageEra where
             , PV2.txInfoData = PV2.unsafeFromList $ Alonzo.transTxWitsDatums (tx ^. witsTxL)
             , PV2.txInfoId = Alonzo.transTxBodyId txBody
             }
-      Right $ \_ -> Right txInfo
+      Right $ \_ -> Right (txInfo, ())
 
   toPlutusArgs = toPlutusV2Args
 
@@ -404,11 +413,13 @@ toPlutusV2Args ::
   EraPlutusTxInfo 'PlutusV2 era =>
   proxy 'PlutusV2 ->
   ProtVer ->
+  ScriptHash ->
   PV2.TxInfo ->
   PlutusPurpose AsIxItem era ->
   Maybe (Data era) ->
+  () ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV2)
-toPlutusV2Args proxy pv txInfo scriptPurpose maybeSpendingData redeemerData =
+toPlutusV2Args proxy pv scriptHash txInfo scriptPurpose maybeSpendingData _topTxInfo redeemerData =
   PlutusV2Args
-    <$> toLegacyPlutusArgs proxy pv (PV2.ScriptContext txInfo) scriptPurpose maybeSpendingData redeemerData
+    <$> toLegacyPlutusArgs proxy pv scriptHash (PV2.ScriptContext txInfo) scriptPurpose maybeSpendingData redeemerData

--- a/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TxInfoSpec.hs
+++ b/eras/babbage/impl/testlib/Test/Cardano/Ledger/Babbage/TxInfoSpec.hs
@@ -51,6 +51,7 @@ import Lens.Micro
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
+import qualified PlutusLedgerApi.V4 as PV4
 import Test.Cardano.Ledger.Alonzo.Arbitrary (alwaysSucceeds)
 import Test.Cardano.Ledger.Binary.Random (mkDummyHash)
 import Test.Cardano.Ledger.Common
@@ -159,7 +160,7 @@ hasReferenceInput slang txInfo =
     SPlutusV1 -> expectationFailure "PlutusV1 does not have reference inputs"
     SPlutusV2 -> PV2.txInfoReferenceInputs txInfo `shouldNotBe` mempty
     SPlutusV3 -> PV3.txInfoReferenceInputs txInfo `shouldNotBe` mempty
-    SPlutusV4 -> PV3.txInfoReferenceInputs txInfo `shouldNotBe` mempty
+    SPlutusV4 -> PV4.txInfoReferenceInputs txInfo `shouldNotBe` mempty
 
 plutusTxInInfoInputs ::
   forall era l. HasCallStack => SLanguage l -> PlutusTxInfo l -> [PlutusTxInInfo era l]
@@ -168,7 +169,7 @@ plutusTxInInfoInputs slang txInfo =
     SPlutusV1 -> error "PlutusV1 not supported"
     SPlutusV2 -> PV2.txInfoInputs txInfo
     SPlutusV3 -> PV3.txInfoInputs txInfo
-    SPlutusV4 -> PV3.txInfoInputs txInfo
+    SPlutusV4 -> PV4.txInfoInputs txInfo
 
 expectOneInput ::
   forall era l.
@@ -188,7 +189,7 @@ expectOneOutput o slang txInfo =
     SPlutusV1 -> expectationFailure "PlutusV1 not supported"
     SPlutusV2 -> PV2.txInfoOutputs txInfo `shouldBe` [o]
     SPlutusV3 -> PV3.txInfoOutputs txInfo `shouldBe` [o]
-    SPlutusV4 -> PV3.txInfoOutputs txInfo `shouldBe` [o]
+    SPlutusV4 -> PV4.txInfoOutputs txInfo `shouldBe` [o]
 
 successfulTranslation ::
   forall era l.
@@ -212,7 +213,7 @@ successfulTranslation slang tx f =
           , ltiMemoizedSubTransactions = mempty
           }
    in case toPlutusTxInfoForPurpose slang lti (SpendingPurpose AsPurpose) of
-        Right txInfo -> f slang txInfo
+        Right (txInfo, _) -> f slang txInfo
         Left e -> assertFailure $ "No translation error was expected, but got: " <> show e
 
 expectTranslationError ::
@@ -237,7 +238,7 @@ expectTranslationError slang tx expected =
           , ltiMemoizedSubTransactions = mempty
           }
    in case toPlutusTxInfoForPurpose slang lti (SpendingPurpose AsPurpose) of
-        Right txInfo ->
+        Right (txInfo, _) ->
           assertFailure $ "This translation was expected to fail, but it succeeded: " <> show txInfo
         Left e -> e `shouldBe` expected
 

--- a/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
+++ b/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs
@@ -30,6 +30,7 @@ module Cardano.Ledger.Conway.TxInfo (
   transTxOutV1,
   transMintValue,
   transTxBodyId,
+  transTxIn,
   transValidityInterval,
   transVotingProcedures,
   transProposal,
@@ -37,6 +38,7 @@ module Cardano.Ledger.Conway.TxInfo (
   transTxCertV1V2,
   transPlutusPurposeV1V2,
   transPlutusPurposeV3,
+  transVoter,
   guardConwayFeaturesForPlutusV1V2,
   transTxInInfoV3,
   scriptPurposeToScriptInfo,
@@ -430,7 +432,7 @@ instance EraPlutusTxInfo 'PlutusV1 ConwayEra where
             , PV1.txInfoData = Alonzo.transTxWitsDatums (tx ^. witsTxL)
             , PV1.txInfoId = Alonzo.transTxBodyId txBody
             }
-      Right $ \_ -> Right txInfo
+      Right $ \_ -> Right (txInfo, ())
 
   toPlutusArgs = Alonzo.toPlutusV1Args
 
@@ -455,7 +457,7 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer Babbage.noScriptHash tx
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -473,7 +475,7 @@ instance EraPlutusTxInfo 'PlutusV2 ConwayEra where
             , PV2.txInfoData = PV2.unsafeFromList $ Alonzo.transTxWitsDatums (tx ^. witsTxL)
             , PV2.txInfoId = Alonzo.transTxBodyId txBody
             }
-      Right $ \_ -> Right txInfo
+      Right $ \_ -> Right (txInfo, ())
 
   toPlutusArgs = Babbage.toPlutusV2Args
 
@@ -501,7 +503,7 @@ instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer Babbage.noScriptHash tx
       -- It is important for memoization for `txInfo` to be a let binding
       let txInfo =
             PV3.TxInfo
@@ -527,7 +529,7 @@ instance EraPlutusTxInfo 'PlutusV3 ConwayEra where
                     Coin 0 -> Nothing
                     coin -> Just $ transCoinToLovelace coin
               }
-      Right $ \_ -> Right txInfo
+      Right $ \_ -> Right (txInfo, ())
 
   toPlutusArgs = toPlutusV3Args
 
@@ -631,9 +633,10 @@ transPlutusPurposeV3 ::
   ) =>
   proxy 'PlutusV3 ->
   ProtVer ->
+  ScriptHash ->
   PlutusPurpose AsIxItem era ->
   Either (ContextError era) PV3.ScriptPurpose
-transPlutusPurposeV3 proxy pv = \case
+transPlutusPurposeV3 proxy pv _scriptHash = \case
   SpendingPurpose (AsIxItem _ txIn) -> pure $ PV3.Spending (transTxIn txIn)
   MintingPurpose (AsIxItem _ policyId) -> pure $ PV3.Minting (Alonzo.transPolicyID policyId)
   CertifyingPurpose (AsIxItem ix txCert) ->
@@ -729,13 +732,14 @@ transPlutusPurposeV1V2 ::
   ) =>
   proxy l ->
   ProtVer ->
+  ScriptHash ->
   PlutusPurpose AsIxItem era ->
   Either (ContextError era) PV2.ScriptPurpose
-transPlutusPurposeV1V2 proxy pv = \case
-  SpendingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoSpending asIxItem
-  MintingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoMinting asIxItem
-  CertifyingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoCertifying asIxItem
-  WithdrawingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv $ AlonzoWithdrawing asIxItem
+transPlutusPurposeV1V2 proxy pv scriptHash = \case
+  SpendingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv scriptHash $ AlonzoSpending asIxItem
+  MintingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv scriptHash $ AlonzoMinting asIxItem
+  CertifyingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv scriptHash $ AlonzoCertifying asIxItem
+  WithdrawingPurpose asIxItem -> Alonzo.transPlutusPurpose proxy pv scriptHash $ AlonzoWithdrawing asIxItem
   purpose -> Left $ inject $ PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem purpose
 
 transProtVer :: ProtVer -> PV3.ProtocolVersion
@@ -746,13 +750,15 @@ toPlutusV3Args ::
   EraPlutusTxInfo 'PlutusV3 era =>
   proxy 'PlutusV3 ->
   ProtVer ->
+  ScriptHash ->
   PV3.TxInfo ->
   PlutusPurpose AsIxItem era ->
   Maybe (Data era) ->
+  () ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV3)
-toPlutusV3Args proxy pv txInfo plutusPurpose maybeSpendingData redeemerData = do
-  scriptPurpose <- toPlutusScriptPurpose proxy pv plutusPurpose
+toPlutusV3Args proxy pv scriptHash txInfo plutusPurpose maybeSpendingData _topTxInfo redeemerData = do
+  scriptPurpose <- toPlutusScriptPurpose proxy pv scriptHash plutusPurpose
   let scriptInfo =
         scriptPurposeToScriptInfo
           scriptPurpose

--- a/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
+++ b/eras/dijkstra/impl/cardano-ledger-dijkstra.cabal
@@ -187,7 +187,7 @@ library testlib
     cardano-data,
     cardano-ledger-allegra:{cardano-ledger-allegra, testlib},
     cardano-ledger-alonzo:{cardano-ledger-alonzo, testlib},
-    cardano-ledger-babbage:testlib,
+    cardano-ledger-babbage:{cardano-ledger-babbage, testlib},
     cardano-ledger-binary:{cardano-ledger-binary, testlib},
     cardano-ledger-conway:{cardano-ledger-conway, testlib},
     cardano-ledger-core:{cardano-ledger-core, testlib},

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra.hs
@@ -143,7 +143,7 @@ mkDijkstraStAnnTopTx ei sysStart pp utxo stAnnTxCache tx =
               ]
         }
     languagesUsed =
-      Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr) <- plutusScriptsUsed]
+      Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr, _) <- plutusScriptsUsed]
    in
     DijkstraStAnnTopTx
       { dsattTx = tx
@@ -195,7 +195,7 @@ mkDijkstraStAnnSubTx ei sysStart pp utxo scriptsProvided plutusScriptsCache tx =
       , dsastScriptsProvided = scriptsProvided
       , dsastTxInfoResult = txInfoResult
       , dsastPlutusLanguagesUsed =
-          Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr) <- plutusScriptsUsed]
+          Set.fromList [plutusLanguage spr | (_, SupportedPlutusRunnable spr, _) <- plutusScriptsUsed]
       , dsastPlutusRunnableCache = plutusScriptsCache
       , dsastPlutusScriptsWithContext =
           scriptsWithContextFromLedgerTxInfoWithResult

--- a/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
+++ b/eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/TxInfo.hs
@@ -33,10 +33,13 @@ import Cardano.Ledger.Alonzo.Plutus.Context (
   SupportedPlutusRunnable (..),
  )
 import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
-import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..))
+import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..), toAsItem, toAsIx, hoistPlutusPurpose)
+import Cardano.Ledger.Alonzo.UTxO (AlonzoScriptsNeeded (..))
 import qualified Cardano.Ledger.Babbage.TxInfo as Babbage
 import Cardano.Ledger.BaseTypes (
   Inject (..),
+  Inclusive(unInclusive),
+  Exclusive(unExclusive),
   ProtVer (..),
   StrictMaybe,
   kindObjectValue,
@@ -58,12 +61,15 @@ import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Era (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Scripts (
   AccountBalanceIntervals (..),
+  AccountBalanceInterval (..),
+  DijkstraEraScript,
   PlutusScript (..),
   pattern GuardingPurpose,
  )
 import Cardano.Ledger.Dijkstra.TxCert (DijkstraTxCert)
 import Cardano.Ledger.Dijkstra.UTxO ()
 import Cardano.Ledger.Plutus (
+  transAccountId,
   Language (..),
   PlutusArgs (..),
   PlutusLanguage,
@@ -75,14 +81,17 @@ import Cardano.Ledger.Plutus (
   transCoinToLovelace,
   transCoinToValue,
   transCred,
+  transAccountAddress,
   transDatum,
   transEpochNo,
   transKeyHash,
+  transScriptHash,
  )
 import Cardano.Ledger.Plutus.Data (Data)
 import Cardano.Ledger.Plutus.ToPlutusData (ToPlutusData (..))
-import Cardano.Ledger.State (StakePoolParams (..))
-import Cardano.Ledger.TxIn (TxId)
+import Cardano.Ledger.State (StakePoolParams (..), UTxO, getScriptsNeeded)
+import Cardano.Ledger.TxIn (TxId, TxIn)
+import Cardano.Ledger.Mary (MaryValue)
 import Control.Arrow (left)
 import Control.DeepSeq (NFData)
 import Control.Monad (forM, unless, zipWithM)
@@ -102,6 +111,7 @@ import Lens.Micro ((^.))
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
+import qualified PlutusLedgerApi.V4 as PV4
 
 data DijkstraContextError era
   = ConwayContextError (ConwayContextError era)
@@ -300,7 +310,7 @@ instance EraPlutusTxInfo 'PlutusV1 DijkstraEra where
             , PV1.txInfoData = Alonzo.transTxWitsDatums (tx ^. witsTxL)
             , PV1.txInfoId = Alonzo.transTxBodyId txBody
             }
-      Right $ \_ -> Right txInfo
+      Right $ \_ -> Right (txInfo, ())
 
   toPlutusArgs = Alonzo.toPlutusV1Args
 
@@ -348,7 +358,7 @@ instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer Babbage.noScriptHash tx
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -366,14 +376,14 @@ instance EraPlutusTxInfo 'PlutusV2 DijkstraEra where
             , PV2.txInfoData = PV2.unsafeFromList $ Alonzo.transTxWitsDatums (tx ^. witsTxL)
             , PV2.txInfoId = Alonzo.transTxBodyId txBody
             }
-      Right $ \_ -> Right txInfo
+      Right $ \_ -> Right (txInfo, ())
 
   toPlutusArgs = Babbage.toPlutusV2Args
 
   toPlutusTxInInfo _ = Babbage.transTxInInfoV2
 
 instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
-  toPlutusTxCert _ _ = pure . transTxCert
+  toPlutusTxCert _ _ = pure . transTxCertV3
 
   toPlutusScriptPurpose = Conway.transPlutusPurposeV3
 
@@ -395,7 +405,7 @@ instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
           [minBound ..]
           (F.toList (txBody ^. outputsTxBodyL))
       txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
+      plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer Babbage.noScriptHash tx
       -- It is important for memoization for `txInfo` to be a let binding
       let
         txInfo =
@@ -422,7 +432,7 @@ instance EraPlutusTxInfo 'PlutusV3 DijkstraEra where
                   Coin 0 -> Nothing
                   coin -> Just $ transCoinToLovelace coin
             }
-      Right $ \_ -> Right txInfo
+      Right $ \_ -> Right (txInfo, ())
 
   toPlutusArgs = Conway.toPlutusV3Args
 
@@ -476,9 +486,9 @@ transFailUnsupportedScriptInSubTx tx =
       inject $
         UnsupportedScriptInSubTx @era (plutusLanguage (Proxy @l)) (txIdTx tx)
 
-transTxCert ::
+transTxCertV3 ::
   (ConwayEraTxCert era, TxCert era ~ DijkstraTxCert era) => TxCert era -> PV3.TxCert
-transTxCert = \case
+transTxCertV3 = \case
   RegPoolTxCert StakePoolParams {sppId, sppVrf} ->
     PV3.TxCertPoolRegister
       (transKeyHash sppId)
@@ -514,24 +524,25 @@ instance ConwayEraPlutusTxInfo 'PlutusV3 DijkstraEra where
   toPlutusChangedParameters _ x = PV3.ChangedParameters (PV3.dataToBuiltinData (toPlutusData x))
 
 instance ConwayEraPlutusTxInfo 'PlutusV4 DijkstraEra where
-  toPlutusChangedParameters _ x = PV3.ChangedParameters (PV3.dataToBuiltinData (toPlutusData x))
+  toPlutusChangedParameters _ x = PV4.ChangedParameters (PV4.dataToBuiltinData (toPlutusData x))
 
 instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
-  toPlutusTxCert _ _ = pure . transTxCert
+  toPlutusTxCert _ _ = pure . transTxCertV4
 
-  toPlutusScriptPurpose _ = error "stub: PlutusV4 not yet implemented"
+  toPlutusScriptPurpose = transPlutusPurposeV4
 
-  toPlutusTxInfo proxy lti@LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} = do
+  toPlutusTxInfo proxy lti@LedgerTxInfo {ltiProtVer, ltiEpochInfo, ltiSystemStart, ltiUTxO, ltiTx} =
     withBothTxLevels ltiTx mkTopTxInfo mkSubTxInfo
     where
       mkTopTxInfo tx = PlutusTxInfoResult $ do
         txInfo <- mkAnyLevelTxInfo tx
         let
-          topTxInfo = txInfo {PV3.txInfoFee = transCoinToLovelace (tx ^. bodyTxL . feeTxBodyL)}
+          txInfoFee = transCoinToLovelace (tx ^. bodyTxL . feeTxBodyL)
+          topTxInfo = txInfo { PV4.txInfoFee }
         Right $ \case
           purpose@(GuardingPurpose AsPurpose) -> do
-            _subTxInfosForGuards <-
-              forM (OMap.elems (tx ^. bodyTxL . subTransactionsTxBodyL)) $ \subTx -> do
+            topTxInfoSubTransactions <-
+              forM (zip [0..] (OMap.elems (tx ^. bodyTxL . subTransactionsTxBodyL))) $ \(subTxIx, subTx) -> do
                 let txId = txIdTx subTx
                 mkTxInfo <-
                   unPlutusTxInfoResult $
@@ -544,13 +555,26 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
                             }
                       Just txInfoResults ->
                         lookupTxInfoResult (plutusSLanguage proxy) txInfoResults
-                left (SubTxContextError txId) $ mkTxInfo purpose
-            -- TODO: Include _subTxInfosForGuards
-            Right topTxInfo
-          _ -> Right topTxInfo
+                (subTxInfo, _) <- left (SubTxContextError txId) $ mkTxInfo purpose
+                -- Override the subTxIx field of the ScriptContext as we know
+                -- the index of the subTx
+                pure $ subTxInfo { PV4.txInfoSubTxIx = Just subTxIx }
+            -- TODO: Implement remaining TopTxInfo fields:
+            --   * topTxInfoDatums: collect datums from requiredTopLevelGuards across sub-txs, keyed by sub-tx index
+            --   * topTxInfoStartingBalanceIntervals: account balance state before the whole tx is applied (from ledger state)
+            --   * topTxInfoSimplified: aggregate fields across all sub-txs + top-level TxInfo
+            let plutusTopTxInfo =
+                  PV4.TopTxInfo
+                    { PV4.topTxInfoSubTransactions
+                    , PV4.topTxInfoDatums = undefined
+                    , PV4.topTxInfoStartingBalanceIntervals = undefined
+                    , PV4.topTxInfoSimplified = undefined
+                    }
+            Right (topTxInfo, Just plutusTopTxInfo)
+          _ -> Right (topTxInfo, Nothing)
       mkSubTxInfo tx = PlutusTxInfoResult $ do
         txInfo <- mkAnyLevelTxInfo tx
-        Right $ \_ -> Right txInfo
+        Right $ \_ -> Right (txInfo, Nothing)
       mkAnyLevelTxInfo ::
         Tx l DijkstraEra ->
         Either (ContextError DijkstraEra) (PlutusTxInfo 'PlutusV4)
@@ -559,6 +583,17 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
           txBody = tx ^. bodyTxL
           txInputs = txBody ^. inputsTxBodyL
           refInputs = txBody ^. referenceInputsTxBodyL
+          AlonzoScriptsNeeded scriptsNeeded = getScriptsNeeded ltiUTxO txBody
+          scriptHashMap =
+            Map.fromList
+              [ (hoistPlutusPurpose toAsIx sp, sh)
+              | (sp, sh) <- scriptsNeeded
+              ]
+          lookupScriptHash ptr =
+            case Map.lookup ptr scriptHashMap of
+              Just sh -> sh
+              -- FIXME (koslambrou) Return error as Either instead?
+              Nothing -> error "transTxRedeemers: unknown redeemer pointer"
         timeRange <-
           Conway.transValidityInterval tx ltiEpochInfo ltiSystemStart (txBody ^. vldtTxBodyL)
         inputsInfo <- mapM (Conway.transTxInInfoV3 ltiUTxO) (Set.toList txInputs)
@@ -571,56 +606,209 @@ instance EraPlutusTxInfo 'PlutusV4 DijkstraEra where
             [minBound ..]
             (F.toList (txBody ^. outputsTxBodyL))
         txCerts <- Alonzo.transTxBodyCerts proxy ltiProtVer txBody
-        plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer tx
+        plutusRedeemers <- Babbage.transTxRedeemers proxy ltiProtVer lookupScriptHash tx
         Right $
-          PV3.TxInfo
-            { PV3.txInfoInputs = inputsInfo
-            , PV3.txInfoOutputs = outputs
-            , PV3.txInfoReferenceInputs = refInputsInfo
-            , PV3.txInfoFee = 0
-            , PV3.txInfoMint = Conway.transMintValue (txBody ^. mintTxBodyL)
-            , PV3.txInfoTxCerts = txCerts
-            , PV3.txInfoWdrl = Conway.transTxBodyWithdrawals txBody
-            , PV3.txInfoValidRange = timeRange
-            , PV3.txInfoSignatories = Alonzo.transTxBodyReqSignerHashes txBody
-            , PV3.txInfoRedeemers = plutusRedeemers
-            , PV3.txInfoData = PV3.unsafeFromList $ Alonzo.transTxWitsDatums (tx ^. witsTxL)
-            , PV3.txInfoId = Conway.transTxBodyId txBody
-            , PV3.txInfoVotes = Conway.transVotingProcedures (txBody ^. votingProceduresTxBodyL)
-            , PV3.txInfoProposalProcedures =
+          PV4.TxInfo
+            { PV4.txInfoId = Conway.transTxBodyId txBody
+            , PV4.txInfoSubTxIx = Nothing
+            , PV4.txInfoInputs = inputsInfo
+            , PV4.txInfoReferenceInputs = refInputsInfo
+            , PV4.txInfoOutputs = outputs
+            , PV4.txInfoFee = 0
+            , PV4.txInfoMint = Conway.transMintValue (txBody ^. mintTxBodyL)
+            , PV4.txInfoTxCerts = txCerts
+            , PV4.txInfoWithdrawals = transTxBodyWithdrawals txBody
+            , PV4.txInfoDirectDeposits = transTxBodyDirectDeposits txBody
+            , PV4.txInfoAccountBalanceIntervals = transTxBodyAccountBalanceIntervals txBody
+            , PV4.txInfoValidRange = timeRange
+            , PV4.txInfoGuards = transTxBodyGuards txBody
+            , PV4.txInfoRequiredTopLevelGuards = transTxBodyRequiredTopLevelGuards txBody
+            , PV4.txInfoRedeemers = plutusRedeemers
+            , PV4.txInfoData = PV4.unsafeFromList $ Alonzo.transTxWitsDatums (tx ^. witsTxL)
+            , PV4.txInfoVotes = Conway.transVotingProcedures (txBody ^. votingProceduresTxBodyL)
+            , PV4.txInfoProposalProcedures =
                 map (Conway.transProposal proxy) $ toList (txBody ^. proposalProceduresTxBodyL)
-            , PV3.txInfoCurrentTreasuryAmount =
+            , PV4.txInfoCurrentTreasuryAmount =
                 strictMaybe Nothing (Just . transCoinToLovelace) $ txBody ^. currentTreasuryValueTxBodyL
-            , PV3.txInfoTreasuryDonation =
-                case txBody ^. treasuryDonationTxBodyL of
-                  Coin 0 -> Nothing
-                  coin -> Just $ transCoinToLovelace coin
+            , PV4.txInfoTreasuryDonation =
+                transCoinToLovelace $ txBody ^. treasuryDonationTxBodyL
             }
 
   toPlutusArgs = toPlutusV4Args
 
-  toPlutusTxInInfo _ = transTxInInfoV3
+  toPlutusTxInInfo _ = transTxInInfoV4
+
+transPlutusPurposeV4 ::
+  forall era proxy.
+  ( ConwayEraPlutusTxInfo 'PlutusV4 era
+  , DijkstraEraScript era
+  , Inject (ConwayContextError era) (ContextError era)
+  ) =>
+  proxy 'PlutusV4 ->
+  ProtVer ->
+  ScriptHash ->
+  PlutusPurpose AsIxItem era ->
+  Either (ContextError era) PV4.ScriptPurpose
+transPlutusPurposeV4 proxy pv scriptHash = \case
+  SpendingPurpose (AsIxItem _ txIn) -> pure $ PV4.Spending plutusScriptHash (Conway.transTxIn txIn)
+  MintingPurpose (AsIxItem _ policyId) -> pure $ PV4.Minting plutusScriptHash (Alonzo.transPolicyID policyId)
+  CertifyingPurpose (AsIxItem ix txCert) ->
+    PV4.Certifying plutusScriptHash (toInteger ix) <$> toPlutusTxCert proxy pv txCert
+  WithdrawingPurpose (AsIxItem _ accountAddress) -> pure $ PV4.Withdrawing plutusScriptHash (transAccountAddress accountAddress)
+  VotingPurpose (AsIxItem _ voter) -> pure $ PV4.Voting plutusScriptHash (Conway.transVoter voter)
+  ProposingPurpose (AsIxItem ix proposal) ->
+    pure $ PV4.Proposing plutusScriptHash (toInteger ix) (Conway.transProposal proxy proposal)
+  GuardingPurpose (AsIxItem ix _guardScriptHash) ->
+    pure $ PV4.Guarding plutusScriptHash (toInteger ix)
+  purpose -> Left $ inject $ PlutusPurposeNotSupported @era $ hoistPlutusPurpose toAsItem purpose
+  where
+    plutusScriptHash = transScriptHash scriptHash
+
+transTxCertV4 ::
+  (ConwayEraTxCert era, TxCert era ~ DijkstraTxCert era) => TxCert era -> PV4.TxCert
+transTxCertV4 = \case
+  RegDepositTxCert stakeCred deposit ->
+    PV4.TxCertRegAccount
+      (PV4.AccountId $ transCred stakeCred)
+      (transCoinToLovelace deposit)
+  UnRegDepositTxCert stakeCred refund ->
+    PV4.TxCertUnRegAccount
+      (PV4.AccountId $ transCred stakeCred)
+      (transCoinToLovelace refund)
+  DelegTxCert stakeCred delegatee ->
+    PV4.TxCertDelegAccount
+      (PV4.AccountId $ transCred stakeCred)
+      $ Conway.transDelegatee delegatee
+  RegDepositDelegTxCert stakeCred delegatee deposit ->
+    PV4.TxCertRegAccountDeleg
+      (PV4.AccountId $ transCred stakeCred)
+      (Conway.transDelegatee delegatee)
+      $ transCoinToLovelace deposit
+  RegPoolTxCert StakePoolParams {sppId, sppVrf} ->
+    PV4.TxCertPoolRegister (transKeyHash sppId)
+      $ PV1.PubKeyHash
+      $ PV1.toBuiltin
+      $ hashToBytes
+      $ unVRFVerKeyHash sppVrf
+  RetirePoolTxCert poolId retireEpochNo ->
+    PV4.TxCertPoolRetire (transKeyHash poolId)
+      $ transEpochNo retireEpochNo
+  AuthCommitteeHotKeyTxCert coldCred hotCred ->
+    PV4.TxCertAuthHotCommittee
+      (Conway.transColdCommitteeCred coldCred)
+      $ Conway.transHotCommitteeCred hotCred
+  ResignCommitteeColdTxCert coldCred _anchor ->
+    PV4.TxCertResignColdCommittee
+      $ Conway.transColdCommitteeCred coldCred
+  RegDRepTxCert drepCred deposit _anchor ->
+    PV4.TxCertRegDRep (Conway.transDRepCred drepCred)
+      $ transCoinToLovelace deposit
+  UnRegDRepTxCert drepCred refund ->
+    PV4.TxCertUnRegDRep (Conway.transDRepCred drepCred)
+      $ transCoinToLovelace refund
+  UpdateDRepTxCert drepCred _anchor ->
+    PV4.TxCertUpdateDRep $ Conway.transDRepCred drepCred
+  _ -> error "Impossible: All TxCerts should have been accounted for"
+
+-- | Translate all `Withdrawal`s from within a `TxBody`
+transTxBodyWithdrawals :: EraTxBody era => TxBody l era -> PV4.Map PV4.AccountId PV4.Lovelace
+transTxBodyWithdrawals txBody =
+  Conway.transMap
+    (transAccountId . aaId)
+    transCoinToLovelace
+    (unWithdrawals $ txBody ^. withdrawalsTxBodyL)
+
+-- | Translate all `DirectDeposits`s from within a `TxBody`
+transTxBodyDirectDeposits :: DijkstraEraTxBody era => TxBody l era -> PV4.Map PV4.AccountId PV4.Lovelace
+transTxBodyDirectDeposits txBody =
+  Conway.transMap
+    (transAccountId . aaId)
+    transCoinToLovelace
+    (unDirectDeposits $ txBody ^. directDepositsTxBodyL)
+
+transTxBodyAccountBalanceIntervals :: DijkstraEraTxBody era => TxBody l era -> PV4.AccountBalanceIntervals
+transTxBodyAccountBalanceIntervals txBody =
+  PV4.AccountBalanceIntervals $
+    Conway.transMap
+      transAccountId
+      transAccountBalanceInterval
+      (unAccountBalanceIntervals $ txBody ^. accountBalanceIntervalsTxBodyL)
+
+transAccountBalanceInterval :: AccountBalanceInterval era -> PV4.AccountBalanceInterval
+transAccountBalanceInterval =
+  \case
+    AccountBalanceLowerBound l -> PV4.AccountBalanceLowerBound $ transCoinToLovelace $ unInclusive l
+    AccountBalanceUpperBound u -> PV4.AccountBalanceUpperBound $ transCoinToLovelace $ unExclusive u
+    AccountBalanceBothBounds l u -> PV4.AccountBalanceBothBounds (transCoinToLovelace $ unInclusive l) (transCoinToLovelace $ unExclusive u)
+    AccountBalanceExact exactCoin -> PV4.AccountBalanceExact $ transCoinToLovelace exactCoin
+
+transTxBodyGuards :: DijkstraEraTxBody era => TxBody l era -> [PV4.Credential]
+transTxBodyGuards txBody = fmap transCred $ toList $ txBody ^. guardsTxBodyL
+
+transTxBodyRequiredTopLevelGuards :: DijkstraEraTxBody era => TxBody l era -> PV4.Map PV4.Credential (Maybe PV4.Datum)
+transTxBodyRequiredTopLevelGuards txBody =
+  Conway.transMap
+    transCred
+    (strictMaybe Nothing (Just . transDatum))
+    (txBody ^. requiredTopLevelGuardsL)
 
 toPlutusV4Args ::
   EraPlutusTxInfo 'PlutusV4 era =>
   proxy 'PlutusV4 ->
   ProtVer ->
-  PV3.TxInfo ->
+  ScriptHash ->
+  PV4.TxInfo ->
   PlutusPurpose AsIxItem era ->
   Maybe (Data era) ->
+  Maybe PV4.TopTxInfo ->
   Data era ->
   Either (ContextError era) (PlutusArgs 'PlutusV4)
-toPlutusV4Args proxy pv txInfo plutusPurpose maybeSpendingData redeemerData = do
-  scriptPurpose <- toPlutusScriptPurpose proxy pv plutusPurpose
+toPlutusV4Args proxy pv scriptHash txInfo plutusPurpose maybeSpendingData maybeTopTxInfo redeemerData = do
+  scriptPurpose <- toPlutusScriptPurpose proxy pv scriptHash plutusPurpose
   let scriptInfo =
-        Conway.scriptPurposeToScriptInfo scriptPurpose (transDatum <$> maybeSpendingData)
+        scriptPurposeToScriptInfo
+          scriptPurpose
+          (transDatum <$> maybeSpendingData)
+          maybeTopTxInfo
+      plutusScriptHash = transScriptHash scriptHash
   pure $
     PlutusV4Args $
-      PV3.ScriptContext
-        { PV3.scriptContextTxInfo = txInfo
-        , PV3.scriptContextRedeemer = Babbage.transRedeemer redeemerData
-        , PV3.scriptContextScriptInfo = scriptInfo
+      PV4.ScriptContext
+        { PV4.scriptContextTxInfo = txInfo
+        , PV4.scriptContextRedeemer = Babbage.transRedeemer redeemerData
+        , PV4.scriptContextScriptInfo = scriptInfo
+        , PV4.scriptContextScriptHash = plutusScriptHash
         }
+
+scriptPurposeToScriptInfo
+  :: PV4.ScriptPurpose
+  -> Maybe PV1.Datum
+  -> Maybe PV4.TopTxInfo
+  -> PV4.ScriptInfo
+scriptPurposeToScriptInfo sp maybeSpendingData maybeTopTxInfo =
+  case sp of
+    PV4.Spending _scriptHash txIn -> PV4.SpendingScript txIn maybeSpendingData
+    PV4.Minting _scriptHash policyId -> PV4.MintingScript policyId
+    PV4.Certifying _scriptHash ix txCert -> PV4.CertifyingScript ix txCert
+    PV4.Withdrawing _scriptHash cred -> PV4.WithdrawingScript $ PV4.AccountId cred
+    PV4.Voting _scriptHash voter -> PV4.VotingScript voter
+    PV4.Proposing _scriptHash ix proposal -> PV4.ProposingScript ix proposal
+    PV4.Guarding _scriptHash ix -> PV4.GuardingScript ix maybeTopTxInfo
+
+-- | Given a TxIn, look it up in the UTxO. If it exists, translate it to the V4 context
+transTxInInfoV4 ::
+  forall era.
+  ( Inject (Babbage.BabbageContextError era) (ContextError era)
+  , Value era ~ MaryValue
+  , BabbageEraTxOut era
+  ) =>
+  UTxO era ->
+  TxIn ->
+  Either (ContextError era) PV4.TxInInfo
+transTxInInfoV4 utxo txIn = do
+  txOut <- left (inject . Babbage.AlonzoContextError @era) $ Alonzo.transLookupTxOut utxo txIn
+  plutusTxOut <- Babbage.transTxOutV2 (TxOutFromInput txIn) txOut
+  Right (PV4.TxInInfo (Conway.transTxIn txIn) plutusTxOut)
 
 checkPointerPresentInOutput ::
   Foldable f =>

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/Arbitrary.hs
@@ -159,7 +159,13 @@ instance Era era => Arbitrary (DijkstraTxCert era) where
       ]
 
 instance Arbitrary DijkstraDelegCert where
-  arbitrary = DijkstraRegDelegCert <$> arbitrary <*> arbitrary <*> arbitrary
+  arbitrary =
+    oneof
+      [ DijkstraRegCert <$> arbitrary <*> arbitrary
+      , DijkstraUnRegCert <$> arbitrary <*> arbitrary
+      , DijkstraDelegCert <$> arbitrary <*> arbitrary
+      , DijkstraRegDelegCert <$> arbitrary <*> arbitrary <*> arbitrary
+      ]
 
 instance
   ( EraPParams era

--- a/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
+++ b/eras/dijkstra/impl/testlib/Test/Cardano/Ledger/Dijkstra/TxInfoSpec.hs
@@ -2,35 +2,71 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Cardano.Ledger.Dijkstra.TxInfoSpec (spec) where
 
+import Cardano.Crypto.Hash.Class (hashToBytes)
 import Cardano.Ledger.Alonzo.Plutus.Context (
   EraPlutusContext (..),
   EraPlutusTxInfo (..),
   LedgerTxInfo (..),
   PlutusTxInfoResult (..),
   SupportedLanguage (..),
+  toPlutusTxCert,
+  toPlutusTxInInfo,
  )
+import qualified Cardano.Ledger.Alonzo.Plutus.TxInfo as Alonzo
+import Cardano.Ledger.Alonzo.Plutus.TxInfo (TxOutSource (..))
+import qualified Cardano.Ledger.Babbage.TxInfo as Babbage
 import Cardano.Ledger.Alonzo.Scripts (AsPurpose (..))
-import Cardano.Ledger.BaseTypes (Globals (..), Inject (..), Network (..), ProtVer (..))
+import Cardano.Ledger.BaseTypes (Exclusive (..), Globals (..), Inclusive (..), Inject (..), Network (..), ProtVer (..), StrictMaybe (..))
+import Cardano.Ledger.Conway.TxCert (ConwayGovCert (..))
+import qualified Cardano.Ledger.Conway.TxInfo as Conway
 import Cardano.Ledger.Credential (Credential (..), StakeReference (..))
+import Cardano.Ledger.Dijkstra (DijkstraEra)
 import Cardano.Ledger.Dijkstra.Core
 import Cardano.Ledger.Dijkstra.Scripts (
+  AccountBalanceInterval (..),
   AccountBalanceIntervals (..),
+  pattern GuardingPurpose,
  )
 import Cardano.Ledger.Dijkstra.State (UTxO (..))
+import Cardano.Ledger.Dijkstra.TxCert (DijkstraDelegCert (..), DijkstraTxCert (..))
 import Cardano.Ledger.Dijkstra.TxInfo (DijkstraContextError (..))
-import Cardano.Ledger.Plutus (Language (..), SLanguage (..), plutusLanguage)
+import Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Hashes (unsafeMakeSafeHash)
+import Cardano.Ledger.Plutus.Data (Data (..))
+import Cardano.Ledger.TxIn (TxId (..), mkTxInPartial)
+import Cardano.Ledger.Plutus (
+  Language (..),
+  PlutusArgs (PlutusV4Args),
+  SLanguage (..),
+  plutusLanguage,
+  transAccountAddress,
+  transAccountId,
+  transCoinToLovelace,
+  transCred,
+  transEpochNo,
+  transKeyHash,
+  transScriptHash,
+ )
+import Cardano.Ledger.State (StakePoolParams (..))
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map.NonEmpty as NEM
 import qualified Data.Map.Strict as Map
+import qualified Data.OMap.Strict as OMap
 import qualified Data.OSet.Strict as OSet
-import Lens.Micro ((&), (.~))
+import Data.Proxy (Proxy (Proxy))
+import Lens.Micro ((&), (.~), (^.))
+import qualified PlutusLedgerApi.V1 as PV1
+import qualified PlutusLedgerApi.V4 as PV4
+import Test.Cardano.Ledger.Binary.Random (mkDummyHash)
 import Test.Cardano.Ledger.Common
+import Test.Cardano.Ledger.Core.KeyPair (KeyPair (..), mkCredential, mkKeyPair)
 import Test.Cardano.Ledger.Core.Utils (testGlobals)
 import Test.Cardano.Ledger.Dijkstra.Arbitrary ()
 
@@ -48,6 +84,320 @@ spec ::
   Spec
 spec = describe "TxInfo" $ do
   describe "PlutusV4" $ do
+    let trans :: DijkstraTxCert DijkstraEra -> PV4.TxCert
+        trans cert =
+          either (error . show) id $
+            toPlutusTxCert @'PlutusV4 @DijkstraEra Proxy (ProtVer (eraProtVerLow @era) 0) cert
+
+    prop "TxCerts are correctly translated" $ \(cert :: DijkstraTxCert DijkstraEra) ->
+      let pv4Cert = trans cert
+       in case (cert, pv4Cert) of
+            (DijkstraTxCertDeleg (DijkstraRegCert cred coin), PV4.TxCertRegAccount accId lovelace) ->
+              accId === PV4.AccountId (transCred cred)
+                .&&. lovelace === transCoinToLovelace coin
+            (DijkstraTxCertDeleg (DijkstraUnRegCert cred coin), PV4.TxCertUnRegAccount accId lovelace) ->
+              accId === PV4.AccountId (transCred cred)
+                .&&. lovelace === transCoinToLovelace coin
+            (DijkstraTxCertDeleg (DijkstraDelegCert cred delegatee), PV4.TxCertDelegAccount accId pDelegatee) ->
+              accId === PV4.AccountId (transCred cred)
+                .&&. pDelegatee === Conway.transDelegatee delegatee
+            (DijkstraTxCertDeleg (DijkstraRegDelegCert cred delegatee coin), PV4.TxCertRegAccountDeleg accId pDelegatee lovelace) ->
+              accId === PV4.AccountId (transCred cred)
+                .&&. pDelegatee === Conway.transDelegatee delegatee
+                .&&. lovelace === transCoinToLovelace coin
+            (DijkstraTxCertPool (RegPool pp), PV4.TxCertPoolRegister pkh vrfHash) ->
+              pkh === transKeyHash (sppId pp)
+                .&&. vrfHash === PV1.PubKeyHash (PV1.toBuiltin (hashToBytes (unVRFVerKeyHash (sppVrf pp))))
+            (DijkstraTxCertPool (RetirePool poolId epochNo), PV4.TxCertPoolRetire pkh epoch) ->
+              pkh === transKeyHash poolId
+                .&&. epoch === transEpochNo epochNo
+            (DijkstraTxCertGov (ConwayAuthCommitteeHotKey coldCred hotCred), PV4.TxCertAuthHotCommittee pCold pHot) ->
+              pCold === Conway.transColdCommitteeCred coldCred
+                .&&. pHot === Conway.transHotCommitteeCred hotCred
+            (DijkstraTxCertGov (ConwayResignCommitteeColdKey coldCred _anchor), PV4.TxCertResignColdCommittee pCold) ->
+              pCold === Conway.transColdCommitteeCred coldCred
+            (DijkstraTxCertGov (ConwayRegDRep drepCred deposit _anchor), PV4.TxCertRegDRep pDrep lovelace) ->
+              pDrep === Conway.transDRepCred drepCred
+                .&&. lovelace === transCoinToLovelace deposit
+            (DijkstraTxCertGov (ConwayUnRegDRep drepCred deposit), PV4.TxCertUnRegDRep pDrep lovelace) ->
+              pDrep === Conway.transDRepCred drepCred
+                .&&. lovelace === transCoinToLovelace deposit
+            (DijkstraTxCertGov (ConwayUpdateDRep drepCred _anchor), PV4.TxCertUpdateDRep pDrep) ->
+              pDrep === Conway.transDRepCred drepCred
+            _ ->
+              counterexample ("Mismatched constructors: " <> show cert <> " -> " <> show pv4Cert) $
+                property False
+
+    prop "ScriptPurposes are correctly translated" $
+      \(purpose :: PlutusPurpose AsIxItem DijkstraEra) (sh :: ScriptHash) ->
+        let pv = ProtVer (eraProtVerLow @era) 0
+            result = toPlutusScriptPurpose @'PlutusV4 @DijkstraEra Proxy pv sh purpose
+            plutusSH = transScriptHash sh
+         in case (purpose, result) of
+              (SpendingPurpose (AsIxItem _ txIn), Right (PV4.Spending pSH pTxIn)) ->
+                pSH === plutusSH
+                  .&&. pTxIn === Conway.transTxIn txIn
+              (MintingPurpose (AsIxItem _ policyId), Right (PV4.Minting pSH pCS)) ->
+                pSH === plutusSH
+                  .&&. pCS === Alonzo.transPolicyID policyId
+              (CertifyingPurpose (AsIxItem ix txCert), Right (PV4.Certifying pSH pIx pCert)) ->
+                pSH === plutusSH
+                  .&&. pIx === toInteger ix
+                  .&&. pCert === trans txCert
+              (WithdrawingPurpose (AsIxItem _ acctAddr), Right (PV4.Withdrawing pSH pCred)) ->
+                pSH === plutusSH
+                  .&&. pCred === transAccountAddress acctAddr
+              (VotingPurpose (AsIxItem _ voter), Right (PV4.Voting pSH pVoter)) ->
+                pSH === plutusSH
+                  .&&. pVoter === Conway.transVoter voter
+              (ProposingPurpose (AsIxItem ix proposal), Right (PV4.Proposing pSH pIx pProposal)) ->
+                pSH === plutusSH
+                  .&&. pIx === toInteger ix
+                  .&&. pProposal === Conway.transProposal (Proxy @'PlutusV4) proposal
+              (GuardingPurpose (AsIxItem ix _guardSH), Right (PV4.Guarding pSH pIx)) ->
+                pSH === plutusSH
+                  .&&. pIx === toInteger ix
+              (_, Left _) ->
+                property True -- unsupported purpose, that's fine
+              _ ->
+                counterexample ("Mismatched: " <> show purpose <> " -> " <> show result) $
+                  property False
+
+    prop "TxInInfo is correctly translated" $ do
+      paymentCred <- arbitrary
+      val <- arbitrary
+      txIn <- arbitrary
+      let
+        txOut = mkBasicTxOut (Addr Testnet paymentCred StakeRefNull) val
+        utxo = UTxO [(txIn, txOut)]
+      pure $ case toPlutusTxInInfo @'PlutusV4 @DijkstraEra Proxy utxo txIn of
+        Left err -> expectationFailure $ "Translation failed: " <> show err
+        Right (PV4.TxInInfo pTxOutRef pTxOut) -> do
+          pTxOutRef `shouldBe` Conway.transTxIn txIn
+          case Babbage.transTxOutV2 @DijkstraEra (TxOutFromInput txIn) txOut of
+            Right expectedTxOut -> pTxOut `shouldBe` expectedTxOut
+            Left err -> expectationFailure $ "TxOut translation failed: " <> show err
+
+    prop "Direct deposits are translated" $ do
+      paymentCred <- arbitrary
+      val <- arbitrary
+      txIn <- arbitrary
+      accountAddr <- arbitrary
+      coin <- arbitrary
+      let
+        dd = DirectDeposits $ Map.singleton accountAddr coin
+        txOut = mkBasicTxOut (Addr Testnet paymentCred StakeRefNull) val
+        utxo = UTxO [(txIn, txOut)]
+        tx =
+          mkBasicTx @era @TopTx $
+            mkBasicTxBody
+              & outputsTxBodyL .~ [txOut]
+              & inputsTxBodyL .~ [txIn]
+              & directDepositsTxBodyL .~ dd
+      pure $ case translateTxInfo @era tx utxo of
+        Left err -> expectationFailure $ "Translation failed: " <> show err
+        Right txInfo ->
+          PV4.txInfoDirectDeposits txInfo
+            `shouldBe` Conway.transMap
+              (transAccountId . aaId)
+              transCoinToLovelace
+              (Map.singleton accountAddr coin)
+
+    prop "Account balance intervals are translated" $ do
+      paymentCred <- arbitrary
+      val <- arbitrary
+      txIn <- arbitrary
+      accountId <- arbitrary
+      interval <- arbitrary
+      let
+        abi = AccountBalanceIntervals $ Map.singleton accountId interval
+        txOut = mkBasicTxOut (Addr Testnet paymentCred StakeRefNull) val
+        utxo = UTxO [(txIn, txOut)]
+        tx =
+          mkBasicTx @era @TopTx $
+            mkBasicTxBody
+              & outputsTxBodyL .~ [txOut]
+              & inputsTxBodyL .~ [txIn]
+              & accountBalanceIntervalsTxBodyL .~ abi
+        expectedInterval = case interval of
+          AccountBalanceLowerBound l ->
+            PV4.AccountBalanceLowerBound $ transCoinToLovelace $ unInclusive l
+          AccountBalanceUpperBound u ->
+            PV4.AccountBalanceUpperBound $ transCoinToLovelace $ unExclusive u
+          AccountBalanceBothBounds l u ->
+            PV4.AccountBalanceBothBounds
+              (transCoinToLovelace $ unInclusive l)
+              (transCoinToLovelace $ unExclusive u)
+          AccountBalanceExact c ->
+            PV4.AccountBalanceExact $ transCoinToLovelace c
+      pure $ case translateTxInfo @era tx utxo of
+        Left err -> expectationFailure $ "Translation failed: " <> show err
+        Right txInfo ->
+          PV4.txInfoAccountBalanceIntervals txInfo
+            `shouldBe` PV4.AccountBalanceIntervals
+              (Conway.transMap transAccountId (const expectedInterval) (Map.singleton accountId interval))
+
+    prop "Guard scripts are translated" $ do
+      paymentCred <- arbitrary
+      val <- arbitrary
+      txIn <- arbitrary
+      guardCred <- arbitrary
+      let
+        txOut = mkBasicTxOut (Addr Testnet paymentCred StakeRefNull) val
+        utxo = UTxO [(txIn, txOut)]
+        tx =
+          mkBasicTx @era @TopTx $
+            mkBasicTxBody
+              & outputsTxBodyL .~ [txOut]
+              & inputsTxBodyL .~ [txIn]
+              & guardsTxBodyL .~ OSet.singleton guardCred
+      pure $ case translateTxInfo @era tx utxo of
+        Left err -> expectationFailure $ "Translation failed: " <> show err
+        Right txInfo ->
+          PV4.txInfoGuards txInfo `shouldBe` [transCred guardCred]
+
+    prop "Required top-level guards are translated" $ do
+      paymentCred <- arbitrary
+      val <- arbitrary
+      txIn <- arbitrary
+      guardCred <- arbitrary
+      let
+        txOut = mkBasicTxOut (Addr Testnet paymentCred StakeRefNull) val
+        utxo = UTxO [(txIn, txOut)]
+        tx =
+          mkBasicTx @era @TopTx $
+            mkBasicTxBody
+              & outputsTxBodyL .~ [txOut]
+              & inputsTxBodyL .~ [txIn]
+              & requiredTopLevelGuardsL .~ Map.singleton guardCred SNothing
+      pure $ case translateTxInfo @era tx utxo of
+        Left err -> expectationFailure $ "Translation failed: " <> show err
+        Right txInfo ->
+          PV4.txInfoRequiredTopLevelGuards txInfo
+            `shouldBe` PV4.unsafeFromList [(transCred guardCred, Nothing)]
+
+    prop "Withdrawals are translated with AccountId" $ do
+      paymentCred <- arbitrary
+      val <- arbitrary
+      txIn <- arbitrary
+      accountAddr <- arbitrary
+      coin <- arbitrary
+      let
+        txOut = mkBasicTxOut (Addr Testnet paymentCred StakeRefNull) val
+        utxo = UTxO [(txIn, txOut)]
+        tx =
+          mkBasicTx @era @TopTx $
+            mkBasicTxBody
+              & outputsTxBodyL .~ [txOut]
+              & inputsTxBodyL .~ [txIn]
+              & withdrawalsTxBodyL .~ Withdrawals (Map.singleton accountAddr coin)
+      pure $ case translateTxInfo @era tx utxo of
+        Left err -> expectationFailure $ "Translation failed: " <> show err
+        Right txInfo ->
+          PV4.txInfoWithdrawals txInfo
+            `shouldBe` Conway.transMap
+              (transAccountId . aaId)
+              transCoinToLovelace
+              (Map.singleton accountAddr coin)
+
+    prop "Fee is set for top-level transactions" $ do
+      paymentCred <- arbitrary
+      val <- arbitrary
+      txIn <- arbitrary
+      fee <- arbitrary
+      let
+        txOut = mkBasicTxOut (Addr Testnet paymentCred StakeRefNull) val
+        utxo = UTxO [(txIn, txOut)]
+        tx =
+          mkBasicTx @era @TopTx $
+            mkBasicTxBody
+              & outputsTxBodyL .~ [txOut]
+              & inputsTxBodyL .~ [txIn]
+              & feeTxBodyL .~ fee
+      pure $ case translateTxInfo @era tx utxo of
+        Left err -> expectationFailure $ "Translation failed: " <> show err
+        Right txInfo -> do
+          PV4.txInfoFee txInfo `shouldBe` transCoinToLovelace fee
+          PV4.txInfoSubTxIx txInfo `shouldBe` Nothing
+
+    prop "Treasury donation is translated" $ do
+      paymentCred <- arbitrary
+      val <- arbitrary
+      txIn <- arbitrary
+      donation <- arbitrary
+      let
+        txOut = mkBasicTxOut (Addr Testnet paymentCred StakeRefNull) val
+        utxo = UTxO [(txIn, txOut)]
+        tx =
+          mkBasicTx @era @TopTx $
+            mkBasicTxBody
+              & outputsTxBodyL .~ [txOut]
+              & inputsTxBodyL .~ [txIn]
+              & treasuryDonationTxBodyL .~ donation
+      pure $ case translateTxInfo @era tx utxo of
+        Left err -> expectationFailure $ "Translation failed: " <> show err
+        Right txInfo ->
+          PV4.txInfoTreasuryDonation txInfo `shouldBe` transCoinToLovelace donation
+
+    prop "ScriptContext is correctly constructed" $
+      \(purpose :: PlutusPurpose AsIxItem DijkstraEra) (sh :: ScriptHash) -> do
+        paymentCred <- arbitrary
+        val <- arbitrary
+        txIn <- arbitrary
+        let
+          pv = ProtVer (eraProtVerLow @era) 0
+          txOut = mkBasicTxOut (Addr Testnet paymentCred StakeRefNull) val
+          utxo = UTxO [(txIn, txOut)]
+          tx =
+            mkBasicTx @era @TopTx $
+              mkBasicTxBody
+                & outputsTxBodyL .~ [txOut]
+                & inputsTxBodyL .~ [txIn]
+          redeemerData = Data $ PV1.I 0
+        pure $ case translateTxInfo @era tx utxo of
+          Left _ -> property True -- TxInfo translation failed, skip
+          Right txInfo ->
+            case toPlutusArgs @'PlutusV4 @DijkstraEra Proxy pv sh txInfo purpose Nothing Nothing redeemerData of
+              Left _ -> property False -- toPlutusArgs should not fail
+              Right (PlutusV4Args sc) ->
+                PV4.scriptContextTxInfo sc === txInfo
+                  .&&. PV4.scriptContextRedeemer sc === Babbage.transRedeemer redeemerData
+                  .&&. PV4.scriptContextScriptHash sc === transScriptHash sh
+                  .&&. checkScriptInfo purpose (PV4.scriptContextScriptInfo sc)
+
+    it "GuardingScript includes sub-transaction infos" $ do
+      let
+        subTx = mkBasicTx @DijkstraEra @SubTx $ mkBasicTxBody @DijkstraEra @SubTx
+        guardSH = ScriptHash $ mkDummyHash (0 :: Int)
+        guardCred = ScriptHashObj guardSH
+        txIn = mkTxInPartial (TxId $ unsafeMakeSafeHash $ mkDummyHash (1 :: Int)) 0
+        txOut = mkBasicTxOut @DijkstraEra (Addr Testnet (mkCredential (mkKeyPair 0 :: KeyPair Payment)) StakeRefNull) (inject $ Coin 1)
+        utxo = UTxO [(txIn, txOut)]
+        tx =
+          mkBasicTx @DijkstraEra @TopTx $
+            mkBasicTxBody
+              & outputsTxBodyL .~ [txOut]
+              & inputsTxBodyL .~ [txIn]
+              & guardsTxBodyL .~ OSet.singleton guardCred
+              & subTransactionsTxBodyL .~ OMap.singleton subTx
+        guardPurpose = GuardingPurpose $ AsIxItem 0 guardSH
+        redeemerData = Data $ PV1.I 0
+        pv = ProtVer (eraProtVerLow @DijkstraEra) 0
+      case translateTxInfo @DijkstraEra tx utxo of
+        Left err -> expectationFailure $ "TxInfo translation failed: " <> show err
+        Right txInfo ->
+          case toPlutusArgs @'PlutusV4 @DijkstraEra Proxy pv guardSH txInfo guardPurpose Nothing Nothing redeemerData of
+            Left err -> expectationFailure $ "toPlutusArgs failed: " <> show err
+            Right (PlutusV4Args sc) ->
+              case PV4.scriptContextScriptInfo sc of
+                PV4.GuardingScript _ix (Just topTxInfo) ->
+                  PV4.topTxInfoSubTransactions topTxInfo `shouldSatisfy` \subTxInfos ->
+                    any (\si -> PV4.txInfoId si == Conway.transTxBodyId (subTx ^. bodyTxL)) subTxInfos
+                PV4.GuardingScript _ix Nothing ->
+                  expectationFailure "GuardingScript should have Just TopTxInfo"
+                other ->
+                  expectationFailure $ "Expected GuardingScript, got: " <> show other
+
     prop "Fails translation when Ptr present in outputs" $ do
       paymentCred <- arbitrary
       ptr <- arbitrary
@@ -77,8 +427,9 @@ spec = describe "TxInfo" $ do
             , ltiMemoizedSubTransactions = mempty
             }
       pure $
-        (($ SpendingPurpose AsPurpose) <$> unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
+        (fmap fst $ ($ SpendingPurpose AsPurpose) =<< unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 ledgerTxInfo))
           `shouldBeLeft` inject (PointerPresentInOutput @era [txOut])
+
   describe "PlutusV1-V3" $ do
     let plutusV1toV3 :: [SupportedLanguage era]
         plutusV1toV3 =
@@ -100,8 +451,8 @@ spec = describe "TxInfo" $ do
               , ltiMemoizedSubTransactions = mempty
               }
           txInfoResult =
-            ($ SpendingPurpose AsPurpose)
-              <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
+            fmap fst $ ($ SpendingPurpose AsPurpose)
+              =<< unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
         txInfoResult
           `shouldBeLeft` inject (UnsupportedScriptInSubTx @era (plutusLanguage slang) (txIdTx tx))
       prop "DirectDepositsNotSupported" $ do
@@ -122,8 +473,8 @@ spec = describe "TxInfo" $ do
               , ltiMemoizedSubTransactions = mempty
               }
           txInfoResult =
-            ($ SpendingPurpose AsPurpose)
-              <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
+            fmap fst $ ($ SpendingPurpose AsPurpose)
+              =<< unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
         pure $
           txInfoResult `shouldBeLeft` inject (DirectDepositsNotSupported @era dd)
       prop "AccountBalanceIntervalsNotSupported" $ \neAccountBalanceIntervals ->
@@ -142,8 +493,8 @@ spec = describe "TxInfo" $ do
               , ltiMemoizedSubTransactions = mempty
               }
           txInfoResult =
-            ($ SpendingPurpose AsPurpose)
-              <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
+            fmap fst $ ($ SpendingPurpose AsPurpose)
+              =<< unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
          in
           txInfoResult `shouldBeLeft` inject (AccountBalanceIntervalsNotSupported @era abi)
       prop "GuardScriptHashesNotSupported" $ \(scriptHash :: ScriptHash) ->
@@ -163,8 +514,8 @@ spec = describe "TxInfo" $ do
               , ltiMemoizedSubTransactions = mempty
               }
           txInfoResult =
-            ($ SpendingPurpose AsPurpose)
-              <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
+            fmap fst $ ($ SpendingPurpose AsPurpose)
+              =<< unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
          in
           txInfoResult `shouldBeLeft` inject (GuardScriptHashesNotSupported @era neScriptHashes)
       prop "RequiredTopLevelGuardsNotSupported" $ \neRequiredTopLevelGuards ->
@@ -182,8 +533,45 @@ spec = describe "TxInfo" $ do
               , ltiMemoizedSubTransactions = mempty
               }
           txInfoResult =
-            ($ SpendingPurpose AsPurpose)
-              <$> unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
+            fmap fst $ ($ SpendingPurpose AsPurpose)
+              =<< unPlutusTxInfoResult (toPlutusTxInfo slang ledgerTxInfo)
          in
           txInfoResult
             `shouldBeLeft` inject (RequiredTopLevelGuardsNotSupported @era neRequiredTopLevelGuards)
+
+translateTxInfo ::
+  forall era.
+  EraPlutusTxInfo 'PlutusV4 era =>
+  Tx TopTx era ->
+  UTxO era ->
+  Either (ContextError era) PV4.TxInfo
+translateTxInfo tx utxo =
+  let lti =
+        LedgerTxInfo
+          { ltiProtVer = ProtVer (eraProtVerLow @era) 0
+          , ltiEpochInfo = epochInfo testGlobals
+          , ltiSystemStart = systemStart testGlobals
+          , ltiUTxO = utxo
+          , ltiTx = tx
+          , ltiMemoizedSubTransactions = mempty
+          }
+   in fmap fst $ ($ SpendingPurpose AsPurpose) =<< unPlutusTxInfoResult (toPlutusTxInfo SPlutusV4 lti)
+
+-- | Check that ScriptInfo matches the purpose it was derived from.
+checkScriptInfo :: PlutusPurpose AsIxItem DijkstraEra -> PV4.ScriptInfo -> Property
+checkScriptInfo purpose scriptInfo =
+  case (purpose, scriptInfo) of
+    (SpendingPurpose _, PV4.SpendingScript {}) -> property True
+    (MintingPurpose _, PV4.MintingScript {}) -> property True
+    (CertifyingPurpose _, PV4.CertifyingScript {}) -> property True
+    (WithdrawingPurpose _, PV4.WithdrawingScript {}) -> property True
+    (VotingPurpose _, PV4.VotingScript {}) -> property True
+    (ProposingPurpose _, PV4.ProposingScript {}) -> property True
+    (GuardingPurpose _, PV4.GuardingScript _ _maybeTopTxInfo) ->
+      property True
+      -- counterexample "GuardingScript should have Just TopTxInfo"
+      --   $ isJust maybeTopTxInfo
+    _ ->
+      counterexample
+        ("ScriptInfo doesn't match purpose: " <> show scriptInfo)
+        $ property False

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoStarIsType #-}
 
@@ -93,6 +92,7 @@ import Numeric.Natural (Natural)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
+import qualified PlutusLedgerApi.V4 as PV4
 import Prelude hiding (decodeFloat)
 
 class Typeable a => DecCBOR a where
@@ -612,6 +612,9 @@ instance DecCBOR PV2.ScriptContext where
   decCBOR = decCBOR >>= decodeScriptContextFromData
 
 instance DecCBOR PV3.ScriptContext where
+  decCBOR = decCBOR >>= decodeScriptContextFromData
+
+instance DecCBOR PV4.ScriptContext where
   decCBOR = decCBOR >>= decodeScriptContextFromData
 
 decodeScriptContextFromData :: (PV3.FromData a, MonadFail m) => PV3.Data -> m a

--- a/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/EncCBOR.hs
+++ b/libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Encoding/EncCBOR.hs
@@ -1,20 +1,14 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoStarIsType #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -105,6 +99,7 @@ import Numeric.Natural (Natural)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
+import qualified PlutusLedgerApi.V4 as PV4
 import Prelude hiding (encodeFloat, (.))
 
 class EncCBOR a where
@@ -455,13 +450,16 @@ instance Plain.ToCBOR PV1.Data where
 instance EncCBOR PV1.Data
 
 instance EncCBOR PV1.ScriptContext where
-  encCBOR = encCBOR . PV3.toData
+  encCBOR = encCBOR . PV1.toData
 
 instance EncCBOR PV2.ScriptContext where
-  encCBOR = encCBOR . PV3.toData
+  encCBOR = encCBOR . PV2.toData
 
 instance EncCBOR PV3.ScriptContext where
   encCBOR = encCBOR . PV3.toData
+
+instance EncCBOR PV4.ScriptContext where
+  encCBOR = encCBOR . PV4.toData
 
 --------------------------------------------------------------------------------
 -- Leios

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/Language.hs
@@ -123,6 +123,7 @@ import qualified PlutusLedgerApi.Common as P (
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V2 as PV2
 import qualified PlutusLedgerApi.V3 as PV3
+import qualified PlutusLedgerApi.V4 as PV4
 import Prettyprinter (Doc, Pretty (..), align, indent, line, vsep, (<+>))
 import System.Random.Stateful
 import qualified UntypedPlutusCore as UPLC
@@ -401,6 +402,9 @@ instance NFData PV2.ScriptContext where
 instance NFData PV3.ScriptContext where
   rnf = rnf . PV3.toData
 
+instance NFData PV4.ScriptContext where
+  rnf = rnf . PV4.toData
+
 instance PV3.ToData (PlutusScriptContext l) => EncCBOR (LegacyPlutusArgs l) where
   encCBOR = encCBOR . legacyPlutusArgsToData
 
@@ -576,7 +580,7 @@ instance PlutusLanguage 'PlutusV3 where
       . unPlutusV3Args
 
 instance PlutusLanguage 'PlutusV4 where
-  newtype PlutusArgs 'PlutusV4 = PlutusV4Args {unPlutusV4Args :: PV3.ScriptContext}
+  newtype PlutusArgs 'PlutusV4 = PlutusV4Args {unPlutusV4Args :: PV4.ScriptContext}
     deriving newtype (Eq, Show, Pretty, EncCBOR, DecCBOR, NFData)
   isLanguage = SPlutusV4
   plutusLanguageTag _ = 0x04

--- a/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/TxInfo.hs
+++ b/libs/cardano-ledger-core/src/Cardano/Ledger/Plutus/TxInfo.hs
@@ -23,6 +23,7 @@ module Cardano.Ledger.Plutus.TxInfo (
   txOutSourceToText,
   transAddr,
   transAccountAddress,
+  transAccountId,
   transRewardAccount,
   transDataHash,
   transKeyHash,
@@ -81,6 +82,7 @@ import Numeric.Natural (Natural)
 import PlutusLedgerApi.V1 (SatInt, fromSatInt)
 import qualified PlutusLedgerApi.V1 as PV1
 import qualified PlutusLedgerApi.V3 as PV3
+import qualified PlutusLedgerApi.V4 as PV4
 
 -- =========================================================
 -- Translate Hashes, Credentials, Certificates etc.
@@ -156,6 +158,9 @@ transAddr = \case
 -- extra `PV1.StakingHash` wrapper is needed.
 transAccountAddress :: AccountAddress -> PV1.Credential
 transAccountAddress (AccountAddress _networkId (AccountId cred)) = transCred cred
+
+transAccountId :: AccountId -> PV4.AccountId
+transAccountId (AccountId cred) = PV4.AccountId $ transCred cred
 
 {-# DEPRECATED transRewardAccount "In favor of `transAccountAddress`" #-}
 transRewardAccount :: AccountAddress -> PV1.Credential

--- a/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
+++ b/libs/cardano-ledger-test/src/Test/Cardano/Ledger/Examples/AlonzoCollectInputs.hs
@@ -94,15 +94,17 @@ collectTwoPhaseScriptInputsOutputOrdering = do
           { pwcProtocolVersion = pvMajor protVer
           , pwcScript = decodePlutusRunnable (pvMajor protVer) plutus
           , pwcArgs = either (error . show) id $ do
-              txInfo <-
+              (txInfo, topTxInfo) <-
                 toPlutusTxInfoForPurpose plutus lti $
                   error "PlutusV1 ScriptPurpose should be unevaluated"
               toPlutusArgs
                 plutus
                 (defaultPParams @AlonzoEra ^. ppProtocolVersionL)
+                (error "ScriptHash not used for PlutusV1")
                 txInfo
                 spendingPurpose1
                 (Just (datum @AlonzoEra))
+                topTxInfo
                 (redeemer @AlonzoEra)
           , pwcExUnits = ExUnits 5000 5000
           , pwcCostModel = zeroTestingCostModel PlutusV1

--- a/libs/ledger-state/ledger-state.cabal
+++ b/libs/ledger-state/ledger-state.cabal
@@ -52,7 +52,7 @@ library
     deepseq,
     foldl,
     microlens,
-    persistent <2.15,
+    persistent <2.19,
     persistent-sqlite,
     prettyprinter,
     text,


### PR DESCRIPTION
* Thread `TopTxInfo` through `PlutusTxInfoResult` for `PV4.ScriptContext`
* Change `PlutusTxInfoResult` to return ``(PlutusTxInfo l, PlutusTopTxInfo l)` instead of just `PlutusTxInfo l`. This allows `toPlutusTxInfo` to produce a TopTxInfo alongside the TxInfo, which is needed for the Guarding script purpose in PlutusV4.

# Description

<!-- Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commits in meaningful sequence and with useful messages.
- [ ] Tests added or updated when needed.
- [ ] `CHANGELOG.md` files updated for packages with externally visible changes.
      **NOTE: _New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#changelogmd)).
- [ ] Versions updated in `.cabal` and `CHANGELOG.md` files when necessary, according to the
      [versioning process](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process).
- [ ] Version bounds in `.cabal` files updated when necessary.
      **NOTE: _If bounds change in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-ledger/blob/master/RELEASING.md#versioning-process)).
- [x] Code formatted (use `scripts/fourmolize.sh`).
- [x] Cabal files formatted (use `scripts/cabal-format.sh`).
- [x] CDDL files are up to date (use `cleret cabal run generate-cddl`)
- [x] [`hie.yaml`](https://github.com/intersectmbo/cardano-ledger/blob/master/hie.yaml) updated (use `scripts/gen-hie.sh`).
- [ ] Self-reviewed the diff.
